### PR TITLE
Share pickup and arrival effective-time core

### DIFF
--- a/backend/api/students/arrival_schedule_handlers.go
+++ b/backend/api/students/arrival_schedule_handlers.go
@@ -95,19 +95,7 @@ type BulkUpsertArrivalScheduleRequest struct {
 
 // Bind implements render.Binder for ArrivalNoteRequest
 func (r *ArrivalNoteRequest) Bind(_ *http.Request) error {
-	if r.NoteDate == "" {
-		return errors.New("note_date is required")
-	}
-	if _, err := time.Parse(dateFormatISO, r.NoteDate); err != nil {
-		return errors.New("invalid note_date format, expected YYYY-MM-DD")
-	}
-	if r.Content == "" {
-		return errors.New("content is required")
-	}
-	if len(r.Content) > 500 {
-		return errors.New("content cannot exceed 500 characters")
-	}
-	return nil
+	return validateCareNoteRequest(r.NoteDate, r.Content)
 }
 
 // Bind implements render.Binder for BulkArrivalScheduleRequest
@@ -120,26 +108,13 @@ func (r *BulkArrivalScheduleRequest) Bind(_ *http.Request) error {
 // bulk-update endpoint and the atomic create-student flow so both paths enforce
 // the same rules.
 func validateArrivalScheduleItems(items []ArrivalScheduleRequestItem) error {
-	seenWeekdays := make(map[int]bool)
-	for i, s := range items {
-		if s.Weekday < schedule.WeekdayMonday || s.Weekday > schedule.WeekdayFriday {
-			return fmt.Errorf("schedule %d: weekday must be between 1 (Monday) and 5 (Friday)", i)
+	return validateCareScheduleItems(items, "expected_arrival", func(item ArrivalScheduleRequestItem) careScheduleItem {
+		return careScheduleItem{
+			Weekday: item.Weekday,
+			Time:    item.ExpectedArrival,
+			Notes:   item.Notes,
 		}
-		if seenWeekdays[s.Weekday] {
-			return fmt.Errorf("schedule %d: duplicate weekday %d", i, s.Weekday)
-		}
-		seenWeekdays[s.Weekday] = true
-		if s.ExpectedArrival == "" {
-			return fmt.Errorf("schedule %d: expected_arrival is required", i)
-		}
-		if _, err := time.Parse("15:04", s.ExpectedArrival); err != nil {
-			return fmt.Errorf("schedule %d: invalid expected_arrival format, expected HH:MM", i)
-		}
-		if s.Notes != nil && len(*s.Notes) > 500 {
-			return fmt.Errorf("schedule %d: notes cannot exceed 500 characters", i)
-		}
-	}
-	return nil
+	})
 }
 
 // toArrivalScheduleModels maps request items onto schedule models stamped with
@@ -167,23 +142,12 @@ func toArrivalScheduleModels(items []ArrivalScheduleRequestItem, studentID, staf
 
 // Bind implements render.Binder for ArrivalExceptionRequest
 func (r *ArrivalExceptionRequest) Bind(_ *http.Request) error {
-	if r.ExceptionDate == "" {
-		return errors.New("exception_date is required")
-	}
-	if _, err := time.Parse(dateFormatISO, r.ExceptionDate); err != nil {
-		return errors.New("invalid exception_date format, expected YYYY-MM-DD")
-	}
-	// expected_arrival is optional (nil = absent/not coming)
-	// but if provided, it must be valid HH:MM format
-	if r.ExpectedArrival != nil && *r.ExpectedArrival != "" {
-		if _, err := time.Parse("15:04", *r.ExpectedArrival); err != nil {
-			return errors.New("invalid expected_arrival format, expected HH:MM")
-		}
-	}
-	if r.Reason != nil && len(*r.Reason) > 255 {
-		return errors.New("reason cannot exceed 255 characters")
-	}
-	return nil
+	return validateCareExceptionRequest(
+		r.ExceptionDate,
+		r.ExpectedArrival,
+		r.Reason,
+		"expected_arrival",
+	)
 }
 
 // Bind implements render.Binder for BulkUpsertArrivalScheduleRequest
@@ -262,56 +226,40 @@ func mapArrivalNoteToResponse(n *schedule.StudentArrivalNote) ArrivalNoteRespons
 
 // verifyArrivalExceptionOwnership checks that an arrival exception exists and belongs to the given student.
 func (rs *Resource) verifyArrivalExceptionOwnership(w http.ResponseWriter, r *http.Request, exceptionID, studentID int64) *schedule.StudentArrivalException {
-	exception, err := rs.ArrivalScheduleService.GetStudentArrivalExceptionByID(r.Context(), exceptionID)
-	if err != nil || exception == nil {
-		renderError(w, r, common.ErrorNotFound(errors.New("arrival exception not found")))
-		return nil
-	}
-	if exception.StudentID != studentID {
-		renderError(w, r, common.ErrorForbidden(errors.New("exception does not belong to this student")))
-		return nil
-	}
-	return exception
+	return verifyCareOwnership(
+		w,
+		r,
+		exceptionID,
+		studentID,
+		"arrival exception not found",
+		"exception does not belong to this student",
+		rs.ArrivalScheduleService.GetStudentArrivalExceptionByID,
+		func(exception *schedule.StudentArrivalException) int64 { return exception.StudentID },
+	)
 }
 
 // verifyArrivalNoteOwnership checks that an arrival note exists and belongs to the given student.
 func (rs *Resource) verifyArrivalNoteOwnership(w http.ResponseWriter, r *http.Request, noteID, studentID int64) *schedule.StudentArrivalNote {
-	note, err := rs.ArrivalScheduleService.GetStudentArrivalNoteByID(r.Context(), noteID)
-	if err != nil || note == nil {
-		renderError(w, r, common.ErrorNotFound(errors.New("arrival note not found")))
-		return nil
-	}
-	if note.StudentID != studentID {
-		renderError(w, r, common.ErrorForbidden(errors.New("note does not belong to this student")))
-		return nil
-	}
-	return note
+	return verifyCareOwnership(
+		w,
+		r,
+		noteID,
+		studentID,
+		"arrival note not found",
+		"note does not belong to this student",
+		rs.ArrivalScheduleService.GetStudentArrivalNoteByID,
+		func(note *schedule.StudentArrivalNote) int64 { return note.StudentID },
+	)
 }
 
 // requireArrivalReadAccess parses the student from URL params and checks read access.
 func (rs *Resource) requireArrivalReadAccess(w http.ResponseWriter, r *http.Request) *users.Student {
-	student, ok := rs.parseAndGetStudent(w, r)
-	if !ok {
-		return nil
-	}
-	if !rs.checkStudentReadAccess(r, student) {
-		renderError(w, r, common.ErrorForbidden(fmt.Errorf("read access required to view arrival schedules")))
-		return nil
-	}
-	return student
+	return rs.requireCareReadAccess(w, r, "arrival")
 }
 
 // requireArrivalWriteAccess parses the student from URL params and verifies full access.
 func (rs *Resource) requireArrivalWriteAccess(w http.ResponseWriter, r *http.Request, action string) *users.Student {
-	student, ok := rs.parseAndGetStudent(w, r)
-	if !ok {
-		return nil
-	}
-	if !rs.checkStudentFullAccess(r, student) {
-		renderError(w, r, common.ErrorForbidden(fmt.Errorf("full access required to %s", action)))
-		return nil
-	}
-	return student
+	return rs.requireCareWriteAccess(w, r, action)
 }
 
 // getStudentArrivalSchedules handles GET /students/{id}/arrival-schedules
@@ -750,27 +698,9 @@ func (rs *Resource) bulkUpsertArrivalSchedules(w http.ResponseWriter, r *http.Re
 	common.Respond(w, r, http.StatusOK, result, "Bulk arrival schedules upserted successfully")
 }
 
-// BulkArrivalTimeRequest represents a request to get arrival times for multiple students
-type BulkArrivalTimeRequest struct {
-	StudentIDs []int64 `json:"student_ids"`
-	Date       *string `json:"date,omitempty"` // Optional date in YYYY-MM-DD format, defaults to today
-}
-
-// Bind implements render.Binder
-func (r *BulkArrivalTimeRequest) Bind(_ *http.Request) error {
-	if len(r.StudentIDs) == 0 {
-		return errors.New("student_ids array cannot be empty")
-	}
-	if len(r.StudentIDs) > 500 {
-		return errors.New("student_ids array cannot exceed 500 items")
-	}
-	if r.Date != nil && *r.Date != "" {
-		if _, err := time.Parse(dateFormatISO, *r.Date); err != nil {
-			return errors.New("invalid date format, expected YYYY-MM-DD")
-		}
-	}
-	return nil
-}
+// BulkArrivalTimeRequest keeps the domain-specific public name while sharing
+// validation and binding with pickup bulk effective-time requests.
+type BulkArrivalTimeRequest = BulkEffectiveTimeRequest
 
 // BulkArrivalDayNoteResponse represents a single day note in bulk arrival time responses
 type BulkArrivalDayNoteResponse struct {
@@ -791,60 +721,39 @@ type BulkArrivalTimeResponse struct {
 
 // getBulkArrivalTimes handles POST /students/arrival-times/bulk
 func (rs *Resource) getBulkArrivalTimes(w http.ResponseWriter, r *http.Request) {
-	req := &BulkArrivalTimeRequest{}
-	if err := render.Bind(r, req); err != nil {
-		renderError(w, r, common.ErrorInvalidRequest(err))
-		return
-	}
+	handleBulkEffectiveTimes(
+		rs,
+		w,
+		r,
+		"Bulk arrival times retrieved successfully",
+		rs.ArrivalScheduleService.GetBulkEffectiveArrivalTimesForDate,
+		mapBulkArrivalTimeResponse,
+	)
+}
 
-	// Filter student IDs to only those the user has access to
-	authorizedIDs, err := rs.filterAuthorizedStudentIDs(r, req.StudentIDs)
-	if err != nil {
-		renderError(w, r, common.ErrorInternalServer(err))
-		return
+func mapBulkArrivalTimeResponse(
+	studentID int64,
+	effectiveTime *scheduleService.EffectiveArrivalTime,
+) BulkArrivalTimeResponse {
+	response := BulkArrivalTimeResponse{
+		StudentID:   studentID,
+		Date:        effectiveTime.Date.Format(dateFormatISO),
+		WeekdayName: effectiveTime.WeekdayName,
+		IsException: effectiveTime.IsException,
+		Notes:       effectiveTime.Notes,
 	}
-
-	if len(authorizedIDs) == 0 {
-		common.Respond(w, r, http.StatusOK, []BulkArrivalTimeResponse{}, "Bulk arrival times retrieved successfully")
-		return
+	if effectiveTime.ArrivalTime != nil {
+		formatted := effectiveTime.ArrivalTime.Format("15:04")
+		response.ExpectedArrival = &formatted
 	}
-
-	date := timezone.TodayDate()
-	if req.Date != nil && *req.Date != "" {
-		parsedDate, _ := timezone.ParseDate(*req.Date)
-		date = parsedDate
-	}
-
-	arrivalTimes, err := rs.ArrivalScheduleService.GetBulkEffectiveArrivalTimesForDate(r.Context(), authorizedIDs, date)
-	if err != nil {
-		renderError(w, r, common.ErrorInternalServer(err))
-		return
-	}
-
-	responses := make([]BulkArrivalTimeResponse, 0, len(arrivalTimes))
-	for studentID, eat := range arrivalTimes {
-		resp := BulkArrivalTimeResponse{
-			StudentID:   studentID,
-			Date:        eat.Date.Format(dateFormatISO),
-			WeekdayName: eat.WeekdayName,
-			IsException: eat.IsException,
-			Notes:       eat.Notes,
+	if len(effectiveTime.DayNotes) > 0 {
+		response.DayNotes = make([]BulkArrivalDayNoteResponse, 0, len(effectiveTime.DayNotes))
+		for _, note := range effectiveTime.DayNotes {
+			response.DayNotes = append(response.DayNotes, BulkArrivalDayNoteResponse{
+				ID:      note.ID,
+				Content: note.Content,
+			})
 		}
-		if eat.ArrivalTime != nil {
-			formatted := eat.ArrivalTime.Format("15:04")
-			resp.ExpectedArrival = &formatted
-		}
-		if len(eat.DayNotes) > 0 {
-			resp.DayNotes = make([]BulkArrivalDayNoteResponse, 0, len(eat.DayNotes))
-			for _, note := range eat.DayNotes {
-				resp.DayNotes = append(resp.DayNotes, BulkArrivalDayNoteResponse{
-					ID:      note.ID,
-					Content: note.Content,
-				})
-			}
-		}
-		responses = append(responses, resp)
 	}
-
-	common.Respond(w, r, http.StatusOK, responses, "Bulk arrival times retrieved successfully")
+	return response
 }

--- a/backend/api/students/effective_time_handler_core.go
+++ b/backend/api/students/effective_time_handler_core.go
@@ -1,0 +1,244 @@
+package students
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
+)
+
+const dateFormatISO = "2006-01-02"
+
+func parseTimeOnly(timeString string) (time.Time, error) {
+	return time.Parse("2006-01-02 15:04", "2000-01-01 "+timeString)
+}
+
+type careScheduleItem struct {
+	Weekday int
+	Time    string
+	Notes   *string
+}
+
+func validateCareScheduleItem(item careScheduleItem, timeField string) error {
+	if item.Weekday < schedule.WeekdayMonday || item.Weekday > schedule.WeekdayFriday {
+		return errors.New("weekday must be between 1 (Monday) and 5 (Friday)")
+	}
+	if item.Time == "" {
+		return fmt.Errorf("%s is required", timeField)
+	}
+	if _, err := time.Parse("15:04", item.Time); err != nil {
+		return fmt.Errorf("invalid %s format, expected HH:MM", timeField)
+	}
+	if item.Notes != nil && len(*item.Notes) > 500 {
+		return errors.New("notes cannot exceed 500 characters")
+	}
+	return nil
+}
+
+func validateCareScheduleItems[T any](
+	items []T,
+	timeField string,
+	mapper func(T) careScheduleItem,
+) error {
+	seenWeekdays := make(map[int]bool)
+	for index, raw := range items {
+		item := mapper(raw)
+		if item.Weekday < schedule.WeekdayMonday || item.Weekday > schedule.WeekdayFriday {
+			return fmt.Errorf(
+				"schedule %d: weekday must be between 1 (Monday) and 5 (Friday)",
+				index,
+			)
+		}
+		if seenWeekdays[item.Weekday] {
+			return fmt.Errorf("schedule %d: duplicate weekday %d", index, item.Weekday)
+		}
+		seenWeekdays[item.Weekday] = true
+		if item.Time == "" {
+			return fmt.Errorf("schedule %d: %s is required", index, timeField)
+		}
+		if _, err := time.Parse("15:04", item.Time); err != nil {
+			return fmt.Errorf(
+				"schedule %d: invalid %s format, expected HH:MM",
+				index,
+				timeField,
+			)
+		}
+		if item.Notes != nil && len(*item.Notes) > 500 {
+			return fmt.Errorf("schedule %d: notes cannot exceed 500 characters", index)
+		}
+	}
+	return nil
+}
+
+func validateCareExceptionRequest(
+	exceptionDate string,
+	value *string,
+	reason *string,
+	timeField string,
+) error {
+	if exceptionDate == "" {
+		return errors.New("exception_date is required")
+	}
+	if _, err := time.Parse(dateFormatISO, exceptionDate); err != nil {
+		return errors.New("invalid exception_date format, expected YYYY-MM-DD")
+	}
+	if value != nil && *value != "" {
+		if _, err := time.Parse("15:04", *value); err != nil {
+			return fmt.Errorf("invalid %s format, expected HH:MM", timeField)
+		}
+	}
+	if reason != nil && len(*reason) > 255 {
+		return errors.New("reason cannot exceed 255 characters")
+	}
+	return nil
+}
+
+func validateCareNoteRequest(noteDate string, content string) error {
+	if noteDate == "" {
+		return errors.New("note_date is required")
+	}
+	if _, err := time.Parse(dateFormatISO, noteDate); err != nil {
+		return errors.New("invalid note_date format, expected YYYY-MM-DD")
+	}
+	if content == "" {
+		return errors.New("content is required")
+	}
+	if len(content) > 500 {
+		return errors.New("content cannot exceed 500 characters")
+	}
+	return nil
+}
+
+func (rs *Resource) requireCareReadAccess(
+	w http.ResponseWriter,
+	r *http.Request,
+	domain string,
+) *users.Student {
+	student, ok := rs.parseAndGetStudent(w, r)
+	if !ok {
+		return nil
+	}
+	if !rs.checkStudentReadAccess(r, student) {
+		renderError(
+			w,
+			r,
+			common.ErrorForbidden(fmt.Errorf("read access required to view %s schedules", domain)),
+		)
+		return nil
+	}
+	return student
+}
+
+func (rs *Resource) requireCareWriteAccess(
+	w http.ResponseWriter,
+	r *http.Request,
+	action string,
+) *users.Student {
+	student, ok := rs.parseAndGetStudent(w, r)
+	if !ok {
+		return nil
+	}
+	if !rs.checkStudentFullAccess(r, student) {
+		renderError(w, r, common.ErrorForbidden(fmt.Errorf("full access required to %s", action)))
+		return nil
+	}
+	return student
+}
+
+func verifyCareOwnership[T any](
+	w http.ResponseWriter,
+	r *http.Request,
+	entityID int64,
+	studentID int64,
+	notFoundMessage string,
+	wrongOwnerMessage string,
+	get func(context.Context, int64) (T, error),
+	owner func(T) int64,
+) T {
+	entity, err := get(r.Context(), entityID)
+	if err != nil || reflect.ValueOf(entity).IsZero() {
+		renderError(w, r, common.ErrorNotFound(errors.New(notFoundMessage)))
+		var zero T
+		return zero
+	}
+	if owner(entity) != studentID {
+		renderError(
+			w,
+			r,
+			common.ErrorForbidden(errors.New(wrongOwnerMessage)),
+		)
+		var zero T
+		return zero
+	}
+	return entity
+}
+
+type BulkEffectiveTimeRequest struct {
+	StudentIDs []int64 `json:"student_ids"`
+	Date       *string `json:"date,omitempty"`
+}
+
+func (r *BulkEffectiveTimeRequest) Bind(_ *http.Request) error {
+	if len(r.StudentIDs) == 0 {
+		return errors.New("student_ids array cannot be empty")
+	}
+	if len(r.StudentIDs) > 500 {
+		return errors.New("student_ids array cannot exceed 500 items")
+	}
+	if r.Date != nil && *r.Date != "" {
+		if _, err := time.Parse(dateFormatISO, *r.Date); err != nil {
+			return errors.New("invalid date format, expected YYYY-MM-DD")
+		}
+	}
+	return nil
+}
+
+func handleBulkEffectiveTimes[T, R any](
+	rs *Resource,
+	w http.ResponseWriter,
+	r *http.Request,
+	successMessage string,
+	fetch func(context.Context, []int64, timezone.Date) (map[int64]*T, error),
+	mapper func(int64, *T) R,
+) {
+	req := &BulkEffectiveTimeRequest{}
+	if err := render.Bind(r, req); err != nil {
+		renderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	authorizedIDs, err := rs.filterAuthorizedStudentIDs(r, req.StudentIDs)
+	if err != nil {
+		renderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+	if len(authorizedIDs) == 0 {
+		common.Respond(w, r, http.StatusOK, []R{}, successMessage)
+		return
+	}
+
+	date := timezone.TodayDate()
+	if req.Date != nil && *req.Date != "" {
+		date, _ = timezone.ParseDate(*req.Date)
+	}
+
+	values, err := fetch(r.Context(), authorizedIDs, date)
+	if err != nil {
+		renderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	response := make([]R, 0, len(values))
+	for studentID, value := range values {
+		response = append(response, mapper(studentID, value))
+	}
+	common.Respond(w, r, http.StatusOK, response, successMessage)
+}

--- a/backend/api/students/pickup_schedule_handlers.go
+++ b/backend/api/students/pickup_schedule_handlers.go
@@ -19,15 +19,6 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// dateFormatISO is the standard date format (YYYY-MM-DD) used for pickup schedules.
-const dateFormatISO = "2006-01-02"
-
-// parseTimeOnly parses a time string (HH:MM) and returns a time.Time with a valid reference date.
-// PostgreSQL TIME columns require a valid date, so we use 2000-01-01 as reference.
-func parseTimeOnly(timeStr string) (time.Time, error) {
-	return time.Parse("2006-01-02 15:04", "2000-01-01 "+timeStr)
-}
-
 // PickupScheduleResponse represents a pickup schedule in API responses
 type PickupScheduleResponse struct {
 	ID          int64   `json:"id"`
@@ -99,36 +90,16 @@ type PickupNoteRequest struct {
 
 // Bind implements render.Binder
 func (r *PickupNoteRequest) Bind(_ *http.Request) error {
-	if r.NoteDate == "" {
-		return errors.New("note_date is required")
-	}
-	if _, err := time.Parse(dateFormatISO, r.NoteDate); err != nil {
-		return errors.New("invalid note_date format, expected YYYY-MM-DD")
-	}
-	if r.Content == "" {
-		return errors.New("content is required")
-	}
-	if len(r.Content) > 500 {
-		return errors.New("content cannot exceed 500 characters")
-	}
-	return nil
+	return validateCareNoteRequest(r.NoteDate, r.Content)
 }
 
 // Bind implements render.Binder
 func (r *PickupScheduleRequest) Bind(_ *http.Request) error {
-	if r.Weekday < schedule.WeekdayMonday || r.Weekday > schedule.WeekdayFriday {
-		return errors.New("weekday must be between 1 (Monday) and 5 (Friday)")
-	}
-	if r.PickupTime == "" {
-		return errors.New("pickup_time is required")
-	}
-	if _, err := time.Parse("15:04", r.PickupTime); err != nil {
-		return errors.New("invalid pickup_time format, expected HH:MM")
-	}
-	if r.Notes != nil && len(*r.Notes) > 500 {
-		return errors.New("notes cannot exceed 500 characters")
-	}
-	return nil
+	return validateCareScheduleItem(careScheduleItem{
+		Weekday: r.Weekday,
+		Time:    r.PickupTime,
+		Notes:   r.Notes,
+	}, "pickup_time")
 }
 
 // Bind implements render.Binder
@@ -140,26 +111,13 @@ func (r *BulkPickupScheduleRequest) Bind(_ *http.Request) error {
 // and notes length for a set of weekly pickup schedule items. Shared by the
 // bulk-update endpoint and the atomic create-student flow.
 func validatePickupScheduleItems(items []PickupScheduleRequest) error {
-	seenWeekdays := make(map[int]bool)
-	for i, s := range items {
-		if s.Weekday < schedule.WeekdayMonday || s.Weekday > schedule.WeekdayFriday {
-			return fmt.Errorf("schedule %d: weekday must be between 1 (Monday) and 5 (Friday)", i)
+	return validateCareScheduleItems(items, "pickup_time", func(item PickupScheduleRequest) careScheduleItem {
+		return careScheduleItem{
+			Weekday: item.Weekday,
+			Time:    item.PickupTime,
+			Notes:   item.Notes,
 		}
-		if seenWeekdays[s.Weekday] {
-			return fmt.Errorf("schedule %d: duplicate weekday %d", i, s.Weekday)
-		}
-		seenWeekdays[s.Weekday] = true
-		if s.PickupTime == "" {
-			return fmt.Errorf("schedule %d: pickup_time is required", i)
-		}
-		if _, err := time.Parse("15:04", s.PickupTime); err != nil {
-			return fmt.Errorf("schedule %d: invalid pickup_time format, expected HH:MM", i)
-		}
-		if s.Notes != nil && len(*s.Notes) > 500 {
-			return fmt.Errorf("schedule %d: notes cannot exceed 500 characters", i)
-		}
-	}
-	return nil
+	})
 }
 
 // toPickupScheduleModels maps request items onto schedule models stamped with
@@ -187,23 +145,7 @@ func toPickupScheduleModels(items []PickupScheduleRequest, studentID, staffID in
 
 // Bind implements render.Binder
 func (r *PickupExceptionRequest) Bind(_ *http.Request) error {
-	if r.ExceptionDate == "" {
-		return errors.New("exception_date is required")
-	}
-	if _, err := time.Parse(dateFormatISO, r.ExceptionDate); err != nil {
-		return errors.New("invalid exception_date format, expected YYYY-MM-DD")
-	}
-	// pickup_time is optional (nil = absent/no pickup)
-	// but if provided, it must be valid HH:MM format
-	if r.PickupTime != nil && *r.PickupTime != "" {
-		if _, err := time.Parse("15:04", *r.PickupTime); err != nil {
-			return errors.New("invalid pickup_time format, expected HH:MM")
-		}
-	}
-	if r.Reason != nil && len(*r.Reason) > 255 {
-		return errors.New("reason cannot exceed 255 characters")
-	}
-	return nil
+	return validateCareExceptionRequest(r.ExceptionDate, r.PickupTime, r.Reason, "pickup_time")
 }
 
 // mapScheduleToResponse converts a schedule model to API response
@@ -256,31 +198,31 @@ func mapNoteToResponse(n *schedule.StudentPickupNote) PickupNoteResponse {
 // verifyExceptionOwnership checks that an exception exists and belongs to the given student.
 // Returns the exception if valid, or writes an error response and returns nil.
 func (rs *Resource) verifyExceptionOwnership(w http.ResponseWriter, r *http.Request, exceptionID, studentID int64) *schedule.StudentPickupException {
-	exception, err := rs.PickupScheduleService.GetStudentPickupExceptionByID(r.Context(), exceptionID)
-	if err != nil || exception == nil {
-		renderError(w, r, common.ErrorNotFound(errors.New("pickup exception not found")))
-		return nil
-	}
-	if exception.StudentID != studentID {
-		renderError(w, r, common.ErrorForbidden(errors.New("exception does not belong to this student")))
-		return nil
-	}
-	return exception
+	return verifyCareOwnership(
+		w,
+		r,
+		exceptionID,
+		studentID,
+		"pickup exception not found",
+		"exception does not belong to this student",
+		rs.PickupScheduleService.GetStudentPickupExceptionByID,
+		func(exception *schedule.StudentPickupException) int64 { return exception.StudentID },
+	)
 }
 
 // verifyNoteOwnership checks that a note exists and belongs to the given student.
 // Returns the note if valid, or writes an error response and returns nil.
 func (rs *Resource) verifyNoteOwnership(w http.ResponseWriter, r *http.Request, noteID, studentID int64) *schedule.StudentPickupNote {
-	note, err := rs.PickupScheduleService.GetStudentPickupNoteByID(r.Context(), noteID)
-	if err != nil || note == nil {
-		renderError(w, r, common.ErrorNotFound(errors.New("pickup note not found")))
-		return nil
-	}
-	if note.StudentID != studentID {
-		renderError(w, r, common.ErrorForbidden(errors.New("note does not belong to this student")))
-		return nil
-	}
-	return note
+	return verifyCareOwnership(
+		w,
+		r,
+		noteID,
+		studentID,
+		"pickup note not found",
+		"note does not belong to this student",
+		rs.PickupScheduleService.GetStudentPickupNoteByID,
+		func(note *schedule.StudentPickupNote) int64 { return note.StudentID },
+	)
 }
 
 // getStaffIDFromJWT extracts the staff ID from JWT claims by looking up the person and staff
@@ -310,30 +252,14 @@ func (rs *Resource) getStaffIDFromJWT(r *http.Request) (int64, error) {
 // supervisors and admins can view pickup data; with all_staff any verified staff can.
 // Returns the student on success or writes an error response and returns nil.
 func (rs *Resource) requirePickupReadAccess(w http.ResponseWriter, r *http.Request) *users.Student {
-	student, ok := rs.parseAndGetStudent(w, r)
-	if !ok {
-		return nil
-	}
-	if !rs.checkStudentReadAccess(r, student) {
-		renderError(w, r, common.ErrorForbidden(fmt.Errorf("read access required to view pickup schedules")))
-		return nil
-	}
-	return student
+	return rs.requireCareReadAccess(w, r, "pickup")
 }
 
 // requirePickupWriteAccess parses the student from URL params and verifies full access.
 // Used for write operations (create, update, delete) that require supervisor/admin access.
 // Returns the student on success or writes an error response and returns nil.
 func (rs *Resource) requirePickupWriteAccess(w http.ResponseWriter, r *http.Request, action string) *users.Student {
-	student, ok := rs.parseAndGetStudent(w, r)
-	if !ok {
-		return nil
-	}
-	if !rs.checkStudentFullAccess(r, student) {
-		renderError(w, r, common.ErrorForbidden(fmt.Errorf("full access required to %s", action)))
-		return nil
-	}
-	return student
+	return rs.requireCareWriteAccess(w, r, action)
 }
 
 // parseEntityID extracts a numeric ID from a URL parameter.
@@ -785,27 +711,9 @@ func (rs *Resource) deleteStudentPickupNote(w http.ResponseWriter, r *http.Reque
 	common.Respond(w, r, http.StatusOK, nil, "Pickup note deleted successfully")
 }
 
-// BulkPickupTimeRequest represents a request to get pickup times for multiple students
-type BulkPickupTimeRequest struct {
-	StudentIDs []int64 `json:"student_ids"`
-	Date       *string `json:"date,omitempty"` // Optional date in YYYY-MM-DD format, defaults to today
-}
-
-// Bind implements render.Binder
-func (r *BulkPickupTimeRequest) Bind(_ *http.Request) error {
-	if len(r.StudentIDs) == 0 {
-		return errors.New("student_ids array cannot be empty")
-	}
-	if len(r.StudentIDs) > 500 {
-		return errors.New("student_ids array cannot exceed 500 items")
-	}
-	if r.Date != nil && *r.Date != "" {
-		if _, err := time.Parse(dateFormatISO, *r.Date); err != nil {
-			return errors.New("invalid date format, expected YYYY-MM-DD")
-		}
-	}
-	return nil
-}
+// BulkPickupTimeRequest keeps the domain-specific public name while sharing
+// validation and binding with arrival bulk effective-time requests.
+type BulkPickupTimeRequest = BulkEffectiveTimeRequest
 
 // BulkDayNoteResponse represents a single day note in bulk pickup time responses
 type BulkDayNoteResponse struct {
@@ -827,66 +735,41 @@ type BulkPickupTimeResponse struct {
 // getBulkPickupTimes handles POST /students/pickup-times/bulk
 // Returns effective pickup times for multiple students on a given date
 func (rs *Resource) getBulkPickupTimes(w http.ResponseWriter, r *http.Request) {
-	req := &BulkPickupTimeRequest{}
-	if err := render.Bind(r, req); err != nil {
-		renderError(w, r, common.ErrorInvalidRequest(err))
-		return
-	}
+	handleBulkEffectiveTimes(
+		rs,
+		w,
+		r,
+		"Bulk pickup times retrieved successfully",
+		rs.PickupScheduleService.GetBulkEffectivePickupTimesForDate,
+		mapBulkPickupTimeResponse,
+	)
+}
 
-	// Filter student IDs to only those the user has access to
-	authorizedIDs, err := rs.filterAuthorizedStudentIDs(r, req.StudentIDs)
-	if err != nil {
-		renderError(w, r, common.ErrorInternalServer(err))
-		return
+func mapBulkPickupTimeResponse(
+	studentID int64,
+	effectiveTime *scheduleService.EffectivePickupTime,
+) BulkPickupTimeResponse {
+	response := BulkPickupTimeResponse{
+		StudentID:   studentID,
+		Date:        effectiveTime.Date.Format(dateFormatISO),
+		WeekdayName: effectiveTime.WeekdayName,
+		IsException: effectiveTime.IsException,
+		Notes:       effectiveTime.Notes,
 	}
-
-	if len(authorizedIDs) == 0 {
-		// No authorized students - return empty result
-		common.Respond(w, r, http.StatusOK, []BulkPickupTimeResponse{}, "Bulk pickup times retrieved successfully")
-		return
+	if effectiveTime.PickupTime != nil {
+		formatted := effectiveTime.PickupTime.Format("15:04")
+		response.PickupTime = &formatted
 	}
-
-	// Determine the date to query
-	date := timezone.TodayDate()
-	if req.Date != nil && *req.Date != "" {
-		parsedDate, _ := timezone.ParseDate(*req.Date) // Already validated in Bind
-		date = parsedDate
-	}
-
-	// Use bulk service method (O(2) queries instead of O(N))
-	pickupTimes, err := rs.PickupScheduleService.GetBulkEffectivePickupTimesForDate(r.Context(), authorizedIDs, date)
-	if err != nil {
-		renderError(w, r, common.ErrorInternalServer(err))
-		return
-	}
-
-	// Convert to response format
-	responses := make([]BulkPickupTimeResponse, 0, len(pickupTimes))
-	for studentID, ept := range pickupTimes {
-		resp := BulkPickupTimeResponse{
-			StudentID:   studentID,
-			Date:        ept.Date.Format(dateFormatISO),
-			WeekdayName: ept.WeekdayName,
-			IsException: ept.IsException,
-			Notes:       ept.Notes,
+	if len(effectiveTime.DayNotes) > 0 {
+		response.DayNotes = make([]BulkDayNoteResponse, 0, len(effectiveTime.DayNotes))
+		for _, note := range effectiveTime.DayNotes {
+			response.DayNotes = append(response.DayNotes, BulkDayNoteResponse{
+				ID:      note.ID,
+				Content: note.Content,
+			})
 		}
-		if ept.PickupTime != nil {
-			formatted := ept.PickupTime.Format("15:04")
-			resp.PickupTime = &formatted
-		}
-		if len(ept.DayNotes) > 0 {
-			resp.DayNotes = make([]BulkDayNoteResponse, 0, len(ept.DayNotes))
-			for _, note := range ept.DayNotes {
-				resp.DayNotes = append(resp.DayNotes, BulkDayNoteResponse{
-					ID:      note.ID,
-					Content: note.Content,
-				})
-			}
-		}
-		responses = append(responses, resp)
 	}
-
-	common.Respond(w, r, http.StatusOK, responses, "Bulk pickup times retrieved successfully")
+	return response
 }
 
 // filterAuthorizedStudentIDs filters the requested student IDs to only those

--- a/backend/database/repositories/schedule/arrival_schedule_repo.go
+++ b/backend/database/repositories/schedule/arrival_schedule_repo.go
@@ -1,649 +1,74 @@
 package schedule
 
 import (
-	"context"
-	"database/sql"
 	"errors"
-	"fmt"
 
-	"github.com/moto-nrw/project-phoenix/database/repositories/base"
-	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/uptrace/bun"
 )
 
-// Table names for arrival schedule repositories.
 const (
 	tableArrivalSchedules  = "schedule.student_arrival_schedules"
 	tableArrivalExceptions = "schedule.student_arrival_exceptions"
 	tableArrivalNotes      = "schedule.student_arrival_notes"
 )
 
-// errArrivalScheduleNil is returned when a nil schedule is passed to a repository method.
-var errArrivalScheduleNil = fmt.Errorf("arrival schedule cannot be nil")
+var (
+	arrivalScheduleConfig = effectiveTimeRepositoryConfig{
+		table:      tableArrivalSchedules,
+		alias:      "student_arrival_schedule",
+		entityName: "StudentArrivalSchedule",
+	}
+	arrivalExceptionConfig = effectiveTimeRepositoryConfig{
+		table:      tableArrivalExceptions,
+		alias:      "student_arrival_exception",
+		entityName: "StudentArrivalException",
+	}
+	arrivalNoteConfig = effectiveTimeRepositoryConfig{
+		table:      tableArrivalNotes,
+		alias:      "student_arrival_note",
+		entityName: "StudentArrivalNote",
+	}
+)
 
-// StudentArrivalScheduleRepository implements schedule.StudentArrivalScheduleRepository interface
 type StudentArrivalScheduleRepository struct {
-	*base.Repository[*schedule.StudentArrivalSchedule]
-	db *bun.DB
+	*studentScheduleRepository[*schedule.StudentArrivalSchedule]
 }
 
-// NewStudentArrivalScheduleRepository creates a new StudentArrivalScheduleRepository
 func NewStudentArrivalScheduleRepository(db *bun.DB) schedule.StudentArrivalScheduleRepository {
-	repo := base.NewRepository[*schedule.StudentArrivalSchedule](db, tableArrivalSchedules, "StudentArrivalSchedule")
-	repo.TenantScoped = true
 	return &StudentArrivalScheduleRepository{
-		Repository: repo,
-		db:         db,
+		studentScheduleRepository: newStudentScheduleRepository[*schedule.StudentArrivalSchedule](
+			db,
+			arrivalScheduleConfig,
+			"expected_arrival",
+			"upsert arrival schedule",
+			errors.New("arrival schedule cannot be nil"),
+		),
 	}
 }
 
-// FindByStudentID finds all arrival schedules for a student
-func (r *StudentArrivalScheduleRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalSchedule, error) {
-	var schedules []*schedule.StudentArrivalSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&schedules).
-		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
-		Where(`"student_arrival_schedule".student_id = ?`, studentID).
-		Order("weekday ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_schedule")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByStudentID,
-			Err: err,
-		}
-	}
-
-	return schedules, nil
-}
-
-// FindByStudentIDAndWeekday finds an arrival schedule for a specific student and weekday
-func (r *StudentArrivalScheduleRepository) FindByStudentIDAndWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentArrivalSchedule, error) {
-	var arrivalSchedule schedule.StudentArrivalSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&arrivalSchedule).
-		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
-		Where(`"student_arrival_schedule".student_id = ?`, studentID).
-		Where(`"student_arrival_schedule".weekday = ?`, weekday)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_schedule")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and weekday",
-			Err: err,
-		}
-	}
-
-	return &arrivalSchedule, nil
-}
-
-// FindByStudentIDsAndWeekday finds arrival schedules for multiple students and a specific weekday (bulk query)
-func (r *StudentArrivalScheduleRepository) FindByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentArrivalSchedule, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentArrivalSchedule{}, nil
-	}
-
-	var schedules []*schedule.StudentArrivalSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&schedules).
-		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
-		Where(`"student_arrival_schedule".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_arrival_schedule".weekday = ?`, weekday)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_schedule")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and weekday",
-			Err: err,
-		}
-	}
-
-	return schedules, nil
-}
-
-// FindByStudentIDs returns every weekday row for the given students in one
-// query. The care-day derivation (#1747) needs the full week per child, not a
-// single weekday: "no row for today" only means "not in care today" when the
-// child has rows for OTHER weekdays — a child with no plan at all must stay
-// visible. A per-weekday query cannot tell those two cases apart, and calling
-// FindByStudentIDsAndWeekday once per date across a planner window would be
-// O(days) queries instead of one.
-func (r *StudentArrivalScheduleRepository) FindByStudentIDs(ctx context.Context, studentIDs []int64) ([]*schedule.StudentArrivalSchedule, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentArrivalSchedule{}, nil
-	}
-
-	var schedules []*schedule.StudentArrivalSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&schedules).
-		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
-		Where(`"student_arrival_schedule".student_id IN (?)`, bun.List(studentIDs)).
-		Order("student_id ASC", "weekday ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_schedule")
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids",
-			Err: err,
-		}
-	}
-
-	return schedules, nil
-}
-
-// UpsertSchedule creates or updates an arrival schedule for a student and weekday
-func (r *StudentArrivalScheduleRepository) UpsertSchedule(ctx context.Context, s *schedule.StudentArrivalSchedule) error {
-	if s == nil {
-		return errArrivalScheduleNil
-	}
-
-	if err := s.Validate(); err != nil {
-		return err
-	}
-
-	base.EnsureTenantID(ctx, s)
-
-	_, err := base.GetDB(ctx, r.db).NewInsert().
-		Model(s).
-		ModelTableExpr(tableArrivalSchedules).
-		On("CONFLICT (tenant_id, student_id, weekday) DO UPDATE").
-		Set("expected_arrival = EXCLUDED.expected_arrival").
-		Set("notes = EXCLUDED.notes").
-		Set("updated_at = NOW()").
-		Returning("id").
-		Exec(ctx)
-
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  "upsert arrival schedule",
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// DeleteByStudentID deletes all arrival schedules for a student
-func (r *StudentArrivalScheduleRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
-	query := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentArrivalSchedule)(nil)).
-		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
-		Where(`"student_arrival_schedule".student_id = ?`, studentID)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_schedule")
-
-	_, err := query.Exec(ctx)
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  opDeleteByStudentID,
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// List retrieves arrival schedules matching the provided query options
-func (r *StudentArrivalScheduleRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalSchedule, error) {
-	rows, err := r.ListWithOptions(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	if rows == nil {
-		rows = make([]*schedule.StudentArrivalSchedule, 0)
-	}
-	return rows, nil
-}
-
-// FindByID overrides base method to ensure schema qualification
-func (r *StudentArrivalScheduleRepository) FindByID(ctx context.Context, id any) (*schedule.StudentArrivalSchedule, error) {
-	var arrivalSchedule schedule.StudentArrivalSchedule
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&arrivalSchedule).
-		ModelTableExpr(`schedule.student_arrival_schedules AS "student_arrival_schedule"`).
-		Where(`"student_arrival_schedule".id = ?`, id)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_schedule")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByID,
-			Err: err,
-		}
-	}
-
-	return &arrivalSchedule, nil
-}
-
-// StudentArrivalExceptionRepository implements schedule.StudentArrivalExceptionRepository interface
 type StudentArrivalExceptionRepository struct {
-	*base.Repository[*schedule.StudentArrivalException]
-	db *bun.DB
+	*studentExceptionRepository[*schedule.StudentArrivalException]
 }
 
-// NewStudentArrivalExceptionRepository creates a new StudentArrivalExceptionRepository
 func NewStudentArrivalExceptionRepository(db *bun.DB) schedule.StudentArrivalExceptionRepository {
-	repo := base.NewRepository[*schedule.StudentArrivalException](db, tableArrivalExceptions, "StudentArrivalException")
-	repo.TenantScoped = true
 	return &StudentArrivalExceptionRepository{
-		Repository: repo,
-		db:         db,
+		studentExceptionRepository: newStudentExceptionRepository[*schedule.StudentArrivalException](
+			db,
+			arrivalExceptionConfig,
+		),
 	}
 }
 
-// FindByStudentID finds all arrival exceptions for a student
-func (r *StudentArrivalExceptionRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
-	var exceptions []*schedule.StudentArrivalException
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id = ?`, studentID).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByStudentID,
-			Err: err,
-		}
-	}
-
-	return exceptions, nil
-}
-
-// FindUpcomingByStudentID finds upcoming arrival exceptions for a student (from today onwards)
-func (r *StudentArrivalExceptionRepository) FindUpcomingByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
-	var exceptions []*schedule.StudentArrivalException
-	today := timezone.TodayDate()
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id = ?`, studentID).
-		Where(`"student_arrival_exception".exception_date >= ?`, today).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find upcoming by student id",
-			Err: err,
-		}
-	}
-
-	return exceptions, nil
-}
-
-// FindByStudentIDAndDate finds an arrival exception for a specific student and date
-func (r *StudentArrivalExceptionRepository) FindByStudentIDAndDate(ctx context.Context, studentID int64, date timezone.Date) (*schedule.StudentArrivalException, error) {
-	var exception schedule.StudentArrivalException
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exception).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id = ?`, studentID).
-		Where(`"student_arrival_exception".exception_date = ?`, date)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and date",
-			Err: err,
-		}
-	}
-
-	return &exception, nil
-}
-
-// FindByStudentIDsAndDate finds arrival exceptions for multiple students and a specific date (bulk query)
-func (r *StudentArrivalExceptionRepository) FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date timezone.Date) ([]*schedule.StudentArrivalException, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentArrivalException{}, nil
-	}
-
-	var exceptions []*schedule.StudentArrivalException
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_arrival_exception".exception_date = ?`, date)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and date",
-			Err: err,
-		}
-	}
-
-	return exceptions, nil
-}
-
-// FindByStudentIDAndDateRange finds arrival exceptions for a student whose
-// exception_date lies in the inclusive [from, to] range.
-func (r *StudentArrivalExceptionRepository) FindByStudentIDAndDateRange(
-	ctx context.Context, studentID int64, from, to timezone.Date,
-) ([]*schedule.StudentArrivalException, error) {
-	var exceptions []*schedule.StudentArrivalException
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id = ?`, studentID).
-		Where(`"student_arrival_exception".exception_date >= ?`, from).
-		Where(`"student_arrival_exception".exception_date <= ?`, to).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and date range",
-			Err: err,
-		}
-	}
-	return exceptions, nil
-}
-
-// FindByStudentIDsAndDateRange finds arrival exceptions for multiple students
-// whose exception_date lies in the inclusive [from, to] range (bulk query).
-// Feeds the care-day derivation across a planner window in one round trip.
-func (r *StudentArrivalExceptionRepository) FindByStudentIDsAndDateRange(
-	ctx context.Context, studentIDs []int64, from, to timezone.Date,
-) ([]*schedule.StudentArrivalException, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentArrivalException{}, nil
-	}
-
-	var exceptions []*schedule.StudentArrivalException
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_arrival_exception".exception_date >= ?`, from).
-		Where(`"student_arrival_exception".exception_date <= ?`, to).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and date range",
-			Err: err,
-		}
-	}
-	return exceptions, nil
-}
-
-// DeleteByStudentID deletes all arrival exceptions for a student
-func (r *StudentArrivalExceptionRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
-	query := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentArrivalException)(nil)).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".student_id = ?`, studentID)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	_, err := query.Exec(ctx)
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  opDeleteByStudentID,
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// DeletePastExceptions deletes all exceptions older than the given date
-func (r *StudentArrivalExceptionRepository) DeletePastExceptions(ctx context.Context, beforeDate timezone.Date) (int64, error) {
-	delQuery := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentArrivalException)(nil)).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".exception_date < ?`, beforeDate)
-
-	delQuery = base.WithTenantFilter(ctx, delQuery, "student_arrival_exception")
-
-	result, err := delQuery.Exec(ctx)
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "delete past exceptions",
-			Err: err,
-		}
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-
-	return rowsAffected, nil
-}
-
-// List retrieves arrival exceptions matching the provided query options
-func (r *StudentArrivalExceptionRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalException, error) {
-	rows, err := r.ListWithOptions(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	if rows == nil {
-		rows = make([]*schedule.StudentArrivalException, 0)
-	}
-	return rows, nil
-}
-
-// FindByID overrides base method to ensure schema qualification
-func (r *StudentArrivalExceptionRepository) FindByID(ctx context.Context, id any) (*schedule.StudentArrivalException, error) {
-	var exception schedule.StudentArrivalException
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exception).
-		ModelTableExpr(`schedule.student_arrival_exceptions AS "student_arrival_exception"`).
-		Where(`"student_arrival_exception".id = ?`, id)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByID,
-			Err: err,
-		}
-	}
-
-	return &exception, nil
-}
-
-// StudentArrivalNoteRepository implements schedule.StudentArrivalNoteRepository interface
 type StudentArrivalNoteRepository struct {
-	*base.Repository[*schedule.StudentArrivalNote]
-	db *bun.DB
+	*studentNoteRepository[*schedule.StudentArrivalNote]
 }
 
-// NewStudentArrivalNoteRepository creates a new StudentArrivalNoteRepository
 func NewStudentArrivalNoteRepository(db *bun.DB) schedule.StudentArrivalNoteRepository {
-	repo := base.NewRepository[*schedule.StudentArrivalNote](db, tableArrivalNotes, "StudentArrivalNote")
-	repo.TenantScoped = true
 	return &StudentArrivalNoteRepository{
-		Repository: repo,
-		db:         db,
+		studentNoteRepository: newStudentNoteRepository[*schedule.StudentArrivalNote](
+			db,
+			arrivalNoteConfig,
+		),
 	}
-}
-
-// FindByStudentID finds all arrival notes for a student
-func (r *StudentArrivalNoteRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalNote, error) {
-	var notes []*schedule.StudentArrivalNote
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&notes).
-		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
-		Where(`"student_arrival_note".student_id = ?`, studentID).
-		Order("note_date ASC", orderCreatedAtASC)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByStudentID,
-			Err: err,
-		}
-	}
-
-	return notes, nil
-}
-
-// FindByStudentIDAndDate finds all arrival notes for a student on a specific date
-func (r *StudentArrivalNoteRepository) FindByStudentIDAndDate(ctx context.Context, studentID int64, date timezone.Date) ([]*schedule.StudentArrivalNote, error) {
-	var notes []*schedule.StudentArrivalNote
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&notes).
-		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
-		Where(`"student_arrival_note".student_id = ?`, studentID).
-		Where(`"student_arrival_note".note_date = ?`, date).
-		Order(orderCreatedAtASC)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and date",
-			Err: err,
-		}
-	}
-
-	return notes, nil
-}
-
-// FindByStudentIDsAndDate finds all arrival notes for multiple students on a specific date (bulk query)
-func (r *StudentArrivalNoteRepository) FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date timezone.Date) ([]*schedule.StudentArrivalNote, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentArrivalNote{}, nil
-	}
-
-	var notes []*schedule.StudentArrivalNote
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&notes).
-		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
-		Where(`"student_arrival_note".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_arrival_note".note_date = ?`, date).
-		Order(orderCreatedAtASC)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and date",
-			Err: err,
-		}
-	}
-
-	return notes, nil
-}
-
-// DeleteByStudentID deletes all arrival notes for a student
-func (r *StudentArrivalNoteRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
-	query := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentArrivalNote)(nil)).
-		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
-		Where(`"student_arrival_note".student_id = ?`, studentID)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_note")
-
-	_, err := query.Exec(ctx)
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  opDeleteByStudentID,
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// DeletePastNotes deletes all notes older than the given date
-func (r *StudentArrivalNoteRepository) DeletePastNotes(ctx context.Context, beforeDate timezone.Date) (int64, error) {
-	delQuery := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentArrivalNote)(nil)).
-		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
-		Where(`"student_arrival_note".note_date < ?`, beforeDate)
-
-	delQuery = base.WithTenantFilter(ctx, delQuery, "student_arrival_note")
-
-	result, err := delQuery.Exec(ctx)
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "delete past notes",
-			Err: err,
-		}
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-
-	return rowsAffected, nil
-}
-
-// List retrieves arrival notes matching the provided query options
-func (r *StudentArrivalNoteRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentArrivalNote, error) {
-	rows, err := r.ListWithOptions(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	if rows == nil {
-		rows = make([]*schedule.StudentArrivalNote, 0)
-	}
-	return rows, nil
-}
-
-// FindByID overrides base method to ensure schema qualification
-func (r *StudentArrivalNoteRepository) FindByID(ctx context.Context, id any) (*schedule.StudentArrivalNote, error) {
-	var note schedule.StudentArrivalNote
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&note).
-		ModelTableExpr(`schedule.student_arrival_notes AS "student_arrival_note"`).
-		Where(`"student_arrival_note".id = ?`, id)
-
-	query = base.WithTenantFilter(ctx, query, "student_arrival_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByID,
-			Err: err,
-		}
-	}
-
-	return &note, nil
 }

--- a/backend/database/repositories/schedule/effective_time_repository.go
+++ b/backend/database/repositories/schedule/effective_time_repository.go
@@ -1,0 +1,573 @@
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/uptrace/bun"
+)
+
+const (
+	opFindByStudentID   = "find by student id"
+	opDeleteByStudentID = "delete by student id"
+	opFindByID          = "find by id"
+	orderCreatedAtASC   = "created_at ASC"
+)
+
+type validatedEntity interface {
+	modelBase.Entity
+	modelBase.Validator
+}
+
+type effectiveTimeRepositoryConfig struct {
+	table      string
+	alias      string
+	entityName string
+}
+
+func newTenantRepository[T modelBase.Entity](
+	db *bun.DB,
+	config effectiveTimeRepositoryConfig,
+) *base.Repository[T] {
+	repo := base.NewRepository[T](db, config.table, config.entityName)
+	repo.TenantScoped = true
+	return repo
+}
+
+func newRepositoryEntity[T modelBase.Entity]() T {
+	entityType := reflect.TypeFor[T]()
+	if entityType.Kind() != reflect.Pointer {
+		panic("effective-time repositories require pointer entities")
+	}
+	return reflect.New(entityType.Elem()).Interface().(T)
+}
+
+type studentScheduleRepository[T validatedEntity] struct {
+	*base.Repository[T]
+	db         *bun.DB
+	config     effectiveTimeRepositoryConfig
+	timeColumn string
+	upsertOp   string
+	nilErr     error
+}
+
+func newStudentScheduleRepository[T validatedEntity](
+	db *bun.DB,
+	config effectiveTimeRepositoryConfig,
+	timeColumn string,
+	upsertOp string,
+	nilErr error,
+) *studentScheduleRepository[T] {
+	return &studentScheduleRepository[T]{
+		Repository: newTenantRepository[T](db, config),
+		db:         db,
+		config:     config,
+		timeColumn: timeColumn,
+		upsertOp:   upsertOp,
+		nilErr:     nilErr,
+	}
+}
+
+func (r *studentScheduleRepository[T]) FindByStudentID(
+	ctx context.Context,
+	studentID int64,
+) ([]T, error) {
+	var schedules []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&schedules).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Order("weekday ASC")
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: opFindByStudentID, Err: err}
+	}
+	return schedules, nil
+}
+
+func (r *studentScheduleRepository[T]) FindByStudentIDAndWeekday(
+	ctx context.Context,
+	studentID int64,
+	weekday int,
+) (T, error) {
+	schedule := newRepositoryEntity[T]()
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(schedule).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Where(fmt.Sprintf(`"%s".weekday = ?`, r.config.alias), weekday)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			var zero T
+			return zero, nil
+		}
+		var zero T
+		return zero, &modelBase.DatabaseError{
+			Op:  "find by student id and weekday",
+			Err: err,
+		}
+	}
+	return schedule, nil
+}
+
+func (r *studentScheduleRepository[T]) FindByStudentIDsAndWeekday(
+	ctx context.Context,
+	studentIDs []int64,
+	weekday int,
+) ([]T, error) {
+	if len(studentIDs) == 0 {
+		return []T{}, nil
+	}
+
+	var schedules []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&schedules).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id IN (?)`, r.config.alias), bun.List(studentIDs)).
+		Where(fmt.Sprintf(`"%s".weekday = ?`, r.config.alias), weekday)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and weekday",
+			Err: err,
+		}
+	}
+	return schedules, nil
+}
+
+func (r *studentScheduleRepository[T]) FindByStudentIDs(
+	ctx context.Context,
+	studentIDs []int64,
+) ([]T, error) {
+	if len(studentIDs) == 0 {
+		return []T{}, nil
+	}
+
+	var schedules []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&schedules).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id IN (?)`, r.config.alias), bun.List(studentIDs)).
+		Order("student_id ASC", "weekday ASC")
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids",
+			Err: err,
+		}
+	}
+	return schedules, nil
+}
+
+func (r *studentScheduleRepository[T]) UpsertSchedule(ctx context.Context, schedule T) error {
+	if reflect.ValueOf(schedule).IsZero() {
+		return r.nilErr
+	}
+	if err := schedule.Validate(); err != nil {
+		return err
+	}
+
+	base.EnsureTenantID(ctx, schedule)
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(schedule).
+		ModelTableExpr(r.config.table).
+		On("CONFLICT (tenant_id, student_id, weekday) DO UPDATE").
+		Set(fmt.Sprintf("%s = EXCLUDED.%s", r.timeColumn, r.timeColumn)).
+		Set("notes = EXCLUDED.notes").
+		Set("updated_at = NOW()").
+		Returning("id").
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{Op: r.upsertOp, Err: err}
+	}
+	return nil
+}
+
+func (r *studentScheduleRepository[T]) DeleteByStudentID(
+	ctx context.Context,
+	studentID int64,
+) error {
+	var model T
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model(model).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: opDeleteByStudentID, Err: err}
+	}
+	return nil
+}
+
+func (r *studentScheduleRepository[T]) List(
+	ctx context.Context,
+	options *modelBase.QueryOptions,
+) ([]T, error) {
+	rows, err := r.ListWithOptions(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	if rows == nil {
+		rows = []T{}
+	}
+	return rows, nil
+}
+
+type studentExceptionRepository[T validatedEntity] struct {
+	*base.Repository[T]
+	db     *bun.DB
+	config effectiveTimeRepositoryConfig
+}
+
+func newStudentExceptionRepository[T validatedEntity](
+	db *bun.DB,
+	config effectiveTimeRepositoryConfig,
+) *studentExceptionRepository[T] {
+	return &studentExceptionRepository[T]{
+		Repository: newTenantRepository[T](db, config),
+		db:         db,
+		config:     config,
+	}
+}
+
+func (r *studentExceptionRepository[T]) FindByStudentID(
+	ctx context.Context,
+	studentID int64,
+) ([]T, error) {
+	var exceptions []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Order("exception_date ASC")
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: opFindByStudentID, Err: err}
+	}
+	return exceptions, nil
+}
+
+func (r *studentExceptionRepository[T]) FindUpcomingByStudentID(
+	ctx context.Context,
+	studentID int64,
+) ([]T, error) {
+	var exceptions []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Where(fmt.Sprintf(`"%s".exception_date >= ?`, r.config.alias), timezone.TodayDate()).
+		Order("exception_date ASC")
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find upcoming by student id",
+			Err: err,
+		}
+	}
+	return exceptions, nil
+}
+
+func (r *studentExceptionRepository[T]) FindByStudentIDAndDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (T, error) {
+	exception := newRepositoryEntity[T]()
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(exception).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Where(fmt.Sprintf(`"%s".exception_date = ?`, r.config.alias), date)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			var zero T
+			return zero, nil
+		}
+		var zero T
+		return zero, &modelBase.DatabaseError{
+			Op:  "find by student id and date",
+			Err: err,
+		}
+	}
+	return exception, nil
+}
+
+func (r *studentExceptionRepository[T]) FindByStudentIDsAndDate(
+	ctx context.Context,
+	studentIDs []int64,
+	date timezone.Date,
+) ([]T, error) {
+	if len(studentIDs) == 0 {
+		return []T{}, nil
+	}
+
+	var exceptions []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id IN (?)`, r.config.alias), bun.List(studentIDs)).
+		Where(fmt.Sprintf(`"%s".exception_date = ?`, r.config.alias), date)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and date",
+			Err: err,
+		}
+	}
+	return exceptions, nil
+}
+
+func (r *studentExceptionRepository[T]) FindByStudentIDAndDateRange(
+	ctx context.Context,
+	studentID int64,
+	from timezone.Date,
+	to timezone.Date,
+) ([]T, error) {
+	var exceptions []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Where(fmt.Sprintf(`"%s".exception_date >= ?`, r.config.alias), from).
+		Where(fmt.Sprintf(`"%s".exception_date <= ?`, r.config.alias), to).
+		Order("exception_date ASC")
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and date range",
+			Err: err,
+		}
+	}
+	return exceptions, nil
+}
+
+func (r *studentExceptionRepository[T]) FindByStudentIDsAndDateRange(
+	ctx context.Context,
+	studentIDs []int64,
+	from timezone.Date,
+	to timezone.Date,
+) ([]T, error) {
+	if len(studentIDs) == 0 {
+		return []T{}, nil
+	}
+
+	var exceptions []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&exceptions).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id IN (?)`, r.config.alias), bun.List(studentIDs)).
+		Where(fmt.Sprintf(`"%s".exception_date >= ?`, r.config.alias), from).
+		Where(fmt.Sprintf(`"%s".exception_date <= ?`, r.config.alias), to).
+		Order("exception_date ASC")
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and date range",
+			Err: err,
+		}
+	}
+	return exceptions, nil
+}
+
+func (r *studentExceptionRepository[T]) DeleteByStudentID(
+	ctx context.Context,
+	studentID int64,
+) error {
+	var model T
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model(model).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: opDeleteByStudentID, Err: err}
+	}
+	return nil
+}
+
+func (r *studentExceptionRepository[T]) DeletePastExceptions(
+	ctx context.Context,
+	beforeDate timezone.Date,
+) (int64, error) {
+	var model T
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model(model).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".exception_date < ?`, r.config.alias), beforeDate)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "delete past exceptions", Err: err}
+	}
+	return result.RowsAffected()
+}
+
+func (r *studentExceptionRepository[T]) List(
+	ctx context.Context,
+	options *modelBase.QueryOptions,
+) ([]T, error) {
+	rows, err := r.ListWithOptions(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	if rows == nil {
+		rows = []T{}
+	}
+	return rows, nil
+}
+
+type studentNoteRepository[T validatedEntity] struct {
+	*base.Repository[T]
+	db     *bun.DB
+	config effectiveTimeRepositoryConfig
+}
+
+func newStudentNoteRepository[T validatedEntity](
+	db *bun.DB,
+	config effectiveTimeRepositoryConfig,
+) *studentNoteRepository[T] {
+	return &studentNoteRepository[T]{
+		Repository: newTenantRepository[T](db, config),
+		db:         db,
+		config:     config,
+	}
+}
+
+func (r *studentNoteRepository[T]) FindByStudentID(
+	ctx context.Context,
+	studentID int64,
+) ([]T, error) {
+	var notes []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Order("note_date ASC", orderCreatedAtASC)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: opFindByStudentID, Err: err}
+	}
+	return notes, nil
+}
+
+func (r *studentNoteRepository[T]) FindByStudentIDAndDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) ([]T, error) {
+	var notes []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID).
+		Where(fmt.Sprintf(`"%s".note_date = ?`, r.config.alias), date).
+		Order(orderCreatedAtASC)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student id and date",
+			Err: err,
+		}
+	}
+	return notes, nil
+}
+
+func (r *studentNoteRepository[T]) FindByStudentIDsAndDate(
+	ctx context.Context,
+	studentIDs []int64,
+	date timezone.Date,
+) ([]T, error) {
+	if len(studentIDs) == 0 {
+		return []T{}, nil
+	}
+
+	var notes []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&notes).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id IN (?)`, r.config.alias), bun.List(studentIDs)).
+		Where(fmt.Sprintf(`"%s".note_date = ?`, r.config.alias), date).
+		Order(orderCreatedAtASC)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by student ids and date",
+			Err: err,
+		}
+	}
+	return notes, nil
+}
+
+func (r *studentNoteRepository[T]) DeleteByStudentID(
+	ctx context.Context,
+	studentID int64,
+) error {
+	var model T
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model(model).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".student_id = ?`, r.config.alias), studentID)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: opDeleteByStudentID, Err: err}
+	}
+	return nil
+}
+
+func (r *studentNoteRepository[T]) DeletePastNotes(
+	ctx context.Context,
+	beforeDate timezone.Date,
+) (int64, error) {
+	var model T
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model(model).
+		ModelTableExpr(fmt.Sprintf(`%s AS "%s"`, r.config.table, r.config.alias)).
+		Where(fmt.Sprintf(`"%s".note_date < ?`, r.config.alias), beforeDate)
+	query = base.WithTenantFilter(ctx, query, r.config.alias)
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "delete past notes", Err: err}
+	}
+	return result.RowsAffected()
+}
+
+func (r *studentNoteRepository[T]) List(
+	ctx context.Context,
+	options *modelBase.QueryOptions,
+) ([]T, error) {
+	rows, err := r.ListWithOptions(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	if rows == nil {
+		rows = []T{}
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/schedule/pickup_schedule.go
+++ b/backend/database/repositories/schedule/pickup_schedule.go
@@ -1,662 +1,74 @@
 package schedule
 
 import (
-	"context"
-	"database/sql"
 	"errors"
-	"fmt"
 
-	"github.com/moto-nrw/project-phoenix/database/repositories/base"
-	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/uptrace/bun"
 )
 
-// Table names for pickup schedule repositories.
 const (
 	tablePickupSchedules  = "schedule.student_pickup_schedules"
 	tablePickupExceptions = "schedule.student_pickup_exceptions"
 	tablePickupNotes      = "schedule.student_pickup_notes"
 )
 
-// Common database operation names to avoid string duplication.
-const (
-	opFindByStudentID   = "find by student id"
-	opDeleteByStudentID = "delete by student id"
-	opFindByID          = "find by id"
-	orderCreatedAtASC   = "created_at ASC"
+var (
+	pickupScheduleConfig = effectiveTimeRepositoryConfig{
+		table:      tablePickupSchedules,
+		alias:      "student_pickup_schedule",
+		entityName: "StudentPickupSchedule",
+	}
+	pickupExceptionConfig = effectiveTimeRepositoryConfig{
+		table:      tablePickupExceptions,
+		alias:      "student_pickup_exception",
+		entityName: "StudentPickupException",
+	}
+	pickupNoteConfig = effectiveTimeRepositoryConfig{
+		table:      tablePickupNotes,
+		alias:      "student_pickup_note",
+		entityName: "StudentPickupNote",
+	}
 )
 
-// errScheduleNil is returned when a nil schedule is passed to a repository method.
-var errScheduleNil = fmt.Errorf("schedule cannot be nil")
-
-// StudentPickupScheduleRepository implements schedule.StudentPickupScheduleRepository interface
 type StudentPickupScheduleRepository struct {
-	*base.Repository[*schedule.StudentPickupSchedule]
-	db *bun.DB
+	*studentScheduleRepository[*schedule.StudentPickupSchedule]
 }
 
-// NewStudentPickupScheduleRepository creates a new StudentPickupScheduleRepository
 func NewStudentPickupScheduleRepository(db *bun.DB) schedule.StudentPickupScheduleRepository {
-	repo := base.NewRepository[*schedule.StudentPickupSchedule](db, tablePickupSchedules, "StudentPickupSchedule")
-	repo.TenantScoped = true
 	return &StudentPickupScheduleRepository{
-		Repository: repo,
-		db:         db,
+		studentScheduleRepository: newStudentScheduleRepository[*schedule.StudentPickupSchedule](
+			db,
+			pickupScheduleConfig,
+			"pickup_time",
+			"upsert schedule",
+			errors.New("schedule cannot be nil"),
+		),
 	}
 }
 
-// FindByStudentID finds all pickup schedules for a student
-func (r *StudentPickupScheduleRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentPickupSchedule, error) {
-	var schedules []*schedule.StudentPickupSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&schedules).
-		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`).
-		Where(`"student_pickup_schedule".student_id = ?`, studentID).
-		Order("weekday ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_schedule")
-
-	err := query.Scan(ctx)
-
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByStudentID,
-			Err: err,
-		}
-	}
-
-	return schedules, nil
-}
-
-// FindByStudentIDAndWeekday finds a pickup schedule for a specific student and weekday
-func (r *StudentPickupScheduleRepository) FindByStudentIDAndWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentPickupSchedule, error) {
-	var pickupSchedule schedule.StudentPickupSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&pickupSchedule).
-		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`).
-		Where(`"student_pickup_schedule".student_id = ?`, studentID).
-		Where(`"student_pickup_schedule".weekday = ?`, weekday)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_schedule")
-
-	err := query.Scan(ctx)
-
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and weekday",
-			Err: err,
-		}
-	}
-
-	return &pickupSchedule, nil
-}
-
-// FindByStudentIDsAndWeekday finds pickup schedules for multiple students and a specific weekday (bulk query)
-func (r *StudentPickupScheduleRepository) FindByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentPickupSchedule, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentPickupSchedule{}, nil
-	}
-
-	var schedules []*schedule.StudentPickupSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&schedules).
-		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`).
-		Where(`"student_pickup_schedule".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_pickup_schedule".weekday = ?`, weekday)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_schedule")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and weekday",
-			Err: err,
-		}
-	}
-
-	return schedules, nil
-}
-
-// FindByStudentIDs returns every weekday row for the given students in one
-// query. Mirror of the arrival-side helper — the care-day derivation (#1747)
-// must distinguish "no row for today" from "no plan at all", which a
-// per-weekday query cannot express.
-func (r *StudentPickupScheduleRepository) FindByStudentIDs(ctx context.Context, studentIDs []int64) ([]*schedule.StudentPickupSchedule, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentPickupSchedule{}, nil
-	}
-
-	var schedules []*schedule.StudentPickupSchedule
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&schedules).
-		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`).
-		Where(`"student_pickup_schedule".student_id IN (?)`, bun.List(studentIDs)).
-		Order("student_id ASC", "weekday ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_schedule")
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids",
-			Err: err,
-		}
-	}
-
-	return schedules, nil
-}
-
-// UpsertSchedule creates or updates a pickup schedule for a student and weekday
-func (r *StudentPickupScheduleRepository) UpsertSchedule(ctx context.Context, s *schedule.StudentPickupSchedule) error {
-	if s == nil {
-		return errScheduleNil
-	}
-
-	if err := s.Validate(); err != nil {
-		return err
-	}
-
-	base.EnsureTenantID(ctx, s)
-
-	_, err := base.GetDB(ctx, r.db).NewInsert().
-		Model(s).
-		ModelTableExpr(tablePickupSchedules).
-		On("CONFLICT (tenant_id, student_id, weekday) DO UPDATE").
-		Set("pickup_time = EXCLUDED.pickup_time").
-		Set("notes = EXCLUDED.notes").
-		Set("updated_at = NOW()").
-		Returning("id").
-		Exec(ctx)
-
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  "upsert schedule",
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// DeleteByStudentID deletes all pickup schedules for a student
-func (r *StudentPickupScheduleRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
-	query := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentPickupSchedule)(nil)).
-		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`).
-		Where(`"student_pickup_schedule".student_id = ?`, studentID)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_schedule")
-
-	_, err := query.Exec(ctx)
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  opDeleteByStudentID,
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// List retrieves pickup schedules matching the provided query options
-func (r *StudentPickupScheduleRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentPickupSchedule, error) {
-	rows, err := r.ListWithOptions(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	if rows == nil {
-		rows = make([]*schedule.StudentPickupSchedule, 0)
-	}
-	return rows, nil
-}
-
-// FindByID overrides base method to ensure schema qualification
-func (r *StudentPickupScheduleRepository) FindByID(ctx context.Context, id any) (*schedule.StudentPickupSchedule, error) {
-	var pickupSchedule schedule.StudentPickupSchedule
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&pickupSchedule).
-		ModelTableExpr(`schedule.student_pickup_schedules AS "student_pickup_schedule"`).
-		Where(`"student_pickup_schedule".id = ?`, id)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_schedule")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByID,
-			Err: err,
-		}
-	}
-
-	return &pickupSchedule, nil
-}
-
-// StudentPickupExceptionRepository implements schedule.StudentPickupExceptionRepository interface
 type StudentPickupExceptionRepository struct {
-	*base.Repository[*schedule.StudentPickupException]
-	db *bun.DB
+	*studentExceptionRepository[*schedule.StudentPickupException]
 }
 
-// NewStudentPickupExceptionRepository creates a new StudentPickupExceptionRepository
 func NewStudentPickupExceptionRepository(db *bun.DB) schedule.StudentPickupExceptionRepository {
-	repo := base.NewRepository[*schedule.StudentPickupException](db, tablePickupExceptions, "StudentPickupException")
-	repo.TenantScoped = true
 	return &StudentPickupExceptionRepository{
-		Repository: repo,
-		db:         db,
+		studentExceptionRepository: newStudentExceptionRepository[*schedule.StudentPickupException](
+			db,
+			pickupExceptionConfig,
+		),
 	}
 }
 
-// FindByStudentID finds all pickup exceptions for a student
-func (r *StudentPickupExceptionRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentPickupException, error) {
-	var exceptions []*schedule.StudentPickupException
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id = ?`, studentID).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	err := query.Scan(ctx)
-
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByStudentID,
-			Err: err,
-		}
-	}
-
-	return exceptions, nil
-}
-
-// FindUpcomingByStudentID finds upcoming pickup exceptions for a student (from today onwards)
-func (r *StudentPickupExceptionRepository) FindUpcomingByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentPickupException, error) {
-	var exceptions []*schedule.StudentPickupException
-	today := timezone.TodayDate()
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id = ?`, studentID).
-		Where(`"student_pickup_exception".exception_date >= ?`, today).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	err := query.Scan(ctx)
-
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find upcoming by student id",
-			Err: err,
-		}
-	}
-
-	return exceptions, nil
-}
-
-// FindByStudentIDAndDate finds a pickup exception for a specific student and date
-func (r *StudentPickupExceptionRepository) FindByStudentIDAndDate(ctx context.Context, studentID int64, date timezone.Date) (*schedule.StudentPickupException, error) {
-	var exception schedule.StudentPickupException
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exception).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id = ?`, studentID).
-		Where(`"student_pickup_exception".exception_date = ?`, date)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	err := query.Scan(ctx)
-
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and date",
-			Err: err,
-		}
-	}
-
-	return &exception, nil
-}
-
-// FindByStudentIDsAndDate finds pickup exceptions for multiple students and a specific date (bulk query)
-func (r *StudentPickupExceptionRepository) FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date timezone.Date) ([]*schedule.StudentPickupException, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentPickupException{}, nil
-	}
-
-	var exceptions []*schedule.StudentPickupException
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_pickup_exception".exception_date = ?`, date)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and date",
-			Err: err,
-		}
-	}
-
-	return exceptions, nil
-}
-
-// FindByStudentIDAndDateRange finds pickup exceptions for a student whose
-// exception_date lies in the inclusive [from, to] range.
-func (r *StudentPickupExceptionRepository) FindByStudentIDAndDateRange(
-	ctx context.Context, studentID int64, from, to timezone.Date,
-) ([]*schedule.StudentPickupException, error) {
-	var exceptions []*schedule.StudentPickupException
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id = ?`, studentID).
-		Where(`"student_pickup_exception".exception_date >= ?`, from).
-		Where(`"student_pickup_exception".exception_date <= ?`, to).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and date range",
-			Err: err,
-		}
-	}
-	return exceptions, nil
-}
-
-// FindByStudentIDsAndDateRange finds pickup exceptions for multiple students
-// whose exception_date lies in the inclusive [from, to] range (bulk query).
-// Feeds the care-day derivation across a planner window in one round trip.
-func (r *StudentPickupExceptionRepository) FindByStudentIDsAndDateRange(
-	ctx context.Context, studentIDs []int64, from, to timezone.Date,
-) ([]*schedule.StudentPickupException, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentPickupException{}, nil
-	}
-
-	var exceptions []*schedule.StudentPickupException
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exceptions).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_pickup_exception".exception_date >= ?`, from).
-		Where(`"student_pickup_exception".exception_date <= ?`, to).
-		Order("exception_date ASC")
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and date range",
-			Err: err,
-		}
-	}
-	return exceptions, nil
-}
-
-// DeleteByStudentID deletes all pickup exceptions for a student
-func (r *StudentPickupExceptionRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
-	query := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentPickupException)(nil)).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".student_id = ?`, studentID)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	_, err := query.Exec(ctx)
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  opDeleteByStudentID,
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// DeletePastExceptions deletes all exceptions older than the given date
-func (r *StudentPickupExceptionRepository) DeletePastExceptions(ctx context.Context, beforeDate timezone.Date) (int64, error) {
-	delQuery := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentPickupException)(nil)).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".exception_date < ?`, beforeDate)
-
-	delQuery = base.WithTenantFilter(ctx, delQuery, "student_pickup_exception")
-
-	result, err := delQuery.Exec(ctx)
-
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "delete past exceptions",
-			Err: err,
-		}
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-
-	return rowsAffected, nil
-}
-
-// List retrieves pickup exceptions matching the provided query options
-func (r *StudentPickupExceptionRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentPickupException, error) {
-	rows, err := r.ListWithOptions(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	if rows == nil {
-		rows = make([]*schedule.StudentPickupException, 0)
-	}
-	return rows, nil
-}
-
-// FindByID overrides base method to ensure schema qualification
-func (r *StudentPickupExceptionRepository) FindByID(ctx context.Context, id any) (*schedule.StudentPickupException, error) {
-	var exception schedule.StudentPickupException
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&exception).
-		ModelTableExpr(`schedule.student_pickup_exceptions AS "student_pickup_exception"`).
-		Where(`"student_pickup_exception".id = ?`, id)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_exception")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByID,
-			Err: err,
-		}
-	}
-
-	return &exception, nil
-}
-
-// StudentPickupNoteRepository implements schedule.StudentPickupNoteRepository interface
 type StudentPickupNoteRepository struct {
-	*base.Repository[*schedule.StudentPickupNote]
-	db *bun.DB
+	*studentNoteRepository[*schedule.StudentPickupNote]
 }
 
-// NewStudentPickupNoteRepository creates a new StudentPickupNoteRepository
 func NewStudentPickupNoteRepository(db *bun.DB) schedule.StudentPickupNoteRepository {
-	repo := base.NewRepository[*schedule.StudentPickupNote](db, tablePickupNotes, "StudentPickupNote")
-	repo.TenantScoped = true
 	return &StudentPickupNoteRepository{
-		Repository: repo,
-		db:         db,
+		studentNoteRepository: newStudentNoteRepository[*schedule.StudentPickupNote](
+			db,
+			pickupNoteConfig,
+		),
 	}
-}
-
-// FindByStudentID finds all pickup notes for a student
-func (r *StudentPickupNoteRepository) FindByStudentID(ctx context.Context, studentID int64) ([]*schedule.StudentPickupNote, error) {
-	var notes []*schedule.StudentPickupNote
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&notes).
-		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`).
-		Where(`"student_pickup_note".student_id = ?`, studentID).
-		Order("note_date ASC", orderCreatedAtASC)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_note")
-
-	err := query.Scan(ctx)
-
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByStudentID,
-			Err: err,
-		}
-	}
-
-	return notes, nil
-}
-
-// FindByStudentIDAndDate finds all pickup notes for a student on a specific date
-func (r *StudentPickupNoteRepository) FindByStudentIDAndDate(ctx context.Context, studentID int64, date timezone.Date) ([]*schedule.StudentPickupNote, error) {
-	var notes []*schedule.StudentPickupNote
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&notes).
-		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`).
-		Where(`"student_pickup_note".student_id = ?`, studentID).
-		Where(`"student_pickup_note".note_date = ?`, date).
-		Order(orderCreatedAtASC)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student id and date",
-			Err: err,
-		}
-	}
-
-	return notes, nil
-}
-
-// FindByStudentIDsAndDate finds all pickup notes for multiple students on a specific date (bulk query)
-func (r *StudentPickupNoteRepository) FindByStudentIDsAndDate(ctx context.Context, studentIDs []int64, date timezone.Date) ([]*schedule.StudentPickupNote, error) {
-	if len(studentIDs) == 0 {
-		return []*schedule.StudentPickupNote{}, nil
-	}
-
-	var notes []*schedule.StudentPickupNote
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&notes).
-		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`).
-		Where(`"student_pickup_note".student_id IN (?)`, bun.List(studentIDs)).
-		Where(`"student_pickup_note".note_date = ?`, date).
-		Order(orderCreatedAtASC)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by student ids and date",
-			Err: err,
-		}
-	}
-
-	return notes, nil
-}
-
-// DeleteByStudentID deletes all pickup notes for a student
-func (r *StudentPickupNoteRepository) DeleteByStudentID(ctx context.Context, studentID int64) error {
-	query := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentPickupNote)(nil)).
-		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`).
-		Where(`"student_pickup_note".student_id = ?`, studentID)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_note")
-
-	_, err := query.Exec(ctx)
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  opDeleteByStudentID,
-			Err: err,
-		}
-	}
-
-	return nil
-}
-
-// DeletePastNotes deletes all notes older than the given date
-func (r *StudentPickupNoteRepository) DeletePastNotes(ctx context.Context, beforeDate timezone.Date) (int64, error) {
-	delQuery := base.GetDB(ctx, r.db).NewDelete().
-		Model((*schedule.StudentPickupNote)(nil)).
-		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`).
-		Where(`"student_pickup_note".note_date < ?`, beforeDate)
-
-	delQuery = base.WithTenantFilter(ctx, delQuery, "student_pickup_note")
-
-	result, err := delQuery.Exec(ctx)
-
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "delete past notes",
-			Err: err,
-		}
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return 0, err
-	}
-
-	return rowsAffected, nil
-}
-
-// List retrieves pickup notes matching the provided query options
-func (r *StudentPickupNoteRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*schedule.StudentPickupNote, error) {
-	rows, err := r.ListWithOptions(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-	if rows == nil {
-		rows = make([]*schedule.StudentPickupNote, 0)
-	}
-	return rows, nil
-}
-
-// FindByID overrides base method to ensure schema qualification
-func (r *StudentPickupNoteRepository) FindByID(ctx context.Context, id any) (*schedule.StudentPickupNote, error) {
-	var note schedule.StudentPickupNote
-
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&note).
-		ModelTableExpr(`schedule.student_pickup_notes AS "student_pickup_note"`).
-		Where(`"student_pickup_note".id = ?`, id)
-
-	query = base.WithTenantFilter(ctx, query, "student_pickup_note")
-
-	err := query.Scan(ctx)
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  opFindByID,
-			Err: err,
-		}
-	}
-
-	return &note, nil
 }

--- a/backend/services/schedule/arrival_service.go
+++ b/backend/services/schedule/arrival_service.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
@@ -16,13 +15,10 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// ArrivalScheduleService defines operations for managing student arrival schedules
+// ArrivalScheduleService defines operations for managing student arrival schedules.
+// The domain-named contract remains stable for all existing consumers.
 type ArrivalScheduleService interface {
-	// Schedule operations
 	GetStudentArrivalSchedules(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalSchedule, error)
-	// GetWeeklySchedulesByStudentIDsAndWeekday returns the raw weekly arrival
-	// schedules of many students for one weekday (issue #584 lookup;
-	// repository result returned verbatim — no exception merging).
 	GetWeeklySchedulesByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentArrivalSchedule, error)
 	GetStudentArrivalScheduleForWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentArrivalSchedule, error)
 	UpsertStudentArrivalSchedule(ctx context.Context, scheduleData *schedule.StudentArrivalSchedule) error
@@ -30,12 +26,7 @@ type ArrivalScheduleService interface {
 	DeleteStudentArrivalSchedule(ctx context.Context, scheduleID int64) error
 	DeleteAllStudentArrivalSchedules(ctx context.Context, studentID int64) error
 
-	// Exception operations
 	GetStudentArrivalExceptionByID(ctx context.Context, exceptionID int64) (*schedule.StudentArrivalException, error)
-	// GetStudentArrivalExceptionForDate returns the arrival exception for a
-	// student on a specific date, or nil when the day has none. The create path
-	// uses it under the day lock to turn an insert that would collide with an
-	// existing row (e.g. a guardian-authored one) into an override.
 	GetStudentArrivalExceptionForDate(ctx context.Context, studentID int64, date timezone.Date) (*schedule.StudentArrivalException, error)
 	GetStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error)
 	GetUpcomingStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error)
@@ -43,18 +34,9 @@ type ArrivalScheduleService interface {
 	UpdateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error
 	DeleteStudentArrivalException(ctx context.Context, exceptionID int64) error
 	DeleteAllStudentArrivalExceptions(ctx context.Context, studentID int64) error
-
-	// CreateOrReclaimException creates an arrival exception for the day, or, when a
-	// row already exists, resolves the collision under the care-exception day lock:
-	// a guardian-authored row is reclaimed for staff (re-resolving the staff author
-	// via resolveStaffID), a staff-authored row raises ErrCareExceptionDayConflict.
 	CreateOrReclaimException(ctx context.Context, studentID int64, date timezone.Date, arrivalTime *time.Time, reason *string, staffID int64, resolveStaffID func() (int64, error)) (*schedule.StudentArrivalException, error)
-	// UpdateException updates an existing arrival exception under the day lock,
-	// applying the guardian-reclaim-on-staff-edit policy and merging the optional
-	// reason/arrival patch onto the locked row.
 	UpdateException(ctx context.Context, exceptionID, studentID int64, date timezone.Date, reason *string, arrivalTime *time.Time, resolveStaffID func() (int64, error)) (*schedule.StudentArrivalException, error)
 
-	// Note operations
 	GetStudentArrivalNoteByID(ctx context.Context, noteID int64) (*schedule.StudentArrivalNote, error)
 	GetStudentArrivalNotes(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalNote, error)
 	GetStudentArrivalNotesForDate(ctx context.Context, studentID int64, date timezone.Date) ([]*schedule.StudentArrivalNote, error)
@@ -63,29 +45,23 @@ type ArrivalScheduleService interface {
 	DeleteStudentArrivalNote(ctx context.Context, noteID int64) error
 	DeleteAllStudentArrivalNotes(ctx context.Context, studentID int64) error
 
-	// Computed operations
 	GetStudentArrivalData(ctx context.Context, studentID int64) (*StudentArrivalData, error)
 	GetEffectiveArrivalTimeForDate(ctx context.Context, studentID int64, date timezone.Date) (*EffectiveArrivalTime, error)
 	GetBulkEffectiveArrivalTimesForDate(ctx context.Context, studentIDs []int64, date timezone.Date) (map[int64]*EffectiveArrivalTime, error)
-
-	// Bulk class operation
 	BulkUpsertBySchoolClass(ctx context.Context, schoolClass string, schedules []ArrivalScheduleInput, createdBy int64) (*BulkUpsertResult, error)
 }
 
-// StudentArrivalData contains combined arrival schedule and exception data
 type StudentArrivalData struct {
 	Schedules  []*schedule.StudentArrivalSchedule  `json:"schedules"`
 	Exceptions []*schedule.StudentArrivalException `json:"exceptions"`
 	Notes      []*schedule.StudentArrivalNote      `json:"notes"`
 }
 
-// ArrivalNoteData represents a single note in the effective arrival time response
 type ArrivalNoteData struct {
 	ID      int64  `json:"id"`
 	Content string `json:"content"`
 }
 
-// EffectiveArrivalTime represents the arrival time for a specific date
 type EffectiveArrivalTime struct {
 	Date        timezone.Date     `json:"date"`
 	ArrivalTime *time.Time        `json:"arrival_time"`
@@ -95,24 +71,17 @@ type EffectiveArrivalTime struct {
 	DayNotes    []ArrivalNoteData `json:"day_notes,omitempty"`
 }
 
-// ArrivalScheduleInput represents input for a single weekday's arrival schedule
 type ArrivalScheduleInput struct {
 	Weekday     int    `json:"weekday"`
-	ArrivalTime string `json:"expected_arrival"` // HH:MM
+	ArrivalTime string `json:"expected_arrival"`
 }
 
-// BulkUpsertResult contains the result of a bulk class upsert operation
 type BulkUpsertResult struct {
 	StudentsAffected    int                `json:"students_affected"`
 	OverwrittenStudents []OverwriteWarning `json:"overwritten_students,omitempty"`
-	// AffectedStudentIDs lists every student whose arrival schedule was written,
-	// so the handler can wake each child's guardians for a live parents-app
-	// refresh (#1725). Internal-only (json:"-") — not part of the staff response
-	// contract.
-	AffectedStudentIDs []int64 `json:"-"`
+	AffectedStudentIDs  []int64            `json:"-"`
 }
 
-// OverwriteWarning warns that a student had an existing individual schedule that was overwritten
 type OverwriteWarning struct {
 	StudentID    int64  `json:"student_id"`
 	StudentName  string `json:"student_name"`
@@ -122,29 +91,22 @@ type OverwriteWarning struct {
 	NewTime      string `json:"new_time"`
 }
 
-// Operation names for ScheduleError.
-const (
-	opCreateStudentArrivalException     = "create student arrival exception"
-	opUpdateStudentArrivalException     = "update student arrival exception"
-	opUpsertBulkStudentArrivalSchedules = "upsert bulk student arrival schedules"
-	opGetStudentArrivalData             = "get student arrival data"
-	opGetEffectiveArrivalTime           = "get effective arrival time"
-	opGetBulkEffectiveArrivalTimes      = "get bulk effective arrival times"
-	opBulkUpsertBySchoolClass           = "bulk upsert arrival schedules by school class"
-)
+const opBulkUpsertBySchoolClass = "bulk upsert arrival schedules by school class"
 
-// arrivalScheduleService implements ArrivalScheduleService
 type arrivalScheduleService struct {
-	scheduleRepo  schedule.StudentArrivalScheduleRepository
-	exceptionRepo schedule.StudentArrivalExceptionRepository
-	noteRepo      schedule.StudentArrivalNoteRepository
-	studentRepo   users.StudentRepository
-	personRepo    users.PersonRepository
-	db            *bun.DB
-	logger        *slog.Logger
+	core *effectiveTimeCore[
+		*schedule.StudentArrivalSchedule,
+		*schedule.StudentArrivalException,
+		*schedule.StudentArrivalNote,
+		arrivalTimeDomain,
+	]
+	scheduleRepo schedule.StudentArrivalScheduleRepository
+	studentRepo  users.StudentRepository
+	personRepo   users.PersonRepository
+	db           *bun.DB
+	logger       *slog.Logger
 }
 
-// NewArrivalScheduleService creates a new arrival schedule service
 func NewArrivalScheduleService(
 	scheduleRepo schedule.StudentArrivalScheduleRepository,
 	exceptionRepo schedule.StudentArrivalExceptionRepository,
@@ -155,13 +117,18 @@ func NewArrivalScheduleService(
 	logger *slog.Logger,
 ) ArrivalScheduleService {
 	return &arrivalScheduleService{
-		scheduleRepo:  scheduleRepo,
-		exceptionRepo: exceptionRepo,
-		noteRepo:      noteRepo,
-		studentRepo:   studentRepo,
-		personRepo:    personRepo,
-		db:            db,
-		logger:        logger,
+		core: newEffectiveTimeCore(
+			scheduleRepo,
+			exceptionRepo,
+			noteRepo,
+			db,
+			arrivalTimeDomain{},
+		),
+		scheduleRepo: scheduleRepo,
+		studentRepo:  studentRepo,
+		personRepo:   personRepo,
+		db:           db,
+		logger:       logger,
 	}
 }
 
@@ -169,658 +136,366 @@ func (s *arrivalScheduleService) getLogger() *slog.Logger {
 	return cmp.Or(s.logger, slog.Default())
 }
 
-// Schedule operations
+func (s *arrivalScheduleService) GetStudentArrivalSchedules(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentArrivalSchedule, error) {
+	return s.core.Schedules(ctx, studentID)
+}
 
-// GetStudentArrivalSchedules returns all arrival schedules for a student
-func (s *arrivalScheduleService) GetStudentArrivalSchedules(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalSchedule, error) {
-	schedules, err := s.scheduleRepo.FindByStudentID(ctx, studentID)
+func (s *arrivalScheduleService) GetWeeklySchedulesByStudentIDsAndWeekday(
+	ctx context.Context,
+	studentIDs []int64,
+	weekday int,
+) ([]*schedule.StudentArrivalSchedule, error) {
+	return s.core.WeeklySchedulesByStudentIDsAndWeekday(ctx, studentIDs, weekday)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalScheduleForWeekday(
+	ctx context.Context,
+	studentID int64,
+	weekday int,
+) (*schedule.StudentArrivalSchedule, error) {
+	return s.core.ScheduleForWeekday(ctx, studentID, weekday)
+}
+
+func (s *arrivalScheduleService) UpsertStudentArrivalSchedule(
+	ctx context.Context,
+	row *schedule.StudentArrivalSchedule,
+) error {
+	return s.core.UpsertSchedule(ctx, row)
+}
+
+func (s *arrivalScheduleService) UpsertBulkStudentArrivalSchedules(
+	ctx context.Context,
+	studentID int64,
+	rows []*schedule.StudentArrivalSchedule,
+) error {
+	return s.core.UpsertBulkSchedules(ctx, studentID, rows)
+}
+
+func (s *arrivalScheduleService) DeleteStudentArrivalSchedule(
+	ctx context.Context,
+	scheduleID int64,
+) error {
+	return s.core.DeleteSchedule(ctx, scheduleID)
+}
+
+func (s *arrivalScheduleService) DeleteAllStudentArrivalSchedules(
+	ctx context.Context,
+	studentID int64,
+) error {
+	return s.core.DeleteAllSchedules(ctx, studentID)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalExceptionByID(
+	ctx context.Context,
+	exceptionID int64,
+) (*schedule.StudentArrivalException, error) {
+	return s.core.ExceptionByID(ctx, exceptionID)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalExceptionForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (*schedule.StudentArrivalException, error) {
+	return s.core.ExceptionForDate(ctx, studentID, date)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalExceptions(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentArrivalException, error) {
+	return s.core.Exceptions(ctx, studentID)
+}
+
+func (s *arrivalScheduleService) GetUpcomingStudentArrivalExceptions(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentArrivalException, error) {
+	return s.core.UpcomingExceptions(ctx, studentID)
+}
+
+func (s *arrivalScheduleService) CreateStudentArrivalException(
+	ctx context.Context,
+	row *schedule.StudentArrivalException,
+) error {
+	return s.core.CreateException(ctx, row)
+}
+
+func (s *arrivalScheduleService) UpdateStudentArrivalException(
+	ctx context.Context,
+	row *schedule.StudentArrivalException,
+) error {
+	return s.core.UpdateExceptionRow(ctx, row)
+}
+
+func (s *arrivalScheduleService) CreateOrReclaimException(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+	arrivalTime *time.Time,
+	reason *string,
+	staffID int64,
+	resolveStaffID func() (int64, error),
+) (*schedule.StudentArrivalException, error) {
+	return s.core.CreateOrReclaimException(
+		ctx,
+		studentID,
+		date,
+		arrivalTime,
+		reason,
+		staffID,
+		resolveStaffID,
+	)
+}
+
+func (s *arrivalScheduleService) UpdateException(
+	ctx context.Context,
+	exceptionID int64,
+	studentID int64,
+	date timezone.Date,
+	reason *string,
+	arrivalTime *time.Time,
+	resolveStaffID func() (int64, error),
+) (*schedule.StudentArrivalException, error) {
+	return s.core.UpdateException(
+		ctx,
+		exceptionID,
+		studentID,
+		date,
+		reason,
+		arrivalTime,
+		resolveStaffID,
+	)
+}
+
+func (s *arrivalScheduleService) DeleteStudentArrivalException(
+	ctx context.Context,
+	exceptionID int64,
+) error {
+	return s.core.DeleteException(ctx, exceptionID)
+}
+
+func (s *arrivalScheduleService) DeleteAllStudentArrivalExceptions(
+	ctx context.Context,
+	studentID int64,
+) error {
+	return s.core.DeleteAllExceptions(ctx, studentID)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalNoteByID(
+	ctx context.Context,
+	noteID int64,
+) (*schedule.StudentArrivalNote, error) {
+	return s.core.NoteByID(ctx, noteID)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalNotes(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentArrivalNote, error) {
+	return s.core.Notes(ctx, studentID)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalNotesForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) ([]*schedule.StudentArrivalNote, error) {
+	return s.core.NotesForDate(ctx, studentID, date)
+}
+
+func (s *arrivalScheduleService) CreateStudentArrivalNote(
+	ctx context.Context,
+	row *schedule.StudentArrivalNote,
+) error {
+	return s.core.CreateNote(ctx, row)
+}
+
+func (s *arrivalScheduleService) UpdateStudentArrivalNote(
+	ctx context.Context,
+	row *schedule.StudentArrivalNote,
+) error {
+	return s.core.UpdateNote(ctx, row)
+}
+
+func (s *arrivalScheduleService) DeleteStudentArrivalNote(
+	ctx context.Context,
+	noteID int64,
+) error {
+	return s.core.DeleteNote(ctx, noteID)
+}
+
+func (s *arrivalScheduleService) DeleteAllStudentArrivalNotes(
+	ctx context.Context,
+	studentID int64,
+) error {
+	return s.core.DeleteAllNotes(ctx, studentID)
+}
+
+func (s *arrivalScheduleService) GetStudentArrivalData(
+	ctx context.Context,
+	studentID int64,
+) (*StudentArrivalData, error) {
+	data, err := s.core.Data(ctx, studentID)
 	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival schedules", Err: err}
-	}
-	return schedules, nil
-}
-
-// GetStudentArrivalScheduleForWeekday returns the arrival schedule for a specific weekday
-func (s *arrivalScheduleService) GetStudentArrivalScheduleForWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentArrivalSchedule, error) {
-	if weekday < schedule.WeekdayMonday || weekday > schedule.WeekdayFriday {
-		return nil, &ScheduleError{Op: "get student arrival schedule for weekday", Err: errors.New("invalid weekday")}
-	}
-
-	arrivalSchedule, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival schedule for weekday", Err: err}
-	}
-	return arrivalSchedule, nil
-}
-
-// UpsertStudentArrivalSchedule creates or updates an arrival schedule
-func (s *arrivalScheduleService) UpsertStudentArrivalSchedule(ctx context.Context, scheduleData *schedule.StudentArrivalSchedule) error {
-	if err := scheduleData.Validate(); err != nil {
-		return &ScheduleError{Op: "upsert student arrival schedule", Err: err}
-	}
-
-	if err := s.scheduleRepo.UpsertSchedule(ctx, scheduleData); err != nil {
-		return &ScheduleError{Op: "upsert student arrival schedule", Err: err}
-	}
-	return nil
-}
-
-// UpsertBulkStudentArrivalSchedules replaces all arrival schedules for a student.
-// This deletes existing schedules and inserts the new ones atomically,
-// ensuring that cleared weekdays are properly removed.
-func (s *arrivalScheduleService) UpsertBulkStudentArrivalSchedules(ctx context.Context, studentID int64, schedules []*schedule.StudentArrivalSchedule) error {
-	// Delete all existing schedules for this student first. The repository
-	// joins the handler's WithTenantTx transaction via the context.
-	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: fmt.Errorf("failed to delete existing schedules: %w", err)}
-	}
-
-	// Insert new schedules
-	for _, sched := range schedules {
-		sched.StudentID = studentID
-		if err := sched.Validate(); err != nil {
-			return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: fmt.Errorf("invalid schedule for weekday %d: %w", sched.Weekday, err)}
-		}
-		sched.SetTenantID(tenant.FromContext(ctx))
-
-		if err := s.scheduleRepo.Create(ctx, sched); err != nil {
-			return &ScheduleError{Op: opUpsertBulkStudentArrivalSchedules, Err: err}
-		}
-	}
-	return nil
-}
-
-// DeleteStudentArrivalSchedule deletes an arrival schedule by ID
-func (s *arrivalScheduleService) DeleteStudentArrivalSchedule(ctx context.Context, scheduleID int64) error {
-	if err := s.scheduleRepo.Delete(ctx, scheduleID); err != nil {
-		return &ScheduleError{Op: "delete student arrival schedule", Err: err}
-	}
-	return nil
-}
-
-// DeleteAllStudentArrivalSchedules deletes all arrival schedules for a student
-func (s *arrivalScheduleService) DeleteAllStudentArrivalSchedules(ctx context.Context, studentID int64) error {
-	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: "delete all student arrival schedules", Err: err}
-	}
-	return nil
-}
-
-// Exception operations
-
-// GetStudentArrivalExceptionByID returns an arrival exception by its ID
-func (s *arrivalScheduleService) GetStudentArrivalExceptionByID(ctx context.Context, exceptionID int64) (*schedule.StudentArrivalException, error) {
-	exception, err := s.exceptionRepo.FindByID(ctx, exceptionID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival exception by id", Err: err}
-	}
-	return exception, nil
-}
-
-// GetStudentArrivalExceptionForDate returns the arrival exception for a student
-// on a specific date, or nil when none exists.
-func (s *arrivalScheduleService) GetStudentArrivalExceptionForDate(ctx context.Context, studentID int64, date timezone.Date) (*schedule.StudentArrivalException, error) {
-	exception, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival exception for date", Err: err}
-	}
-	return exception, nil
-}
-
-// GetStudentArrivalExceptions returns all arrival exceptions for a student
-func (s *arrivalScheduleService) GetStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
-	exceptions, err := s.exceptionRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival exceptions", Err: err}
-	}
-	return exceptions, nil
-}
-
-// GetUpcomingStudentArrivalExceptions returns upcoming arrival exceptions for a student
-func (s *arrivalScheduleService) GetUpcomingStudentArrivalExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalException, error) {
-	exceptions, err := s.exceptionRepo.FindUpcomingByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get upcoming student arrival exceptions", Err: err}
-	}
-	return exceptions, nil
-}
-
-// CreateStudentArrivalException creates a new arrival exception
-func (s *arrivalScheduleService) CreateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error {
-	if err := exception.Validate(); err != nil {
-		return &ScheduleError{Op: opCreateStudentArrivalException, Err: err}
-	}
-
-	// Check for existing exception on the same date
-	existing, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, exception.StudentID, exception.ExceptionDate)
-	if err != nil {
-		return &ScheduleError{Op: opCreateStudentArrivalException, Err: err}
-	}
-	if existing != nil {
-		return &ScheduleError{Op: opCreateStudentArrivalException, Err: errors.New("exception already exists for this date")}
-	}
-
-	exception.SetTenantID(tenant.FromContext(ctx))
-	if err := s.exceptionRepo.Create(ctx, exception); err != nil {
-		return &ScheduleError{Op: opCreateStudentArrivalException, Err: err}
-	}
-	return nil
-}
-
-// UpdateStudentArrivalException updates an existing arrival exception
-func (s *arrivalScheduleService) UpdateStudentArrivalException(ctx context.Context, exception *schedule.StudentArrivalException) error {
-	if err := exception.Validate(); err != nil {
-		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: err}
-	}
-
-	// Check if changing date would conflict with another exception
-	existing, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, exception.StudentID, exception.ExceptionDate)
-	if err != nil {
-		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: err}
-	}
-	if existing != nil && existing.ID != exception.ID {
-		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: errors.New("exception already exists for this date")}
-	}
-
-	if err := s.exceptionRepo.Update(ctx, exception); err != nil {
-		return &ScheduleError{Op: opUpdateStudentArrivalException, Err: err}
-	}
-	return nil
-}
-
-// CreateOrReclaimException creates a staff arrival exception for the day, or
-// resolves a collision with an already-existing row under the day lock. A
-// guardian-authored row is reclaimed for staff; a staff-authored row is refused
-// with ErrCareExceptionDayConflict so a concurrent staff edit is not silently
-// overwritten.
-func (s *arrivalScheduleService) CreateOrReclaimException(ctx context.Context, studentID int64, date timezone.Date, arrivalTime *time.Time, reason *string, staffID int64, resolveStaffID func() (int64, error)) (*schedule.StudentArrivalException, error) {
-	var exception *schedule.StudentArrivalException
-	tenantID := tenant.FromContext(ctx)
-	if err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		if err := LockCareExceptionDay(txCtx, s.db, studentID, date); err != nil {
-			return err
-		}
-
-		existing, err := s.GetStudentArrivalExceptionForDate(txCtx, studentID, date)
-		if err != nil {
-			return err
-		}
-		if existing != nil {
-			if existing.Source != schedule.ExceptionSourceGuardian {
-				return ErrCareExceptionDayConflict
-			}
-			sid, staffErr := resolveStaffID()
-			if staffErr != nil || sid == 0 {
-				return ErrCareExceptionStaffProfileRequired
-			}
-			updated := &schedule.StudentArrivalException{
-				StudentID:       studentID,
-				ExceptionDate:   date,
-				ExpectedArrival: arrivalTime,
-				Reason:          reason,
-				Source:          schedule.ExceptionSourceStaff,
-				CreatedBy:       sid,
-			}
-			updated.ID = existing.ID
-			updated.CreatedAt = existing.CreatedAt
-			updated.SetTenantID(existing.TenantID)
-			exception = updated
-			return s.UpdateStudentArrivalException(txCtx, updated)
-		}
-
-		exception = &schedule.StudentArrivalException{
-			StudentID:       studentID,
-			ExceptionDate:   date,
-			ExpectedArrival: arrivalTime,
-			Reason:          reason,
-			Source:          schedule.ExceptionSourceStaff,
-			CreatedBy:       staffID,
-		}
-		return s.CreateStudentArrivalException(txCtx, exception)
-	}); err != nil {
 		return nil, err
 	}
-	return exception, nil
-}
-
-// UpdateException updates an existing arrival exception under the day lock. A
-// staff edit takes ownership of the day: a guardian-authored row is reclaimed
-// (staff author stamped, guardian link dropped); staff-authored rows keep their
-// original author. The optional reason/arrival patch is merged onto the locked
-// row.
-func (s *arrivalScheduleService) UpdateException(ctx context.Context, exceptionID, studentID int64, date timezone.Date, reason *string, arrivalTime *time.Time, resolveStaffID func() (int64, error)) (*schedule.StudentArrivalException, error) {
-	var exception *schedule.StudentArrivalException
-	tenantID := tenant.FromContext(ctx)
-	if err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		if err := LockCareExceptionDay(txCtx, s.db, studentID, date); err != nil {
-			return err
-		}
-		freshException, err := s.GetStudentArrivalExceptionByID(txCtx, exceptionID)
-		if err != nil {
-			return err
-		}
-		if freshException == nil {
-			return ErrCareExceptionNotFound
-		}
-		if freshException.StudentID != studentID {
-			return ErrCareExceptionWrongStudent
-		}
-
-		source := freshException.Source
-		createdBy := freshException.CreatedBy
-		createdByGuardian := freshException.CreatedByGuardian
-		if freshException.Source == schedule.ExceptionSourceGuardian {
-			sid, staffErr := resolveStaffID()
-			if staffErr != nil || sid == 0 {
-				return ErrCareExceptionStaffProfileRequired
-			}
-			source = schedule.ExceptionSourceStaff
-			createdBy = sid
-			createdByGuardian = nil
-		}
-
-		expectedArrival := freshException.ExpectedArrival
-		if expectedArrival != nil {
-			normalized := timezone.WallClock(*expectedArrival)
-			expectedArrival = &normalized
-		}
-
-		updated := &schedule.StudentArrivalException{
-			StudentID:         studentID,
-			ExceptionDate:     date,
-			ExpectedArrival:   expectedArrival,
-			Reason:            freshException.Reason,
-			Source:            source,
-			CreatedBy:         createdBy,
-			CreatedByGuardian: createdByGuardian,
-		}
-		updated.ID = exceptionID
-		updated.CreatedAt = freshException.CreatedAt
-		updated.SetTenantID(freshException.TenantID)
-
-		if reason != nil {
-			updated.Reason = reason
-		}
-		if arrivalTime != nil {
-			updated.ExpectedArrival = arrivalTime
-		}
-
-		exception = updated
-		return s.UpdateStudentArrivalException(txCtx, updated)
-	}); err != nil {
-		return nil, err
-	}
-	return exception, nil
-}
-
-// DeleteStudentArrivalException deletes an arrival exception by ID
-func (s *arrivalScheduleService) DeleteStudentArrivalException(ctx context.Context, exceptionID int64) error {
-	if err := s.exceptionRepo.Delete(ctx, exceptionID); err != nil {
-		return &ScheduleError{Op: "delete student arrival exception", Err: err}
-	}
-	return nil
-}
-
-// DeleteAllStudentArrivalExceptions deletes all arrival exceptions for a student
-func (s *arrivalScheduleService) DeleteAllStudentArrivalExceptions(ctx context.Context, studentID int64) error {
-	if err := s.exceptionRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: "delete all student arrival exceptions", Err: err}
-	}
-	return nil
-}
-
-// Note operations
-
-// GetStudentArrivalNoteByID returns an arrival note by its ID
-func (s *arrivalScheduleService) GetStudentArrivalNoteByID(ctx context.Context, noteID int64) (*schedule.StudentArrivalNote, error) {
-	note, err := s.noteRepo.FindByID(ctx, noteID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival note by id", Err: err}
-	}
-	return note, nil
-}
-
-// GetStudentArrivalNotes returns all arrival notes for a student
-func (s *arrivalScheduleService) GetStudentArrivalNotes(ctx context.Context, studentID int64) ([]*schedule.StudentArrivalNote, error) {
-	notes, err := s.noteRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival notes", Err: err}
-	}
-	return notes, nil
-}
-
-// GetStudentArrivalNotesForDate returns arrival notes for a student on a specific date
-func (s *arrivalScheduleService) GetStudentArrivalNotesForDate(ctx context.Context, studentID int64, date timezone.Date) ([]*schedule.StudentArrivalNote, error) {
-	notes, err := s.noteRepo.FindByStudentIDAndDate(ctx, studentID, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student arrival notes for date", Err: err}
-	}
-	return notes, nil
-}
-
-// CreateStudentArrivalNote creates a new arrival note
-func (s *arrivalScheduleService) CreateStudentArrivalNote(ctx context.Context, note *schedule.StudentArrivalNote) error {
-	if err := note.Validate(); err != nil {
-		return &ScheduleError{Op: "create student arrival note", Err: err}
-	}
-
-	note.SetTenantID(tenant.FromContext(ctx))
-	if err := s.noteRepo.Create(ctx, note); err != nil {
-		return &ScheduleError{Op: "create student arrival note", Err: err}
-	}
-	return nil
-}
-
-// UpdateStudentArrivalNote updates an existing arrival note
-func (s *arrivalScheduleService) UpdateStudentArrivalNote(ctx context.Context, note *schedule.StudentArrivalNote) error {
-	if err := note.Validate(); err != nil {
-		return &ScheduleError{Op: "update student arrival note", Err: err}
-	}
-
-	if err := s.noteRepo.Update(ctx, note); err != nil {
-		return &ScheduleError{Op: "update student arrival note", Err: err}
-	}
-	return nil
-}
-
-// DeleteStudentArrivalNote deletes an arrival note by ID
-func (s *arrivalScheduleService) DeleteStudentArrivalNote(ctx context.Context, noteID int64) error {
-	if err := s.noteRepo.Delete(ctx, noteID); err != nil {
-		return &ScheduleError{Op: "delete student arrival note", Err: err}
-	}
-	return nil
-}
-
-// DeleteAllStudentArrivalNotes deletes all arrival notes for a student
-func (s *arrivalScheduleService) DeleteAllStudentArrivalNotes(ctx context.Context, studentID int64) error {
-	if err := s.noteRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: "delete all student arrival notes", Err: err}
-	}
-	return nil
-}
-
-// Computed operations
-
-// GetStudentArrivalData returns combined schedule, exception, and note data for a student.
-// Returns all exceptions and notes (not just upcoming) to support week view navigation to past weeks.
-func (s *arrivalScheduleService) GetStudentArrivalData(ctx context.Context, studentID int64) (*StudentArrivalData, error) {
-	schedules, err := s.scheduleRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetStudentArrivalData, Err: err}
-	}
-
-	exceptions, err := s.exceptionRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetStudentArrivalData, Err: err}
-	}
-
-	notes, err := s.noteRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetStudentArrivalData, Err: err}
-	}
-
 	return &StudentArrivalData{
-		Schedules:  schedules,
-		Exceptions: exceptions,
-		Notes:      notes,
+		Schedules:  data.Schedules,
+		Exceptions: data.Exceptions,
+		Notes:      data.Notes,
 	}, nil
 }
 
-// GetEffectiveArrivalTimeForDate calculates the effective arrival time for a specific date
-func (s *arrivalScheduleService) GetEffectiveArrivalTimeForDate(ctx context.Context, studentID int64, date timezone.Date) (*EffectiveArrivalTime, error) {
-	weekday := int(date.Weekday())
-
-	// Convert Go weekday (Sunday=0) to ISO weekday (Monday=1)
-	if weekday == 0 {
-		weekday = 7
-	}
-
-	result := &EffectiveArrivalTime{
-		Date:        date,
-		WeekdayName: schedule.WeekdayNames[weekday],
-	}
-
-	// Weekend check
-	if weekday > schedule.WeekdayFriday {
-		return result, nil
-	}
-
-	// Check for exception on this date first
-	exception, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
+func (s *arrivalScheduleService) GetEffectiveArrivalTimeForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (*EffectiveArrivalTime, error) {
+	result, err := s.core.EffectiveTimeForDate(ctx, studentID, date)
 	if err != nil {
-		return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
+		return nil, err
 	}
-
-	if exception != nil {
-		result.IsException = true
-		result.ArrivalTime = exception.ExpectedArrival
-		if reason := arrivalNoteOverride(exception.Reason); reason != "" {
-			result.Notes = reason
-		} else {
-			sched, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
-			if err != nil {
-				return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
-			}
-			result.Notes = arrivalScheduleNotes(sched)
-		}
-	} else {
-		// Fall back to regular schedule
-		sched, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
-		if err != nil {
-			return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
-		}
-
-		if sched != nil {
-			result.ArrivalTime = &sched.ExpectedArrival
-			result.Notes = arrivalScheduleNotes(sched)
-		}
-	}
-
-	// Load day notes
-	dayNotes, err := s.noteRepo.FindByStudentIDAndDate(ctx, studentID, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetEffectiveArrivalTime, Err: err}
-	}
-	for _, n := range dayNotes {
-		result.DayNotes = append(result.DayNotes, ArrivalNoteData{ID: n.ID, Content: n.Content})
-	}
-
-	return result, nil
+	return arrivalEffectiveTime(result), nil
 }
 
-// GetBulkEffectiveArrivalTimesForDate calculates effective arrival times for multiple students on a given date
-// Uses bulk database queries for optimal performance (O(3) queries instead of O(N))
-func (s *arrivalScheduleService) GetBulkEffectiveArrivalTimesForDate(ctx context.Context, studentIDs []int64, date timezone.Date) (map[int64]*EffectiveArrivalTime, error) {
-	if len(studentIDs) == 0 {
-		return make(map[int64]*EffectiveArrivalTime), nil
-	}
-
-	weekday := int(date.Weekday())
-
-	// Convert Go weekday (Sunday=0) to ISO weekday (Monday=1)
-	if weekday == 0 {
-		weekday = 7
-	}
-
-	result := make(map[int64]*EffectiveArrivalTime, len(studentIDs))
-
-	// Initialize results for all students
-	for _, studentID := range studentIDs {
-		result[studentID] = &EffectiveArrivalTime{
-			Date:        date,
-			WeekdayName: schedule.WeekdayNames[weekday],
-		}
-	}
-
-	// Weekend check - all students have no arrival time
-	if weekday > schedule.WeekdayFriday {
-		return result, nil
-	}
-
-	// Bulk fetch all exceptions for the given date (single query)
-	exceptions, err := s.exceptionRepo.FindByStudentIDsAndDate(ctx, studentIDs, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetBulkEffectiveArrivalTimes, Err: err}
-	}
-
-	// Build exception map for O(1) lookup
-	exceptionMap := make(map[int64]*schedule.StudentArrivalException, len(exceptions))
-	for _, exc := range exceptions {
-		exceptionMap[exc.StudentID] = exc
-	}
-
-	// Bulk fetch all schedules for the given weekday (single query)
-	schedules, err := s.scheduleRepo.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetBulkEffectiveArrivalTimes, Err: err}
-	}
-
-	// Build schedule map for O(1) lookup
-	scheduleMap := make(map[int64]*schedule.StudentArrivalSchedule, len(schedules))
-	for _, sched := range schedules {
-		scheduleMap[sched.StudentID] = sched
-	}
-
-	// Bulk fetch all notes for the given date (single query)
-	notes, err := s.noteRepo.FindByStudentIDsAndDate(ctx, studentIDs, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetBulkEffectiveArrivalTimes, Err: err}
-	}
-
-	// Build notes map for grouping by student
-	notesMap := make(map[int64][]*schedule.StudentArrivalNote)
-	for _, n := range notes {
-		notesMap[n.StudentID] = append(notesMap[n.StudentID], n)
-	}
-
-	// Merge results: exception takes precedence over schedule
-	mergeArrivalResults(studentIDs, result, exceptionMap, scheduleMap, notesMap)
-
-	return result, nil
-}
-
-// mergeArrivalResults merges exception, schedule, and note data into effective arrival times
-func mergeArrivalResults(
+func (s *arrivalScheduleService) GetBulkEffectiveArrivalTimesForDate(
+	ctx context.Context,
 	studentIDs []int64,
-	result map[int64]*EffectiveArrivalTime,
-	exceptionMap map[int64]*schedule.StudentArrivalException,
-	scheduleMap map[int64]*schedule.StudentArrivalSchedule,
-	notesMap map[int64][]*schedule.StudentArrivalNote,
-) {
-	for _, studentID := range studentIDs {
-		r := result[studentID]
-		sched := scheduleMap[studentID]
-
-		// Check for exception first (takes priority)
-		if exc, ok := exceptionMap[studentID]; ok {
-			r.IsException = true
-			r.ArrivalTime = exc.ExpectedArrival
-			if reason := arrivalNoteOverride(exc.Reason); reason != "" {
-				r.Notes = reason
-			} else {
-				r.Notes = arrivalScheduleNotes(sched)
-			}
-		} else if sched != nil {
-			// Fall back to regular schedule
-			r.ArrivalTime = &sched.ExpectedArrival
-			r.Notes = arrivalScheduleNotes(sched)
-		}
-
-		// Attach day notes
-		if dayNotes, ok := notesMap[studentID]; ok {
-			for _, n := range dayNotes {
-				r.DayNotes = append(r.DayNotes, ArrivalNoteData{ID: n.ID, Content: n.Content})
-			}
-		}
+	date timezone.Date,
+) (map[int64]*EffectiveArrivalTime, error) {
+	results, err := s.core.BulkEffectiveTimesForDate(ctx, studentIDs, date)
+	if err != nil {
+		return nil, err
 	}
+	mapped := make(map[int64]*EffectiveArrivalTime, len(results))
+	for studentID, result := range results {
+		mapped[studentID] = arrivalEffectiveTime(result)
+	}
+	return mapped, nil
 }
 
-// BulkUpsertBySchoolClass upserts arrival schedules for all students in a school class
-func (s *arrivalScheduleService) BulkUpsertBySchoolClass(ctx context.Context, schoolClass string, schedules []ArrivalScheduleInput, createdBy int64) (*BulkUpsertResult, error) {
+func arrivalEffectiveTime(result *effectiveTimeResult) *EffectiveArrivalTime {
+	mapped := &EffectiveArrivalTime{
+		Date:        result.Date,
+		ArrivalTime: result.Time,
+		WeekdayName: result.WeekdayName,
+		IsException: result.IsException,
+		Notes:       result.Notes,
+	}
+	for _, note := range result.DayNotes {
+		mapped.DayNotes = append(mapped.DayNotes, ArrivalNoteData(note))
+	}
+	return mapped
+}
+
+func (s *arrivalScheduleService) BulkUpsertBySchoolClass(
+	ctx context.Context,
+	schoolClass string,
+	schedules []ArrivalScheduleInput,
+	createdBy int64,
+) (*BulkUpsertResult, error) {
 	if schoolClass == "" {
-		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: errors.New("school_class is required")}
+		return nil, &ScheduleError{
+			Op:  opBulkUpsertBySchoolClass,
+			Err: errors.New("school_class is required"),
+		}
 	}
 	if len(schedules) == 0 {
-		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: errors.New("schedules cannot be empty")}
+		return nil, &ScheduleError{
+			Op:  opBulkUpsertBySchoolClass,
+			Err: errors.New("schedules cannot be empty"),
+		}
 	}
 
-	// Query all students in this school class within the current tenant
 	students, err := s.studentRepo.FindBySchoolClass(ctx, schoolClass)
 	if err != nil {
-		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: fmt.Errorf("failed to find students for class %s: %w", schoolClass, err)}
+		return nil, &ScheduleError{
+			Op:  opBulkUpsertBySchoolClass,
+			Err: fmt.Errorf("failed to find students for class %s: %w", schoolClass, err),
+		}
 	}
-
 	if len(students) == 0 {
 		return &BulkUpsertResult{StudentsAffected: 0}, nil
 	}
 
 	tenantID := tenant.FromContext(ctx)
 	warnings := make([]OverwriteWarning, 0)
-
-	// Parse arrival times upfront
 	parsedTimes := make(map[int]time.Time, len(schedules))
 	for _, input := range schedules {
-		t, err := time.Parse("2006-01-02 15:04", "2000-01-01 "+input.ArrivalTime)
+		value, err := time.Parse("2006-01-02 15:04", "2000-01-01 "+input.ArrivalTime)
 		if err != nil {
-			return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: fmt.Errorf("invalid expected_arrival %q for weekday %d: %w", input.ArrivalTime, input.Weekday, err)}
+			return nil, &ScheduleError{
+				Op: opBulkUpsertBySchoolClass,
+				Err: fmt.Errorf(
+					"invalid expected_arrival %q for weekday %d: %w",
+					input.ArrivalTime,
+					input.Weekday,
+					err,
+				),
+			}
 		}
-		parsedTimes[input.Weekday] = t
+		parsedTimes[input.Weekday] = value
 	}
 
-	// Wrap everything in a transaction
-	if err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+	err = tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
 		for _, student := range students {
-			// Fetch existing schedules for this student to detect overwrites
 			existing, err := s.scheduleRepo.FindByStudentID(txCtx, student.ID)
 			if err != nil {
-				return fmt.Errorf("failed to fetch existing schedules for student %d: %w", student.ID, err)
+				return fmt.Errorf(
+					"failed to fetch existing schedules for student %d: %w",
+					student.ID,
+					err,
+				)
 			}
 
-			// Build map of existing schedules by weekday for overwrite detection
 			existingByWeekday := make(map[int]*schedule.StudentArrivalSchedule, len(existing))
-			for _, ex := range existing {
-				existingByWeekday[ex.Weekday] = ex
+			for _, row := range existing {
+				existingByWeekday[row.Weekday] = row
 			}
 
-			// Upsert each weekday
 			for _, input := range schedules {
 				arrivalTime := parsedTimes[input.Weekday]
-
-				// Check for overwrite
-				if ex, ok := existingByWeekday[input.Weekday]; ok {
-					if ex.ExpectedArrival.Format("15:04") != arrivalTime.Format("15:04") {
-						// Get student name for the warning
-						studentName := s.getStudentName(txCtx, student)
-						warnings = append(warnings, OverwriteWarning{
-							StudentID:    student.ID,
-							StudentName:  studentName,
-							Weekday:      input.Weekday,
-							WeekdayName:  schedule.WeekdayNames[input.Weekday],
-							PreviousTime: ex.ExpectedArrival.Format("15:04"),
-							NewTime:      arrivalTime.Format("15:04"),
-						})
-					}
+				if existingRow, ok := existingByWeekday[input.Weekday]; ok &&
+					existingRow.ExpectedArrival.Format("15:04") != arrivalTime.Format("15:04") {
+					warnings = append(warnings, OverwriteWarning{
+						StudentID:    student.ID,
+						StudentName:  s.getStudentName(txCtx, student),
+						Weekday:      input.Weekday,
+						WeekdayName:  schedule.WeekdayNames[input.Weekday],
+						PreviousTime: existingRow.ExpectedArrival.Format("15:04"),
+						NewTime:      arrivalTime.Format("15:04"),
+					})
 				}
 
-				sched := &schedule.StudentArrivalSchedule{
+				row := &schedule.StudentArrivalSchedule{
 					StudentID:       student.ID,
 					Weekday:         input.Weekday,
 					ExpectedArrival: arrivalTime,
 					CreatedBy:       createdBy,
 				}
-				sched.SetTenantID(tenantID)
-
-				if err := s.scheduleRepo.UpsertSchedule(txCtx, sched); err != nil {
-					return fmt.Errorf("failed to upsert schedule for student %d weekday %d: %w", student.ID, input.Weekday, err)
+				row.SetTenantID(tenantID)
+				if err := s.scheduleRepo.UpsertSchedule(txCtx, row); err != nil {
+					return fmt.Errorf(
+						"failed to upsert schedule for student %d weekday %d: %w",
+						student.ID,
+						input.Weekday,
+						err,
+					)
 				}
 			}
 		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, &ScheduleError{Op: opBulkUpsertBySchoolClass, Err: err}
 	}
 
-	s.getLogger().Info("bulk upsert arrival schedules by school class",
+	s.getLogger().Info(
+		"bulk upsert arrival schedules by school class",
 		slog.String("school_class", schoolClass),
 		slog.Int("students_affected", len(students)),
 		slog.Int("weekdays_set", len(schedules)),
@@ -831,7 +506,6 @@ func (s *arrivalScheduleService) BulkUpsertBySchoolClass(ctx context.Context, sc
 	for _, student := range students {
 		affectedIDs = append(affectedIDs, student.ID)
 	}
-
 	return &BulkUpsertResult{
 		StudentsAffected:    len(students),
 		OverwrittenStudents: warnings,
@@ -839,9 +513,10 @@ func (s *arrivalScheduleService) BulkUpsertBySchoolClass(ctx context.Context, sc
 	}, nil
 }
 
-// getStudentName resolves a student's display name from their person record.
-// Returns a fallback string on any error so callers can always produce a warning.
-func (s *arrivalScheduleService) getStudentName(ctx context.Context, student *users.Student) string {
+func (s *arrivalScheduleService) getStudentName(
+	ctx context.Context,
+	student *users.Student,
+) string {
 	if s.personRepo == nil {
 		return fmt.Sprintf("Student %d", student.ID)
 	}
@@ -850,26 +525,4 @@ func (s *arrivalScheduleService) getStudentName(ctx context.Context, student *us
 		return fmt.Sprintf("Student %d", student.ID)
 	}
 	return person.FirstName + " " + person.LastName
-}
-
-func arrivalNoteOverride(reason *string) string {
-	if reason == nil {
-		return ""
-	}
-
-	return strings.TrimSpace(*reason)
-}
-
-func arrivalScheduleNotes(sched *schedule.StudentArrivalSchedule) string {
-	if sched == nil || sched.Notes == nil {
-		return ""
-	}
-
-	return strings.TrimSpace(*sched.Notes)
-}
-
-// GetWeeklySchedulesByStudentIDsAndWeekday returns the raw weekly arrival
-// schedules of many students for one weekday.
-func (s *arrivalScheduleService) GetWeeklySchedulesByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentArrivalSchedule, error) {
-	return s.scheduleRepo.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
 }

--- a/backend/services/schedule/effective_time_domains.go
+++ b/backend/services/schedule/effective_time_domains.go
@@ -1,0 +1,143 @@
+package schedule
+
+import (
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+type pickupTimeDomain struct{}
+
+func (pickupTimeDomain) Name() string {
+	return "pickup"
+}
+
+func (pickupTimeDomain) CollisionPolicy() exceptionCollisionPolicy {
+	return exceptionCollisionUpdate
+}
+
+func (pickupTimeDomain) ScheduleFields(row *schedule.StudentPickupSchedule) effectiveScheduleFields {
+	return effectiveScheduleFields{
+		StudentID: row.StudentID,
+		Weekday:   row.Weekday,
+		Time:      row.PickupTime,
+		Notes:     row.Notes,
+	}
+}
+
+func (pickupTimeDomain) SetScheduleStudentID(row *schedule.StudentPickupSchedule, studentID int64) {
+	row.StudentID = studentID
+}
+
+func (pickupTimeDomain) ExceptionFields(row *schedule.StudentPickupException) effectiveExceptionFields {
+	return effectiveExceptionFields{
+		ID:                row.ID,
+		StudentID:         row.StudentID,
+		Date:              row.ExceptionDate,
+		Time:              row.PickupTime,
+		Reason:            row.Reason,
+		Source:            row.Source,
+		CreatedBy:         row.CreatedBy,
+		CreatedByGuardian: row.CreatedByGuardian,
+		CreatedAt:         row.CreatedAt,
+		TenantID:          row.TenantID,
+	}
+}
+
+func (pickupTimeDomain) NewException(fields effectiveExceptionFields) *schedule.StudentPickupException {
+	row := &schedule.StudentPickupException{
+		StudentID:         fields.StudentID,
+		ExceptionDate:     fields.Date,
+		PickupTime:        fields.Time,
+		Reason:            fields.Reason,
+		Source:            fields.Source,
+		CreatedBy:         fields.CreatedBy,
+		CreatedByGuardian: fields.CreatedByGuardian,
+	}
+	row.ID = fields.ID
+	row.CreatedAt = fields.CreatedAt
+	row.SetTenantID(fields.TenantID)
+	return row
+}
+
+func (pickupTimeDomain) AssignException(
+	target *schedule.StudentPickupException,
+	source *schedule.StudentPickupException,
+) {
+	*target = *source
+}
+
+func (pickupTimeDomain) NoteFields(row *schedule.StudentPickupNote) effectiveNoteFields {
+	return effectiveNoteFields{
+		ID:        row.ID,
+		StudentID: row.StudentID,
+		Content:   row.Content,
+	}
+}
+
+type arrivalTimeDomain struct{}
+
+func (arrivalTimeDomain) Name() string {
+	return "arrival"
+}
+
+func (arrivalTimeDomain) CollisionPolicy() exceptionCollisionPolicy {
+	return exceptionCollisionReject
+}
+
+func (arrivalTimeDomain) ScheduleFields(row *schedule.StudentArrivalSchedule) effectiveScheduleFields {
+	return effectiveScheduleFields{
+		StudentID: row.StudentID,
+		Weekday:   row.Weekday,
+		Time:      row.ExpectedArrival,
+		Notes:     row.Notes,
+	}
+}
+
+func (arrivalTimeDomain) SetScheduleStudentID(row *schedule.StudentArrivalSchedule, studentID int64) {
+	row.StudentID = studentID
+}
+
+func (arrivalTimeDomain) ExceptionFields(row *schedule.StudentArrivalException) effectiveExceptionFields {
+	return effectiveExceptionFields{
+		ID:                row.ID,
+		StudentID:         row.StudentID,
+		Date:              row.ExceptionDate,
+		Time:              row.ExpectedArrival,
+		Reason:            row.Reason,
+		Source:            row.Source,
+		CreatedBy:         row.CreatedBy,
+		CreatedByGuardian: row.CreatedByGuardian,
+		CreatedAt:         row.CreatedAt,
+		TenantID:          row.TenantID,
+	}
+}
+
+func (arrivalTimeDomain) NewException(fields effectiveExceptionFields) *schedule.StudentArrivalException {
+	row := &schedule.StudentArrivalException{
+		StudentID:         fields.StudentID,
+		ExceptionDate:     fields.Date,
+		ExpectedArrival:   fields.Time,
+		Reason:            fields.Reason,
+		Source:            fields.Source,
+		CreatedBy:         fields.CreatedBy,
+		CreatedByGuardian: fields.CreatedByGuardian,
+	}
+	row.ID = fields.ID
+	row.CreatedAt = fields.CreatedAt
+	row.SetTenantID(fields.TenantID)
+	return row
+}
+
+func (arrivalTimeDomain) AssignException(
+	target *schedule.StudentArrivalException,
+	source *schedule.StudentArrivalException,
+) {
+	*target = *source
+}
+
+func (arrivalTimeDomain) NoteFields(row *schedule.StudentArrivalNote) effectiveNoteFields {
+	return effectiveNoteFields{
+		ID:        row.ID,
+		StudentID: row.StudentID,
+		Content:   row.Content,
+	}
+}

--- a/backend/services/schedule/effective_time_service.go
+++ b/backend/services/schedule/effective_time_service.go
@@ -1,0 +1,837 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+type effectiveTimeEntity interface {
+	modelBase.Entity
+	modelBase.Validator
+	modelBase.TenantScoped
+}
+
+type effectiveScheduleRepository[S effectiveTimeEntity] interface {
+	FindByStudentID(context.Context, int64) ([]S, error)
+	FindByStudentIDAndWeekday(context.Context, int64, int) (S, error)
+	FindByStudentIDsAndWeekday(context.Context, []int64, int) ([]S, error)
+	UpsertSchedule(context.Context, S) error
+	Create(context.Context, S) error
+	Delete(context.Context, any) error
+	DeleteByStudentID(context.Context, int64) error
+}
+
+type effectiveExceptionRepository[E effectiveTimeEntity] interface {
+	FindByID(context.Context, any) (E, error)
+	FindByStudentID(context.Context, int64) ([]E, error)
+	FindUpcomingByStudentID(context.Context, int64) ([]E, error)
+	FindByStudentIDAndDate(context.Context, int64, timezone.Date) (E, error)
+	FindByStudentIDsAndDate(context.Context, []int64, timezone.Date) ([]E, error)
+	Create(context.Context, E) error
+	Update(context.Context, E) error
+	Delete(context.Context, any) error
+	DeleteByStudentID(context.Context, int64) error
+}
+
+type effectiveNoteRepository[N effectiveTimeEntity] interface {
+	FindByID(context.Context, any) (N, error)
+	FindByStudentID(context.Context, int64) ([]N, error)
+	FindByStudentIDAndDate(context.Context, int64, timezone.Date) ([]N, error)
+	FindByStudentIDsAndDate(context.Context, []int64, timezone.Date) ([]N, error)
+	Create(context.Context, N) error
+	Update(context.Context, N) error
+	Delete(context.Context, any) error
+	DeleteByStudentID(context.Context, int64) error
+}
+
+type effectiveScheduleFields struct {
+	StudentID int64
+	Weekday   int
+	Time      time.Time
+	Notes     *string
+}
+
+type effectiveExceptionFields struct {
+	ID                int64
+	StudentID         int64
+	Date              timezone.Date
+	Time              *time.Time
+	Reason            *string
+	Source            string
+	CreatedBy         int64
+	CreatedByGuardian *int64
+	CreatedAt         time.Time
+	TenantID          int64
+}
+
+type effectiveNoteFields struct {
+	ID        int64
+	StudentID int64
+	Content   string
+}
+
+type effectiveTimeDomain[S effectiveTimeEntity, E effectiveTimeEntity, N effectiveTimeEntity] interface {
+	Name() string
+	CollisionPolicy() exceptionCollisionPolicy
+	ScheduleFields(S) effectiveScheduleFields
+	SetScheduleStudentID(S, int64)
+	ExceptionFields(E) effectiveExceptionFields
+	NewException(effectiveExceptionFields) E
+	AssignException(E, E)
+	NoteFields(N) effectiveNoteFields
+}
+
+type exceptionCollisionPolicy uint8
+
+const (
+	exceptionCollisionReject exceptionCollisionPolicy = iota
+	exceptionCollisionUpdate
+)
+
+type effectiveTimeData[S, E, N any] struct {
+	Schedules  []S
+	Exceptions []E
+	Notes      []N
+}
+
+type effectiveDayNote struct {
+	ID      int64
+	Content string
+}
+
+type effectiveTimeResult struct {
+	Date        timezone.Date
+	Time        *time.Time
+	WeekdayName string
+	IsException bool
+	Notes       string
+	DayNotes    []effectiveDayNote
+}
+
+type effectiveTimeCore[
+	S effectiveTimeEntity,
+	E effectiveTimeEntity,
+	N effectiveTimeEntity,
+	D effectiveTimeDomain[S, E, N],
+] struct {
+	schedules  effectiveScheduleRepository[S]
+	exceptions effectiveExceptionRepository[E]
+	notes      effectiveNoteRepository[N]
+	db         *bun.DB
+	domain     D
+}
+
+func newEffectiveTimeCore[
+	S effectiveTimeEntity,
+	E effectiveTimeEntity,
+	N effectiveTimeEntity,
+	D effectiveTimeDomain[S, E, N],
+](
+	schedules effectiveScheduleRepository[S],
+	exceptions effectiveExceptionRepository[E],
+	notes effectiveNoteRepository[N],
+	db *bun.DB,
+	domain D,
+) *effectiveTimeCore[S, E, N, D] {
+	return &effectiveTimeCore[S, E, N, D]{
+		schedules:  schedules,
+		exceptions: exceptions,
+		notes:      notes,
+		db:         db,
+		domain:     domain,
+	}
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) operation(action string) string {
+	return fmt.Sprintf(action, c.domain.Name())
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) Schedules(
+	ctx context.Context,
+	studentID int64,
+) ([]S, error) {
+	rows, err := c.schedules.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{
+			Op:  c.operation("get student %s schedules"),
+			Err: err,
+		}
+	}
+	return rows, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) ScheduleForWeekday(
+	ctx context.Context,
+	studentID int64,
+	weekday int,
+) (S, error) {
+	if weekday < scheduleModel.WeekdayMonday || weekday > scheduleModel.WeekdayFriday {
+		var zero S
+		return zero, &ScheduleError{
+			Op:  c.operation("get student %s schedule for weekday"),
+			Err: errors.New("invalid weekday"),
+		}
+	}
+
+	row, err := c.schedules.FindByStudentIDAndWeekday(ctx, studentID, weekday)
+	if err != nil {
+		var zero S
+		return zero, &ScheduleError{
+			Op:  c.operation("get student %s schedule for weekday"),
+			Err: err,
+		}
+	}
+	return row, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) UpsertSchedule(
+	ctx context.Context,
+	row S,
+) error {
+	if err := row.Validate(); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("upsert student %s schedule"),
+			Err: err,
+		}
+	}
+	if err := c.schedules.UpsertSchedule(ctx, row); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("upsert student %s schedule"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) UpsertBulkSchedules(
+	ctx context.Context,
+	studentID int64,
+	rows []S,
+) error {
+	op := c.operation("upsert bulk student %s schedules")
+	if err := c.schedules.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{
+			Op:  op,
+			Err: fmt.Errorf("failed to delete existing schedules: %w", err),
+		}
+	}
+
+	for _, row := range rows {
+		c.domain.SetScheduleStudentID(row, studentID)
+		fields := c.domain.ScheduleFields(row)
+		if err := row.Validate(); err != nil {
+			return &ScheduleError{
+				Op:  op,
+				Err: fmt.Errorf("invalid schedule for weekday %d: %w", fields.Weekday, err),
+			}
+		}
+		row.SetTenantID(tenant.FromContext(ctx))
+		if err := c.schedules.Create(ctx, row); err != nil {
+			return &ScheduleError{Op: op, Err: err}
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) DeleteSchedule(
+	ctx context.Context,
+	scheduleID int64,
+) error {
+	if err := c.schedules.Delete(ctx, scheduleID); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("delete student %s schedule"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) DeleteAllSchedules(
+	ctx context.Context,
+	studentID int64,
+) error {
+	if err := c.schedules.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("delete all student %s schedules"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) ExceptionByID(
+	ctx context.Context,
+	exceptionID int64,
+) (E, error) {
+	row, err := c.exceptions.FindByID(ctx, exceptionID)
+	if err != nil {
+		var zero E
+		return zero, &ScheduleError{
+			Op:  c.operation("get student %s exception by id"),
+			Err: err,
+		}
+	}
+	return row, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) ExceptionForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (E, error) {
+	row, err := c.exceptions.FindByStudentIDAndDate(ctx, studentID, date)
+	if err != nil {
+		var zero E
+		return zero, &ScheduleError{
+			Op:  c.operation("get student %s exception for date"),
+			Err: err,
+		}
+	}
+	return row, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) Exceptions(
+	ctx context.Context,
+	studentID int64,
+) ([]E, error) {
+	rows, err := c.exceptions.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{
+			Op:  c.operation("get student %s exceptions"),
+			Err: err,
+		}
+	}
+	return rows, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) UpcomingExceptions(
+	ctx context.Context,
+	studentID int64,
+) ([]E, error) {
+	rows, err := c.exceptions.FindUpcomingByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{
+			Op:  c.operation("get upcoming student %s exceptions"),
+			Err: err,
+		}
+	}
+	return rows, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) CreateException(
+	ctx context.Context,
+	row E,
+) error {
+	op := c.operation("create student %s exception")
+	if err := row.Validate(); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+
+	fields := c.domain.ExceptionFields(row)
+	existing, err := c.exceptions.FindByStudentIDAndDate(ctx, fields.StudentID, fields.Date)
+	if err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	if !isZeroEntity(existing) {
+		if c.domain.CollisionPolicy() == exceptionCollisionReject {
+			return &ScheduleError{
+				Op:  op,
+				Err: errors.New("exception already exists for this date"),
+			}
+		}
+
+		existingFields := c.domain.ExceptionFields(existing)
+		existingFields.Time = fields.Time
+		existingFields.Reason = fields.Reason
+		updated := c.domain.NewException(existingFields)
+		if err := c.exceptions.Update(ctx, updated); err != nil {
+			return &ScheduleError{Op: op, Err: err}
+		}
+		c.domain.AssignException(row, updated)
+		return nil
+	}
+
+	row.SetTenantID(tenant.FromContext(ctx))
+	if err := c.exceptions.Create(ctx, row); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) UpdateExceptionRow(
+	ctx context.Context,
+	row E,
+) error {
+	op := c.operation("update student %s exception")
+	if err := row.Validate(); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+
+	fields := c.domain.ExceptionFields(row)
+	existing, err := c.exceptions.FindByStudentIDAndDate(ctx, fields.StudentID, fields.Date)
+	if err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	if !isZeroEntity(existing) && c.domain.ExceptionFields(existing).ID != fields.ID {
+		return &ScheduleError{
+			Op:  op,
+			Err: errors.New("exception already exists for this date"),
+		}
+	}
+
+	if err := c.exceptions.Update(ctx, row); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) CreateOrReclaimException(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+	value *time.Time,
+	reason *string,
+	staffID int64,
+	resolveStaffID func() (int64, error),
+) (E, error) {
+	var result E
+	tenantID := tenant.FromContext(ctx)
+	err := tenant.WithTenantTx(ctx, c.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		if err := LockCareExceptionDay(txCtx, c.db, studentID, date); err != nil {
+			return err
+		}
+
+		existing, err := c.ExceptionForDate(txCtx, studentID, date)
+		if err != nil {
+			return err
+		}
+		if !isZeroEntity(existing) {
+			existingFields := c.domain.ExceptionFields(existing)
+			if existingFields.Source != scheduleModel.ExceptionSourceGuardian {
+				return ErrCareExceptionDayConflict
+			}
+			resolvedStaffID, staffErr := resolveStaffID()
+			if staffErr != nil || resolvedStaffID == 0 {
+				return ErrCareExceptionStaffProfileRequired
+			}
+			result = c.domain.NewException(effectiveExceptionFields{
+				ID:        existingFields.ID,
+				StudentID: studentID,
+				Date:      date,
+				Time:      value,
+				Reason:    reason,
+				Source:    scheduleModel.ExceptionSourceStaff,
+				CreatedBy: resolvedStaffID,
+				CreatedAt: existingFields.CreatedAt,
+				TenantID:  existingFields.TenantID,
+			})
+			return c.UpdateExceptionRow(txCtx, result)
+		}
+
+		result = c.domain.NewException(effectiveExceptionFields{
+			StudentID: studentID,
+			Date:      date,
+			Time:      value,
+			Reason:    reason,
+			Source:    scheduleModel.ExceptionSourceStaff,
+			CreatedBy: staffID,
+		})
+		return c.CreateException(txCtx, result)
+	})
+	if err != nil {
+		var zero E
+		return zero, err
+	}
+	return result, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) UpdateException(
+	ctx context.Context,
+	exceptionID int64,
+	studentID int64,
+	date timezone.Date,
+	reason *string,
+	value *time.Time,
+	resolveStaffID func() (int64, error),
+) (E, error) {
+	var result E
+	tenantID := tenant.FromContext(ctx)
+	err := tenant.WithTenantTx(ctx, c.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		if err := LockCareExceptionDay(txCtx, c.db, studentID, date); err != nil {
+			return err
+		}
+
+		fresh, err := c.ExceptionByID(txCtx, exceptionID)
+		if err != nil {
+			return err
+		}
+		if isZeroEntity(fresh) {
+			return ErrCareExceptionNotFound
+		}
+
+		fields := c.domain.ExceptionFields(fresh)
+		if fields.StudentID != studentID {
+			return ErrCareExceptionWrongStudent
+		}
+		if fields.Source == scheduleModel.ExceptionSourceGuardian {
+			resolvedStaffID, staffErr := resolveStaffID()
+			if staffErr != nil || resolvedStaffID == 0 {
+				return ErrCareExceptionStaffProfileRequired
+			}
+			fields.Source = scheduleModel.ExceptionSourceStaff
+			fields.CreatedBy = resolvedStaffID
+			fields.CreatedByGuardian = nil
+		}
+
+		fields.StudentID = studentID
+		fields.Date = date
+		if fields.Time != nil {
+			normalized := timezone.WallClock(*fields.Time)
+			fields.Time = &normalized
+		}
+		if reason != nil {
+			fields.Reason = reason
+		}
+		if value != nil {
+			fields.Time = value
+		}
+
+		result = c.domain.NewException(fields)
+		return c.UpdateExceptionRow(txCtx, result)
+	})
+	if err != nil {
+		var zero E
+		return zero, err
+	}
+	return result, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) DeleteException(
+	ctx context.Context,
+	exceptionID int64,
+) error {
+	if err := c.exceptions.Delete(ctx, exceptionID); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("delete student %s exception"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) DeleteAllExceptions(
+	ctx context.Context,
+	studentID int64,
+) error {
+	if err := c.exceptions.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("delete all student %s exceptions"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) NoteByID(
+	ctx context.Context,
+	noteID int64,
+) (N, error) {
+	row, err := c.notes.FindByID(ctx, noteID)
+	if err != nil {
+		var zero N
+		return zero, &ScheduleError{
+			Op:  c.operation("get student %s note by id"),
+			Err: err,
+		}
+	}
+	return row, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) Notes(
+	ctx context.Context,
+	studentID int64,
+) ([]N, error) {
+	rows, err := c.notes.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{
+			Op:  c.operation("get student %s notes"),
+			Err: err,
+		}
+	}
+	return rows, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) NotesForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) ([]N, error) {
+	rows, err := c.notes.FindByStudentIDAndDate(ctx, studentID, date)
+	if err != nil {
+		return nil, &ScheduleError{
+			Op:  c.operation("get student %s notes for date"),
+			Err: err,
+		}
+	}
+	return rows, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) CreateNote(
+	ctx context.Context,
+	row N,
+) error {
+	op := c.operation("create student %s note")
+	if err := row.Validate(); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	row.SetTenantID(tenant.FromContext(ctx))
+	if err := c.notes.Create(ctx, row); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) UpdateNote(
+	ctx context.Context,
+	row N,
+) error {
+	op := c.operation("update student %s note")
+	if err := row.Validate(); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	if err := c.notes.Update(ctx, row); err != nil {
+		return &ScheduleError{Op: op, Err: err}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) DeleteNote(
+	ctx context.Context,
+	noteID int64,
+) error {
+	if err := c.notes.Delete(ctx, noteID); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("delete student %s note"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) DeleteAllNotes(
+	ctx context.Context,
+	studentID int64,
+) error {
+	if err := c.notes.DeleteByStudentID(ctx, studentID); err != nil {
+		return &ScheduleError{
+			Op:  c.operation("delete all student %s notes"),
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) Data(
+	ctx context.Context,
+	studentID int64,
+) (*effectiveTimeData[S, E, N], error) {
+	op := c.operation("get student %s data")
+	schedules, err := c.schedules.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	exceptions, err := c.exceptions.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	notes, err := c.notes.FindByStudentID(ctx, studentID)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	return &effectiveTimeData[S, E, N]{
+		Schedules:  schedules,
+		Exceptions: exceptions,
+		Notes:      notes,
+	}, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) EffectiveTimeForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (*effectiveTimeResult, error) {
+	weekday := effectiveISOWeekday(date)
+	result := &effectiveTimeResult{
+		Date:        date,
+		WeekdayName: scheduleModel.WeekdayNames[weekday],
+	}
+	if weekday > scheduleModel.WeekdayFriday {
+		return result, nil
+	}
+
+	op := c.operation("get effective %s time")
+	exception, err := c.exceptions.FindByStudentIDAndDate(ctx, studentID, date)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	if !isZeroEntity(exception) {
+		fields := c.domain.ExceptionFields(exception)
+		result.IsException = true
+		result.Time = fields.Time
+		result.Notes = trimmed(fields.Reason)
+		if result.Notes == "" {
+			schedule, err := c.schedules.FindByStudentIDAndWeekday(ctx, studentID, weekday)
+			if err != nil {
+				return nil, &ScheduleError{Op: op, Err: err}
+			}
+			result.Notes = c.scheduleNotes(schedule)
+		}
+	} else {
+		schedule, err := c.schedules.FindByStudentIDAndWeekday(ctx, studentID, weekday)
+		if err != nil {
+			return nil, &ScheduleError{Op: op, Err: err}
+		}
+		if !isZeroEntity(schedule) {
+			fields := c.domain.ScheduleFields(schedule)
+			value := fields.Time
+			result.Time = &value
+			result.Notes = trimmed(fields.Notes)
+		}
+	}
+
+	notes, err := c.notes.FindByStudentIDAndDate(ctx, studentID, date)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	for _, note := range notes {
+		fields := c.domain.NoteFields(note)
+		result.DayNotes = append(result.DayNotes, effectiveDayNote{
+			ID:      fields.ID,
+			Content: fields.Content,
+		})
+	}
+	return result, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) BulkEffectiveTimesForDate(
+	ctx context.Context,
+	studentIDs []int64,
+	date timezone.Date,
+) (map[int64]*effectiveTimeResult, error) {
+	if len(studentIDs) == 0 {
+		return map[int64]*effectiveTimeResult{}, nil
+	}
+
+	weekday := effectiveISOWeekday(date)
+	result := make(map[int64]*effectiveTimeResult, len(studentIDs))
+	for _, studentID := range studentIDs {
+		result[studentID] = &effectiveTimeResult{
+			Date:        date,
+			WeekdayName: scheduleModel.WeekdayNames[weekday],
+		}
+	}
+	if weekday > scheduleModel.WeekdayFriday {
+		return result, nil
+	}
+
+	op := c.operation("get bulk effective %s times")
+	exceptions, err := c.exceptions.FindByStudentIDsAndDate(ctx, studentIDs, date)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	exceptionMap := make(map[int64]E, len(exceptions))
+	for _, exception := range exceptions {
+		exceptionMap[c.domain.ExceptionFields(exception).StudentID] = exception
+	}
+
+	schedules, err := c.schedules.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	scheduleMap := make(map[int64]S, len(schedules))
+	for _, schedule := range schedules {
+		scheduleMap[c.domain.ScheduleFields(schedule).StudentID] = schedule
+	}
+
+	notes, err := c.notes.FindByStudentIDsAndDate(ctx, studentIDs, date)
+	if err != nil {
+		return nil, &ScheduleError{Op: op, Err: err}
+	}
+	notesMap := make(map[int64][]N)
+	for _, note := range notes {
+		fields := c.domain.NoteFields(note)
+		notesMap[fields.StudentID] = append(notesMap[fields.StudentID], note)
+	}
+
+	for _, studentID := range studentIDs {
+		target := result[studentID]
+		schedule := scheduleMap[studentID]
+		if exception, ok := exceptionMap[studentID]; ok {
+			fields := c.domain.ExceptionFields(exception)
+			target.IsException = true
+			target.Time = fields.Time
+			target.Notes = trimmed(fields.Reason)
+			if target.Notes == "" {
+				target.Notes = c.scheduleNotes(schedule)
+			}
+		} else if !isZeroEntity(schedule) {
+			fields := c.domain.ScheduleFields(schedule)
+			value := fields.Time
+			target.Time = &value
+			target.Notes = trimmed(fields.Notes)
+		}
+
+		for _, note := range notesMap[studentID] {
+			fields := c.domain.NoteFields(note)
+			target.DayNotes = append(target.DayNotes, effectiveDayNote{
+				ID:      fields.ID,
+				Content: fields.Content,
+			})
+		}
+	}
+	return result, nil
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) WeeklySchedulesByStudentIDsAndWeekday(
+	ctx context.Context,
+	studentIDs []int64,
+	weekday int,
+) ([]S, error) {
+	return c.schedules.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
+}
+
+func (c *effectiveTimeCore[S, E, N, D]) scheduleNotes(schedule S) string {
+	if isZeroEntity(schedule) {
+		return ""
+	}
+	return trimmed(c.domain.ScheduleFields(schedule).Notes)
+}
+
+func effectiveISOWeekday(date timezone.Date) int {
+	weekday := int(date.Weekday())
+	if weekday == 0 {
+		return scheduleModel.WeekdaySunday
+	}
+	return weekday
+}
+
+func trimmed(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func isZeroEntity[T any](value T) bool {
+	return reflect.ValueOf(value).IsZero()
+}

--- a/backend/services/schedule/pickup_schedule_service.go
+++ b/backend/services/schedule/pickup_schedule_service.go
@@ -2,24 +2,18 @@ package schedule
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
-	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
-// PickupScheduleService defines operations for managing student pickup schedules
+// PickupScheduleService defines operations for managing student pickup schedules.
+// The domain-named contract is intentionally stable because IoT, planning,
+// reminders, exports, and messaging consume it directly.
 type PickupScheduleService interface {
-	// Schedule operations
 	GetStudentPickupSchedules(ctx context.Context, studentID int64) ([]*schedule.StudentPickupSchedule, error)
-	// GetWeeklySchedulesByStudentIDsAndWeekday returns the raw weekly pickup
-	// schedules of many students for one weekday (issue #584 lookup;
-	// repository result returned verbatim — no exception merging).
 	GetWeeklySchedulesByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentPickupSchedule, error)
 	GetStudentPickupScheduleForWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentPickupSchedule, error)
 	UpsertStudentPickupSchedule(ctx context.Context, scheduleData *schedule.StudentPickupSchedule) error
@@ -27,13 +21,7 @@ type PickupScheduleService interface {
 	DeleteStudentPickupSchedule(ctx context.Context, scheduleID int64) error
 	DeleteAllStudentPickupSchedules(ctx context.Context, studentID int64) error
 
-	// Exception operations
 	GetStudentPickupExceptionByID(ctx context.Context, exceptionID int64) (*schedule.StudentPickupException, error)
-	// GetStudentPickupExceptionForDate returns the pickup exception for a student
-	// on a specific date, or nil when the day has none. The create path uses it
-	// under the day lock to detect a row that already exists (e.g. one a guardian
-	// just authored) and turn the insert into an override instead of colliding
-	// with the unique (student_id, exception_date) index.
 	GetStudentPickupExceptionForDate(ctx context.Context, studentID int64, date timezone.Date) (*schedule.StudentPickupException, error)
 	GetStudentPickupExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentPickupException, error)
 	GetUpcomingStudentPickupExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentPickupException, error)
@@ -41,18 +29,9 @@ type PickupScheduleService interface {
 	UpdateStudentPickupException(ctx context.Context, exception *schedule.StudentPickupException) error
 	DeleteStudentPickupException(ctx context.Context, exceptionID int64) error
 	DeleteAllStudentPickupExceptions(ctx context.Context, studentID int64) error
-
-	// CreateOrReclaimException creates a pickup exception for the day, or, when a
-	// row already exists, resolves the collision under the care-exception day lock:
-	// a guardian-authored row is reclaimed for staff (re-resolving the staff author
-	// via resolveStaffID), a staff-authored row raises ErrCareExceptionDayConflict.
 	CreateOrReclaimException(ctx context.Context, studentID int64, date timezone.Date, pickupTime *time.Time, reason *string, staffID int64, resolveStaffID func() (int64, error)) (*schedule.StudentPickupException, error)
-	// UpdateException updates an existing pickup exception under the day lock,
-	// applying the guardian-reclaim-on-staff-edit policy and merging the optional
-	// reason/pickup patch onto the locked row.
 	UpdateException(ctx context.Context, exceptionID, studentID int64, date timezone.Date, reason *string, pickupTime *time.Time, resolveStaffID func() (int64, error)) (*schedule.StudentPickupException, error)
 
-	// Note operations
 	GetStudentPickupNoteByID(ctx context.Context, noteID int64) (*schedule.StudentPickupNote, error)
 	GetStudentPickupNotes(ctx context.Context, studentID int64) ([]*schedule.StudentPickupNote, error)
 	GetStudentPickupNotesForDate(ctx context.Context, studentID int64, date timezone.Date) ([]*schedule.StudentPickupNote, error)
@@ -61,26 +40,22 @@ type PickupScheduleService interface {
 	DeleteStudentPickupNote(ctx context.Context, noteID int64) error
 	DeleteAllStudentPickupNotes(ctx context.Context, studentID int64) error
 
-	// Computed operations
 	GetStudentPickupData(ctx context.Context, studentID int64) (*StudentPickupData, error)
 	GetEffectivePickupTimeForDate(ctx context.Context, studentID int64, date timezone.Date) (*EffectivePickupTime, error)
 	GetBulkEffectivePickupTimesForDate(ctx context.Context, studentIDs []int64, date timezone.Date) (map[int64]*EffectivePickupTime, error)
 }
 
-// StudentPickupData contains combined pickup schedule and exception data
 type StudentPickupData struct {
 	Schedules  []*schedule.StudentPickupSchedule  `json:"schedules"`
 	Exceptions []*schedule.StudentPickupException `json:"exceptions"`
 	Notes      []*schedule.StudentPickupNote      `json:"notes"`
 }
 
-// NoteData represents a single note in the effective pickup time response
 type NoteData struct {
 	ID      int64  `json:"id"`
 	Content string `json:"content"`
 }
 
-// EffectivePickupTime represents the pickup time for a specific date
 type EffectivePickupTime struct {
 	Date        timezone.Date `json:"date"`
 	PickupTime  *time.Time    `json:"pickup_time"`
@@ -90,25 +65,15 @@ type EffectivePickupTime struct {
 	DayNotes    []NoteData    `json:"day_notes,omitempty"`
 }
 
-// Operation names for ScheduleError.
-const (
-	opCreateStudentPickupException     = "create student pickup exception"
-	opUpdateStudentPickupException     = "update student pickup exception"
-	opUpsertBulkStudentPickupSchedules = "upsert bulk student pickup schedules"
-	opGetStudentPickupData             = "get student pickup data"
-	opGetEffectivePickupTime           = "get effective pickup time"
-	opGetBulkEffectivePickupTimes      = "get bulk effective pickup times"
-)
-
-// pickupScheduleService implements PickupScheduleService
 type pickupScheduleService struct {
-	scheduleRepo  schedule.StudentPickupScheduleRepository
-	exceptionRepo schedule.StudentPickupExceptionRepository
-	noteRepo      schedule.StudentPickupNoteRepository
-	db            *bun.DB
+	core *effectiveTimeCore[
+		*schedule.StudentPickupSchedule,
+		*schedule.StudentPickupException,
+		*schedule.StudentPickupNote,
+		pickupTimeDomain,
+	]
 }
 
-// NewPickupScheduleService creates a new pickup schedule service
 func NewPickupScheduleService(
 	scheduleRepo schedule.StudentPickupScheduleRepository,
 	exceptionRepo schedule.StudentPickupExceptionRepository,
@@ -116,603 +81,268 @@ func NewPickupScheduleService(
 	db *bun.DB,
 ) PickupScheduleService {
 	return &pickupScheduleService{
-		scheduleRepo:  scheduleRepo,
-		exceptionRepo: exceptionRepo,
-		noteRepo:      noteRepo,
-		db:            db,
+		core: newEffectiveTimeCore(
+			scheduleRepo,
+			exceptionRepo,
+			noteRepo,
+			db,
+			pickupTimeDomain{},
+		),
 	}
 }
 
-// Schedule operations
+func (s *pickupScheduleService) GetStudentPickupSchedules(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentPickupSchedule, error) {
+	return s.core.Schedules(ctx, studentID)
+}
 
-// GetStudentPickupSchedules returns all pickup schedules for a student
-func (s *pickupScheduleService) GetStudentPickupSchedules(ctx context.Context, studentID int64) ([]*schedule.StudentPickupSchedule, error) {
-	schedules, err := s.scheduleRepo.FindByStudentID(ctx, studentID)
+func (s *pickupScheduleService) GetWeeklySchedulesByStudentIDsAndWeekday(
+	ctx context.Context,
+	studentIDs []int64,
+	weekday int,
+) ([]*schedule.StudentPickupSchedule, error) {
+	return s.core.WeeklySchedulesByStudentIDsAndWeekday(ctx, studentIDs, weekday)
+}
+
+func (s *pickupScheduleService) GetStudentPickupScheduleForWeekday(
+	ctx context.Context,
+	studentID int64,
+	weekday int,
+) (*schedule.StudentPickupSchedule, error) {
+	return s.core.ScheduleForWeekday(ctx, studentID, weekday)
+}
+
+func (s *pickupScheduleService) UpsertStudentPickupSchedule(
+	ctx context.Context,
+	row *schedule.StudentPickupSchedule,
+) error {
+	return s.core.UpsertSchedule(ctx, row)
+}
+
+func (s *pickupScheduleService) UpsertBulkStudentPickupSchedules(
+	ctx context.Context,
+	studentID int64,
+	rows []*schedule.StudentPickupSchedule,
+) error {
+	return s.core.UpsertBulkSchedules(ctx, studentID, rows)
+}
+
+func (s *pickupScheduleService) DeleteStudentPickupSchedule(
+	ctx context.Context,
+	scheduleID int64,
+) error {
+	return s.core.DeleteSchedule(ctx, scheduleID)
+}
+
+func (s *pickupScheduleService) DeleteAllStudentPickupSchedules(
+	ctx context.Context,
+	studentID int64,
+) error {
+	return s.core.DeleteAllSchedules(ctx, studentID)
+}
+
+func (s *pickupScheduleService) GetStudentPickupExceptionByID(
+	ctx context.Context,
+	exceptionID int64,
+) (*schedule.StudentPickupException, error) {
+	return s.core.ExceptionByID(ctx, exceptionID)
+}
+
+func (s *pickupScheduleService) GetStudentPickupExceptionForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (*schedule.StudentPickupException, error) {
+	return s.core.ExceptionForDate(ctx, studentID, date)
+}
+
+func (s *pickupScheduleService) GetStudentPickupExceptions(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentPickupException, error) {
+	return s.core.Exceptions(ctx, studentID)
+}
+
+func (s *pickupScheduleService) GetUpcomingStudentPickupExceptions(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentPickupException, error) {
+	return s.core.UpcomingExceptions(ctx, studentID)
+}
+
+func (s *pickupScheduleService) CreateStudentPickupException(
+	ctx context.Context,
+	row *schedule.StudentPickupException,
+) error {
+	return s.core.CreateException(ctx, row)
+}
+
+func (s *pickupScheduleService) UpdateStudentPickupException(
+	ctx context.Context,
+	row *schedule.StudentPickupException,
+) error {
+	return s.core.UpdateExceptionRow(ctx, row)
+}
+
+func (s *pickupScheduleService) CreateOrReclaimException(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+	pickupTime *time.Time,
+	reason *string,
+	staffID int64,
+	resolveStaffID func() (int64, error),
+) (*schedule.StudentPickupException, error) {
+	return s.core.CreateOrReclaimException(
+		ctx,
+		studentID,
+		date,
+		pickupTime,
+		reason,
+		staffID,
+		resolveStaffID,
+	)
+}
+
+func (s *pickupScheduleService) UpdateException(
+	ctx context.Context,
+	exceptionID int64,
+	studentID int64,
+	date timezone.Date,
+	reason *string,
+	pickupTime *time.Time,
+	resolveStaffID func() (int64, error),
+) (*schedule.StudentPickupException, error) {
+	return s.core.UpdateException(
+		ctx,
+		exceptionID,
+		studentID,
+		date,
+		reason,
+		pickupTime,
+		resolveStaffID,
+	)
+}
+
+func (s *pickupScheduleService) DeleteStudentPickupException(
+	ctx context.Context,
+	exceptionID int64,
+) error {
+	return s.core.DeleteException(ctx, exceptionID)
+}
+
+func (s *pickupScheduleService) DeleteAllStudentPickupExceptions(
+	ctx context.Context,
+	studentID int64,
+) error {
+	return s.core.DeleteAllExceptions(ctx, studentID)
+}
+
+func (s *pickupScheduleService) GetStudentPickupNoteByID(
+	ctx context.Context,
+	noteID int64,
+) (*schedule.StudentPickupNote, error) {
+	return s.core.NoteByID(ctx, noteID)
+}
+
+func (s *pickupScheduleService) GetStudentPickupNotes(
+	ctx context.Context,
+	studentID int64,
+) ([]*schedule.StudentPickupNote, error) {
+	return s.core.Notes(ctx, studentID)
+}
+
+func (s *pickupScheduleService) GetStudentPickupNotesForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) ([]*schedule.StudentPickupNote, error) {
+	return s.core.NotesForDate(ctx, studentID, date)
+}
+
+func (s *pickupScheduleService) CreateStudentPickupNote(
+	ctx context.Context,
+	row *schedule.StudentPickupNote,
+) error {
+	return s.core.CreateNote(ctx, row)
+}
+
+func (s *pickupScheduleService) UpdateStudentPickupNote(
+	ctx context.Context,
+	row *schedule.StudentPickupNote,
+) error {
+	return s.core.UpdateNote(ctx, row)
+}
+
+func (s *pickupScheduleService) DeleteStudentPickupNote(
+	ctx context.Context,
+	noteID int64,
+) error {
+	return s.core.DeleteNote(ctx, noteID)
+}
+
+func (s *pickupScheduleService) DeleteAllStudentPickupNotes(
+	ctx context.Context,
+	studentID int64,
+) error {
+	return s.core.DeleteAllNotes(ctx, studentID)
+}
+
+func (s *pickupScheduleService) GetStudentPickupData(
+	ctx context.Context,
+	studentID int64,
+) (*StudentPickupData, error) {
+	data, err := s.core.Data(ctx, studentID)
 	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup schedules", Err: err}
-	}
-	return schedules, nil
-}
-
-// GetStudentPickupScheduleForWeekday returns the pickup schedule for a specific weekday
-func (s *pickupScheduleService) GetStudentPickupScheduleForWeekday(ctx context.Context, studentID int64, weekday int) (*schedule.StudentPickupSchedule, error) {
-	if weekday < schedule.WeekdayMonday || weekday > schedule.WeekdayFriday {
-		return nil, &ScheduleError{Op: "get student pickup schedule for weekday", Err: errors.New("invalid weekday")}
-	}
-
-	pickupSchedule, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup schedule for weekday", Err: err}
-	}
-	return pickupSchedule, nil
-}
-
-// UpsertStudentPickupSchedule creates or updates a pickup schedule
-func (s *pickupScheduleService) UpsertStudentPickupSchedule(ctx context.Context, scheduleData *schedule.StudentPickupSchedule) error {
-	if err := scheduleData.Validate(); err != nil {
-		return &ScheduleError{Op: "upsert student pickup schedule", Err: err}
-	}
-
-	if err := s.scheduleRepo.UpsertSchedule(ctx, scheduleData); err != nil {
-		return &ScheduleError{Op: "upsert student pickup schedule", Err: err}
-	}
-	return nil
-}
-
-// UpsertBulkStudentPickupSchedules replaces all pickup schedules for a student.
-// This deletes existing schedules and inserts the new ones atomically,
-// ensuring that cleared weekdays are properly removed.
-func (s *pickupScheduleService) UpsertBulkStudentPickupSchedules(ctx context.Context, studentID int64, schedules []*schedule.StudentPickupSchedule) error {
-	// Delete all existing schedules for this student first. The repository
-	// joins the handler's WithTenantTx transaction via the context.
-	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: opUpsertBulkStudentPickupSchedules, Err: fmt.Errorf("failed to delete existing schedules: %w", err)}
-	}
-
-	// Insert new schedules
-	for _, sched := range schedules {
-		sched.StudentID = studentID
-		if err := sched.Validate(); err != nil {
-			return &ScheduleError{Op: opUpsertBulkStudentPickupSchedules, Err: fmt.Errorf("invalid schedule for weekday %d: %w", sched.Weekday, err)}
-		}
-		sched.SetTenantID(tenant.FromContext(ctx))
-
-		if err := s.scheduleRepo.Create(ctx, sched); err != nil {
-			return &ScheduleError{Op: opUpsertBulkStudentPickupSchedules, Err: err}
-		}
-	}
-	return nil
-}
-
-// DeleteStudentPickupSchedule deletes a pickup schedule by ID
-func (s *pickupScheduleService) DeleteStudentPickupSchedule(ctx context.Context, scheduleID int64) error {
-	if err := s.scheduleRepo.Delete(ctx, scheduleID); err != nil {
-		return &ScheduleError{Op: "delete student pickup schedule", Err: err}
-	}
-	return nil
-}
-
-// DeleteAllStudentPickupSchedules deletes all pickup schedules for a student
-func (s *pickupScheduleService) DeleteAllStudentPickupSchedules(ctx context.Context, studentID int64) error {
-	if err := s.scheduleRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: "delete all student pickup schedules", Err: err}
-	}
-	return nil
-}
-
-// Exception operations
-
-// GetStudentPickupExceptionByID returns a pickup exception by its ID
-func (s *pickupScheduleService) GetStudentPickupExceptionByID(ctx context.Context, exceptionID int64) (*schedule.StudentPickupException, error) {
-	exception, err := s.exceptionRepo.FindByID(ctx, exceptionID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup exception by id", Err: err}
-	}
-	return exception, nil
-}
-
-// GetStudentPickupExceptionForDate returns the pickup exception for a student on
-// a specific date, or nil when none exists.
-func (s *pickupScheduleService) GetStudentPickupExceptionForDate(ctx context.Context, studentID int64, date timezone.Date) (*schedule.StudentPickupException, error) {
-	exception, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup exception for date", Err: err}
-	}
-	return exception, nil
-}
-
-// GetStudentPickupExceptions returns all pickup exceptions for a student
-func (s *pickupScheduleService) GetStudentPickupExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentPickupException, error) {
-	exceptions, err := s.exceptionRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup exceptions", Err: err}
-	}
-	return exceptions, nil
-}
-
-// GetUpcomingStudentPickupExceptions returns upcoming pickup exceptions for a student
-func (s *pickupScheduleService) GetUpcomingStudentPickupExceptions(ctx context.Context, studentID int64) ([]*schedule.StudentPickupException, error) {
-	exceptions, err := s.exceptionRepo.FindUpcomingByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get upcoming student pickup exceptions", Err: err}
-	}
-	return exceptions, nil
-}
-
-// CreateStudentPickupException creates a new pickup exception
-func (s *pickupScheduleService) CreateStudentPickupException(ctx context.Context, exception *schedule.StudentPickupException) error {
-	if err := exception.Validate(); err != nil {
-		return &ScheduleError{Op: opCreateStudentPickupException, Err: err}
-	}
-
-	// Check for existing exception on the same date
-	existing, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, exception.StudentID, exception.ExceptionDate)
-	if err != nil {
-		return &ScheduleError{Op: opCreateStudentPickupException, Err: err}
-	}
-	if existing != nil {
-		existing.PickupTime = exception.PickupTime
-		existing.Reason = exception.Reason
-		if err := s.exceptionRepo.Update(ctx, existing); err != nil {
-			return &ScheduleError{Op: opCreateStudentPickupException, Err: err}
-		}
-		*exception = *existing
-		return nil
-	}
-
-	exception.SetTenantID(tenant.FromContext(ctx))
-	if err := s.exceptionRepo.Create(ctx, exception); err != nil {
-		return &ScheduleError{Op: opCreateStudentPickupException, Err: err}
-	}
-	return nil
-}
-
-// UpdateStudentPickupException updates an existing pickup exception
-func (s *pickupScheduleService) UpdateStudentPickupException(ctx context.Context, exception *schedule.StudentPickupException) error {
-	if err := exception.Validate(); err != nil {
-		return &ScheduleError{Op: opUpdateStudentPickupException, Err: err}
-	}
-
-	// Check if changing date would conflict with another exception
-	existing, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, exception.StudentID, exception.ExceptionDate)
-	if err != nil {
-		return &ScheduleError{Op: opUpdateStudentPickupException, Err: err}
-	}
-	if existing != nil && existing.ID != exception.ID {
-		return &ScheduleError{Op: opUpdateStudentPickupException, Err: errors.New("exception already exists for this date")}
-	}
-
-	if err := s.exceptionRepo.Update(ctx, exception); err != nil {
-		return &ScheduleError{Op: opUpdateStudentPickupException, Err: err}
-	}
-	return nil
-}
-
-// CreateOrReclaimException creates a staff pickup exception for the day, or
-// resolves a collision with an already-existing row under the day lock. A
-// guardian-authored row is reclaimed for staff; a staff-authored row is refused
-// with ErrCareExceptionDayConflict so a concurrent staff edit is not silently
-// overwritten.
-func (s *pickupScheduleService) CreateOrReclaimException(ctx context.Context, studentID int64, date timezone.Date, pickupTime *time.Time, reason *string, staffID int64, resolveStaffID func() (int64, error)) (*schedule.StudentPickupException, error) {
-	var exception *schedule.StudentPickupException
-	tenantID := tenant.FromContext(ctx)
-	if err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		if err := LockCareExceptionDay(txCtx, s.db, studentID, date); err != nil {
-			return err
-		}
-
-		existing, err := s.GetStudentPickupExceptionForDate(txCtx, studentID, date)
-		if err != nil {
-			return err
-		}
-		if existing != nil {
-			if existing.Source != schedule.ExceptionSourceGuardian {
-				return ErrCareExceptionDayConflict
-			}
-			sid, staffErr := resolveStaffID()
-			if staffErr != nil || sid == 0 {
-				return ErrCareExceptionStaffProfileRequired
-			}
-			updated := &schedule.StudentPickupException{
-				StudentID:     studentID,
-				ExceptionDate: date,
-				PickupTime:    pickupTime,
-				Reason:        reason,
-				Source:        schedule.ExceptionSourceStaff,
-				CreatedBy:     sid,
-			}
-			updated.ID = existing.ID
-			updated.CreatedAt = existing.CreatedAt
-			updated.SetTenantID(existing.TenantID)
-			exception = updated
-			return s.UpdateStudentPickupException(txCtx, updated)
-		}
-
-		exception = &schedule.StudentPickupException{
-			StudentID:     studentID,
-			ExceptionDate: date,
-			PickupTime:    pickupTime,
-			Reason:        reason,
-			Source:        schedule.ExceptionSourceStaff,
-			CreatedBy:     staffID,
-		}
-		return s.CreateStudentPickupException(txCtx, exception)
-	}); err != nil {
 		return nil, err
 	}
-	return exception, nil
-}
-
-// UpdateException updates an existing pickup exception under the day lock. A
-// staff edit takes ownership of the day: a guardian-authored row is reclaimed
-// (staff author stamped, guardian link dropped); staff-authored rows keep their
-// original author. The optional reason/pickup patch is merged onto the locked
-// row.
-func (s *pickupScheduleService) UpdateException(ctx context.Context, exceptionID, studentID int64, date timezone.Date, reason *string, pickupTime *time.Time, resolveStaffID func() (int64, error)) (*schedule.StudentPickupException, error) {
-	var exception *schedule.StudentPickupException
-	tenantID := tenant.FromContext(ctx)
-	if err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		if err := LockCareExceptionDay(txCtx, s.db, studentID, date); err != nil {
-			return err
-		}
-		freshException, err := s.GetStudentPickupExceptionByID(txCtx, exceptionID)
-		if err != nil {
-			return err
-		}
-		if freshException == nil {
-			return ErrCareExceptionNotFound
-		}
-		if freshException.StudentID != studentID {
-			return ErrCareExceptionWrongStudent
-		}
-
-		source := freshException.Source
-		createdBy := freshException.CreatedBy
-		createdByGuardian := freshException.CreatedByGuardian
-		if freshException.Source == schedule.ExceptionSourceGuardian {
-			sid, staffErr := resolveStaffID()
-			if staffErr != nil || sid == 0 {
-				return ErrCareExceptionStaffProfileRequired
-			}
-			source = schedule.ExceptionSourceStaff
-			createdBy = sid
-			createdByGuardian = nil
-		}
-
-		pickupTimeValue := freshException.PickupTime
-		if pickupTimeValue != nil {
-			normalized := timezone.WallClock(*pickupTimeValue)
-			pickupTimeValue = &normalized
-		}
-
-		updated := &schedule.StudentPickupException{
-			StudentID:         studentID,
-			ExceptionDate:     date,
-			PickupTime:        pickupTimeValue,
-			Reason:            freshException.Reason,
-			Source:            source,
-			CreatedBy:         createdBy,
-			CreatedByGuardian: createdByGuardian,
-		}
-		updated.ID = exceptionID
-		updated.CreatedAt = freshException.CreatedAt
-		updated.SetTenantID(freshException.TenantID)
-
-		if reason != nil {
-			updated.Reason = reason
-		}
-		if pickupTime != nil {
-			updated.PickupTime = pickupTime
-		}
-
-		exception = updated
-		return s.UpdateStudentPickupException(txCtx, updated)
-	}); err != nil {
-		return nil, err
-	}
-	return exception, nil
-}
-
-// DeleteStudentPickupException deletes a pickup exception by ID
-func (s *pickupScheduleService) DeleteStudentPickupException(ctx context.Context, exceptionID int64) error {
-	if err := s.exceptionRepo.Delete(ctx, exceptionID); err != nil {
-		return &ScheduleError{Op: "delete student pickup exception", Err: err}
-	}
-	return nil
-}
-
-// DeleteAllStudentPickupExceptions deletes all pickup exceptions for a student
-func (s *pickupScheduleService) DeleteAllStudentPickupExceptions(ctx context.Context, studentID int64) error {
-	if err := s.exceptionRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: "delete all student pickup exceptions", Err: err}
-	}
-	return nil
-}
-
-// Note operations
-
-// GetStudentPickupNoteByID returns a pickup note by its ID
-func (s *pickupScheduleService) GetStudentPickupNoteByID(ctx context.Context, noteID int64) (*schedule.StudentPickupNote, error) {
-	note, err := s.noteRepo.FindByID(ctx, noteID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup note by id", Err: err}
-	}
-	return note, nil
-}
-
-// GetStudentPickupNotes returns all pickup notes for a student
-func (s *pickupScheduleService) GetStudentPickupNotes(ctx context.Context, studentID int64) ([]*schedule.StudentPickupNote, error) {
-	notes, err := s.noteRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup notes", Err: err}
-	}
-	return notes, nil
-}
-
-// GetStudentPickupNotesForDate returns pickup notes for a student on a specific date
-func (s *pickupScheduleService) GetStudentPickupNotesForDate(ctx context.Context, studentID int64, date timezone.Date) ([]*schedule.StudentPickupNote, error) {
-	notes, err := s.noteRepo.FindByStudentIDAndDate(ctx, studentID, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: "get student pickup notes for date", Err: err}
-	}
-	return notes, nil
-}
-
-// CreateStudentPickupNote creates a new pickup note
-func (s *pickupScheduleService) CreateStudentPickupNote(ctx context.Context, note *schedule.StudentPickupNote) error {
-	if err := note.Validate(); err != nil {
-		return &ScheduleError{Op: "create student pickup note", Err: err}
-	}
-
-	note.SetTenantID(tenant.FromContext(ctx))
-	if err := s.noteRepo.Create(ctx, note); err != nil {
-		return &ScheduleError{Op: "create student pickup note", Err: err}
-	}
-	return nil
-}
-
-// UpdateStudentPickupNote updates an existing pickup note
-func (s *pickupScheduleService) UpdateStudentPickupNote(ctx context.Context, note *schedule.StudentPickupNote) error {
-	if err := note.Validate(); err != nil {
-		return &ScheduleError{Op: "update student pickup note", Err: err}
-	}
-
-	if err := s.noteRepo.Update(ctx, note); err != nil {
-		return &ScheduleError{Op: "update student pickup note", Err: err}
-	}
-	return nil
-}
-
-// DeleteStudentPickupNote deletes a pickup note by ID
-func (s *pickupScheduleService) DeleteStudentPickupNote(ctx context.Context, noteID int64) error {
-	if err := s.noteRepo.Delete(ctx, noteID); err != nil {
-		return &ScheduleError{Op: "delete student pickup note", Err: err}
-	}
-	return nil
-}
-
-// DeleteAllStudentPickupNotes deletes all pickup notes for a student
-func (s *pickupScheduleService) DeleteAllStudentPickupNotes(ctx context.Context, studentID int64) error {
-	if err := s.noteRepo.DeleteByStudentID(ctx, studentID); err != nil {
-		return &ScheduleError{Op: "delete all student pickup notes", Err: err}
-	}
-	return nil
-}
-
-// Computed operations
-
-// GetStudentPickupData returns combined schedule, exception, and note data for a student.
-// Returns all exceptions and notes (not just upcoming) to support week view navigation to past weeks.
-func (s *pickupScheduleService) GetStudentPickupData(ctx context.Context, studentID int64) (*StudentPickupData, error) {
-	schedules, err := s.scheduleRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetStudentPickupData, Err: err}
-	}
-
-	exceptions, err := s.exceptionRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetStudentPickupData, Err: err}
-	}
-
-	notes, err := s.noteRepo.FindByStudentID(ctx, studentID)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetStudentPickupData, Err: err}
-	}
-
 	return &StudentPickupData{
-		Schedules:  schedules,
-		Exceptions: exceptions,
-		Notes:      notes,
+		Schedules:  data.Schedules,
+		Exceptions: data.Exceptions,
+		Notes:      data.Notes,
 	}, nil
 }
 
-// GetEffectivePickupTimeForDate calculates the effective pickup time for a specific date
-func (s *pickupScheduleService) GetEffectivePickupTimeForDate(ctx context.Context, studentID int64, date timezone.Date) (*EffectivePickupTime, error) {
-	weekday := int(date.Weekday())
-
-	// Convert Go weekday (Sunday=0) to ISO weekday (Monday=1)
-	if weekday == 0 {
-		weekday = 7
-	}
-
-	result := &EffectivePickupTime{
-		Date:        date,
-		WeekdayName: schedule.WeekdayNames[weekday],
-	}
-
-	// Weekend check
-	if weekday > schedule.WeekdayFriday {
-		return result, nil
-	}
-
-	// Check for exception on this date first
-	exception, err := s.exceptionRepo.FindByStudentIDAndDate(ctx, studentID, date)
+func (s *pickupScheduleService) GetEffectivePickupTimeForDate(
+	ctx context.Context,
+	studentID int64,
+	date timezone.Date,
+) (*EffectivePickupTime, error) {
+	result, err := s.core.EffectiveTimeForDate(ctx, studentID, date)
 	if err != nil {
-		return nil, &ScheduleError{Op: opGetEffectivePickupTime, Err: err}
+		return nil, err
 	}
-
-	if exception != nil {
-		result.IsException = true
-		result.PickupTime = exception.PickupTime
-		if reason := pickupNoteOverride(exception.Reason); reason != "" {
-			result.Notes = reason
-		} else {
-			sched, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
-			if err != nil {
-				return nil, &ScheduleError{Op: opGetEffectivePickupTime, Err: err}
-			}
-			result.Notes = pickupScheduleNotes(sched)
-		}
-	} else {
-		// Fall back to regular schedule
-		sched, err := s.scheduleRepo.FindByStudentIDAndWeekday(ctx, studentID, weekday)
-		if err != nil {
-			return nil, &ScheduleError{Op: opGetEffectivePickupTime, Err: err}
-		}
-
-		if sched != nil {
-			result.PickupTime = &sched.PickupTime
-			result.Notes = pickupScheduleNotes(sched)
-		}
-	}
-
-	// Load day notes
-	dayNotes, err := s.noteRepo.FindByStudentIDAndDate(ctx, studentID, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetEffectivePickupTime, Err: err}
-	}
-	for _, n := range dayNotes {
-		result.DayNotes = append(result.DayNotes, NoteData{ID: n.ID, Content: n.Content})
-	}
-
-	return result, nil
+	return pickupEffectiveTime(result), nil
 }
 
-// GetBulkEffectivePickupTimesForDate calculates effective pickup times for multiple students on a given date
-// Uses bulk database queries for optimal performance (O(2) queries instead of O(N))
-func (s *pickupScheduleService) GetBulkEffectivePickupTimesForDate(ctx context.Context, studentIDs []int64, date timezone.Date) (map[int64]*EffectivePickupTime, error) {
-	if len(studentIDs) == 0 {
-		return make(map[int64]*EffectivePickupTime), nil
-	}
-
-	weekday := int(date.Weekday())
-
-	// Convert Go weekday (Sunday=0) to ISO weekday (Monday=1)
-	if weekday == 0 {
-		weekday = 7
-	}
-
-	result := make(map[int64]*EffectivePickupTime, len(studentIDs))
-
-	// Initialize results for all students
-	for _, studentID := range studentIDs {
-		result[studentID] = &EffectivePickupTime{
-			Date:        date,
-			WeekdayName: schedule.WeekdayNames[weekday],
-		}
-	}
-
-	// Weekend check - all students have no pickup time
-	if weekday > schedule.WeekdayFriday {
-		return result, nil
-	}
-
-	// Bulk fetch all exceptions for the given date (single query)
-	exceptions, err := s.exceptionRepo.FindByStudentIDsAndDate(ctx, studentIDs, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetBulkEffectivePickupTimes, Err: err}
-	}
-
-	// Build exception map for O(1) lookup
-	exceptionMap := make(map[int64]*schedule.StudentPickupException, len(exceptions))
-	for _, exc := range exceptions {
-		exceptionMap[exc.StudentID] = exc
-	}
-
-	// Bulk fetch all schedules for the given weekday (single query)
-	schedules, err := s.scheduleRepo.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetBulkEffectivePickupTimes, Err: err}
-	}
-
-	// Build schedule map for O(1) lookup
-	scheduleMap := make(map[int64]*schedule.StudentPickupSchedule, len(schedules))
-	for _, sched := range schedules {
-		scheduleMap[sched.StudentID] = sched
-	}
-
-	// Bulk fetch all notes for the given date (single query)
-	notes, err := s.noteRepo.FindByStudentIDsAndDate(ctx, studentIDs, date)
-	if err != nil {
-		return nil, &ScheduleError{Op: opGetBulkEffectivePickupTimes, Err: err}
-	}
-
-	// Build notes map for grouping by student
-	notesMap := make(map[int64][]*schedule.StudentPickupNote)
-	for _, n := range notes {
-		notesMap[n.StudentID] = append(notesMap[n.StudentID], n)
-	}
-
-	// Merge results: exception takes precedence over schedule
-	mergePickupResults(studentIDs, result, exceptionMap, scheduleMap, notesMap)
-
-	return result, nil
-}
-
-// mergePickupResults merges exception, schedule, and note data into effective pickup times
-func mergePickupResults(
+func (s *pickupScheduleService) GetBulkEffectivePickupTimesForDate(
+	ctx context.Context,
 	studentIDs []int64,
-	result map[int64]*EffectivePickupTime,
-	exceptionMap map[int64]*schedule.StudentPickupException,
-	scheduleMap map[int64]*schedule.StudentPickupSchedule,
-	notesMap map[int64][]*schedule.StudentPickupNote,
-) {
-	for _, studentID := range studentIDs {
-		r := result[studentID]
-		sched := scheduleMap[studentID]
-
-		// Check for exception first (takes priority)
-		if exc, ok := exceptionMap[studentID]; ok {
-			r.IsException = true
-			r.PickupTime = exc.PickupTime
-			if reason := pickupNoteOverride(exc.Reason); reason != "" {
-				r.Notes = reason
-			} else {
-				r.Notes = pickupScheduleNotes(sched)
-			}
-		} else if sched != nil {
-			// Fall back to regular schedule
-			r.PickupTime = &sched.PickupTime
-			r.Notes = pickupScheduleNotes(sched)
-		}
-
-		// Attach day notes
-		if dayNotes, ok := notesMap[studentID]; ok {
-			for _, n := range dayNotes {
-				r.DayNotes = append(r.DayNotes, NoteData{ID: n.ID, Content: n.Content})
-			}
-		}
+	date timezone.Date,
+) (map[int64]*EffectivePickupTime, error) {
+	results, err := s.core.BulkEffectiveTimesForDate(ctx, studentIDs, date)
+	if err != nil {
+		return nil, err
 	}
+	mapped := make(map[int64]*EffectivePickupTime, len(results))
+	for studentID, result := range results {
+		mapped[studentID] = pickupEffectiveTime(result)
+	}
+	return mapped, nil
 }
 
-func pickupNoteOverride(reason *string) string {
-	if reason == nil {
-		return ""
+func pickupEffectiveTime(result *effectiveTimeResult) *EffectivePickupTime {
+	mapped := &EffectivePickupTime{
+		Date:        result.Date,
+		PickupTime:  result.Time,
+		WeekdayName: result.WeekdayName,
+		IsException: result.IsException,
+		Notes:       result.Notes,
 	}
-
-	return strings.TrimSpace(*reason)
-}
-
-func pickupScheduleNotes(sched *schedule.StudentPickupSchedule) string {
-	if sched == nil || sched.Notes == nil {
-		return ""
+	for _, note := range result.DayNotes {
+		mapped.DayNotes = append(mapped.DayNotes, NoteData(note))
 	}
-
-	return strings.TrimSpace(*sched.Notes)
-}
-
-// GetWeeklySchedulesByStudentIDsAndWeekday returns the raw weekly pickup
-// schedules of many students for one weekday.
-func (s *pickupScheduleService) GetWeeklySchedulesByStudentIDsAndWeekday(ctx context.Context, studentIDs []int64, weekday int) ([]*schedule.StudentPickupSchedule, error) {
-	return s.scheduleRepo.FindByStudentIDsAndWeekday(ctx, studentIDs, weekday)
+	return mapped
 }


### PR DESCRIPTION
## Summary
- replace the duplicate pickup/arrival repository trios with typed shared tenant-scoped repositories
- route both services through one effective-time core with a typed domain strategy
- share handler validation, access checks, ownership checks, and bulk response orchestration while keeping routes and JSON contracts unchanged

## Behavior preserved
- pickup same-date exception creation updates the existing row
- arrival same-date exception creation still returns an error
- both domain-named service interfaces remain intact for external callers
- arrival class bulk upsert remains arrival-only
- pickup and arrival SSE writes still run through their existing after-commit hooks

## Test plan
- `go test ./database/repositories/schedule ./services/schedule ./api/students -run 'Pickup|Arrival' -count=1`
- `go test -race ./database/repositories/schedule ./services/schedule ./api/students -run 'Pickup|Arrival' -count=1`
- `go vet ./...`
- `golangci-lint run`
- backend architecture and hermetic-test ratchets
- `pnpm run check`
- Docker Compose browser QA: edited both weekly plans, created both dated exceptions and notes, reloaded, and verified persistence

The serial full backend run reached all packages. All changed packages passed; one unrelated parent-announcement repository test failed once and passed on an isolated rerun.

Closes #1855
