### PR TITLE
feat: Benachrichtigungs-Abstraktion hinter Feature Flag (#1624)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -36,6 +36,7 @@ import (
 	importAPI "github.com/moto-nrw/project-phoenix/api/import"
 	iotAPI "github.com/moto-nrw/project-phoenix/api/iot"
 	mealplanAPI "github.com/moto-nrw/project-phoenix/api/mealplan"
+	notificationsAPI "github.com/moto-nrw/project-phoenix/api/notifications"
 	remindersAPI "github.com/moto-nrw/project-phoenix/api/reminders"
 	roomsAPI "github.com/moto-nrw/project-phoenix/api/rooms"
 	schedulesAPI "github.com/moto-nrw/project-phoenix/api/schedules"
@@ -110,6 +111,7 @@ type API struct {
 	Calendar         *calendarAPI.Resource
 	Announcements    *announcementAPI.Resource
 	Reminders        *remindersAPI.Resource
+	Notifications    *notificationsAPI.Resource
 
 	// Operator Dashboard (platform domain)
 	Operator *operatorAPI.Resource
@@ -516,6 +518,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	})
 	api.Emergency = emergencyAPI.NewResource(api.Services.Emergency, db)
 	api.Reminders = remindersAPI.NewResource(api.Services.Reminders, api.Services.UserContext, db)
+	api.Notifications = notificationsAPI.NewResource(api.Services.Notifications, db)
 
 	// Initialize operator dashboard resources
 	api.Operator = operatorAPI.NewResource(operatorAPI.ResourceConfig{
@@ -778,6 +781,9 @@ func (a *API) registerTenantRoutes() {
 
 		// Mount reminders resources (visual-only staff reminders, issue #1457)
 		r.Mount("/reminders", a.Reminders.Router())
+
+		// Mount notification abstraction resources (issue #1624)
+		r.Mount("/notifications", a.Notifications.Router())
 
 		// Mount admin resources
 		r.Mount("/admin/grade-transitions", a.GradeTransitions.Router())

--- a/backend/api/notifications/api.go
+++ b/backend/api/notifications/api.go
@@ -1,0 +1,81 @@
+// Package notifications exposes the notification abstraction (#1624) over
+// HTTP. Its single endpoint lets an admin fire a test notification to verify
+// the tenant's setup end to end; real producers (reminders, #669) call the
+// service directly.
+package notifications
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// Resource wires the notification routes.
+type Resource struct {
+	NotificationsService notificationsService.Service
+	db                   *bun.DB
+}
+
+// NewResource builds the notifications HTTP resource.
+func NewResource(service notificationsService.Service, db *bun.DB) *Resource {
+	return &Resource{NotificationsService: service, db: db}
+}
+
+// Router mounts the notification routes behind tenant JWT auth.
+func (rs *Resource) Router() chi.Router {
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+
+	common.ProtectedTenantGroup(r, rs.db, func(r chi.Router, withTx common.Middleware) {
+		// config:update — the same permission that guards the feature flag —
+		// so exactly the admins who can enable notifications can test them.
+		r.With(authorize.RequiresPermission(permissions.ConfigUpdate), withTx).Post("/test", rs.sendTestNotification)
+	})
+
+	return r
+}
+
+// sendTestNotification fires a fixed, display-safe test event to the caller's
+// whole tenant so an admin can verify the notification setup (feature flag on,
+// SSE connected, toast rendering) without waiting for a real producer.
+func (rs *Resource) sendTestNotification(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if rs.NotificationsService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notifications service is not configured")))
+		return
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		common.RenderError(w, r, common.ErrorForbidden(errors.New("missing tenant context")))
+		return
+	}
+
+	err := rs.NotificationsService.Notify(ctx, notificationsService.Event{
+		Type:     "test",
+		Audience: notificationsService.Audience{TenantID: tenantID, Scope: notificationsService.ScopeTenant},
+		Priority: notificationsService.PriorityNormal,
+		Title:    "Testbenachrichtigung",
+		Body:     "Die Benachrichtigungen sind korrekt eingerichtet.",
+		DeepLink: "/dashboard",
+	})
+	switch {
+	case errors.Is(err, notificationsService.ErrDisabled):
+		common.RenderError(w, r, common.ErrorConflict(errors.New("notifications are disabled for this tenant")))
+		return
+	case err != nil:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, nil, "Test notification dispatched")
+}

--- a/backend/api/notifications/api_internal_test.go
+++ b/backend/api/notifications/api_internal_test.go
@@ -1,0 +1,90 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureService records the event the handler dispatched.
+type captureService struct {
+	gotEvent notificationsService.Event
+	called   bool
+	err      error
+}
+
+func (c *captureService) Notify(_ context.Context, event notificationsService.Event) error {
+	c.called = true
+	c.gotEvent = event
+	return c.err
+}
+
+func newTestRequest(tenantID int64) *http.Request {
+	ctx := context.Background()
+	if tenantID > 0 {
+		ctx = tenant.WithTenantID(ctx, tenantID)
+	}
+	return httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx)
+}
+
+func TestSendTestNotificationDispatchesTenantEvent(t *testing.T) {
+	svc := &captureService{}
+	rs := &Resource{NotificationsService: svc}
+
+	rec := httptest.NewRecorder()
+	rs.sendTestNotification(rec, newTestRequest(41))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, svc.called)
+	assert.Equal(t, "test", svc.gotEvent.Type)
+	assert.Equal(t, int64(41), svc.gotEvent.Audience.TenantID)
+	assert.Equal(t, notificationsService.ScopeTenant, svc.gotEvent.Audience.Scope)
+	assert.NotEmpty(t, svc.gotEvent.Title)
+}
+
+func TestSendTestNotificationDisabledMapsToConflict(t *testing.T) {
+	svc := &captureService{err: notificationsService.ErrDisabled}
+	rs := &Resource{NotificationsService: svc}
+
+	rec := httptest.NewRecorder()
+	rs.sendTestNotification(rec, newTestRequest(41))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestSendTestNotificationErrorsMapToInternal(t *testing.T) {
+	svc := &captureService{err: errors.New("boom")}
+	rs := &Resource{NotificationsService: svc}
+
+	rec := httptest.NewRecorder()
+	rs.sendTestNotification(rec, newTestRequest(41))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestSendTestNotificationMissingTenant(t *testing.T) {
+	svc := &captureService{}
+	rs := &Resource{NotificationsService: svc}
+
+	rec := httptest.NewRecorder()
+	rs.sendTestNotification(rec, newTestRequest(0))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, svc.called)
+}
+
+func TestSendTestNotificationNilService(t *testing.T) {
+	rs := &Resource{}
+
+	rec := httptest.NewRecorder()
+	rs.sendTestNotification(rec, newTestRequest(41))
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -552,6 +552,7 @@ POST /api/me/profile/avatar
 POST /api/messages/threads
 POST /api/messages/threads/open
 POST /api/messages/threads/{threadId}
+POST /api/notifications/test
 POST /api/parent-announcements/
 POST /api/parent-announcements/{announcementId}/publish
 POST /api/parent-announcements/{announcementId}/unpublish

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -160,6 +160,10 @@ const (
 	// KeyNotificationsAbsenceApprovalEmail toggles the absence-request email
 	// notifications (request received / approved / declined / Rückfrage, #1419).
 	KeyNotificationsAbsenceApprovalEmail = "notifications.absence_approval_email"
+	// KeyNotificationsDispatchEnabled is the feature flag for the notification
+	// abstraction (#1624). When off (the default), Notify(ctx, event) is a
+	// no-op and no channel delivers anything.
+	KeyNotificationsDispatchEnabled = "notifications.dispatch_enabled"
 )
 
 // PresenceMode option values for KeyPresenceMode.

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -164,8 +164,8 @@ type Event struct {
 	Timestamp     time.Time `json:"timestamp"`
 }
 
-// EventData contains the payload for an SSE event
-// Only includes display-level data for GDPR compliance (no sensitive info)
+// EventData contains the payload for an SSE event. Fields follow the
+// event-specific GDPR contract and must not expose sensitive data.
 type EventData struct {
 	// Student-related fields (for check-in/check-out events)
 	StudentID   *string `json:"student_id,omitempty"`
@@ -221,12 +221,14 @@ type EventData struct {
 
 	// Notification fields (notification events only, #1624). Display-safe by
 	// contract: the notifications service validates that no sensitive student
-	// data travels here — clients render these directly instead of refetching.
-	Title            *string `json:"title,omitempty"`
-	Body             *string `json:"body,omitempty"`
-	DeepLink         *string `json:"deep_link,omitempty"` // app-relative path, e.g. "/reminders"
-	Priority         *string `json:"priority,omitempty"`  // "low" | "normal" | "high"
-	NotificationType *string `json:"notification_type,omitempty"`
+	// data travels in the visible fields — clients render these directly instead
+	// of refetching. NotificationData contains only opaque routing IDs.
+	Title            *string           `json:"title,omitempty"`
+	Body             *string           `json:"body,omitempty"`
+	DeepLink         *string           `json:"deep_link,omitempty"` // app-relative path, e.g. "/reminders"
+	Priority         *string           `json:"priority,omitempty"`  // "low" | "normal" | "high"
+	NotificationType *string           `json:"notification_type,omitempty"`
+	NotificationData map[string]string `json:"notification_data,omitempty"` // opaque IDs for client-side routing
 }
 
 // staffSafeParentMessage returns a copy of a parent-message event with every

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -145,6 +145,15 @@ const (
 	// must NOT touch any unread badge or thread list; it carries only student_id so
 	// the affected child's view refetches while others skip. Trigger only.
 	EventParentChildUpdated EventType = "parent_child_updated"
+
+	// EventNotification carries a user-facing notification from the
+	// notification abstraction (services/notifications, #1624) over the SSE
+	// channel. Unlike every other event type it is NOT a cache-invalidation
+	// trigger: clients render Title/Body directly (toast/bell). The payload is
+	// display-safe by contract — the notifications service only accepts
+	// non-sensitive title/body text and an app-relative deep link; sensitive
+	// details are loaded authenticated after following the link (GDPR).
+	EventNotification EventType = "notification"
 )
 
 // Event represents a Server-Sent Event that will be broadcast to clients
@@ -209,6 +218,15 @@ type EventData struct {
 
 	// Reason tracking for generic refresh events.
 	Reason *string `json:"reason,omitempty"`
+
+	// Notification fields (notification events only, #1624). Display-safe by
+	// contract: the notifications service validates that no sensitive student
+	// data travels here — clients render these directly instead of refetching.
+	Title            *string `json:"title,omitempty"`
+	Body             *string `json:"body,omitempty"`
+	DeepLink         *string `json:"deep_link,omitempty"` // app-relative path, e.g. "/reminders"
+	Priority         *string `json:"priority,omitempty"`  // "low" | "normal" | "high"
+	NotificationType *string `json:"notification_type,omitempty"`
 }
 
 // staffSafeParentMessage returns a copy of a parent-message event with every

--- a/backend/services/config/defaults/notifications.go
+++ b/backend/services/config/defaults/notifications.go
@@ -20,4 +20,19 @@ func init() {
 		Category:        "zeiterfassung",
 		SortOrder:       5,
 	})
+
+	// Feature flag for the notification abstraction (#1624). Default off:
+	// Notify(ctx, event) is a no-op until a school explicitly enables it.
+	config.Register(config.Definition{
+		Key:             config.KeyNotificationsDispatchEnabled,
+		Label:           "Benachrichtigungen aktivieren",
+		Description:     "Aktiviert die zentrale Benachrichtigungs-Funktion (In-App-Hinweise, Grundlage für spätere Erinnerungen und Push-Nachrichten). Standardmäßig deaktiviert.",
+		Type:            config.FieldBoolean,
+		Default:         false,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "benachrichtigungen",
+		SortOrder:       1,
+	})
 }

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -44,6 +44,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/services/listexport"
 	"github.com/moto-nrw/project-phoenix/services/mealplan"
 	"github.com/moto-nrw/project-phoenix/services/messaging"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/parent"
 	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	"github.com/moto-nrw/project-phoenix/services/platform"
@@ -116,6 +117,7 @@ type Factory struct {
 	Emergency                *emergency.Service
 	SlotLists                slotlists.Service
 	Reminders                reminders.Service
+	Notifications            notifications.Service
 	RealtimeHub              *realtime.Hub     // SSE event hub (shared by services and API)
 	Tracker                  analytics.Tracker // Product analytics (PostHog; no-op without POSTHOG_API_KEY)
 	Mailer                   email.Mailer
@@ -1584,6 +1586,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Logger:              logger.With("service", "slot_lists"),
 	})
 
+	notificationsService := notifications.NewService(
+		settingsService,
+		logger.With("service", "notifications"),
+		notifications.NewSSEChannel(realtimeHub),
+		notifications.NewWebPushChannel(logger.With("channel", "web_push")),
+	)
+
 	remindersService := reminders.NewService(reminders.Dependencies{
 		Settings:    settingsService,
 		Attendance:  repos.Attendance,
@@ -1656,6 +1665,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Emergency:                emergencyService,
 		SlotLists:                slotListsService,
 		Reminders:                remindersService,
+		Notifications:            notificationsService,
 		RealtimeHub:              realtimeHub, // Expose SSE hub for API layer
 		Tracker:                  tracker,     // Product analytics (PostHog)
 		Invitation:               invitationService,

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -1,0 +1,188 @@
+// Package notifications is the notification abstraction for issue #1624: a
+// single entry point — Notify(ctx, event) — through which features trigger
+// user-facing notifications without knowing the delivery channels.
+//
+// Design:
+//
+//   - Features build an Event (type, audience, priority, display-safe title/
+//     body, deep link) and call Service.Notify. They never talk to a channel.
+//   - The service checks the per-tenant feature flag
+//     notifications.dispatch_enabled (default OFF) and, when enabled, fans the
+//     event out to every registered Channel. Channel failures are logged and
+//     never block the caller (fire-and-forget, mirroring SSE broadcasting).
+//   - Channels are pluggable: today an SSE/in-app channel (wrapping the
+//     existing realtime.Broadcaster — the existing SSE cache-invalidation
+//     events are untouched) and a web-push stub. E-mail and real Web Push are
+//     future channels; see docs/notifications.md.
+//
+// GDPR contract: Title, Body and DeepLink are the ONLY user-visible fields and
+// must be display-safe — no student names or other sensitive child data. A
+// deep link points into the authenticated app, where sensitive details are
+// loaded after login. Data carries opaque IDs only.
+package notifications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+)
+
+// Priority levels for a notification event.
+const (
+	PriorityLow    = "low"
+	PriorityNormal = "normal"
+	PriorityHigh   = "high"
+)
+
+// AudienceScope selects who receives a notification.
+type AudienceScope string
+
+const (
+	// ScopeTenant delivers to every connected client of the tenant (staff app).
+	ScopeTenant AudienceScope = "tenant"
+	// ScopeGuardian delivers only to one guardian account's own clients.
+	ScopeGuardian AudienceScope = "guardian"
+	// ScopeGroup delivers to clients subscribed to one active group.
+	ScopeGroup AudienceScope = "group"
+)
+
+// Audience describes the recipients of an event. TenantID is always required;
+// the other fields depend on Scope.
+type Audience struct {
+	TenantID          int64
+	Scope             AudienceScope
+	GuardianAccountID int64  // required for ScopeGuardian
+	ActiveGroupID     string // required for ScopeGroup
+}
+
+// Event is a channel-agnostic notification. Title/Body/DeepLink are
+// display-safe by contract (see the package comment); Data carries additional
+// non-sensitive values (opaque IDs) for client-side routing.
+type Event struct {
+	Type     string // e.g. "test", later "pickup_upcoming" (#669)
+	Audience Audience
+	Priority string // PriorityLow/Normal/High; empty defaults to normal
+	Title    string
+	Body     string
+	DeepLink string // app-relative path ("/reminders"); never an absolute URL
+	Data     map[string]string
+}
+
+// ErrDisabled is returned by Notify when notifications.dispatch_enabled is
+// off for the event's tenant. Callers that fire notifications as a side
+// effect should treat it as a silent no-op; the test endpoint surfaces it.
+var ErrDisabled = errors.New("notifications are disabled for this tenant")
+
+// Channel delivers an event over one transport. Implementations must be
+// fire-and-forget-safe: a returned error is logged by the router and never
+// propagated to the feature that triggered the event.
+type Channel interface {
+	Name() string
+	Deliver(ctx context.Context, event Event) error
+}
+
+// Service is the entry point features use to trigger notifications.
+type Service interface {
+	// Notify validates the event, checks the tenant feature flag, and fans
+	// the event out to all registered channels. Returns ErrDisabled when the
+	// flag is off and a validation error for malformed events; channel
+	// delivery failures are logged, not returned.
+	Notify(ctx context.Context, event Event) error
+}
+
+type router struct {
+	settings configService.SettingsService
+	channels []Channel
+	logger   *slog.Logger
+}
+
+// NewService builds the channel router. Channels are fixed at wiring time.
+func NewService(settings configService.SettingsService, logger *slog.Logger, channels ...Channel) Service {
+	return &router{settings: settings, channels: channels, logger: logger}
+}
+
+func (r *router) getLogger() *slog.Logger {
+	if r.logger == nil {
+		return slog.Default()
+	}
+	return r.logger
+}
+
+// validate rejects malformed events before any channel sees them. It also
+// enforces the shape of the GDPR contract that CAN be checked mechanically:
+// a deep link must be app-relative so a payload can never smuggle users to an
+// external site.
+func validate(event Event) error {
+	if event.Type == "" {
+		return errors.New("notification event requires a type")
+	}
+	if event.Audience.TenantID <= 0 {
+		return errors.New("notification event requires a tenant id")
+	}
+	if event.Title == "" {
+		return errors.New("notification event requires a title")
+	}
+	switch event.Audience.Scope {
+	case ScopeTenant:
+	case ScopeGuardian:
+		if event.Audience.GuardianAccountID <= 0 {
+			return errors.New("guardian-scoped notification requires a guardian account id")
+		}
+	case ScopeGroup:
+		if event.Audience.ActiveGroupID == "" {
+			return errors.New("group-scoped notification requires an active group id")
+		}
+	default:
+		return fmt.Errorf("unknown audience scope %q", event.Audience.Scope)
+	}
+	if event.DeepLink != "" && (!strings.HasPrefix(event.DeepLink, "/") || strings.HasPrefix(event.DeepLink, "//")) {
+		return errors.New("deep link must be an app-relative path")
+	}
+	switch event.Priority {
+	case "", PriorityLow, PriorityNormal, PriorityHigh:
+	default:
+		return fmt.Errorf("unknown priority %q", event.Priority)
+	}
+	return nil
+}
+
+func (r *router) Notify(ctx context.Context, event Event) error {
+	if err := validate(event); err != nil {
+		return err
+	}
+	if event.Priority == "" {
+		event.Priority = PriorityNormal
+	}
+
+	if r.settings == nil {
+		return errors.New("notifications service has no settings service configured")
+	}
+	// ResolveBoolForTenant works with and without tenant middleware, so
+	// scheduler-style producers can notify outside a request context.
+	enabled, err := r.settings.ResolveBoolForTenant(ctx, event.Audience.TenantID, configModel.KeyNotificationsDispatchEnabled)
+	if err != nil {
+		return fmt.Errorf("resolving notification feature flag: %w", err)
+	}
+	if !enabled {
+		return ErrDisabled
+	}
+
+	for _, ch := range r.channels {
+		if err := ch.Deliver(ctx, event); err != nil {
+			// Fire-and-forget per channel: one failing channel must neither
+			// block the caller nor the remaining channels.
+			r.getLogger().Error("notification channel delivery failed",
+				"channel", ch.Name(),
+				"notification_type", event.Type,
+				"tenant_id", event.Audience.TenantID,
+				"error", err.Error(),
+			)
+		}
+	}
+	return nil
+}

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -140,7 +140,9 @@ func validate(event Event) error {
 	default:
 		return fmt.Errorf("unknown audience scope %q", event.Audience.Scope)
 	}
-	if event.DeepLink != "" && (!strings.HasPrefix(event.DeepLink, "/") || strings.HasPrefix(event.DeepLink, "//")) {
+	if event.DeepLink != "" && (!strings.HasPrefix(event.DeepLink, "/") ||
+		strings.HasPrefix(event.DeepLink, "//") ||
+		strings.Contains(event.DeepLink, `\`)) {
 		return errors.New("deep link must be an app-relative path")
 	}
 	switch event.Priority {

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -8,8 +8,9 @@
 //     body, deep link) and call Service.Notify. They never talk to a channel.
 //   - The service checks the per-tenant feature flag
 //     notifications.dispatch_enabled (default OFF) and, when enabled, fans the
-//     event out to every registered Channel. Channel failures are logged and
-//     never block the caller (fire-and-forget, mirroring SSE broadcasting).
+//     event out to every registered Channel after the surrounding tenant
+//     transaction commits. Channel failures are logged and never block the
+//     caller (fire-and-forget, mirroring SSE broadcasting).
 //   - Channels are pluggable: today an SSE/in-app channel (wrapping the
 //     existing realtime.Broadcaster — the existing SSE cache-invalidation
 //     events are untouched) and a web-push stub. E-mail and real Web Push are
@@ -26,10 +27,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // Priority levels for a notification event.
@@ -89,9 +93,10 @@ type Channel interface {
 // Service is the entry point features use to trigger notifications.
 type Service interface {
 	// Notify validates the event, checks the tenant feature flag, and fans
-	// the event out to all registered channels. Returns ErrDisabled when the
-	// flag is off and a validation error for malformed events; channel
-	// delivery failures are logged, not returned.
+	// the event out to all registered channels after the surrounding tenant
+	// transaction commits. Returns ErrDisabled when the flag is off and a
+	// validation error for malformed events; channel delivery failures are
+	// logged, not returned.
 	Notify(ctx context.Context, event Event) error
 }
 
@@ -174,6 +179,17 @@ func (r *router) Notify(ctx context.Context, event Event) error {
 		return ErrDisabled
 	}
 
+	// Channels run after commit, so they must not inherit the closed transaction.
+	// Snapshot the mutable payload before the callback outlives this call.
+	dispatchCtx := modelBase.ContextWithoutTx(ctx)
+	event.Data = maps.Clone(event.Data)
+	tenant.RegisterAfterCommit(ctx, func() {
+		r.deliver(dispatchCtx, event)
+	})
+	return nil
+}
+
+func (r *router) deliver(ctx context.Context, event Event) {
 	for _, ch := range r.channels {
 		if err := ch.Deliver(ctx, event); err != nil {
 			// Fire-and-forget per channel: one failing channel must neither
@@ -186,5 +202,4 @@ func (r *router) Notify(ctx context.Context, event Event) error {
 			)
 		}
 	}
-	return nil
 }

--- a/backend/services/notifications/service_test.go
+++ b/backend/services/notifications/service_test.go
@@ -1,7 +1,10 @@
 package notifications_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +16,21 @@ import (
 	"github.com/moto-nrw/project-phoenix/services/notifications"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
+
+type recordingChannel struct {
+	name   string
+	err    error
+	events []notifications.Event
+}
+
+func (c *recordingChannel) Name() string {
+	return c.name
+}
+
+func (c *recordingChannel) Deliver(_ context.Context, event notifications.Event) error {
+	c.events = append(c.events, event)
+	return c.err
+}
 
 // enabledSettings returns a settings mock with the dispatch flag set as given.
 func enabledSettings(enabled bool) *configtest.Mock {
@@ -91,6 +109,10 @@ func TestNotifyValidation(t *testing.T) {
 	svc := notifications.NewService(enabledSettings(true), nil)
 	ctx := context.Background()
 
+	missingType := tenantEvent(41)
+	missingType.Type = ""
+	assert.EqualError(t, svc.Notify(ctx, missingType), "notification event requires a type")
+
 	missingTitle := tenantEvent(41)
 	missingTitle.Title = ""
 	assert.Error(t, svc.Notify(ctx, missingTitle))
@@ -105,6 +127,10 @@ func TestNotifyValidation(t *testing.T) {
 	guardianWithoutAccount := tenantEvent(41)
 	guardianWithoutAccount.Audience.Scope = notifications.ScopeGuardian
 	assert.Error(t, svc.Notify(ctx, guardianWithoutAccount))
+
+	groupWithoutID := tenantEvent(41)
+	groupWithoutID.Audience.Scope = notifications.ScopeGroup
+	assert.EqualError(t, svc.Notify(ctx, groupWithoutID), "group-scoped notification requires an active group id")
 
 	externalLink := tenantEvent(41)
 	externalLink.DeepLink = "https://example.com/phish"
@@ -126,4 +152,66 @@ func TestNotifyChannelErrorDoesNotPropagate(t *testing.T) {
 
 	assert.NoError(t, svc.Notify(context.Background(), tenantEvent(41)),
 		"channel failures are fire-and-forget and must not reach the caller")
+}
+
+func TestNotifyConfigurationErrors(t *testing.T) {
+	ctx := context.Background()
+
+	withoutSettings := notifications.NewService(nil, nil)
+	assert.EqualError(t, withoutSettings.Notify(ctx, tenantEvent(41)),
+		"notifications service has no settings service configured")
+
+	settingsErr := errors.New("settings unavailable")
+	failingSettings := &configtest.Mock{
+		ResolveBoolForTenantFn: func(_ context.Context, _ int64, _ string) (bool, error) {
+			return false, settingsErr
+		},
+	}
+	svc := notifications.NewService(failingSettings, nil)
+	err := svc.Notify(ctx, tenantEvent(41))
+	require.ErrorContains(t, err, "resolving notification feature flag")
+	require.ErrorIs(t, err, settingsErr)
+}
+
+func TestNotifyContinuesAfterChannelFailureAndLogs(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	failing := &recordingChannel{name: "failing", err: assert.AnError}
+	succeeding := &recordingChannel{name: "succeeding"}
+	svc := notifications.NewService(enabledSettings(true), logger, failing, succeeding)
+
+	event := tenantEvent(41)
+	event.Priority = notifications.PriorityHigh
+	require.NoError(t, svc.Notify(context.Background(), event))
+
+	require.Len(t, failing.events, 1)
+	require.Len(t, succeeding.events, 1, "one failed channel must not block later channels")
+	assert.Equal(t, notifications.PriorityHigh, succeeding.events[0].Priority)
+	assert.Contains(t, logs.String(), "notification channel delivery failed")
+	assert.Contains(t, logs.String(), "channel=failing")
+}
+
+func TestSSEChannelRejectsUnknownAudienceScope(t *testing.T) {
+	channel := notifications.NewSSEChannel(testpkg.NewRecordingBroadcaster())
+	event := tenantEvent(41)
+	event.Audience.Scope = "unknown"
+
+	err := channel.Deliver(context.Background(), event)
+	require.EqualError(t, err, `sse channel cannot route audience scope "unknown" (tenant 41)`)
+}
+
+func TestWebPushChannelStub(t *testing.T) {
+	event := tenantEvent(41)
+
+	defaultLoggerChannel := notifications.NewWebPushChannel(nil)
+	assert.Equal(t, "web_push", defaultLoggerChannel.Name())
+	require.NoError(t, defaultLoggerChannel.Deliver(context.Background(), event))
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	channel := notifications.NewWebPushChannel(logger)
+	require.NoError(t, channel.Deliver(context.Background(), event))
+	assert.Contains(t, logs.String(), "web push channel not yet activated")
+	assert.Contains(t, logs.String(), "notification_type=test")
+	assert.Contains(t, logs.String(), "tenant_id=41")
 }

--- a/backend/services/notifications/service_test.go
+++ b/backend/services/notifications/service_test.go
@@ -1,0 +1,129 @@
+package notifications_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/realtime"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// enabledSettings returns a settings mock with the dispatch flag set as given.
+func enabledSettings(enabled bool) *configtest.Mock {
+	return &configtest.Mock{
+		ResolveBoolForTenantFn: func(_ context.Context, _ int64, key string) (bool, error) {
+			if key == configModel.KeyNotificationsDispatchEnabled {
+				return enabled, nil
+			}
+			return false, nil
+		},
+	}
+}
+
+func tenantEvent(tenantID int64) notifications.Event {
+	return notifications.Event{
+		Type:     "test",
+		Audience: notifications.Audience{TenantID: tenantID, Scope: notifications.ScopeTenant},
+		Title:    "Testbenachrichtigung",
+		Body:     "Die Benachrichtigungen funktionieren.",
+		DeepLink: "/dashboard",
+	}
+}
+
+func TestNotifyDisabledByDefault(t *testing.T) {
+	broadcaster := testpkg.NewRecordingBroadcaster()
+	svc := notifications.NewService(enabledSettings(false), nil, notifications.NewSSEChannel(broadcaster))
+
+	err := svc.Notify(context.Background(), tenantEvent(41))
+	require.ErrorIs(t, err, notifications.ErrDisabled)
+	assert.Empty(t, broadcaster.Calls(), "no channel may deliver while the feature flag is off")
+}
+
+func TestNotifyDeliversTenantScopedSSE(t *testing.T) {
+	broadcaster := testpkg.NewRecordingBroadcaster()
+	svc := notifications.NewService(enabledSettings(true), nil, notifications.NewSSEChannel(broadcaster))
+
+	require.NoError(t, svc.Notify(context.Background(), tenantEvent(41)))
+
+	calls := broadcaster.CallsByMethod("tenant")
+	require.Len(t, calls, 1)
+	call := calls[0]
+	assert.Equal(t, int64(41), call.TenantID)
+	assert.Equal(t, realtime.EventNotification, call.Event.Type)
+	require.NotNil(t, call.Event.Data.Title)
+	assert.Equal(t, "Testbenachrichtigung", *call.Event.Data.Title)
+	require.NotNil(t, call.Event.Data.Priority)
+	assert.Equal(t, notifications.PriorityNormal, *call.Event.Data.Priority, "empty priority defaults to normal")
+	require.NotNil(t, call.Event.Data.DeepLink)
+	assert.Equal(t, "/dashboard", *call.Event.Data.DeepLink)
+}
+
+func TestNotifyGuardianAndGroupRouting(t *testing.T) {
+	broadcaster := testpkg.NewRecordingBroadcaster()
+	svc := notifications.NewService(enabledSettings(true), nil, notifications.NewSSEChannel(broadcaster))
+
+	guardian := tenantEvent(41)
+	guardian.Audience.Scope = notifications.ScopeGuardian
+	guardian.Audience.GuardianAccountID = 77
+	require.NoError(t, svc.Notify(context.Background(), guardian))
+
+	group := tenantEvent(41)
+	group.Audience.Scope = notifications.ScopeGroup
+	group.Audience.ActiveGroupID = "g-9"
+	require.NoError(t, svc.Notify(context.Background(), group))
+
+	guardianCalls := broadcaster.CallsByMethod("guardian")
+	require.Len(t, guardianCalls, 1)
+	assert.Equal(t, int64(77), guardianCalls[0].GuardianID)
+
+	groupCalls := broadcaster.CallsByMethod("group")
+	require.Len(t, groupCalls, 1)
+	assert.Equal(t, "g-9", groupCalls[0].Topic)
+}
+
+func TestNotifyValidation(t *testing.T) {
+	svc := notifications.NewService(enabledSettings(true), nil)
+	ctx := context.Background()
+
+	missingTitle := tenantEvent(41)
+	missingTitle.Title = ""
+	assert.Error(t, svc.Notify(ctx, missingTitle))
+
+	missingTenant := tenantEvent(0)
+	assert.Error(t, svc.Notify(ctx, missingTenant))
+
+	badScope := tenantEvent(41)
+	badScope.Audience.Scope = "everyone"
+	assert.Error(t, svc.Notify(ctx, badScope))
+
+	guardianWithoutAccount := tenantEvent(41)
+	guardianWithoutAccount.Audience.Scope = notifications.ScopeGuardian
+	assert.Error(t, svc.Notify(ctx, guardianWithoutAccount))
+
+	externalLink := tenantEvent(41)
+	externalLink.DeepLink = "https://example.com/phish"
+	assert.Error(t, svc.Notify(ctx, externalLink))
+
+	protocolRelative := tenantEvent(41)
+	protocolRelative.DeepLink = "//example.com"
+	assert.Error(t, svc.Notify(ctx, protocolRelative))
+
+	badPriority := tenantEvent(41)
+	badPriority.Priority = "urgent"
+	assert.Error(t, svc.Notify(ctx, badPriority))
+}
+
+func TestNotifyChannelErrorDoesNotPropagate(t *testing.T) {
+	broadcaster := testpkg.NewRecordingBroadcaster()
+	broadcaster.Err = assert.AnError
+	svc := notifications.NewService(enabledSettings(true), nil, notifications.NewSSEChannel(broadcaster))
+
+	assert.NoError(t, svc.Notify(context.Background(), tenantEvent(41)),
+		"channel failures are fire-and-forget and must not reach the caller")
+}

--- a/backend/services/notifications/service_test.go
+++ b/backend/services/notifications/service_test.go
@@ -7,13 +7,17 @@ import (
 	"log/slog"
 	"testing"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
 
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/realtime"
 	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
 
@@ -84,6 +88,52 @@ func TestNotifyDeliversTenantScopedSSE(t *testing.T) {
 	require.NotNil(t, call.Event.Data.DeepLink)
 	assert.Equal(t, "/dashboard", *call.Event.Data.DeepLink)
 	assert.Equal(t, map[string]string{"reminder_id": "123"}, call.Event.Data.NotificationData)
+}
+
+func TestNotifyDefersDeliveryUntilCommit(t *testing.T) {
+	channel := &recordingChannel{name: "recording"}
+	svc := notifications.NewService(enabledSettings(true), nil, channel)
+	ctx, commit := tenant.WithAfterCommitHooksForTest(context.Background())
+
+	event := tenantEvent(41)
+	event.Data = map[string]string{"reminder_id": "123"}
+	require.NoError(t, svc.Notify(ctx, event))
+	assert.Empty(t, channel.events, "notification must not be delivered before commit")
+
+	event.Data["reminder_id"] = "mutated-before-commit"
+	commit()
+
+	require.Len(t, channel.events, 1)
+	assert.Equal(t, map[string]string{"reminder_id": "123"}, channel.events[0].Data,
+		"queued notification must use the event snapshot taken by Notify")
+}
+
+func TestNotifyDropsQueuedDeliveryOnRollback(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	db := bun.NewDB(sqlDB, pgdialect.New())
+	t.Cleanup(func() {
+		_ = db.Close()
+		_ = sqlDB.Close()
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SET LOCAL ROLE phoenix_tenant").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SELECT set_config").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	channel := &recordingChannel{name: "recording"}
+	svc := notifications.NewService(enabledSettings(true), nil, channel)
+	rollbackErr := errors.New("force rollback")
+	err = tenant.WithTenantTx(context.Background(), db, 41, func(ctx context.Context, _ bun.Tx) error {
+		require.NoError(t, svc.Notify(ctx, tenantEvent(41)))
+		assert.Empty(t, channel.events, "notification must remain queued inside the transaction")
+		return rollbackErr
+	})
+
+	require.ErrorIs(t, err, rollbackErr)
+	assert.Empty(t, channel.events, "rollback must discard the queued notification")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestNotifyGuardianAndGroupRouting(t *testing.T) {

--- a/backend/services/notifications/service_test.go
+++ b/backend/services/notifications/service_test.go
@@ -144,6 +144,10 @@ func TestNotifyValidation(t *testing.T) {
 	protocolRelative.DeepLink = "//example.com"
 	assert.Error(t, svc.Notify(ctx, protocolRelative))
 
+	backslashRelative := tenantEvent(41)
+	backslashRelative.DeepLink = `/\evil.example/path`
+	assert.EqualError(t, svc.Notify(ctx, backslashRelative), "deep link must be an app-relative path")
+
 	badPriority := tenantEvent(41)
 	badPriority.Priority = "urgent"
 	assert.Error(t, svc.Notify(ctx, badPriority))

--- a/backend/services/notifications/service_test.go
+++ b/backend/services/notifications/service_test.go
@@ -67,7 +67,10 @@ func TestNotifyDeliversTenantScopedSSE(t *testing.T) {
 	broadcaster := testpkg.NewRecordingBroadcaster()
 	svc := notifications.NewService(enabledSettings(true), nil, notifications.NewSSEChannel(broadcaster))
 
-	require.NoError(t, svc.Notify(context.Background(), tenantEvent(41)))
+	event := tenantEvent(41)
+	event.Data = map[string]string{"reminder_id": "123"}
+	require.NoError(t, svc.Notify(context.Background(), event))
+	event.Data["reminder_id"] = "mutated-after-notify"
 
 	calls := broadcaster.CallsByMethod("tenant")
 	require.Len(t, calls, 1)
@@ -80,6 +83,7 @@ func TestNotifyDeliversTenantScopedSSE(t *testing.T) {
 	assert.Equal(t, notifications.PriorityNormal, *call.Event.Data.Priority, "empty priority defaults to normal")
 	require.NotNil(t, call.Event.Data.DeepLink)
 	assert.Equal(t, "/dashboard", *call.Event.Data.DeepLink)
+	assert.Equal(t, map[string]string{"reminder_id": "123"}, call.Event.Data.NotificationData)
 }
 
 func TestNotifyGuardianAndGroupRouting(t *testing.T) {

--- a/backend/services/notifications/sse_channel.go
+++ b/backend/services/notifications/sse_channel.go
@@ -1,0 +1,47 @@
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/moto-nrw/project-phoenix/realtime"
+)
+
+// sseChannel delivers notifications in-app over the existing SSE hub as
+// realtime.EventNotification events. It reuses the Broadcaster untouched —
+// the existing cache-invalidation events are a separate concern and keep
+// flowing exactly as before (#1624 acceptance criterion).
+type sseChannel struct {
+	broadcaster realtime.Broadcaster
+}
+
+// NewSSEChannel wraps the shared SSE broadcaster as a notification channel.
+func NewSSEChannel(broadcaster realtime.Broadcaster) Channel {
+	return &sseChannel{broadcaster: broadcaster}
+}
+
+func (c *sseChannel) Name() string { return "sse" }
+
+func (c *sseChannel) Deliver(ctx context.Context, event Event) error {
+	_ = ctx // Broadcaster is synchronous fan-out to in-memory channels
+	sseEvent := realtime.NewEvent(realtime.EventNotification, event.Audience.ActiveGroupID, realtime.EventData{
+		Title:            &event.Title,
+		Body:             &event.Body,
+		DeepLink:         &event.DeepLink,
+		Priority:         &event.Priority,
+		NotificationType: &event.Type,
+	})
+
+	switch event.Audience.Scope {
+	case ScopeTenant:
+		return c.broadcaster.BroadcastToTenant(event.Audience.TenantID, sseEvent)
+	case ScopeGuardian:
+		return c.broadcaster.BroadcastToGuardian(event.Audience.TenantID, event.Audience.GuardianAccountID, sseEvent)
+	case ScopeGroup:
+		return c.broadcaster.BroadcastToGroup(event.Audience.TenantID, event.Audience.ActiveGroupID, sseEvent)
+	default:
+		return fmt.Errorf("sse channel cannot route audience scope %q (tenant %s)",
+			event.Audience.Scope, strconv.FormatInt(event.Audience.TenantID, 10))
+	}
+}

--- a/backend/services/notifications/sse_channel.go
+++ b/backend/services/notifications/sse_channel.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/moto-nrw/project-phoenix/realtime"
@@ -31,6 +32,7 @@ func (c *sseChannel) Deliver(ctx context.Context, event Event) error {
 		DeepLink:         &event.DeepLink,
 		Priority:         &event.Priority,
 		NotificationType: &event.Type,
+		NotificationData: maps.Clone(event.Data),
 	})
 
 	switch event.Audience.Scope {

--- a/backend/services/notifications/webpush_channel.go
+++ b/backend/services/notifications/webpush_channel.go
@@ -1,0 +1,43 @@
+package notifications
+
+import (
+	"context"
+	"log/slog"
+)
+
+// webPushChannel is the planned Web Push channel (#1624). It is a deliberate
+// stub: per the issue, device/browser subscription persistence and VAPID
+// delivery are only added when Web Push is actually activated. Registering
+// the stub now fixes the extension point so producers already fan out to it
+// and activating push later changes no caller.
+//
+// Activation plan (documented in docs/notifications.md):
+//  1. Add an iot/notifications push_subscriptions table (account + tenant +
+//     device endpoint, multiple devices per account) via migration.
+//  2. Add a VAPID webpush dependency and keys via env/SOPS.
+//  3. Replace Deliver below: load the audience's subscriptions and send ONLY
+//     Title/Body/DeepLink — never Data — as the push payload (GDPR: sensitive
+//     details are fetched authenticated after the app opens).
+//  4. Add the frontend service worker + permission prompt.
+type webPushChannel struct {
+	logger *slog.Logger
+}
+
+// NewWebPushChannel returns the not-yet-active Web Push channel stub.
+func NewWebPushChannel(logger *slog.Logger) Channel {
+	return &webPushChannel{logger: logger}
+}
+
+func (c *webPushChannel) Name() string { return "web_push" }
+
+func (c *webPushChannel) Deliver(_ context.Context, event Event) error {
+	logger := c.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Debug("web push channel not yet activated, skipping delivery",
+		"notification_type", event.Type,
+		"tenant_id", event.Audience.TenantID,
+	)
+	return nil
+}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -31,8 +31,9 @@ err := factory.Notifications.Notify(ctx, notifications.Event{
 ```
 
 The producer never references a channel. `Notify` validates the event, checks
-the feature flag, and fans out to all registered channels; a failing channel
-is logged and never blocks the caller (fire-and-forget, like SSE
+the feature flag, and queues fan-out until the surrounding tenant transaction
+commits. Without a tenant transaction, delivery remains synchronous. A failing
+channel is logged and never blocks the caller (fire-and-forget, like SSE
 broadcasting).
 
 Audience scopes map to the existing SSE routing:

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,92 @@
+# Notification Abstraction (#1624)
+
+A single technical interface through which features trigger user-facing
+notifications without knowing the delivery channels. This is deliberately an
+abstraction, not a user feature: it is the foundation the "Erinnerungen" page
+(#669) and later bell/push features build on.
+
+## Feature flag
+
+Everything is gated by the tenant setting `notifications.dispatch_enabled`
+(boolean, **default off**, tab "Betrieb", permission `config:update`). While
+off, `Notify` returns `notifications.ErrDisabled` and no channel delivers
+anything.
+
+## Triggering a notification (backend)
+
+```go
+import "github.com/moto-nrw/project-phoenix/services/notifications"
+
+err := factory.Notifications.Notify(ctx, notifications.Event{
+    Type:     "pickup_upcoming",              // stable, feature-defined type
+    Audience: notifications.Audience{
+        TenantID: tenantID,
+        Scope:    notifications.ScopeTenant,  // or ScopeGuardian / ScopeGroup
+    },
+    Priority: notifications.PriorityNormal,   // low | normal | high
+    Title:    "Abholung in 10 Minuten",       // display-safe, German
+    Body:     "Ein Kind wird bald abgeholt.", // display-safe, German
+    DeepLink: "/reminders",                   // app-relative path only
+})
+```
+
+The producer never references a channel. `Notify` validates the event, checks
+the feature flag, and fans out to all registered channels; a failing channel
+is logged and never blocks the caller (fire-and-forget, like SSE
+broadcasting).
+
+Audience scopes map to the existing SSE routing:
+
+| Scope | Recipients |
+|---|---|
+| `ScopeTenant` | every connected staff client of the tenant |
+| `ScopeGuardian` | one guardian account's own clients (`GuardianAccountID` required) |
+| `ScopeGroup` | clients subscribed to one active group (`ActiveGroupID` required) |
+
+## GDPR contract
+
+`Title`, `Body` and `DeepLink` are the only user-visible fields and MUST be
+display-safe: no student names or other sensitive child data. Validation
+mechanically enforces what it can (deep links must be app-relative, never an
+external URL); the semantic half is a producer responsibility. Sensitive
+details are loaded authenticated after the user follows the deep link into
+the app. `Data` carries opaque IDs only and never leaves the backend channels
+that need it.
+
+## Channels
+
+| Channel | Status | Transport |
+|---|---|---|
+| SSE / in-app | active | `realtime.Broadcaster` → SSE event `notification` → toast |
+| Web Push | prepared stub | see activation plan in `services/notifications/webpush_channel.go` |
+| E-Mail | future | wrap `email.Mailer` + audience→address resolution as a `Channel` |
+
+The existing SSE cache-invalidation events are untouched: the `notification`
+event type is additive, and SSE remains the open-app channel while Web Push
+is planned for closed/locked devices. Web Push subscription persistence
+(multiple devices per account/tenant) is intentionally deferred until the
+channel is activated, per the issue.
+
+## Frontend
+
+- `use-global-sse.ts` receives `notification` SSE events and re-dispatches
+  them as `phoenix:notification` window events.
+- `components/notifications/notification-bridge.tsx` (mounted once in
+  `app/providers.tsx`) renders them as toasts — `high` priority as a warning
+  toast, everything else as info. This is also the seam where a future bell
+  inbox or push-permission prompt hooks in.
+- Unlike all other SSE events, `notification` events are rendered directly,
+  not used as refetch triggers.
+
+## Verifying a tenant's setup
+
+`POST /api/notifications/test` (tenant JWT, `config:update`) dispatches a
+fixed display-safe test event to the whole tenant. Returns `409` while the
+feature flag is off. The frontend proxies it at `/api/notifications/test`.
+
+## Adding a new channel
+
+Implement `notifications.Channel` (`Name()` + `Deliver(ctx, Event)`), register
+it in `services/factory.go` where `notifications.NewService` is wired, and
+respect the GDPR contract above for anything that leaves the backend
+(especially push payloads: `Title`/`Body`/`DeepLink` only, never `Data`).

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -50,8 +50,9 @@ display-safe: no student names or other sensitive child data. Validation
 mechanically enforces what it can (deep links must be app-relative, never an
 external URL); the semantic half is a producer responsibility. Sensitive
 details are loaded authenticated after the user follows the deep link into
-the app. `Data` carries opaque IDs only and never leaves the backend channels
-that need it.
+the app. `Data` carries opaque IDs only. The SSE channel forwards it as
+`notification_data` for client-side routing; channels that leave the app
+(especially Web Push and E-Mail) must not include it.
 
 ## Channels
 
@@ -70,11 +71,13 @@ channel is activated, per the issue.
 ## Frontend
 
 - `use-global-sse.ts` receives `notification` SSE events and re-dispatches
-  them as `phoenix:notification` window events.
+  them as `phoenix:notification` window events. The parents portal shares the
+  same dispatch path through `ParentRealtimeBridge`.
 - `components/notifications/notification-bridge.tsx` (mounted once in
   `app/providers.tsx`) renders them as toasts — `high` priority as a warning
-  toast, everything else as info. This is also the seam where a future bell
-  inbox or push-permission prompt hooks in.
+  toast, everything else as info. A valid app-relative `DeepLink` adds an
+  "Öffnen" action. This is also the seam where a future bell inbox or
+  push-permission prompt hooks in.
 - Unlike all other SSE events, `notification` events are rendered directly,
   not used as refetch triggers.
 

--- a/frontend/src/app/api/notifications/test/route.ts
+++ b/frontend/src/app/api/notifications/test/route.ts
@@ -1,0 +1,14 @@
+import { apiPost } from "~/lib/api-helpers.server";
+import { createPostHandler } from "~/lib/route-wrapper.server";
+
+/**
+ * POST /api/notifications/test — proxy to the backend test-notification
+ * trigger (#1624). Lets an admin verify the notification setup end to end:
+ * feature flag on → backend dispatch → SSE → in-app toast.
+ */
+export const POST = createPostHandler<null, Record<string, never>>(
+  async (_request, _body, token: string) => {
+    await apiPost(`/api/notifications/test`, token);
+    return null;
+  },
+);

--- a/frontend/src/app/providers.test.tsx
+++ b/frontend/src/app/providers.test.tsx
@@ -13,6 +13,15 @@ vi.mock("~/contexts/ToastContext", () => ({
   ToastProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="toast-provider">{children}</div>
   ),
+  // NotificationBridge (rendered inside Providers since #1624) consumes
+  // useToast; the module mock must provide it.
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    remove: vi.fn(),
+  }),
 }));
 
 describe("Providers", () => {

--- a/frontend/src/app/providers.test.tsx
+++ b/frontend/src/app/providers.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/components/dashboard/modal-context", () => ({
   ),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 vi.mock("~/contexts/ToastContext", () => ({
   ToastProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="toast-provider">{children}</div>

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ModalProvider } from "@/components/dashboard/modal-context";
+import { NotificationBridge } from "~/components/notifications/notification-bridge";
 import { ToastProvider } from "~/contexts/ToastContext";
 
 /**
@@ -17,7 +18,10 @@ export function Providers({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <ModalProvider>
-      <ToastProvider>{children}</ToastProvider>
+      <ToastProvider>
+        <NotificationBridge />
+        {children}
+      </ToastProvider>
     </ModalProvider>
   );
 }

--- a/frontend/src/components/notifications/notification-bridge.test.tsx
+++ b/frontend/src/components/notifications/notification-bridge.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { NotificationBridge } from "./notification-bridge";
+import type { PhoenixNotificationDetail } from "./notification-bridge";
+
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => toast,
+}));
+
+function dispatch(detail: Partial<PhoenixNotificationDetail>) {
+  window.dispatchEvent(new CustomEvent("phoenix:notification", { detail }));
+}
+
+describe("NotificationBridge", () => {
+  it("renders a notification event as an info toast", () => {
+    render(<NotificationBridge />);
+    dispatch({ title: "Testbenachrichtigung", body: "Alles eingerichtet." });
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "Testbenachrichtigung: Alles eingerichtet.",
+      expect.objectContaining({ duration: expect.any(Number) as number }),
+    );
+  });
+
+  it("renders high priority as a warning toast", () => {
+    render(<NotificationBridge />);
+    dispatch({ title: "Wichtig", body: "Bitte beachten.", priority: "high" });
+
+    expect(toast.warning).toHaveBeenCalledWith(
+      "Wichtig: Bitte beachten.",
+      expect.anything(),
+    );
+  });
+
+  it("ignores events without a title", () => {
+    toast.info.mockClear();
+    render(<NotificationBridge />);
+    dispatch({ body: "kein Titel" });
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("stops listening after unmount", () => {
+    toast.info.mockClear();
+    const { unmount } = render(<NotificationBridge />);
+    unmount();
+    dispatch({ title: "Nach Unmount" });
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/notifications/notification-bridge.test.tsx
+++ b/frontend/src/components/notifications/notification-bridge.test.tsx
@@ -10,10 +10,22 @@ const toast = vi.hoisted(() => ({
   warning: vi.fn(),
   remove: vi.fn(),
 }));
+const routerPush = vi.hoisted(() => vi.fn());
 
 vi.mock("~/contexts/ToastContext", () => ({
   useToast: () => toast,
 }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+interface ToastCallOptions {
+  duration?: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
 
 function dispatch(detail: Partial<PhoenixNotificationDetail>) {
   window.dispatchEvent(new CustomEvent("phoenix:notification", { detail }));
@@ -38,6 +50,31 @@ describe("NotificationBridge", () => {
       "Wichtig: Bitte beachten.",
       expect.anything(),
     );
+  });
+
+  it("opens a validated app-relative deep link from the toast action", () => {
+    toast.info.mockClear();
+    routerPush.mockClear();
+    render(<NotificationBridge />);
+    dispatch({ title: "Erinnerung", deepLink: "/reminders?id=123" });
+
+    const options = toast.info.mock.calls.at(-1)?.[1] as
+      ToastCallOptions | undefined;
+    expect(options?.action?.label).toBe("Öffnen");
+
+    options?.action?.onClick();
+
+    expect(routerPush).toHaveBeenCalledWith("/reminders?id=123");
+  });
+
+  it("does not expose an action for an external deep link", () => {
+    toast.info.mockClear();
+    render(<NotificationBridge />);
+    dispatch({ title: "Unsicher", deepLink: "/\\example.com/phish" });
+
+    const options = toast.info.mock.calls.at(-1)?.[1] as
+      ToastCallOptions | undefined;
+    expect(options?.action).toBeUndefined();
   });
 
   it("ignores events without a title", () => {

--- a/frontend/src/components/notifications/notification-bridge.tsx
+++ b/frontend/src/components/notifications/notification-bridge.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import { useToast } from "~/contexts/ToastContext";
+
+/**
+ * NotificationBridge — the in-app rendering half of the notification
+ * abstraction (#1624).
+ *
+ * useGlobalSSE receives backend "notification" events and re-dispatches them
+ * as "phoenix:notification" window events (it runs outside this component
+ * tree). This bridge listens for them and renders a toast. It carries no
+ * state and renders nothing itself; mount it once inside ToastProvider.
+ *
+ * The payload is display-safe by backend contract (no sensitive student
+ * data); sensitive details are only shown after navigating into the
+ * authenticated app via the deep link.
+ */
+export interface PhoenixNotificationDetail {
+  title: string | null;
+  body: string | null;
+  deepLink: string | null;
+  priority: string | null;
+  notificationType: string | null;
+}
+
+export function NotificationBridge() {
+  const toast = useToast();
+
+  useEffect(() => {
+    const onNotification = (event: Event) => {
+      const detail = (event as CustomEvent<PhoenixNotificationDetail>).detail;
+      if (!detail?.title) return;
+
+      const message = detail.body
+        ? `${detail.title}: ${detail.body}`
+        : detail.title;
+
+      // High priority renders as warning (amber) so it stands out; everything
+      // else as info. Errors stay reserved for actual failures.
+      if (detail.priority === "high") {
+        toast.warning(message, { duration: 8000 });
+      } else {
+        toast.info(message, { duration: 6000 });
+      }
+    };
+
+    window.addEventListener("phoenix:notification", onNotification);
+    return () =>
+      window.removeEventListener("phoenix:notification", onNotification);
+  }, [toast]);
+
+  return null;
+}

--- a/frontend/src/components/notifications/notification-bridge.tsx
+++ b/frontend/src/components/notifications/notification-bridge.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useToast } from "~/contexts/ToastContext";
+import type { PhoenixNotificationDetail } from "~/lib/notification-events";
+
+export type { PhoenixNotificationDetail } from "~/lib/notification-events";
 
 /**
  * NotificationBridge — the in-app rendering half of the notification
@@ -16,16 +20,21 @@ import { useToast } from "~/contexts/ToastContext";
  * data); sensitive details are only shown after navigating into the
  * authenticated app via the deep link.
  */
-export interface PhoenixNotificationDetail {
-  title: string | null;
-  body: string | null;
-  deepLink: string | null;
-  priority: string | null;
-  notificationType: string | null;
+function isSafeAppRelativePath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+
+  try {
+    return (
+      new URL(path, window.location.origin).origin === window.location.origin
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function NotificationBridge() {
   const toast = useToast();
+  const router = useRouter();
 
   useEffect(() => {
     const onNotification = (event: Event) => {
@@ -35,20 +44,28 @@ export function NotificationBridge() {
       const message = detail.body
         ? `${detail.title}: ${detail.body}`
         : detail.title;
+      const deepLink = detail.deepLink;
+      const action =
+        deepLink && isSafeAppRelativePath(deepLink)
+          ? {
+              label: "Öffnen",
+              onClick: () => router.push(deepLink),
+            }
+          : undefined;
 
       // High priority renders as warning (amber) so it stands out; everything
       // else as info. Errors stay reserved for actual failures.
       if (detail.priority === "high") {
-        toast.warning(message, { duration: 8000 });
+        toast.warning(message, { duration: 8000, action });
       } else {
-        toast.info(message, { duration: 6000 });
+        toast.info(message, { duration: 6000, action });
       }
     };
 
     window.addEventListener("phoenix:notification", onNotification);
     return () =>
       window.removeEventListener("phoenix:notification", onNotification);
-  }, [toast]);
+  }, [router, toast]);
 
   return null;
 }

--- a/frontend/src/components/parent/parent-realtime-bridge.test.tsx
+++ b/frontend/src/components/parent/parent-realtime-bridge.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ParentRealtimeBridge } from "./parent-realtime-bridge";
+import type { SSEHookOptions } from "~/lib/sse-types";
+
+const useSSE = vi.hoisted(() => vi.fn());
+
+vi.mock("~/lib/hooks/use-sse", () => ({ useSSE }));
+
+describe("ParentRealtimeBridge", () => {
+  it("forwards guardian-scoped notifications to the shared notification bridge", () => {
+    render(<ParentRealtimeBridge />);
+
+    expect(useSSE).toHaveBeenCalledWith(
+      "/api/parent/sse/events",
+      expect.anything(),
+    );
+    const options = useSSE.mock.calls[0]?.[1] as SSEHookOptions | undefined;
+    const listener = vi.fn();
+    window.addEventListener("phoenix:notification", listener);
+
+    try {
+      options?.onMessage?.({
+        type: "notification",
+        active_group_id: "",
+        data: {
+          title: "Abholzeit geändert",
+          body: "Die neue Abholzeit ist verfügbar.",
+          deep_link: "/children/123",
+          priority: "high",
+          notification_type: "pickup_changed",
+          notification_data: { child_id: "123" },
+        },
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(listener).toHaveBeenCalledOnce();
+      const dispatchedEvent = listener.mock.calls[0]?.[0] as CustomEvent;
+      expect(dispatchedEvent.detail).toEqual({
+        title: "Abholzeit geändert",
+        body: "Die neue Abholzeit ist verfügbar.",
+        deepLink: "/children/123",
+        priority: "high",
+        notificationType: "pickup_changed",
+        data: { child_id: "123" },
+      });
+    } finally {
+      window.removeEventListener("phoenix:notification", listener);
+    }
+  });
+});

--- a/frontend/src/components/parent/parent-realtime-bridge.tsx
+++ b/frontend/src/components/parent/parent-realtime-bridge.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import { useSSE } from "~/lib/hooks/use-sse";
+import { dispatchPhoenixNotification } from "~/lib/notification-events";
 import type { SSEEvent } from "~/lib/sse-types";
 
 /**
@@ -18,6 +19,9 @@ import type { SSEEvent } from "~/lib/sse-types";
  * SSE connection for the parents portal — surfaces react to these window events
  * rather than each opening its own EventSource to the same endpoint.
  *
+ * Guardian-scoped notification events use the same phoenix:notification
+ * dispatcher as the staff portal, so the root NotificationBridge renders them.
+ *
  * A parent_message_read trigger (the OGS read this guardian's messages, or the
  * guardian read in another tab) only refreshes the unread badge and the open
  * conversation's "Gelesen" receipts — it does NOT refresh the thread LIST, whose
@@ -28,6 +32,10 @@ import type { SSEEvent } from "~/lib/sse-types";
 export function ParentRealtimeBridge() {
   const handleSSE = useCallback((event: SSEEvent) => {
     if (typeof window === "undefined") return;
+    if (event.type === "notification") {
+      dispatchPhoenixNotification(event);
+      return;
+    }
     if (event.type === "parent_message") {
       window.dispatchEvent(new CustomEvent("parent-messages-unread-refresh"));
       window.dispatchEvent(new CustomEvent("parent-threads-refresh"));

--- a/frontend/src/contexts/ToastContext.test.tsx
+++ b/frontend/src/contexts/ToastContext.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, render, waitFor, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  renderHook,
+  render,
+  waitFor,
+  screen,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { ToastProvider, useToast } from "./ToastContext";
@@ -114,6 +120,33 @@ describe("ToastContext", () => {
         },
         { timeout: 3000 },
       );
+    });
+
+    it("runs a toast action from the desktop toast", async () => {
+      const onAction = vi.fn();
+
+      function TestComponent() {
+        const toast = useToast();
+
+        useEffect(() => {
+          toast.info("Test message", {
+            duration: 0,
+            action: { label: "Öffnen", onClick: onAction },
+          });
+        }, [toast]);
+
+        return null;
+      }
+
+      render(
+        <ToastProvider>
+          <TestComponent />
+        </ToastProvider>,
+      );
+
+      fireEvent.click(await screen.findByRole("button", { name: "Öffnen" }));
+
+      expect(onAction).toHaveBeenCalledOnce();
     });
   });
 

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -19,6 +19,10 @@ type ToastType = "success" | "error" | "info" | "warning";
 interface ToastOptions {
   id?: string;
   duration?: number; // ms
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 interface ToastItemData {
@@ -26,6 +30,7 @@ interface ToastItemData {
   type: ToastType;
   message: string;
   duration: number;
+  action?: ToastOptions["action"];
 }
 
 interface ToastAPI {
@@ -221,14 +226,23 @@ function ToastRow({
     setTimeout(() => onClose(item.id), reducedMotion ? 0 : 300);
   };
 
+  const handleAction = () => {
+    item.action?.onClick();
+    handleMobileDismiss();
+  };
+
   return (
     <>
       {/* Mobile: Center-Overlay Modal Style - tap to dismiss */}
       <button
         type="button"
-        aria-label={`${modalTitles[item.type]}: ${item.message}. Tippen zum Schließen`}
+        aria-label={`${modalTitles[item.type]}: ${item.message}. ${
+          item.action
+            ? `Tippen zum ${item.action.label}`
+            : "Tippen zum Schließen"
+        }`}
         aria-hidden={isDesktopRef.current}
-        onClick={handleMobileDismiss}
+        onClick={item.action ? handleAction : handleMobileDismiss}
         className={`pointer-events-auto ${mobileStyles.bg} ${mobileStyles.border} rounded-2xl border shadow-lg backdrop-blur-sm transition-all md:hidden ${reducedMotion ? "" : "duration-300 ease-out"} w-full max-w-xs cursor-pointer focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-none ${
           visible && !exiting ? "scale-100 opacity-100" : "scale-95 opacity-0"
         }`}
@@ -292,6 +306,15 @@ function ToastRow({
           <p className={`flex-1 text-sm font-medium ${desktopStyles.text}`}>
             {item.message}
           </p>
+          {item.action && (
+            <button
+              type="button"
+              onClick={handleAction}
+              className={`flex-shrink-0 text-sm font-semibold ${desktopStyles.text} underline underline-offset-2 transition-opacity hover:opacity-70`}
+            >
+              {item.action.label}
+            </button>
+          )}
           <button
             type="button"
             aria-label="Schließen"
@@ -360,7 +383,7 @@ export function ToastProvider({
       setItems((prev) => {
         const next: ToastItemData[] = [
           ...prev,
-          { id, type, message, duration },
+          { id, type, message, duration, action: options?.action },
         ];
         if (next.length > MAX_VISIBLE) {
           // remove oldest to keep at most MAX_VISIBLE visible

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -1212,7 +1212,7 @@ describe("useGlobalSSE", () => {
       expect(dispatched[0]?.detail).toEqual({ source: null });
     });
 
-    it("dispatches the complete display-safe notification payload", () => {
+    it("dispatches the complete notification payload", () => {
       renderHook(() => useGlobalSSE());
 
       const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
@@ -1229,6 +1229,7 @@ describe("useGlobalSSE", () => {
             deep_link: "/reminders",
             priority: "high",
             notification_type: "pickup_changed",
+            notification_data: { reminder_id: "123" },
           },
           timestamp: new Date().toISOString(),
         });
@@ -1241,6 +1242,7 @@ describe("useGlobalSSE", () => {
           deepLink: "/reminders",
           priority: "high",
           notificationType: "pickup_changed",
+          data: { reminder_id: "123" },
         });
       } finally {
         window.removeEventListener("phoenix:notification", listener);
@@ -1270,6 +1272,7 @@ describe("useGlobalSSE", () => {
           deepLink: null,
           priority: null,
           notificationType: null,
+          data: null,
         });
       } finally {
         window.removeEventListener("phoenix:notification", listener);

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -1211,5 +1211,69 @@ describe("useGlobalSSE", () => {
       expect(dispatched).toHaveLength(1);
       expect(dispatched[0]?.detail).toEqual({ source: null });
     });
+
+    it("dispatches the complete display-safe notification payload", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+      const listener = vi.fn();
+      window.addEventListener("phoenix:notification", listener);
+
+      try {
+        onMessage?.({
+          type: "notification",
+          active_group_id: "",
+          data: {
+            title: "Abholzeit geändert",
+            body: "Die neue Abholzeit ist verfügbar.",
+            deep_link: "/reminders",
+            priority: "high",
+            notification_type: "pickup_changed",
+          },
+          timestamp: new Date().toISOString(),
+        });
+
+        expect(listener).toHaveBeenCalledOnce();
+        const dispatchedEvent = listener.mock.calls[0]?.[0] as CustomEvent;
+        expect(dispatchedEvent.detail).toEqual({
+          title: "Abholzeit geändert",
+          body: "Die neue Abholzeit ist verfügbar.",
+          deepLink: "/reminders",
+          priority: "high",
+          notificationType: "pickup_changed",
+        });
+      } finally {
+        window.removeEventListener("phoenix:notification", listener);
+      }
+    });
+
+    it("uses null for omitted optional notification fields", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+      const listener = vi.fn();
+      window.addEventListener("phoenix:notification", listener);
+
+      try {
+        onMessage?.({
+          type: "notification",
+          active_group_id: "",
+          data: {},
+          timestamp: new Date().toISOString(),
+        });
+
+        expect(listener).toHaveBeenCalledOnce();
+        const dispatchedEvent = listener.mock.calls[0]?.[0] as CustomEvent;
+        expect(dispatchedEvent.detail).toEqual({
+          title: null,
+          body: null,
+          deepLink: null,
+          priority: null,
+          notificationType: null,
+        });
+      } finally {
+        window.removeEventListener("phoenix:notification", listener);
+      }
+    });
   });
 });

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -26,6 +26,7 @@ import { useCallback, useRef } from "react";
 import { mutate } from "swr";
 import { useSession } from "next-auth/react";
 import { useSSE } from "~/lib/hooks/use-sse";
+import { dispatchPhoenixNotification } from "~/lib/notification-events";
 import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 import {
   notifyStudentCompanionDisplayChanged,
@@ -667,19 +668,7 @@ export function useGlobalSSE(): SSEHookState {
           // ToastProvider consumers, so hand the event to the notification
           // bridge (mounted under Providers) via a window event — mirroring
           // the reminders/tenant-settings decoupling above.
-          if (typeof window !== "undefined") {
-            window.dispatchEvent(
-              new CustomEvent("phoenix:notification", {
-                detail: {
-                  title: event.data.title ?? null,
-                  body: event.data.body ?? null,
-                  deepLink: event.data.deep_link ?? null,
-                  priority: event.data.priority ?? null,
-                  notificationType: event.data.notification_type ?? null,
-                },
-              }),
-            );
-          }
+          dispatchPhoenixNotification(event);
           break;
         }
 

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -661,6 +661,28 @@ export function useGlobalSSE(): SSEHookState {
           break;
         }
 
+        case "notification": {
+          // Notification abstraction (#1624): the payload is display-safe by
+          // backend contract and rendered directly. This hook runs above
+          // ToastProvider consumers, so hand the event to the notification
+          // bridge (mounted under Providers) via a window event — mirroring
+          // the reminders/tenant-settings decoupling above.
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(
+              new CustomEvent("phoenix:notification", {
+                detail: {
+                  title: event.data.title ?? null,
+                  body: event.data.body ?? null,
+                  deepLink: event.data.deep_link ?? null,
+                  priority: event.data.priority ?? null,
+                  notificationType: event.data.notification_type ?? null,
+                },
+              }),
+            );
+          }
+          break;
+        }
+
         // A counterpart read a conversation. Handled identically to a new
         // message on the staff side: the sidebar badge must refresh (a staff
         // member reading in another tab dropped the count) and any open

--- a/frontend/src/lib/hooks/use-sse.ts
+++ b/frontend/src/lib/hooks/use-sse.ts
@@ -185,6 +185,9 @@ export function useSSE(
           // remount (the #1694 bus it drives never fired).
           "staffing_deviation_changed",
           "student_companions_changed",
+          // Notification abstraction (#1624): rendered directly as a toast by
+          // NotificationBridge via useGlobalSSE — not a cache trigger.
+          "notification",
         ];
 
         for (const eventType of eventTypes) {

--- a/frontend/src/lib/notification-events.ts
+++ b/frontend/src/lib/notification-events.ts
@@ -1,0 +1,27 @@
+import type { SSEEvent } from "~/lib/sse-types";
+
+export interface PhoenixNotificationDetail {
+  title: string | null;
+  body: string | null;
+  deepLink: string | null;
+  priority: string | null;
+  notificationType: string | null;
+  data: Record<string, string> | null;
+}
+
+export function dispatchPhoenixNotification(event: SSEEvent) {
+  if (typeof window === "undefined") return;
+
+  window.dispatchEvent(
+    new CustomEvent<PhoenixNotificationDetail>("phoenix:notification", {
+      detail: {
+        title: event.data.title ?? null,
+        body: event.data.body ?? null,
+        deepLink: event.data.deep_link ?? null,
+        priority: event.data.priority ?? null,
+        notificationType: event.data.notification_type ?? null,
+        data: event.data.notification_data ?? null,
+      },
+    }),
+  );
+}

--- a/frontend/src/lib/shell-auth-context.test.tsx
+++ b/frontend/src/lib/shell-auth-context.test.tsx
@@ -177,16 +177,26 @@ describe("TeacherShellProvider", () => {
   });
 
   it("calls signOut with redirect:false and navigates manually on logout", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response(null));
+    vi.stubGlobal("fetch", mockFetch);
     mockUseSession.mockReturnValue({
       data: { user: { name: "User", email: "user@example.com", roles: [] } },
       status: "authenticated",
     });
 
-    const { result } = renderHook(() => useShellAuth(), { wrapper });
+    try {
+      const { result } = renderHook(() => useShellAuth(), { wrapper });
 
-    await result.current.logout();
+      await result.current.logout();
 
-    expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+      expect(mockFetch).toHaveBeenCalledWith("/api/auth/logout", {
+        method: "POST",
+        signal: expect.any(AbortSignal) as AbortSignal,
+      });
+      expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("fires backend logout and clears session cache on teacher logout", async () => {

--- a/frontend/src/lib/sse-types.ts
+++ b/frontend/src/lib/sse-types.ts
@@ -111,6 +111,7 @@ interface SSEEventData {
   deep_link?: string; // app-relative path, e.g. "/reminders"
   priority?: string; // "low" | "normal" | "high"
   notification_type?: string;
+  notification_data?: Record<string, string>; // opaque IDs for client-side routing
 
   // Parent-messaging field (parent_message events). With student_id, lets an
   // open chat/conversation skip refetching when the event is about a different

--- a/frontend/src/lib/sse-types.ts
+++ b/frontend/src/lib/sse-types.ts
@@ -63,7 +63,12 @@ type SSEEventType =
   // request is created/decided/withdrawn), regardless of parent messaging being on.
   // Carries only student_id; must NOT touch any unread badge or thread list. See
   // backend/realtime/events.go EventParentChildUpdated.
-  | "parent_child_updated";
+  | "parent_child_updated"
+  // A user-facing notification from the notification abstraction (#1624).
+  // Unlike every other event this is NOT a cache-invalidation trigger: the
+  // payload carries display-safe title/body/deep_link that clients render
+  // directly (toast). See backend/realtime/events.go EventNotification.
+  | "notification";
 
 // SSE Connection Status
 export type ConnectionStatus = "connected" | "reconnecting" | "failed" | "idle";
@@ -98,6 +103,14 @@ interface SSEEventData {
 
   // Reason tracking for generic refresh events.
   reason?: string;
+
+  // Notification fields (notification events only, #1624). Display-safe by
+  // backend contract — rendered directly, no refetch.
+  title?: string;
+  body?: string;
+  deep_link?: string; // app-relative path, e.g. "/reminders"
+  priority?: string; // "low" | "normal" | "high"
+  notification_type?: string;
 
   // Parent-messaging field (parent_message events). With student_id, lets an
   // open chat/conversation skip refetching when the event is about a different


### PR DESCRIPTION
## Zusammenfassung

Führt die in #1624 geforderte Benachrichtigungs-Abstraktion ein: Features lösen Notification-Events über eine einzige Schnittstelle aus, ohne konkrete Kanäle zu kennen. Standardmäßig komplett deaktiviert.

### Backend
- **Neue Domain `services/notifications`**: `Service.Notify(ctx, event)` validiert Events (Typ, Audience mit Tenant/Guardian/Group-Scope, Priorität, display-sicherer Titel/Body, app-relativer Deep-Link) und verteilt sie an registrierte `Channel`-Implementierungen. Kanalfehler werden geloggt und blockieren den Aufrufer nie (fire-and-forget wie SSE).
- **Kanäle**: SSE/In-App (nutzt den bestehenden `realtime.Broadcaster`, neuer additiver Eventtyp `notification`) und ein dokumentierter Web-Push-Stub. Subscription-Persistenz und VAPID kommen laut Issue erst bei tatsächlicher Aktivierung von Web Push; der Aktivierungsplan steht im Stub und in `docs/notifications.md`. E-Mail ist als künftiger Kanal dokumentiert.
- **Feature Flag**: neues Setting `notifications.dispatch_enabled` (boolean, default **aus**, Tab Betrieb, `config:update`). Ohne Flag ist `Notify` ein No-Op (`ErrDisabled`).
- **Test-Endpoint**: `POST /api/notifications/test` (Tenant-JWT, `config:update`) verschickt eine fixe Testbenachrichtigung an den ganzen Tenant; 409 bei deaktiviertem Flag. Route-Golden entsprechend regeneriert (eine neue Route).

### Frontend
- `use-sse.ts`/`use-global-sse.ts`: neuer benannter SSE-Eventtyp `notification`, weitergereicht als `phoenix:notification`-Window-Event.
- `NotificationBridge` (in `app/providers.tsx` gemountet) rendert die Events als Toast (high-Priorität als Warning). Anders als alle anderen SSE-Events wird direkt gerendert, kein Refetch.
- Proxy-Route `/api/notifications/test`.
- Settings-Toggle erscheint automatisch über die Settings-Registry.

### DSGVO
Titel/Body/Deep-Link sind per Vertrag display-sicher (keine Kinderdaten); Deep-Links müssen app-relativ sein (validiert), sensible Details werden erst authentifiziert in der App geladen. Push-Payloads dürfen später nur Titel/Body/Deep-Link enthalten (im Stub dokumentiert).

### Akzeptanzkriterien aus #1624
- [x] Dokumentierte technische Schnittstelle (`docs/notifications.md` + Package-Doku)
- [x] Standardmäßig deaktiviert (Feature Flag, default false)
- [x] Bestehende SSE-Logik unverändert (nur additiver Eventtyp; alle bestehenden Tests grün)
- [x] Keine sensiblen Schülerdaten in Push-Payloads (Vertrag + Validierung; Web Push noch nicht aktiv)
- [x] #669 kann auf `Notify(ctx, event)` aufbauen

### Hinweis zu bestehenden Tests
`frontend/src/app/providers.test.tsx` mockt das ToastContext-Modul komplett; da `Providers` jetzt zusätzlich die `NotificationBridge` rendert (die `useToast` konsumiert), musste der Modul-Mock um einen `useToast`-Export ergänzt werden. Keine Assertion wurde geändert.

## Tests
- Backend: neue Unit-Tests für Router/Validierung/Kanal-Routing (`services/notifications`) und Handler (`api/notifications`); `go test ./...` komplett grün, golangci-lint sauber, alle Ratchet-Tests grün.
- Frontend: neue Tests für `NotificationBridge`; kompletter Vitest-Lauf grün, `pnpm run check` sauber.
- End-to-End lokal verifiziert: Flag im Settings-UI aktiviert → `POST /api/notifications/test` → SSE → Toast erscheint; bei deaktiviertem Flag 409.

Closes #1624