### PR TITLE
feat(staff): Staff-Navigation an operations.group_mode koppeln

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.test.tsx
@@ -106,6 +106,7 @@ vi.mock("~/lib/swr/hooks", () => ({
 
 vi.mock("~/lib/tenant-context", () => ({
   useNFCEnabled: vi.fn(() => true),
+  useOpenCareGroupMode: vi.fn(() => false),
   usePresenceMode: vi.fn(() => "detailed"),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
   useTenantRoutingModeSafe: vi.fn(() => "path"),
@@ -126,7 +127,11 @@ vi.mock("~/lib/dashboard-helpers", () => ({
 import { useSession } from "next-auth/react";
 import { isAdmin } from "~/lib/auth-utils";
 import { useSWRAuth } from "~/lib/swr/hooks";
-import { useNFCEnabled, usePresenceMode } from "~/lib/tenant-context";
+import {
+  useNFCEnabled,
+  useOpenCareGroupMode,
+  usePresenceMode,
+} from "~/lib/tenant-context";
 
 // Helper to create SWR mock return values
 function mockSWR(
@@ -153,6 +158,7 @@ describe("DashboardPage", () => {
     vi.mocked(isAdmin).mockReturnValue(true);
     vi.mocked(useSWRAuth).mockReturnValue(mockSWR(mockDashboardData));
     vi.mocked(useNFCEnabled).mockReturnValue(true);
+    vi.mocked(useOpenCareGroupMode).mockReturnValue(false);
     vi.mocked(usePresenceMode).mockReturnValue("detailed");
   });
 
@@ -241,6 +247,21 @@ describe("DashboardPage", () => {
       expect(screen.getByText("Laufende Aktivitäten")).toBeInTheDocument();
       // "Aktive Gruppen" appears both as stat card title and info card title
       expect(screen.getAllByText("Aktive Gruppen")).toHaveLength(2);
+      expect(screen.getByText("Personal heute")).toBeInTheDocument();
+    });
+  });
+
+  it("hides group dashboard surfaces in open-care group mode", async () => {
+    vi.mocked(useOpenCareGroupMode).mockReturnValue(true);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Aktive Gruppen")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /Aktive Gruppen/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Kinder anwesend")).toBeInTheDocument();
       expect(screen.getByText("Personal heute")).toBeInTheDocument();
     });
   });

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -16,7 +16,11 @@ import {
 } from "~/lib/dashboard-helpers";
 import { useSWRAuth } from "~/lib/swr/hooks";
 import { RoleGuard } from "~/components/auth/role-guard";
-import { useNFCEnabled, usePresenceMode } from "~/lib/tenant-context";
+import {
+  useNFCEnabled,
+  useOpenCareGroupMode,
+  usePresenceMode,
+} from "~/lib/tenant-context";
 import { DashboardSkeleton } from "./page-skeleton";
 
 const logger = createLogger({ component: "DashboardPage" });
@@ -255,6 +259,7 @@ function DashboardContent() {
   const router = useTenantRouter();
   const tenantPath = useTenantAwarePath();
   const nfcEnabled = useNFCEnabled();
+  const openCareGroupMode = useOpenCareGroupMode();
   const presenceMode = usePresenceMode();
   const showActivitySurfaces = nfcEnabled && presenceMode !== "binary";
   const { data: session, status } = useSession({
@@ -368,14 +373,16 @@ function DashboardContent() {
           loading={isLoading}
           href="/students/search?status=entschuldigt"
         />
-        <StatCard
-          title="Aktive Gruppen"
-          value={dashboardData?.activeOGSGroups ?? 0}
-          icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-          color="from-[#83CD2D] to-[#70b525]"
-          loading={isLoading}
-          href="/ogs-groups"
-        />
+        {!openCareGroupMode ? (
+          <StatCard
+            title="Aktive Gruppen"
+            value={dashboardData?.activeOGSGroups ?? 0}
+            icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+            color="from-[#83CD2D] to-[#70b525]"
+            loading={isLoading}
+            href="/ogs-groups"
+          />
+        ) : null}
         {showActivitySurfaces ? (
           <StatCard
             title="Aktive Aktivitäten"
@@ -535,56 +542,58 @@ function DashboardContent() {
         ) : null}
 
         {/* Active Groups */}
-        <InfoCard
-          title="Aktive Gruppen"
-          icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-          href="/ogs-groups"
-        >
-          {(() => {
-            if (isLoading) {
+        {!openCareGroupMode ? (
+          <InfoCard
+            title="Aktive Gruppen"
+            icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+            href="/ogs-groups"
+          >
+            {(() => {
+              if (isLoading) {
+                return (
+                  <div className="space-y-3">
+                    {[1, 2, 3].map((i) => (
+                      <div
+                        key={i}
+                        className="h-14 animate-pulse rounded-lg bg-gray-100"
+                      ></div>
+                    ))}
+                  </div>
+                );
+              }
+              const groups = dashboardData?.activeGroupsSummary;
+              if (!groups || groups.length === 0) {
+                return (
+                  <p className="py-8 text-center text-sm text-gray-500">
+                    Keine aktiven Gruppen
+                  </p>
+                );
+              }
               return (
-                <div className="space-y-3">
-                  {[1, 2, 3].map((i) => (
+                <div className="space-y-2">
+                  {groups.slice(0, 5).map((group) => (
                     <div
-                      key={i}
-                      className="h-14 animate-pulse rounded-lg bg-gray-100"
-                    ></div>
+                      key={`${group.type}-${group.name}`}
+                      className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3 transition-colors hover:bg-gray-100/50"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-gray-900">
+                          {group.name}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {group.location} • {group.studentCount} Kinder
+                        </p>
+                      </div>
+                      <div
+                        className={`h-2.5 w-2.5 rounded-full ${getGroupStatusColor(group.status)} ml-2 flex-shrink-0`}
+                      ></div>
+                    </div>
                   ))}
                 </div>
               );
-            }
-            const groups = dashboardData?.activeGroupsSummary;
-            if (!groups || groups.length === 0) {
-              return (
-                <p className="py-8 text-center text-sm text-gray-500">
-                  Keine aktiven Gruppen
-                </p>
-              );
-            }
-            return (
-              <div className="space-y-2">
-                {groups.slice(0, 5).map((group) => (
-                  <div
-                    key={`${group.type}-${group.name}`}
-                    className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3 transition-colors hover:bg-gray-100/50"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-gray-900">
-                        {group.name}
-                      </p>
-                      <p className="text-xs text-gray-500">
-                        {group.location} • {group.studentCount} Kinder
-                      </p>
-                    </div>
-                    <div
-                      className={`h-2.5 w-2.5 rounded-full ${getGroupStatusColor(group.status)} ml-2 flex-shrink-0`}
-                    ></div>
-                  </div>
-                ))}
-              </div>
-            );
-          })()}
-        </InfoCard>
+            })()}
+          </InfoCard>
+        ) : null}
 
         {/* Betreuer Summary */}
         <InfoCard

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.school-checkin.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.school-checkin.test.tsx
@@ -53,6 +53,10 @@ vi.mock("~/lib/hooks/use-school-checkin-mode", () => ({
 vi.mock("~/lib/tenant-context", () => ({
   useTenant: vi.fn(() => ({ tenantSlug: "test-tenant", tenant: null })),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
+  // OpenCareModeGuard (#1544) wraps the page; fixed_groups keeps it inert.
+  // Its useTenantAwarePath call needs the routing-mode selector too.
+  useOpenCareGroupMode: vi.fn(() => false),
+  useTenantRoutingModeSafe: vi.fn(() => "subdomain"),
   // useStudentPhotosEnabled (used by ogs-groups for the avatar-clearance
   // spacer) reads tenant.studentPhotosEnabled via this selector. The mock
   // returns null which makes the hook resolve to enabled=false — fine for

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -12,6 +12,7 @@ import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { RoleGuard } from "~/components/auth/role-guard";
+import { OpenCareModeGuard } from "~/components/tenant/open-care-mode-guard";
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { Alert } from "~/components/ui/alert";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
@@ -1623,6 +1624,14 @@ function OGSGroupPageContent() {
 
 // Main component with Suspense wrapper
 export default function OGSGroupPage() {
+  return (
+    <OpenCareModeGuard>
+      <OGSGroupPageGuarded />
+    </OpenCareModeGuard>
+  );
+}
+
+function OGSGroupPageGuarded() {
   return (
     <RoleGuard variant="staffOnly" fallback={<OgsGroupsPageSkeleton />}>
       <Suspense fallback={<OgsGroupsPageSkeleton />}>

--- a/frontend/src/components/auth/smart-redirect.test.tsx
+++ b/frontend/src/components/auth/smart-redirect.test.tsx
@@ -39,6 +39,7 @@ vi.mock("~/lib/redirect-utils", () => ({
 
 vi.mock("~/lib/tenant-context", () => ({
   usePresenceMode: vi.fn(() => "detailed"),
+  useOpenCareGroupMode: vi.fn(() => false),
   useTenantSlugSafe: vi.fn(() => "test-tenant"),
   useTenantRoutingModeSafe: vi.fn(() => "path"),
   useNFCEnabled: vi.fn(() => true),
@@ -166,6 +167,7 @@ describe("SmartRedirect", () => {
         isSupervising: true,
       }),
       "detailed",
+      false,
     );
   });
 
@@ -178,6 +180,7 @@ describe("SmartRedirect", () => {
       expect.anything(),
       expect.anything(),
       "binary",
+      false,
     );
   });
 });

--- a/frontend/src/components/auth/smart-redirect.tsx
+++ b/frontend/src/components/auth/smart-redirect.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useSupervision } from "~/lib/supervision-context";
 import { useSmartRedirectPath } from "~/lib/redirect-utils";
-import { usePresenceMode } from "~/lib/tenant-context";
+import { useOpenCareGroupMode, usePresenceMode } from "~/lib/tenant-context";
 import { useTenantAwarePath } from "~/lib/tenant-path";
 
 interface SmartRedirectProps {
@@ -20,6 +20,7 @@ export function SmartRedirect({ onRedirect }: SmartRedirectProps) {
   const tenantPath = useTenantAwarePath();
   const { data: session, status } = useSession();
   const presenceMode = usePresenceMode();
+  const openCareGroupMode = useOpenCareGroupMode();
   const { hasGroups, isLoadingGroups, isSupervising, isLoadingSupervision } =
     useSupervision();
 
@@ -32,6 +33,7 @@ export function SmartRedirect({ onRedirect }: SmartRedirectProps) {
       isLoadingSupervision,
     },
     presenceMode,
+    openCareGroupMode,
   );
 
   useEffect(() => {

--- a/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
@@ -1011,6 +1011,34 @@ describe("MobileBottomNav", () => {
       expect(screen.getByText("Betreuungsplan")).toBeInTheDocument();
     });
 
+    it("hides the Gruppe main item for open-care staff (#1544)", () => {
+      mockIsAdmin.mockReturnValue(false);
+      mockUseSession.mockReturnValue(createMockSession(false));
+      mockUseOpenCareGroupMode.mockReturnValue(true);
+
+      render(<MobileBottomNav />);
+
+      const hrefs = screen
+        .getAllByRole("link")
+        .map((link) => link.getAttribute("href"));
+      expect(hrefs).not.toContain("/ogs-groups");
+      // Die übrigen Staff-Einstiege bleiben erhalten.
+      expect(hrefs).toContain("/active-supervisions");
+      expect(hrefs).toContain("/students/search");
+    });
+
+    it("keeps the Gruppe main item for fixed-groups staff (#1544)", () => {
+      mockIsAdmin.mockReturnValue(false);
+      mockUseSession.mockReturnValue(createMockSession(false));
+
+      render(<MobileBottomNav />);
+
+      const hrefs = screen
+        .getAllByRole("link")
+        .map((link) => link.getAttribute("href"));
+      expect(hrefs).toContain("/ogs-groups");
+    });
+
     it("hides the planning entries when timetable.enabled is false", () => {
       mockUseSWRDefault.mockReturnValue({
         data: {

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -614,7 +614,11 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
 
   // Filter additional navigation items based on permissions
   const filteredMainItemsByMode = filteredMainItems.filter(
-    (item) => showActivityNav || !NFC_ONLY_HREFS.has(item.href),
+    (item) =>
+      (showActivityNav || !NFC_ONLY_HREFS.has(item.href)) &&
+      // Bei offener Betreuung gibt es keine "meine Gruppe" — der
+      // gruppenbasierte Einstieg entfällt (#1544).
+      !(openCareGroupMode && item.href === "/ogs-groups"),
   );
 
   const filteredAdditionalItems = additionalNavItems.filter((item) => {

--- a/frontend/src/components/dashboard/sidebar.test.tsx
+++ b/frontend/src/components/dashboard/sidebar.test.tsx
@@ -1786,4 +1786,45 @@ describe("Sidebar", () => {
       expect(screen.getByText("Gruppenzugriff")).toBeInTheDocument();
     });
   });
+
+  describe("Meine Gruppe gating (#1544)", () => {
+    beforeEach(() => {
+      mockIsAdmin.mockReturnValue(false);
+      mockUseSupervision.mockReturnValue({
+        hasGroups: true,
+        isSupervising: false,
+        isLoadingGroups: false,
+        isLoadingSupervision: false,
+        adminOverviewEnabled: false,
+        supervisedRooms: [],
+        groups: [],
+        refresh: vi.fn(),
+      });
+    });
+
+    afterEach(() => {
+      mockUseOpenCareGroupMode.mockReturnValue(false);
+    });
+
+    it("hides the Meine Gruppe accordion for open-care tenants", () => {
+      mockUseOpenCareGroupMode.mockReturnValue(true);
+
+      render(<Sidebar />);
+
+      expect(screen.queryByText("Meine Gruppe")).not.toBeInTheDocument();
+      expect(screen.queryByText("Meine Gruppen")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Keine Gruppen zugeordnet"),
+      ).not.toBeInTheDocument();
+      // Aufsicht und Kindersuche bleiben als Staff-Einstiege erhalten.
+      expect(screen.getByText("Aktuelle Aufsicht")).toBeInTheDocument();
+      expect(screen.getByText("Kindersuche")).toBeInTheDocument();
+    });
+
+    it("shows the Meine Gruppe accordion for fixed-groups tenants", () => {
+      render(<Sidebar />);
+
+      expect(screen.getByText("Meine Gruppe")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -1241,8 +1241,10 @@ function SidebarContent({ className = "" }: SidebarProps) {
             .filter((item) => item.href === "/dashboard")
             .map(renderNavItem)}
 
-          {/* Meine Gruppen accordion (staff only) */}
-          {showStaffAccordions && (
+          {/* Meine Gruppen accordion (staff only; hidden in open-care group
+              mode because there is no concept of "meine Gruppe" — staff work
+              with all children instead, #1544) */}
+          {showStaffAccordions && !openCareGroupMode && (
             <SidebarAccordionSection
               icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
               label={

--- a/frontend/src/components/tenant/open-care-mode-guard.test.tsx
+++ b/frontend/src/components/tenant/open-care-mode-guard.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Opt out of the global tenant-provider mock so the guard sees the real
+// TenantContext wired up by its wrapping TenantProvider.
+vi.unmock("~/lib/tenant-context");
+
+import { TenantProvider } from "~/lib/tenant-context";
+import { OpenCareModeGuard } from "./open-care-mode-guard";
+import type { TenantInfo } from "~/lib/tenant-api";
+
+// `redirect()` throws a Next.js-internal error synchronously. We mock the
+// module so the test can assert the throw (incl. target path) without a
+// Next runtime.
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`);
+  },
+}));
+
+function makeTenant(
+  groupMode: "fixed_groups" | "open_care" = "fixed_groups",
+): TenantInfo {
+  return {
+    tenantId: 1,
+    slug: "demo",
+    name: "Demo",
+    subdomain: "demo",
+    organizationId: 10,
+    organizationName: "Org",
+    settings: {},
+    presenceMode: "detailed",
+    studentPhotosEnabled: false,
+    nfcEnabled: false,
+    messagingEnabled: false,
+    displayEnabled: false,
+    gradeLevelMax: 4,
+    groupMode,
+  };
+}
+
+describe("OpenCareModeGuard", () => {
+  it("renders children in fixed-groups mode", () => {
+    render(
+      <TenantProvider tenantSlug="demo" tenant={makeTenant("fixed_groups")}>
+        <OpenCareModeGuard>
+          <div>protected-content</div>
+        </OpenCareModeGuard>
+      </TenantProvider>,
+    );
+    expect(screen.getByText("protected-content")).toBeInTheDocument();
+  });
+
+  it("redirects to the Kindersuche in open-care mode", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(
+      () =>
+        render(
+          <TenantProvider tenantSlug="demo" tenant={makeTenant("open_care")}>
+            <OpenCareModeGuard>
+              <div>protected-content</div>
+            </OpenCareModeGuard>
+          </TenantProvider>,
+        ),
+      // TenantProvider defaults to path routing in tests, so the target is
+      // tenant-prefixed. Subdomain mode would redirect to /students/search.
+    ).toThrow("NEXT_REDIRECT:/demo/students/search");
+
+    errorSpy.mockRestore();
+  });
+
+  it("renders children when no tenant context (safe default is fixed_groups)", () => {
+    // Outside a TenantProvider the hook returns false — first paint on cold
+    // load should NOT bounce staff off the group page.
+    render(
+      <OpenCareModeGuard>
+        <div>protected-content</div>
+      </OpenCareModeGuard>,
+    );
+    expect(screen.getByText("protected-content")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/tenant/open-care-mode-guard.tsx
+++ b/frontend/src/components/tenant/open-care-mode-guard.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { redirect } from "next/navigation";
+import { useOpenCareGroupMode } from "~/lib/tenant-context";
+import { useTenantAwarePath } from "~/lib/tenant-path";
+
+/**
+ * OpenCareModeGuard — redirects to the Kindersuche when the tenant runs in
+ * open-care group mode (operations.group_mode = "open_care").
+ *
+ * Open-care tenants have no concept of "meine Gruppe", so the group-based
+ * staff entry page (/ogs-groups) is misleading there. Navigation already
+ * hides the entry (#1544); this guard covers direct URL entry by sending the
+ * user to the open-care staff entry point instead of a dead group page.
+ *
+ * Same component-not-hook rationale as BinaryModeGuard: the gate lives at
+ * the route boundary and renders nothing before redirecting.
+ */
+export function OpenCareModeGuard({ children }: { children: React.ReactNode }) {
+  const openCareGroupMode = useOpenCareGroupMode();
+  const tenantPath = useTenantAwarePath();
+  if (openCareGroupMode) {
+    redirect(tenantPath("/students/search"));
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/lib/redirect-utils.test.ts
+++ b/frontend/src/lib/redirect-utils.test.ts
@@ -122,6 +122,42 @@ describe("redirect-utils", () => {
       expect(result).toBe("/students/search");
     });
 
+    it("should return /students/search for open-care caregivers (#1544)", () => {
+      const session = createSession(["user"]);
+      const supervisionState: SupervisionState = {
+        hasGroups: false,
+        isLoadingGroups: false,
+        isSupervising: true,
+        isLoadingSupervision: false,
+      };
+
+      const result = getSmartRedirectPath(
+        session,
+        supervisionState,
+        "detailed",
+        true,
+      );
+      expect(result).toBe("/students/search");
+    });
+
+    it("should return /students/search for open-care caregivers with groups (#1544)", () => {
+      const session = createSession(["user"]);
+      const supervisionState: SupervisionState = {
+        hasGroups: true,
+        isLoadingGroups: false,
+        isSupervising: false,
+        isLoadingSupervision: false,
+      };
+
+      const result = getSmartRedirectPath(
+        session,
+        supervisionState,
+        "detailed",
+        true,
+      );
+      expect(result).toBe("/students/search");
+    });
+
     it("should return /ogs-groups as default for regular users", () => {
       const session = createSession(["user"]);
       const supervisionState: SupervisionState = {

--- a/frontend/src/lib/redirect-utils.ts
+++ b/frontend/src/lib/redirect-utils.ts
@@ -17,21 +17,23 @@ export interface SupervisionState {
  * Determines the best redirect path for a user based on their permissions and supervision state
  * Priority order:
  * 1. Binary-mode caregivers: /students/search
- * 2. Caregivers with groups: /ogs-groups
- * 3. Caregivers actively supervising: /active-supervisions
- * 4. Other caregivers: /ogs-groups
- * 5. Admin-only users: /dashboard
+ * 2. Open-care caregivers: /students/search (no group concept, #1544)
+ * 3. Caregivers with groups: /ogs-groups
+ * 4. Caregivers actively supervising: /active-supervisions
+ * 5. Other caregivers: /ogs-groups
+ * 6. Admin-only users: /dashboard
  */
 export function getSmartRedirectPath(
   session: Session | null,
   supervisionState: SupervisionState,
   presenceMode: PresenceMode = "detailed",
+  openCareGroupMode = false,
 ): string {
   const canUseCaregiverFlows = isCaregiver(session);
   const canUseAdminFlows = hasRole(session, "admin");
 
   if (canUseCaregiverFlows) {
-    if (presenceMode === "binary") {
+    if (presenceMode === "binary" || openCareGroupMode) {
       return "/students/search";
     }
 
@@ -69,6 +71,7 @@ export function useSmartRedirectPath(
   session: Session | null,
   supervisionState: SupervisionState,
   presenceMode: PresenceMode = "detailed",
+  openCareGroupMode = false,
 ): { redirectPath: string; isReady: boolean } {
   const isReady =
     !supervisionState.isLoadingGroups && !supervisionState.isLoadingSupervision;
@@ -76,6 +79,7 @@ export function useSmartRedirectPath(
     session,
     supervisionState,
     presenceMode,
+    openCareGroupMode,
   );
 
   return {


### PR DESCRIPTION
## Zusammenfassung

Schliesst #1544. `operations.group_mode` steuert jetzt die Staff-Navigation und die Einstiegsseiten.

Bei `open_care` (offene Betreuung, kein Konzept von "meine Gruppe"):
- **Desktop-Sidebar**: das "Meine Gruppe(n)"-Akkordeon wird nicht mehr angezeigt (damit auch kein "Keine Gruppen zugeordnet"-Leerzustand).
- **Mobile Bottom-Nav**: der "Gruppe"-Slot (`/ogs-groups`) entfaellt; Aufsicht, Suchen und Aktivitaeten bleiben.
- **Smart Redirect nach Login**: Betreuende landen auf `/students/search` statt `/ogs-groups` (gleiches Muster wie der Binary-Mode).
- **Direktzugriff auf `/ogs-groups`**: neuer `OpenCareModeGuard` (Muster von `BinaryModeGuard`, aber Redirect statt 404) leitet auf die Kindersuche um.

Bei `fixed_groups` bleibt alles visuell und funktional unveraendert.

## Tests
- Neue Faelle fuer beide Modi in `sidebar.test.tsx`, `mobile-bottom-nav.test.tsx`, `redirect-utils.test.ts` und `open-care-mode-guard.test.tsx`.
- Bestehende Tests: nur mechanische Anpassungen (Mock-Exports fuer den neuen Hook-Aufruf, ein zusaetzliches Argument in zwei `toHaveBeenCalledWith`-Assertions); keine Verhaltens-Assertion geaendert.
- `pnpm run check` gruen, alle betroffenen Vitest-Suiten gruen.
- End-to-end lokal verifiziert (beide Modi, Desktop + Mobile, Login-Redirect und Direktzugriff); Screenshots folgen als Kommentar.