### PR TITLE
refactor(ui-kit): StatusBadge + EmptyState components, OverflowMenu link/separator support, duplicate-site migrations

### DIFF
--- a/.claude/rules/frontend-ui-kit.md
+++ b/.claude/rules/frontend-ui-kit.md
@@ -77,6 +77,9 @@ An unexplained bespoke component is a review failure, not a style preference.
 | Loading / skeleton | `Loading`, `Skeleton` | `~/components/ui/loading`, `~/components/ui/skeleton` |
 | Avatar | `Avatar` | `~/components/ui/avatar` |
 | Location / presence badge | `LocationBadge`, `PresenceBadge`, `StudentPresenceBadge` | `~/components/ui/location-badge`, etc. |
+| Semantic status pill (fixed tone set) | `StatusBadge` — tinted pill + dot, `tone` = `blue` `green` `orange` `red` `gray` (brand hexes) | `~/components/ui/status-badge` |
+| Data-driven status pill (raw hex) | `StatusDotBadge` | `~/components/ui/status-dot-badge` |
+| Empty / no-results state | `EmptyState` — optional icon, title, description, action slot | `~/components/ui/empty-state` |
 | Back navigation | `BackButton`, `MobileBackButton` | `~/components/ui/back-button`, `~/components/ui/mobile-back-button` |
 | Overlay / side panel | `Drawer`, slide-over | `~/components/ui/drawer`, `~/components/ui/slide-over` |
 | API error message text | `getApiErrorMessage` | `~/lib/api-error-message` |
@@ -131,7 +134,7 @@ Standard 4px scale — Tailwind `p-*` / `gap-*` / `m-*` map 1:1: `1`=4 · `2`=8 
 
 ## Kit gaps — extend the kit, don't inline a bespoke control
 
-Compact / ghost / icon-only buttons now EXIST on `ui/Button` (`variant="ghost"`, `size="compact"`, `size="icon"`) — use those for dense toolbar/menu/icon chrome instead of hand-rolling. A modal-footer / in-form action height now EXISTS too: `size="md"` (`px-4 py-2 text-sm`) — use it for slide-over / modal footers and dense form actions instead of the oversized page sizes (`sm`/`base`/`lg`/`xl` are all `px-5 py-3`). A shared `Checkbox` (brand-green checked state) now EXISTS at `ui/checkbox` — never hand-roll a raw `<input type="checkbox">` with an ad-hoc accent color. The kit still does **not** have a generic `DropdownMenu`/popover-menu or a `Select` (native `<select>` styled to the kit `Input` look via the `moto-select` utility is the current convention). When you need a genuinely missing primitive, ADD it to `frontend/src/components/ui/` so the next screen reuses it — do not hand-roll a one-off `<button className="…">` inline. Call out the addition in the PR description.
+Compact / ghost / icon-only buttons now EXIST on `ui/Button` (`variant="ghost"`, `size="compact"`, `size="icon"`) — use those for dense toolbar/menu/icon chrome instead of hand-rolling. A modal-footer / in-form action height now EXISTS too: `size="md"` (`px-4 py-2 text-sm`) — use it for slide-over / modal footers and dense form actions instead of the oversized page sizes (`sm`/`base`/`lg`/`xl` are all `px-5 py-3`). A shared `Checkbox` (brand-green checked state) now EXISTS at `ui/checkbox` — never hand-roll a raw `<input type="checkbox">` with an ad-hoc accent color. A generic kebab/dropdown menu now EXISTS: `ui/page-header/OverflowMenu` covers action menus fully (portal-rendered, header/radio/separator entries, `href` link items incl. `external`, destructive tone, badges) — never hand-roll a `menuOpen` + click-outside menu again. Semantic status pills (`ui/status-badge`, tone-based) and empty states (`ui/empty-state`) now EXIST too. The kit still does **not** have a `Select` (native `<select>` styled to the kit `Input` look via the `moto-select` utility is the current convention). When you need a genuinely missing primitive, ADD it to `frontend/src/components/ui/` so the next screen reuses it — do not hand-roll a one-off `<button className="…">` inline. Call out the addition in the PR description.
 
 ## Gotchas
 

--- a/frontend/.claude/skills/ui-before-after/SKILL.md
+++ b/frontend/.claude/skills/ui-before-after/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ui-before-after
+description: Use when a UI change needs before/after screenshot pairs for a PR or review. Triggers on "vorher/nachher", "before/after screenshots", visual comparison of a frontend refactor, or verifying that a migration did not change the look.
+metadata:
+  author: moto-nrw
+  version: "1.0.0"
+---
+
+# Before/After UI Screenshot Pairs
+
+Produce matched before/after screenshots of frontend changes by hot-swapping
+`frontend/src` between two git states on a RUNNING dev server, capturing the
+same interactions twice with agent-browser, and compositing pairs side by side.
+
+Core idea: the dev server (Turbopack) hot-reloads mounted sources, so you never
+rebuild or restart anything between the two states — only the source tree flips.
+
+## Prerequisites
+
+- Working tree is CLEAN (changes committed). Verify: `git status --short` is empty.
+- Local stack running: backend/postgres/mailpit via `docker compose up -d`.
+- Frontend: **prefer local `pnpm dev`** (`PORT=<port> pnpm dev` in `frontend/`,
+  with `frontend/.env.local` pointing `API_URL`/`NEXT_PUBLIC_API_URL` at the
+  compose server port). The dockerized dev frontend reproducibly crash-loops
+  compiling `[tenant]` pages (known Turbopack trap) — do not fight it.
+- Seeded data + login: slug and credentials come from `backend/.seed-state.json`
+  (fallback password `Test1234%`). Operator login needs an email MFA code —
+  fetch it from Mailpit: `curl localhost:<MAILPIT_PORT>/api/v1/messages`.
+- Use a dedicated agent-browser session: `agent-browser --session <name> ...`
+  (the default session is shared across concurrent Claude sessions).
+
+## Workflow
+
+1. **Plan the shot list first.** One entry per changed surface: URL, the exact
+   interaction (open menu X, search gibberish for the empty state), and the
+   state needed (own post for owner-only menus, seeded rows for badges).
+   Create any needed data ONCE before starting — it must exist in both passes.
+2. **BEFORE pass** — flip sources to the baseline:
+   ```bash
+   git checkout origin/development -- frontend/src   # or any base ref
+   ```
+   Wait for recompile on first page hit (~2-3s), then walk the shot list:
+   ```bash
+   agent-browser --session s open <url>
+   agent-browser --session s snapshot -i -c   # fresh refs EVERY page/state change
+   agent-browser --session s click @eN        # e.g. open the kebab menu
+   agent-browser --session s screenshot shots/before/<nn>-<name>.png
+   ```
+3. **AFTER pass** — restore and repeat the identical list:
+   ```bash
+   git checkout HEAD -- frontend/src
+   ```
+   Same URLs, same interactions, same filenames under `shots/after/`.
+4. **Composite pairs** (ImageMagick, left=before right=after):
+   ```bash
+   for f in before/*.png; do n=$(basename "$f")
+     magick "$f" -resize 50% -bordercolor gray -border 1 /tmp/b.png
+     magick "after/$n" -resize 50% -bordercolor gray -border 1 /tmp/a.png
+     magick /tmp/b.png /tmp/a.png +append "pair-$n"
+   done
+   ```
+5. **Verify sources are restored**: `git status --short` must be empty again.
+6. Deliver: Read the `pair-*.png` files to show them inline; for the PR, give
+   the user the local paths to attach manually (never host via releases/gists —
+   see the PR-screenshots rule in the root CLAUDE.md).
+
+## Gotchas (all hit in practice)
+
+- **Refs go stale after every hot-reload/re-render** — re-run `snapshot -i -c`
+  before each interaction; a `fill` on a stale ref reports success but does
+  nothing. If a page renders empty after the source flip, `reload` once.
+- **Same viewport both passes**: set `agent-browser set viewport 1440 900` once
+  at the start; a viewport mismatch makes pairs useless.
+- **Identical data both passes**: never create/delete records between the
+  passes; timestamps ("vor X Minuten") will differ — that is acceptable.
+- **Menus/popovers**: screenshot with the menu OPEN, then `press Escape`
+  before navigating on.
+- **`git checkout <ref> -- frontend/src` only replaces tracked files** — new
+  files added by your branch remain on disk during the BEFORE pass. That is
+  fine (they are unimported in the old state), but do not delete them.
+- Empty states are usually reachable by searching gibberish (`xyznichts`).
+
+## Scope
+
+Screenshot comparison only. For stack bootstrap (ports, certs, seeding) see
+the worktree-setup memory/docs; for general browser driving see the
+`agent-browser` skill.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -77,6 +77,10 @@ src/app/
 
 Build all new UI from `src/components/ui/` (and `ui/page-header/`); never hand-roll buttons/cards/modals/tables. Brand colors come only from `LOCATION_COLORS` (`src/lib/location-helper.ts`) via arbitrary-value hex (`bg-[#83CD2D]`) — never generic Tailwind hues (`bg-green-500`), which are different colors. Component map, hex table, radius/spacing tokens, gotchas, and the design checklist: **`.claude/rules/frontend-ui-kit.md`**. Search `src/components/` and `src/lib/` for existing code before writing anything new.
 
+### Before/After Screenshots for UI Changes (MANDATORY)
+
+When a change alters what a school user sees (new screen, migrated component, layout/styling change), produce paired before/after screenshots via the `ui-before-after` skill (`.claude/skills/ui-before-after/`): capture the identical interactions against the base ref and your branch, composite them into `pair-*.png` images, and at the end tell the user the local file paths so they can attach the images to the PR manually (GitHub has no API for native attachment uploads; never host screenshots via releases, tags, or Gists — see the PR-screenshots rule in the root `CLAUDE.md`). Backend-only changes and pure refactors with zero visual delta are exempt, but a consolidation refactor that claims "no visual change" should prove it with a pair.
+
 ## Architecture Patterns
 
 ### Route Handlers (Next.js 16)

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -10,6 +10,8 @@ import {
 } from "react";
 import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
+import { Building2 } from "lucide-react";
+import { EmptyState } from "~/components/ui/empty-state";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { useUpdateUrlParams } from "~/hooks/useUpdateUrlParams";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
@@ -589,31 +591,11 @@ function RoomsPageContent() {
           ) : null}
 
           {filteredRooms.length === 0 && !showTransitAssignment ? (
-            <div className="py-12 text-center">
-              <div className="flex flex-col items-center gap-4">
-                <svg
-                  className="h-12 w-12 text-gray-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                  />
-                </svg>
-                <div>
-                  <h3 className="text-lg font-medium text-gray-900">
-                    Keine Räume gefunden
-                  </h3>
-                  <p className="text-gray-600">
-                    Versuchen Sie Ihre Suchkriterien anzupassen.
-                  </p>
-                </div>
-              </div>
-            </div>
+            <EmptyState
+              icon={<Building2 className="h-12 w-12" strokeWidth={1.5} />}
+              title="Keine Räume gefunden"
+              description="Versuchen Sie Ihre Suchkriterien anzupassen."
+            />
           ) : null}
 
           {filteredRooms.length > 0 ? (

--- a/frontend/src/app/[tenant]/(protected)/suggestions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/suggestions/page.tsx
@@ -4,7 +4,9 @@ import { useState, useMemo, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
+import { Lightbulb, Search } from "lucide-react";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { EmptyState as UIEmptyState } from "~/components/ui/empty-state";
 import type { FilterConfig } from "~/components/ui/page-header/types";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { SuggestionCard } from "~/components/suggestions/suggestion-card";
@@ -272,57 +274,29 @@ function EmptyState({
 }) {
   if (hasSearch) {
     return (
-      <div className="flex flex-col items-center gap-3 py-12 text-center">
-        <svg
-          className="h-12 w-12 text-gray-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={1.5}
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          />
-        </svg>
-        <p className="text-lg font-medium text-gray-900">
-          Keine Ergebnisse gefunden
-        </p>
-        <p className="text-sm text-gray-500">
-          Versuche einen anderen Suchbegriff.
-        </p>
-      </div>
+      <UIEmptyState
+        icon={<Search className="h-12 w-12" strokeWidth={1.5} />}
+        title="Keine Ergebnisse gefunden"
+        description="Versuche einen anderen Suchbegriff."
+      />
     );
   }
 
   return (
-    <div className="flex flex-col items-center gap-4 py-12 text-center">
-      <svg
-        className="h-12 w-12 text-gray-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.5}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-        />
-      </svg>
-      <p className="text-lg font-medium text-gray-900">Noch keine Beiträge</p>
-      <p className="text-sm text-gray-500">
-        Teile Ideen, melde Probleme oder schlage Verbesserungen vor.
-      </p>
-      <button
-        type="button"
-        onClick={onCreateClick}
-        className="mt-2 rounded-full bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
-      >
-        Neuer Beitrag
-      </button>
-    </div>
+    <UIEmptyState
+      icon={<Lightbulb className="h-12 w-12" strokeWidth={1.5} />}
+      title="Noch keine Beiträge"
+      description="Teile Ideen, melde Probleme oder schlage Verbesserungen vor."
+      action={
+        <button
+          type="button"
+          onClick={onCreateClick}
+          className="rounded-full bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
+        >
+          Neuer Beitrag
+        </button>
+      }
+    />
   );
 }
 

--- a/frontend/src/app/operator/announcements/page.tsx
+++ b/frontend/src/app/operator/announcements/page.tsx
@@ -4,8 +4,9 @@ import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
 // eslint-disable-next-line no-restricted-imports -- operator pages use useOperatorAuth, not NextAuth
 import useSWR from "swr";
-import { MoreVertical, Pencil, Trash2, Send, Check } from "lucide-react";
+import { Pencil, Trash2, Send, Check } from "lucide-react";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import type { FilterConfig } from "~/components/ui/page-header/types";
 import { Modal, ConfirmationModal } from "~/components/ui/modal";
 import { Skeleton } from "~/components/ui/skeleton";
@@ -1076,10 +1077,8 @@ function AnnouncementCard({
   readonly onPublish: (a: Announcement) => void;
 }) {
   const currentTimestamp = useCurrentTimestamp();
-  const [menuOpen, setMenuOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
@@ -1089,59 +1088,26 @@ function AnnouncementCard({
     }
   }, [announcement.content]);
 
-  // Close menu on click outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setMenuOpen(false);
-      }
-    }
-    if (menuOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () =>
-        document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [menuOpen]);
-
   return (
     <div className="relative rounded-3xl border border-gray-100/50 bg-white/90 p-5 pr-12 shadow-sm backdrop-blur-md transition-all duration-150">
       {/* Kebab menu - absolute top right */}
-      <div className="absolute top-3 right-3" ref={menuRef}>
-        <button
-          type="button"
-          onClick={() => setMenuOpen(!menuOpen)}
-          className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
-          aria-label="Menü öffnen"
-        >
-          <MoreVertical className="h-5 w-5" />
-        </button>
-
-        {menuOpen && (
-          <div className="absolute top-full right-0 z-50 mt-1 w-40 overflow-hidden rounded-xl border border-gray-100 bg-white py-1 shadow-lg">
-            <button
-              type="button"
-              onClick={() => {
-                setMenuOpen(false);
-                onEdit(announcement);
-              }}
-              className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-50"
-            >
-              <Pencil className="h-4 w-4" />
-              Bearbeiten
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setMenuOpen(false);
-                onDelete(announcement);
-              }}
-              className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-red-600 transition-colors hover:bg-red-50"
-            >
-              <Trash2 className="h-4 w-4" />
-              Löschen
-            </button>
-          </div>
-        )}
+      <div className="absolute top-3 right-3">
+        <OverflowMenu
+          ariaLabel="Menü öffnen"
+          items={[
+            {
+              label: "Bearbeiten",
+              icon: <Pencil className="h-4 w-4" />,
+              onClick: () => onEdit(announcement),
+            },
+            {
+              label: "Löschen",
+              icon: <Trash2 className="h-4 w-4" />,
+              destructive: true,
+              onClick: () => onDelete(announcement),
+            },
+          ]}
+        />
       </div>
 
       {/* Type label */}

--- a/frontend/src/app/operator/provisioning/provisioning-shared.tsx
+++ b/frontend/src/app/operator/provisioning/provisioning-shared.tsx
@@ -1,6 +1,7 @@
 import { Children, isValidElement } from "react";
 import { Skeleton } from "~/components/ui/skeleton";
 import { CustomSelect } from "~/components/ui/custom-select";
+import { EmptyState as UIEmptyState } from "~/components/ui/empty-state";
 
 export function FormField({
   label,
@@ -98,30 +99,34 @@ export function EmptyState({
   readonly onAction: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center gap-3 py-12 text-center">
-      <svg
-        className="h-12 w-12 text-gray-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.5}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21"
-        />
-      </svg>
-      <p className="text-lg font-medium text-gray-900">{title}</p>
-      <p className="text-sm text-gray-500">{description}</p>
-      <button
-        type="button"
-        onClick={onAction}
-        className="mt-2 rounded-full bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
-      >
-        {buttonLabel}
-      </button>
-    </div>
+    <UIEmptyState
+      icon={
+        <svg
+          className="h-12 w-12"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21"
+          />
+        </svg>
+      }
+      title={title}
+      description={description}
+      action={
+        <button
+          type="button"
+          onClick={onAction}
+          className="rounded-full bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
+        >
+          {buttonLabel}
+        </button>
+      }
+    />
   );
 }
 
@@ -132,12 +137,7 @@ export function SimpleEmptyState({
   readonly title: string;
   readonly description: string;
 }) {
-  return (
-    <div className="flex flex-col items-center gap-3 py-12 text-center">
-      <p className="text-lg font-medium text-gray-900">{title}</p>
-      <p className="text-sm text-gray-500">{description}</p>
-    </div>
-  );
+  return <UIEmptyState title={title} description={description} />;
 }
 
 export function SelectWithChevron({

--- a/frontend/src/components/enrollment/admin-enrollment-change-requests.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-change-requests.tsx
@@ -24,6 +24,10 @@ import {
 import { useTenantAwarePath } from "~/lib/tenant-path";
 import { createLogger } from "~/lib/logger";
 import { CustomSelect } from "~/components/ui/custom-select";
+import {
+  StatusBadge,
+  type StatusBadgeTone,
+} from "~/components/ui/status-badge";
 import { EnrollmentChangeRequestDiff } from "~/components/enrollment/enrollment-change-request-diff";
 import { changedEnrollmentChangeRequestLabels } from "~/lib/enrollment-change-request-diff";
 
@@ -40,15 +44,15 @@ const CHANGE_REQUEST_STATUS_LABELS: Record<
   cancelled: "Abgebrochen",
 };
 
-const CHANGE_REQUEST_STATUS_STYLES: Record<
+const CHANGE_REQUEST_STATUS_TONES: Record<
   AdminEnrollmentChangeRequestStatus,
-  { bg: string; dot: string; text: string }
+  StatusBadgeTone
 > = {
-  pending_review: { bg: "#EEF3FF", dot: "#5080D8", text: "#355A9A" },
-  needs_parent_response: { bg: "#FFF4E6", dot: "#F78C10", text: "#8A5600" },
-  approved: { bg: "#83CD2D1A", dot: "#83CD2D", text: "#5A8B1F" },
-  rejected: { bg: "#FF31301A", dot: "#FF3130", text: "#9F1F1E" },
-  cancelled: { bg: "#F3F4F6", dot: "#9CA3AF", text: "#4B5563" },
+  pending_review: "blue",
+  needs_parent_response: "orange",
+  approved: "green",
+  rejected: "red",
+  cancelled: "gray",
 };
 
 const STATUS_OPTIONS: Array<{
@@ -621,19 +625,11 @@ function ChangeRequestStatusBadge({
 }: {
   readonly status: AdminEnrollmentChangeRequestStatus;
 }) {
-  const styles = CHANGE_REQUEST_STATUS_STYLES[status];
   return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
-      style={{ backgroundColor: styles.bg, color: styles.text }}
-    >
-      <span
-        className="h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: styles.dot }}
-        aria-hidden="true"
-      />
-      {CHANGE_REQUEST_STATUS_LABELS[status]}
-    </span>
+    <StatusBadge
+      label={CHANGE_REQUEST_STATUS_LABELS[status]}
+      tone={CHANGE_REQUEST_STATUS_TONES[status]}
+    />
   );
 }
 

--- a/frontend/src/components/enrollment/admin-enrollment-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-detail.tsx
@@ -49,38 +49,12 @@ import {
   useWaitlistEnabled,
 } from "~/lib/tenant-context";
 
+import {
+  CHILD_STATUS_LABELS,
+  ChildStatusBadge,
+} from "~/components/enrollment/child-status-badge";
+
 const logger = createLogger({ component: "AdminEnrollmentDetail" });
-
-const STATUS_LABELS: Record<ChildStatus, string> = {
-  submitted: "Eingegangen",
-  under_review: "In Prüfung",
-  approved: "Bestätigt",
-  waitlisted: "Warteliste",
-  rejected: "Abgelehnt",
-  withdrawn: "Zurückgezogen",
-  pending_renewal: "Wartet auf Verlängerung",
-  auto_renewed: "Vorgemerkt",
-  pending_admin_review: "Manuelle Prüfung",
-};
-
-const STATUS_COLORS: Record<
-  ChildStatus,
-  { bg: string; dot: string; text: string }
-> = {
-  submitted: { bg: "#EEF3FF", dot: "#5080D8", text: "#355A9A" },
-  under_review: { bg: "#EEF3FF", dot: "#5080D8", text: "#355A9A" },
-  approved: { bg: "#83CD2D1A", dot: "#83CD2D", text: "#5A8B1F" },
-  waitlisted: { bg: "#FFF4E6", dot: "#F78C10", text: "#8A5600" },
-  rejected: { bg: "#FF31301A", dot: "#FF3130", text: "#9F1F1E" },
-  withdrawn: { bg: "#F3F4F6", dot: "#9CA3AF", text: "#4B5563" },
-  pending_renewal: { bg: "#FFF4E6", dot: "#F78C10", text: "#8A5600" },
-  auto_renewed: { bg: "#EEF3FF", dot: "#5080D8", text: "#355A9A" },
-  pending_admin_review: {
-    bg: "#F3F4F6",
-    dot: "#9CA3AF",
-    text: "#4B5563",
-  },
-};
 
 const TERMINAL: ReadonlySet<ChildStatus> = new Set([
   "approved",
@@ -169,7 +143,7 @@ export function AdminEnrollmentDetail({ requestId }: Props) {
     try {
       await decideAdminChild(requestId, childId, status, reason || undefined);
       setInfo(
-        `Entscheidung gespeichert: ${STATUS_LABELS[status as ChildStatus]}`,
+        `Entscheidung gespeichert: ${CHILD_STATUS_LABELS[status as ChildStatus]}`,
       );
       await load();
     } catch (err) {
@@ -324,23 +298,6 @@ export function AdminEnrollmentDetail({ requestId }: Props) {
         }}
       />
     </div>
-  );
-}
-
-export function StatusBadge({ status }: Readonly<{ status: ChildStatus }>) {
-  const styles = STATUS_COLORS[status];
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
-      style={{ backgroundColor: styles.bg, color: styles.text }}
-    >
-      <span
-        className="h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: styles.dot }}
-        aria-hidden="true"
-      />
-      {STATUS_LABELS[status]}
-    </span>
   );
 }
 
@@ -502,7 +459,7 @@ function ChildInformationCard({
             ) : null}
           </div>
         </div>
-        <StatusBadge status={child.status} />
+        <ChildStatusBadge status={child.status} />
       </div>
       <div className="space-y-4 p-4">
         {child.status_reason ? (
@@ -667,7 +624,7 @@ function ReviewSidebar({
                       : "Keine Klassenstufe"}
                 </p>
               </div>
-              <StatusBadge status={child.status} />
+              <ChildStatusBadge status={child.status} />
             </div>
             <div className="mt-3 rounded-xl border border-gray-100 bg-gray-50/70 px-3 py-2 text-sm text-gray-600">
               {TERMINAL.has(child.status)

--- a/frontend/src/components/enrollment/admin-enrollment-phase-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-phase-detail.tsx
@@ -62,75 +62,16 @@ import { PublicLinkCopyButton } from "~/components/enrollment/public-link-copy-b
 import { createLogger } from "~/lib/logger";
 import { studentService } from "~/lib/api";
 import { useSWRAuth } from "~/lib/swr";
+import {
+  CHILD_STATUS_LABELS,
+  ChildStatusBadge,
+} from "~/components/enrollment/child-status-badge";
 
 const logger = createLogger({ component: "AdminEnrollmentPhaseDetail" });
 
 const ALL_STATUS_FILTER = "all";
 const ALL_VALUE = "all";
 const DAY_COUNT_OPTIONS = [0, 1, 2, 3, 4, 5] as const;
-
-const STATUS_LABELS: Record<ChildStatus, string> = {
-  submitted: "Eingegangen",
-  under_review: "In Prüfung",
-  approved: "Bestätigt",
-  waitlisted: "Warteliste",
-  rejected: "Abgelehnt",
-  withdrawn: "Zurückgezogen",
-  pending_renewal: "Wartet auf Verlängerung",
-  auto_renewed: "Vorgemerkt",
-  pending_admin_review: "Manuelle Prüfung",
-};
-
-const STATUS_COLORS: Record<
-  ChildStatus,
-  { bg: string; dot: string; text: string }
-> = {
-  submitted: {
-    bg: "#EEF3FF",
-    dot: "#5080D8",
-    text: "#355A9A",
-  },
-  under_review: {
-    bg: "#EEF3FF",
-    dot: "#5080D8",
-    text: "#355A9A",
-  },
-  approved: {
-    bg: "#83CD2D1A",
-    dot: "#83CD2D",
-    text: "#5A8B1F",
-  },
-  waitlisted: {
-    bg: "#FFF4E6",
-    dot: "#F78C10",
-    text: "#8A5600",
-  },
-  rejected: {
-    bg: "#FF31301A",
-    dot: "#FF3130",
-    text: "#9F1F1E",
-  },
-  withdrawn: {
-    bg: "#F3F4F6",
-    dot: "#9CA3AF",
-    text: "#4B5563",
-  },
-  pending_renewal: {
-    bg: "#FFF4E6",
-    dot: "#F78C10",
-    text: "#8A5600",
-  },
-  auto_renewed: {
-    bg: "#EEF3FF",
-    dot: "#5080D8",
-    text: "#355A9A",
-  },
-  pending_admin_review: {
-    bg: "#F3F4F6",
-    dot: "#9CA3AF",
-    text: "#4B5563",
-  },
-};
 
 const OPEN_STATUSES = new Set<ChildStatus>([
   "submitted",
@@ -430,7 +371,7 @@ export function AdminEnrollmentPhaseDetail({ phaseId }: Props) {
       try {
         await decideAdminChild(row.request_id, row.child_id, status);
         toast.success(
-          `Entscheidung gespeichert: ${STATUS_LABELS[status as ChildStatus]}`,
+          `Entscheidung gespeichert: ${CHILD_STATUS_LABELS[status as ChildStatus]}`,
         );
         await loadData();
         await loadReport(reportFilters);
@@ -496,8 +437,8 @@ export function AdminEnrollmentPhaseDetail({ phaseId }: Props) {
       {
         key: "status",
         header: "Status",
-        render: (row) => <StatusBadge status={row.status} />,
-        sortValue: (row) => STATUS_LABELS[row.status],
+        render: (row) => <ChildStatusBadge status={row.status} />,
+        sortValue: (row) => CHILD_STATUS_LABELS[row.status],
       },
       {
         key: "offerings",
@@ -677,10 +618,12 @@ export function AdminEnrollmentPhaseDetail({ phaseId }: Props) {
                 }
                 options={[
                   { value: ALL_STATUS_FILTER, label: "Alle" },
-                  ...Object.entries(STATUS_LABELS).map(([value, label]) => ({
-                    value,
-                    label,
-                  })),
+                  ...Object.entries(CHILD_STATUS_LABELS).map(
+                    ([value, label]) => ({
+                      value,
+                      label,
+                    }),
+                  ),
                 ]}
               />
             </SelectField>
@@ -1356,23 +1299,6 @@ function PhaseChildActions({
         <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
       </Link>
     </div>
-  );
-}
-
-function StatusBadge({ status }: Readonly<{ status: ChildStatus }>) {
-  const styles = STATUS_COLORS[status];
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
-      style={{ backgroundColor: styles.bg, color: styles.text }}
-    >
-      <span
-        className="h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: styles.dot }}
-        aria-hidden="true"
-      />
-      {STATUS_LABELS[status]}
-    </span>
   );
 }
 

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { createPortal } from "react-dom";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CalendarDays,
   Check,
   ClipboardList,
   Copy,
-  MoreVertical,
   Pencil,
   Plus,
   Trash2,
@@ -48,6 +46,7 @@ import {
   type DataTableColumn,
 } from "~/components/ui/data-table";
 import { CustomSelect } from "~/components/ui/custom-select";
+import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 
 const logger = createLogger({ component: "CareOfferingsEditor" });
 
@@ -1073,12 +1072,6 @@ interface CareOfferingActionsProps {
   readonly onDelete: () => void;
 }
 
-interface MenuPosition {
-  top: number;
-  left: number;
-  alignRight: boolean;
-}
-
 function CareOfferingActions({
   offering,
   saving,
@@ -1087,138 +1080,33 @@ function CareOfferingActions({
   onClone,
   onDelete,
 }: CareOfferingActionsProps) {
-  const [open, setOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [position, setPosition] = useState<MenuPosition>({
-    top: 0,
-    left: 0,
-    alignRight: false,
-  });
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!open || !buttonRef.current) return;
-    const rect = buttonRef.current.getBoundingClientRect();
-    const menuWidth = 224;
-    const alignRight = rect.left + menuWidth > window.innerWidth - 16;
-    setPosition({
-      top: rect.bottom + 6,
-      left: alignRight ? rect.right : rect.left,
-      alignRight,
-    });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        menuRef.current &&
-        event.target instanceof Node &&
-        !menuRef.current.contains(event.target)
-      ) {
-        setOpen(false);
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handleScroll() {
-      setOpen(false);
-    }
-
-    window.addEventListener("scroll", handleScroll, true);
-    return () => window.removeEventListener("scroll", handleScroll, true);
-  }, [open]);
-
-  const menu = open && mounted && (
-    <div
-      ref={menuRef}
-      role="menu"
-      tabIndex={-1}
-      aria-label={`Aktionen für ${offering.name}`}
-      className="fixed z-[9999] w-56 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 text-left shadow-lg"
-      style={{
-        top: position.top,
-        left: position.alignRight ? "auto" : position.left,
-        right: position.alignRight ? window.innerWidth - position.left : "auto",
-      }}
-    >
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onEdit();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <Pencil className="h-4 w-4 text-gray-500" aria-hidden />
-        Bearbeiten
-      </button>
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onClone();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <Copy className="h-4 w-4 text-gray-500" aria-hidden />
-        Duplizieren
-      </button>
-      <div className="my-1 h-px bg-gray-100" />
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onDelete();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm font-medium text-[#CC2626] transition-colors hover:bg-[#FF3130]/10 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={deleting || saving}
-      >
-        <Trash2 className="h-4 w-4" aria-hidden />
-        {deleting ? "Löscht..." : "Löschen"}
-      </button>
-    </div>
-  );
-
   return (
     <div className="flex justify-end">
-      <button
-        ref={buttonRef}
-        type="button"
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label={`Aktionen für ${offering.name}`}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-      >
-        <MoreVertical className="h-4 w-4" aria-hidden="true" />
-      </button>
-      {mounted ? createPortal(menu, document.body) : null}
+      <OverflowMenu
+        ariaLabel={`Aktionen für ${offering.name}`}
+        items={[
+          {
+            label: "Bearbeiten",
+            icon: <Pencil className="h-4 w-4" aria-hidden />,
+            disabled: saving,
+            onClick: onEdit,
+          },
+          {
+            label: "Duplizieren",
+            icon: <Copy className="h-4 w-4" aria-hidden />,
+            disabled: saving,
+            onClick: onClone,
+          },
+          { kind: "separator" },
+          {
+            label: deleting ? "Löscht..." : "Löschen",
+            icon: <Trash2 className="h-4 w-4" aria-hidden />,
+            destructive: true,
+            disabled: deleting || saving,
+            onClick: onDelete,
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/frontend/src/components/enrollment/child-status-badge.tsx
+++ b/frontend/src/components/enrollment/child-status-badge.tsx
@@ -1,0 +1,42 @@
+import type { ChildStatus } from "~/lib/enrollment-admin-api";
+import {
+  StatusBadge,
+  type StatusBadgeTone,
+} from "~/components/ui/status-badge";
+
+// Shared label + tone maps for enrollment child statuses. Previously duplicated
+// verbatim in admin-enrollment-detail and admin-enrollment-phase-detail (#1629).
+export const CHILD_STATUS_LABELS: Record<ChildStatus, string> = {
+  submitted: "Eingegangen",
+  under_review: "In Prüfung",
+  approved: "Bestätigt",
+  waitlisted: "Warteliste",
+  rejected: "Abgelehnt",
+  withdrawn: "Zurückgezogen",
+  pending_renewal: "Wartet auf Verlängerung",
+  auto_renewed: "Vorgemerkt",
+  pending_admin_review: "Manuelle Prüfung",
+};
+
+const CHILD_STATUS_TONES: Record<ChildStatus, StatusBadgeTone> = {
+  submitted: "blue",
+  under_review: "blue",
+  approved: "green",
+  waitlisted: "orange",
+  rejected: "red",
+  withdrawn: "gray",
+  pending_renewal: "orange",
+  auto_renewed: "blue",
+  pending_admin_review: "gray",
+};
+
+export function ChildStatusBadge({
+  status,
+}: Readonly<{ status: ChildStatus }>) {
+  return (
+    <StatusBadge
+      label={CHILD_STATUS_LABELS[status]}
+      tone={CHILD_STATUS_TONES[status]}
+    />
+  );
+}

--- a/frontend/src/components/enrollment/enrollment-form-editor.tsx
+++ b/frontend/src/components/enrollment/enrollment-form-editor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { createPortal } from "react-dom";
 import {
   useCallback,
   useEffect,
@@ -27,7 +26,6 @@ import {
   Info,
   ListPlus,
   Lock,
-  MoreVertical,
   Pencil,
   Plus,
   ShieldCheck,
@@ -38,6 +36,7 @@ import { useToast } from "~/contexts/ToastContext";
 import { ConfirmationModal, Modal } from "~/components/ui/modal";
 import { FormModal } from "~/components/ui/form-modal";
 import { Button } from "~/components/ui/button";
+import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import { Input } from "~/components/ui/input";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { BooleanField } from "~/components/settings/fields/boolean-field";
@@ -1341,8 +1340,8 @@ function TemplateOverviewRow({
         </div>
       </div>
       <div className="flex justify-start gap-2 md:justify-end">
-        <TemplateActionsMenu
-          label={`Aktionen für ${schema.name}`}
+        <OverflowMenu
+          ariaLabel={`Aktionen für ${schema.name}`}
           items={[
             {
               label: "Prüfen",
@@ -1374,149 +1373,12 @@ function TemplateOverviewRow({
               label: "Löschen",
               icon: <Trash2 className="h-4 w-4" aria-hidden />,
               onClick: onDelete,
-              variant: "danger",
+              destructive: true,
             },
           ]}
         />
       </div>
     </article>
-  );
-}
-
-interface TemplateActionItem {
-  readonly label: string;
-  readonly icon: ReactNode;
-  readonly onClick: () => void;
-  readonly variant?: "default" | "danger";
-}
-
-interface TemplateActionsMenuPosition {
-  top: number;
-  left: number;
-  alignRight: boolean;
-}
-
-function TemplateActionsMenu({
-  label,
-  items,
-}: Readonly<{
-  label: string;
-  items: TemplateActionItem[];
-}>) {
-  const [open, setOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [position, setPosition] = useState<TemplateActionsMenuPosition>({
-    top: 0,
-    left: 0,
-    alignRight: false,
-  });
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!open || !buttonRef.current) return;
-    const rect = buttonRef.current.getBoundingClientRect();
-    const menuWidth = 224;
-    const alignRight = rect.left + menuWidth > window.innerWidth - 16;
-    setPosition({
-      top: rect.bottom + 6,
-      left: alignRight ? rect.right : rect.left,
-      alignRight,
-    });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        menuRef.current &&
-        event.target instanceof Node &&
-        !menuRef.current.contains(event.target)
-      ) {
-        setOpen(false);
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handleScroll() {
-      setOpen(false);
-    }
-
-    window.addEventListener("scroll", handleScroll, true);
-    return () => window.removeEventListener("scroll", handleScroll, true);
-  }, [open]);
-
-  const menu = open && mounted && (
-    <div
-      ref={menuRef}
-      role="menu"
-      tabIndex={-1}
-      aria-label={label}
-      className="fixed z-[9999] w-56 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 text-left shadow-lg"
-      style={{
-        top: position.top,
-        left: position.alignRight ? "auto" : position.left,
-        right: position.alignRight ? window.innerWidth - position.left : "auto",
-      }}
-    >
-      {items.map((item) => (
-        <button
-          key={item.label}
-          type="button"
-          role="menuitem"
-          onClick={() => {
-            setOpen(false);
-            item.onClick();
-          }}
-          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50"
-        >
-          <span
-            className={`h-4 w-4 ${
-              item.variant === "danger" ? "text-[#FF3130]" : "text-gray-500"
-            }`}
-          >
-            {item.icon}
-          </span>
-          {item.label}
-        </button>
-      ))}
-    </div>
-  );
-
-  return (
-    <div className="flex justify-end">
-      <button
-        ref={buttonRef}
-        type="button"
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label={label}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-      >
-        <MoreVertical className="h-4 w-4" aria-hidden="true" />
-      </button>
-      {mounted ? createPortal(menu, document.body) : null}
-    </div>
   );
 }
 

--- a/frontend/src/components/enrollment/phases-editor.tsx
+++ b/frontend/src/components/enrollment/phases-editor.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { createPortal } from "react-dom";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  OverflowMenu,
+  type OverflowMenuEntry,
+} from "~/components/ui/page-header/OverflowMenu";
 import {
   CalendarClock,
   CalendarPlus,
@@ -14,7 +16,6 @@ import {
   ExternalLink,
   FileText,
   Link2,
-  MoreVertical,
   Pencil,
   Power,
   Trash2,
@@ -849,14 +850,6 @@ interface PhaseActionsProps {
   readonly onDelete: () => void;
 }
 
-interface PhaseActionsMenuPosition {
-  top: number;
-  left: number;
-  alignRight: boolean;
-}
-
-const PHASE_ACTIONS_MENU_HEIGHT = 292;
-
 function PhaseActions({
   phase,
   tenantSlug,
@@ -872,235 +865,83 @@ function PhaseActions({
   onToggleActive,
   onDelete,
 }: PhaseActionsProps) {
-  const [open, setOpen] = useState(false);
   const [lateInviteOpen, setLateInviteOpen] = useState(false);
   const [manualOpen, setManualOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [position, setPosition] = useState<PhaseActionsMenuPosition>({
-    top: 0,
-    left: 0,
-    alignRight: false,
-  });
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const hasReviewList = tenantSlug && phase.rollover_source_phase_id;
   const phaseUrl = useEnrollmentPublicUrl({ tenantSlug, phaseId: phase.id });
   const enrollmentsHref = tenantPath(
     `/admin/enrollments/phases/${encodeURIComponent(phase.id)}`,
   );
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (!open || !buttonRef.current) return;
-
-    const rect = buttonRef.current.getBoundingClientRect();
-    const menuWidth = 240;
-    const measuredHeight = menuRef.current?.offsetHeight ?? 0;
-    const menuHeight =
-      measuredHeight > 0 ? measuredHeight : PHASE_ACTIONS_MENU_HEIGHT;
-    const alignRight = rect.left + menuWidth > window.innerWidth - 16;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const placeAbove = spaceBelow < menuHeight + 16 && rect.top > spaceBelow;
-    const top = placeAbove
-      ? Math.max(8, rect.top - 6 - menuHeight)
-      : rect.bottom + 6;
-    setPosition({
-      top,
-      left: alignRight ? rect.right : rect.left,
-      alignRight,
-    });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        menuRef.current &&
-        event.target instanceof Node &&
-        !menuRef.current.contains(event.target)
-      ) {
-        setOpen(false);
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handleScroll() {
-      setOpen(false);
-    }
-
-    window.addEventListener("scroll", handleScroll, true);
-    return () => window.removeEventListener("scroll", handleScroll, true);
-  }, [open]);
-
-  const menu = open && mounted && (
-    <div
-      ref={menuRef}
-      role="menu"
-      tabIndex={-1}
-      aria-label={`Aktionen für ${phase.name}`}
-      className="fixed z-[9999] w-60 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 text-left shadow-lg"
-      style={{
-        top: position.top,
-        left: position.alignRight ? "auto" : position.left,
-        right: position.alignRight ? window.innerWidth - position.left : "auto",
-      }}
-    >
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onEdit();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <Pencil className="h-4 w-4 text-gray-500" aria-hidden />
-        Bearbeiten
-      </button>
-
-      <a
-        href={`/enroll/${encodeURIComponent(phase.id)}`}
-        target="_blank"
-        rel="noreferrer"
-        role="menuitem"
-        tabIndex={0}
-        onClick={() => setOpen(false)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50"
-      >
-        <ExternalLink className="h-4 w-4 text-gray-500" aria-hidden />
-        Formular ansehen
-      </a>
-
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          setLateInviteOpen(true);
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <Link2 className="h-4 w-4 text-gray-500" aria-hidden />
-        Nachzügler-Link erstellen
-      </button>
-
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          setManualOpen(true);
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <UserCheck className="h-4 w-4 text-gray-500" aria-hidden />
-        Manuelle Anmeldung
-      </button>
-
-      <Link
-        href={enrollmentsHref}
-        role="menuitem"
-        tabIndex={0}
-        onClick={() => setOpen(false)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50"
-      >
-        <ClipboardList className="h-4 w-4 text-gray-500" aria-hidden />
-        Anmeldungen ansehen
-      </Link>
-
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onAssignForm();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <FileText className="h-4 w-4 text-gray-500" aria-hidden />
-        Formular zuweisen
-      </button>
-
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onRollover();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving || rolloverActive}
-      >
-        <CalendarPlus className="h-4 w-4 text-gray-500" aria-hidden />
-        Anschlussphase erstellen
-      </button>
-
-      {hasReviewList ? (
-        <Link
-          href={`/enrollment-phases/${encodeURIComponent(phase.id)}/review`}
-          role="menuitem"
-          tabIndex={0}
-          onClick={() => setOpen(false)}
-          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50"
-        >
-          <Check className="h-4 w-4 text-gray-500" aria-hidden />
-          Prüfliste öffnen
-        </Link>
-      ) : null}
-
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onToggleActive();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={saving}
-      >
-        <Power className="h-4 w-4 text-gray-500" aria-hidden />
-        {phase.is_active ? "Deaktivieren" : "Aktivieren"}
-      </button>
-
-      <div className="my-1 h-px bg-gray-100" />
-
-      <button
-        type="button"
-        role="menuitem"
-        onClick={() => {
-          setOpen(false);
-          onDelete();
-        }}
-        className="flex w-full items-center gap-2 px-3 py-2 text-sm font-medium text-[#CC2626] transition-colors hover:bg-[#FF3130]/10 disabled:cursor-not-allowed disabled:opacity-50"
-        disabled={deleting || saving}
-      >
-        <Trash2 className="h-4 w-4" aria-hidden />
-        {deleting ? "Löscht..." : "Löschen"}
-      </button>
-    </div>
-  );
+  const menuEntries: OverflowMenuEntry[] = [
+    {
+      label: "Bearbeiten",
+      icon: <Pencil className="h-4 w-4" aria-hidden />,
+      disabled: saving,
+      onClick: onEdit,
+    },
+    {
+      label: "Formular ansehen",
+      icon: <ExternalLink className="h-4 w-4" aria-hidden />,
+      href: `/enroll/${encodeURIComponent(phase.id)}`,
+      external: true,
+      onClick: () => undefined,
+    },
+    {
+      label: "Nachzügler-Link erstellen",
+      icon: <Link2 className="h-4 w-4" aria-hidden />,
+      disabled: saving,
+      onClick: () => setLateInviteOpen(true),
+    },
+    {
+      label: "Manuelle Anmeldung",
+      icon: <UserCheck className="h-4 w-4" aria-hidden />,
+      disabled: saving,
+      onClick: () => setManualOpen(true),
+    },
+    {
+      label: "Anmeldungen ansehen",
+      icon: <ClipboardList className="h-4 w-4" aria-hidden />,
+      href: enrollmentsHref,
+      onClick: () => undefined,
+    },
+    {
+      label: "Formular zuweisen",
+      icon: <FileText className="h-4 w-4" aria-hidden />,
+      disabled: saving,
+      onClick: onAssignForm,
+    },
+    {
+      label: "Anschlussphase erstellen",
+      icon: <CalendarPlus className="h-4 w-4" aria-hidden />,
+      disabled: saving || rolloverActive,
+      onClick: onRollover,
+    },
+    ...(hasReviewList
+      ? [
+          {
+            label: "Prüfliste öffnen",
+            icon: <Check className="h-4 w-4" aria-hidden />,
+            href: `/enrollment-phases/${encodeURIComponent(phase.id)}/review`,
+            onClick: () => undefined,
+          },
+        ]
+      : []),
+    {
+      label: phase.is_active ? "Deaktivieren" : "Aktivieren",
+      icon: <Power className="h-4 w-4" aria-hidden />,
+      disabled: saving,
+      onClick: onToggleActive,
+    },
+    { kind: "separator" },
+    {
+      label: deleting ? "Löscht..." : "Löschen",
+      icon: <Trash2 className="h-4 w-4" aria-hidden />,
+      destructive: true,
+      disabled: deleting || saving,
+      onClick: onDelete,
+    },
+  ];
 
   return (
     <>
@@ -1111,24 +952,15 @@ function PhaseActions({
             componentId={`PhaseActions:${phase.id}`}
           />
         ) : null}
-        <div>
-          <button
-            ref={buttonRef}
-            type="button"
-            onClick={() => setOpen((prev) => !prev)}
-            aria-label={`Aktionen für ${phase.name}`}
-            aria-haspopup="menu"
-            aria-expanded={open}
-            className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-800 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${
-              highlight
-                ? "border-[#83CD2D] bg-[#83CD2D]/10 text-[#5F9F20] shadow-[0_0_0_4px_rgba(131,205,45,0.18)]"
-                : "border-gray-200"
-            }`}
-          >
-            <MoreVertical className="h-4 w-4" aria-hidden="true" />
-          </button>
-          {mounted ? createPortal(menu, document.body) : null}
-        </div>
+        <OverflowMenu
+          ariaLabel={`Aktionen für ${phase.name}`}
+          items={menuEntries}
+          triggerClassName={
+            highlight
+              ? "bg-[#83CD2D]/10 shadow-[0_0_0_4px_rgba(131,205,45,0.18)]"
+              : ""
+          }
+        />
       </div>
       <LateInviteModal
         isOpen={lateInviteOpen}

--- a/frontend/src/components/students/student-enrollments-tab.tsx
+++ b/frontend/src/components/students/student-enrollments-tab.tsx
@@ -17,10 +17,10 @@ import {
   ChildOfferingAdjustment,
   ChildOfferings,
   RequestExtraSection,
-  StatusBadge,
   formatDateTime,
   formatPlainDate,
 } from "~/components/enrollment/admin-enrollment-detail";
+import { ChildStatusBadge } from "~/components/enrollment/child-status-badge";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentEnrollmentsTab" });
@@ -199,7 +199,7 @@ function EnrollmentRequestCard({
                   ) : null}
                 </div>
               </div>
-              <StatusBadge status={child.status} />
+              <ChildStatusBadge status={child.status} />
             </div>
 
             {child.status_reason ? (

--- a/frontend/src/components/suggestions/suggestion-card.tsx
+++ b/frontend/src/components/suggestions/suggestion-card.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import type { Suggestion } from "~/lib/suggestions-helpers";
 import { STATUS_LABELS, STATUS_STYLES } from "~/lib/suggestions-helpers";
+import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import { CommentAccordion } from "./comment-accordion";
 import { VoteButtons } from "./vote-buttons";
 import { getRelativeTime, getInitials } from "~/lib/format-utils";
@@ -22,11 +23,9 @@ export function SuggestionCard({
   onDelete,
   onVoteChange,
 }: SuggestionCardProps) {
-  const [menuOpen, setMenuOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
   const descRef = useRef<HTMLParagraphElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const isOwner = suggestion.authorId === currentAccountId;
 
   useEffect(() => {
@@ -35,17 +34,6 @@ export function SuggestionCard({
       setIsClamped(el.scrollHeight > el.clientHeight);
     }
   }, [suggestion.description]);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [menuOpen]);
 
   return (
     <div className="overflow-hidden rounded-3xl border border-gray-100/50 bg-white/90 shadow-sm backdrop-blur-md transition-all duration-150 md:hover:-translate-y-0.5 md:hover:border-blue-200/50 md:hover:shadow-sm">
@@ -68,46 +56,20 @@ export function SuggestionCard({
                 {STATUS_LABELS[suggestion.status]}
               </span>
               {isOwner && (
-                <div className="relative" ref={menuRef}>
-                  <button
-                    type="button"
-                    onClick={() => setMenuOpen(!menuOpen)}
-                    className="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
-                    aria-label="Aktionen"
-                  >
-                    <svg
-                      className="h-5 w-5"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
-                    </svg>
-                  </button>
-                  {menuOpen && (
-                    <div className="absolute right-0 z-10 mt-1 w-36 rounded-lg border border-gray-200 bg-white p-1 shadow-lg">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setMenuOpen(false);
-                          onEdit(suggestion);
-                        }}
-                        className="flex w-full items-center rounded-md px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100"
-                      >
-                        Bearbeiten
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setMenuOpen(false);
-                          onDelete(suggestion);
-                        }}
-                        className="flex w-full items-center rounded-md px-3 py-1.5 text-sm text-red-600 hover:bg-red-50"
-                      >
-                        Löschen
-                      </button>
-                    </div>
-                  )}
-                </div>
+                <OverflowMenu
+                  ariaLabel="Aktionen"
+                  items={[
+                    {
+                      label: "Bearbeiten",
+                      onClick: () => onEdit(suggestion),
+                    },
+                    {
+                      label: "Löschen",
+                      destructive: true,
+                      onClick: () => onDelete(suggestion),
+                    },
+                  ]}
+                />
               )}
             </div>
           </div>

--- a/frontend/src/components/ui/empty-state.stories.tsx
+++ b/frontend/src/components/ui/empty-state.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Lightbulb, Search } from "lucide-react";
+
+import { Button } from "./button";
+import { EmptyState } from "./empty-state";
+
+const meta = {
+  title: "components/ui/EmptyState",
+  component: EmptyState,
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    title: "Keine Ergebnisse gefunden",
+    description: "Versuche einen anderen Suchbegriff.",
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    icon: <Search className="h-12 w-12" strokeWidth={1.5} />,
+    title: "Keine Ergebnisse gefunden",
+    description: "Versuche einen anderen Suchbegriff.",
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    icon: <Lightbulb className="h-12 w-12" strokeWidth={1.5} />,
+    title: "Noch keine Beiträge",
+    description: "Teile Ideen, melde Probleme oder schlage Verbesserungen vor.",
+    action: (
+      <Button type="button" size="md">
+        Neuer Beitrag
+      </Button>
+    ),
+  },
+};

--- a/frontend/src/components/ui/empty-state.test.tsx
+++ b/frontend/src/components/ui/empty-state.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(
+      <EmptyState
+        title="Keine Ergebnisse gefunden"
+        description="Versuche einen anderen Suchbegriff."
+      />,
+    );
+    expect(screen.getByText("Keine Ergebnisse gefunden")).toBeInTheDocument();
+    expect(
+      screen.getByText("Versuche einen anderen Suchbegriff."),
+    ).toBeInTheDocument();
+  });
+
+  it("omits description when not provided", () => {
+    const { container } = render(<EmptyState title="Leer" />);
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+  });
+
+  it("renders the action slot", () => {
+    render(
+      <EmptyState
+        title="Noch keine Beiträge"
+        action={<button type="button">Neuer Beitrag</button>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Neuer Beitrag" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the icon from assistive tech", () => {
+    const { container } = render(
+      <EmptyState title="Leer" icon={<svg data-testid="icon" />} />,
+    );
+    const iconWrapper = container.querySelector("span[aria-hidden='true']");
+    expect(iconWrapper).not.toBeNull();
+  });
+});

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+// Centered empty-state block: optional muted icon, title, description, and an
+// optional action slot. Extracted from the operator provisioning pages and the
+// tenant list pages, which all hand-rolled this same column (#1629). Pass the
+// icon as a ReactNode (an inline SVG or a lucide icon sized h-12 w-12) so
+// existing screens keep their exact artwork.
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className = "",
+}: {
+  readonly icon?: ReactNode;
+  readonly title: string;
+  readonly description?: string;
+  readonly action?: ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <div
+      className={`flex flex-col items-center gap-3 py-12 text-center ${className}`}
+    >
+      {icon != null ? (
+        <span className="text-gray-400" aria-hidden="true">
+          {icon}
+        </span>
+      ) : null}
+      <p className="text-lg font-medium text-gray-900">{title}</p>
+      {description != null && description !== "" ? (
+        <p className="max-w-md text-sm leading-relaxed text-gray-500">
+          {description}
+        </p>
+      ) : null}
+      {action != null ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/page-header/OverflowMenu.test.tsx
+++ b/frontend/src/components/ui/page-header/OverflowMenu.test.tsx
@@ -264,6 +264,50 @@ describe("OverflowMenu", () => {
     }
   });
 
+  it("keeps the menu inside a narrow viewport when neither side has enough room", () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalGetRect = window.HTMLElement.prototype.getBoundingClientRect;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 320,
+    });
+    window.HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        left: 150,
+        right: 190,
+        top: 0,
+        bottom: 0,
+        width: 40,
+        height: 0,
+        x: 150,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    try {
+      render(
+        <OverflowMenu
+          items={[{ label: "Export", onClick: () => undefined }]}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /Weitere Aktionen/i }),
+      );
+      const menu = screen.getByRole("menu");
+
+      expect(menu.style.right).toBe(`${window.innerWidth - 220 - 8}px`);
+      expect(menu.style.left).toBe("");
+      expect(menu.style.minWidth).toBe("220px");
+      expect(menu.style.maxWidth).toBe("304px");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      window.HTMLElement.prototype.getBoundingClientRect = originalGetRect;
+    }
+  });
+
   it("flips the menu above the trigger when it sits near the viewport bottom", () => {
     // A trigger low in the viewport (little room below it) must anchor the menu
     // by `bottom` (above the trigger) instead of `top`, so it never drops below

--- a/frontend/src/components/ui/page-header/OverflowMenu.tsx
+++ b/frontend/src/components/ui/page-header/OverflowMenu.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import Link from "next/link";
 import { Check, MoreVertical } from "lucide-react";
 
 export interface OverflowMenuItem {
@@ -25,6 +26,20 @@ export interface OverflowMenuItem {
   readonly destructive?: boolean;
   /** When true, the item renders disabled and its onClick is suppressed. */
   readonly disabled?: boolean;
+  /**
+   * When set, the item renders as a link (next/link, or a plain anchor with
+   * `target="_blank"` when `external` is true) instead of a button, keeping
+   * native link semantics (middle-click, cmd-click). `onClick` still fires
+   * after the menu closes — pass a no-op when only navigation is needed.
+   */
+  readonly href?: string;
+  /** With `href`: open in a new tab via a plain anchor (noopener noreferrer). */
+  readonly external?: boolean;
+}
+
+/** Non-interactive thin divider between item groups. */
+interface OverflowMenuSeparator {
+  readonly kind: "separator";
 }
 
 /** Non-interactive uppercase label grouping the entries below it. */
@@ -43,7 +58,10 @@ interface OverflowMenuRadioItem {
 }
 
 export type OverflowMenuEntry =
-  OverflowMenuItem | OverflowMenuHeader | OverflowMenuRadioItem;
+  | OverflowMenuItem
+  | OverflowMenuHeader
+  | OverflowMenuRadioItem
+  | OverflowMenuSeparator;
 
 interface OverflowMenuProps {
   /** Menu items to render. Empty array → renders nothing. */
@@ -299,6 +317,16 @@ export function OverflowMenu({
                   );
                 }
 
+                if ("kind" in entry && entry.kind === "separator") {
+                  return (
+                    <div
+                      key={`separator-${index}`}
+                      role="separator"
+                      className="my-1 h-px bg-gray-100"
+                    />
+                  );
+                }
+
                 const item = entry;
                 const colorClass = item.destructive
                   ? "text-red-600"
@@ -306,6 +334,58 @@ export function OverflowMenu({
                 const interactive = item.disabled
                   ? "cursor-not-allowed opacity-50"
                   : "hover:bg-gray-50 active:bg-gray-100";
+                const itemClassName = `flex w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium transition-colors ${colorClass} ${interactive}`;
+
+                const inner = (
+                  <>
+                    {item.icon != null ? (
+                      <span className="flex size-4 flex-shrink-0 items-center justify-center text-gray-500">
+                        {item.icon}
+                      </span>
+                    ) : null}
+                    <span className="flex-1 truncate">{item.label}</span>
+                    {item.badge != null ? (
+                      <span className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-gray-100 px-1.5 text-[11px] font-semibold text-gray-700 tabular-nums">
+                        {item.badge}
+                      </span>
+                    ) : null}
+                  </>
+                );
+
+                if (item.href != null && !item.disabled) {
+                  const onLinkActivate = () => {
+                    setIsOpen(false);
+                    item.onClick();
+                  };
+                  if (item.external) {
+                    return (
+                      <a
+                        key={`item-${item.label}`}
+                        role="menuitem"
+                        tabIndex={0}
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={onLinkActivate}
+                        className={itemClassName}
+                      >
+                        {inner}
+                      </a>
+                    );
+                  }
+                  return (
+                    <Link
+                      key={`item-${item.label}`}
+                      role="menuitem"
+                      tabIndex={0}
+                      href={item.href}
+                      onClick={onLinkActivate}
+                      className={itemClassName}
+                    >
+                      {inner}
+                    </Link>
+                  );
+                }
 
                 return (
                   <button
@@ -319,19 +399,9 @@ export function OverflowMenu({
                       item.onClick();
                     }}
                     onKeyDown={onItemKey(item)}
-                    className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium transition-colors ${colorClass} ${interactive}`}
+                    className={itemClassName}
                   >
-                    {item.icon != null ? (
-                      <span className="flex size-4 flex-shrink-0 items-center justify-center text-gray-500">
-                        {item.icon}
-                      </span>
-                    ) : null}
-                    <span className="flex-1 truncate">{item.label}</span>
-                    {item.badge != null ? (
-                      <span className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-gray-100 px-1.5 text-[11px] font-semibold text-gray-700 tabular-nums">
-                        {item.badge}
-                      </span>
-                    ) : null}
+                    {inner}
                   </button>
                 );
               })}

--- a/frontend/src/components/ui/page-header/OverflowMenu.tsx
+++ b/frontend/src/components/ui/page-header/OverflowMenu.tsx
@@ -168,14 +168,16 @@ export function OverflowMenu({
     };
   }, [isOpen]);
 
-  // Decide alignment when opening. The menu is min 220px wide; we need to
-  // ensure it stays inside the viewport regardless of where the trigger sits.
+  // Decide alignment when opening. The menu is 220px wide when the viewport
+  // permits; constrain it on smaller viewports so every action stays reachable.
   //
   // - Default to right-anchored (`right-0` → menu extends LEFT from the
   //   trigger's right edge). This is safe in the common case where the
   //   kebab sits near the right edge of the page (action area).
-  // - Only flip to left-anchored (`left-0` → menu extends RIGHT) when the
-  //   trigger sits near the LEFT edge with not enough room on its left.
+  // - Flip to left-anchored (`left-0` → menu extends RIGHT) when the trigger
+  //   sits near the LEFT edge with not enough room on its left.
+  // - If neither side fits, use the side with more room and clamp to the
+  //   viewport inset.
   const handleOpen = () => {
     const rect = triggerRef.current?.getBoundingClientRect();
     if (rect != null) {
@@ -216,13 +218,31 @@ export function OverflowMenu({
           width: cr.width - inset * 2,
         });
       } else {
-        // Default to right-anchored (menu extends LEFT from the trigger's right
-        // edge); flip to left-anchored only when the trigger sits too close to
-        // the left edge for the menu to extend leftward.
-        const style: CSSProperties =
-          rect.left >= 220
-            ? { ...vertical, right: window.innerWidth - rect.right }
-            : { ...vertical, left: rect.left };
+        const menuWidth = 220;
+        const availableWidth = Math.max(
+          0,
+          window.innerWidth - viewportInset * 2,
+        );
+        const renderedWidth = Math.min(menuWidth, availableWidth);
+        const roomLeft = rect.right - viewportInset;
+        const roomRight = window.innerWidth - rect.left - viewportInset;
+        const size: CSSProperties = {
+          minWidth: renderedWidth,
+          maxWidth: availableWidth,
+        };
+        const maxOffset = Math.max(
+          viewportInset,
+          window.innerWidth - renderedWidth - viewportInset,
+        );
+        const clampOffset = (offset: number) =>
+          Math.min(Math.max(viewportInset, offset), maxOffset);
+        const alignRight =
+          roomLeft >= renderedWidth ||
+          (roomRight < renderedWidth && roomLeft >= roomRight);
+        const horizontal: CSSProperties = alignRight
+          ? { right: clampOffset(window.innerWidth - rect.right) }
+          : { left: clampOffset(rect.left) };
+        const style: CSSProperties = { ...vertical, ...size, ...horizontal };
         setMenuStyle(style);
       }
     }

--- a/frontend/src/components/ui/status-badge.stories.tsx
+++ b/frontend/src/components/ui/status-badge.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { StatusBadge } from "./status-badge";
+
+const meta = {
+  title: "components/ui/StatusBadge",
+  component: StatusBadge,
+} satisfies Meta<typeof StatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Green: Story = {
+  args: { label: "Bestätigt", tone: "green" },
+};
+
+export const Blue: Story = {
+  args: { label: "In Prüfung", tone: "blue" },
+};
+
+export const Orange: Story = {
+  args: { label: "Warteliste", tone: "orange" },
+};
+
+export const Red: Story = {
+  args: { label: "Abgelehnt", tone: "red" },
+};
+
+export const Gray: Story = {
+  args: { label: "Zurückgezogen", tone: "gray" },
+};
+
+export const AllTones: Story = {
+  args: { label: "Bestätigt", tone: "green" },
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <StatusBadge label="In Prüfung" tone="blue" />
+      <StatusBadge label="Bestätigt" tone="green" />
+      <StatusBadge label="Warteliste" tone="orange" />
+      <StatusBadge label="Abgelehnt" tone="red" />
+      <StatusBadge label="Zurückgezogen" tone="gray" />
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/status-badge.test.tsx
+++ b/frontend/src/components/ui/status-badge.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StatusBadge } from "./status-badge";
+
+describe("StatusBadge", () => {
+  it("renders the label", () => {
+    render(<StatusBadge label="Bestätigt" tone="green" />);
+    expect(screen.getByText("Bestätigt")).toBeInTheDocument();
+  });
+
+  it("applies the tone colors via inline styles", () => {
+    render(<StatusBadge label="Abgelehnt" tone="red" />);
+    const label = screen.getByText("Abgelehnt");
+    const pill = label.closest("span[class*='rounded-full']");
+    expect(pill).not.toBeNull();
+    expect((pill as HTMLElement).style.color).toBe("#9F1F1E");
+  });
+
+  it("renders a decorative dot hidden from assistive tech", () => {
+    const { container } = render(
+      <StatusBadge label="Warteliste" tone="orange" />,
+    );
+    const dot = container.querySelector("span[aria-hidden='true']");
+    expect(dot).not.toBeNull();
+  });
+});

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -1,0 +1,40 @@
+// Tinted status pill with dot, the enrollment-page badge recipe (#1629).
+// Tones map to the brand hexes from LOCATION_COLORS with matching tinted
+// backgrounds and darkened label colors. Use this whenever a status is one of
+// a fixed set of semantic outcomes; for data-driven colors (a raw hex from
+// LOCATION_COLORS) use StatusDotBadge instead.
+export type StatusBadgeTone = "blue" | "green" | "orange" | "red" | "gray";
+
+const TONES: Record<
+  StatusBadgeTone,
+  { bg: string; dot: string; text: string }
+> = {
+  blue: { bg: "#EEF3FF", dot: "#5080D8", text: "#355A9A" },
+  green: { bg: "#83CD2D1A", dot: "#83CD2D", text: "#5A8B1F" },
+  orange: { bg: "#FFF4E6", dot: "#F78C10", text: "#8A5600" },
+  red: { bg: "#FF31301A", dot: "#FF3130", text: "#9F1F1E" },
+  gray: { bg: "#F3F4F6", dot: "#9CA3AF", text: "#4B5563" },
+};
+
+export function StatusBadge({
+  label,
+  tone,
+}: {
+  readonly label: string;
+  readonly tone: StatusBadgeTone;
+}) {
+  const styles = TONES[tone];
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
+      style={{ backgroundColor: styles.bg, color: styles.text }}
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: styles.dot }}
+        aria-hidden="true"
+      />
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
Part of #1629 (UI-Kit konsolidieren). Implements the verified build/extend items from the issue audit and migrates the confirmed duplicate clusters onto the kit.

## Kit additions

- **`ui/status-badge`** — tinted status pill with dot and `tone` prop (`blue` / `green` / `orange` / `red` / `gray`), extracted verbatim from the enrollment badge recipe (brand hexes, tinted backgrounds, darkened label colors). Complements the data-driven `StatusDotBadge`.
- **`ui/empty-state`** — centered icon / title / description / action block, extracted from the operator provisioning pages. Icon is a `ReactNode` slot so existing screens keep their exact artwork.
- **`ui/page-header/OverflowMenu`** — extended with `href` link items (rendered as `next/link`, or a plain `target="_blank"` anchor with `external: true`, keeping native middle-click/cmd-click semantics) and `{ kind: "separator" }` entries. This closes the gap that kept six screens hand-rolling kebab menus.

## Migrations

**Status badges** — the three word-identical `STATUS_COLORS` + badge copies now share `components/enrollment/child-status-badge.tsx` (labels + tones) built on the kit:
- `admin-enrollment-detail.tsx` (also previously exported `StatusBadge` to `student-enrollments-tab.tsx`, rewired)
- `admin-enrollment-phase-detail.tsx`
- `admin-enrollment-change-requests.tsx`

**Empty states**:
- `operator/provisioning/provisioning-shared.tsx` `EmptyState` / `SimpleEmptyState` now render the kit component (covers ~10 operator call sites: schools, persons, accounts, devices, unregistered-tags)
- tenant `suggestions` page (search + no-content variants)
- tenant `rooms` page (no-results block)
- `dienstplan-view` deliberately left untouched — its empty state is a documented smaller design variant

**Kebab menus** — five hand-rolled `menuOpen` + click-outside + portal implementations replaced by `OverflowMenu`; ~500 lines of dead menu plumbing deleted:
- `suggestions/suggestion-card.tsx`
- `app/operator/announcements/page.tsx`
- `enrollment-form-editor.tsx` (`TemplateActionsMenu` deleted)
- `phases-editor.tsx` (`PhaseActions` menu incl. link items and separator; highlight state preserved via `triggerClassName`)
- `care-offerings-editor.tsx` (`CareOfferingActions` menu)

**Canon**: `.claude/rules/frontend-ui-kit.md` gained table entries for `StatusBadge` / `StatusDotBadge` / `EmptyState` and an updated kit-gaps section (kebab/dropdown menus are no longer a gap).

## Verification

- `pnpm run check` (verify-locales + oxlint + tsc): clean
- `pnpm run test:run`: 12,091 passed; the only failures (3) are in `chart.test.tsx` and reproduce identically on the untouched branch (locale-dependent number formatting in the local environment, unrelated)
- New tests: `status-badge.test.tsx`, `empty-state.test.tsx`; stories for both components
- Visual verification: migrated screens checked in the running app (screenshots in comment below)

## Not in this PR (follow-ups per issue)

Lint ratchet for generic brand colors (needs test-gated allowlist seeding), page-by-page rewires (substitutions, mensa_history, …), Parents-portal surface migration, knip pass for orphaned domain components.

Closes nothing — #1629 stays open as the umbrella issue.