### PR TITLE
refactor(ui-kit): substitutions page + parents portal onto the shared kit

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/substitutions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/substitutions/page.test.tsx
@@ -168,10 +168,10 @@ vi.mock("~/components/ui/modal", () => ({
     ) : null,
 }));
 
-// Mock Alert
+// Mock Alert — mirrors the real message-prop API
 vi.mock("~/components/ui/alert", () => ({
-  Alert: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="alert">{children}</div>
+  Alert: ({ message }: { message: string }) => (
+    <div data-testid="alert">{message}</div>
   ),
 }));
 

--- a/frontend/src/app/[tenant]/(protected)/substitutions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/substitutions/page.tsx
@@ -11,6 +11,8 @@ import type {
 } from "~/components/ui/page-header/types";
 import { Modal, ConfirmationModal } from "~/components/ui/modal";
 import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { EmptyState } from "~/components/ui/empty-state";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { substitutionService } from "~/lib/substitution-api";
 import { groupService } from "~/lib/api";
@@ -476,10 +478,10 @@ function SubstitutionPageContent() {
       );
     }
     return (
-      <div className="py-12 text-center">
-        <div className="flex flex-col items-center gap-4">
+      <EmptyState
+        icon={
           <svg
-            className="h-12 w-12 text-gray-400"
+            className="h-12 w-12"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -491,16 +493,10 @@ function SubstitutionPageContent() {
               d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
             />
           </svg>
-          <div>
-            <h3 className="text-lg font-medium text-gray-900">
-              Keine Fachkräfte gefunden
-            </h3>
-            <p className="text-gray-600">
-              Versuche deine Suchkriterien anzupassen.
-            </p>
-          </div>
-        </div>
-      </div>
+        }
+        title="Keine Fachkräfte gefunden"
+        description="Versuche deine Suchkriterien anzupassen."
+      />
     );
   };
 
@@ -544,8 +540,8 @@ function SubstitutionPageContent() {
 
         {/* Error Alert */}
         {error && (
-          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4">
-            <p className="text-sm text-red-800">{error}</p>
+          <div className="mb-6">
+            <Alert type="error" message={error} />
           </div>
         )}
 
@@ -631,8 +627,10 @@ function SubstitutionPageContent() {
                                   </p>
                                 </div>
                               </div>
-                              <button
+                              <Button
                                 type="button"
+                                variant="outline_danger"
+                                size="md"
                                 onClick={() =>
                                   handleEndSubstitutionClick(
                                     substitution.id,
@@ -641,10 +639,10 @@ function SubstitutionPageContent() {
                                   )
                                 }
                                 disabled={isMutating}
-                                className="w-full rounded-xl border border-[#FF3130]/20 bg-[#FF3130]/10 px-4 py-2.5 text-sm font-medium text-[#FF3130] transition-colors duration-200 hover:border-[#FF3130]/30 hover:bg-[#FF3130]/20"
+                                className="w-full"
                               >
                                 Beenden
-                              </button>
+                              </Button>
                             </div>
 
                             {/* Desktop layout */}
@@ -667,8 +665,10 @@ function SubstitutionPageContent() {
                                   </p>
                                 </div>
                               </div>
-                              <button
+                              <Button
                                 type="button"
+                                variant="outline_danger"
+                                size="md"
                                 onClick={() =>
                                   handleEndSubstitutionClick(
                                     substitution.id,
@@ -677,10 +677,10 @@ function SubstitutionPageContent() {
                                   )
                                 }
                                 disabled={isMutating}
-                                className="ml-4 rounded-xl border border-[#FF3130]/20 bg-[#FF3130]/10 px-4 py-2 text-sm font-medium whitespace-nowrap text-[#FF3130] transition-colors duration-200 hover:border-[#FF3130]/30 hover:bg-[#FF3130]/20"
+                                className="ml-4 whitespace-nowrap"
                               >
                                 Beenden
-                              </button>
+                              </Button>
                             </div>
                           </div>
                         </div>
@@ -776,8 +776,10 @@ function SubstitutionPageContent() {
                                   </p>
                                 </div>
                               </div>
-                              <button
+                              <Button
                                 type="button"
+                                variant="outline_danger"
+                                size="md"
                                 onClick={() =>
                                   handleEndSubstitutionClick(
                                     substitution.id,
@@ -786,10 +788,10 @@ function SubstitutionPageContent() {
                                   )
                                 }
                                 disabled={isMutating}
-                                className="w-full rounded-xl border border-[#FF3130]/20 bg-[#FF3130]/10 px-4 py-2.5 text-sm font-medium text-[#FF3130] transition-colors duration-200 hover:border-[#FF3130]/30 hover:bg-[#FF3130]/20"
+                                className="w-full"
                               >
                                 Beenden
-                              </button>
+                              </Button>
                             </div>
 
                             {/* Desktop layout */}
@@ -817,8 +819,10 @@ function SubstitutionPageContent() {
                                   </p>
                                 </div>
                               </div>
-                              <button
+                              <Button
                                 type="button"
+                                variant="outline_danger"
+                                size="md"
                                 onClick={() =>
                                   handleEndSubstitutionClick(
                                     substitution.id,
@@ -827,10 +831,10 @@ function SubstitutionPageContent() {
                                   )
                                 }
                                 disabled={isMutating}
-                                className="ml-4 rounded-xl border border-[#FF3130]/20 bg-[#FF3130]/10 px-4 py-2 text-sm font-medium whitespace-nowrap text-[#FF3130] transition-colors duration-200 hover:border-[#FF3130]/30 hover:bg-[#FF3130]/20"
+                                className="ml-4 whitespace-nowrap"
                               >
                                 Beenden
-                              </button>
+                              </Button>
                             </div>
                           </div>
                         </div>
@@ -983,47 +987,27 @@ function SubstitutionPageContent() {
 
           {/* Action Buttons */}
           <div className="flex gap-3 pt-4">
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="md"
               onClick={closePopup}
-              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-[border-color,background-color,box-shadow] duration-200 hover:border-gray-400 hover:bg-gray-50 hover:shadow-sm"
+              className="flex-1"
             >
               Abbrechen
-            </button>
+            </Button>
 
-            <button
+            <Button
               type="button"
+              variant="primary"
+              size="md"
               onClick={handleAssignSubstitution}
-              disabled={isMutating}
-              className="flex-1 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition-[background-color,box-shadow] duration-200 hover:bg-gray-800 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
+              isLoading={isMutating}
+              loadingText="Wird zugewiesen..."
+              className="flex-1"
             >
-              {isMutating ? (
-                <span className="flex items-center justify-center gap-2">
-                  <svg
-                    className="h-4 w-4 animate-spin text-white"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  Wird zugewiesen...
-                </span>
-              ) : (
-                "Zuweisen"
-              )}
-            </button>
+              Zuweisen
+            </Button>
           </div>
         </div>
       </Modal>

--- a/frontend/src/app/parents/messages/page.tsx
+++ b/frontend/src/app/parents/messages/page.tsx
@@ -238,7 +238,7 @@ export default function ParentMessagesPage() {
 
 function Hero() {
   return (
-    <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+    <section className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
       <div className="p-5 sm:p-6 lg:p-8">
         <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
           Austausch mit der OGS

--- a/frontend/src/components/parent/child-detail.tsx
+++ b/frontend/src/components/parent/child-detail.tsx
@@ -165,7 +165,7 @@ export function ChildDetail({ studentId }: Props) {
   if (!child) {
     return (
       <div className="mx-auto max-w-7xl">
-        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+        <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
           <BackBar />
           <div className="p-6 text-sm leading-6 text-gray-600">
             {t("notFound")}
@@ -282,7 +282,7 @@ function ChildDetailContent({ child }: Readonly<{ child: Child }>) {
         onAction={openAction}
       />
 
-      <section className="hidden overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm lg:block">
+      <section className="moto-content-surface hidden overflow-hidden rounded-2xl border shadow-sm lg:block">
         <div className="grid gap-0 lg:grid-cols-[minmax(0,1.25fr)_minmax(20rem,0.75fr)] xl:grid-cols-[minmax(0,1.35fr)_minmax(22rem,0.8fr)]">
           <div>
             <BackBar />
@@ -328,7 +328,7 @@ function ChildDetailContent({ child }: Readonly<{ child: Child }>) {
       </section>
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(24rem,0.8fr)]">
-        <section className="min-w-0 rounded-2xl border border-gray-200 bg-white shadow-sm max-lg:hidden">
+        <section className="moto-content-surface min-w-0 rounded-2xl border shadow-sm max-lg:hidden">
           <div className="p-5 sm:p-6">
             <PanelHeader
               eyebrow={t("masterDataEyebrow")}
@@ -413,7 +413,7 @@ function MobileChildAppView({
 
   return (
     <div className="space-y-5 lg:hidden">
-      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
         <BackBar />
         <div className="p-5">
           <div className="flex min-w-0 items-center gap-4">

--- a/frontend/src/components/parent/child-master-data.tsx
+++ b/frontend/src/components/parent/child-master-data.tsx
@@ -147,7 +147,7 @@ function ChildMasterDataContent({
 
   return (
     <div className="mx-auto w-full max-w-7xl space-y-6">
-      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
         <BackBar studentId={studentId} />
         <div className="p-5 sm:p-6">
           <h1 className="text-2xl font-semibold text-gray-900">{t("title")}</h1>

--- a/frontend/src/components/parent/ogs-conversation.tsx
+++ b/frontend/src/components/parent/ogs-conversation.tsx
@@ -211,7 +211,7 @@ export function OgsConversation({
     >
       {showBack ? <BackBar /> : null}
 
-      <section className="flex min-h-0 flex-1 flex-col rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <section className="moto-content-surface flex min-h-0 flex-1 flex-col rounded-2xl border shadow-sm">
         <div className="border-b border-gray-100 px-5 py-4 sm:px-6">
           <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
             Austausch mit der OGS

--- a/frontend/src/components/parent/parent-children-page.tsx
+++ b/frontend/src/components/parent/parent-children-page.tsx
@@ -78,7 +78,7 @@ export function ParentChildrenPage() {
 
   return (
     <div className="mx-auto w-full max-w-7xl space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <section className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
         <div className="p-5 sm:p-6 lg:p-8">
           <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
             {t("eyebrow")}

--- a/frontend/src/components/parent/parent-dashboard.tsx
+++ b/frontend/src/components/parent/parent-dashboard.tsx
@@ -21,24 +21,26 @@ import {
 import { createLogger } from "~/lib/logger";
 import { formatLocalizedDate } from "~/lib/localized-date-format";
 import { useParentNewsEnabled } from "~/lib/hooks/use-parent-news-enabled";
+import {
+  StatusBadge,
+  type StatusBadgeTone,
+} from "~/components/ui/status-badge";
 
 const logger = createLogger({ component: "ParentDashboard" });
 
-const statusTone: Record<
-  EnrollmentChildStatus | ChildStatus,
-  { bg: string; text: string; dot: string }
-> = {
-  submitted: { bg: "#5080D814", text: "#3558A8", dot: "#5080D8" },
-  under_review: { bg: "#F78C1014", text: "#9A5B0A", dot: "#F78C10" },
-  approved: { bg: "#83CD2D1F", text: "#5A8E1F", dot: "#83CD2D" },
-  waitlisted: { bg: "#F78C1014", text: "#9A5B0A", dot: "#F78C10" },
-  rejected: { bg: "#FF313014", text: "#CC2626", dot: "#FF3130" },
-  withdrawn: { bg: "#F3F4F6", text: "#4B5563", dot: "#6B7280" },
-  pending: { bg: "#83CD2D1F", text: "#5A8E1F", dot: "#83CD2D" },
-  active: { bg: "#83CD2D1F", text: "#5A8E1F", dot: "#83CD2D" },
-  inactive: { bg: "#F3F4F6", text: "#4B5563", dot: "#6B7280" },
-  alumnus: { bg: "#F3F4F6", text: "#4B5563", dot: "#6B7280" },
-};
+const statusTone: Record<EnrollmentChildStatus | ChildStatus, StatusBadgeTone> =
+  {
+    submitted: "blue",
+    under_review: "orange",
+    approved: "green",
+    waitlisted: "orange",
+    rejected: "red",
+    withdrawn: "gray",
+    pending: "green",
+    active: "green",
+    inactive: "gray",
+    alumnus: "gray",
+  };
 
 interface ChildOverviewItem {
   readonly key: string;
@@ -186,7 +188,7 @@ export function ParentDashboard() {
 
   return (
     <div className="mx-auto w-full max-w-7xl space-y-6">
-      <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <section className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
         <div className="grid gap-0 lg:grid-cols-[minmax(0,1.25fr)_minmax(20rem,0.75fr)]">
           <div className="p-5 sm:p-6 lg:p-8">
             <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
@@ -285,11 +287,8 @@ function HeroChildItem({ item }: Readonly<{ item: ChildOverviewItem }>) {
         <p className="truncate text-sm text-gray-600">{item.schoolName}</p>
       </div>
       {item.statusLabel ? (
-        <span
-          className="shrink-0 rounded-full px-2 py-1 text-[11px] font-semibold"
-          style={{ backgroundColor: tone.bg, color: tone.text }}
-        >
-          {t("open")}
+        <span className="shrink-0">
+          <StatusBadge label={t("open")} tone={tone} />
         </span>
       ) : (
         <ArrowRight

--- a/frontend/src/components/parent/parent-meal-plan-page.tsx
+++ b/frontend/src/components/parent/parent-meal-plan-page.tsx
@@ -252,7 +252,7 @@ export function ParentMealPlanPage() {
           {t("loadError")}
         </section>
       ) : schools.length === 0 ? (
-        <section className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500 shadow-sm">
+        <section className="moto-content-surface rounded-2xl border p-6 text-sm text-gray-500 shadow-sm">
           {t("empty")}
         </section>
       ) : (
@@ -309,7 +309,7 @@ export function ParentMealPlanPage() {
                   (() => {
                     const dishes = dishesByDate.get(today) ?? [];
                     return (
-                      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                      <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
                         <div className="flex items-center justify-between gap-2 border-b border-gray-200 px-4 py-3">
                           <div className="text-sm font-semibold text-gray-900">
                             {weekdayLabel(today)}
@@ -333,7 +333,7 @@ export function ParentMealPlanPage() {
                     );
                   })()}
 
-                <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
                   <div className="border-b border-gray-200 px-4 py-2.5 text-xs font-semibold tracking-wide text-gray-500 uppercase">
                     {weekOffset === 0 ? t("weekHeading") : t("nextWeek")}
                   </div>
@@ -380,7 +380,7 @@ export function ParentMealPlanPage() {
               </div>
 
               {/* Desktop: full five-column week grid. */}
-              <div className="hidden overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm md:block">
+              <div className="moto-content-surface hidden overflow-hidden rounded-2xl border shadow-sm md:block">
                 <div className="grid grid-cols-5 divide-x divide-gray-200">
                   {weekDates.map((date) => {
                     const dishes = dishesByDate.get(date) ?? [];


### PR DESCRIPTION
Teil von #1629 (Folge-PR zu #2004): setzt den nächsten Schritt aus "Pages bereichsweise aufs Kit umverdrahten" um — die Gruppenzugriff-Seite (substitutions) und das Eltern-Portal.

## Änderungen

### Gruppenzugriff (`substitutions/page.tsx`)
- "Keine Fachkräfte gefunden" nutzt jetzt `ui/EmptyState` (gleiche Ikone, gleicher Text)
- Seiten-Fehlerbanner nutzt `ui/Alert` (die Datei nutzte Alert bereits im Modal — jetzt konsistent)
- Die vier hand-gerollten "Beenden"-Buttons (2x mobil, 2x Desktop, wortgleich dupliziert) sind jetzt `ui/Button variant="outline_danger" size="md"`
- Modal-Footer (Abbrechen/Zuweisen) nutzt `ui/Button size="md"` mit `isLoading`/`loadingText` statt Inline-SVG-Spinner

### Eltern-Portal
- 13 ausgeschriebene Karten-Klassenketten (`rounded-2xl border border-gray-200 bg-white shadow-sm`) durch die kanonische `moto-content-surface`-Klasse ersetzt (`border`-Utility bleibt, da die Klasse nur border-color setzt): `child-detail`, `child-master-data`, `ogs-conversation`, `parent-children-page`, `parent-dashboard`, `parent-meal-plan-page`, `parents/messages`
- `parent-dashboard`: lokale `statusTone`-Hex-Map durch `ui/StatusBadge`-Tone-Mapping ersetzt (submitted→blue, under_review/waitlisted→orange, approved/pending/active→green, rejected→red, Rest→gray)

### Test-Anpassung (begründet)
`substitutions/page.test.tsx` mockte `ui/Alert` mit `children`-Shape; die echte Komponente hat eine `message`-Prop. Der Mock wurde an die reale API angeglichen — **alle Assertions sind unverändert** (Fehlertext muss weiterhin sichtbar sein).

## Bewusst NICHT enthalten (Scope aus dem Issue-Audit)
- Orange/Lila-Farbvereinheitlichung + Zusammenführung des duplizierten ~90-Zeilen-Kartenblocks in substitutions (braucht eine Produkt-Farbentscheidung, keine mechanische Migration)
- Die zwei kompakten dashed "Keine aktiven ..."-Platzhalter (bewusst kleinere Inline-Variante, analog dienstplan-view)
- Skeleton-Platzhalter mit derselben Klassenkette (kosmetisch inert)
- `staff/[id]` lokales OverflowMenu-Duplikat (kanonischer Referenz-Screen, eigener PR)
- Lint-Ratchet, ConfigDrivenModal, ui/select-Adoption (eigene Folge-PRs laut Issue-Plan)

## Verifikation
- `pnpm run check` grün (zero warnings)
- Voller Frontend-Testlauf: 12100/12103 grün; die 3 Fails in `ui/chart.test.tsx` sind lokal-locale-bedingt und bestehen identisch auf sauberem `origin/development` (gegengetestet via stash)
- End-to-end im Browser verifiziert (Tenant-Admin + Eltern-Login): Zuweisen-Modal, Tagesübergabe + längerfristiger Zugriff anlegen/beenden, alle Eltern-Seiten
- Vorher/Nachher-Screenshot-Paare (links vorher, rechts nachher) für alle 10 Screens erstellt — werden als Kommentar-Attachments nachgereicht

