### PR TITLE
feat(time-tracking): DATEV-Fundament — Personalnummer, Lohnart-Mapping, Mandantendaten (#1417 Tranche 2b)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -470,6 +470,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Suggestions = suggestionsAPI.NewResource(api.Services.Suggestions, db)
 	api.Schedules = schedulesAPI.NewResource(api.Services.Schedule, db)
 	api.Settings = configAPI.NewSettingsResource(api.Services.Settings, db, api.Services.RealtimeHub, repoFactory.FormSchema)
+	api.Settings.SetPayrollStatusService(api.Services.PayrollStatus)
 	api.Settings.OnValueSet(api.Services.SettingsSideEffects.Dispatch)
 	api.Active = activeAPI.NewResource(api.Services.Active, api.Services.Users, api.Services.Education, api.Services.Schulhof, api.Services.UserContext, api.Services.Settings, db, logger.With("handler", "active"))
 	api.IoT = iotAPI.NewResource(iotAPI.ServiceDependencies{

--- a/backend/api/config/payroll_status_api.go
+++ b/backend/api/config/payroll_status_api.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+)
+
+// getPayrollStatus reports the payroll configuration state (#1417): Lohnart
+// mapping, LODAS header identifiers, and how many staff still lack a
+// Personalnummer. The /payroll page renders this; the later DATEV writers
+// run the same service check before producing a file.
+func (rs *SettingsResource) getPayrollStatus(w http.ResponseWriter, r *http.Request) {
+	if rs.payrollStatus == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("payroll status service is not wired")))
+		return
+	}
+	status, err := rs.payrollStatus.GetPayrollStatus(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, status, "Payroll status retrieved successfully")
+}

--- a/backend/api/config/payroll_status_api_test.go
+++ b/backend/api/config/payroll_status_api_test.go
@@ -1,0 +1,49 @@
+// Router-level tests for GET /api/settings/payroll-status (#1417): the
+// payroll configuration state sits behind config:manage — the same tier that
+// writes the payroll settings. config:read/config:update never see it (the
+// response carries a staff-without-Personalnummer count).
+package config_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPayrollStatusAPI_ManageOnly(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+	router := ctx.resource.SettingsRouter()
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/payroll-status", nil,
+		mint(t, adminClaimsWithConfigPerms()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+	body := rr.Body.String()
+	for _, field := range []string{
+		`"categories"`, `"beraternummer"`, `"mandantennummer"`,
+		`"lodas_header_complete"`, `"configured_categories"`, `"total_categories"`,
+		`"staff_total"`, `"staff_without_personnel_number"`,
+	} {
+		assert.Contains(t, body, field)
+	}
+	// Fresh tenant configuration is empty by design — nothing invented.
+	assert.Contains(t, body, `"lodas_header_complete":false`)
+}
+
+func TestPayrollStatusAPI_ReadAndUpdateTiersAreRejected(t *testing.T) {
+	ctx := setupSettingsTest(t)
+	defer func() { _ = ctx.db.Close() }()
+	router := ctx.resource.SettingsRouter()
+
+	claims := testutil.TeacherTestClaims(2)
+	claims.Permissions = append(claims.Permissions, permissions.ConfigRead, permissions.ConfigUpdate)
+
+	req := testutil.NewAuthenticatedRequest(t, "GET", "/payroll-status", nil, mint(t, claims))
+	rr := testutil.ExecuteRequest(router, req)
+	assert.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
+}

--- a/backend/api/config/settings_api.go
+++ b/backend/api/config/settings_api.go
@@ -88,12 +88,12 @@ type SettingsResource struct {
 	db                *bun.DB
 	broadcaster       realtime.Broadcaster
 	onValueSet        ValueSetCallback
-	payrollStatus     configSvc.PayrollStatusService
+	payrollStatus     configSvc.PayrollStatusGetter
 }
 
 // SetPayrollStatusService wires the payroll configuration status (#1417).
 // Setter instead of a constructor parameter, mirroring OnValueSet.
-func (rs *SettingsResource) SetPayrollStatusService(svc configSvc.PayrollStatusService) {
+func (rs *SettingsResource) SetPayrollStatusService(svc configSvc.PayrollStatusGetter) {
 	rs.payrollStatus = svc
 }
 

--- a/backend/api/config/settings_api.go
+++ b/backend/api/config/settings_api.go
@@ -88,6 +88,13 @@ type SettingsResource struct {
 	db                *bun.DB
 	broadcaster       realtime.Broadcaster
 	onValueSet        ValueSetCallback
+	payrollStatus     configSvc.PayrollStatusService
+}
+
+// SetPayrollStatusService wires the payroll configuration status (#1417).
+// Setter instead of a constructor parameter, mirroring OnValueSet.
+func (rs *SettingsResource) SetPayrollStatusService(svc configSvc.PayrollStatusService) {
+	rs.payrollStatus = svc
 }
 
 // OnValueSet registers a callback that runs after a setting value change is
@@ -131,6 +138,11 @@ func (rs *SettingsResource) SettingsRouter() chi.Router {
 		settingsWrite := authorize.RequiresAnyPermission(permissions.ConfigUpdate, permissions.ConfigManage)
 
 		r.With(authorize.RequiresPermission(permissions.ConfigRead), withTx).Get("/schema", rs.getSchema)
+		// Payroll configuration status (#1417): config:manage only — the
+		// same tier that writes the payroll settings; carries a per-tenant
+		// staff-without-Personalnummer count (count only, no names).
+		r.With(authorize.RequiresPermission(permissions.ConfigManage), withTx).Get("/payroll-status", rs.getPayrollStatus)
+
 		r.With(settingsWrite, withTx).Get("/values/{key}/reveal", rs.revealValue)
 		r.With(settingsWrite, withTx).Put("/values/{key}", rs.setValue)
 		r.With(settingsWrite, withTx).Delete("/values/{key}", rs.resetValue)

--- a/backend/api/config/settings_integration_test.go
+++ b/backend/api/config/settings_integration_test.go
@@ -65,6 +65,7 @@ func setupSettingsTest(t *testing.T) *settingsTestContext {
 	db, svc := testutil.SetupAPITest(t)
 
 	resource := configAPI.NewSettingsResource(svc.Settings, db, nil)
+	resource.SetPayrollStatusService(svc.PayrollStatus)
 
 	return &settingsTestContext{
 		db:       db,

--- a/backend/api/staff/api.go
+++ b/backend/api/staff/api.go
@@ -108,6 +108,12 @@ func (rs *Resource) Router() chi.Router {
 		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}", rs.updateStaff)
 		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Delete("/{id}", rs.deleteStaff)
 
+		// Personnel number (payroll identifier, #1417): time_tracking:manage
+		// like every payroll-relevant per-person write of this issue —
+		// deliberately not the users:read/update tier of the directory.
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Get("/{id}/payroll-number", rs.getPayrollNumber)
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Put("/{id}/payroll-number", rs.updatePayrollNumber)
+
 		// Work schedule endpoints expose contractual target hours.
 		r.With(authorize.RequiresAnyPermission(permissions.TimeTrackingManage, permissions.TimeTrackingOwn), withTx).Get("/{id}/schedule", rs.getSchedule)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Put("/{id}/schedule", rs.updateSchedule)

--- a/backend/api/staff/overview_api_test.go
+++ b/backend/api/staff/overview_api_test.go
@@ -26,6 +26,7 @@ type overviewAPIContext struct {
 	staffID int64
 	get     func(path string, perms ...string) *httptest.ResponseRecorder
 	post    func(path, body string, perms ...string) *httptest.ResponseRecorder
+	put     func(path, body string, perms ...string) *httptest.ResponseRecorder
 }
 
 func setupOverviewAPI(t *testing.T) *overviewAPIContext {
@@ -60,6 +61,14 @@ func setupOverviewAPI(t *testing.T) *overviewAPIContext {
 		},
 		post: func(path, body string, perms ...string) *httptest.ResponseRecorder {
 			req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+			req.Header.Set("Authorization", "Bearer "+token(perms...))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			tc.router.ServeHTTP(rec, req)
+			return rec
+		},
+		put: func(path, body string, perms ...string) *httptest.ResponseRecorder {
+			req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(body))
 			req.Header.Set("Authorization", "Bearer "+token(perms...))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()

--- a/backend/api/staff/payroll_api_test.go
+++ b/backend/api/staff/payroll_api_test.go
@@ -44,6 +44,13 @@ func TestPayrollNumberAPI_StableErrorCodes(t *testing.T) {
 	rec := ctx.put(fmt.Sprintf("/staff/%d/payroll-number", first.ID), `{"personnel_number":"90110"}`, "time_tracking:manage")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
+	// Omitting the field is not a clear operation. Only explicit null clears.
+	rec = ctx.put(fmt.Sprintf("/staff/%d/payroll-number", first.ID), `{"note":"fehlt"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	rec = ctx.get(fmt.Sprintf("/staff/%d/payroll-number", first.ID), "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"personnel_number":"90110"`)
+
 	// Duplicate within the tenant → 409 with a stable code on the wire.
 	rec = ctx.put(fmt.Sprintf("/staff/%d/payroll-number", second.ID), `{"personnel_number":"90110"}`, "time_tracking:manage")
 	require.Equal(t, http.StatusConflict, rec.Code, rec.Body.String())

--- a/backend/api/staff/payroll_api_test.go
+++ b/backend/api/staff/payroll_api_test.go
@@ -1,0 +1,61 @@
+// Router-level tests for GET/PUT /api/staff/{id}/payroll-number (#1417):
+// the Personalnummer feeds payroll, so it sits behind time_tracking:manage —
+// deliberately NOT the users:read/users:update directory tier.
+package staff_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayrollNumberAPI_PermissionSplit(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+	target := testpkg.CreateTestStaff(t, ctx.tc.db, "Payroll", fmt.Sprintf("API-%d", time.Now().UnixNano()))
+	path := fmt.Sprintf("/staff/%d/payroll-number", target.ID)
+
+	// The directory tiers never see or write the payroll identifier.
+	rec := ctx.get(path, "users:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+	rec = ctx.put(path, `{"personnel_number":"90100"}`, "users:update")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+
+	// time_tracking:manage writes and reads back.
+	rec = ctx.put(path, `{"personnel_number":"90100","note":"Ersteinrichtung"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"personnel_number":"90100"`)
+
+	rec = ctx.get(path, "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"personnel_number":"90100"`)
+}
+
+func TestPayrollNumberAPI_StableErrorCodes(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+	suffix := time.Now().UnixNano()
+	first := testpkg.CreateTestStaff(t, ctx.tc.db, "Payroll", fmt.Sprintf("Erste-%d", suffix))
+	second := testpkg.CreateTestStaff(t, ctx.tc.db, "Payroll", fmt.Sprintf("Zweite-%d", suffix))
+
+	rec := ctx.put(fmt.Sprintf("/staff/%d/payroll-number", first.ID), `{"personnel_number":"90110"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Duplicate within the tenant → 409 with a stable code on the wire.
+	rec = ctx.put(fmt.Sprintf("/staff/%d/payroll-number", second.ID), `{"personnel_number":"90110"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusConflict, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"personnel_number_taken"`)
+
+	// Malformed value → 400 with a stable code.
+	rec = ctx.put(fmt.Sprintf("/staff/%d/payroll-number", second.ID), `{"personnel_number":"12a"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"personnel_number_invalid"`)
+
+	// Clearing via null succeeds.
+	rec = ctx.put(fmt.Sprintf("/staff/%d/payroll-number", first.ID), `{"personnel_number":null,"note":"Austritt"}`, "time_tracking:manage")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"personnel_number":null`)
+}

--- a/backend/api/staff/payroll_handlers.go
+++ b/backend/api/staff/payroll_handlers.go
@@ -1,6 +1,7 @@
 package staff
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -18,11 +19,21 @@ import (
 // PayrollNumberRequest sets or clears the Personalnummer. Note is optional
 // context for the audit trail.
 type PayrollNumberRequest struct {
-	PersonnelNumber *string `json:"personnel_number"`
-	Note            string  `json:"note"`
+	PersonnelNumber json.RawMessage `json:"personnel_number"`
+	Note            string          `json:"note"`
+
+	personnelNumberValue *string
 }
 
-func (p *PayrollNumberRequest) Bind(_ *http.Request) error { return nil }
+func (p *PayrollNumberRequest) Bind(_ *http.Request) error {
+	if len(p.PersonnelNumber) == 0 {
+		return errors.New("personnel_number is required")
+	}
+	if err := json.Unmarshal(p.PersonnelNumber, &p.personnelNumberValue); err != nil {
+		return errors.New("personnel_number must be a string or null")
+	}
+	return nil
+}
 
 // PayrollNumberResponse mirrors the stored state after a read or write.
 type PayrollNumberResponse struct {
@@ -65,7 +76,7 @@ func (rs *Resource) updatePayrollNumber(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	staff, err := rs.PersonService.UpdatePersonnelNumber(r.Context(), id, req.PersonnelNumber, changedBy, req.Note)
+	staff, err := rs.PersonService.UpdatePersonnelNumber(r.Context(), id, req.personnelNumberValue, changedBy, req.Note)
 	if err != nil {
 		switch {
 		case errors.Is(err, usersSvc.ErrPersonnelNumberInvalid):

--- a/backend/api/staff/payroll_handlers.go
+++ b/backend/api/staff/payroll_handlers.go
@@ -1,0 +1,83 @@
+package staff
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+)
+
+// Personnel number maintenance (#1417 Tranche 2b). Gated on
+// time_tracking:manage like every other payroll-relevant per-person write of
+// #1417 — deliberately NOT users:update: users:read/update is held by people
+// who maintain the staff directory, the Personalnummer feeds payroll.
+
+// PayrollNumberRequest sets or clears the Personalnummer. Note is optional
+// context for the audit trail.
+type PayrollNumberRequest struct {
+	PersonnelNumber *string `json:"personnel_number"`
+	Note            string  `json:"note"`
+}
+
+func (p *PayrollNumberRequest) Bind(_ *http.Request) error { return nil }
+
+// PayrollNumberResponse mirrors the stored state after a read or write.
+type PayrollNumberResponse struct {
+	StaffID         int64   `json:"staff_id"`
+	PersonnelNumber *string `json:"personnel_number"`
+}
+
+// getPayrollNumber returns the staff member's Personalnummer. A separate
+// sub-resource instead of a field on GET /{id}: that endpoint is users:read,
+// and the payroll identifier stays behind time_tracking:manage.
+func (rs *Resource) getPayrollNumber(w http.ResponseWriter, r *http.Request) {
+	id, ok := common.ParseInt64IDWithError(w, r, "id", common.MsgInvalidStaffID)
+	if !ok {
+		return
+	}
+	staff, err := rs.PersonService.GetStaffByID(r.Context(), id)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorNotFound(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, &PayrollNumberResponse{StaffID: staff.ID, PersonnelNumber: staff.PersonnelNumber}, "Personnel number retrieved successfully")
+}
+
+// updatePayrollNumber sets or clears the Personalnummer. The service writes
+// the audit row in the same tenant transaction and maps duplicates to a
+// stable conflict code.
+func (rs *Resource) updatePayrollNumber(w http.ResponseWriter, r *http.Request) {
+	id, ok := common.ParseInt64IDWithError(w, r, "id", common.MsgInvalidStaffID)
+	if !ok {
+		return
+	}
+	req := &PayrollNumberRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	changedBy, err := rs.resolveEditorStaffID(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+
+	staff, err := rs.PersonService.UpdatePersonnelNumber(r.Context(), id, req.PersonnelNumber, changedBy, req.Note)
+	if err != nil {
+		switch {
+		case errors.Is(err, usersSvc.ErrPersonnelNumberInvalid):
+			common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "personnel_number_invalid"))
+		case errors.Is(err, usersSvc.ErrPersonnelNumberTaken):
+			common.RenderError(w, r, common.ErrorConflictWithCode(err, "personnel_number_taken"))
+		case modelBase.IsNoRows(err):
+			common.RenderError(w, r, common.ErrorNotFound(err))
+		default:
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
+		return
+	}
+	common.Respond(w, r, http.StatusOK, &PayrollNumberResponse{StaffID: staff.ID, PersonnelNumber: staff.PersonnelNumber}, "Personnel number updated successfully")
+}

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -265,6 +265,7 @@ GET /api/schedules/timeframes/active
 GET /api/schedules/timeframes/by-range
 GET /api/schedules/timeframes/{id}
 GET /api/settings/login-image
+GET /api/settings/payroll-status
 GET /api/settings/schema
 GET /api/settings/values/{key}/reveal
 GET /api/shift-types/
@@ -286,6 +287,7 @@ GET /api/staff/{id}
 GET /api/staff/{id}/absences
 GET /api/staff/{id}/avatar
 GET /api/staff/{id}/groups
+GET /api/staff/{id}/payroll-number
 GET /api/staff/{id}/schedule
 GET /api/staff/{id}/substitutions
 GET /api/staff/{id}/time-tracking/adjustments
@@ -758,6 +760,7 @@ PUT /api/staff-shifts/{id}/cancellation
 PUT /api/staff-shifts/{id}/move
 PUT /api/staff/pin
 PUT /api/staff/{id}
+PUT /api/staff/{id}/payroll-number
 PUT /api/staff/{id}/schedule
 PUT /api/staff/{id}/time-tracking/sessions/{sessionId}
 PUT /api/staff/{id}/vacation/quota

--- a/backend/api/usercontext/usercontext_test.go
+++ b/backend/api/usercontext/usercontext_test.go
@@ -188,7 +188,16 @@ func TestGetCurrentStaff_Success(t *testing.T) {
 	tc := setupTestContext(t)
 	defer func() { _ = tc.db.Close() }()
 
-	_, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Staff", "Test")
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Staff", "Test")
+	personnelNumber := "90001"
+	teacher.Staff.PersonnelNumber = &personnelNumber
+	_, err := tc.db.NewUpdate().
+		Model(teacher.Staff).
+		ModelTableExpr(`users.staff AS "staff"`).
+		Column("personnel_number").
+		WherePK().
+		Exec(context.Background())
+	require.NoError(t, err)
 
 	claims := testutil.TeacherTestClaims(int(account.ID))
 	req := testutil.NewAuthenticatedRequest(t, "GET", "/staff", nil,
@@ -198,6 +207,7 @@ func TestGetCurrentStaff_Success(t *testing.T) {
 	rr := testutil.ExecuteRequest(tc.router, req)
 
 	testutil.AssertSuccessResponse(t, rr, http.StatusOK)
+	assert.NotContains(t, rr.Body.String(), "personnel_number")
 }
 
 func TestGetCurrentStaff_NotStaff(t *testing.T) {

--- a/backend/database/migrations/001015229_payroll_foundation.go
+++ b/backend/database/migrations/001015229_payroll_foundation.go
@@ -1,0 +1,102 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	payrollFoundationVersion     = "1.15.229"
+	payrollFoundationDescription = "Add users.staff.personnel_number + audit.personnel_number_changes for the DATEV payroll foundation (#1417)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     payrollFoundationVersion,
+		Description: payrollFoundationDescription,
+		DependsOn: []string{
+			auditAppendOnlyGrantsVersion,
+			studentFieldEditsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return payrollFoundationUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return payrollFoundationDown(ctx, db)
+		},
+	)
+}
+
+// payrollFoundationUp lays the ground for the DATEV exports (#1417 2b):
+// both LODAS and Lohn und Gehalt match employees via the payroll system's
+// Personalnummer, which nothing in Phoenix stored so far.
+//
+// personnel_number lives on users.staff and is therefore school-scoped. A
+// person working at two schools of the same Träger has two staff rows; the
+// number belongs to the employer, so both rows should carry the SAME value —
+// per-tenant RLS makes that consistency unenforceable here. Documented as a
+// known gap (needs the org-wide read layer, see #1986 "Standort-Filter").
+// Uniqueness IS enforced within a tenant: one number, one person. The partial
+// index skips soft-deleted rows so an offboarded person's number can be
+// reassigned.
+//
+// audit.personnel_number_changes records every change: personnel numbers are
+// what payroll bills against, so a silent edit is an audit finding. Same
+// append-only shape as audit.time_tracking_deletions (1.15.227); staff_id and
+// changed_by carry no FK on purpose so the trail survives offboarding.
+func payrollFoundationUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.229: Adding personnel_number + audit.personnel_number_changes...")
+
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE users.staff ADD COLUMN IF NOT EXISTS personnel_number TEXT;
+
+		CREATE UNIQUE INDEX IF NOT EXISTS uq_staff_tenant_personnel_number
+			ON users.staff (tenant_id, personnel_number)
+			WHERE personnel_number IS NOT NULL AND deleted_at IS NULL;
+
+		CREATE TABLE IF NOT EXISTS audit.personnel_number_changes (
+			id          BIGSERIAL PRIMARY KEY,
+			tenant_id   BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			staff_id    BIGINT NOT NULL,
+			changed_by  BIGINT NOT NULL,
+			old_value   TEXT NOT NULL DEFAULT '',
+			new_value   TEXT NOT NULL DEFAULT '',
+			note        TEXT NOT NULL DEFAULT '',
+			occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_personnel_number_changes_tenant_occurred
+			ON audit.personnel_number_changes (tenant_id, occurred_at DESC);
+
+		ALTER TABLE audit.personnel_number_changes ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY tenant_isolation_personnel_number_changes ON audit.personnel_number_changes
+			USING (tenant_id = current_setting('app.current_tenant_id')::BIGINT);
+		ALTER TABLE audit.personnel_number_changes FORCE ROW LEVEL SECURITY;
+
+		GRANT SELECT, INSERT ON audit.personnel_number_changes TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE audit.personnel_number_changes_id_seq TO phoenix_tenant;
+		REVOKE UPDATE, DELETE ON audit.personnel_number_changes FROM phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating payroll foundation objects: %w", err)
+	}
+	return nil
+}
+
+func payrollFoundationDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.229: Dropping payroll foundation objects...")
+	_, err := db.ExecContext(ctx, `
+		DROP TABLE IF EXISTS audit.personnel_number_changes;
+		DROP INDEX IF EXISTS users.uq_staff_tenant_personnel_number;
+		ALTER TABLE users.staff DROP COLUMN IF EXISTS personnel_number;
+	`)
+	if err != nil {
+		return fmt.Errorf("error rolling back payroll foundation: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/audit/personnel_number_change.go
+++ b/backend/database/repositories/audit/personnel_number_change.go
@@ -1,0 +1,36 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/uptrace/bun"
+)
+
+type PersonnelNumberChangeRepository struct {
+	db *bun.DB
+}
+
+func NewPersonnelNumberChangeRepository(db *bun.DB) auditModels.PersonnelNumberChangeRepository {
+	return &PersonnelNumberChangeRepository{db: db}
+}
+
+func (r *PersonnelNumberChangeRepository) Create(ctx context.Context, event *auditModels.PersonnelNumberChange) error {
+	if event == nil {
+		return fmt.Errorf("personnel number change audit event is required")
+	}
+	if err := event.Validate(); err != nil {
+		return fmt.Errorf("invalid personnel number change audit event: %w", err)
+	}
+	base.EnsureTenantID(ctx, event)
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(event).
+		ModelTableExpr(`audit.personnel_number_changes AS "personnel_number_change"`).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("create personnel number change audit event: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/audit/personnel_number_change.go
+++ b/backend/database/repositories/audit/personnel_number_change.go
@@ -13,7 +13,7 @@ type PersonnelNumberChangeRepository struct {
 	db *bun.DB
 }
 
-func NewPersonnelNumberChangeRepository(db *bun.DB) auditModels.PersonnelNumberChangeRepository {
+func NewPersonnelNumberChangeRepository(db *bun.DB) auditModels.PersonnelNumberChangeCreator {
 	return &PersonnelNumberChangeRepository{db: db}
 }
 

--- a/backend/database/repositories/audit/time_tracking_audit_log.go
+++ b/backend/database/repositories/audit/time_tracking_audit_log.go
@@ -118,6 +118,16 @@ var auditLogBranches = map[string]string{
 			) AS detail
 		FROM audit.time_tracking_deletions d
 		WHERE d.tenant_id = %s`,
+	auditModels.AuditLogSourcePersonnelNumber: `
+		SELECT c.occurred_at AS occurred_at, 'personnel_number' AS source, c.id AS entry_id,
+			c.staff_id AS staff_id, ARRAY[c.staff_id] AS staff_ids,
+			c.changed_by AS actor_staff_id, FALSE AS actor_is_system,
+			c.note AS reason,
+			jsonb_build_object(
+				'old_value', c.old_value, 'new_value', c.new_value
+			) AS detail
+		FROM audit.personnel_number_changes c
+		WHERE c.tenant_id = %s`,
 }
 
 const auditLogDefaultLimit = 50

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -169,7 +169,7 @@ type Factory struct {
 	StudentFieldEdit             auditModels.StudentFieldEditRepository
 	UnregisteredTagScan          auditModels.UnregisteredTagScanRepository
 	TimeTrackingDeletion         auditModels.TimeTrackingDeletionRepository
-	PersonnelNumberChange        auditModels.PersonnelNumberChangeRepository
+	PersonnelNumberChange        auditModels.PersonnelNumberChangeCreator
 	TimeTrackingAuditLog         auditModels.TimeTrackingAuditLogRepository
 
 	// Platform domain (operator dashboard)

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -169,6 +169,7 @@ type Factory struct {
 	StudentFieldEdit             auditModels.StudentFieldEditRepository
 	UnregisteredTagScan          auditModels.UnregisteredTagScanRepository
 	TimeTrackingDeletion         auditModels.TimeTrackingDeletionRepository
+	PersonnelNumberChange        auditModels.PersonnelNumberChangeRepository
 	TimeTrackingAuditLog         auditModels.TimeTrackingAuditLogRepository
 
 	// Platform domain (operator dashboard)
@@ -361,6 +362,7 @@ func NewFactory(db *bun.DB) *Factory {
 		StudentFieldEdit:             audit.NewStudentFieldEditRepository(db),
 		UnregisteredTagScan:          audit.NewUnregisteredTagScanRepository(db),
 		TimeTrackingDeletion:         audit.NewTimeTrackingDeletionRepository(db),
+		PersonnelNumberChange:        audit.NewPersonnelNumberChangeRepository(db),
 		TimeTrackingAuditLog:         audit.NewTimeTrackingAuditLogRepository(db),
 
 		// Platform repositories

--- a/backend/database/repositories/users/staff.go
+++ b/backend/database/repositories/users/staff.go
@@ -32,6 +32,28 @@ func NewStaffRepository(db *bun.DB) users.StaffRepository {
 	}
 }
 
+// FindByIDForUpdate retrieves a staff row with a SELECT … FOR UPDATE lock.
+// Payroll-number changes use the lock to derive their audit old_value from
+// the last committed value when concurrent updates target the same staff row.
+func (r *StaffRepository) FindByIDForUpdate(ctx context.Context, id int64) (*users.Staff, error) {
+	staff := new(users.Staff)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(staff).
+		ModelTableExpr(`users.staff AS "staff"`).
+		Where(`"staff".id = ?`, id).
+		For("UPDATE")
+
+	query = base.WithTenantFilter(ctx, query, "staff")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find staff by id for update",
+			Err: err,
+		}
+	}
+	return staff, nil
+}
+
 // FindByPersonID retrieves a staff member by their person ID
 func (r *StaffRepository) FindByPersonID(ctx context.Context, personID int64) (*users.Staff, error) {
 	staff := new(users.Staff)

--- a/backend/models/audit/personnel_number_change.go
+++ b/backend/models/audit/personnel_number_change.go
@@ -1,0 +1,46 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/uptrace/bun"
+)
+
+// PersonnelNumberChange is an append-only audit row for a change to a staff
+// member's Personalnummer (#1417). The number is what payroll bills against,
+// so every change keeps old and new value; note is optional context. Written
+// in the same tenant transaction as the update — no change without a trace,
+// same contract as audit.time_tracking_deletions.
+type PersonnelNumberChange struct {
+	bun.BaseModel `bun:"schema:audit,table:personnel_number_changes"`
+	ID            int64 `bun:"id,pk,autoincrement" json:"id"`
+	base.TenantModel
+	StaffID    int64     `bun:"staff_id,notnull" json:"staff_id"`
+	ChangedBy  int64     `bun:"changed_by,notnull" json:"changed_by"`
+	OldValue   string    `bun:"old_value,notnull" json:"old_value"`
+	NewValue   string    `bun:"new_value,notnull" json:"new_value"`
+	Note       string    `bun:"note,notnull" json:"note"`
+	OccurredAt time.Time `bun:"occurred_at,nullzero,notnull,default:now()" json:"occurred_at"`
+}
+
+func (c *PersonnelNumberChange) Validate() error {
+	if c.StaffID <= 0 {
+		return errors.New("staff_id is required")
+	}
+	if c.ChangedBy <= 0 {
+		return errors.New("changed_by is required")
+	}
+	if c.OldValue == c.NewValue {
+		return errors.New("old and new value are identical")
+	}
+	return nil
+}
+
+// PersonnelNumberChangeRepository is append-only; reads happen through the
+// cross-source audit log query.
+type PersonnelNumberChangeRepository interface {
+	Create(ctx context.Context, event *PersonnelNumberChange) error
+}

--- a/backend/models/audit/personnel_number_change.go
+++ b/backend/models/audit/personnel_number_change.go
@@ -39,8 +39,8 @@ func (c *PersonnelNumberChange) Validate() error {
 	return nil
 }
 
-// PersonnelNumberChangeRepository is append-only; reads happen through the
+// PersonnelNumberChangeCreator is append-only; reads happen through the
 // cross-source audit log query.
-type PersonnelNumberChangeRepository interface {
+type PersonnelNumberChangeCreator interface {
 	Create(ctx context.Context, event *PersonnelNumberChange) error
 }

--- a/backend/models/audit/time_tracking_audit_log.go
+++ b/backend/models/audit/time_tracking_audit_log.go
@@ -11,12 +11,13 @@ import (
 // Time-tracking audit log sources (#1417). One value per change trail that
 // feeds the cross-staff audit view.
 const (
-	AuditLogSourceSessionEdit = "session_edit"
-	AuditLogSourceAbsence     = "absence"
-	AuditLogSourceAdjustment  = "adjustment"
-	AuditLogSourceMonthClose  = "month_close"
-	AuditLogSourceMonthReopen = "month_reopen"
-	AuditLogSourceDeletion    = "deletion"
+	AuditLogSourceSessionEdit     = "session_edit"
+	AuditLogSourceAbsence         = "absence"
+	AuditLogSourceAdjustment      = "adjustment"
+	AuditLogSourceMonthClose      = "month_close"
+	AuditLogSourceMonthReopen     = "month_reopen"
+	AuditLogSourceDeletion        = "deletion"
+	AuditLogSourcePersonnelNumber = "personnel_number"
 )
 
 // ValidAuditLogSources lists every accepted `sources` filter value.
@@ -27,6 +28,7 @@ var ValidAuditLogSources = []string{
 	AuditLogSourceMonthClose,
 	AuditLogSourceMonthReopen,
 	AuditLogSourceDeletion,
+	AuditLogSourcePersonnelNumber,
 }
 
 // TimeTrackingAuditLogEntry is one event in the merged feed: the common

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -331,3 +331,35 @@ const (
 	KeyRemindersActivityStartLeadMinutes  = "reminders.activity_start_lead_minutes"
 	KeyRemindersActivityOverdueEnabled    = "reminders.activity_overdue_enabled"
 )
+
+// Payroll foundation settings (#1417 Tranche 2b). Lohnartnummern are
+// mandant-specific DATEV numbers — there are NO defaults on purpose: a
+// plausible-looking preset would silently bill wrong. Empty means "not
+// configured yet"; the later DATEV writers refuse to produce a file until
+// the configuration is complete. Definitions live in defaults/payroll.go.
+const (
+	KeyPayrollLohnartRegelarbeit       = "payroll.lohnart_regelarbeit"
+	KeyPayrollLohnartPlusStunden       = "payroll.lohnart_plus_stunden"
+	KeyPayrollLohnartAuszahlung        = "payroll.lohnart_auszahlung"
+	KeyPayrollLohnartFreizeitausgleich = "payroll.lohnart_freizeitausgleich"
+	KeyPayrollLohnartKrank             = "payroll.lohnart_krank"
+	KeyPayrollLohnartUrlaub            = "payroll.lohnart_urlaub"
+	KeyPayrollLohnartFortbildung       = "payroll.lohnart_fortbildung"
+
+	// Unit per category, only where day values exist (sick/vacation/training).
+	// The remaining categories are minute sums with no day representation, so
+	// they are always exported in hours and carry no unit setting.
+	KeyPayrollEinheitKrank       = "payroll.einheit_krank"
+	KeyPayrollEinheitUrlaub      = "payroll.einheit_urlaub"
+	KeyPayrollEinheitFortbildung = "payroll.einheit_fortbildung"
+
+	// LODAS file-header identifiers; Lohn und Gehalt does not need them.
+	KeyPayrollDatevBeraternummer   = "payroll.datev_beraternummer"
+	KeyPayrollDatevMandantennummer = "payroll.datev_mandantennummer"
+)
+
+// Payroll unit select values.
+const (
+	PayrollUnitHours = "stunden"
+	PayrollUnitDays  = "tage"
+)

--- a/backend/models/config/registry.go
+++ b/backend/models/config/registry.go
@@ -83,6 +83,7 @@ type Definition struct {
 // ValidationRules defines constraints on a setting value.
 type ValidationRules struct {
 	Required        bool           `json:"required,omitempty"`
+	AllowEmpty      bool           `json:"allow_empty,omitempty"` // Permit an empty string without applying Pattern
 	Min             *float64       `json:"min,omitempty"`
 	Max             *float64       `json:"max,omitempty"`
 	Pattern         *string        `json:"pattern,omitempty"` // Regex pattern for string/password fields

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -189,6 +189,9 @@ type StudentRepository interface {
 type StaffRepository interface {
 	base.CRUDRepository[*Staff]
 
+	// FindByIDForUpdate retrieves and locks a staff row for a transaction.
+	FindByIDForUpdate(ctx context.Context, id int64) (*Staff, error)
+
 	// FindByPersonID retrieves a staff member by their person ID
 	FindByPersonID(ctx context.Context, personID int64) (*Staff, error)
 

--- a/backend/models/users/staff.go
+++ b/backend/models/users/staff.go
@@ -15,14 +15,25 @@ const (
 	EmploymentTypeMinijob  = "minijob"
 )
 
+// PersonnelNumberUniqueConstraintName is the partial unique index enforcing
+// one Personalnummer per person within a tenant (migration 1.15.229). The
+// service layer maps 23505 on it to a stable conflict error.
+const PersonnelNumberUniqueConstraintName = "uq_staff_tenant_personnel_number"
+
 // Staff represents a staff member in the system
 type Staff struct {
 	base.Model `bun:"schema:users,table:staff"`
 	base.TenantModel
-	PersonID           int64          `bun:"person_id,notnull" json:"person_id"`
-	StaffNotes         string         `bun:"staff_notes" json:"staff_notes,omitempty"`
-	EmploymentType     *string        `bun:"employment_type" json:"employment_type,omitempty"`
-	WorkTimeModelID    *int64         `bun:"work_time_model_id" json:"work_time_model_id,omitempty"`
+	PersonID        int64   `bun:"person_id,notnull" json:"person_id"`
+	StaffNotes      string  `bun:"staff_notes" json:"staff_notes,omitempty"`
+	EmploymentType  *string `bun:"employment_type" json:"employment_type,omitempty"`
+	WorkTimeModelID *int64  `bun:"work_time_model_id" json:"work_time_model_id,omitempty"`
+	// PersonnelNumber is the payroll system's Personalnummer (DATEV LODAS /
+	// Lohn und Gehalt match employees by it, #1417). Unique per tenant via
+	// partial index; NULL means "not assigned yet". School-scoped like the
+	// row itself — a person at two schools of one Träger should carry the
+	// same value in both rows, which RLS cannot enforce (documented gap).
+	PersonnelNumber    *string        `bun:"personnel_number" json:"personnel_number,omitempty"`
 	RotationAnchorDate *timezone.Date `bun:"rotation_anchor_date,type:date" json:"rotation_anchor_date,omitempty"`
 	DeletedAt          *time.Time     `bun:"deleted_at,soft_delete,nullzero" json:"-"`
 

--- a/backend/models/users/staff.go
+++ b/backend/models/users/staff.go
@@ -33,7 +33,9 @@ type Staff struct {
 	// partial index; NULL means "not assigned yet". School-scoped like the
 	// row itself — a person at two schools of one Träger should carry the
 	// same value in both rows, which RLS cannot enforce (documented gap).
-	PersonnelNumber    *string        `bun:"personnel_number" json:"personnel_number,omitempty"`
+	// Generic Staff JSON must not expose it; payroll handlers use a dedicated,
+	// permission-gated response.
+	PersonnelNumber    *string        `bun:"personnel_number" json:"-"`
 	RotationAnchorDate *timezone.Date `bun:"rotation_anchor_date,type:date" json:"rotation_anchor_date,omitempty"`
 	DeletedAt          *time.Time     `bun:"deleted_at,soft_delete,nullzero" json:"-"`
 

--- a/backend/models/users/staff_test.go
+++ b/backend/models/users/staff_test.go
@@ -1,10 +1,28 @@
 package users
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
 )
+
+func TestStaff_JSONOmitsPersonnelNumber(t *testing.T) {
+	personnelNumber := "90001"
+	staff := &Staff{
+		PersonID:        1,
+		PersonnelNumber: &personnelNumber,
+	}
+
+	payload, err := json.Marshal(staff)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(payload), "personnel_number") {
+		t.Fatalf("json.Marshal() exposed personnel_number: %s", payload)
+	}
+}
 
 func TestStaff_Validate(t *testing.T) {
 	tests := []struct {

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -1453,3 +1453,66 @@ func TestAutoCheckoutSettings(t *testing.T) {
 	assert.Equal(t, float64(0), *grace.Validation.Min)
 	assert.Equal(t, float64(240), *grace.Validation.Max)
 }
+
+// TestPayrollSettings pins the DATEV payroll foundation (#1417 Tranche 2b).
+// The empty defaults are the point: Lohnartnummern are mandant-specific and
+// a plausible preset would silently bill wrong. Any change that introduces a
+// non-empty default here must be treated as a billing bug, not a convenience.
+func TestPayrollSettings(t *testing.T) {
+	lohnarten := []string{
+		config.KeyPayrollLohnartRegelarbeit,
+		config.KeyPayrollLohnartPlusStunden,
+		config.KeyPayrollLohnartAuszahlung,
+		config.KeyPayrollLohnartFreizeitausgleich,
+		config.KeyPayrollLohnartKrank,
+		config.KeyPayrollLohnartUrlaub,
+		config.KeyPayrollLohnartFortbildung,
+	}
+	for _, key := range lohnarten {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "%s should be registered", key)
+		assert.Equal(t, config.FieldText, def.Type, key)
+		assert.Equal(t, "", def.Default, "%s must default to EMPTY — never invent Lohnart numbers", key)
+		assert.Equal(t, "abrechnung", def.Tab, key)
+		assert.Equal(t, "lohnarten", def.Category, key)
+		assert.Equal(t, "config:manage", def.WritePermission, key)
+		assert.Equal(t, config.AccessAdminOnly, def.AccessPolicy, key)
+		require.NotNil(t, def.Validation, key)
+		require.NotNil(t, def.Validation.Pattern, key)
+		assert.Equal(t, `^\d{1,4}$`, *def.Validation.Pattern, key)
+	}
+
+	units := []string{
+		config.KeyPayrollEinheitKrank,
+		config.KeyPayrollEinheitUrlaub,
+		config.KeyPayrollEinheitFortbildung,
+	}
+	for _, key := range units {
+		def := config.GetDefinition(key)
+		require.NotNilf(t, def, "%s should be registered", key)
+		assert.Equal(t, config.FieldSelect, def.Type, key)
+		assert.Equal(t, "", def.Default, "%s must default to 'not set' — the unit comes from the Träger's Lohnart definition", key)
+		assert.Equal(t, "abrechnung", def.Tab, key)
+		assert.Equal(t, "config:manage", def.WritePermission, key)
+		require.NotNil(t, def.Options, key)
+		require.Len(t, def.Options.Static, 3, key)
+	}
+
+	berater := config.GetDefinition(config.KeyPayrollDatevBeraternummer)
+	require.NotNil(t, berater)
+	assert.Equal(t, config.FieldText, berater.Type)
+	assert.Equal(t, "", berater.Default)
+	assert.Equal(t, "config:manage", berater.WritePermission)
+	require.NotNil(t, berater.Validation)
+	require.NotNil(t, berater.Validation.Pattern)
+	assert.Equal(t, `^\d{1,7}$`, *berater.Validation.Pattern)
+
+	mandant := config.GetDefinition(config.KeyPayrollDatevMandantennummer)
+	require.NotNil(t, mandant)
+	assert.Equal(t, config.FieldText, mandant.Type)
+	assert.Equal(t, "", mandant.Default)
+	assert.Equal(t, "config:manage", mandant.WritePermission)
+	require.NotNil(t, mandant.Validation)
+	require.NotNil(t, mandant.Validation.Pattern)
+	assert.Equal(t, `^\d{1,5}$`, *mandant.Validation.Pattern)
+}

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -1011,6 +1011,8 @@ func TestSecuritySettings(t *testing.T) {
 	assert.Equal(t, "devices", def.Tab)
 	assert.Equal(t, "pin", def.Category)
 	assert.Equal(t, "config:manage", def.WritePermission)
+	require.NotNil(t, def.Validation)
+	assert.False(t, def.Validation.AllowEmpty)
 	require.NotNil(t, def.DependsOn)
 	assert.Equal(t, config.KeyAttendanceNFCEnabled, def.DependsOn.Key)
 	assert.Equal(t, "eq", def.DependsOn.Condition)
@@ -1479,6 +1481,7 @@ func TestPayrollSettings(t *testing.T) {
 		assert.Equal(t, config.AccessAdminOnly, def.AccessPolicy, key)
 		require.NotNil(t, def.Validation, key)
 		require.NotNil(t, def.Validation.Pattern, key)
+		assert.True(t, def.Validation.AllowEmpty, key)
 		assert.Equal(t, `^\d{1,4}$`, *def.Validation.Pattern, key)
 	}
 
@@ -1505,6 +1508,7 @@ func TestPayrollSettings(t *testing.T) {
 	assert.Equal(t, "config:manage", berater.WritePermission)
 	require.NotNil(t, berater.Validation)
 	require.NotNil(t, berater.Validation.Pattern)
+	assert.True(t, berater.Validation.AllowEmpty)
 	assert.Equal(t, `^\d{1,7}$`, *berater.Validation.Pattern)
 
 	mandant := config.GetDefinition(config.KeyPayrollDatevMandantennummer)
@@ -1514,5 +1518,6 @@ func TestPayrollSettings(t *testing.T) {
 	assert.Equal(t, "config:manage", mandant.WritePermission)
 	require.NotNil(t, mandant.Validation)
 	require.NotNil(t, mandant.Validation.Pattern)
+	assert.True(t, mandant.Validation.AllowEmpty)
 	assert.Equal(t, `^\d{1,5}$`, *mandant.Validation.Pattern)
 }

--- a/backend/services/config/defaults/payroll.go
+++ b/backend/services/config/defaults/payroll.go
@@ -57,7 +57,7 @@ func init() {
 			Tab:             "abrechnung",
 			Category:        "lohnarten",
 			SortOrder:       l.sort,
-			Validation:      &config.ValidationRules{Pattern: &lohnartPattern},
+			Validation:      &config.ValidationRules{Pattern: &lohnartPattern, AllowEmpty: true},
 			AccessPolicy:    config.AccessAdminOnly,
 		})
 	}
@@ -99,7 +99,7 @@ func init() {
 		Tab:             "abrechnung",
 		Category:        "datev_mandant",
 		SortOrder:       10,
-		Validation:      &config.ValidationRules{Pattern: &beraterPattern},
+		Validation:      &config.ValidationRules{Pattern: &beraterPattern, AllowEmpty: true},
 		AccessPolicy:    config.AccessAdminOnly,
 	})
 
@@ -114,7 +114,7 @@ func init() {
 		Tab:             "abrechnung",
 		Category:        "datev_mandant",
 		SortOrder:       20,
-		Validation:      &config.ValidationRules{Pattern: &mandantPattern},
+		Validation:      &config.ValidationRules{Pattern: &mandantPattern, AllowEmpty: true},
 		AccessPolicy:    config.AccessAdminOnly,
 	})
 }

--- a/backend/services/config/defaults/payroll.go
+++ b/backend/services/config/defaults/payroll.go
@@ -4,6 +4,11 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/config"
 )
 
+const (
+	payrollReadPermission  = "config:read"
+	payrollWritePermission = "config:manage"
+)
+
 // Payroll foundation (#1417 Tranche 2b): Lohnart mapping and DATEV client
 // identifiers for the upcoming LODAS / Lohn und Gehalt writers.
 //
@@ -47,8 +52,8 @@ func init() {
 			Description:     "Mandantenspezifische DATEV-Lohnartnummer (1 bis 4 Ziffern). Leer bedeutet: noch nicht konfiguriert; ohne Nummer erzeugt der spätere DATEV-Export keine Zeile für diese Kategorie.",
 			Type:            config.FieldText,
 			Default:         "",
-			ReadPermission:  "config:read",
-			WritePermission: "config:manage",
+			ReadPermission:  payrollReadPermission,
+			WritePermission: payrollWritePermission,
 			Tab:             "abrechnung",
 			Category:        "lohnarten",
 			SortOrder:       l.sort,
@@ -73,8 +78,8 @@ func init() {
 			Description:     "Ob die zugehörige DATEV-Lohnart Stunden oder Tage erwartet. Richtet sich nach der Lohnart-Definition im Lohnsystem des Trägers.",
 			Type:            config.FieldSelect,
 			Default:         "",
-			ReadPermission:  "config:read",
-			WritePermission: "config:manage",
+			ReadPermission:  payrollReadPermission,
+			WritePermission: payrollWritePermission,
 			Tab:             "abrechnung",
 			Category:        "lohnarten",
 			SortOrder:       u.sort,
@@ -89,8 +94,8 @@ func init() {
 		Description:     "Beraternummer für den Kopf der LODAS-Datei (1 bis 7 Ziffern). Ohne diesen Wert kann keine LODAS-Datei erzeugt werden; Lohn und Gehalt benötigt ihn nicht.",
 		Type:            config.FieldText,
 		Default:         "",
-		ReadPermission:  "config:read",
-		WritePermission: "config:manage",
+		ReadPermission:  payrollReadPermission,
+		WritePermission: payrollWritePermission,
 		Tab:             "abrechnung",
 		Category:        "datev_mandant",
 		SortOrder:       10,
@@ -104,8 +109,8 @@ func init() {
 		Description:     "Mandantennummer für den Kopf der LODAS-Datei (1 bis 5 Ziffern). Ohne diesen Wert kann keine LODAS-Datei erzeugt werden; Lohn und Gehalt benötigt ihn nicht.",
 		Type:            config.FieldText,
 		Default:         "",
-		ReadPermission:  "config:read",
-		WritePermission: "config:manage",
+		ReadPermission:  payrollReadPermission,
+		WritePermission: payrollWritePermission,
 		Tab:             "abrechnung",
 		Category:        "datev_mandant",
 		SortOrder:       20,

--- a/backend/services/config/defaults/payroll.go
+++ b/backend/services/config/defaults/payroll.go
@@ -1,0 +1,115 @@
+package defaults
+
+import (
+	"github.com/moto-nrw/project-phoenix/models/config"
+)
+
+// Payroll foundation (#1417 Tranche 2b): Lohnart mapping and DATEV client
+// identifiers for the upcoming LODAS / Lohn und Gehalt writers.
+//
+// Every Lohnart default is deliberately the EMPTY STRING. The numbers are
+// mandant-specific; no Träger has provided a list yet, and a plausible
+// preset would later bill silently wrong. Empty required configuration is
+// the desired state, not a defect — the writers fail fast on it.
+//
+// These settings are maintained on the dedicated /payroll page, not on the
+// generic settings page (the "abrechnung" tab is filtered out there).
+func init() {
+	lohnartPattern := `^\d{1,4}$`
+	beraterPattern := `^\d{1,7}$`
+	mandantPattern := `^\d{1,5}$`
+
+	unitOptions := &config.SelectOptions{
+		Static: []config.SelectOption{
+			{Label: "Nicht festgelegt", Value: ""},
+			{Label: "Stunden", Value: config.PayrollUnitHours},
+			{Label: "Tage", Value: config.PayrollUnitDays},
+		},
+	}
+
+	lohnarten := []struct {
+		key   string
+		label string
+		sort  int
+	}{
+		{config.KeyPayrollLohnartRegelarbeit, "Lohnart Regelarbeit", 10},
+		{config.KeyPayrollLohnartPlusStunden, "Lohnart Plus-Stunden", 20},
+		{config.KeyPayrollLohnartAuszahlung, "Lohnart Auszahlung", 30},
+		{config.KeyPayrollLohnartFreizeitausgleich, "Lohnart Freizeitausgleich", 40},
+		{config.KeyPayrollLohnartKrank, "Lohnart Krank", 50},
+		{config.KeyPayrollLohnartUrlaub, "Lohnart Urlaub", 60},
+		{config.KeyPayrollLohnartFortbildung, "Lohnart Fortbildung", 70},
+	}
+	for _, l := range lohnarten {
+		config.Register(config.Definition{
+			Key:             l.key,
+			Label:           l.label,
+			Description:     "Mandantenspezifische DATEV-Lohnartnummer (1 bis 4 Ziffern). Leer bedeutet: noch nicht konfiguriert; ohne Nummer erzeugt der spätere DATEV-Export keine Zeile für diese Kategorie.",
+			Type:            config.FieldText,
+			Default:         "",
+			ReadPermission:  "config:read",
+			WritePermission: "config:manage",
+			Tab:             "abrechnung",
+			Category:        "lohnarten",
+			SortOrder:       l.sort,
+			Validation:      &config.ValidationRules{Pattern: &lohnartPattern},
+			AccessPolicy:    config.AccessAdminOnly,
+		})
+	}
+
+	units := []struct {
+		key   string
+		label string
+		sort  int
+	}{
+		{config.KeyPayrollEinheitKrank, "Einheit Krank", 55},
+		{config.KeyPayrollEinheitUrlaub, "Einheit Urlaub", 65},
+		{config.KeyPayrollEinheitFortbildung, "Einheit Fortbildung", 75},
+	}
+	for _, u := range units {
+		config.Register(config.Definition{
+			Key:             u.key,
+			Label:           u.label,
+			Description:     "Ob die zugehörige DATEV-Lohnart Stunden oder Tage erwartet. Richtet sich nach der Lohnart-Definition im Lohnsystem des Trägers.",
+			Type:            config.FieldSelect,
+			Default:         "",
+			ReadPermission:  "config:read",
+			WritePermission: "config:manage",
+			Tab:             "abrechnung",
+			Category:        "lohnarten",
+			SortOrder:       u.sort,
+			Options:         unitOptions,
+			AccessPolicy:    config.AccessAdminOnly,
+		})
+	}
+
+	config.Register(config.Definition{
+		Key:             config.KeyPayrollDatevBeraternummer,
+		Label:           "DATEV-Beraternummer",
+		Description:     "Beraternummer für den Kopf der LODAS-Datei (1 bis 7 Ziffern). Ohne diesen Wert kann keine LODAS-Datei erzeugt werden; Lohn und Gehalt benötigt ihn nicht.",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "abrechnung",
+		Category:        "datev_mandant",
+		SortOrder:       10,
+		Validation:      &config.ValidationRules{Pattern: &beraterPattern},
+		AccessPolicy:    config.AccessAdminOnly,
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyPayrollDatevMandantennummer,
+		Label:           "DATEV-Mandantennummer",
+		Description:     "Mandantennummer für den Kopf der LODAS-Datei (1 bis 5 Ziffern). Ohne diesen Wert kann keine LODAS-Datei erzeugt werden; Lohn und Gehalt benötigt ihn nicht.",
+		Type:            config.FieldText,
+		Default:         "",
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "abrechnung",
+		Category:        "datev_mandant",
+		SortOrder:       20,
+		Validation:      &config.ValidationRules{Pattern: &mandantPattern},
+		AccessPolicy:    config.AccessAdminOnly,
+	})
+}

--- a/backend/services/config/payroll_status_service.go
+++ b/backend/services/config/payroll_status_service.go
@@ -51,8 +51,8 @@ type PayrollStatus struct {
 	StaffWithoutPersonnelNumber int `json:"staff_without_personnel_number"`
 }
 
-// PayrollStatusService reports the payroll configuration state.
-type PayrollStatusService interface {
+// PayrollStatusGetter reports the payroll configuration state.
+type PayrollStatusGetter interface {
 	GetPayrollStatus(ctx context.Context) (*PayrollStatus, error)
 }
 
@@ -61,18 +61,20 @@ type payrollStatusService struct {
 	staffRepo userModels.StaffRepository
 }
 
-func NewPayrollStatusService(settings SettingsService, staffRepo userModels.StaffRepository) PayrollStatusService {
+func NewPayrollStatusService(settings SettingsService, staffRepo userModels.StaffRepository) PayrollStatusGetter {
 	return &payrollStatusService{settings: settings, staffRepo: staffRepo}
 }
 
-// payrollCategories fixes ID, label, and settings keys per category. The
-// order matches the registry sort order and the later export column order.
-var payrollCategories = []struct {
+type payrollCategory struct {
 	id      string
 	label   string
 	key     string
 	unitKey string
-}{
+}
+
+// payrollCategories fixes ID, label, and settings keys per category. The
+// order matches the registry sort order and the later export column order.
+var payrollCategories = []payrollCategory{
 	{"regelarbeit", "Regelarbeit", configModel.KeyPayrollLohnartRegelarbeit, ""},
 	{"plus_stunden", "Plus-Stunden", configModel.KeyPayrollLohnartPlusStunden, ""},
 	{"auszahlung", "Auszahlung", configModel.KeyPayrollLohnartAuszahlung, ""},
@@ -83,58 +85,98 @@ var payrollCategories = []struct {
 }
 
 func (s *payrollStatusService) GetPayrollStatus(ctx context.Context) (*PayrollStatus, error) {
-	status := &PayrollStatus{TotalCategories: len(payrollCategories)}
-
-	for _, cat := range payrollCategories {
-		number, err := s.settings.ResolveString(ctx, cat.key)
-		if err != nil {
-			return nil, fmt.Errorf("resolve %s: %w", cat.key, err)
-		}
-		entry := PayrollCategoryStatus{
-			ID:         cat.id,
-			Label:      cat.label,
-			Number:     number,
-			SettingKey: cat.key,
-		}
-		if cat.unitKey != "" {
-			unit, err := s.settings.ResolveString(ctx, cat.unitKey)
-			if err != nil {
-				return nil, fmt.Errorf("resolve %s: %w", cat.unitKey, err)
-			}
-			entry.Unit = unit
-			entry.UnitRequired = true
-			entry.UnitSettingKey = cat.unitKey
-		}
-		if entry.Number != "" && (!entry.UnitRequired || entry.Unit != "") {
-			status.ConfiguredCategories++
-		}
-		status.Categories = append(status.Categories, entry)
+	categories, configuredCategories, err := s.resolvePayrollCategories(ctx)
+	if err != nil {
+		return nil, err
 	}
 
+	berater, mandant, err := s.resolveLodasHeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	staffTotal, staffWithoutPersonnelNumber, err := s.countStaffPersonnelNumbers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PayrollStatus{
+		Categories:                  categories,
+		Beraternummer:               berater,
+		Mandantennummer:             mandant,
+		LodasHeaderComplete:         berater != "" && mandant != "",
+		ConfiguredCategories:        configuredCategories,
+		TotalCategories:             len(payrollCategories),
+		StaffTotal:                  staffTotal,
+		StaffWithoutPersonnelNumber: staffWithoutPersonnelNumber,
+	}, nil
+}
+
+func (s *payrollStatusService) resolvePayrollCategories(ctx context.Context) ([]PayrollCategoryStatus, int, error) {
+	categories := make([]PayrollCategoryStatus, 0, len(payrollCategories))
+	configuredCategories := 0
+	for _, category := range payrollCategories {
+		entry, err := s.resolvePayrollCategory(ctx, category)
+		if err != nil {
+			return nil, 0, err
+		}
+		if entry.Number != "" && (!entry.UnitRequired || entry.Unit != "") {
+			configuredCategories++
+		}
+		categories = append(categories, entry)
+	}
+	return categories, configuredCategories, nil
+}
+
+func (s *payrollStatusService) resolvePayrollCategory(ctx context.Context, category payrollCategory) (PayrollCategoryStatus, error) {
+	number, err := s.settings.ResolveString(ctx, category.key)
+	if err != nil {
+		return PayrollCategoryStatus{}, fmt.Errorf("resolve %s: %w", category.key, err)
+	}
+	entry := PayrollCategoryStatus{
+		ID:         category.id,
+		Label:      category.label,
+		Number:     number,
+		SettingKey: category.key,
+	}
+	if category.unitKey == "" {
+		return entry, nil
+	}
+
+	unit, err := s.settings.ResolveString(ctx, category.unitKey)
+	if err != nil {
+		return PayrollCategoryStatus{}, fmt.Errorf("resolve %s: %w", category.unitKey, err)
+	}
+	entry.Unit = unit
+	entry.UnitRequired = true
+	entry.UnitSettingKey = category.unitKey
+	return entry, nil
+}
+
+func (s *payrollStatusService) resolveLodasHeader(ctx context.Context) (string, string, error) {
 	berater, err := s.settings.ResolveString(ctx, configModel.KeyPayrollDatevBeraternummer)
 	if err != nil {
-		return nil, fmt.Errorf("resolve beraternummer: %w", err)
+		return "", "", fmt.Errorf("resolve beraternummer: %w", err)
 	}
 	mandant, err := s.settings.ResolveString(ctx, configModel.KeyPayrollDatevMandantennummer)
 	if err != nil {
-		return nil, fmt.Errorf("resolve mandantennummer: %w", err)
+		return "", "", fmt.Errorf("resolve mandantennummer: %w", err)
 	}
-	status.Beraternummer = berater
-	status.Mandantennummer = mandant
-	status.LodasHeaderComplete = berater != "" && mandant != ""
+	return berater, mandant, nil
+}
 
+func (s *payrollStatusService) countStaffPersonnelNumbers(ctx context.Context) (int, int, error) {
 	// Tenant staff counts fit in memory (a school has tens of staff, not
 	// thousands); the soft-delete filter comes from the repository.
 	staff, err := s.staffRepo.List(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("list staff: %w", err)
+		return 0, 0, fmt.Errorf("list staff: %w", err)
 	}
-	status.StaffTotal = len(staff)
+	withoutPersonnelNumber := 0
 	for _, st := range staff {
 		if st.PersonnelNumber == nil || *st.PersonnelNumber == "" {
-			status.StaffWithoutPersonnelNumber++
+			withoutPersonnelNumber++
 		}
 	}
-
-	return status, nil
+	return len(staff), withoutPersonnelNumber, nil
 }

--- a/backend/services/config/payroll_status_service.go
+++ b/backend/services/config/payroll_status_service.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// Payroll configuration status (#1417 Tranche 2b). One source of truth for
+// "can a DATEV file be produced yet": the /payroll page renders this today,
+// and the LODAS / Lohn und Gehalt writers (follow-up PR) call the same
+// method before writing — a file must never be produced from incomplete
+// configuration. Which Lohnart categories are REQUIRED is deliberately not
+// decided here: an unconfigured category simply exports no line; the status
+// reports facts, the writers enforce their own per-format minimums.
+
+// PayrollCategoryStatus is one Lohnart category with its configured values.
+type PayrollCategoryStatus struct {
+	// ID is the stable category identifier (e.g. "regelarbeit").
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	// Number is the tenant's Lohnartnummer, empty when not configured.
+	Number string `json:"number"`
+	// Unit is "stunden" / "tage" / "" and only meaningful when UnitRequired.
+	Unit string `json:"unit,omitempty"`
+	// UnitRequired marks the categories that carry day values (sick /
+	// vacation / training) and therefore need a unit choice.
+	UnitRequired bool `json:"unit_required"`
+	// SettingKey / UnitSettingKey let the UI write through the settings API.
+	SettingKey     string `json:"setting_key"`
+	UnitSettingKey string `json:"unit_setting_key,omitempty"`
+}
+
+// PayrollStatus is the complete payroll configuration state of a tenant.
+type PayrollStatus struct {
+	Categories      []PayrollCategoryStatus `json:"categories"`
+	Beraternummer   string                  `json:"beraternummer"`
+	Mandantennummer string                  `json:"mandantennummer"`
+	// LodasHeaderComplete is true when both LODAS header identifiers are
+	// set. Lohn und Gehalt does not need them.
+	LodasHeaderComplete bool `json:"lodas_header_complete"`
+	// ConfiguredCategories counts categories with a Lohnartnummer whose
+	// unit requirement (if any) is also satisfied.
+	ConfiguredCategories int `json:"configured_categories"`
+	TotalCategories      int `json:"total_categories"`
+	StaffTotal           int `json:"staff_total"`
+	// StaffWithoutPersonnelNumber counts active staff the payroll system
+	// could not match. Count only — names stay behind time_tracking:manage.
+	StaffWithoutPersonnelNumber int `json:"staff_without_personnel_number"`
+}
+
+// PayrollStatusService reports the payroll configuration state.
+type PayrollStatusService interface {
+	GetPayrollStatus(ctx context.Context) (*PayrollStatus, error)
+}
+
+type payrollStatusService struct {
+	settings  SettingsService
+	staffRepo userModels.StaffRepository
+}
+
+func NewPayrollStatusService(settings SettingsService, staffRepo userModels.StaffRepository) PayrollStatusService {
+	return &payrollStatusService{settings: settings, staffRepo: staffRepo}
+}
+
+// payrollCategories fixes ID, label, and settings keys per category. The
+// order matches the registry sort order and the later export column order.
+var payrollCategories = []struct {
+	id      string
+	label   string
+	key     string
+	unitKey string
+}{
+	{"regelarbeit", "Regelarbeit", configModel.KeyPayrollLohnartRegelarbeit, ""},
+	{"plus_stunden", "Plus-Stunden", configModel.KeyPayrollLohnartPlusStunden, ""},
+	{"auszahlung", "Auszahlung", configModel.KeyPayrollLohnartAuszahlung, ""},
+	{"freizeitausgleich", "Freizeitausgleich", configModel.KeyPayrollLohnartFreizeitausgleich, ""},
+	{"krank", "Krank", configModel.KeyPayrollLohnartKrank, configModel.KeyPayrollEinheitKrank},
+	{"urlaub", "Urlaub", configModel.KeyPayrollLohnartUrlaub, configModel.KeyPayrollEinheitUrlaub},
+	{"fortbildung", "Fortbildung", configModel.KeyPayrollLohnartFortbildung, configModel.KeyPayrollEinheitFortbildung},
+}
+
+func (s *payrollStatusService) GetPayrollStatus(ctx context.Context) (*PayrollStatus, error) {
+	status := &PayrollStatus{TotalCategories: len(payrollCategories)}
+
+	for _, cat := range payrollCategories {
+		number, err := s.settings.ResolveString(ctx, cat.key)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s: %w", cat.key, err)
+		}
+		entry := PayrollCategoryStatus{
+			ID:         cat.id,
+			Label:      cat.label,
+			Number:     number,
+			SettingKey: cat.key,
+		}
+		if cat.unitKey != "" {
+			unit, err := s.settings.ResolveString(ctx, cat.unitKey)
+			if err != nil {
+				return nil, fmt.Errorf("resolve %s: %w", cat.unitKey, err)
+			}
+			entry.Unit = unit
+			entry.UnitRequired = true
+			entry.UnitSettingKey = cat.unitKey
+		}
+		if entry.Number != "" && (!entry.UnitRequired || entry.Unit != "") {
+			status.ConfiguredCategories++
+		}
+		status.Categories = append(status.Categories, entry)
+	}
+
+	berater, err := s.settings.ResolveString(ctx, configModel.KeyPayrollDatevBeraternummer)
+	if err != nil {
+		return nil, fmt.Errorf("resolve beraternummer: %w", err)
+	}
+	mandant, err := s.settings.ResolveString(ctx, configModel.KeyPayrollDatevMandantennummer)
+	if err != nil {
+		return nil, fmt.Errorf("resolve mandantennummer: %w", err)
+	}
+	status.Beraternummer = berater
+	status.Mandantennummer = mandant
+	status.LodasHeaderComplete = berater != "" && mandant != ""
+
+	// Tenant staff counts fit in memory (a school has tens of staff, not
+	// thousands); the soft-delete filter comes from the repository.
+	staff, err := s.staffRepo.List(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list staff: %w", err)
+	}
+	status.StaffTotal = len(staff)
+	for _, st := range staff {
+		if st.PersonnelNumber == nil || *st.PersonnelNumber == "" {
+			status.StaffWithoutPersonnelNumber++
+		}
+	}
+
+	return status, nil
+}

--- a/backend/services/config/payroll_status_service_test.go
+++ b/backend/services/config/payroll_status_service_test.go
@@ -19,7 +19,7 @@ import (
 // shows and the later DATEV writers check before producing a file. Settings
 // come from a configtest.Mock (Rule 13); staff counts from real fixtures.
 
-func payrollStatusFixture(t *testing.T, values map[string]string) (configSvc.PayrollStatusService, *repositories.Factory, context.Context) {
+func payrollStatusFixture(t *testing.T, values map[string]string) (configSvc.PayrollStatusGetter, *repositories.Factory, context.Context) {
 	t.Helper()
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })

--- a/backend/services/config/payroll_status_service_test.go
+++ b/backend/services/config/payroll_status_service_test.go
@@ -1,0 +1,104 @@
+package config_test
+
+import (
+	"testing"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+)
+
+// Payroll status (#1417): the same completeness verdict the /payroll page
+// shows and the later DATEV writers check before producing a file. Settings
+// come from a configtest.Mock (Rule 13); staff counts from real fixtures.
+
+func payrollStatusFixture(t *testing.T, values map[string]string) (configSvc.PayrollStatusService, *repositories.Factory, context.Context) {
+	t.Helper()
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	repos := repositories.NewFactory(db)
+
+	settings := &configtest.Mock{
+		ResolveStringFn: func(_ context.Context, key string) (string, error) {
+			return values[key], nil
+		},
+	}
+	return configSvc.NewPayrollStatusService(settings, repos.Staff), repos, testpkg.TenantContext(1)
+}
+
+func TestPayrollStatus_EmptyConfigurationIsReportedNotInvented(t *testing.T) {
+	svc, _, ctx := payrollStatusFixture(t, map[string]string{})
+
+	status, err := svc.GetPayrollStatus(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 7, status.TotalCategories)
+	assert.Equal(t, 0, status.ConfiguredCategories)
+	assert.False(t, status.LodasHeaderComplete)
+	assert.Equal(t, "", status.Beraternummer)
+	require.Len(t, status.Categories, 7)
+	for _, cat := range status.Categories {
+		assert.Equal(t, "", cat.Number, "no category may carry an invented default: %s", cat.ID)
+	}
+
+	// The three day-value categories carry the unit requirement.
+	unitRequired := map[string]bool{}
+	for _, cat := range status.Categories {
+		unitRequired[cat.ID] = cat.UnitRequired
+	}
+	assert.True(t, unitRequired["krank"])
+	assert.True(t, unitRequired["urlaub"])
+	assert.True(t, unitRequired["fortbildung"])
+	assert.False(t, unitRequired["regelarbeit"])
+	assert.False(t, unitRequired["auszahlung"])
+}
+
+func TestPayrollStatus_CompletenessCounting(t *testing.T) {
+	svc, _, ctx := payrollStatusFixture(t, map[string]string{
+		configModel.KeyPayrollLohnartRegelarbeit:   "9001",
+		configModel.KeyPayrollLohnartKrank:         "9002", // no unit yet → not complete
+		configModel.KeyPayrollLohnartUrlaub:        "9003",
+		configModel.KeyPayrollEinheitUrlaub:        configModel.PayrollUnitDays,
+		configModel.KeyPayrollDatevBeraternummer:   "9999999",
+		configModel.KeyPayrollDatevMandantennummer: "99999",
+	})
+
+	status, err := svc.GetPayrollStatus(ctx)
+	require.NoError(t, err)
+
+	// regelarbeit (no unit needed) + urlaub (number AND unit); krank lacks
+	// its unit and must not count as configured.
+	assert.Equal(t, 2, status.ConfiguredCategories)
+	assert.True(t, status.LodasHeaderComplete)
+}
+
+func TestPayrollStatus_CountsStaffWithoutPersonnelNumber(t *testing.T) {
+	svc, repos, ctx := payrollStatusFixture(t, map[string]string{})
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	before, err := svc.GetPayrollStatus(ctx)
+	require.NoError(t, err)
+
+	withNumber := testpkg.CreateTestStaff(t, db, "Payroll", "MitNummer")
+	withoutNumber := testpkg.CreateTestStaff(t, db, "Payroll", "OhneNummer")
+	_ = withoutNumber
+
+	number := "90040"
+	withNumber.PersonnelNumber = &number
+	require.NoError(t, repos.Staff.Update(ctx, withNumber))
+
+	after, err := svc.GetPayrollStatus(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.StaffTotal+2, after.StaffTotal)
+	assert.Equal(t, before.StaffWithoutPersonnelNumber+1, after.StaffWithoutPersonnelNumber,
+		"exactly one of the two new staff lacks a personnel number")
+}

--- a/backend/services/config/settings_service.go
+++ b/backend/services/config/settings_service.go
@@ -449,9 +449,9 @@ func validateValue(def *config.Definition, value any) error {
 		if !ok {
 			return fmt.Errorf("expected a string")
 		}
-		// Empty strings are valid for optional settings even when their
-		// configured non-empty values must match a pattern.
-		if def.Validation != nil && def.Validation.CompiledPattern != nil && str != "" {
+		if def.Validation != nil &&
+			def.Validation.CompiledPattern != nil &&
+			(str != "" || !def.Validation.AllowEmpty) {
 			if !def.Validation.CompiledPattern.MatchString(str) {
 				return fmt.Errorf("value does not match required pattern")
 			}

--- a/backend/services/config/settings_service.go
+++ b/backend/services/config/settings_service.go
@@ -444,17 +444,13 @@ func validateValue(def *config.Definition, value any) error {
 			return err
 		}
 
-	case config.FieldText, config.FieldTextarea:
-		if _, ok := value.(string); !ok {
-			return fmt.Errorf("expected a string")
-		}
-
-	case config.FieldPassword:
+	case config.FieldText, config.FieldTextarea, config.FieldPassword:
 		str, ok := value.(string)
 		if !ok {
 			return fmt.Errorf("expected a string")
 		}
-		// Apply pattern validation from registry definition if present
+		// Empty strings are valid for optional settings even when their
+		// configured non-empty values must match a pattern.
 		if def.Validation != nil && def.Validation.CompiledPattern != nil && str != "" {
 			if !def.Validation.CompiledPattern.MatchString(str) {
 				return fmt.Errorf("value does not match required pattern")

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -1306,7 +1306,7 @@ func TestSetValue_TextPatternValidation(t *testing.T) {
 		Default:    "",
 		Tab:        "abrechnung",
 		Category:   "lohnarten",
-		Validation: &config.ValidationRules{Pattern: &pattern},
+		Validation: &config.ValidationRules{Pattern: &pattern, AllowEmpty: true},
 	})
 
 	svc := createService(newMockValueRepo(), &mockAuditRepo{})
@@ -1396,7 +1396,7 @@ func TestSetValue_PINAccepts4Digits(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSetValue_PINAcceptsEmpty(t *testing.T) {
+func TestSetValue_PINRejectsEmpty(t *testing.T) {
 	setupTest(t)
 	pinPattern := `^\d{4}$`
 	config.Register(config.Definition{
@@ -1412,7 +1412,8 @@ func TestSetValue_PINAcceptsEmpty(t *testing.T) {
 	svc := createService(newMockValueRepo(), &mockAuditRepo{})
 
 	err := svc.SetValue(tenantCtx(1), "security.ogs_device_pin", "", nil, nil)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match required pattern")
 }
 
 // =============================================================================

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -1296,6 +1296,43 @@ func TestSetValue_TextRejectsNonString(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected a string")
 }
 
+func TestSetValue_TextPatternValidation(t *testing.T) {
+	setupTest(t)
+	pattern := `^\d{1,4}$`
+	config.Register(config.Definition{
+		Key:        "payroll.lohnart_test",
+		Label:      "Lohnart",
+		Type:       config.FieldText,
+		Default:    "",
+		Tab:        "abrechnung",
+		Category:   "lohnarten",
+		Validation: &config.ValidationRules{Pattern: &pattern},
+	})
+
+	svc := createService(newMockValueRepo(), &mockAuditRepo{})
+
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "empty remains valid", value: ""},
+		{name: "numeric value matches", value: "1234"},
+		{name: "letters are rejected", value: "12a", wantErr: true},
+		{name: "too many digits are rejected", value: "12345", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := svc.SetValue(tenantCtx(1), "payroll.lohnart_test", tc.value, nil, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "does not match required pattern")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 // =============================================================================
 // PIN validation tests
 // =============================================================================

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -90,7 +90,7 @@ type Factory struct {
 	Checkin                  *iotcheckin.CheckinService
 	StaffClock               *staffclock.Service
 	Settings                 config.SettingsService
-	PayrollStatus            config.PayrollStatusService
+	PayrollStatus            config.PayrollStatusGetter
 	Schedule                 schedule.Service
 	StaffShifts              schedule.StaffShiftService
 	StaffShiftSeries         schedule.StaffShiftSeriesService

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -90,6 +90,7 @@ type Factory struct {
 	Checkin                  *iotcheckin.CheckinService
 	StaffClock               *staffclock.Service
 	Settings                 config.SettingsService
+	PayrollStatus            config.PayrollStatusService
 	Schedule                 schedule.Service
 	StaffShifts              schedule.StaffShiftService
 	StaffShiftSeries         schedule.StaffShiftSeriesService
@@ -313,15 +314,16 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 
 	// Initialize users service first (needed for active service)
 	usersService := users.NewPersonService(users.PersonServiceDependencies{
-		PersonRepo:      repos.Person,
-		RFIDRepo:        repos.RFIDCard,
-		AccountRepo:     repos.Account,
-		StudentRepo:     repos.Student,
-		StaffRepo:       repos.Staff,
-		TeacherRepo:     repos.Teacher,
-		DB:              db,
-		SettingsService: settingsService,
-		Logger:          logger.With("service", "users"),
+		PersonRepo:           repos.Person,
+		RFIDRepo:             repos.RFIDCard,
+		AccountRepo:          repos.Account,
+		StudentRepo:          repos.Student,
+		StaffRepo:            repos.Staff,
+		TeacherRepo:          repos.Teacher,
+		PersonnelNumberAudit: repos.PersonnelNumberChange,
+		DB:                   db,
+		SettingsService:      settingsService,
+		Logger:               logger.With("service", "users"),
 	})
 
 	// Initialize guardian service
@@ -1731,6 +1733,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Checkin:                  checkinService,
 		StaffClock:               staffClockService,
 		Settings:                 settingsService,
+		PayrollStatus:            config.NewPayrollStatusService(settingsService, repos.Staff),
 		Schedule:                 scheduleService,
 		StaffShifts:              staffShiftService,
 		StaffShiftSeries:         staffShiftSeriesService,

--- a/backend/services/schedule/staff_shift_service_mock_test.go
+++ b/backend/services/schedule/staff_shift_service_mock_test.go
@@ -146,6 +146,9 @@ func (m *shiftMockStaffRepo) FindByID(ctx context.Context, id interface{}) (*use
 
 // The remaining StaffRepository methods are unused by the shift service.
 func (m *shiftMockStaffRepo) Create(context.Context, *usersModels.Staff) error { return nil }
+func (m *shiftMockStaffRepo) FindByIDForUpdate(ctx context.Context, id int64) (*usersModels.Staff, error) {
+	return m.FindByID(ctx, id)
+}
 func (m *shiftMockStaffRepo) FindByPersonID(context.Context, int64) (*usersModels.Staff, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/services/users/interface.go
+++ b/backend/services/users/interface.go
@@ -125,10 +125,10 @@ type PersonService interface {
 	// staff row still persists, mirroring the historical api/staff behaviour.
 	CreateStaffWithTeacher(ctx context.Context, input CreateStaffInput) (staff *userModels.Staff, teacher *userModels.Teacher, teacherCreationFailed bool, err error)
 
-	// UpdateStaffWithTeacher persists the (already mutated) staff row,
-	// reloads it with person data, and applies the requested teacher-record
-	// change. Teacher-record failures are non-fatal and reported through the
-	// returned TeacherAction; the staff update always persists.
+	// UpdateStaffWithTeacher applies the already-mutated directory fields to
+	// a freshly locked staff row, reloads it with person data, and applies the
+	// requested teacher-record change. Teacher-record failures are non-fatal
+	// and reported through the returned TeacherAction.
 	UpdateStaffWithTeacher(ctx context.Context, staff *userModels.Staff, isTeacher bool, specialization, role, qualifications string) (*userModels.Teacher, TeacherAction, error)
 
 	// UpdatePersonnelNumber sets or clears (nil / empty) the staff member's

--- a/backend/services/users/interface.go
+++ b/backend/services/users/interface.go
@@ -131,6 +131,12 @@ type PersonService interface {
 	// returned TeacherAction; the staff update always persists.
 	UpdateStaffWithTeacher(ctx context.Context, staff *userModels.Staff, isTeacher bool, specialization, role, qualifications string) (*userModels.Teacher, TeacherAction, error)
 
+	// UpdatePersonnelNumber sets or clears (nil / empty) the staff member's
+	// payroll Personalnummer (#1417). Writes an audit row in the same tenant
+	// transaction; returns ErrPersonnelNumberTaken on a per-tenant duplicate
+	// and ErrPersonnelNumberInvalid on a malformed value.
+	UpdatePersonnelNumber(ctx context.Context, staffID int64, value *string, changedByStaffID int64, note string) (*userModels.Staff, error)
+
 	// GetStudentsWithGroupsByTeacher retrieves students with group info supervised by a teacher
 	GetStudentsWithGroupsByTeacher(ctx context.Context, teacherID int64) ([]StudentWithGroup, error)
 

--- a/backend/services/users/person_service.go
+++ b/backend/services/users/person_service.go
@@ -558,18 +558,27 @@ func (s *personService) CreateStaffWithTeacher(ctx context.Context, input Create
 	return staff, teacher, teacherCreationFailed, nil
 }
 
-// UpdateStaffWithTeacher persists the (already mutated) staff row, reloads it
-// with person data, and applies the requested teacher-record change.
-// Teacher-record failures are non-fatal; the staff update always persists.
+// UpdateStaffWithTeacher applies the mutable directory fields to a freshly
+// locked staff row, reloads it with person data, and applies the requested
+// teacher-record change. Teacher-record failures are non-fatal; the staff
+// update always persists.
 func (s *personService) UpdateStaffWithTeacher(ctx context.Context, staff *userModels.Staff, isTeacher bool, specialization, role, qualifications string) (*userModels.Teacher, TeacherAction, error) {
 	var teacher *userModels.Teacher
 	action := TeacherActionNone
 
 	tenantID := tenant.FromContext(ctx)
 	if err := tenant.WithTenantTx(ctx, s.DB, tenantID, func(ctx context.Context, _ bun.Tx) error {
-		if err := s.StaffRepo.Update(ctx, staff); err != nil {
+		currentStaff, err := s.StaffRepo.FindByIDForUpdate(ctx, staff.ID)
+		if err != nil {
 			return err
 		}
+		currentStaff.PersonID = staff.PersonID
+		currentStaff.StaffNotes = staff.StaffNotes
+
+		if err := s.StaffRepo.Update(ctx, currentStaff); err != nil {
+			return err
+		}
+		*staff = *currentStaff
 
 		// Reload staff with person data; fall back to loading the person alone.
 		if reloaded, err := s.StaffRepo.FindWithPerson(ctx, staff.ID); err == nil {

--- a/backend/services/users/person_service.go
+++ b/backend/services/users/person_service.go
@@ -47,7 +47,7 @@ type PersonServiceDependencies struct {
 	TeacherRepo userModels.TeacherRepository
 	// PersonnelNumberAudit is required for UpdatePersonnelNumber; the write
 	// path refuses to run without it (no change without a trace, #1417).
-	PersonnelNumberAudit auditModels.PersonnelNumberChangeRepository
+	PersonnelNumberAudit auditModels.PersonnelNumberChangeCreator
 
 	// Infrastructure
 	DB              *bun.DB

--- a/backend/services/users/person_service.go
+++ b/backend/services/users/person_service.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -44,6 +45,9 @@ type PersonServiceDependencies struct {
 	StudentRepo userModels.StudentRepository
 	StaffRepo   userModels.StaffRepository
 	TeacherRepo userModels.TeacherRepository
+	// PersonnelNumberAudit is required for UpdatePersonnelNumber; the write
+	// path refuses to run without it (no change without a trace, #1417).
+	PersonnelNumberAudit auditModels.PersonnelNumberChangeRepository
 
 	// Infrastructure
 	DB              *bun.DB

--- a/backend/services/users/staff_payroll.go
+++ b/backend/services/users/staff_payroll.go
@@ -1,0 +1,100 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// Personnel number update (#1417 Tranche 2b): the payroll system's
+// Personalnummer is what DATEV bills against, so the write path has two hard
+// rules: uniqueness per tenant (mapped to a stable conflict error) and no
+// change without an audit row — the audit insert runs in the same tenant
+// transaction, before the update, mirroring the tombstone contract of #2001.
+
+// ErrPersonnelNumberTaken marks a Personalnummer already assigned to another
+// staff member of the same tenant — HTTP 409.
+var ErrPersonnelNumberTaken = errors.New("personnel number already assigned to another staff member")
+
+// ErrPersonnelNumberInvalid marks a syntactically invalid Personalnummer — HTTP 400.
+var ErrPersonnelNumberInvalid = errors.New("invalid personnel number")
+
+// personnelNumberPattern accepts what both DATEV systems can match on:
+// digits only. The length cap is deliberately looser than any single DATEV
+// format — the writers (#1417 follow-up) enforce their exact per-format
+// bounds; this layer only blocks obvious junk.
+var personnelNumberPattern = regexp.MustCompile(`^\d{1,9}$`)
+
+// UpdatePersonnelNumber sets or clears (value nil / empty) the staff
+// member's Personalnummer. A no-op change writes no audit row.
+func (s *personService) UpdatePersonnelNumber(ctx context.Context, staffID int64, value *string, changedByStaffID int64, note string) (*userModels.Staff, error) {
+	if s.PersonnelNumberAudit == nil {
+		return nil, fmt.Errorf("personnel number audit repository is not wired; refusing unaudited change")
+	}
+	if changedByStaffID <= 0 {
+		return nil, fmt.Errorf("changed-by staff id is required")
+	}
+
+	normalized := normalizePersonnelNumber(value)
+	if normalized != nil && !personnelNumberPattern.MatchString(*normalized) {
+		return nil, ErrPersonnelNumberInvalid
+	}
+
+	var updated *userModels.Staff
+	tenantID := tenant.FromContext(ctx)
+	if err := tenant.WithTenantTx(ctx, s.DB, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		staff, err := s.StaffRepo.FindByID(ctx, staffID)
+		if err != nil {
+			return err
+		}
+
+		oldValue := derefString(staff.PersonnelNumber)
+		newValue := derefString(normalized)
+		if oldValue == newValue {
+			updated = staff
+			return nil
+		}
+
+		if err := s.PersonnelNumberAudit.Create(ctx, &auditModels.PersonnelNumberChange{
+			StaffID:   staff.ID,
+			ChangedBy: changedByStaffID,
+			OldValue:  oldValue,
+			NewValue:  newValue,
+			Note:      strings.TrimSpace(note),
+		}); err != nil {
+			return fmt.Errorf("write personnel number audit: %w", err)
+		}
+
+		staff.PersonnelNumber = normalized
+		if err := s.StaffRepo.Update(ctx, staff); err != nil {
+			if base.IsUniqueViolationOn(err, userModels.PersonnelNumberUniqueConstraintName) {
+				return ErrPersonnelNumberTaken
+			}
+			return err
+		}
+		updated = staff
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func normalizePersonnelNumber(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/backend/services/users/staff_payroll.go
+++ b/backend/services/users/staff_payroll.go
@@ -51,41 +51,51 @@ func (s *personService) UpdatePersonnelNumber(ctx context.Context, staffID int64
 	var updated *userModels.Staff
 	tenantID := tenant.FromContext(ctx)
 	if err := tenant.WithTenantTx(ctx, s.DB, tenantID, func(ctx context.Context, _ bun.Tx) error {
-		staff, err := s.StaffRepo.FindByID(ctx, staffID)
-		if err != nil {
-			return err
-		}
-
-		oldValue := derefString(staff.PersonnelNumber)
-		newValue := derefString(normalized)
-		if oldValue == newValue {
-			updated = staff
-			return nil
-		}
-
-		if err := s.PersonnelNumberAudit.Create(ctx, &auditModels.PersonnelNumberChange{
-			StaffID:   staff.ID,
-			ChangedBy: changedByStaffID,
-			OldValue:  oldValue,
-			NewValue:  newValue,
-			Note:      strings.TrimSpace(note),
-		}); err != nil {
-			return fmt.Errorf("write personnel number audit: %w", err)
-		}
-
-		staff.PersonnelNumber = normalized
-		if err := s.StaffRepo.Update(ctx, staff); err != nil {
-			if base.IsUniqueViolationOn(err, userModels.PersonnelNumberUniqueConstraintName) {
-				return ErrPersonnelNumberTaken
-			}
-			return err
-		}
-		updated = staff
-		return nil
+		var err error
+		updated, err = s.updatePersonnelNumberInTx(ctx, staffID, normalized, changedByStaffID, note)
+		return err
 	}); err != nil {
 		return nil, err
 	}
 	return updated, nil
+}
+
+func (s *personService) updatePersonnelNumberInTx(
+	ctx context.Context,
+	staffID int64,
+	normalized *string,
+	changedByStaffID int64,
+	note string,
+) (*userModels.Staff, error) {
+	staff, err := s.StaffRepo.FindByID(ctx, staffID)
+	if err != nil {
+		return nil, err
+	}
+
+	oldValue := derefString(staff.PersonnelNumber)
+	newValue := derefString(normalized)
+	if oldValue == newValue {
+		return staff, nil
+	}
+
+	if err := s.PersonnelNumberAudit.Create(ctx, &auditModels.PersonnelNumberChange{
+		StaffID:   staff.ID,
+		ChangedBy: changedByStaffID,
+		OldValue:  oldValue,
+		NewValue:  newValue,
+		Note:      strings.TrimSpace(note),
+	}); err != nil {
+		return nil, fmt.Errorf("write personnel number audit: %w", err)
+	}
+
+	staff.PersonnelNumber = normalized
+	if err := s.StaffRepo.Update(ctx, staff); err != nil {
+		if base.IsUniqueViolationOn(err, userModels.PersonnelNumberUniqueConstraintName) {
+			return nil, ErrPersonnelNumberTaken
+		}
+		return nil, err
+	}
+	return staff, nil
 }
 
 func normalizePersonnelNumber(value *string) *string {

--- a/backend/services/users/staff_payroll.go
+++ b/backend/services/users/staff_payroll.go
@@ -67,7 +67,7 @@ func (s *personService) updatePersonnelNumberInTx(
 	changedByStaffID int64,
 	note string,
 ) (*userModels.Staff, error) {
-	staff, err := s.StaffRepo.FindByID(ctx, staffID)
+	staff, err := s.StaffRepo.FindByIDForUpdate(ctx, staffID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/services/users/staff_payroll_test.go
+++ b/backend/services/users/staff_payroll_test.go
@@ -3,7 +3,10 @@ package users_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
@@ -25,6 +28,35 @@ type payrollScenario struct {
 	repos *repositories.Factory
 	svc   usersSvc.PersonService
 	ctx   context.Context
+}
+
+type serializingStaffRepo struct {
+	userModels.StaffRepository
+	calls           atomic.Int32
+	firstLocked     chan struct{}
+	secondAttempted chan struct{}
+	secondRead      chan struct{}
+	releaseFirst    chan struct{}
+}
+
+func (r *serializingStaffRepo) FindByIDForUpdate(ctx context.Context, id int64) (*userModels.Staff, error) {
+	call := r.calls.Add(1)
+	if call == 2 {
+		close(r.secondAttempted)
+	}
+
+	staff, err := r.StaffRepository.FindByIDForUpdate(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	switch call {
+	case 1:
+		close(r.firstLocked)
+		<-r.releaseFirst
+	case 2:
+		close(r.secondRead)
+	}
+	return staff, nil
 }
 
 func newPayrollScenario(t *testing.T) *payrollScenario {
@@ -132,6 +164,97 @@ func TestUpdatePersonnelNumber_DuplicateIsConflictAndLeavesNoAudit(t *testing.T)
 
 	_, err = s.svc.UpdatePersonnelNumber(s.ctx, second.ID, &value, actor.ID, "")
 	require.NoError(t, err, "an offboarded holder must free the number")
+}
+
+func TestUpdatePersonnelNumber_SerializesConcurrentAuditValues(t *testing.T) {
+	s := newPayrollScenario(t)
+	staff := testpkg.CreateTestStaff(t, s.db, "Payroll", "Parallel")
+	actor := testpkg.CreateTestStaff(t, s.db, "Payroll", "Aktor")
+
+	staffRepo := &serializingStaffRepo{
+		StaffRepository: s.repos.Staff,
+		firstLocked:     make(chan struct{}),
+		secondAttempted: make(chan struct{}),
+		secondRead:      make(chan struct{}),
+		releaseFirst:    make(chan struct{}),
+	}
+	svc := usersSvc.NewPersonService(usersSvc.PersonServiceDependencies{
+		PersonRepo:           s.repos.Person,
+		RFIDRepo:             s.repos.RFIDCard,
+		AccountRepo:          s.repos.Account,
+		StudentRepo:          s.repos.Student,
+		StaffRepo:            staffRepo,
+		TeacherRepo:          s.repos.Teacher,
+		PersonnelNumberAudit: s.repos.PersonnelNumberChange,
+		DB:                   s.db,
+	})
+
+	personnelNumberSeed := staff.ID % 10_000_000
+	firstValue := fmt.Sprintf("7%07d1", personnelNumberSeed)
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdatePersonnelNumber(s.ctx, staff.ID, &firstValue, actor.ID, "Erste Änderung")
+		firstDone <- err
+	}()
+
+	select {
+	case <-staffRepo.firstLocked:
+	case err := <-firstDone:
+		require.NoError(t, err)
+		t.Fatal("first update returned before holding the staff row lock")
+	case <-time.After(2 * time.Second):
+		t.Fatal("first update did not acquire the staff row lock")
+	}
+
+	secondValue := fmt.Sprintf("7%07d2", personnelNumberSeed)
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdatePersonnelNumber(s.ctx, staff.ID, &secondValue, actor.ID, "Zweite Änderung")
+		secondDone <- err
+	}()
+
+	select {
+	case <-staffRepo.secondAttempted:
+	case <-time.After(2 * time.Second):
+		close(staffRepo.releaseFirst)
+		t.Fatal("second update did not attempt to lock the staff row")
+	}
+
+	released := false
+	defer func() {
+		if !released {
+			close(staffRepo.releaseFirst)
+		}
+	}()
+	select {
+	case <-staffRepo.secondRead:
+		close(staffRepo.releaseFirst)
+		released = true
+		t.Fatal("second update read the staff row while the first transaction held its lock")
+	case <-time.After(150 * time.Millisecond):
+		close(staffRepo.releaseFirst)
+		released = true
+	}
+
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("first update did not finish")
+	}
+	select {
+	case err := <-secondDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second update did not finish")
+	}
+
+	rows := s.auditRows(t, staff.ID)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "", rows[0].OldValue)
+	assert.Equal(t, firstValue, rows[0].NewValue)
+	assert.Equal(t, firstValue, rows[1].OldValue)
+	assert.Equal(t, secondValue, rows[1].NewValue)
 }
 
 func TestUpdatePersonnelNumber_Validation(t *testing.T) {

--- a/backend/services/users/staff_payroll_test.go
+++ b/backend/services/users/staff_payroll_test.go
@@ -257,6 +257,34 @@ func TestUpdatePersonnelNumber_SerializesConcurrentAuditValues(t *testing.T) {
 	assert.Equal(t, secondValue, rows[1].NewValue)
 }
 
+func TestUpdateStaffWithTeacher_PreservesConcurrentPersonnelNumber(t *testing.T) {
+	s := newPayrollScenario(t)
+	staff := testpkg.CreateTestStaff(t, s.db, "Payroll", "Stale")
+	actor := testpkg.CreateTestStaff(t, s.db, "Payroll", "Aktor")
+
+	staleStaff, err := s.repos.Staff.FindByID(s.ctx, staff.ID)
+	require.NoError(t, err)
+
+	value := fmt.Sprintf("6%07d1", staff.ID%10_000_000)
+	_, err = s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, &value, actor.ID, "Ersteinrichtung")
+	require.NoError(t, err)
+
+	staleStaff.StaffNotes = "Aktualisierte Notiz"
+	_, _, err = s.svc.UpdateStaffWithTeacher(s.ctx, staleStaff, false, "", "", "")
+	require.NoError(t, err)
+
+	reloaded, err := s.repos.Staff.FindByID(s.ctx, staff.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.PersonnelNumber)
+	assert.Equal(t, value, *reloaded.PersonnelNumber)
+	assert.Equal(t, "Aktualisierte Notiz", reloaded.StaffNotes)
+
+	rows := s.auditRows(t, staff.ID)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "", rows[0].OldValue)
+	assert.Equal(t, value, rows[0].NewValue)
+}
+
 func TestUpdatePersonnelNumber_Validation(t *testing.T) {
 	s := newPayrollScenario(t)
 	staff := testpkg.CreateTestStaff(t, s.db, "Payroll", "Valid")

--- a/backend/services/users/staff_payroll_test.go
+++ b/backend/services/users/staff_payroll_test.go
@@ -1,0 +1,189 @@
+package users_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// Personnel number write path (#1417 Tranche 2b): unique per tenant, every
+// change audited in the same transaction, duplicates mapped to a stable
+// sentinel. Test numbers are recognizably artificial — never copy them into
+// real configuration.
+
+type payrollScenario struct {
+	db    *bun.DB
+	repos *repositories.Factory
+	svc   usersSvc.PersonService
+	ctx   context.Context
+}
+
+func newPayrollScenario(t *testing.T) *payrollScenario {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repos := repositories.NewFactory(db)
+	svc := usersSvc.NewPersonService(usersSvc.PersonServiceDependencies{
+		PersonRepo:           repos.Person,
+		RFIDRepo:             repos.RFIDCard,
+		AccountRepo:          repos.Account,
+		StudentRepo:          repos.Student,
+		StaffRepo:            repos.Staff,
+		TeacherRepo:          repos.Teacher,
+		PersonnelNumberAudit: repos.PersonnelNumberChange,
+		DB:                   db,
+	})
+
+	return &payrollScenario{db: db, repos: repos, svc: svc, ctx: testpkg.TenantContext(1)}
+}
+
+func (s *payrollScenario) auditRows(t *testing.T, staffID int64) []*auditModels.PersonnelNumberChange {
+	t.Helper()
+	var rows []*auditModels.PersonnelNumberChange
+	err := s.db.NewSelect().
+		Model(&rows).
+		ModelTableExpr(`audit.personnel_number_changes AS "personnel_number_change"`).
+		Where(`"personnel_number_change".staff_id = ?`, staffID).
+		Order("id ASC").
+		Scan(context.Background())
+	require.NoError(t, err)
+	return rows
+}
+
+func TestUpdatePersonnelNumber_SetChangeClear(t *testing.T) {
+	s := newPayrollScenario(t)
+	staff := testpkg.CreateTestStaff(t, s.db, "Payroll", "Nummer")
+	actor := testpkg.CreateTestStaff(t, s.db, "Payroll", "Aktor")
+
+	// Set
+	value := "90001"
+	updated, err := s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, &value, actor.ID, "Ersteinrichtung")
+	require.NoError(t, err)
+	require.NotNil(t, updated.PersonnelNumber)
+	assert.Equal(t, "90001", *updated.PersonnelNumber)
+
+	rows := s.auditRows(t, staff.ID)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "", rows[0].OldValue)
+	assert.Equal(t, "90001", rows[0].NewValue)
+	assert.Equal(t, actor.ID, rows[0].ChangedBy)
+	assert.Equal(t, "Ersteinrichtung", rows[0].Note)
+
+	// No-op: same value writes no second audit row
+	_, err = s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, &value, actor.ID, "")
+	require.NoError(t, err)
+	require.Len(t, s.auditRows(t, staff.ID), 1, "a no-op change must not produce an audit row")
+
+	// Change
+	changed := " 90002 " // whitespace is normalized away
+	updated, err = s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, &changed, actor.ID, "Korrektur")
+	require.NoError(t, err)
+	assert.Equal(t, "90002", *updated.PersonnelNumber)
+	rows = s.auditRows(t, staff.ID)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "90001", rows[1].OldValue)
+	assert.Equal(t, "90002", rows[1].NewValue)
+
+	// Clear
+	updated, err = s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, nil, actor.ID, "Austritt")
+	require.NoError(t, err)
+	assert.Nil(t, updated.PersonnelNumber)
+	rows = s.auditRows(t, staff.ID)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "90002", rows[2].OldValue)
+	assert.Equal(t, "", rows[2].NewValue)
+}
+
+func TestUpdatePersonnelNumber_DuplicateIsConflictAndLeavesNoAudit(t *testing.T) {
+	s := newPayrollScenario(t)
+	first := testpkg.CreateTestStaff(t, s.db, "Payroll", "Erste")
+	second := testpkg.CreateTestStaff(t, s.db, "Payroll", "Zweite")
+	actor := testpkg.CreateTestStaff(t, s.db, "Payroll", "Aktor")
+
+	value := "90010"
+	_, err := s.svc.UpdatePersonnelNumber(s.ctx, first.ID, &value, actor.ID, "")
+	require.NoError(t, err)
+
+	_, err = s.svc.UpdatePersonnelNumber(s.ctx, second.ID, &value, actor.ID, "")
+	require.ErrorIs(t, err, usersSvc.ErrPersonnelNumberTaken)
+
+	assert.Empty(t, s.auditRows(t, second.ID), "the rolled-back change must not leave an audit row")
+
+	// The number can be reassigned after the holder is offboarded (partial
+	// index skips soft-deleted rows).
+	_, err = s.db.NewUpdate().
+		Model((*userModels.Staff)(nil)).
+		ModelTableExpr(`users.staff AS "staff"`).
+		Set("deleted_at = NOW()").
+		Where(`"staff".id = ?`, first.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+
+	_, err = s.svc.UpdatePersonnelNumber(s.ctx, second.ID, &value, actor.ID, "")
+	require.NoError(t, err, "an offboarded holder must free the number")
+}
+
+func TestUpdatePersonnelNumber_Validation(t *testing.T) {
+	s := newPayrollScenario(t)
+	staff := testpkg.CreateTestStaff(t, s.db, "Payroll", "Valid")
+	actor := testpkg.CreateTestStaff(t, s.db, "Payroll", "Aktor")
+
+	for _, invalid := range []string{"12a", "1 2", "-5", "1234567890"} {
+		v := invalid
+		_, err := s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, &v, actor.ID, "")
+		require.ErrorIs(t, err, usersSvc.ErrPersonnelNumberInvalid, "value %q must be rejected", invalid)
+	}
+
+	// Missing audit wiring refuses the change entirely (fail fast).
+	unwired := usersSvc.NewPersonService(usersSvc.PersonServiceDependencies{
+		StaffRepo: s.repos.Staff,
+		DB:        s.db,
+	})
+	v := "90020"
+	_, err := unwired.UpdatePersonnelNumber(s.ctx, staff.ID, &v, actor.ID, "")
+	require.Error(t, err, "without the audit repository no change may happen")
+}
+
+func TestUpdatePersonnelNumber_AppearsInAuditFeed(t *testing.T) {
+	s := newPayrollScenario(t)
+	staff := testpkg.CreateTestStaff(t, s.db, "Payroll", "Feed")
+	actor := testpkg.CreateTestStaff(t, s.db, "Payroll", "FeedAktor")
+
+	value := "90030"
+	_, err := s.svc.UpdatePersonnelNumber(s.ctx, staff.ID, &value, actor.ID, "Feed-Test")
+	require.NoError(t, err)
+
+	entries, err := s.repos.TimeTrackingAuditLog.ListEntries(s.ctx, auditModels.TimeTrackingAuditLogFilter{
+		StaffID: staff.ID,
+		Sources: []string{auditModels.AuditLogSourcePersonnelNumber},
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, auditModels.AuditLogSourcePersonnelNumber, entry.Source)
+	require.NotNil(t, entry.StaffID)
+	assert.Equal(t, staff.ID, *entry.StaffID)
+	require.NotNil(t, entry.ActorStaffID)
+	assert.Equal(t, actor.ID, *entry.ActorStaffID)
+	assert.Equal(t, "Feed-Test", entry.Reason)
+
+	var detail struct {
+		OldValue string `json:"old_value"`
+		NewValue string `json:"new_value"`
+	}
+	require.NoError(t, json.Unmarshal(entry.Detail, &detail))
+	assert.Equal(t, "", detail.OldValue)
+	assert.Equal(t, "90030", detail.NewValue)
+}

--- a/backend/services/users/userstest/mocks.go
+++ b/backend/services/users/userstest/mocks.go
@@ -58,6 +58,7 @@ type PersonServiceMock struct {
 	CountStudentsByGroupIDsFn        func(ctx context.Context, groupIDs []int64) (map[int64]int, error)
 	CreateStaffWithTeacherFn         func(ctx context.Context, input users.CreateStaffInput) (staff *userModels.Staff, teacher *userModels.Teacher, teacherCreationFailed bool, err error)
 	UpdateStaffWithTeacherFn         func(ctx context.Context, staff *userModels.Staff, isTeacher bool, specialization, role, qualifications string) (*userModels.Teacher, users.TeacherAction, error)
+	UpdatePersonnelNumberFn          func(ctx context.Context, staffID int64, value *string, changedByStaffID int64, note string) (*userModels.Staff, error)
 	GetStudentsWithGroupsByTeacherFn func(ctx context.Context, teacherID int64) ([]users.StudentWithGroup, error)
 	GetAllStudentsWithGroupsFn       func(ctx context.Context) ([]users.StudentWithGroup, error)
 }
@@ -293,6 +294,13 @@ func (m *PersonServiceMock) UpdateStaffWithTeacher(ctx context.Context, staff *u
 		return m.UpdateStaffWithTeacherFn(ctx, staff, isTeacher, specialization, role, qualifications)
 	}
 	return nil, users.TeacherActionNone, nil
+}
+
+func (m *PersonServiceMock) UpdatePersonnelNumber(ctx context.Context, staffID int64, value *string, changedByStaffID int64, note string) (*userModels.Staff, error) {
+	if m.UpdatePersonnelNumberFn != nil {
+		return m.UpdatePersonnelNumberFn(ctx, staffID, value, changedByStaffID, note)
+	}
+	return nil, nil
 }
 
 func (m *PersonServiceMock) GetStudentsWithGroupsByTeacher(ctx context.Context, teacherID int64) ([]users.StudentWithGroup, error) {

--- a/backend/test/repo_mocks.go
+++ b/backend/test/repo_mocks.go
@@ -149,6 +149,7 @@ func (m *SchoolRepoMock) CountNonDeletedByOrganizationID(ctx context.Context, or
 type StaffRepoMock struct {
 	CreateFn                        func(ctx context.Context, entity *users.Staff) error
 	FindByIDFn                      func(ctx context.Context, id any) (*users.Staff, error)
+	FindByIDForUpdateFn             func(ctx context.Context, id int64) (*users.Staff, error)
 	UpdateFn                        func(ctx context.Context, entity *users.Staff) error
 	DeleteFn                        func(ctx context.Context, id any) error
 	ListFn                          func(ctx context.Context, filters map[string]any) ([]*users.Staff, error)
@@ -178,6 +179,13 @@ func (m *StaffRepoMock) FindByID(ctx context.Context, id any) (*users.Staff, err
 		return m.FindByIDFn(ctx, id)
 	}
 	return nil, nil
+}
+
+func (m *StaffRepoMock) FindByIDForUpdate(ctx context.Context, id int64) (*users.Staff, error) {
+	if m.FindByIDForUpdateFn != nil {
+		return m.FindByIDForUpdateFn(ctx, id)
+	}
+	return m.FindByID(ctx, id)
 }
 
 func (m *StaffRepoMock) Update(ctx context.Context, entity *users.Staff) error {

--- a/frontend/src/app/[tenant]/(protected)/payroll/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/payroll/page.test.tsx
@@ -1,0 +1,114 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import PayrollPage from "./page";
+
+const { mutateMock, setSettingValueMock } = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  setSettingValueMock: vi.fn(),
+}));
+
+vi.mock("swr", () => ({
+  default: () => ({
+    data: {
+      categories: [
+        {
+          id: "regular",
+          label: "Regelarbeit",
+          number: "",
+          unit: "",
+          unitRequired: false,
+          settingKey: "payroll.lohnart_regelarbeit",
+          unitSettingKey: null,
+        },
+      ],
+      beraternummer: "",
+      mandantennummer: "",
+      lodasHeaderComplete: false,
+      configuredCategories: 0,
+      totalCategories: 1,
+      staffTotal: 1,
+      staffWithoutPersonnelNumber: 1,
+    },
+    error: undefined,
+    mutate: mutateMock,
+  }),
+}));
+
+vi.mock("~/lib/hooks/use-require-permission", () => ({
+  useRequirePermission: () => ({
+    isReady: true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("~/lib/settings-api", () => ({
+  setSettingValue: setSettingValueMock,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("PayrollPage autosave", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateMock.mockResolvedValue(undefined);
+  });
+
+  it("serializes overlapping saves for the same setting key", async () => {
+    const firstSave = deferred<string | null>();
+    setSettingValueMock
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce(null);
+
+    render(<PayrollPage />);
+
+    const input = screen.getByRole("textbox", {
+      name: "Lohnartnummer Regelarbeit",
+    });
+    fireEvent.change(input, { target: { value: "1001" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(setSettingValueMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(input, { target: { value: "1002" } });
+    fireEvent.blur(input);
+
+    expect(setSettingValueMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstSave.resolve(null);
+      await firstSave.promise;
+    });
+
+    await waitFor(() => {
+      expect(setSettingValueMock).toHaveBeenCalledTimes(2);
+    });
+    expect(setSettingValueMock).toHaveBeenNthCalledWith(
+      1,
+      "payroll.lohnart_regelarbeit",
+      "1001",
+    );
+    expect(setSettingValueMock).toHaveBeenNthCalledWith(
+      2,
+      "payroll.lohnart_regelarbeit",
+      "1002",
+    );
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+import { Alert } from "~/components/ui/alert";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { Input } from "~/components/ui/input";
+import { Loading } from "~/components/ui/loading";
+import { useRequirePermission } from "~/lib/hooks/use-require-permission";
+import {
+  duplicateLohnartNumbers,
+  fetchPayrollStatus,
+  type PayrollStatus,
+} from "~/lib/payroll-api";
+import { setSettingValue } from "~/lib/settings-api";
+
+// Abrechnung (#1417 Tranche 2b): maintenance surface for the DATEV payroll
+// foundation — Lohnart mapping and LODAS client identifiers. Values are
+// settings-backed (config.setting_values, audited via config.setting_audit);
+// this page is the hand-written panel over them, following the
+// personalization-tab precedent instead of the auto-generated settings tab.
+//
+// There are deliberately NO defaults: Lohnartnummern are mandant-specific,
+// and an invented preset would silently bill wrong. Empty is the honest
+// starting state; the later DATEV writers refuse to export while required
+// pieces are missing.
+
+const UNIT_OPTIONS = [
+  { value: "", label: "Nicht festgelegt" },
+  { value: "stunden", label: "Stunden" },
+  { value: "tage", label: "Tage" },
+];
+
+export default function PayrollPage() {
+  const { isReady, isLoading: permissionLoading } = useRequirePermission([
+    "config:manage",
+  ]);
+
+  const {
+    data: status,
+    error,
+    mutate,
+  } = useSWR(isReady ? "payroll-status" : null, fetchPayrollStatus);
+
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const save = async (key: string, value: string) => {
+    setSaveError(null);
+    const message = await setSettingValue(key, value);
+    if (message) {
+      setSaveError(message);
+    }
+    await mutate();
+  };
+
+  if (permissionLoading || !isReady) {
+    return <Loading fullPage />;
+  }
+  if (error) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        <Alert
+          type="error"
+          message="Die Abrechnungs-Konfiguration konnte nicht geladen werden."
+        />
+      </div>
+    );
+  }
+  if (!status) {
+    return <Loading fullPage />;
+  }
+
+  const duplicates = duplicateLohnartNumbers(status);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-5 px-4 py-6">
+      <div>
+        <h1 className="text-xl font-bold text-gray-900">Abrechnung</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Zuordnung der Zeiterfassungs-Kategorien zu den Lohnarten des
+          Lohnsystems und DATEV-Mandantendaten. Grundlage für den späteren
+          DATEV-Export (LODAS und Lohn und Gehalt).
+        </p>
+      </div>
+
+      <ReadinessCard status={status} />
+
+      {saveError && <Alert type="error" message={saveError} />}
+      {duplicates.length > 0 && (
+        <Alert
+          type="warning"
+          message={`Lohnartnummer ${duplicates.join(", ")} ist mehreren Kategorien zugeordnet. Das ist zulässig, führt aber meist zu doppelt gebuchten Stunden — bitte prüfen.`}
+        />
+      )}
+
+      <LohnartenCard status={status} onSave={save} />
+      <DatevCard status={status} onSave={save} />
+    </div>
+  );
+}
+
+function ReadinessCard({ status }: { readonly status: PayrollStatus }) {
+  const items: { label: string; ok: boolean; detail: string }[] = [
+    {
+      label: "Lohnarten",
+      ok: status.configuredCategories > 0,
+      detail: `${status.configuredCategories} von ${status.totalCategories} Kategorien konfiguriert`,
+    },
+    {
+      label: "DATEV-Mandant (nur LODAS)",
+      ok: status.lodasHeaderComplete,
+      detail: status.lodasHeaderComplete
+        ? "Berater- und Mandantennummer gesetzt"
+        : "Berater- oder Mandantennummer fehlt",
+    },
+    {
+      label: "Personalnummern",
+      ok: status.staffWithoutPersonnelNumber === 0,
+      detail:
+        status.staffWithoutPersonnelNumber === 0
+          ? `Alle ${status.staffTotal} Beschäftigten haben eine Personalnummer`
+          : `${status.staffWithoutPersonnelNumber} von ${status.staffTotal} Beschäftigten ohne Personalnummer (Pflege im Stammdaten-Tab der Person)`,
+    },
+  ];
+
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+      <h2 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
+        Vollständigkeit
+      </h2>
+      <ul className="mt-3 space-y-2">
+        {items.map((item) => (
+          <li key={item.label} className="flex items-start gap-2 text-sm">
+            <span
+              aria-hidden
+              className={`mt-0.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
+                item.ok ? "bg-[#83CD2D]" : "bg-[#F78C10]"
+              }`}
+            />
+            <span>
+              <span className="font-medium text-gray-800">{item.label}:</span>{" "}
+              <span className="text-gray-600">{item.detail}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-3 text-xs text-gray-500">
+        Ohne vollständige Konfiguration erzeugt der spätere DATEV-Export keine
+        Datei. Eine Kategorie ohne Lohnartnummer wird nicht exportiert.
+      </p>
+    </div>
+  );
+}
+
+function LohnartenCard({
+  status,
+  onSave,
+}: {
+  readonly status: PayrollStatus;
+  readonly onSave: (key: string, value: string) => Promise<void>;
+}) {
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+      <h2 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
+        Lohnarten
+      </h2>
+      <p className="mt-1 text-xs text-gray-500">
+        Mandantenspezifische Lohnartnummern aus dem Lohnsystem des Trägers (1
+        bis 4 Ziffern). Für Krank, Urlaub und Fortbildung zusätzlich die
+        Einheit, die die Lohnart erwartet.
+      </p>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full min-w-[28rem] text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 text-left text-xs font-semibold tracking-wide text-gray-400 uppercase">
+              <th className="py-2 pr-4">Kategorie</th>
+              <th className="py-2 pr-4">Lohnartnummer</th>
+              <th className="py-2">Einheit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {status.categories.map((cat) => (
+              <LohnartRow key={cat.id} cat={cat} onSave={onSave} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function LohnartRow({
+  cat,
+  onSave,
+}: {
+  readonly cat: PayrollStatus["categories"][number];
+  readonly onSave: (key: string, value: string) => Promise<void>;
+}) {
+  const [number, setNumber] = useState(cat.number);
+  useEffect(() => setNumber(cat.number), [cat.number]);
+
+  const valid = number.trim() === "" || /^\d{1,4}$/.test(number.trim());
+
+  return (
+    <tr className="border-b border-gray-100 last:border-0">
+      <td className="py-2 pr-4 font-medium text-gray-800">{cat.label}</td>
+      <td className="py-2 pr-4">
+        <Input
+          aria-label={`Lohnartnummer ${cat.label}`}
+          value={number}
+          onChange={(e) => setNumber(e.target.value)}
+          onBlur={() => {
+            const trimmed = number.trim();
+            if (valid && trimmed !== cat.number) {
+              void onSave(cat.settingKey, trimmed);
+            }
+          }}
+          placeholder="Nicht konfiguriert"
+          inputMode="numeric"
+          className="h-9 max-w-[10rem] py-1 text-sm tabular-nums"
+        />
+        {!valid && (
+          <p className="mt-1 text-xs text-[#FF3130]">1 bis 4 Ziffern.</p>
+        )}
+      </td>
+      <td className="py-2">
+        {cat.unitRequired && cat.unitSettingKey ? (
+          <CustomSelect
+            ariaLabel={`Einheit ${cat.label}`}
+            value={cat.unit}
+            options={UNIT_OPTIONS}
+            onChange={(next) => {
+              if (next !== cat.unit && cat.unitSettingKey) {
+                void onSave(cat.unitSettingKey, next);
+              }
+            }}
+            triggerClassName="moto-content-surface h-9 w-auto min-w-[10rem] hover:border-gray-300"
+          />
+        ) : (
+          <span className="text-xs text-gray-400">Stunden (fest)</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function DatevCard({
+  status,
+  onSave,
+}: {
+  readonly status: PayrollStatus;
+  readonly onSave: (key: string, value: string) => Promise<void>;
+}) {
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+      <h2 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
+        DATEV-Mandant
+      </h2>
+      <p className="mt-1 text-xs text-gray-500">
+        Kennzahlen für den Kopf der LODAS-Datei. Lohn und Gehalt benötigt sie
+        nicht.
+      </p>
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <DatevNumberField
+          label="Beraternummer"
+          settingKey="payroll.datev_beraternummer"
+          current={status.beraternummer}
+          maxDigits={7}
+          onSave={onSave}
+        />
+        <DatevNumberField
+          label="Mandantennummer"
+          settingKey="payroll.datev_mandantennummer"
+          current={status.mandantennummer}
+          maxDigits={5}
+          onSave={onSave}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DatevNumberField({
+  label,
+  settingKey,
+  current,
+  maxDigits,
+  onSave,
+}: {
+  readonly label: string;
+  readonly settingKey: string;
+  readonly current: string;
+  readonly maxDigits: number;
+  readonly onSave: (key: string, value: string) => Promise<void>;
+}) {
+  const [value, setValue] = useState(current);
+  useEffect(() => setValue(current), [current]);
+
+  const valid =
+    value.trim() === "" ||
+    new RegExp(`^\\d{1,${maxDigits}}$`).test(value.trim());
+
+  return (
+    <div>
+      <label
+        htmlFor={`datev-${settingKey}`}
+        className="mb-1 block text-sm font-medium text-gray-700"
+      >
+        {label}
+      </label>
+      <Input
+        id={`datev-${settingKey}`}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={() => {
+          const trimmed = value.trim();
+          if (valid && trimmed !== current) {
+            void onSave(settingKey, trimmed);
+          }
+        }}
+        placeholder="Nicht konfiguriert"
+        inputMode="numeric"
+        className="h-9 py-1 text-sm tabular-nums"
+      />
+      {!valid && (
+        <p className="mt-1 text-xs text-[#FF3130]">
+          1 bis {maxDigits} Ziffern.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
@@ -298,7 +298,7 @@ function DatevNumberField({
 
   const valid =
     value.trim() === "" ||
-    new RegExp(`^\\d{1,${maxDigits}}$`).test(value.trim());
+    new RegExp(String.raw`^\d{1,${maxDigits}}$`).test(value.trim());
 
   return (
     <div>

--- a/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import { Alert } from "~/components/ui/alert";
 import { CustomSelect } from "~/components/ui/custom-select";
@@ -43,15 +43,34 @@ export default function PayrollPage() {
   } = useSWR(isReady ? "payroll-status" : null, fetchPayrollStatus);
 
   const [saveError, setSaveError] = useState<string | null>(null);
+  const saveQueues = useRef(new Map<string, Promise<void>>());
 
-  const save = async (key: string, value: string) => {
-    setSaveError(null);
-    const message = await setSettingValue(key, value);
-    if (message) {
-      setSaveError(message);
-    }
-    await mutate();
-  };
+  const save = useCallback(
+    (key: string, value: string) => {
+      const previous = saveQueues.current.get(key) ?? Promise.resolve();
+      const next = previous
+        .then(async () => {
+          setSaveError(null);
+          const message = await setSettingValue(key, value);
+          if (message) {
+            setSaveError(message);
+          }
+          await mutate();
+        })
+        .catch(() => {
+          setSaveError("Einstellung konnte nicht gespeichert werden.");
+        });
+
+      saveQueues.current.set(key, next);
+      void next.finally(() => {
+        if (saveQueues.current.get(key) === next) {
+          saveQueues.current.delete(key);
+        }
+      });
+      return next;
+    },
+    [mutate],
+  );
 
   if (permissionLoading || !isReady) {
     return <Loading fullPage />;

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
@@ -141,6 +141,12 @@ describe("StaffDetailContent permissions", () => {
     expect(
       screen.queryByRole("button", { name: "Arbeitszeitmodell" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Stammdaten" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Bearbeiten" }),
+    ).toBeInTheDocument();
     expect(replaceMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
@@ -147,6 +147,32 @@ describe("StaffDetailContent permissions", () => {
     expect(
       screen.getByRole("button", { name: "Bearbeiten" }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Abrechnung" }),
+    ).not.toBeInTheDocument();
     expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("links payroll settings for managers with config permission", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "7",
+          token: "test-token",
+          roles: ["teacher"],
+          permissions: ["time_tracking:manage", "config:manage"],
+        },
+        expires: "2099-01-01T00:00:00.000Z",
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+
+    render(<StaffDetailContent />);
+
+    expect(screen.getByRole("link", { name: "Abrechnung" })).toHaveAttribute(
+      "href",
+      "/payroll",
+    );
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -221,6 +221,7 @@ export default function StaffDetailContent() {
   const staffId = params.id as string;
   const canEdit = isAdmin(session);
   const canManageTimeTracking = hasPermission(session, "time_tracking:manage");
+  const canManagePayrollSettings = hasPermission(session, "config:manage");
   const canViewTimeTracking = canEdit || canManageTimeTracking;
 
   const {
@@ -409,6 +410,7 @@ export default function StaffDetailContent() {
             <StammdatenTab
               staffId={staffId}
               canManagePayroll={canManageTimeTracking}
+              canManagePayrollSettings={canManagePayrollSettings}
             />
           </TabsPrimitive.Content>
         ) : null}

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -367,13 +367,13 @@ export default function StaffDetailContent() {
               )}
             </span>
           </TabsTrigger>
+          {canManageTimeTracking ? (
+            <TabsTrigger value="stammdaten">Stammdaten</TabsTrigger>
+          ) : null}
           {canEdit ? (
-            <>
-              <TabsTrigger value="stammdaten">Stammdaten</TabsTrigger>
-              <TabsTrigger value="dokumente" disabled>
-                Dokumente
-              </TabsTrigger>
-            </>
+            <TabsTrigger value="dokumente" disabled>
+              Dokumente
+            </TabsTrigger>
           ) : null}
         </TabsList>
 
@@ -404,16 +404,19 @@ export default function StaffDetailContent() {
           />
         </TabsPrimitive.Content>
 
-        {canEdit ? (
-          <>
-            <TabsPrimitive.Content value="stammdaten">
-              <StammdatenTab staffId={staffId} canEdit={canEdit} />
-            </TabsPrimitive.Content>
+        {canManageTimeTracking ? (
+          <TabsPrimitive.Content value="stammdaten">
+            <StammdatenTab
+              staffId={staffId}
+              canManagePayroll={canManageTimeTracking}
+            />
+          </TabsPrimitive.Content>
+        ) : null}
 
-            <TabsPrimitive.Content value="dokumente">
-              <PlaceholderTab title="Dokumente" />
-            </TabsPrimitive.Content>
-          </>
+        {canEdit ? (
+          <TabsPrimitive.Content value="dokumente">
+            <PlaceholderTab title="Dokumente" />
+          </TabsPrimitive.Content>
         ) : null}
       </Tabs>
     </div>

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -19,6 +19,7 @@ import { hasPermission, isAdmin } from "~/lib/auth-utils";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { AbwesenheitenTab } from "~/components/staff/abwesenheiten-tab";
 import { ArbeitszeitmodellTab } from "~/components/staff/arbeitszeitmodell-tab";
+import { StammdatenTab } from "~/components/staff/stammdaten-tab";
 import { UebersichtTab } from "~/components/staff/uebersicht-tab";
 import { ZeiterfassungTab } from "~/components/staff/zeiterfassung-tab";
 import { staffAbsenceService } from "~/lib/staff-api";
@@ -368,9 +369,7 @@ export default function StaffDetailContent() {
           </TabsTrigger>
           {canEdit ? (
             <>
-              <TabsTrigger value="stammdaten" disabled>
-                Stammdaten
-              </TabsTrigger>
+              <TabsTrigger value="stammdaten">Stammdaten</TabsTrigger>
               <TabsTrigger value="dokumente" disabled>
                 Dokumente
               </TabsTrigger>
@@ -408,7 +407,7 @@ export default function StaffDetailContent() {
         {canEdit ? (
           <>
             <TabsPrimitive.Content value="stammdaten">
-              <PlaceholderTab title="Stammdaten" />
+              <StammdatenTab staffId={staffId} canEdit={canEdit} />
             </TabsPrimitive.Content>
 
             <TabsPrimitive.Content value="dokumente">

--- a/frontend/src/app/api/settings/payroll-status/route.ts
+++ b/frontend/src/app/api/settings/payroll-status/route.ts
@@ -1,0 +1,3 @@
+import { proxyGet } from "~/lib/route-proxy.server";
+
+export const GET = proxyGet(() => "/api/settings/payroll-status");

--- a/frontend/src/app/api/staff/[id]/payroll-number/route.ts
+++ b/frontend/src/app/api/staff/[id]/payroll-number/route.ts
@@ -1,0 +1,10 @@
+import { proxyGet, proxyPut } from "~/lib/route-proxy.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+export const GET = proxyGet(
+  (p) => `/api/staff/${requirePathSegmentParam(p)}/payroll-number`,
+);
+
+export const PUT = proxyPut(
+  (p) => `/api/staff/${requirePathSegmentParam(p)}/payroll-number`,
+);

--- a/frontend/src/components/dashboard/sidebar.test.tsx
+++ b/frontend/src/components/dashboard/sidebar.test.tsx
@@ -864,6 +864,21 @@ describe("Sidebar", () => {
       expect(screen.getByText("Einstellungen")).toBeInTheDocument();
     });
 
+    // Abrechnung (#1417) gates on config:manage; the shared hasPermission
+    // mock grants permissions to admins only.
+    it("renders Abrechnung only for config:manage holders", () => {
+      mockIsAdmin.mockReturnValue(true);
+      mockUseSession.mockReturnValue(createMockSession(true));
+      const { unmount } = render(<Sidebar />);
+      expect(screen.getByText("Abrechnung")).toBeInTheDocument();
+      unmount();
+
+      mockIsAdmin.mockReturnValue(false);
+      mockUseSession.mockReturnValue(createMockSession(false));
+      render(<Sidebar />);
+      expect(screen.queryByText("Abrechnung")).not.toBeInTheDocument();
+    });
+
     it("highlights active icon color for active links", () => {
       mockUsePathname.mockReturnValue("/activities");
 

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -136,6 +136,13 @@ const NAV_ITEMS: NavItem[] = [
     alwaysShow: true,
   },
   {
+    href: "/payroll",
+    label: "Abrechnung",
+    icon: "M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z",
+    activeColor: "text-[#83CD2D]",
+    requiresPermission: "config:manage",
+  },
+  {
     href: "#",
     label: "Berichte",
     icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -745,6 +745,27 @@ export const appChapters: readonly GuideChapter[] = [
           "Gruppenzugriff mit verfügbaren Fachkräften und Dialog Zugriff gewähren.",
         image: "/help/screens/vertretungen.webp",
       },
+      {
+        id: "abrechnung-vorbereiten",
+        title: "Abrechnung vorbereiten (DATEV)",
+        icon: ClipboardList,
+        summary:
+          "Lohnarten, DATEV-Mandantendaten und Personalnummern pflegen, damit Zeiterfassungsdaten später an die Lohnabrechnung übergeben werden können (nur mit Berechtigung `config:manage`).",
+        steps: [
+          "`Abrechnung` in der Seitenleiste öffnen. Die Karte `Vollständigkeit` zeigt, welche Angaben noch fehlen.",
+          "Unter `Lohnarten` für jede Kategorie (Regelarbeit, Plus-Stunden, Auszahlung, Freizeitausgleich, Krank, Urlaub, Fortbildung) die Lohnartnummer aus dem Lohnsystem des Trägers eintragen. Die Nummern liefert das Lohnbüro; es gibt bewusst keine Vorbelegung. Eine Kategorie ohne Nummer wird später einfach nicht exportiert.",
+          "Bei Krank, Urlaub und Fortbildung zusätzlich die `Einheit` wählen: ob die Lohnart im Lohnsystem Stunden oder Tage erwartet.",
+          "Unter `DATEV-Mandant` die Beraternummer und Mandantennummer eintragen. Beide stehen im DATEV-Bestand des Lohnbüros und werden nur für den LODAS-Export benötigt.",
+          "Für jede Person die Personalnummer aus dem Lohnsystem hinterlegen: `Mitarbeiter` -> Person öffnen -> Reiter `Stammdaten` -> `Bearbeiten`. Die Nummer ist pro Schule eindeutig; Änderungen erscheinen im Änderungsprotokoll.",
+        ],
+        callout: {
+          title: "Keine Nummern erfinden",
+          body: "Lohnartnummern und Personalnummern müssen exakt den Werten im Lohnsystem des Trägers entsprechen. Eine plausibel aussehende, aber falsche Nummer führt zu still falscher Abrechnung. Im Zweifel beim Lohnbüro nachfragen und Felder leer lassen.",
+          tone: "red",
+        },
+        screenshot:
+          "Abrechnungsseite mit Vollständigkeits-Karte, Lohnarten-Tabelle und DATEV-Mandantendaten.",
+      },
     ],
   },
   {

--- a/frontend/src/components/settings/settings-page.tsx
+++ b/frontend/src/components/settings/settings-page.tsx
@@ -328,11 +328,16 @@ export function useSettingsTabs(): {
         label: tabLabels[key] ?? key,
         icon: tabIcons[key] ?? defaultTabIcon,
       }))
-    : (schema?.tabs ?? []).map((tab) => ({
-        id: `settings-${tab.key}`,
-        label: tabLabels[tab.key] ?? tab.label,
-        icon: tabIcons[tab.key] ?? defaultTabIcon,
-      }));
+    : (schema?.tabs ?? [])
+        // Payroll settings (#1417) have their own maintenance page under
+        // /payroll — rendering the auto-generated tab here would create a
+        // second, worse surface for the same values.
+        .filter((tab) => tab.key !== "abrechnung")
+        .map((tab) => ({
+          id: `settings-${tab.key}`,
+          label: tabLabels[tab.key] ?? tab.label,
+          icon: tabIcons[tab.key] ?? defaultTabIcon,
+        }));
 
   // Personalisierung is always available (permission-gated inside the component)
   const personalizationTab = {

--- a/frontend/src/components/staff/staff-audit-log.tsx
+++ b/frontend/src/components/staff/staff-audit-log.tsx
@@ -127,6 +127,13 @@ function describeEvent(event: AuditLogEvent): string {
           : "";
       return `Abwesenheit gelöscht: ${type} ${from === to ? from : `${from}–${to}`}`;
     }
+    case "personnel_number": {
+      const oldValue = typeof d.old_value === "string" ? d.old_value : "";
+      const newValue = typeof d.new_value === "string" ? d.new_value : "";
+      const from = oldValue === "" ? "nicht gesetzt" : oldValue;
+      const to = newValue === "" ? "entfernt" : newValue;
+      return `Personalnummer: ${from} → ${to}`;
+    }
   }
 }
 

--- a/frontend/src/components/staff/stammdaten-tab.test.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.test.tsx
@@ -49,7 +49,13 @@ describe("StammdatenTab", () => {
       mutate,
     };
 
-    render(<StammdatenTab staffId="42" canManagePayroll />);
+    render(
+      <StammdatenTab
+        staffId="42"
+        canManagePayroll
+        canManagePayrollSettings={false}
+      />,
+    );
 
     expect(
       screen.getByText("Die Personalnummer konnte nicht geladen werden."),
@@ -72,11 +78,39 @@ describe("StammdatenTab", () => {
       mutate,
     };
 
-    render(<StammdatenTab staffId="42" canManagePayroll />);
+    render(
+      <StammdatenTab staffId="42" canManagePayroll canManagePayrollSettings />,
+    );
 
     expect(screen.getByText("Nicht gesetzt")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Bearbeiten" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Abrechnung" })).toHaveAttribute(
+      "href",
+      "/payroll",
+    );
+  });
+
+  it("zeigt ohne Settings-Berechtigung keinen Link zur Abrechnung", () => {
+    swrResult.current = {
+      data: null,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate,
+    };
+
+    render(
+      <StammdatenTab
+        staffId="42"
+        canManagePayroll
+        canManagePayrollSettings={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: "Abrechnung" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/staff/stammdaten-tab.test.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StammdatenTab } from "./stammdaten-tab";
+
+const mutate = vi.hoisted(() => vi.fn());
+const useSWRAuth = vi.hoisted(() => vi.fn());
+const swrResult = vi.hoisted(() => ({
+  current: {
+    data: undefined as string | null | undefined,
+    error: undefined as Error | undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate,
+  },
+}));
+
+vi.mock("~/lib/swr", () => ({
+  useSWRAuth,
+}));
+
+vi.mock("~/lib/staff-api", () => ({
+  staffPayrollNumberService: {
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+describe("StammdatenTab", () => {
+  beforeEach(() => {
+    mutate.mockReset();
+    useSWRAuth.mockReset();
+    useSWRAuth.mockImplementation(() => swrResult.current);
+    swrResult.current = {
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate,
+    };
+  });
+
+  it("zeigt bei einem Ladefehler keinen vermeintlich leeren Wert", () => {
+    swrResult.current = {
+      data: undefined,
+      error: new Error("request failed"),
+      isLoading: false,
+      isValidating: false,
+      mutate,
+    };
+
+    render(<StammdatenTab staffId="42" canManagePayroll />);
+
+    expect(
+      screen.getByText("Die Personalnummer konnte nicht geladen werden."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Nicht gesetzt")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Bearbeiten" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Erneut laden" }));
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("zeigt einen erfolgreich geladenen Nullwert als nicht gesetzt", () => {
+    swrResult.current = {
+      data: null,
+      error: undefined,
+      isLoading: false,
+      isValidating: false,
+      mutate,
+    };
+
+    render(<StammdatenTab staffId="42" canManagePayroll />);
+
+    expect(screen.getByText("Nicht gesetzt")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Bearbeiten" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/staff/stammdaten-tab.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Loading } from "~/components/ui/loading";
@@ -24,7 +25,9 @@ export function StammdatenTab({
 
   const {
     data: personnelNumber,
+    error,
     isLoading,
+    isValidating,
     mutate,
   } = useSWRAuth(`staff-payroll-number-${staffId}`, () =>
     staffPayrollNumberService.get(staffId),
@@ -32,6 +35,27 @@ export function StammdatenTab({
 
   if (isLoading) {
     return <Loading fullPage={false} />;
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <Alert
+          type="error"
+          message="Die Personalnummer konnte nicht geladen werden."
+        />
+        <Button
+          type="button"
+          size="compact"
+          variant="outline"
+          isLoading={isValidating}
+          loadingText="Wird geladen..."
+          onClick={() => void mutate()}
+        >
+          Erneut laden
+        </Button>
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/components/staff/stammdaten-tab.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.tsx
@@ -17,9 +17,11 @@ import { staffPayrollNumberService } from "~/lib/staff-api";
 export function StammdatenTab({
   staffId,
   canManagePayroll,
+  canManagePayrollSettings,
 }: {
   readonly staffId: string;
   readonly canManagePayroll: boolean;
+  readonly canManagePayrollSettings: boolean;
 }) {
   const [editorOpen, setEditorOpen] = useState(false);
 
@@ -98,9 +100,13 @@ export function StammdatenTab({
 
         <p className="mt-4 text-xs text-gray-500">
           Lohnarten und DATEV-Mandantendaten werden zentral unter{" "}
-          <Link href="/payroll" className="text-[#5080D8] hover:underline">
-            Abrechnung
-          </Link>{" "}
+          {canManagePayrollSettings ? (
+            <Link href="/payroll" className="text-[#5080D8] hover:underline">
+              Abrechnung
+            </Link>
+          ) : (
+            "Abrechnung"
+          )}{" "}
           gepflegt.
         </p>
       </div>

--- a/frontend/src/components/staff/stammdaten-tab.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Loading } from "~/components/ui/loading";
+import { Modal } from "~/components/ui/modal";
+import { useSWRAuth } from "~/lib/swr";
+import { staffPayrollNumberService } from "~/lib/staff-api";
+
+// Stammdaten tab (#1417 Tranche 2b): starts with the single Abrechnung
+// section (Personalnummer). #1423 fills in the remaining Stammdaten sections
+// around it — deliberately activated early so the payroll identifier has ONE
+// home instead of a second maintenance surface.
+export function StammdatenTab({
+  staffId,
+  canEdit,
+}: {
+  readonly staffId: string;
+  readonly canEdit: boolean;
+}) {
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  const {
+    data: personnelNumber,
+    isLoading,
+    mutate,
+  } = useSWRAuth(`staff-payroll-number-${staffId}`, () =>
+    staffPayrollNumberService.get(staffId),
+  );
+
+  if (isLoading) {
+    return <Loading fullPage={false} />;
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
+              Abrechnung
+            </h3>
+            <p className="mt-1 text-xs text-gray-500">
+              Personalnummer aus dem Lohnsystem des Trägers. Ohne sie kann der
+              spätere DATEV-Export diese Person keiner Abrechnung zuordnen.
+            </p>
+          </div>
+          {canEdit && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="compact"
+              onClick={() => setEditorOpen(true)}
+            >
+              Bearbeiten
+            </Button>
+          )}
+        </div>
+
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <dt className="text-xs font-medium text-gray-500">
+              Personalnummer
+            </dt>
+            <dd className="mt-1 text-sm font-semibold text-gray-800 tabular-nums">
+              {personnelNumber ?? (
+                <span className="font-normal text-gray-400">Nicht gesetzt</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+
+        <p className="mt-4 text-xs text-gray-500">
+          Lohnarten und DATEV-Mandantendaten werden zentral unter{" "}
+          <Link href="/payroll" className="text-[#5080D8] hover:underline">
+            Abrechnung
+          </Link>{" "}
+          gepflegt.
+        </p>
+      </div>
+
+      {editorOpen && (
+        <PersonnelNumberModal
+          staffId={staffId}
+          current={personnelNumber ?? null}
+          onClose={() => setEditorOpen(false)}
+          onSaved={() => {
+            setEditorOpen(false);
+            void mutate();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function PersonnelNumberModal({
+  staffId,
+  current,
+  onClose,
+  onSaved,
+}: {
+  readonly staffId: string;
+  readonly current: string | null;
+  readonly onClose: () => void;
+  readonly onSaved: () => void;
+}) {
+  const [value, setValue] = useState(current ?? "");
+  const [note, setNote] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = value.trim();
+  const valid = trimmed === "" || /^\d{1,9}$/.test(trimmed);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await staffPayrollNumberService.update(
+        staffId,
+        trimmed === "" ? null : trimmed,
+        note.trim(),
+      );
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Speichern fehlgeschlagen");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} title="Personalnummer bearbeiten">
+      <div className="space-y-4">
+        <div>
+          <label
+            htmlFor="personnel-number"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Personalnummer
+          </label>
+          <Input
+            id="personnel-number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="z. B. 1023"
+            inputMode="numeric"
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Nur Ziffern. Leer lassen, um die Nummer zu entfernen. Die Nummer
+            muss der Personalnummer im Lohnsystem entsprechen und ist pro Schule
+            eindeutig.
+          </p>
+          {!valid && (
+            <p className="mt-1 text-xs text-[#FF3130]">
+              Nur Ziffern, höchstens 9 Stellen.
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="personnel-number-note"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Begründung (optional)
+          </label>
+          <Input
+            id="personnel-number-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Erscheint im Änderungsprotokoll"
+          />
+        </div>
+
+        {error && <p className="text-sm text-[#FF3130]">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" size="md" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={handleSave}
+            disabled={saving || !valid || trimmed === (current ?? "").trim()}
+          >
+            {saving ? "Speichert…" : "Speichern"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/staff/stammdaten-tab.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.tsx
@@ -15,10 +15,10 @@ import { staffPayrollNumberService } from "~/lib/staff-api";
 // home instead of a second maintenance surface.
 export function StammdatenTab({
   staffId,
-  canEdit,
+  canManagePayroll,
 }: {
   readonly staffId: string;
-  readonly canEdit: boolean;
+  readonly canManagePayroll: boolean;
 }) {
   const [editorOpen, setEditorOpen] = useState(false);
 
@@ -47,7 +47,7 @@ export function StammdatenTab({
               spätere DATEV-Export diese Person keiner Abrechnung zuordnen.
             </p>
           </div>
-          {canEdit && (
+          {canManagePayroll && (
             <Button
               type="button"
               variant="ghost"

--- a/frontend/src/lib/payroll-api.test.ts
+++ b/frontend/src/lib/payroll-api.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./session-cache", () => ({
+  sessionFetch: vi.fn(),
+}));
+
+import { sessionFetch } from "./session-cache";
 import {
   duplicateLohnartNumbers,
+  fetchPayrollStatus,
   mapPayrollStatus,
   type PayrollStatus,
 } from "./payroll-api";
+
+const mockedSessionFetch = vi.mocked(sessionFetch);
 
 const backendStatus = {
   categories: [
@@ -51,6 +60,40 @@ describe("mapPayrollStatus", () => {
     expect(status.categories[1]?.unitSettingKey).toBe("payroll.einheit_krank");
     expect(status.lodasHeaderComplete).toBe(false);
     expect(status.staffWithoutPersonnelNumber).toBe(19);
+  });
+});
+
+describe("fetchPayrollStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches and maps the payroll status", async () => {
+    mockedSessionFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: backendStatus }),
+    } as Response);
+
+    const status = await fetchPayrollStatus();
+
+    expect(mockedSessionFetch).toHaveBeenCalledWith(
+      "/api/settings/payroll-status",
+    );
+    expect(status.categories[0]?.settingKey).toBe(
+      "payroll.lohnart_regelarbeit",
+    );
+    expect(status.staffTotal).toBe(21);
+  });
+
+  it("reports a failed status request", async () => {
+    mockedSessionFetch.mockResolvedValue({
+      ok: false,
+      statusText: "Forbidden",
+    } as Response);
+
+    await expect(fetchPayrollStatus()).rejects.toThrow(
+      "Failed to fetch payroll status: Forbidden",
+    );
   });
 });
 

--- a/frontend/src/lib/payroll-api.test.ts
+++ b/frontend/src/lib/payroll-api.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  duplicateLohnartNumbers,
+  mapPayrollStatus,
+  type PayrollStatus,
+} from "./payroll-api";
+
+const backendStatus = {
+  categories: [
+    {
+      id: "regelarbeit",
+      label: "Regelarbeit",
+      number: "9001",
+      unit_required: false,
+      setting_key: "payroll.lohnart_regelarbeit",
+    },
+    {
+      id: "krank",
+      label: "Krank",
+      number: "9002",
+      unit: "tage",
+      unit_required: true,
+      setting_key: "payroll.lohnart_krank",
+      unit_setting_key: "payroll.einheit_krank",
+    },
+  ],
+  beraternummer: "9999999",
+  mandantennummer: "",
+  lodas_header_complete: false,
+  configured_categories: 2,
+  total_categories: 7,
+  staff_total: 21,
+  staff_without_personnel_number: 19,
+};
+
+describe("mapPayrollStatus", () => {
+  it("maps snake_case wire fields and defaults missing units", () => {
+    const status = mapPayrollStatus(backendStatus);
+
+    expect(status.categories).toHaveLength(2);
+    expect(status.categories[0]).toEqual({
+      id: "regelarbeit",
+      label: "Regelarbeit",
+      number: "9001",
+      unit: "",
+      unitRequired: false,
+      settingKey: "payroll.lohnart_regelarbeit",
+      unitSettingKey: null,
+    });
+    expect(status.categories[1]?.unit).toBe("tage");
+    expect(status.categories[1]?.unitSettingKey).toBe("payroll.einheit_krank");
+    expect(status.lodasHeaderComplete).toBe(false);
+    expect(status.staffWithoutPersonnelNumber).toBe(19);
+  });
+});
+
+describe("duplicateLohnartNumbers", () => {
+  const base = mapPayrollStatus(backendStatus);
+
+  const withNumbers = (numbers: string[]): PayrollStatus => ({
+    ...base,
+    categories: numbers.map((number, i) => ({
+      id: `cat-${i}`,
+      label: `Kategorie ${i}`,
+      number,
+      unit: "",
+      unitRequired: false,
+      settingKey: `payroll.cat_${i}`,
+      unitSettingKey: null,
+    })),
+  });
+
+  it("reports numbers assigned to more than one category", () => {
+    expect(
+      duplicateLohnartNumbers(withNumbers(["9001", "9002", "9001"])),
+    ).toEqual(["9001"]);
+  });
+
+  it("ignores empty (unconfigured) numbers", () => {
+    expect(duplicateLohnartNumbers(withNumbers(["", "", "9001"]))).toEqual([]);
+  });
+});

--- a/frontend/src/lib/payroll-api.ts
+++ b/frontend/src/lib/payroll-api.ts
@@ -1,0 +1,94 @@
+// Payroll configuration status (#1417 Tranche 2b): the /payroll page's data
+// source. Requires config:manage — callers gate rendering on the permission
+// so no request fires without it. Values are written through the generic
+// settings API (setSettingValue) using the setting keys this status carries.
+
+import { sessionFetch } from "./session-cache";
+
+interface BackendPayrollCategoryStatus {
+  id: string;
+  label: string;
+  number: string;
+  unit?: string;
+  unit_required: boolean;
+  setting_key: string;
+  unit_setting_key?: string;
+}
+
+interface BackendPayrollStatus {
+  categories: BackendPayrollCategoryStatus[];
+  beraternummer: string;
+  mandantennummer: string;
+  lodas_header_complete: boolean;
+  configured_categories: number;
+  total_categories: number;
+  staff_total: number;
+  staff_without_personnel_number: number;
+}
+
+interface PayrollCategoryStatus {
+  id: string;
+  label: string;
+  number: string;
+  unit: string;
+  unitRequired: boolean;
+  settingKey: string;
+  unitSettingKey: string | null;
+}
+
+export interface PayrollStatus {
+  categories: PayrollCategoryStatus[];
+  beraternummer: string;
+  mandantennummer: string;
+  lodasHeaderComplete: boolean;
+  configuredCategories: number;
+  totalCategories: number;
+  staffTotal: number;
+  staffWithoutPersonnelNumber: number;
+}
+
+export function mapPayrollStatus(data: BackendPayrollStatus): PayrollStatus {
+  return {
+    categories: (data.categories ?? []).map((cat) => ({
+      id: cat.id,
+      label: cat.label,
+      number: cat.number,
+      unit: cat.unit ?? "",
+      unitRequired: cat.unit_required,
+      settingKey: cat.setting_key,
+      unitSettingKey: cat.unit_setting_key ?? null,
+    })),
+    beraternummer: data.beraternummer,
+    mandantennummer: data.mandantennummer,
+    lodasHeaderComplete: data.lodas_header_complete,
+    configuredCategories: data.configured_categories,
+    totalCategories: data.total_categories,
+    staffTotal: data.staff_total,
+    staffWithoutPersonnelNumber: data.staff_without_personnel_number,
+  };
+}
+
+export async function fetchPayrollStatus(): Promise<PayrollStatus> {
+  const response = await sessionFetch("/api/settings/payroll-status");
+  if (!response.ok) {
+    throw new Error(`Failed to fetch payroll status: ${response.statusText}`);
+  }
+  const json = (await response.json()) as { data: BackendPayrollStatus };
+  return mapPayrollStatus(json.data);
+}
+
+/**
+ * Lohnartnummern that appear on more than one category. Not an error — a
+ * Träger may legitimately book two categories on one Lohnart — but worth a
+ * warning, because a duplicate usually is a typo that would double-book.
+ */
+export function duplicateLohnartNumbers(status: PayrollStatus): string[] {
+  const seen = new Map<string, number>();
+  for (const cat of status.categories) {
+    if (cat.number === "") continue;
+    seen.set(cat.number, (seen.get(cat.number) ?? 0) + 1);
+  }
+  return [...seen.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([number]) => number);
+}

--- a/frontend/src/lib/staff-api.ts
+++ b/frontend/src/lib/staff-api.ts
@@ -1427,7 +1427,60 @@ class StaffMonthCloseService {
   }
 }
 
+// Personalnummer (#1417): payroll identifier maintained on the Stammdaten
+// tab. time_tracking:manage backend-side — callers gate rendering on the
+// permission so no request fires without it.
+class StaffPayrollNumberService {
+  async get(staffId: string): Promise<string | null> {
+    const response = await sessionFetch(`/api/staff/${staffId}/payroll-number`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch payroll number: ${response.statusText}`);
+    }
+    const json = (await response.json()) as {
+      data: { personnel_number: string | null };
+    };
+    return json.data.personnel_number;
+  }
+
+  async update(
+    staffId: string,
+    personnelNumber: string | null,
+    note: string,
+  ): Promise<string | null> {
+    const response = await sessionFetch(
+      `/api/staff/${staffId}/payroll-number`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ personnel_number: personnelNumber, note }),
+      },
+    );
+    if (!response.ok) {
+      const error = await readStaffAPIError(
+        response,
+        "Personalnummer konnte nicht gespeichert werden",
+      );
+      if (error.code === "personnel_number_taken") {
+        throw new Error(
+          "Diese Personalnummer ist in dieser Schule bereits vergeben.",
+        );
+      }
+      if (error.code === "personnel_number_invalid") {
+        throw new Error(
+          "Ungültige Personalnummer: nur Ziffern, höchstens 9 Stellen.",
+        );
+      }
+      throw new Error(error.message);
+    }
+    const json = (await response.json()) as {
+      data: { personnel_number: string | null };
+    };
+    return json.data.personnel_number;
+  }
+}
+
 export const staffService = new StaffService();
+export const staffPayrollNumberService = new StaffPayrollNumberService();
 export const staffScheduleService = new StaffScheduleService();
 export const workTimeModelService = new WorkTimeModelService();
 export const staffHistoryService = new StaffHistoryService();

--- a/frontend/src/lib/staff-audit-log-api.ts
+++ b/frontend/src/lib/staff-audit-log-api.ts
@@ -14,7 +14,8 @@ export type AuditLogSource =
   | "adjustment"
   | "month_close"
   | "month_reopen"
-  | "deletion";
+  | "deletion"
+  | "personnel_number";
 
 export interface BackendAuditLogEvent {
   occurred_at: string;
@@ -68,6 +69,7 @@ export const auditLogSourceLabels: Record<AuditLogSource, string> = {
   month_close: "Monatsabschluss",
   month_reopen: "Monat geöffnet",
   deletion: "Löschung",
+  personnel_number: "Personalnummer",
 };
 
 export function mapAuditLogEvent(data: BackendAuditLogEvent): AuditLogEvent {

--- a/frontend/src/lib/staff-payroll-number-api.test.ts
+++ b/frontend/src/lib/staff-payroll-number-api.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./session-cache", () => ({
+  sessionFetch: vi.fn(),
+}));
+
+import { sessionFetch } from "./session-cache";
+import { staffPayrollNumberService } from "./staff-api";
+
+const mockedSessionFetch = vi.mocked(sessionFetch);
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ data }),
+  } as Response;
+}
+
+function errorResponse(code: string, message = "backend error"): Response {
+  return {
+    ok: false,
+    text: () => Promise.resolve(JSON.stringify({ code, error: message })),
+  } as Response;
+}
+
+describe("staffPayrollNumberService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches the current personnel number", async () => {
+    mockedSessionFetch.mockResolvedValue(
+      jsonResponse({ personnel_number: "90001" }),
+    );
+
+    await expect(staffPayrollNumberService.get("42")).resolves.toBe("90001");
+    expect(mockedSessionFetch).toHaveBeenCalledWith(
+      "/api/staff/42/payroll-number",
+    );
+  });
+
+  it("updates the personnel number and note", async () => {
+    mockedSessionFetch.mockResolvedValue(
+      jsonResponse({ personnel_number: "90002" }),
+    );
+
+    await expect(
+      staffPayrollNumberService.update("42", "90002", "Korrektur"),
+    ).resolves.toBe("90002");
+    expect(mockedSessionFetch).toHaveBeenCalledWith(
+      "/api/staff/42/payroll-number",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          personnel_number: "90002",
+          note: "Korrektur",
+        }),
+      },
+    );
+  });
+
+  it("reports a failed read", async () => {
+    mockedSessionFetch.mockResolvedValue({
+      ok: false,
+      statusText: "Forbidden",
+    } as Response);
+
+    await expect(staffPayrollNumberService.get("42")).rejects.toThrow(
+      "Failed to fetch payroll number: Forbidden",
+    );
+  });
+
+  it.each([
+    [
+      "personnel_number_taken",
+      "Diese Personalnummer ist in dieser Schule bereits vergeben.",
+    ],
+    [
+      "personnel_number_invalid",
+      "Ungültige Personalnummer: nur Ziffern, höchstens 9 Stellen.",
+    ],
+    ["other", "backend error"],
+  ])("maps update error %s", async (code, expectedMessage) => {
+    mockedSessionFetch.mockResolvedValue(errorResponse(code));
+
+    await expect(
+      staffPayrollNumberService.update("42", "90002", ""),
+    ).rejects.toThrow(expectedMessage);
+  });
+});


### PR DESCRIPTION
Teil von #1417, sechster PR (Tranche 2b, zweiter Teil). Baut auf #1986/#1988/#1995/#2001/#2005 auf.

## Problem

Der Cross-MA-Export aus #2005 liefert typisierte Monats- und Tageszeilen, aber nichts davon ist an eine Lohnabrechnung anschlussfähig. Beide DATEV-Wege (LODAS ASCII, Lohn und Gehalt ASCII) matchen Beschäftigte über die Personalnummer des Lohnsystems, beziffern jede Zeile über eine mandantenspezifische Lohnartnummer, und LODAS verlangt Berater- und Mandantennummer im Dateikopf. Keines der drei Dinge existierte. Dieser PR baut ausschließlich dieses Fundament plus die Pflege-Oberflächen — keine Writer, keine Dateiformate.

## Personalnummer: Spalte auf users.staff, Mehrschul-Lücke bewusst offen

`users.staff.personnel_number` (nullable), Eindeutigkeit pro Tenant über einen partiellen Unique-Index (`WHERE personnel_number IS NOT NULL AND deleted_at IS NULL` — eine offboardete Person gibt ihre Nummer frei). Duplikat → 409 mit stabilem Code `personnel_number_taken`, Format-Verstoß → 400 `personnel_number_invalid` (nur Ziffern, max. 9 Stellen; die exakten Formatgrenzen je DATEV-System erzwingt der Writer-PR).

**Bekannte Lücke, dokumentiert statt übersehen:** Die Personalnummer gehört zum Arbeitgeber, `users.staff` ist schulscoped. Wer an zwei Schulen desselben Trägers arbeitet, hat zwei Staff-Zeilen und sollte in beiden dieselbe Nummer tragen — das ist im aktuellen Tenant-Modell nicht erzwingbar (RLS, kein Org-Layer; Befund aus #1986 gilt unverändert). Der Export aus #2005 ist selbst tenant-scoped, zwei Dateien mit derselben Nummer führt das Lohnsystem korrekt zusammen; nur die Konsistenz der Nummer über die Tenants bleibt manuell. Eine echte Lösung braucht die org-weite Leseschicht und damit ein eigenes Issue.

**Pflege-Ort:** Der bisher deaktivierte Stammdaten-Tab auf `/staff/{id}` (Placeholder aus #1422) ist jetzt aktiv, mit vorerst genau einer Sektion „Abrechnung". #1423 füllt die übrigen Sektionen später um sie herum — kein zweiter Ort für dieselben Daten.

**Permission:** `time_tracking:manage`, das etablierte #1417-Muster für personenbezogene Abrechnungsdaten — bewusst NICHT `users:read`/`users:update` (die Directory-Stufe hat jeder, der die Mitarbeiterliste pflegt). `staff:financial` aus #1423 existiert noch nicht und ist dort für Bank-/Steuerdaten (IBAN, Steuer-ID) vorgesehen; sie hier vorzugreifen hieße, ein noch nicht designtes Permission-Modell festzulegen. Wenn #1423 kommt, kann die Sektion umziehen.

**Audit:** Jede Änderung schreibt in derselben Tenant-Transaktion eine Zeile in die neue append-only Tabelle `audit.personnel_number_changes` (Muster `time_tracking_deletions`, Migration 1.15.229); ohne verdrahtetes Audit-Repo schlägt die Änderung fehl. Die Tabelle ist als neue Quelle `personnel_number` ins Änderungsprotokoll aus #2001 eingehängt (UNION-Branch, Filter, deutsches Label, Detail alt→neu). Begründung: personenbezogen und abrechnungswirksam — direkt nach „Löschen ohne Spur gibt es nicht mehr" (#2001) darf ausgerechnet die Personalnummer nicht das einzige unprotokollierte Feld sein.

## Lohnart-Mapping: Settings-Storage, handgeschriebenes Panel

Regelkonform im Settings-System (kein Abweichungs-Absatz nötig): 7 Lohnart-Textfelder + 3 Einheit-Selects + Berater-/Mandantennummer in `services/config/defaults/payroll.go`, Tab `abrechnung`, `config:manage`, `AccessAdminOnly`. Das löst Audit (`config.setting_audit`), RLS und Permission-Plumbing gratis. Der Einwand „viele flache Felder sind dort schlecht zu pflegen" trifft die auto-generierte UI, nicht den Storage — deshalb bekommt der Tab ein handgeschriebenes Panel nach dem `personalization-tab`-Vorbild und wird aus der generischen Settings-Seite herausgefiltert.

- **Keine erfundenen Lohnartnummern.** Jeder Default ist der leere String; `TestPayrollSettings` pinnt das mit der Begründung, dass ein nicht-leerer Default ein Abrechnungsfehler wäre. Auch Tests nutzen erkennbar künstliche Nummern.
- **Einheit (Stunden/Tage) nur für Krank, Urlaub, Fortbildung** — die einzigen Kategorien mit Tageswerten. Die übrigen sind reine Minutensummen, ein Tage-Select dort wäre nicht bedienbar.
- **Doppelte Lohnartnummern warnen, nicht blocken** (abgestimmt): meist ein Tippfehler, der doppelt buchen würde, aber nicht sicher falsch.
- **Benanntes Risiko:** Ergibt der 2c-Spike Lohnarten pro Beschäftigungstyp, explodieren flache Keys — dann Migration auf eine eigene Tabelle. Jetzt dafür zu bauen wäre Spekulation gegen den Spike.

## Berater-/Mandantennummer und der fehlende-Konfiguration-Fall

Zwei Text-Settings mit Ziffern-Pattern (Beraternummer max. 7, Mandantennummer max. 5 Stellen — verifiziert gegen DATEV-Bestandslogik; die strikte LODAS-Kopfprüfung gehört zum Writer). Leer ist der legitime Ausgangszustand. Der spätere Export reagiert fail-fast: `PayrollStatusService.GetPayrollStatus` ist die eine Vollständigkeitsprüfung, die heute die `/payroll`-Seite rendert und die die Writer vor dem Schreiben aufrufen — keine Datei aus unvollständiger Konfiguration, und der Nutzer sieht die Lücken, bevor er den Export überhaupt anklickt. Welche Lohnart-Kategorien PFLICHT sind, entscheidet bewusst erst der Writer-PR (eine unkonfigurierte Kategorie exportiert schlicht keine Zeile); der Status meldet Fakten: konfigurierte Kategorien, LODAS-Kopf, Beschäftigte ohne Personalnummer (nur Anzahl — Namen bleiben hinter `time_tracking:manage`).

## Neue Oberflächen

- **`/payroll` („Abrechnung", eigener Seitenleisten-Eintrag, `config:manage`):** Vollständigkeits-Karte (drei Ampel-Zeilen), Lohnarten-Tabelle (Nummer + Einheit, Speichern bei Verlassen des Felds, Duplikat-Warnung), DATEV-Mandant-Karte. UI-Kit durchgehend (`moto-content-surface`, `Input`, `CustomSelect`, `Alert`); neue Komponenten sind die Seiten-Sektionen selbst.
- **Stammdaten-Tab auf `/staff/{id}`:** Sektion „Abrechnung" mit Personalnummer, Edit-Modal (optionale Begründung fürs Protokoll), Verweis auf `/payroll`.
- **Änderungsprotokoll:** neue Quelle „Personalnummer" inkl. Filter-Option (ergibt sich aus der Label-Map) und Satzform „Personalnummer: nicht gesetzt → 1023".
- Neue Proxy-Routen: `app/api/staff/[id]/payroll-number` (GET/PUT), `app/api/settings/payroll-status` (GET) — generische `proxyGet`/`proxyPut`.

## Fürs DATEV-Follow-up notiert (nicht eingebaut)

`MonthExportRow` kann **Fortbildung nicht abbilden**: `AbsenceTypeTraining` fällt in `creditAbsenceDays` in den default-Zweig und landet ungetrennt in `CreditedOtherMinutes`; Tageszähler existieren nur für Krank/Urlaub. Für eine Lohnart „Fortbildung" (in Stunden getrennt von „Sonstige" oder in Tagen) braucht der Writer-PR den Split `CreditedTrainingMinutes`/`TrainingDays` in Aggregat und Row. Bewusst nicht hier, weil es die #2005-Zeilen anfasst und dort getestet wird. Konfigurierbar ist die Kategorie trotzdem schon.

## Anmerkungen für Review

- **Bestehende Test-Fixtures mechanisch erweitert (keine Assertion geändert):** `PersonService` hat die neue Interface-Methode → `userstest.PersonServiceMock` um `UpdatePersonnelNumberFn` ergänzt; `setupSettingsTest` verdrahtet den neuen Status-Service; `overviewAPIContext` hat jetzt einen `put`-Helper (gleiche Form wie `post`).
- Routen-Golden regeneriert: genau die drei neuen Routen.
- `PersonnelNumberAudit` hängt als neues Feld an `PersonServiceDependencies` (nil-Guard verweigert unauditierte Änderungen), nicht als Konstruktor-Umbau.

## Bewusst nicht im Scope

Beide DATEV-Writer, jedes Dateiformat, PDF, Änderungen am #2005-Export, der Fortbildung-Split (siehe oben), Org-weite Personalnummern-Konsistenz, `staff:financial`.

## Verifikation

- Backend: voller `go test ./...`-Lauf grün (sequentiell gegen die Test-DB), `golangci-lint run` 0 Issues auf allen angefassten Paketen, alle Ratchets grün (Handler-Layer, Service-Repository, Handler-Complexity, Model-Ceremony, Hermetic, DateColumnTypes), Migration 1.15.229 gegen Dev- und Test-DB gelaufen.
- Neue hermetische Tests: Set/Change/Clear mit Audit-Zeilen, No-op ohne Audit-Zeile, Duplikat → Sentinel UND Rollback der Audit-Zeile, Freigabe der Nummer nach Soft-Delete, Format-Validierung, Verweigerung ohne Audit-Repo, Eintrag im #2001-Feed mit Akteur und Detail. Settings-Registrierung gepinnt (leere Defaults!). PayrollStatus: leere Konfiguration, Zähl-Logik (Nummer ohne Einheit zählt nicht), Staff-Zählung. API: Permission-Splits (403 für `users:read`/`users:update` bzw. `config:read`+`config:update`), stabile Fehlercodes auf der Leitung.
- Frontend: `pnpm run check` ohne Warnungen, `knip` grün; neue Tests für Status-Mapping, Duplikat-Erkennung, Sidebar-Gating. Voller Vitest-Lauf: 12096 grün, 3 Fails ausschließlich die auf `development` identisch fehlschlagenden `chart.test.tsx`-Fälle (vorbestehend, in #1995/#2001 dokumentiert).
- Durchstich über die laufende Dev-Umgebung: als Admin `/payroll` geöffnet (leerer Zustand mit drei orangen Ampeln), vollständiges Mapping gepflegt (7 Nummern, 3 Einheiten, Berater-/Mandantennummer), Persistenz nach Reload verifiziert; für zwei Beschäftigte Personalnummern über den Stammdaten-Tab gesetzt (1023/1024), Duplikat-Versuch mit deutschem 409-Text abgefangen, beide Änderungen mit Akteur und Begründung im Änderungsprotokoll, Audit-Zeilen in `audit.personnel_number_changes` per SQL verifiziert, Vollständigkeits-Karte zählt 19 von 21 ohne Nummer. Mobile geprüft.
- Help-Guide: neuer Schritt „Abrechnung vorbereiten (DATEV)" im Kapitel Mitarbeiter, inklusive Warnung, keine Nummern zu erfinden.

Screenshots folgen als Kommentar.

Closes nichts; #1417 läuft weiter (offen: 2c-Spike, DATEV-Writer, Fortbildung-Split).
