### PR TITLE
fix(frontend): keep mobile header within viewport, merge tenant switcher into brand

### DIFF
--- a/frontend/src/components/dashboard/header.test.tsx
+++ b/frontend/src/components/dashboard/header.test.tsx
@@ -35,7 +35,7 @@ vi.mock("next-auth/react", () => ({
 }));
 
 vi.mock("~/components/tenant/tenant-switcher", () => ({
-  TenantSwitcher: () => <div data-testid="tenant-switcher">Tenant</div>,
+  BrandTenantSwitcher: () => <div data-testid="tenant-switcher">Tenant</div>,
 }));
 
 vi.mock("~/components/ui/logout-modal", () => ({
@@ -175,9 +175,11 @@ describe("Header", () => {
     Object.defineProperty(window, "scrollY", { value: 0, writable: true });
   });
 
-  it("renders brand link and divider", () => {
+  it("renders brand tenant switcher and divider", () => {
     render(<Header />);
-    expect(screen.getByTestId("brand-link")).toBeInTheDocument();
+    // Teacher mode renders the brand as tenant switcher (#2011); the
+    // plain BrandLink is reserved for operator/parent shells.
+    expect(screen.getByTestId("tenant-switcher")).toBeInTheDocument();
     expect(screen.getByTestId("divider")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { LogoutModal } from "~/components/ui/logout-modal";
-import { TenantSwitcher } from "~/components/tenant/tenant-switcher";
+import { BrandTenantSwitcher } from "~/components/tenant/tenant-switcher";
 import { useShellAuth } from "~/lib/shell-auth-context";
 import { useBreadcrumb } from "~/lib/breadcrumb-context";
 import { LanguageSwitcher } from "~/components/parent/language-switcher";
@@ -171,13 +171,25 @@ export function Header() {
             isScrolled ? "h-12 lg:h-16" : "h-14 lg:h-16"
           }`}
         >
-          {/* Left section: Logo + Brand + Context */}
-          <div className="flex flex-shrink-0 items-center space-x-4">
-            <BrandLink
-              isScrolled={isScrolled}
-              href={homeUrl}
-              label={brandLabel}
-            />
+          {/* Left section: Logo + Brand + Context — must be allowed to
+              shrink (min-w-0) so long tenant names / breadcrumbs truncate
+              instead of pushing the header past the viewport (#2011) */}
+          <div className="flex min-w-0 flex-1 items-center space-x-4">
+            {mode === "teacher" ? (
+              // Brand doubles as tenant switcher when the account has
+              // multiple tenants; renders a plain BrandLink otherwise.
+              <BrandTenantSwitcher
+                isScrolled={isScrolled}
+                href={homeUrl}
+                label={brandLabel}
+              />
+            ) : (
+              <BrandLink
+                isScrolled={isScrolled}
+                href={homeUrl}
+                label={brandLabel}
+              />
+            )}
             <BreadcrumbDivider />
             <HeaderBreadcrumb
               pathname={pathname}
@@ -197,7 +209,7 @@ export function Header() {
           </div>
 
           {/* Right section: Actions + Profile */}
-          <div className="ml-auto flex items-center space-x-3">
+          <div className="ml-auto flex flex-shrink-0 items-center space-x-3">
             {/* Desktop actions */}
             <div className="hidden items-center space-x-2 lg:flex">
               <SessionWarning isExpired={isSessionExpired} variant="desktop" />
@@ -211,7 +223,6 @@ export function Header() {
             </div>
 
             {mode === "teacher" ? <RemindersBell /> : null}
-            {mode === "teacher" ? <TenantSwitcher /> : null}
             {mode === "parent" ? <LanguageSwitcher compact /> : null}
 
             {/* User menu */}

--- a/frontend/src/components/dashboard/header/brand-link.tsx
+++ b/frontend/src/components/dashboard/header/brand-link.tsx
@@ -7,6 +7,42 @@ import Link from "next/link";
 import Image from "next/image";
 
 /**
+ * Logo image shared by BrandLink and BrandTenantSwitcher.
+ */
+export function BrandLogo() {
+  return (
+    <Image
+      src="/images/moto_transparent.webp"
+      alt=""
+      width={56}
+      height={40}
+      className="h-8 w-11 shrink-0 object-contain sm:h-10 sm:w-14"
+      priority
+    />
+  );
+}
+
+/**
+ * Typography for the brand label. Uses leading-tight (not leading-none):
+ * the span truncates via overflow-hidden, and a line box smaller than the
+ * font's ascent+descent clips descenders (g, j, p, q, y).
+ */
+export function brandLabelClass(
+  isScrolled: boolean,
+  usesTenantLabel: boolean,
+): string {
+  return `truncate leading-tight transition-all duration-150 ${
+    usesTenantLabel
+      ? `font-semibold text-gray-900 ${
+          isScrolled ? "text-sm lg:text-base" : "text-base lg:text-lg"
+        }`
+      : `[font-family:var(--font-moto)] font-bold text-gray-950 ${
+          isScrolled ? "text-xl lg:text-[22px]" : "text-[22px]"
+        }`
+  }`;
+}
+
+/**
  * Brand link with logo and text
  */
 interface BrandLinkProps {
@@ -28,29 +64,10 @@ export function BrandLink({
       href={href}
       className="group flex max-w-[180px] min-w-0 items-center space-x-3 sm:max-w-[240px] lg:max-w-[280px]"
     >
-      <div>
-        <Image
-          src="/images/moto_transparent.webp"
-          alt=""
-          width={56}
-          height={40}
-          className="h-8 w-11 object-contain sm:h-10 sm:w-14"
-          priority
-        />
-      </div>
+      <BrandLogo />
 
       <div className="flex min-w-0 items-center space-x-3">
-        <span
-          className={`truncate leading-none transition-all duration-150 ${
-            usesTenantLabel
-              ? `font-semibold text-gray-900 ${
-                  isScrolled ? "text-sm lg:text-base" : "text-base lg:text-lg"
-                }`
-              : `[font-family:var(--font-moto)] font-bold text-gray-950 ${
-                  isScrolled ? "text-xl lg:text-[22px]" : "text-[22px]"
-                }`
-          }`}
-        >
+        <span className={brandLabelClass(isScrolled, usesTenantLabel)}>
           {displayLabel}
         </span>
       </div>

--- a/frontend/src/components/tenant/tenant-switcher.stories.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { installStorybookFetch, jsonResponse } from "~storybook/mocks/fetch";
-import { TenantSwitcher } from "./tenant-switcher";
+import { BrandTenantSwitcher } from "./tenant-switcher";
 
 /** Minimal shape returned by the backend's `/api/auth/account-tenants` endpoint. */
 interface AccountTenantBackendFixture {
@@ -63,8 +63,8 @@ function mockAccountTenants(tenants: AccountTenantBackendFixture[]) {
 }
 
 const meta = {
-  title: "tenant/TenantSwitcher",
-  component: TenantSwitcher,
+  title: "tenant/BrandTenantSwitcher",
+  component: BrandTenantSwitcher,
   parameters: {
     docs: {
       description: {
@@ -73,16 +73,16 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof TenantSwitcher>;
+} satisfies Meta<typeof BrandTenantSwitcher>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
  * The account only has access to one tenant (the storybook default), so the
- * switcher intentionally renders nothing.
+ * brand renders as a plain link — name shown, no dropdown (#2011).
  */
-export const SingleTenantRendersNothing: Story = {
+export const SingleTenantPlainBrand: Story = {
   beforeEach: () => mockAccountTenants(singleTenant),
 };
 

--- a/frontend/src/components/tenant/tenant-switcher.test.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.test.tsx
@@ -51,7 +51,44 @@ vi.mock("~/env", () => ({
   },
 }));
 
-import { TenantSwitcher } from "./tenant-switcher";
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+    onClick?: () => void;
+  }) => (
+    <a href={href} className={className} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    width,
+    height,
+  }: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} width={width} height={height} />
+  ),
+}));
+
+import { BrandTenantSwitcher } from "./tenant-switcher";
+
+const TRIGGER_LABEL = "Einrichtung wechseln";
 
 // ============================================================================
 // Test Data
@@ -91,7 +128,7 @@ const tenantC = {
 // Tests
 // ============================================================================
 
-describe("TenantSwitcher", () => {
+describe("BrandTenantSwitcher", () => {
   let originalLocation: Location;
 
   beforeEach(() => {
@@ -121,63 +158,82 @@ describe("TenantSwitcher", () => {
     });
   });
 
-  it("skips tenant fetch when not authenticated", async () => {
+  function openDropdown() {
+    fireEvent.click(screen.getByRole("button", { name: TRIGGER_LABEL }));
+  }
+
+  it("skips tenant fetch when not authenticated and renders the plain brand", async () => {
     mockUseSession.mockReturnValue({ status: "loading" });
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
 
-    const { container } = render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher label="School A" />);
 
     // Wait a tick to ensure the effect had a chance to fire
     await waitFor(() => {
       expect(mockListAvailableTenants).not.toHaveBeenCalled();
     });
 
-    expect(container.innerHTML).toBe("");
+    // No dropdown trigger — just the brand link
+    expect(
+      screen.queryByRole("button", { name: TRIGGER_LABEL }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("School A")).toBeInTheDocument();
   });
 
-  it("renders nothing when user has zero tenants", async () => {
+  it("renders the plain brand link when user has zero tenants", async () => {
     mockListAvailableTenants.mockResolvedValue([]);
-    const { container } = render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
       expect(mockListAvailableTenants).toHaveBeenCalled();
     });
 
-    expect(container.innerHTML).toBe("");
+    expect(
+      screen.queryByRole("button", { name: TRIGGER_LABEL }),
+    ).not.toBeInTheDocument();
+    // Fallback brand label when no tenant label is provided
+    expect(screen.getByText("moto")).toBeInTheDocument();
   });
 
-  it("renders nothing when user has only one tenant", async () => {
+  it("renders name without dropdown when user has only one tenant", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA]);
-    const { container } = render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher label="School A" />);
 
     await waitFor(() => {
       expect(mockListAvailableTenants).toHaveBeenCalled();
     });
 
-    expect(container.innerHTML).toBe("");
+    expect(screen.getByText("School A")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: TRIGGER_LABEL }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders trigger button with current tenant name when user has multiple tenants", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
+    expect(screen.getByText("School A")).toBeInTheDocument();
   });
 
   it("opens dropdown on click and shows other tenants", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    // Click trigger to open dropdown
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
 
     // Should show the other tenant
     expect(screen.getByText("School B")).toBeInTheDocument();
@@ -186,14 +242,15 @@ describe("TenantSwitcher", () => {
   it("closes dropdown on outside click", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    // Open dropdown
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
     expect(screen.getByText("School B")).toBeInTheDocument();
 
     // Click outside
@@ -207,14 +264,15 @@ describe("TenantSwitcher", () => {
   it("executes switch flow on tenant selection", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    // Open dropdown and select tenant B
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
     fireEvent.click(screen.getByText("School B"));
 
     await waitFor(() => {
@@ -235,14 +293,15 @@ describe("TenantSwitcher", () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
     mockPerformTenantSwitch.mockRejectedValue(new Error("switch failed"));
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    // Open dropdown and select tenant B
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
     fireEvent.click(screen.getByText("School B"));
 
     await waitFor(() => {
@@ -260,18 +319,44 @@ describe("TenantSwitcher", () => {
   it("shows organization headers when tenants span multiple orgs", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB, tenantC]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    // Open dropdown
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
 
     // Should show org headers since there are 2 organizations
     expect(screen.getByText("Org Alpha")).toBeInTheDocument();
     expect(screen.getByText("Org Beta")).toBeInTheDocument();
+  });
+
+  it("links the current tenant entry to the dashboard instead of offering it as a switch target", async () => {
+    mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
+
+    render(<BrandTenantSwitcher href="/dashboard" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
+    });
+
+    openDropdown();
+
+    // Current tenant appears as a link home, never as a switch button
+    const currentEntry = screen.getByRole("link", { name: /School A/ });
+    expect(currentEntry).toHaveAttribute("href", "/dashboard");
+    expect(
+      screen.queryByRole("button", { name: "School A" }),
+    ).not.toBeInTheDocument();
+
+    // Selecting the current entry must not trigger a switch
+    fireEvent.click(currentEntry);
+    expect(mockPerformTenantSwitch).not.toHaveBeenCalled();
   });
 
   // Regression tests for #1975: slug and subdomain are independent columns
@@ -286,13 +371,15 @@ describe("TenantSwitcher", () => {
     };
     mockListAvailableTenants.mockResolvedValue([tenantA, divergentTenantB]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
     fireEvent.click(screen.getByText("School B"));
 
     await waitFor(() => {
@@ -316,31 +403,40 @@ describe("TenantSwitcher", () => {
     };
     mockListAvailableTenants.mockResolvedValue([divergentTenantA, tenantB]);
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     // currentSlug (URL) is "school-a" — must match via subdomain, so the
     // trigger shows the school name, not the raw slug fallback.
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
+    expect(screen.getByText("School A")).toBeInTheDocument();
 
-    // The current tenant must not appear as a switch target.
-    fireEvent.click(screen.getByText("School A"));
-    expect(screen.getAllByText("School A")).toHaveLength(1);
-    expect(screen.getByText("School B")).toBeInTheDocument();
+    // The current tenant must not appear as a switch-target button.
+    openDropdown();
+    expect(
+      screen.queryByRole("button", { name: "School A" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "School B" }),
+    ).toBeInTheDocument();
   });
 
   it("shows a visible error message when switching fails", async () => {
     mockListAvailableTenants.mockResolvedValue([tenantA, tenantB]);
     mockPerformTenantSwitch.mockRejectedValue(new Error("switch failed"));
 
-    render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("School A")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: TRIGGER_LABEL }),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
     fireEvent.click(screen.getByText("School B"));
 
     await waitFor(() => {
@@ -350,24 +446,27 @@ describe("TenantSwitcher", () => {
     });
 
     // Re-opening the dropdown clears the error.
-    fireEvent.click(screen.getByText("School A"));
+    openDropdown();
     expect(
       screen.queryByText(/Wechsel zu School B fehlgeschlagen/),
     ).not.toBeInTheDocument();
   });
 
-  it("logs error when listing tenants fails", async () => {
+  it("falls back to the brand link and logs when listing tenants fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(vi.fn());
     mockListAvailableTenants.mockRejectedValue(new Error("fetch failed"));
 
-    const { container } = render(<TenantSwitcher />);
+    render(<BrandTenantSwitcher label="School A" />);
 
     await waitFor(() => {
       expect(consoleError).toHaveBeenCalled();
     });
 
-    // Should render nothing
-    expect(container.innerHTML).toBe("");
+    // Falls back to the plain brand — never a dropdown
+    expect(
+      screen.queryByRole("button", { name: TRIGGER_LABEL }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("School A")).toBeInTheDocument();
     consoleError.mockRestore();
   });
 });

--- a/frontend/src/components/tenant/tenant-switcher.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import Link from "next/link";
 import { signIn, useSession } from "next-auth/react";
 import { mutate } from "~/lib/swr";
 import {
@@ -13,12 +14,27 @@ import { createLogger } from "~/lib/logger";
 import { trackEvent } from "~/lib/analytics";
 import { env } from "~/env";
 import { Alert } from "~/components/ui/alert";
+import {
+  BrandLink,
+  BrandLogo,
+  brandLabelClass,
+} from "~/components/dashboard/header/brand-link";
 
-const logger = createLogger({ component: "TenantSwitcher" });
+const logger = createLogger({ component: "BrandTenantSwitcher" });
+
+interface BrandTenantSwitcherProps {
+  readonly isScrolled?: boolean;
+  readonly href?: string;
+  readonly label?: string | null;
+}
 
 /**
- * Dropdown component that lets users switch between tenants they have access to.
- * Only renders when the user has more than one available tenant.
+ * Brand area (logo + facility name) that doubles as the tenant switcher.
+ *
+ * With one (or zero) available tenants it renders the plain BrandLink —
+ * name shown, no dropdown. With multiple tenants the brand itself becomes
+ * the dropdown trigger (#2011), replacing the separate switcher element
+ * that used to overflow the header on mobile.
  *
  * Switch flow (per spec 04-frontend.md):
  * 1. Call switchTenant(slug) to get new JWT tokens
@@ -27,7 +43,11 @@ const logger = createLogger({ component: "TenantSwitcher" });
  * 4. Clear session cache for fresh token resolution
  * 5. Hard-navigate to new tenant URL
  */
-export function TenantSwitcher() {
+export function BrandTenantSwitcher({
+  isScrolled = false,
+  href = "/dashboard",
+  label,
+}: BrandTenantSwitcherProps) {
   const [tenants, setTenants] = useState<TenantSummary[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
@@ -106,15 +126,16 @@ export function TenantSwitcher() {
     [isSwitching, currentSlug],
   );
 
-  // Only render when user has multiple tenants
+  // Single (or unknown) tenant: plain brand link, no dropdown
   if (tenants.length <= 1) {
-    return null;
+    return <BrandLink isScrolled={isScrolled} href={href} label={label} />;
   }
 
   // currentSlug comes from the URL, which is the tenant's subdomain — so
   // match against subdomain, not the independent slug column (#1975).
   const currentTenant = tenants.find((t) => t.subdomain === currentSlug);
   const otherTenants = tenants.filter((t) => t.subdomain !== currentSlug);
+  const displayLabel = currentTenant?.name ?? label?.trim() ?? currentSlug;
 
   // Group other tenants by organization
   const grouped = new Map<string, TenantSummary[]>();
@@ -126,8 +147,8 @@ export function TenantSwitcher() {
   }
 
   return (
-    <div ref={dropdownRef} className="relative">
-      {/* Trigger button */}
+    <div ref={dropdownRef} className="relative min-w-0">
+      {/* Brand as trigger */}
       <button
         type="button"
         onClick={() => {
@@ -135,10 +156,14 @@ export function TenantSwitcher() {
           setIsOpen(!isOpen);
         }}
         disabled={isSwitching}
-        className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label="Einrichtung wechseln"
+        className="-mx-1.5 flex max-w-[200px] min-w-0 items-center gap-2 rounded-lg px-1.5 py-1 transition-colors hover:bg-gray-100 disabled:opacity-50 sm:max-w-[260px] lg:max-w-[300px]"
       >
-        <span className="max-w-[140px] truncate">
-          {currentTenant?.name ?? currentSlug}
+        <BrandLogo />
+        <span className={brandLabelClass(isScrolled, true)}>
+          {displayLabel}
         </span>
         <svg
           className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${isOpen ? "rotate-180" : ""}`}
@@ -157,7 +182,29 @@ export function TenantSwitcher() {
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-1 w-64 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+        <div className="absolute left-0 z-50 mt-1 w-64 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+          {currentTenant && (
+            <Link
+              href={href}
+              onClick={() => setIsOpen(false)}
+              className="flex items-center gap-2 border-b border-gray-100 px-3 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50"
+            >
+              <span className="truncate">{currentTenant.name}</span>
+              <svg
+                className="ml-auto h-4 w-4 shrink-0 text-[#83CD2D]"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </Link>
+          )}
           {[...grouped.entries()].map(([orgName, orgTenants]) => (
             <div key={orgName}>
               {grouped.size > 1 && (
@@ -184,7 +231,7 @@ export function TenantSwitcher() {
       {/* Visible feedback when a switch fails — a silent no-op here caused
           #1975 to go unnoticed. */}
       {switchError && !isOpen && (
-        <div className="absolute right-0 z-50 mt-1 w-72">
+        <div className="absolute left-0 z-50 mt-1 w-72">
           <Alert type="error" message={switchError} />
         </div>
       )}


### PR DESCRIPTION
Closes #2011

## Problem
1. On mobile (~375px) the header was wider than the viewport (measured: 514px page width at 375px viewport), because the left brand section had `flex-shrink-0` and the separate `TenantSwitcher` on the right duplicated the facility name. The whole page scrolled horizontally and the profile menu sat off-screen.
2. Descenders (g, j, p, q, y) in the facility name were clipped: the brand label combined `truncate` (overflow-hidden) with `leading-none`, so the line box was smaller than ascent+descent.

## Fix
- **Brand = tenant switcher**: new `BrandTenantSwitcher` (refactored from `TenantSwitcher`). With one (or zero) available tenants it renders the plain `BrandLink` — name shown, no dropdown. With multiple tenants the brand (logo + name + chevron) opens the switch dropdown; the separate right-side switcher element is gone. The current tenant appears at the top of the dropdown as a link home (with a check mark), so the old brand-click-to-dashboard shortcut survives. Switch flow logic (subdomain contract #1975, error alert) is unchanged.
- **Shrinkable left section**: `min-w-0 flex-1` on the left header section, `flex-shrink-0` on the right, truncation on the label — long names truncate instead of widening the page.
- **Descender fix**: `leading-none` → `leading-tight` on the brand label.

## Acceptance criteria (all verified in the browser, local stack, 375x812)
- ✅ No horizontal scrolling on mobile: page scrollWidth 367px at 375px viewport (before: 514px)
- ✅ Tenant switch reachable via the logo/name area; no separate element on the right
- ✅ Single tenant: name shown, no dropdown (verified with a single-tenant admin account)
- ✅ Descenders fully rendered ("Staging Testschule")
- ✅ Long names truncate cleanly
- ✅ Full switch round-trip executed end to end (switch API + redirect to target subdomain)

## Test changes (deliberate, per the issue's acceptance criteria)
`tenant-switcher.test.tsx`: the old component rendered **nothing** for ≤1 tenant; the new behavior (per issue) renders the plain brand link instead. Those render expectations were updated accordingly; the #1975 subdomain-contract regressions, the switch-flow assertions, and the visible-error test keep their original intent. One new test covers the current-tenant entry (link home, never a switch target). `header.test.tsx` mock renamed to match.

## UI-kit note
The dropdown reuses the existing tenant-switcher dropdown markup (relocated trigger) rather than `OverflowMenu`, because `OverflowMenu` renders its own kebab trigger and has no custom-trigger slot — the brand itself must be the trigger here.

## Screenshots
Before/after pairs captured locally (attach manually): `frontend/shots/pair-*.png`
