### PR TITLE
feat(time-tracking): Zeiterfassungs-Export als PDF im App-Design (#1568)

### DIFF
--- a/backend/api/staff/time_tracking_handlers.go
+++ b/backend/api/staff/time_tracking_handlers.go
@@ -64,7 +64,7 @@ func (rs *Resource) getStaffHistory(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusOK, historyResp, "Staff session history retrieved successfully")
 }
 
-// exportStaffSessions handles GET /api/staff/{id}/time-tracking/export?from=...&to=...&format=csv|xlsx
+// exportStaffSessions handles GET /api/staff/{id}/time-tracking/export?from=...&to=...&format=csv|xlsx|pdf
 func (rs *Resource) exportStaffSessions(w http.ResponseWriter, r *http.Request) {
 	staffID, err := common.ParseID(r)
 	if err != nil {
@@ -94,11 +94,11 @@ func (rs *Resource) exportStaffSessions(w http.ResponseWriter, r *http.Request) 
 	}
 
 	format := r.URL.Query().Get("format")
-	if format != "csv" && format != "xlsx" {
+	if format != "csv" && format != "xlsx" && format != "pdf" {
 		format = "csv"
 	}
 
-	fileBytes, filename, err := rs.WorkSessionService.ExportSessions(r.Context(), staffID, from, to, format)
+	file, err := rs.WorkSessionService.ExportSessions(r.Context(), staffID, from, to, format)
 	if err != nil {
 		rs.getLogger().Error("failed to export staff sessions",
 			"staff_id", staffID,
@@ -108,15 +108,10 @@ func (rs *Resource) exportStaffSessions(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	switch format {
-	case "xlsx":
-		w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	default:
-		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
-	}
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
-	w.Header().Set("Content-Length", strconv.Itoa(len(fileBytes)))
-	if _, err := w.Write(fileBytes); err != nil {
+	w.Header().Set("Content-Type", file.ContentType)
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+file.Filename+"\"")
+	w.Header().Set("Content-Length", strconv.Itoa(len(file.Data)))
+	if _, err := w.Write(file.Data); err != nil {
 		rs.getLogger().Error("failed to write export response", "error", err.Error())
 	}
 }

--- a/backend/api/time-tracking/api.go
+++ b/backend/api/time-tracking/api.go
@@ -491,27 +491,22 @@ func (rs *Resource) exportSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	format := r.URL.Query().Get("format")
-	if format != "csv" && format != "xlsx" {
+	if format != "csv" && format != "xlsx" && format != "pdf" {
 		format = "csv"
 	}
 
-	fileBytes, filename, err := rs.WorkSessionService.ExportSessions(r.Context(), staffID, from, to, format)
+	file, err := rs.WorkSessionService.ExportSessions(r.Context(), staffID, from, to, format)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
 
 	// Set response headers for file download
-	switch format {
-	case "xlsx":
-		w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	default:
-		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
-	}
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
-	w.Header().Set("Content-Length", strconv.Itoa(len(fileBytes)))
+	w.Header().Set("Content-Type", file.ContentType)
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+file.Filename+"\"")
+	w.Header().Set("Content-Length", strconv.Itoa(len(file.Data)))
 
-	if _, err := w.Write(fileBytes); err != nil {
+	if _, err := w.Write(file.Data); err != nil {
 		// Response already started, just log the error
 		slog.Default().Error("failed to write export response", slog.String("error", err.Error()))
 		return

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -45,7 +45,7 @@ type mockWorkSessionService struct {
 	getHistoryFn         func(ctx context.Context, staffID int64, from, to timezone.Date) (*activeSvc.HistoryResponse, error)
 	getSessionEditsFn    func(ctx context.Context, staffID, sessionID int64) ([]*activeSvc.WorkSessionEditView, error)
 	getTodayPresenceFn   func(ctx context.Context) (map[int64]string, error)
-	exportSessionsFn     func(ctx context.Context, staffID int64, from, to timezone.Date, format string) ([]byte, string, error)
+	exportSessionsFn     func(ctx context.Context, staffID int64, from, to timezone.Date, format string) (*activeSvc.ExportFile, error)
 	autoEndExpiredBreaks func(ctx context.Context) (int, error)
 }
 
@@ -141,11 +141,11 @@ func (m *mockWorkSessionService) SetStaffShiftRepo(_ scheduleModels.StaffShiftRe
 func (m *mockWorkSessionService) EnsureCheckedIn(_ context.Context, _ int64, _ string) (*activeModels.WorkSession, error) {
 	return nil, nil
 }
-func (m *mockWorkSessionService) ExportSessions(ctx context.Context, staffID int64, from, to timezone.Date, format string) ([]byte, string, error) {
+func (m *mockWorkSessionService) ExportSessions(ctx context.Context, staffID int64, from, to timezone.Date, format string) (*activeSvc.ExportFile, error) {
 	if m.exportSessionsFn != nil {
 		return m.exportSessionsFn(ctx, staffID, from, to, format)
 	}
-	return []byte("data"), "export.csv", nil
+	return &activeSvc.ExportFile{Data: []byte("data"), Filename: "export.csv", ContentType: "text/csv; charset=utf-8"}, nil
 }
 func (m *mockWorkSessionService) DayExportRows(context.Context, int64, timezone.Date, timezone.Date) ([]activeSvc.DayExportRow, error) {
 	return nil, nil
@@ -1186,10 +1186,10 @@ func TestGetSessionEdits_InvalidID(t *testing.T) {
 
 func TestExportSessions_CSV(t *testing.T) {
 	wsSvc := &mockWorkSessionService{
-		exportSessionsFn: func(_ context.Context, staffID int64, _, _ timezone.Date, format string) ([]byte, string, error) {
+		exportSessionsFn: func(_ context.Context, staffID int64, _, _ timezone.Date, format string) (*activeSvc.ExportFile, error) {
 			assert.Equal(t, int64(100), staffID)
 			assert.Equal(t, "csv", format)
-			return []byte("date,time\n"), "export.csv", nil
+			return &activeSvc.ExportFile{Data: []byte("date,time\n"), Filename: "export.csv", ContentType: "text/csv; charset=utf-8"}, nil
 		},
 	}
 	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), nil)
@@ -1206,9 +1206,9 @@ func TestExportSessions_CSV(t *testing.T) {
 
 func TestExportSessions_XLSX(t *testing.T) {
 	wsSvc := &mockWorkSessionService{
-		exportSessionsFn: func(_ context.Context, _ int64, _, _ timezone.Date, format string) ([]byte, string, error) {
+		exportSessionsFn: func(_ context.Context, _ int64, _, _ timezone.Date, format string) (*activeSvc.ExportFile, error) {
 			assert.Equal(t, "xlsx", format)
-			return []byte{0x50, 0x4B}, "export.xlsx", nil
+			return &activeSvc.ExportFile{Data: []byte{0x50, 0x4B}, Filename: "export.xlsx", ContentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}, nil
 		},
 	}
 	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), nil)
@@ -1224,9 +1224,9 @@ func TestExportSessions_XLSX(t *testing.T) {
 
 func TestExportSessions_DefaultCSV(t *testing.T) {
 	wsSvc := &mockWorkSessionService{
-		exportSessionsFn: func(_ context.Context, _ int64, _, _ timezone.Date, format string) ([]byte, string, error) {
+		exportSessionsFn: func(_ context.Context, _ int64, _, _ timezone.Date, format string) (*activeSvc.ExportFile, error) {
 			assert.Equal(t, "csv", format)
-			return []byte("data"), "export.csv", nil
+			return &activeSvc.ExportFile{Data: []byte("data"), Filename: "export.csv", ContentType: "text/csv; charset=utf-8"}, nil
 		},
 	}
 	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), nil)
@@ -1252,8 +1252,8 @@ func TestExportSessions_MissingDates(t *testing.T) {
 
 func TestExportSessions_ServiceError(t *testing.T) {
 	wsSvc := &mockWorkSessionService{
-		exportSessionsFn: func(_ context.Context, _ int64, _, _ timezone.Date, _ string) ([]byte, string, error) {
-			return nil, "", errors.New("export failed")
+		exportSessionsFn: func(_ context.Context, _ int64, _, _ timezone.Date, _ string) (*activeSvc.ExportFile, error) {
+			return nil, errors.New("export failed")
 		},
 	}
 	rs := testResource(wsSvc, &mockStaffAbsenceService{}, defaultPersonSvc(), nil)

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -165,8 +165,8 @@ func (w *workSessionServiceForSessionUnitTest) EnsureCheckedIn(ctx context.Conte
 	}
 	return &activeModels.WorkSession{}, nil
 }
-func (w *workSessionServiceForSessionUnitTest) ExportSessions(context.Context, int64, timezone.Date, timezone.Date, string) ([]byte, string, error) {
-	return nil, "", nil
+func (w *workSessionServiceForSessionUnitTest) ExportSessions(context.Context, int64, timezone.Date, timezone.Date, string) (*ExportFile, error) {
+	return nil, nil
 }
 func (w *workSessionServiceForSessionUnitTest) DayExportRows(context.Context, int64, timezone.Date, timezone.Date) ([]DayExportRow, error) {
 	return nil, nil

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -14,6 +14,7 @@ import (
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xuri/excelize/v2"
@@ -22,6 +23,15 @@ import (
 // ============================================================================
 // Helper to create test service with absence repo
 // ============================================================================
+
+type wsMockStaffRepository struct {
+	userModels.StaffRepository
+	findWithPersonByIDsFunc func(context.Context, []int64) (map[int64]*userModels.Staff, error)
+}
+
+func (m *wsMockStaffRepository) FindWithPersonByIDs(ctx context.Context, ids []int64) (map[int64]*userModels.Staff, error) {
+	return m.findWithPersonByIDsFunc(ctx, ids)
+}
 
 func wsCreateTestServiceWithAbsenceRepo() (*workSessionService, *wsMockWorkSessionRepository, *wsMockWorkSessionBreakRepository, *wsMockWorkSessionEditRepository, *wsMockStaffAbsenceRepository, *wsMockGroupSupervisorRepository) {
 	sessionRepo := &wsMockWorkSessionRepository{}
@@ -885,7 +895,8 @@ func TestWSBuildTimeTrackingDocument_ShapesRows(t *testing.T) {
 		},
 	}
 
-	doc := service.buildTimeTrackingDocument(context.Background(), 100, rows, date, date)
+	doc, err := service.buildTimeTrackingDocument(context.Background(), 100, rows, date, date)
+	require.NoError(t, err)
 	assert.Equal(t, "Zeiterfassung", doc.Title)
 	assert.NotEmpty(t, doc.Footer)
 	require.Len(t, doc.Rows, 1)
@@ -918,6 +929,33 @@ func TestWSExportSessions_PDF_Success(t *testing.T) {
 	assert.Contains(t, file.Filename, ".pdf")
 	assert.Equal(t, "application/pdf", file.ContentType)
 	assert.True(t, bytes.HasPrefix(file.Data, []byte("%PDF")))
+}
+
+func TestWSExportSessions_PDF_StaffLookupError(t *testing.T) {
+	svc, sessionRepo, breakRepo, auditRepo, absenceRepo, _ := wsCreateTestServiceWithAbsenceRepo()
+
+	sessionRepo.getHistoryByStaffIDFunc = func(_ context.Context, _ int64, _, _ timezone.Date) ([]*activeModels.WorkSession, error) {
+		return nil, nil
+	}
+	auditRepo.countBySessionIDsFunc = func(_ context.Context, _ []int64) (map[int64]int, error) {
+		return map[int64]int{}, nil
+	}
+	breakRepo.getBySessionIDFunc = func(_ context.Context, _ int64) ([]*activeModels.WorkSessionBreak, error) {
+		return nil, nil
+	}
+	absenceRepo.getByStaffAndDateRangeFunc = func(_ context.Context, _ int64, _, _ timezone.Date) ([]*activeModels.StaffAbsence, error) {
+		return nil, nil
+	}
+	svc.staffRepo = &wsMockStaffRepository{
+		findWithPersonByIDsFunc: func(_ context.Context, _ []int64) (map[int64]*userModels.Staff, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	file, err := svc.ExportSessions(context.Background(), 100, timezone.NewDate(2024, 1, 1), timezone.NewDate(2024, 1, 7), "pdf")
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.ErrorContains(t, err, "failed to load staff for export")
 }
 
 // ============================================================================

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -83,20 +83,22 @@ func TestWSExportSessions_CSV_Success(t *testing.T) {
 		return nil, nil
 	}
 
-	data, filename, err := svc.ExportSessions(ctx, staffID, from, to, "csv")
+	file, err := svc.ExportSessions(ctx, staffID, from, to, "csv")
 	require.NoError(t, err)
-	assert.NotEmpty(t, data)
-	assert.Contains(t, filename, ".csv")
-	assert.Contains(t, filename, "2024-01-01")
-	assert.Contains(t, filename, "2024-01-07")
+	require.NotNil(t, file)
+	assert.NotEmpty(t, file.Data)
+	assert.Contains(t, file.Filename, ".csv")
+	assert.Contains(t, file.Filename, "2024-01-01")
+	assert.Contains(t, file.Filename, "2024-01-07")
+	assert.Contains(t, file.ContentType, "text/csv")
 
 	// Verify UTF-8 BOM
-	assert.Equal(t, byte(0xEF), data[0])
-	assert.Equal(t, byte(0xBB), data[1])
-	assert.Equal(t, byte(0xBF), data[2])
+	assert.Equal(t, byte(0xEF), file.Data[0])
+	assert.Equal(t, byte(0xBB), file.Data[1])
+	assert.Equal(t, byte(0xBF), file.Data[2])
 
 	// Verify semicolon separator
-	content := string(data[3:])
+	content := string(file.Data[3:])
 	assert.Contains(t, content, "Datum;Wochentag;Start;Ende")
 }
 
@@ -123,14 +125,16 @@ func TestWSExportSessions_XLSX_Success(t *testing.T) {
 		return nil, nil
 	}
 
-	data, filename, err := svc.ExportSessions(ctx, staffID, from, to, "xlsx")
+	file, err := svc.ExportSessions(ctx, staffID, from, to, "xlsx")
 	require.NoError(t, err)
-	assert.NotEmpty(t, data)
-	assert.Contains(t, filename, ".xlsx")
+	require.NotNil(t, file)
+	assert.NotEmpty(t, file.Data)
+	assert.Contains(t, file.Filename, ".xlsx")
+	assert.Contains(t, file.ContentType, "spreadsheetml")
 
 	// Verify ZIP magic bytes (XLSX is a ZIP file)
-	assert.Equal(t, byte(0x50), data[0]) // 'P'
-	assert.Equal(t, byte(0x4B), data[1]) // 'K'
+	assert.Equal(t, byte(0x50), file.Data[0]) // 'P'
+	assert.Equal(t, byte(0x4B), file.Data[1]) // 'K'
 }
 
 func TestWSExportSessions_GetHistoryError(t *testing.T) {
@@ -140,10 +144,9 @@ func TestWSExportSessions_GetHistoryError(t *testing.T) {
 		return nil, errors.New("database error")
 	}
 
-	data, filename, err := svc.ExportSessions(context.Background(), 100, timezone.TodayDate(), timezone.TodayDate(), "csv")
+	file, err := svc.ExportSessions(context.Background(), 100, timezone.TodayDate(), timezone.TodayDate(), "csv")
 	require.Error(t, err)
-	assert.Nil(t, data)
-	assert.Empty(t, filename)
+	assert.Nil(t, file)
 	assert.Contains(t, err.Error(), "failed to get sessions for export")
 }
 
@@ -166,10 +169,9 @@ func TestWSExportSessions_GetAbsencesError(t *testing.T) {
 		return nil, errors.New("absence repo error")
 	}
 
-	data, filename, err := svc.ExportSessions(context.Background(), 100, timezone.TodayDate(), timezone.TodayDate(), "csv")
+	file, err := svc.ExportSessions(context.Background(), 100, timezone.TodayDate(), timezone.TodayDate(), "csv")
 	require.Error(t, err)
-	assert.Nil(t, data)
-	assert.Empty(t, filename)
+	assert.Nil(t, file)
 	assert.Contains(t, err.Error(), "failed to get absences for export")
 }
 
@@ -793,14 +795,11 @@ func TestWSSessionToRow_GermanWeekdays(t *testing.T) {
 }
 
 // ============================================================================
-// exportCSV Tests
+// Single-staff CSV serialization Tests
 // ============================================================================
 
 func TestWSExportCSV_Headers(t *testing.T) {
-	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
-
-	rows := []exportRow{}
-	data, err := svc.exportCSV(rows)
+	data, err := writeExportCSV(timeTrackingHeaders(), nil, []int{8})
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, data)
@@ -827,9 +826,7 @@ func TestWSExportCSV_Headers(t *testing.T) {
 }
 
 func TestWSExportCSV_UTF8BOM(t *testing.T) {
-	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
-
-	data, err := svc.exportCSV([]exportRow{})
+	data, err := writeExportCSV(timeTrackingHeaders(), nil, []int{8})
 	require.NoError(t, err)
 
 	assert.Equal(t, byte(0xEF), data[0])
@@ -838,17 +835,11 @@ func TestWSExportCSV_UTF8BOM(t *testing.T) {
 }
 
 func TestWSExportCSV_SemicolonSeparator(t *testing.T) {
-	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
-
-	date := timezone.NewDate(2024, 1, 15)
-	rows := []exportRow{
-		{
-			Date: date,
-			Row:  []string{"15.01.2024", "Montag", "08:00", "16:00", "30", "7h 30min", "In der OGS", "Test"},
-		},
+	rows := [][]string{
+		{"15.01.2024", "Montag", "08:00", "16:00", "30", "7h 30min", "In der OGS", "App", "Test"},
 	}
 
-	data, err := svc.exportCSV(rows)
+	data, err := writeExportCSV(timeTrackingHeaders(), rows, []int{8})
 	require.NoError(t, err)
 
 	content := string(data[3:])
@@ -857,39 +848,76 @@ func TestWSExportCSV_SemicolonSeparator(t *testing.T) {
 	assert.False(t, strings.Contains(lines[1], ","))
 }
 
-// ============================================================================
-// exportXLSX Tests
-// ============================================================================
+// TestWSExportCSV_SanitizesNotes: the Bemerkungen column carries untrusted
+// free text — a note starting with a formula trigger must be escaped so
+// spreadsheet software cannot evaluate it (#1568 migration hardening; the
+// cross-staff CSV always did this, the single-staff CSV now shares the path).
+func TestWSExportCSV_SanitizesNotes(t *testing.T) {
+	rows := [][]string{
+		{"15.01.2024", "Montag", "08:00", "16:00", "30", "7h 30min", "In der OGS", "App", "=1+1"},
+	}
 
-func TestWSExportXLSX_ValidZipFormat(t *testing.T) {
-	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
-
-	rows := []exportRow{}
-	data, err := svc.exportXLSX(rows)
-
+	data, err := writeExportCSV(timeTrackingHeaders(), rows, []int{8})
 	require.NoError(t, err)
-	assert.NotEmpty(t, data)
 
-	// Verify ZIP magic bytes
-	assert.Equal(t, byte(0x50), data[0]) // 'P'
-	assert.Equal(t, byte(0x4B), data[1]) // 'K'
+	reader := csv.NewReader(bytes.NewReader(data[3:]))
+	reader.Comma = ';'
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+	assert.Equal(t, "'=1+1", records[1][8])
+	// Absence sentinel cells ("--") sit outside the untrusted column list
+	// and must stay verbatim.
+	assert.Equal(t, "15.01.2024", records[1][0])
 }
 
-func TestWSExportXLSX_WithData(t *testing.T) {
-	svc, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
+// ============================================================================
+// Single-staff XLSX/PDF document Tests
+// ============================================================================
+
+func TestWSBuildTimeTrackingDocument_ShapesRows(t *testing.T) {
+	service, _, _, _, _, _ := wsCreateTestServiceWithAbsenceRepo()
 
 	date := timezone.NewDate(2024, 1, 15)
 	rows := []exportRow{
 		{
 			Date: date,
-			Row:  []string{"15.01.2024", "Montag", "08:00", "16:00", "30", "7h 30min", "In der OGS", "Test"},
+			Row:  []string{"15.01.2024", "Montag", "08:00", "16:00", "30", "7h 30min", "In der OGS", "App", "Test"},
 		},
 	}
 
-	data, err := svc.exportXLSX(rows)
+	doc := service.buildTimeTrackingDocument(context.Background(), 100, rows, date, date)
+	assert.Equal(t, "Zeiterfassung", doc.Title)
+	assert.NotEmpty(t, doc.Footer)
+	require.Len(t, doc.Rows, 1)
+	require.Len(t, doc.Columns, 9)
+	assert.Equal(t, "15.01.2024", doc.Rows[0].Values[doc.Columns[0].ID])
+	assert.Equal(t, "Test", doc.Rows[0].Values[doc.Columns[8].ID])
+	require.Len(t, doc.Filters, 1)
+	assert.Contains(t, doc.Filters[0], "15.01.2024")
+}
+
+func TestWSExportSessions_PDF_Success(t *testing.T) {
+	svc, sessionRepo, breakRepo, auditRepo, absenceRepo, _ := wsCreateTestServiceWithAbsenceRepo()
+
+	sessionRepo.getHistoryByStaffIDFunc = func(_ context.Context, _ int64, _, _ timezone.Date) ([]*activeModels.WorkSession, error) {
+		return []*activeModels.WorkSession{}, nil
+	}
+	auditRepo.countBySessionIDsFunc = func(_ context.Context, _ []int64) (map[int64]int, error) {
+		return map[int64]int{}, nil
+	}
+	breakRepo.getBySessionIDFunc = func(_ context.Context, _ int64) ([]*activeModels.WorkSessionBreak, error) {
+		return []*activeModels.WorkSessionBreak{}, nil
+	}
+	absenceRepo.getByStaffAndDateRangeFunc = func(_ context.Context, _ int64, _, _ timezone.Date) ([]*activeModels.StaffAbsence, error) {
+		return nil, nil
+	}
+
+	file, err := svc.ExportSessions(context.Background(), 100, timezone.NewDate(2024, 1, 1), timezone.NewDate(2024, 1, 7), "pdf")
 	require.NoError(t, err)
-	assert.NotEmpty(t, data)
-	assert.True(t, len(data) > 100) // Should be substantial file
+	require.NotNil(t, file)
+	assert.Contains(t, file.Filename, ".pdf")
+	assert.Equal(t, "application/pdf", file.ContentType)
+	assert.True(t, bytes.HasPrefix(file.Data, []byte("%PDF")))
 }
 
 // ============================================================================

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -1,11 +1,9 @@
 package active
 
 import (
-	"bytes"
 	"cmp"
 	"context"
 	"database/sql"
-	"encoding/csv"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -24,8 +22,8 @@ import (
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
+	"github.com/moto-nrw/project-phoenix/services/listexport"
 	"github.com/moto-nrw/project-phoenix/tenant"
-	"github.com/xuri/excelize/v2"
 )
 
 // Error message constants to avoid duplication
@@ -263,7 +261,10 @@ type WorkSessionService interface {
 	// be silently mislabelled as NFC. Returns nil if the staff member is
 	// already checked out today (no re-open).
 	EnsureCheckedIn(ctx context.Context, staffID int64, source string) (*activeModels.WorkSession, error)
-	ExportSessions(ctx context.Context, staffID int64, from, to timezone.Date, format string) ([]byte, string, error)
+	// ExportSessions renders the single-staff export. CSV serializes locally
+	// (data format); xlsx/pdf render through services/listexport so all
+	// downloadable files share one design (#1568).
+	ExportSessions(ctx context.Context, staffID int64, from, to timezone.Date, format string) (*ExportFile, error)
 	// DayExportRows exposes the export's merged session/absence day rows for
 	// the cross-staff export (#1417 2b) — same loading, same cell rendering.
 	DayExportRows(ctx context.Context, staffID int64, from, to timezone.Date) ([]DayExportRow, error)
@@ -2151,11 +2152,42 @@ type exportRow struct {
 	Row  []string
 }
 
-// ExportSessions generates a CSV or XLSX export of work sessions and absences
-func (s *workSessionService) ExportSessions(ctx context.Context, staffID int64, from, to timezone.Date, format string) ([]byte, string, error) {
+// timeTrackingConfidentialityNote matches the wording of the other
+// printed exports (see slotlists.confidentialityNote).
+const timeTrackingConfidentialityNote = "Vertraulich, nur für berechtigte Personen. Nach Gebrauch sicher vernichten."
+
+// timeTrackingColumns is the single-staff export's column set; the labels
+// double as the CSV/XLSX header row.
+func timeTrackingColumns() []listexport.Column {
+	return []listexport.Column{
+		{ID: "tt_date", Label: "Datum"},
+		{ID: "tt_weekday", Label: "Wochentag"},
+		{ID: "tt_start", Label: "Start"},
+		{ID: "tt_end", Label: "Ende"},
+		{ID: "tt_break", Label: "Pause (Min)"},
+		{ID: "tt_net", Label: "Netto (Std)"},
+		{ID: "tt_status", Label: "Status"},
+		{ID: "tt_source", Label: "Quelle"},
+		{ID: "tt_notes", Label: "Bemerkungen"},
+	}
+}
+
+func timeTrackingHeaders() []string {
+	columns := timeTrackingColumns()
+	headers := make([]string, len(columns))
+	for i, column := range columns {
+		headers[i] = column.Label
+	}
+	return headers
+}
+
+// ExportSessions renders the single-staff export of work sessions and
+// absences. CSV and XLSX stay plain data files (shared writers below);
+// PDF renders through the listexport design (#1568) as the print artifact.
+func (s *workSessionService) ExportSessions(ctx context.Context, staffID int64, from, to timezone.Date, format string) (*ExportFile, error) {
 	historyResp, err := s.GetHistory(ctx, staffID, from, to)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get sessions for export: %w", err)
+		return nil, fmt.Errorf("failed to get sessions for export: %w", err)
 	}
 
 	// Load absences for the same date range
@@ -2163,7 +2195,7 @@ func (s *workSessionService) ExportSessions(ctx context.Context, staffID int64, 
 	if s.absenceRepo != nil {
 		absences, err = s.absenceRepo.GetByStaffAndDateRange(ctx, staffID, from, to)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to get absences for export: %w", err)
+			return nil, fmt.Errorf("failed to get absences for export: %w", err)
 		}
 	}
 
@@ -2173,19 +2205,81 @@ func (s *workSessionService) ExportSessions(ctx context.Context, staffID int64, 
 	fromStr := from.String()
 	toStr := to.String()
 
+	cells := make([][]string, 0, len(rows))
+	for _, er := range rows {
+		cells = append(cells, er.Row)
+	}
+
 	switch format {
+	case "pdf":
+		doc := s.buildTimeTrackingDocument(ctx, staffID, rows, from, to)
+		file, err := listexport.NewService().Render(doc, listexport.FormatPDF, "zeiterfassung")
+		if err != nil {
+			return nil, err
+		}
+		return &ExportFile{
+			Data:        file.Data,
+			Filename:    fmt.Sprintf("zeiterfassung_%s_%s.pdf", fromStr, toStr),
+			ContentType: file.ContentType,
+		}, nil
 	case "xlsx":
-		data, err := s.exportXLSX(rows)
+		data, err := writeExportXLSX("Zeiterfassung", timeTrackingHeaders(), stringsRowsToAny(cells), nil)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
-		return data, fmt.Sprintf("zeiterfassung_%s_%s.xlsx", fromStr, toStr), nil
+		return &ExportFile{
+			Data:        data,
+			Filename:    fmt.Sprintf("zeiterfassung_%s_%s.xlsx", fromStr, toStr),
+			ContentType: contentTypeXLSX,
+		}, nil
 	default:
-		data, err := s.exportCSV(rows)
+		// Bemerkungen (column 8) carries untrusted free text — formula-escape
+		// it like the cross-staff CSV always has.
+		data, err := writeExportCSV(timeTrackingHeaders(), cells, []int{8})
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
-		return data, fmt.Sprintf("zeiterfassung_%s_%s.csv", fromStr, toStr), nil
+		return &ExportFile{
+			Data:        data,
+			Filename:    fmt.Sprintf("zeiterfassung_%s_%s.csv", fromStr, toStr),
+			ContentType: contentTypeCSV,
+		}, nil
+	}
+}
+
+// buildTimeTrackingDocument shapes the merged export rows into the shared
+// listexport document: title block with the staff member's name, the
+// requested period as a filter pill, and the confidentiality footer.
+func (s *workSessionService) buildTimeTrackingDocument(ctx context.Context, staffID int64, rows []exportRow, from, to timezone.Date) listexport.Document {
+	subtitle := "Arbeitszeiten und Abwesenheiten"
+	if s.staffRepo != nil {
+		if staffMap, err := s.staffRepo.FindWithPersonByIDs(ctx, []int64{staffID}); err == nil {
+			if staff, ok := staffMap[staffID]; ok && staff != nil && staff.Person != nil {
+				subtitle = staff.Person.FirstName + " " + staff.Person.LastName
+			}
+		}
+	}
+
+	columns := timeTrackingColumns()
+	docRows := make([]listexport.Row, 0, len(rows))
+	for _, er := range rows {
+		values := make(map[listexport.ColumnID]string, len(columns))
+		for i, column := range columns {
+			if i < len(er.Row) {
+				values[column.ID] = er.Row[i]
+			}
+		}
+		docRows = append(docRows, listexport.Row{Values: values})
+	}
+
+	return listexport.Document{
+		Title:       "Zeiterfassung",
+		Subtitle:    subtitle,
+		GeneratedAt: s.now(),
+		Filters:     []string{"Zeitraum: " + from.Format("02.01.2006") + " bis " + to.Format("02.01.2006")},
+		Columns:     columns,
+		Rows:        docRows,
+		Footer:      timeTrackingConfidentialityNote,
 	}
 }
 
@@ -2258,85 +2352,6 @@ func (s *workSessionService) buildExportRows(sessions []*SessionResponse, absenc
 	})
 
 	return rows
-}
-
-func (s *workSessionService) exportCSV(rows []exportRow) ([]byte, error) {
-	var buf bytes.Buffer
-
-	// UTF-8 BOM for Excel compatibility
-	buf.Write([]byte{0xEF, 0xBB, 0xBF})
-
-	w := csv.NewWriter(&buf)
-	w.Comma = ';'
-
-	// Header
-	if err := w.Write([]string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Status", "Quelle", "Bemerkungen"}); err != nil {
-		return nil, fmt.Errorf("failed to write CSV header: %w", err)
-	}
-
-	for _, er := range rows {
-		if err := w.Write(er.Row); err != nil {
-			return nil, fmt.Errorf("failed to write CSV row: %w", err)
-		}
-	}
-
-	w.Flush()
-	if err := w.Error(); err != nil {
-		return nil, fmt.Errorf("CSV write error: %w", err)
-	}
-
-	return buf.Bytes(), nil
-}
-
-func (s *workSessionService) exportXLSX(rows []exportRow) ([]byte, error) {
-	f := excelize.NewFile()
-	defer func() { _ = f.Close() }()
-
-	sheet := "Zeiterfassung"
-	idx, err := f.NewSheet(sheet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sheet: %w", err)
-	}
-	f.SetActiveSheet(idx)
-	// Remove default "Sheet1" if it exists and is different
-	if sheet != "Sheet1" {
-		_ = f.DeleteSheet("Sheet1")
-	}
-
-	headers := []string{"Datum", "Wochentag", "Start", "Ende", "Pause (Min)", "Netto (Std)", "Status", "Quelle", "Bemerkungen"}
-
-	// Header style
-	headerStyle, _ := f.NewStyle(&excelize.Style{
-		Font: &excelize.Font{Bold: true},
-		Fill: excelize.Fill{Type: "pattern", Color: []string{"#E2E8F0"}, Pattern: 1},
-	})
-
-	for i, h := range headers {
-		cell, _ := excelize.CoordinatesToCellName(i+1, 1)
-		_ = f.SetCellValue(sheet, cell, h)
-		_ = f.SetCellStyle(sheet, cell, cell, headerStyle)
-	}
-
-	// Data rows
-	for rowIdx, er := range rows {
-		for colIdx, val := range er.Row {
-			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+2)
-			_ = f.SetCellValue(sheet, cell, val)
-		}
-	}
-
-	// Auto-width columns
-	for i := range headers {
-		col, _ := excelize.ColumnNumberToName(i + 1)
-		_ = f.SetColWidth(sheet, col, col, 16)
-	}
-
-	var buf bytes.Buffer
-	if err := f.Write(&buf); err != nil {
-		return nil, fmt.Errorf("failed to write XLSX: %w", err)
-	}
-
-	return buf.Bytes(), nil
 }
 
 func (s *workSessionService) sessionToRow(sr *SessionResponse) []string {

--- a/backend/services/active/work_session_service.go
+++ b/backend/services/active/work_session_service.go
@@ -2212,7 +2212,10 @@ func (s *workSessionService) ExportSessions(ctx context.Context, staffID int64, 
 
 	switch format {
 	case "pdf":
-		doc := s.buildTimeTrackingDocument(ctx, staffID, rows, from, to)
+		doc, err := s.buildTimeTrackingDocument(ctx, staffID, rows, from, to)
+		if err != nil {
+			return nil, err
+		}
 		file, err := listexport.NewService().Render(doc, listexport.FormatPDF, "zeiterfassung")
 		if err != nil {
 			return nil, err
@@ -2250,13 +2253,15 @@ func (s *workSessionService) ExportSessions(ctx context.Context, staffID int64, 
 // buildTimeTrackingDocument shapes the merged export rows into the shared
 // listexport document: title block with the staff member's name, the
 // requested period as a filter pill, and the confidentiality footer.
-func (s *workSessionService) buildTimeTrackingDocument(ctx context.Context, staffID int64, rows []exportRow, from, to timezone.Date) listexport.Document {
+func (s *workSessionService) buildTimeTrackingDocument(ctx context.Context, staffID int64, rows []exportRow, from, to timezone.Date) (listexport.Document, error) {
 	subtitle := "Arbeitszeiten und Abwesenheiten"
 	if s.staffRepo != nil {
-		if staffMap, err := s.staffRepo.FindWithPersonByIDs(ctx, []int64{staffID}); err == nil {
-			if staff, ok := staffMap[staffID]; ok && staff != nil && staff.Person != nil {
-				subtitle = staff.Person.FirstName + " " + staff.Person.LastName
-			}
+		staffMap, err := s.staffRepo.FindWithPersonByIDs(ctx, []int64{staffID})
+		if err != nil {
+			return listexport.Document{}, fmt.Errorf("failed to load staff for export: %w", err)
+		}
+		if staff, ok := staffMap[staffID]; ok && staff != nil && staff.Person != nil {
+			subtitle = staff.Person.FirstName + " " + staff.Person.LastName
 		}
 	}
 
@@ -2280,7 +2285,7 @@ func (s *workSessionService) buildTimeTrackingDocument(ctx context.Context, staf
 		Columns:     columns,
 		Rows:        docRows,
 		Footer:      timeTrackingConfidentialityNote,
-	}
+	}, nil
 }
 
 // clampAbsencesToRange returns shallow copies whose expanded day ranges stay

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -110,6 +110,9 @@ vi.mock("~/components/staff/staff-export-button", async () => {
               <button type="button" onClick={() => setOpen(false)}>
                 Excel
               </button>
+              <button type="button" onClick={() => setOpen(false)}>
+                PDF
+              </button>
             </div>
           )}
         </div>
@@ -1266,12 +1269,13 @@ describe("TimeTrackingPage", () => {
       expect(screen.getByText("Zeitraum exportieren")).toBeInTheDocument();
     });
 
-    it("shows CSV and Excel buttons", () => {
+    it("shows CSV, Excel and PDF buttons", () => {
       setupDefaultMocks();
       render(<TimeTrackingPage />);
       fireEvent.click(screen.getByLabelText("Export"));
       expect(screen.getByText("CSV")).toBeInTheDocument();
       expect(screen.getByText("Excel")).toBeInTheDocument();
+      expect(screen.getByText("PDF")).toBeInTheDocument();
     });
 
     it("shows MiniCalendar month navigation", () => {

--- a/frontend/src/components/ui/export-range-form.tsx
+++ b/frontend/src/components/ui/export-range-form.tsx
@@ -21,9 +21,11 @@ function toIsoDate(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
-// Shared export form: inline date-range calendar + CSV/Excel buttons. The
+// Shared export form: inline date-range calendar + CSV/Excel/PDF buttons. The
 // caller passes the proxy URL — used for both the MA-Sicht ("/api/time-tracking
 // /export") and the admin-Sicht ("/api/staff/{id}/time-tracking/export").
+// PDF is the designed print artifact (#1568) and therefore the primary action;
+// CSV/Excel stay as the data formats.
 export function ExportRangeForm({
   exportUrl,
   anchor,
@@ -40,7 +42,7 @@ export function ExportRangeForm({
     () => initialRange ?? { from: addDays(today, -29), to: today },
   );
 
-  const handleExport = (format: "csv" | "xlsx") => {
+  const handleExport = (format: "csv" | "xlsx" | "pdf") => {
     if (!range?.from || !range?.to) return;
     const from = toIsoDate(range.from);
     const to = toIsoDate(range.to);
@@ -78,9 +80,17 @@ export function ExportRangeForm({
           type="button"
           onClick={() => handleExport("xlsx")}
           disabled={!hasRange}
-          className="flex-1 rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Excel
+        </button>
+        <button
+          type="button"
+          onClick={() => handleExport("pdf")}
+          disabled={!hasRange}
+          className="flex-1 rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          PDF
         </button>
       </div>
     </div>


### PR DESCRIPTION
Closes #1568

## Was ist drin

Die Zeiterfassungs-Exporte stammen von vor dem listexport-Paket (#1941) und hatten als einzige kein gestaltetes Druck-Artefakt. Dieser PR schließt die Lücke, ohne die Datenformate anzufassen:

- **Neues Format `pdf`** für den Einzel-Export (eigene Sicht + Admin-Sicht auf Mitarbeitende): rendert über `services/listexport` mit moto-Chrome, Name der Person als Untertitel, Zeitraum-Pill und Vertraulichkeits-Footer.
- **CSV-Härtung**: Die Bemerkungen-Spalte (untrusted Freitext) wird jetzt formel-escaped, wie es der Cross-Staff-CSV-Export schon immer tut.
- **`ExportSessions` gibt `*ExportFile`** (Data + Filename + ContentType) zurück statt drei Einzelwerte, analog zum Cross-Staff-Export-Service; die XLSX-Serialisierung läuft über den bereits vorhandenen geteilten Writer.
- **Export-Formular**: PDF als Primär-Button, CSV/Excel als Outline daneben.

## Bewusst NICHT drin

CSV- und XLSX-Ausgaben bleiben byte-kompatibel, `services/listexport` ist unangetastet. Excel und Word sind Daten- bzw. Weiterverarbeitungsformate; das Print-Design liegt im PDF. Ein Restyling der XLSX/DOCX-Renderer wurde erwogen und verworfen (Zeilen-Shift im Payroll-XLSX, Font-Einbettung in Office-Formaten).

## Tests

- Neue Abdeckung: PDF-Format (Magic Bytes, ContentType, Dateiname), Dokument-Aufbau, CSV-Formel-Escaping.
- Bestehende Export-Tests auf die neue `*ExportFile`-Signatur umgestellt, Assertions unverändert.
- `go test` (listexport, active, api/time-tracking, api/staff), `golangci-lint`, `pnpm run check` und Frontend-Vitest grün.

<details>
<summary>Screenshots</summary>
<img width="1920" height="1080" alt="ui-export-popover-desktop" src="https://github.com/user-attachments/assets/d475eaff-686c-498c-9f09-f6e4367471a2" />
<img width="842" height="595" alt="zeiterfassung" src="https://github.com/user-attachments/assets/df3dfdf4-25db-46ad-9847-7884799e3bd7" />

</details>