### PR TITLE
refactor(notifications): deduplicate web push plumbing

### DIFF
--- a/backend/api/notifications/push_handlers.go
+++ b/backend/api/notifications/push_handlers.go
@@ -1,14 +1,19 @@
 package notifications
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 
-	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 )
+
+// The Handle* functions below are shared with the parent portal
+// (api/parent/push_handlers.go): both portals speak the same wire format and
+// differ only in which PushSubscriptionService methods they bind.
 
 // pushSubscriptionRequest mirrors the browser's PushSubscription JSON.
 type pushSubscriptionRequest struct {
@@ -19,8 +24,7 @@ type pushSubscriptionRequest struct {
 	} `json:"keys"`
 }
 
-// Bind implements render.Binder.
-func (req *pushSubscriptionRequest) Bind(_ *http.Request) error {
+func (req *pushSubscriptionRequest) validate() error {
 	if req.Endpoint == "" {
 		return errors.New("endpoint is required")
 	}
@@ -30,9 +34,9 @@ func (req *pushSubscriptionRequest) Bind(_ *http.Request) error {
 	return nil
 }
 
-// getPushPublicKey returns the VAPID public key the browser subscribes with.
-func (rs *Resource) getPushPublicKey(w http.ResponseWriter, r *http.Request) {
-	key, err := rs.PushService.PublicKey()
+// HandlePushPublicKey serves the VAPID public key the browser subscribes with.
+func HandlePushPublicKey(w http.ResponseWriter, r *http.Request, service notificationsService.PushSubscriptionService) {
+	key, err := service.PublicKey()
 	if errors.Is(err, notificationsService.ErrWebPushNotConfigured) {
 		common.RenderError(w, r, common.ErrorNotFound(err))
 		return
@@ -40,16 +44,25 @@ func (rs *Resource) getPushPublicKey(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusOK, map[string]string{"public_key": key}, "")
 }
 
-// subscribePush registers (or refreshes) the caller's device for Web Push.
-func (rs *Resource) subscribePush(w http.ResponseWriter, r *http.Request) {
+// HandleSubscribePush parses the browser subscription and persists it via the
+// portal-specific subscribe function (staff Subscribe / parent SubscribeParent).
+func HandleSubscribePush(
+	w http.ResponseWriter,
+	r *http.Request,
+	accountID int64,
+	subscribe func(ctx context.Context, accountID int64, input notificationsService.PushSubscriptionInput) error,
+) {
 	r.Body = http.MaxBytesReader(w, r.Body, 8<<10)
-	req := &pushSubscriptionRequest{}
-	if err := render.Bind(r, req); err != nil {
+	req := pushSubscriptionRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}
-	claims := jwt.ClaimsFromCtx(r.Context())
-	err := rs.PushService.Subscribe(r.Context(), int64(claims.ID), notificationsService.PushSubscriptionInput{
+	if err := req.validate(); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	err := subscribe(r.Context(), accountID, notificationsService.PushSubscriptionInput{
 		Endpoint:  req.Endpoint,
 		P256dh:    req.Keys.P256dh,
 		Auth:      req.Keys.Auth,
@@ -58,30 +71,46 @@ func (rs *Resource) subscribePush(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case errors.Is(err, notificationsService.ErrWebPushNotConfigured):
 		common.RenderError(w, r, common.ErrorConflict(err))
-		return
 	case errors.Is(err, notificationsService.ErrInvalidPushSubscription):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		return
 	case err != nil:
 		common.RenderError(w, r, common.ErrorInternalServerWrap("Push-Registrierung konnte nicht gespeichert werden.", err))
-		return
+	default:
+		common.Respond(w, r, http.StatusNoContent, nil, "")
 	}
-	common.Respond(w, r, http.StatusNoContent, nil, "")
 }
 
-// unsubscribePush removes the caller's device registration (best effort).
-// The endpoint travels as a query parameter because DELETE bodies don't
-// survive every proxy layer.
-func (rs *Resource) unsubscribePush(w http.ResponseWriter, r *http.Request) {
+// HandleUnsubscribePush removes the caller's device registration (best
+// effort). The endpoint travels as a query parameter because DELETE bodies
+// don't survive every proxy layer.
+func HandleUnsubscribePush(
+	w http.ResponseWriter,
+	r *http.Request,
+	accountID int64,
+	unsubscribe func(ctx context.Context, accountID int64, endpoint string) error,
+) {
 	endpoint := r.URL.Query().Get("endpoint")
 	if endpoint == "" {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("endpoint query parameter is required")))
 		return
 	}
-	claims := jwt.ClaimsFromCtx(r.Context())
-	if err := rs.PushService.Unsubscribe(r.Context(), int64(claims.ID), endpoint); err != nil {
+	if err := unsubscribe(r.Context(), accountID, endpoint); err != nil {
 		common.RenderError(w, r, common.ErrorInternalServerWrap("Push-Registrierung konnte nicht entfernt werden.", err))
 		return
 	}
 	common.Respond(w, r, http.StatusNoContent, nil, "")
+}
+
+func (rs *Resource) getPushPublicKey(w http.ResponseWriter, r *http.Request) {
+	HandlePushPublicKey(w, r, rs.PushService)
+}
+
+func (rs *Resource) subscribePush(w http.ResponseWriter, r *http.Request) {
+	claims := jwt.ClaimsFromCtx(r.Context())
+	HandleSubscribePush(w, r, int64(claims.ID), rs.PushService.Subscribe)
+}
+
+func (rs *Resource) unsubscribePush(w http.ResponseWriter, r *http.Request) {
+	claims := jwt.ClaimsFromCtx(r.Context())
+	HandleUnsubscribePush(w, r, int64(claims.ID), rs.PushService.Unsubscribe)
 }

--- a/backend/api/parent/push_handlers.go
+++ b/backend/api/parent/push_handlers.go
@@ -1,32 +1,20 @@
 package parent
 
 import (
-	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
+	notificationsAPI "github.com/moto-nrw/project-phoenix/api/notifications"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
-	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 )
 
-// pushSubscriptionRequest mirrors the browser's PushSubscription JSON.
-type pushSubscriptionRequest struct {
-	Endpoint string `json:"endpoint"`
-	Keys     struct {
-		P256dh string `json:"p256dh"`
-		Auth   string `json:"auth"`
-	} `json:"keys"`
-}
+// The push endpoints share their implementation with the staff portal
+// (api/notifications): same wire format, same error classification. Only the
+// parent claims guard and the parent-specific service methods differ.
 
 // getPushPublicKey returns the VAPID public key the browser subscribes with.
 func (rs *Resource) getPushPublicKey(w http.ResponseWriter, r *http.Request) {
-	key, err := rs.PushService.PublicKey()
-	if errors.Is(err, notificationsService.ErrWebPushNotConfigured) {
-		common.RenderError(w, r, common.ErrorNotFound(err))
-		return
-	}
-	common.Respond(w, r, http.StatusOK, map[string]string{"public_key": key}, "")
+	notificationsAPI.HandlePushPublicKey(w, r, rs.PushService)
 }
 
 // subscribePush registers the parent's device across every school the
@@ -37,36 +25,7 @@ func (rs *Resource) subscribePush(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorUnauthorized(jwt.ErrTokenUnauthorized))
 		return
 	}
-
-	r.Body = http.MaxBytesReader(w, r.Body, 8<<10)
-	req := pushSubscriptionRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		return
-	}
-	if req.Endpoint == "" || req.Keys.P256dh == "" || req.Keys.Auth == "" {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("endpoint and keys are required")))
-		return
-	}
-
-	err := rs.PushService.SubscribeParent(r.Context(), int64(claims.ID), notificationsService.PushSubscriptionInput{
-		Endpoint:  req.Endpoint,
-		P256dh:    req.Keys.P256dh,
-		Auth:      req.Keys.Auth,
-		UserAgent: r.UserAgent(),
-	})
-	switch {
-	case errors.Is(err, notificationsService.ErrWebPushNotConfigured):
-		common.RenderError(w, r, common.ErrorConflict(err))
-		return
-	case errors.Is(err, notificationsService.ErrInvalidPushSubscription):
-		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		return
-	case err != nil:
-		common.RenderError(w, r, common.ErrorInternalServerWrap("Push-Registrierung konnte nicht gespeichert werden.", err))
-		return
-	}
-	common.Respond(w, r, http.StatusNoContent, nil, "")
+	notificationsAPI.HandleSubscribePush(w, r, int64(claims.ID), rs.PushService.SubscribeParent)
 }
 
 // unsubscribePush removes the parent's device registration (best effort).
@@ -76,16 +35,5 @@ func (rs *Resource) unsubscribePush(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorUnauthorized(jwt.ErrTokenUnauthorized))
 		return
 	}
-
-	endpoint := r.URL.Query().Get("endpoint")
-	if endpoint == "" {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("endpoint query parameter is required")))
-		return
-	}
-
-	if err := rs.PushService.UnsubscribeParent(r.Context(), int64(claims.ID), endpoint); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServerWrap("Push-Registrierung konnte nicht entfernt werden.", err))
-		return
-	}
-	common.Respond(w, r, http.StatusNoContent, nil, "")
+	notificationsAPI.HandleUnsubscribePush(w, r, int64(claims.ID), rs.PushService.UnsubscribeParent)
 }

--- a/backend/database/repositories/iot/push_subscription.go
+++ b/backend/database/repositories/iot/push_subscription.go
@@ -152,19 +152,27 @@ func (r *PushSubscriptionRepository) DeleteStaffByAccountID(ctx context.Context,
 	return nil
 }
 
-// FindForTenantStaff returns all staff-portal subscriptions of the current tenant.
-func (r *PushSubscriptionRepository) FindForTenantStaff(ctx context.Context) ([]*iot.PushSubscription, error) {
-	var subs []*iot.PushSubscription
+// activeSubscriptionsQuery is the shared scaffolding of every Find* method:
+// subscriptions of the given portal whose account is active and whose
+// account-tenant mapping is active, tenant-filtered. Callers add their
+// role-specific predicates before scanning.
+func (r *PushSubscriptionRepository) activeSubscriptionsQuery(ctx context.Context, subs *[]*iot.PushSubscription, portal string) *bun.SelectQuery {
 	query := base.GetDB(ctx, r.DB).NewSelect().
-		Model(&subs).
+		Model(subs).
 		ModelTableExpr(tablePushSubscriptions+` AS "push_subscription"`).
 		Join(activeAccountJoin).
 		Join(activeAccountTenantJoin).
-		Where(pushPortalFilter, iot.PushPortalStaff).
+		Where(pushPortalFilter, portal).
 		Where(`"account".active = ?`, true).
-		Where(`"account_tenant".status = ?`, authModels.AccountTenantStatusActive).
+		Where(`"account_tenant".status = ?`, authModels.AccountTenantStatusActive)
+	return base.WithTenantFilter(ctx, query, "push_subscription")
+}
+
+// FindForTenantStaff returns all staff-portal subscriptions of the current tenant.
+func (r *PushSubscriptionRepository) FindForTenantStaff(ctx context.Context) ([]*iot.PushSubscription, error) {
+	var subs []*iot.PushSubscription
+	query := r.activeSubscriptionsQuery(ctx, &subs, iot.PushPortalStaff).
 		Where(nonGuardianRoleFilter, authModels.BaseRoleGuardian)
-	query = base.WithTenantFilter(ctx, query, "push_subscription")
 	if err := query.Scan(ctx); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "find staff push subscriptions", Err: err}
 	}
@@ -176,14 +184,7 @@ func (r *PushSubscriptionRepository) FindForTenantStaff(ctx context.Context) ([]
 // directly or through a tenant role. This mirrors the SSE authorization scope.
 func (r *PushSubscriptionRepository) FindForTenantAdmins(ctx context.Context) ([]*iot.PushSubscription, error) {
 	var subs []*iot.PushSubscription
-	query := base.GetDB(ctx, r.DB).NewSelect().
-		Model(&subs).
-		ModelTableExpr(tablePushSubscriptions+` AS "push_subscription"`).
-		Join(activeAccountJoin).
-		Join(activeAccountTenantJoin).
-		Where(pushPortalFilter, iot.PushPortalStaff).
-		Where(`"account".active = ?`, true).
-		Where(`"account_tenant".status = ?`, authModels.AccountTenantStatusActive).
+	query := r.activeSubscriptionsQuery(ctx, &subs, iot.PushPortalStaff).
 		Where(nonGuardianRoleFilter, authModels.BaseRoleGuardian).
 		Where(`EXISTS (
 			SELECT 1
@@ -210,7 +211,6 @@ func (r *PushSubscriptionRepository) FindForTenantAdmins(ctx context.Context) ([
 			    OR ("p".resource = '*' AND "p".action = '*')
 			  )
 		)`)
-	query = base.WithTenantFilter(ctx, query, "push_subscription")
 	if err := query.Scan(ctx); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "find admin push subscriptions", Err: err}
 	}
@@ -225,17 +225,9 @@ func (r *PushSubscriptionRepository) FindForGuardians(ctx context.Context, guard
 		return nil, nil
 	}
 	var subs []*iot.PushSubscription
-	query := base.GetDB(ctx, r.DB).NewSelect().
-		Model(&subs).
-		ModelTableExpr(tablePushSubscriptions+` AS "push_subscription"`).
-		Join(activeAccountJoin).
-		Join(activeAccountTenantJoin).
-		Where(pushPortalFilter, iot.PushPortalParent).
-		Where(`"account".active = ?`, true).
-		Where(`"account_tenant".status = ?`, authModels.AccountTenantStatusActive).
+	query := r.activeSubscriptionsQuery(ctx, &subs, iot.PushPortalParent).
 		Where(guardianRoleFilter, authModels.BaseRoleGuardian).
 		Where(`"push_subscription".account_id IN (?)`, bun.List(guardianAccountIDs))
-	query = base.WithTenantFilter(ctx, query, "push_subscription")
 	if err := query.Scan(ctx); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "find guardian push subscriptions", Err: err}
 	}

--- a/backend/database/repositories/iot/push_subscription_repository_test.go
+++ b/backend/database/repositories/iot/push_subscription_repository_test.go
@@ -28,22 +28,6 @@ func cleanupPushSubscriptions(t *testing.T, db *bun.DB, accountIDs ...int64) {
 	require.NoError(t, err)
 }
 
-func createAccountTenantMapping(t *testing.T, db *bun.DB, accountID, tenantID int64) {
-	t.Helper()
-	now := time.Now()
-	mapping := &authModels.AccountTenant{
-		AccountID:   accountID,
-		TenantID:    tenantID,
-		Status:      authModels.AccountTenantStatusActive,
-		ActivatedAt: &now,
-	}
-	_, err := db.NewInsert().
-		Model(mapping).
-		ModelTableExpr("auth.account_tenants").
-		Exec(context.Background())
-	require.NoError(t, err)
-}
-
 func createPushTestSchool(t *testing.T, db *bun.DB) *platformModels.School {
 	t.Helper()
 	var organizationID int64
@@ -169,8 +153,8 @@ func TestPushSubscriptionRepository(t *testing.T) {
 	guardian := testpkg.CreateTestAccount(t, db, fmt.Sprintf("push-parent-%d@example.com", time.Now().UnixNano()))
 	defer testpkg.CleanupAuthFixtures(t, db, account.ID, guardian.ID)
 	defer cleanupPushSubscriptions(t, db, account.ID, guardian.ID)
-	createAccountTenantMapping(t, db, account.ID, 1)
-	createAccountTenantMapping(t, db, guardian.ID, 1)
+	testpkg.MapAccountToTenant(t, db, account.ID, 1)
+	testpkg.MapAccountToTenant(t, db, guardian.ID, 1)
 	assignSystemRole(t, db, account.ID, 1, authModels.BaseRoleUser)
 	assignSystemRole(t, db, guardian.ID, 1, authModels.BaseRoleGuardian)
 
@@ -422,7 +406,7 @@ func TestPushSubscriptionRepositoryEffectiveAdmins(t *testing.T) {
 		roleAdmin.ID:   "role-admin",
 		ordinary.ID:    "ordinary",
 	} {
-		createAccountTenantMapping(t, db, accountID, 1)
+		testpkg.MapAccountToTenant(t, db, accountID, 1)
 		assignSystemRole(t, db, accountID, 1, authModels.BaseRoleUser)
 		require.NoError(t, repo.Upsert(ctx, newSubscription(
 			accountID,

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/sliceutil"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -355,18 +356,11 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	if a.Priority == usersModels.ParentAnnouncementPriorityImportant {
 		priority = notifications.PriorityHigh
 	}
-	accountIDs := make([]int64, 0, len(recipients))
-	seen := make(map[int64]struct{}, len(recipients))
+	rawAccountIDs := make([]int64, 0, len(recipients))
 	for _, recipient := range recipients {
-		if recipient.AccountID <= 0 {
-			continue
-		}
-		if _, exists := seen[recipient.AccountID]; exists {
-			continue
-		}
-		seen[recipient.AccountID] = struct{}{}
-		accountIDs = append(accountIDs, recipient.AccountID)
+		rawAccountIDs = append(rawAccountIDs, recipient.AccountID)
 	}
+	accountIDs := sliceutil.UniquePositive(rawAccountIDs)
 	if len(accountIDs) == 0 {
 		return nil
 	}

--- a/backend/services/notifications/webpush_channel.go
+++ b/backend/services/notifications/webpush_channel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/iot"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
+	"golang.org/x/sync/semaphore"
 )
 
 // pushSender abstracts the actual Web Push HTTP request so tests can fake the
@@ -62,7 +63,7 @@ type webPushChannel struct {
 	logger *slog.Logger
 	// Shared across deliveries so concurrent notification batches cannot each
 	// consume maxConcurrentPushSends outbound connections.
-	sendSlots chan struct{}
+	sendSem *semaphore.Weighted
 }
 
 // NewWebPushChannel returns the Web Push channel. With unset VAPID keys the
@@ -70,12 +71,12 @@ type webPushChannel struct {
 // today's behavior.
 func NewWebPushChannel(db *bun.DB, repo iot.PushSubscriptionRepository, vapid VAPIDConfig, logger *slog.Logger) Channel {
 	return &webPushChannel{
-		db:        db,
-		repo:      repo,
-		vapid:     vapid,
-		sender:    webpushGoSender{client: newWebPushHTTPClient()},
-		logger:    logger,
-		sendSlots: make(chan struct{}, maxConcurrentPushSends),
+		db:      db,
+		repo:    repo,
+		vapid:   vapid,
+		sender:  webpushGoSender{client: newWebPushHTTPClient()},
+		logger:  logger,
+		sendSem: semaphore.NewWeighted(maxConcurrentPushSends),
 	}
 }
 
@@ -173,17 +174,13 @@ func (c *webPushChannel) sendAll(ctx context.Context, event Event, payload []byt
 	var wg sync.WaitGroup
 
 	for _, sub := range subs {
-		select {
-		case c.sendSlots <- struct{}{}:
-		case <-ctx.Done():
-			wg.Wait()
-			return
+		if err := c.sendSem.Acquire(ctx, 1); err != nil {
+			break
 		}
-
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			defer func() { <-c.sendSlots }()
+			defer c.sendSem.Release(1)
 			c.sendOne(ctx, event, payload, sub, ttl, urgency)
 		}()
 	}

--- a/backend/services/notifications/webpush_channel_internal_test.go
+++ b/backend/services/notifications/webpush_channel_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
+	"golang.org/x/sync/semaphore"
 )
 
 // fakePushRepo implements the subscription lookups the channel needs; the
@@ -122,11 +123,11 @@ func testSub(id, tenantID int64, endpoint string) *iot.PushSubscription {
 
 func testChannel(repo *fakePushRepo, sender *fakeSender) *webPushChannel {
 	return &webPushChannel{
-		repo:      repo,
-		vapid:     testVAPID(),
-		sender:    sender,
-		logger:    slog.Default(),
-		sendSlots: make(chan struct{}, maxConcurrentPushSends),
+		repo:    repo,
+		vapid:   testVAPID(),
+		sender:  sender,
+		logger:  slog.Default(),
+		sendSem: semaphore.NewWeighted(maxConcurrentPushSends),
 	}
 }
 

--- a/frontend/src/components/settings/push-notification-section.test.tsx
+++ b/frontend/src/components/settings/push-notification-section.test.tsx
@@ -3,10 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PushNotificationSection } from "./push-notification-section";
 
 const pushApi = vi.hoisted(() => ({
+  ensurePushConfigured: vi.fn(),
+  getExistingSubscription: vi.fn(),
   isPushConfigurationMissing: vi.fn(),
   isPushSupported: vi.fn(),
   needsIOSInstall: vi.fn(),
-  syncExistingPushSubscription: vi.fn(),
   subscribePush: vi.fn(),
   unsubscribePush: vi.fn(),
 }));
@@ -23,7 +24,8 @@ describe("PushNotificationSection", () => {
     pushApi.isPushConfigurationMissing.mockReturnValue(false);
     pushApi.needsIOSInstall.mockReturnValue(false);
     pushApi.isPushSupported.mockReturnValue(true);
-    pushApi.syncExistingPushSubscription.mockResolvedValue(null);
+    pushApi.ensurePushConfigured.mockResolvedValue(undefined);
+    pushApi.getExistingSubscription.mockResolvedValue(null);
     stubNotificationPermission("default");
   });
 
@@ -57,7 +59,7 @@ describe("PushNotificationSection", () => {
   });
 
   it("shows a disabled state when VAPID is not configured", async () => {
-    pushApi.syncExistingPushSubscription.mockRejectedValue(
+    pushApi.ensurePushConfigured.mockRejectedValue(
       new Error("web push is not configured"),
     );
     pushApi.isPushConfigurationMissing.mockReturnValue(true);
@@ -84,7 +86,7 @@ describe("PushNotificationSection", () => {
 
   it("subscribes via the push API and flips to the active state", async () => {
     pushApi.subscribePush.mockImplementation(() => {
-      pushApi.syncExistingPushSubscription.mockResolvedValue({
+      pushApi.getExistingSubscription.mockResolvedValue({
         endpoint: "https://push.example/e",
       });
       return Promise.resolve();
@@ -126,11 +128,11 @@ describe("PushNotificationSection", () => {
   });
 
   it("unsubscribes and flips back to the inactive state", async () => {
-    pushApi.syncExistingPushSubscription.mockResolvedValue({
+    pushApi.getExistingSubscription.mockResolvedValue({
       endpoint: "https://push.example/e",
     });
     pushApi.unsubscribePush.mockImplementation(() => {
-      pushApi.syncExistingPushSubscription.mockResolvedValue(null);
+      pushApi.getExistingSubscription.mockResolvedValue(null);
       return Promise.resolve();
     });
 

--- a/frontend/src/components/settings/push-notification-section.tsx
+++ b/frontend/src/components/settings/push-notification-section.tsx
@@ -6,11 +6,12 @@ import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { createLogger } from "~/lib/logger";
 import {
+  ensurePushConfigured,
+  getExistingSubscription,
   isPushConfigurationMissing,
   isPushSupported,
   needsIOSInstall,
   subscribePush,
-  syncExistingPushSubscription,
   unsubscribePush,
   type PushPortal,
 } from "~/lib/push-api";
@@ -57,7 +58,10 @@ export function PushNotificationSection({
       return;
     }
     try {
-      const subscription = await syncExistingPushSubscription(portal);
+      // Read-only state check: the actual server-side re-sync happens once per
+      // session via PushSubscriptionSync at the provider root.
+      await ensurePushConfigured(portal);
+      const subscription = await getExistingSubscription();
       setState(subscription ? "subscribed" : "unsubscribed");
     } catch (err) {
       if (isPushConfigurationMissing(err)) {
@@ -75,50 +79,44 @@ export function PushNotificationSection({
     void refresh();
   }, [refresh]);
 
-  const enable = async () => {
+  const runToggle = async (
+    action: () => Promise<void>,
+    successMessage: string,
+    logEvent: string,
+    fallbackError: string,
+  ) => {
     setBusy(true);
     setError(null);
     setMessage(null);
     try {
-      await subscribePush(portal);
-      setMessage("Benachrichtigungen sind auf diesem Gerät aktiviert.");
-      await refresh();
+      await action();
+      setMessage(successMessage);
     } catch (err) {
-      logger.error("push_subscribe_failed", {
+      logger.error(logEvent, {
         error: err instanceof Error ? err.message : String(err),
       });
-      setError(
-        err instanceof Error
-          ? err.message
-          : "Benachrichtigungen konnten nicht aktiviert werden.",
-      );
-      await refresh();
+      setError(err instanceof Error ? err.message : fallbackError);
     } finally {
+      await refresh();
       setBusy(false);
     }
   };
 
-  const disable = async () => {
-    setBusy(true);
-    setError(null);
-    setMessage(null);
-    try {
-      await unsubscribePush(portal);
-      setMessage("Benachrichtigungen sind auf diesem Gerät deaktiviert.");
-      await refresh();
-    } catch (err) {
-      logger.error("push_unsubscribe_failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      setError(
-        err instanceof Error
-          ? err.message
-          : "Benachrichtigungen konnten nicht deaktiviert werden.",
-      );
-    } finally {
-      setBusy(false);
-    }
-  };
+  const enable = () =>
+    runToggle(
+      () => subscribePush(portal),
+      "Benachrichtigungen sind auf diesem Gerät aktiviert.",
+      "push_subscribe_failed",
+      "Benachrichtigungen konnten nicht aktiviert werden.",
+    );
+
+  const disable = () =>
+    runToggle(
+      () => unsubscribePush(portal),
+      "Benachrichtigungen sind auf diesem Gerät deaktiviert.",
+      "push_unsubscribe_failed",
+      "Benachrichtigungen konnten nicht deaktiviert werden.",
+    );
 
   return (
     <div className="moto-content-surface rounded-2xl border p-4 backdrop-blur-sm md:p-6">

--- a/frontend/src/lib/push-api.ts
+++ b/frontend/src/lib/push-api.ts
@@ -128,6 +128,14 @@ async function getPushPublicKey(
   }
 }
 
+/**
+ * Preflights server-side push configuration. Resolves when VAPID is set up;
+ * rejects with an error matching isPushConfigurationMissing otherwise.
+ */
+export async function ensurePushConfigured(portal: PushPortal): Promise<void> {
+  await getPushPublicKey(portal);
+}
+
 /** Registers /sw.js (idempotent) and returns the registration. */
 async function registerPushServiceWorker(): Promise<ServiceWorkerRegistration> {
   const registration = await navigator.serviceWorker.register("/sw.js");
@@ -163,12 +171,25 @@ export async function subscribePush(portal: PushPortal): Promise<void> {
 
   const registration = await registerPushServiceWorker();
   const existing = await registration.pushManager.getSubscription();
+  await rebindAndSync(portal, registration, existing, publicKey);
+}
+
+/**
+ * Rebinds `existing` (or creates a fresh subscription) to the current server
+ * key and persists the result server-side.
+ */
+async function rebindAndSync(
+  portal: PushPortal,
+  registration: ServiceWorkerRegistration,
+  existing: PushSubscription | null,
+  publicKey: Uint8Array<ArrayBuffer>,
+): Promise<PushSubscription> {
   const subscription =
     existing && applicationServerKeyMatches(existing, publicKey)
       ? existing
       : await replaceBrowserSubscription(registration, existing, publicKey);
-
   await syncSubscription(portal, subscription);
+  return subscription;
 }
 
 async function replaceBrowserSubscription(
@@ -226,11 +247,7 @@ export async function syncExistingPushSubscription(
   const existing = await registration.pushManager.getSubscription();
   if (!existing) return null;
 
-  const subscription = applicationServerKeyMatches(existing, publicKey)
-    ? existing
-    : await replaceBrowserSubscription(registration, existing, publicKey);
-  await syncSubscription(portal, subscription);
-  return subscription;
+  return rebindAndSync(portal, registration, existing, publicKey);
 }
 
 /**


### PR DESCRIPTION
Follow-up zu #2006 (Web-Push-Aktivierung, bereits gemerged). Reiner Refactor, kein Verhaltens-Change:

- Push-Handler-Bodies zwischen Staff- und Eltern-Portal geteilt statt zweier fast identischer Kopien
- Hand-gebautes Send-Concurrency-Limit durch `x/sync/semaphore` ersetzt
- Gemeinsames Query-Scaffolding im PushSubscription-Repository herausgezogen
- `sliceutil.UniquePositive` und die geteilte Account-Tenant-Fixture wiederverwendet
- Doppelten client-seitigen Subscription-Re-Sync beim Mount der Section entfernt

Netto -38 Zeilen. Verifiziert: betroffene Backend-Pakete (notifications, api/notifications, api/parent, repositories/iot, announcement) grün, `pnpm run check` + Vitest (4363 Tests) grün.