### PR TITLE
fix: Scrollbalken bleibt innerhalb der abgerundeten Fläche

### DIFF
--- a/frontend/src/components/staff/dienstplan-skeleton.tsx
+++ b/frontend/src/components/staff/dienstplan-skeleton.tsx
@@ -30,35 +30,37 @@ function HeaderSkeleton() {
 function GridSkeletonBody() {
   return (
     <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-      <div className="max-w-full overflow-x-auto rounded-2xl border border-gray-100">
-        <table className="w-full min-w-[960px] border-collapse text-sm">
-          <tbody className="divide-y divide-gray-100">
-            {Array.from({ length: 6 }, (_, row) => (
-              <tr key={row} className="bg-white">
+      <div className="max-w-full overflow-hidden rounded-2xl border border-gray-100">
+        <div className="max-w-full overflow-x-auto">
+          <table className="w-full min-w-[960px] border-collapse text-sm">
+            <tbody className="divide-y divide-gray-100">
+              {Array.from({ length: 6 }, (_, row) => (
+                <tr key={row} className="bg-white">
+                  <td className="px-4 py-2">
+                    <Skeleton className="h-4 w-32 rounded" />
+                  </td>
+                  {Array.from({ length: 5 }, (_, col) => (
+                    <td key={col} className="px-3 py-2">
+                      <Skeleton className="h-9 w-full rounded-md" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-gray-200 bg-gray-50">
                 <td className="px-4 py-2">
-                  <Skeleton className="h-4 w-32 rounded" />
+                  <Skeleton className="h-4 w-28 rounded" />
                 </td>
                 {Array.from({ length: 5 }, (_, col) => (
                   <td key={col} className="px-3 py-2">
-                    <Skeleton className="h-9 w-full rounded-md" />
+                    <Skeleton className="h-4 w-8 rounded" />
                   </td>
                 ))}
               </tr>
-            ))}
-          </tbody>
-          <tfoot>
-            <tr className="border-t border-gray-200 bg-gray-50">
-              <td className="px-4 py-2">
-                <Skeleton className="h-4 w-28 rounded" />
-              </td>
-              {Array.from({ length: 5 }, (_, col) => (
-                <td key={col} className="px-3 py-2">
-                  <Skeleton className="h-4 w-8 rounded" />
-                </td>
-              ))}
-            </tr>
-          </tfoot>
-        </table>
+            </tfoot>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/staff/staff-session-table.tsx
+++ b/frontend/src/components/staff/staff-session-table.tsx
@@ -310,273 +310,279 @@ export function StaffSessionTable({
           message="Der Stundenkonto-Start konnte nicht geladen werden. Soweit das Soll geladen wurde, werden Salden an Tagen ohne Soll weiterhin angezeigt; vor dem Kontostart können sie aber von der Monatskarte abweichen. Bitte die Seite neu laden."
         />
       )}
-      <div className="max-w-full overflow-x-auto rounded-2xl border border-gray-100">
-        <table className="w-full min-w-[960px] text-left text-sm">
-          <thead className="bg-gray-50 text-xs font-semibold tracking-wider text-gray-500 uppercase">
-            <tr>
-              <th className="px-4 py-3">Datum</th>
-              <th className="px-4 py-3">Tag</th>
-              {showPlan && (
-                <th className="px-4 py-3 tabular-nums">Plan (Schicht)</th>
-              )}
-              <th className="px-4 py-3 tabular-nums">Check-in</th>
-              <th className="px-4 py-3 tabular-nums">Check-out</th>
-              <th className="px-4 py-3 text-right tabular-nums">Pause</th>
-              <th className="px-4 py-3 text-right tabular-nums">Soll</th>
-              <th className="px-4 py-3 text-right tabular-nums">Ist</th>
-              <th className="px-4 py-3 text-right tabular-nums">Saldo</th>
-              <th className="px-4 py-3">Status</th>
-              <th className="px-4 py-3">Quelle</th>
-              <th className="px-4 py-3">Hinweis</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {days.map((day) => {
-              const key = toDateKey(day);
-              const dow = toIsoDayOfWeek(day);
-              const session = sessionsByDate.get(key);
-              const absence = absencesByDate.get(key);
-              const holidayName = holidays?.get(key);
-              const closingReason = closingDays?.get(key);
-              // Ein fehlgeschlagener ODER noch laufender Targets-Fetch darf
-              // NICHT auf den aktuellen Plan zurückfallen (#1842): der Tag
-              // bleibt ungelöst, damit die Tabelle keinen erfundenen
-              // Soll-/Saldo-Wert behauptet — weder dauerhaft (Fehler) noch
-              // kurzzeitig beim Zeitraumwechsel (pending, stale Map).
-              const { unresolved: targetUnresolved, displayed: target } =
-                resolveDayTarget(day);
-              const isFuture = day > today;
-              const isToday = sameDay(day, today);
-              const ist = session?.net_minutes ?? 0;
-              // Saldo eines Tages ist Ist minus Soll — auch bei Soll 0 auf
-              // einem geplanten freien Tag (#1967). Vor einem untermonatigen
-              // Stundenkonto-Start zählt die Monatskarte allerdings weder
-              // Soll noch Ist. GetDailyTargets liefert dort ebenfalls 0, kann
-              // diesen Fall also nicht allein von einem freien Tag
-              // unterscheiden; dafür braucht die Zeile zusätzlich den
-              // konfigurierten Starttag.
-              const isBeforeAccountStart =
-                accountStartDate !== null &&
-                accountStartDate !== "" &&
-                key.slice(0, 7) === accountStartDate.slice(0, 7) &&
-                key < accountStartDate;
-              const balanceUnresolved =
-                targetUnresolved || (target === 0 && accountStartDatePending);
-              const delta = session ? ist - target : 0;
-              const status = computeRowStatus(
-                session,
-                absence,
-                key,
-                holidayName,
-                closingReason,
-                target,
-                isFuture,
-              );
-              const isExpanded = expandedKey === key;
-              const hasAuditHistory = (session?.audit_count ?? 0) > 0;
-              // Only rows with audit history are interactive — clicking an
-              // unchanged row should not toggle anything since there is
-              // nothing to reveal.
-              const canExpand = hasAuditHistory && session != null;
-              // Edit / nachtragen is available for past or present days,
-              // regardless of whether a session already exists. The SquarePen
-              // action lands on Tranche 1b — for now the wiring is in place
-              // and the click is a no-op + logger entry. Future days and
-              // absence-only days don't get the action.
-              //
-              // Wochenendtage bekommen sie sehr wohl (#1967): eine Zeile ist
-              // nur sichtbar, wenn dort real gearbeitet oder geplant wurde,
-              // und genau die muss korrigierbar sein.
-              const isWeekend = dow >= 5;
-              const canEdit = isAdminView && !isFuture && absence == null;
-              return (
-                <Fragment key={key}>
-                  <tr
-                    onClick={() => {
-                      if (!canExpand) return;
-                      setExpandedKey((prev) => (prev === key ? null : key));
-                    }}
-                    onKeyDown={(event) => {
-                      if (
-                        !canExpand ||
-                        (event.key !== "Enter" && event.key !== " ")
-                      ) {
-                        return;
+      {/* Radius, Rand und Ausschnitt bleiben auf der Fläche, gescrollt wird im
+          inneren Container. Sonst zeichnet der Browser die Scrollleiste quer
+          durch die abgerundeten Ecken und über den unteren Rand hinaus. */}
+      <div className="max-w-full overflow-hidden rounded-2xl border border-gray-100">
+        <div className="max-w-full overflow-x-auto">
+          <table className="w-full min-w-[960px] text-left text-sm">
+            <thead className="bg-gray-50 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+              <tr>
+                <th className="px-4 py-3">Datum</th>
+                <th className="px-4 py-3">Tag</th>
+                {showPlan && (
+                  <th className="px-4 py-3 tabular-nums">Plan (Schicht)</th>
+                )}
+                <th className="px-4 py-3 tabular-nums">Check-in</th>
+                <th className="px-4 py-3 tabular-nums">Check-out</th>
+                <th className="px-4 py-3 text-right tabular-nums">Pause</th>
+                <th className="px-4 py-3 text-right tabular-nums">Soll</th>
+                <th className="px-4 py-3 text-right tabular-nums">Ist</th>
+                <th className="px-4 py-3 text-right tabular-nums">Saldo</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Quelle</th>
+                <th className="px-4 py-3">Hinweis</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {days.map((day) => {
+                const key = toDateKey(day);
+                const dow = toIsoDayOfWeek(day);
+                const session = sessionsByDate.get(key);
+                const absence = absencesByDate.get(key);
+                const holidayName = holidays?.get(key);
+                const closingReason = closingDays?.get(key);
+                // Ein fehlgeschlagener ODER noch laufender Targets-Fetch darf
+                // NICHT auf den aktuellen Plan zurückfallen (#1842): der Tag
+                // bleibt ungelöst, damit die Tabelle keinen erfundenen
+                // Soll-/Saldo-Wert behauptet — weder dauerhaft (Fehler) noch
+                // kurzzeitig beim Zeitraumwechsel (pending, stale Map).
+                const { unresolved: targetUnresolved, displayed: target } =
+                  resolveDayTarget(day);
+                const isFuture = day > today;
+                const isToday = sameDay(day, today);
+                const ist = session?.net_minutes ?? 0;
+                // Saldo eines Tages ist Ist minus Soll — auch bei Soll 0 auf
+                // einem geplanten freien Tag (#1967). Vor einem untermonatigen
+                // Stundenkonto-Start zählt die Monatskarte allerdings weder
+                // Soll noch Ist. GetDailyTargets liefert dort ebenfalls 0, kann
+                // diesen Fall also nicht allein von einem freien Tag
+                // unterscheiden; dafür braucht die Zeile zusätzlich den
+                // konfigurierten Starttag.
+                const isBeforeAccountStart =
+                  accountStartDate !== null &&
+                  accountStartDate !== "" &&
+                  key.slice(0, 7) === accountStartDate.slice(0, 7) &&
+                  key < accountStartDate;
+                const balanceUnresolved =
+                  targetUnresolved || (target === 0 && accountStartDatePending);
+                const delta = session ? ist - target : 0;
+                const status = computeRowStatus(
+                  session,
+                  absence,
+                  key,
+                  holidayName,
+                  closingReason,
+                  target,
+                  isFuture,
+                );
+                const isExpanded = expandedKey === key;
+                const hasAuditHistory = (session?.audit_count ?? 0) > 0;
+                // Only rows with audit history are interactive — clicking an
+                // unchanged row should not toggle anything since there is
+                // nothing to reveal.
+                const canExpand = hasAuditHistory && session != null;
+                // Edit / nachtragen is available for past or present days,
+                // regardless of whether a session already exists. The SquarePen
+                // action lands on Tranche 1b — for now the wiring is in place
+                // and the click is a no-op + logger entry. Future days and
+                // absence-only days don't get the action.
+                //
+                // Wochenendtage bekommen sie sehr wohl (#1967): eine Zeile ist
+                // nur sichtbar, wenn dort real gearbeitet oder geplant wurde,
+                // und genau die muss korrigierbar sein.
+                const isWeekend = dow >= 5;
+                const canEdit = isAdminView && !isFuture && absence == null;
+                return (
+                  <Fragment key={key}>
+                    <tr
+                      onClick={() => {
+                        if (!canExpand) return;
+                        setExpandedKey((prev) => (prev === key ? null : key));
+                      }}
+                      onKeyDown={(event) => {
+                        if (
+                          !canExpand ||
+                          (event.key !== "Enter" && event.key !== " ")
+                        ) {
+                          return;
+                        }
+                        event.preventDefault();
+                        setExpandedKey((prev) => (prev === key ? null : key));
+                      }}
+                      tabIndex={canExpand ? 0 : undefined}
+                      aria-expanded={canExpand ? isExpanded : undefined}
+                      aria-label={
+                        canExpand
+                          ? `${formatShortDate(day)}: Änderungshistorie ${isExpanded ? "schließen" : "öffnen"}`
+                          : undefined
                       }
-                      event.preventDefault();
-                      setExpandedKey((prev) => (prev === key ? null : key));
-                    }}
-                    tabIndex={canExpand ? 0 : undefined}
-                    aria-expanded={canExpand ? isExpanded : undefined}
-                    aria-label={
-                      canExpand
-                        ? `${formatShortDate(day)}: Änderungshistorie ${isExpanded ? "schließen" : "öffnen"}`
-                        : undefined
-                    }
-                    className={`${canExpand ? "cursor-pointer" : ""} transition-colors hover:bg-gray-50 ${
-                      isExpanded
-                        ? "bg-gray-50"
-                        : isToday
-                          ? "bg-amber-50/40"
-                          : isWeekend
-                            ? "bg-gray-50/60"
-                            : ""
-                    } ${isFuture ? "opacity-40" : ""}`}
-                  >
-                    <td className="px-4 py-3 text-gray-700 tabular-nums">
-                      <div className="flex items-center gap-1.5">
-                        {canExpand ? (
-                          <ChevronRight
-                            className={`h-3.5 w-3.5 shrink-0 text-gray-400 transition-transform ${
-                              isExpanded ? "rotate-90" : ""
-                            }`}
-                          />
-                        ) : (
-                          <span className="inline-block h-3.5 w-3.5 shrink-0" />
-                        )}
-                        {formatShortDate(day)}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      {dayLabels[dow]}
-                    </td>
-                    {showPlan && (
-                      <td className="px-4 py-3 text-gray-500 tabular-nums">
-                        <PlannedShiftCell shifts={shiftsByDate.get(key)} />
+                      className={`${canExpand ? "cursor-pointer" : ""} transition-colors hover:bg-gray-50 ${
+                        isExpanded
+                          ? "bg-gray-50"
+                          : isToday
+                            ? "bg-amber-50/40"
+                            : isWeekend
+                              ? "bg-gray-50/60"
+                              : ""
+                      } ${isFuture ? "opacity-40" : ""}`}
+                    >
+                      <td className="px-4 py-3 text-gray-700 tabular-nums">
+                        <div className="flex items-center gap-1.5">
+                          {canExpand ? (
+                            <ChevronRight
+                              className={`h-3.5 w-3.5 shrink-0 text-gray-400 transition-transform ${
+                                isExpanded ? "rotate-90" : ""
+                              }`}
+                            />
+                          ) : (
+                            <span className="inline-block h-3.5 w-3.5 shrink-0" />
+                          )}
+                          {formatShortDate(day)}
+                        </div>
                       </td>
-                    )}
-                    <td className="px-4 py-3 text-gray-700 tabular-nums">
-                      {session?.check_in_time
-                        ? formatTimeOnly(session.check_in_time)
-                        : "–"}
-                    </td>
-                    <td className="px-4 py-3 text-gray-700 tabular-nums">
-                      {session?.check_out_time ? (
-                        formatTimeOnly(session.check_out_time)
-                      ) : session ? (
-                        <span className="inline-flex items-center rounded-full bg-[#83CD2D]/10 px-2 py-0.5 text-xs font-medium text-[#70b525]">
-                          <span className="mr-1.5 h-1.5 w-1.5 animate-pulse rounded-full bg-[#83CD2D]" />
-                          eingestempelt
-                        </span>
-                      ) : (
-                        "–"
+                      <td className="px-4 py-3 text-gray-500">
+                        {dayLabels[dow]}
+                      </td>
+                      {showPlan && (
+                        <td className="px-4 py-3 text-gray-500 tabular-nums">
+                          <PlannedShiftCell shifts={shiftsByDate.get(key)} />
+                        </td>
                       )}
-                    </td>
-                    <td className="px-4 py-3 text-right text-gray-500 tabular-nums">
-                      {session ? formatDuration(session.break_minutes) : "–"}
-                    </td>
-                    <td className="px-4 py-3 text-right text-gray-500 tabular-nums">
-                      {targetUnresolved ? (
-                        <span
-                          title={
-                            dailyTargetsError === true
-                              ? "Soll konnte nicht geladen werden"
-                              : "Soll wird geladen"
-                          }
-                        >
-                          {dailyTargetsError === true ? "?" : "…"}
-                        </span>
-                      ) : target > 0 ? (
-                        formatDuration(target)
-                      ) : (
-                        "–"
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-right font-medium text-gray-700 tabular-nums">
-                      {session ? formatDuration(ist) : "–"}
-                    </td>
-                    <td className="px-4 py-3 text-right tabular-nums">
-                      {session &&
-                      !isFuture &&
-                      !balanceUnresolved &&
-                      !isBeforeAccountStart ? (
-                        <span className={deltaClass(delta)}>
-                          {formatSignedDuration(delta)}
-                        </span>
-                      ) : (
-                        "–"
-                      )}
-                    </td>
-                    <td className="px-4 py-3">
-                      {status && <StatusBadge status={status} />}
-                    </td>
-                    <td className="px-4 py-3">
-                      <SourceBadge session={session} />
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center justify-between gap-3">
-                        <HintBadges
-                          session={session}
-                          holidayName={holidayName}
-                        />
-                        {canEdit && (
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (onEditDay) {
-                                onEditDay(
-                                  day,
-                                  session ?? null,
-                                  absence ?? null,
-                                );
-                              } else {
-                                setEditModal({
-                                  mode: session == null ? "nachtragen" : "edit",
-                                  date: day,
-                                  session: session ?? null,
-                                });
-                              }
-                            }}
-                            aria-label={
-                              session == null
-                                ? "Eintrag nachtragen"
-                                : "Eintrag bearbeiten"
-                            }
-                            title={
-                              session == null
-                                ? "Eintrag nachtragen"
-                                : "Eintrag bearbeiten"
-                            }
-                            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
-                          >
-                            <SquarePen className="h-4 w-4" />
-                          </button>
+                      <td className="px-4 py-3 text-gray-700 tabular-nums">
+                        {session?.check_in_time
+                          ? formatTimeOnly(session.check_in_time)
+                          : "–"}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700 tabular-nums">
+                        {session?.check_out_time ? (
+                          formatTimeOnly(session.check_out_time)
+                        ) : session ? (
+                          <span className="inline-flex items-center rounded-full bg-[#83CD2D]/10 px-2 py-0.5 text-xs font-medium text-[#70b525]">
+                            <span className="mr-1.5 h-1.5 w-1.5 animate-pulse rounded-full bg-[#83CD2D]" />
+                            eingestempelt
+                          </span>
+                        ) : (
+                          "–"
                         )}
-                      </div>
-                    </td>
-                  </tr>
-                  {isExpanded && session && (
-                    <tr className="border-b border-gray-100 bg-gray-50/50">
-                      <td colSpan={columnCount} className="px-4 py-3">
-                        <SessionEditHistory
-                          staffId={staffId}
-                          sessionId={session.id}
-                          fetchEdits={fetchEdits}
-                          onEdit={
-                            isAdminView
-                              ? () => {
-                                  if (onEditDay) {
-                                    onEditDay(day, session, absence ?? null);
-                                  } else {
-                                    setEditModal({
-                                      mode: "edit",
-                                      date: day,
-                                      session,
-                                    });
-                                  }
+                      </td>
+                      <td className="px-4 py-3 text-right text-gray-500 tabular-nums">
+                        {session ? formatDuration(session.break_minutes) : "–"}
+                      </td>
+                      <td className="px-4 py-3 text-right text-gray-500 tabular-nums">
+                        {targetUnresolved ? (
+                          <span
+                            title={
+                              dailyTargetsError === true
+                                ? "Soll konnte nicht geladen werden"
+                                : "Soll wird geladen"
+                            }
+                          >
+                            {dailyTargetsError === true ? "?" : "…"}
+                          </span>
+                        ) : target > 0 ? (
+                          formatDuration(target)
+                        ) : (
+                          "–"
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium text-gray-700 tabular-nums">
+                        {session ? formatDuration(ist) : "–"}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        {session &&
+                        !isFuture &&
+                        !balanceUnresolved &&
+                        !isBeforeAccountStart ? (
+                          <span className={deltaClass(delta)}>
+                            {formatSignedDuration(delta)}
+                          </span>
+                        ) : (
+                          "–"
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        {status && <StatusBadge status={status} />}
+                      </td>
+                      <td className="px-4 py-3">
+                        <SourceBadge session={session} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <HintBadges
+                            session={session}
+                            holidayName={holidayName}
+                          />
+                          {canEdit && (
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (onEditDay) {
+                                  onEditDay(
+                                    day,
+                                    session ?? null,
+                                    absence ?? null,
+                                  );
+                                } else {
+                                  setEditModal({
+                                    mode:
+                                      session == null ? "nachtragen" : "edit",
+                                    date: day,
+                                    session: session ?? null,
+                                  });
                                 }
-                              : undefined
-                          }
-                        />
+                              }}
+                              aria-label={
+                                session == null
+                                  ? "Eintrag nachtragen"
+                                  : "Eintrag bearbeiten"
+                              }
+                              title={
+                                session == null
+                                  ? "Eintrag nachtragen"
+                                  : "Eintrag bearbeiten"
+                              }
+                              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                            >
+                              <SquarePen className="h-4 w-4" />
+                            </button>
+                          )}
+                        </div>
                       </td>
                     </tr>
-                  )}
-                </Fragment>
-              );
-            })}
-          </tbody>
-        </table>
+                    {isExpanded && session && (
+                      <tr className="border-b border-gray-100 bg-gray-50/50">
+                        <td colSpan={columnCount} className="px-4 py-3">
+                          <SessionEditHistory
+                            staffId={staffId}
+                            sessionId={session.id}
+                            fetchEdits={fetchEdits}
+                            onEdit={
+                              isAdminView
+                                ? () => {
+                                    if (onEditDay) {
+                                      onEditDay(day, session, absence ?? null);
+                                    } else {
+                                      setEditModal({
+                                        mode: "edit",
+                                        date: day,
+                                        session,
+                                      });
+                                    }
+                                  }
+                                : undefined
+                            }
+                          />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
         {!isAdminView && (
           <p className="border-t border-gray-100 bg-gray-50 px-4 py-2 text-xs text-gray-500">
             Eigene Arbeitszeiten können in der Zeiterfassung-Seite bearbeitet

--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -138,154 +138,163 @@ export function DataTable<T>({
         </div>
       )}
 
-      <div className="moto-content-surface overflow-x-auto rounded-2xl border shadow-sm backdrop-blur-md">
-        <table className="w-full border-collapse text-left text-sm">
-          <thead>
-            <tr className="border-b border-gray-100 text-xs font-medium text-gray-500">
-              {columns.map((col) => {
-                const align = alignClass[col.align ?? "left"];
-                const sortable = Boolean(col.sortValue);
-                const active = sort?.key === col.key;
-                if (!sortable) {
+      {/* Radius, Rand und Ausschnitt bleiben auf der Kartenfläche, gescrollt
+          wird im inneren Container. Sonst zeichnet der Browser die
+          Scrollleiste quer durch die abgerundeten Ecken und über den unteren
+          Rand hinaus. */}
+      <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm backdrop-blur-md">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-xs font-medium text-gray-500">
+                {columns.map((col) => {
+                  const align = alignClass[col.align ?? "left"];
+                  const sortable = Boolean(col.sortValue);
+                  const active = sort?.key === col.key;
+                  if (!sortable) {
+                    return (
+                      <th
+                        key={col.key}
+                        scope="col"
+                        className={`px-5 py-3 ${align} ${col.headerClassName ?? ""}`}
+                      >
+                        {col.header}
+                      </th>
+                    );
+                  }
+                  const ariaSort: "ascending" | "descending" | "none" = active
+                    ? sort?.direction === "asc"
+                      ? "ascending"
+                      : "descending"
+                    : "none";
+                  const indicator = active
+                    ? sort?.direction === "asc"
+                      ? "↑"
+                      : "↓"
+                    : "↕";
+                  // Accessible name combines the visible header with a state hint.
+                  // We deliberately avoid embedding the column header verbatim
+                  // into a separate aria-label so the button's name is always
+                  // strictly more specific than the column header text — this
+                  // keeps name-based queries that target row-action buttons
+                  // (e.g. {name: "Konten"}) from matching the sort header.
+                  // The aria-sort attribute on the <th> communicates the
+                  // current sort direction to assistive tech independently.
+                  const stateHint = active
+                    ? sort?.direction === "asc"
+                      ? "aufsteigend sortiert"
+                      : "absteigend sortiert"
+                    : "Spalte sortieren";
                   return (
                     <th
                       key={col.key}
                       scope="col"
+                      aria-sort={ariaSort}
                       className={`px-5 py-3 ${align} ${col.headerClassName ?? ""}`}
                     >
-                      {col.header}
+                      <button
+                        type="button"
+                        onClick={() => toggleSort(col.key)}
+                        className={`inline-flex items-center gap-1 font-medium transition-colors select-none hover:text-gray-700 focus:rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 ${align}`}
+                      >
+                        <span>{col.header}</span>
+                        <span
+                          aria-hidden="true"
+                          className={active ? "text-gray-700" : "text-gray-300"}
+                        >
+                          {indicator}
+                        </span>
+                        <span className="sr-only">{` – ${stateHint}`}</span>
+                      </button>
                     </th>
                   );
-                }
-                const ariaSort: "ascending" | "descending" | "none" = active
-                  ? sort?.direction === "asc"
-                    ? "ascending"
-                    : "descending"
-                  : "none";
-                const indicator = active
-                  ? sort?.direction === "asc"
-                    ? "↑"
-                    : "↓"
-                  : "↕";
-                // Accessible name combines the visible header with a state hint.
-                // We deliberately avoid embedding the column header verbatim
-                // into a separate aria-label so the button's name is always
-                // strictly more specific than the column header text — this
-                // keeps name-based queries that target row-action buttons
-                // (e.g. {name: "Konten"}) from matching the sort header.
-                // The aria-sort attribute on the <th> communicates the
-                // current sort direction to assistive tech independently.
-                const stateHint = active
-                  ? sort?.direction === "asc"
-                    ? "aufsteigend sortiert"
-                    : "absteigend sortiert"
-                  : "Spalte sortieren";
-                return (
-                  <th
-                    key={col.key}
-                    scope="col"
-                    aria-sort={ariaSort}
-                    className={`px-5 py-3 ${align} ${col.headerClassName ?? ""}`}
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <tr>
+                  <td
+                    colSpan={columns.length}
+                    className="px-5 py-10 text-center text-sm text-gray-500"
+                  >
+                    Wird geladen…
+                  </td>
+                </tr>
+              ) : sortedRows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={columns.length}
+                    className="px-5 py-10 text-center text-sm text-gray-500"
+                  >
+                    {emptyState ?? "Keine Einträge vorhanden."}
+                  </td>
+                </tr>
+              ) : (
+                visibleRows.map((row) => {
+                  const rowKey = getRowKey(row);
+                  const rowClasses = [
+                    "border-b border-gray-50 last:border-0 transition-colors",
+                    clickable ? "cursor-pointer hover:bg-gray-50" : "",
+                    rowClassName ? rowClassName(row) : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ");
+                  return (
+                    <tr
+                      key={rowKey}
+                      className={rowClasses}
+                      onClick={onRowClick ? () => onRowClick(row) : undefined}
+                      onKeyDown={
+                        onRowClick
+                          ? (event) => {
+                              if (event.target !== event.currentTarget) {
+                                return;
+                              }
+                              if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+                                onRowClick(row);
+                              }
+                            }
+                          : undefined
+                      }
+                      tabIndex={clickable ? 0 : undefined}
+                      role={clickable ? "button" : undefined}
+                    >
+                      {columns.map((col) => {
+                        const align = alignClass[col.align ?? "left"];
+                        return (
+                          <td
+                            key={col.key}
+                            className={`px-5 py-3 align-middle text-gray-900 ${align} ${col.className ?? ""}`}
+                          >
+                            {col.render(row)}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })
+              )}
+              {!isLoading && hasMore && (
+                <tr className="border-t border-gray-100">
+                  <td
+                    colSpan={columns.length}
+                    className="px-5 py-3 text-center"
                   >
                     <button
                       type="button"
-                      onClick={() => toggleSort(col.key)}
-                      className={`inline-flex items-center gap-1 font-medium transition-colors select-none hover:text-gray-700 focus:rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 ${align}`}
+                      onClick={loadMore}
+                      className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                     >
-                      <span>{col.header}</span>
-                      <span
-                        aria-hidden="true"
-                        className={active ? "text-gray-700" : "text-gray-300"}
-                      >
-                        {indicator}
-                      </span>
-                      <span className="sr-only">{` – ${stateHint}`}</span>
+                      {`Mehr laden (${visibleRows.length} von ${sortedRows.length})`}
                     </button>
-                  </th>
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {isLoading ? (
-              <tr>
-                <td
-                  colSpan={columns.length}
-                  className="px-5 py-10 text-center text-sm text-gray-500"
-                >
-                  Wird geladen…
-                </td>
-              </tr>
-            ) : sortedRows.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={columns.length}
-                  className="px-5 py-10 text-center text-sm text-gray-500"
-                >
-                  {emptyState ?? "Keine Einträge vorhanden."}
-                </td>
-              </tr>
-            ) : (
-              visibleRows.map((row) => {
-                const rowKey = getRowKey(row);
-                const rowClasses = [
-                  "border-b border-gray-50 last:border-0 transition-colors",
-                  clickable ? "cursor-pointer hover:bg-gray-50" : "",
-                  rowClassName ? rowClassName(row) : "",
-                ]
-                  .filter(Boolean)
-                  .join(" ");
-                return (
-                  <tr
-                    key={rowKey}
-                    className={rowClasses}
-                    onClick={onRowClick ? () => onRowClick(row) : undefined}
-                    onKeyDown={
-                      onRowClick
-                        ? (event) => {
-                            if (event.target !== event.currentTarget) {
-                              return;
-                            }
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              onRowClick(row);
-                            }
-                          }
-                        : undefined
-                    }
-                    tabIndex={clickable ? 0 : undefined}
-                    role={clickable ? "button" : undefined}
-                  >
-                    {columns.map((col) => {
-                      const align = alignClass[col.align ?? "left"];
-                      return (
-                        <td
-                          key={col.key}
-                          className={`px-5 py-3 align-middle text-gray-900 ${align} ${col.className ?? ""}`}
-                        >
-                          {col.render(row)}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                );
-              })
-            )}
-            {!isLoading && hasMore && (
-              <tr className="border-t border-gray-100">
-                <td colSpan={columns.length} className="px-5 py-3 text-center">
-                  <button
-                    type="button"
-                    onClick={loadMore}
-                    className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
-                  >
-                    {`Mehr laden (${visibleRows.length} von ${sortedRows.length})`}
-                  </button>
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/resource-grid.test.tsx
+++ b/frontend/src/components/ui/resource-grid.test.tsx
@@ -38,6 +38,13 @@ function renderGrid(
 }
 
 describe("ResourceGrid", () => {
+  it("clips the rounded surface without becoming a scroll container", () => {
+    const { container } = renderGrid();
+
+    expect(container.firstElementChild).toHaveClass("overflow-clip");
+    expect(container.firstElementChild).not.toHaveClass("overflow-hidden");
+  });
+
   it("renders the row header in a sticky first column", () => {
     renderGrid();
 

--- a/frontend/src/components/ui/resource-grid.tsx
+++ b/frontend/src/components/ui/resource-grid.tsx
@@ -90,91 +90,100 @@ export function ResourceGrid<TRow>({
   const columnMinWidth = COLUMN_MIN_WIDTH_CLASS[columnMode];
 
   return (
+    // Radius, Rand und Ausschnitt sitzen auf der Fläche, gescrollt wird im
+    // inneren Container. Sonst zeichnet der Browser die Scrollleiste über die
+    // volle Breite der Box, quer durch die abgerundeten Ecken und über den
+    // unteren Rand hinaus. Der Fokusring wandert per :has() mit nach außen,
+    // weil overflow-hidden einen Ring am inneren Element abschneiden würde.
     <div
-      role={ariaLabel ? "region" : undefined}
-      aria-label={ariaLabel}
-      aria-describedby={scrollHintId}
-      tabIndex={0}
-      onKeyDown={(event) => {
-        if (event.target !== event.currentTarget) return;
-        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-        event.preventDefault();
-        event.currentTarget.scrollBy({
-          left: event.key === "ArrowLeft" ? -240 : 240,
-          behavior: "smooth",
-        });
-      }}
-      className={`max-w-full overflow-x-auto overscroll-x-contain rounded-2xl border border-gray-200 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none ${className ?? ""}`}
+      className={`max-w-full overflow-hidden rounded-2xl border border-gray-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-gray-900 ${className ?? ""}`}
     >
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr className="bg-gray-50 text-left">
-            <th
-              scope="col"
-              className="sticky left-0 z-10 min-w-[180px] bg-gray-50 px-2 py-1.5 text-xs font-medium text-gray-500"
-            >
-              {cornerHeader}
-            </th>
-            {columns.map((column) => (
+      <div
+        role={ariaLabel ? "region" : undefined}
+        aria-label={ariaLabel}
+        aria-describedby={scrollHintId}
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) return;
+          if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+          event.preventDefault();
+          event.currentTarget.scrollBy({
+            left: event.key === "ArrowLeft" ? -240 : 240,
+            behavior: "smooth",
+          });
+        }}
+        className="max-w-full overflow-x-auto overscroll-x-contain focus-visible:outline-none"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="bg-gray-50 text-left">
               <th
-                key={column.key}
                 scope="col"
-                className={`${columnMinWidth} px-2 py-1.5 text-xs font-medium text-gray-500 ${
-                  column.isCurrent ? "bg-gray-100" : ""
-                }`}
+                className="sticky left-0 z-10 min-w-[180px] bg-gray-50 px-2 py-1.5 text-xs font-medium text-gray-500"
               >
-                <span className="block">{column.label}</span>
-                {column.sublabel && (
-                  <span className="block font-normal text-gray-400">
-                    {column.sublabel}
-                  </span>
-                )}
+                {cornerHeader}
               </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => {
-            return (
-              <tr key={getRowKey(row)} className="border-t border-gray-100">
+              {columns.map((column) => (
                 <th
-                  scope="row"
-                  className="sticky left-0 z-10 min-w-[180px] bg-white px-2 py-1.5 text-left align-top font-normal"
+                  key={column.key}
+                  scope="col"
+                  className={`${columnMinWidth} px-2 py-1.5 text-xs font-medium text-gray-500 ${
+                    column.isCurrent ? "bg-gray-100" : ""
+                  }`}
                 >
-                  {renderRowHeader(row)}
+                  <span className="block">{column.label}</span>
+                  {column.sublabel && (
+                    <span className="block font-normal text-gray-400">
+                      {column.sublabel}
+                    </span>
+                  )}
                 </th>
-                {columns.map((column) => {
-                  const cell = renderCell(row, column);
-                  const showEmptyButton =
-                    cell == null && emptyCellLabel && onEmptyCellClick;
-                  return (
-                    <td
-                      key={column.key}
-                      className={`border-l border-gray-100 px-1 py-1 align-top ${
-                        column.isCurrent ? "bg-gray-50" : ""
-                      }`}
-                    >
-                      {cell != null ? (
-                        cell
-                      ) : showEmptyButton ? (
-                        <button
-                          type="button"
-                          onClick={() => onEmptyCellClick(row, column)}
-                          aria-label={emptyCellLabel(row, column)}
-                          className="flex min-h-14 w-full items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
-                        >
-                          <Plus className="h-4 w-4" aria-hidden="true" />
-                        </button>
-                      ) : null}
-                    </td>
-                  );
-                })}
-              </tr>
-            );
-          })}
-        </tbody>
-        {footer && <tfoot>{footer}</tfoot>}
-      </table>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              return (
+                <tr key={getRowKey(row)} className="border-t border-gray-100">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 min-w-[180px] bg-white px-2 py-1.5 text-left align-top font-normal"
+                  >
+                    {renderRowHeader(row)}
+                  </th>
+                  {columns.map((column) => {
+                    const cell = renderCell(row, column);
+                    const showEmptyButton =
+                      cell == null && emptyCellLabel && onEmptyCellClick;
+                    return (
+                      <td
+                        key={column.key}
+                        className={`border-l border-gray-100 px-1 py-1 align-top ${
+                          column.isCurrent ? "bg-gray-50" : ""
+                        }`}
+                      >
+                        {cell != null ? (
+                          cell
+                        ) : showEmptyButton ? (
+                          <button
+                            type="button"
+                            onClick={() => onEmptyCellClick(row, column)}
+                            aria-label={emptyCellLabel(row, column)}
+                            className="flex min-h-14 w-full items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
+                          >
+                            <Plus className="h-4 w-4" aria-hidden="true" />
+                          </button>
+                        ) : null}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+          {footer && <tfoot>{footer}</tfoot>}
+        </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ui/resource-grid.tsx
+++ b/frontend/src/components/ui/resource-grid.tsx
@@ -94,9 +94,12 @@ export function ResourceGrid<TRow>({
     // inneren Container. Sonst zeichnet der Browser die Scrollleiste über die
     // volle Breite der Box, quer durch die abgerundeten Ecken und über den
     // unteren Rand hinaus. Der Fokusring wandert per :has() mit nach außen,
-    // weil overflow-hidden einen Ring am inneren Element abschneiden würde.
+    // weil der Ausschnitt einen Ring am inneren Element abschneiden würde.
+    // overflow-clip beschneidet dabei ohne einen zusätzlichen Scroll-Container
+    // zu erzeugen, damit die sticky Zeilenköpfe am inneren Scroll-Container
+    // ausgerichtet bleiben.
     <div
-      className={`max-w-full overflow-hidden rounded-2xl border border-gray-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-gray-900 ${className ?? ""}`}
+      className={`max-w-full overflow-clip rounded-2xl border border-gray-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-gray-900 ${className ?? ""}`}
     >
       <div
         role={ariaLabel ? "region" : undefined}


### PR DESCRIPTION
Closes #2027

## Problem

Bei horizontal scrollbaren Tabellen und Rastern saß `overflow-x-auto` direkt auf der Kartenfläche, die gleichzeitig Radius, Rand und Schatten trägt. Der Browser zeichnet die Scrollleiste über die volle Breite dieser Box, also quer durch die abgerundeten Ecken und über den unteren Rand hinaus.

## Lösung

Die Karte behält Radius, Rand und Schatten und bekommt `overflow-hidden`, das Scrollen wandert in einen inneren Container. Damit beschneidet der Radius die Scrollleiste. Fix sitzt in den geteilten Komponenten, nicht pro Seite.

| Datei | Wirkt auf |
|---|---|
| `ui/data-table.tsx` | Kalenderzeiträume, Schließtage und alle weiteren DataTable-Seiten |
| `ui/resource-grid.tsx` | Dienstplan Woche und Halbjahr |
| `staff/staff-session-table.tsx` | Zeiterfassungs-Tabelle |
| `staff/dienstplan-skeleton.tsx` | Ladezustand des Dienstplan-Rasters |

Beim `ResourceGrid` bleiben `tabIndex`, Tastatur-Handler, `role`/`aria` und `overscroll-x-contain` auf dem inneren Scroll-Container. Der Fokusring wandert per `has-[:focus-visible]:` nach außen, weil `overflow-hidden` einen Ring am inneren Element abschneiden würde. Die `:focus-visible`-Semantik bleibt damit erhalten, im Gegensatz zu `focus-within`, das auch bei Mausklick zünden würde.

## Akzeptanzkriterien

- [x] Kalenderzeiträume und Schließtage: Scrollleiste bleibt innerhalb der Karte, Ecken intakt
- [x] Dienstplan-Raster (Woche und Halbjahr) und Zeiterfassungs-Tabelle ebenso
- [x] Sticky-Spalte bleibt bei `scrollLeft` 463 exakt 1 px innerhalb der Kartenkante
- [x] Pfeiltasten scrollen das Raster unverändert, Fokusring liegt sichtbar um die Fläche
- [x] Kein Seiten-Scroll nach rechts: `documentElement.scrollWidth == clientWidth`

## Verifikation

Visuell geprüft in Chromium bei 1600x1000 gegen die Demo-Instanz. Der Pixeldiff der Vollbilder vorher/nachher ist genau eine Region, 11x4 px an der linken unteren Ecke der Karte, also exakt der gemeldete Eckenartefakt.

DOM-Messung nach dem Fix: Karte `overflow: hidden` + `border-radius: 24px`, innerer Container `overflow-x: auto` mit Radius 0. Bei der Zeiterfassungs-Tabelle mit echtem Overflow (973 > 704 px) liegen die 8 px Scrollleiste innerhalb der Karte.

`pnpm run check` läuft sauber durch. Tests für `resource-grid`, `dienstplan-resource-grid`, `dienstplan-view` und `plan-design-guards` sind grün (207). In `components/staff` + `components/ui` sind 1194 von 1197 grün; die drei Fehlschläge liegen in `ui/chart.test.tsx` und fallen auf dem ungepatchten Stand identisch um, sind also bereits auf `development` rot.

## Screenshots

<details>
<summary>Vorher / Nachher</summary>
<img width="1600" height="1000" alt="after-calendar-periods" src="https://github.com/user-attachments/assets/158b164b-1f94-4495-a992-660d14667521" />
<img width="1600" height="1000" alt="after-dienstplan-halbjahr-focus" src="https://github.com/user-attachments/assets/96585175-40c5-499e-9f6d-3183518d0631" />
<img width="1600" height="1000" alt="after-dienstplan-halbjahr" src="https://github.com/user-attachments/assets/e4d5a16c-e675-4f8a-8890-e9349422a425" />
<img width="1600" height="1000" alt="after-dienstplan" src="https://github.com/user-attachments/assets/ec19ad8f-ab2e-49e7-b9c6-b2a972691916" />
<img width="1100" height="900" alt="after-zeiterfassung-scrollbar" src="https://github.com/user-attachments/assets/b8d550a8-9df4-49ac-a0f9-e947c477d779" />
<img width="1600" height="1000" alt="before-dienstplan-halbjahr" src="https://github.com/user-attachments/assets/adece925-2cdc-46f5-8efd-2dc0883334bd" />
<img width="1292" height="388" alt="corner-vergleich" src="https://github.com/user-attachments/assets/d1bc6371-91be-4844-a408-8ca6469798b4" />

</details>

## Nicht in diesem PR

Zwei Stellen außerhalb der geteilten Komponenten tragen dasselbe Muster, sind aber weder Tabelle noch Raster und nicht Teil der Akzeptanzkriterien:

- `admin/pending-invitations-list.tsx:179` — eigene Tabelle mit `overflow-x-auto rounded-xl border`
- `staff/arbeitszeitmodell-tab.tsx:738` — Chip-Streifen der Rotationswochen mit `overflow-x-auto rounded-full`

Alle übrigen `overflow-x-auto`-Fundstellen wurden geprüft und sind unkritisch: entweder ohne Radius innerhalb einer Karte mit Padding, Tab-Leisten mit `border-b` statt Radius, oder bereits mit dem korrekten äußeren `overflow-hidden`.
