### PR TITLE
fix(dienstplan): leerer und gefüllter Plan rastern gleich

### DIFF
--- a/frontend/src/components/staff/dienstplan-halbjahr-grid.tsx
+++ b/frontend/src/components/staff/dienstplan-halbjahr-grid.tsx
@@ -363,6 +363,9 @@ function HalbjahrGridInner({
     </span>
   );
 
+  // Interaktive Zellinhalte tragen flex-1: das ResourceGrid gibt der Zelle eine
+  // Mindesthöhe, ohne Füllen bliebe die Klick-/Hoverfläche kleiner als ihre
+  // Zelle (Issue #2026).
   const renderCell = (
     member: StaffScheduleStaff,
     column: ResourceGridColumn,
@@ -385,7 +388,7 @@ function HalbjahrGridInner({
           type="button"
           onClick={() => state.retry()}
           aria-label={`Woche ${kw} erneut laden`}
-          className="flex min-h-8 w-full items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
+          className="flex w-full flex-1 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
         >
           <RotateCw className="h-4 w-4" aria-hidden="true" />
         </button>
@@ -402,7 +405,7 @@ function HalbjahrGridInner({
         type="button"
         onClick={() => onWeekClick(column.key)}
         aria-label={`Woche ${kw} öffnen, ${member.firstName} ${member.lastName}`}
-        className="flex w-full items-center justify-center rounded-md px-1 py-1.5 transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
+        className="flex w-full flex-1 items-center justify-center rounded-md px-1 py-1.5 transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
       >
         <CoverageIndicator
           state="covered"

--- a/frontend/src/components/staff/dienstplan-resource-grid.test.tsx
+++ b/frontend/src/components/staff/dienstplan-resource-grid.test.tsx
@@ -156,6 +156,15 @@ describe("DienstplanResourceGrid stacking", () => {
       .map((el) => el.textContent);
     expect(times).toEqual(["08:00–10:00", "10:30–15:00"]);
   });
+
+  it("extends the filled-cell hover group across the cell height", () => {
+    renderGrid({ shiftsByStaff: shiftMap("2026-07-06", [baseShift()]) });
+
+    const addShiftButton = screen.getByRole("button", {
+      name: "Schicht anlegen, Ada Lovelace, Mo 06.07.",
+    });
+    expect(addShiftButton.parentElement).toHaveClass("group", "flex-1");
+  });
 });
 
 describe("DienstplanResourceGrid status mapping", () => {

--- a/frontend/src/components/staff/dienstplan-resource-grid.tsx
+++ b/frontend/src/components/staff/dienstplan-resource-grid.tsx
@@ -542,8 +542,10 @@ export function DienstplanResourceGrid({
       a.startTime.localeCompare(b.startTime),
     );
 
+    // Die Mindesthöhe der Zelle liegt im ResourceGrid, damit leere und gefüllte
+    // Zellen dieselbe Zeilenhöhe ergeben (Issue #2026).
     return (
-      <div className="group flex min-h-14 flex-col gap-1">
+      <div className="group flex flex-col gap-1">
         {sortedShifts.map((shift) =>
           renderShiftEntry(member, date, shift, dayIsAbsent),
         )}

--- a/frontend/src/components/staff/dienstplan-resource-grid.tsx
+++ b/frontend/src/components/staff/dienstplan-resource-grid.tsx
@@ -545,7 +545,7 @@ export function DienstplanResourceGrid({
     // Die Mindesthöhe der Zelle liegt im ResourceGrid, damit leere und gefüllte
     // Zellen dieselbe Zeilenhöhe ergeben (Issue #2026).
     return (
-      <div className="group flex flex-col gap-1">
+      <div className="group flex flex-1 flex-col gap-1">
         {sortedShifts.map((shift) =>
           renderShiftEntry(member, date, shift, dayIsAbsent),
         )}

--- a/frontend/src/components/staff/dienstplan-skeleton.tsx
+++ b/frontend/src/components/staff/dienstplan-skeleton.tsx
@@ -1,17 +1,23 @@
 "use client";
 
+import { CapacityStrip } from "~/components/ui/capacity-strip";
 import {
   RESOURCE_GRID_METRICS,
   resourceGridMinWidth,
 } from "~/components/ui/resource-grid";
 import { Skeleton } from "~/components/ui/skeleton";
 
-// Das Skelett rastert wie das echte Wochenraster: dieselbe Spaltenzahl,
-// dieselben Spaltenbreiten aus RESOURCE_GRID_METRICS und dieselbe
-// Zellen-Mindesthöhe (Issue #2026). Ändert sich die Metrik im ResourceGrid,
-// wandert sie automatisch mit.
+// Das Skelett rastert wie das echte Wochenraster (Issue #2026). Die Maße —
+// Spaltenbreiten und Zellen-Mindesthöhe — kommen aus RESOURCE_GRID_METRICS und
+// wandern mit; die Tabellenstruktur (Ränder, Paddings, sticky Personenspalte)
+// ist bewusst nachgebaut, weil das ResourceGrid Textspalten-Köpfe erwartet und
+// hier nur Platzhalter stehen. Ändert sich dort die Struktur, muss sie hier
+// nachgezogen werden.
 const SKELETON_DAY_COLUMNS = 5;
-const CELL_MIN_HEIGHT = RESOURCE_GRID_METRICS.cellMinHeightClass.days;
+const DAY_COLUMN_INDEXES = Array.from(
+  { length: SKELETON_DAY_COLUMNS },
+  (_, index) => index,
+);
 
 // The PlanningContextBar header placeholder (title, week nav, view switcher,
 // "Schichtarten verwalten" action). Only used by the full-page skeleton — once
@@ -49,16 +55,16 @@ function GridSkeletonBody() {
           >
             <colgroup>
               <col style={{ width: RESOURCE_GRID_METRICS.rowHeaderWidth }} />
-              {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+              {DAY_COLUMN_INDEXES.map((col) => (
                 <col key={col} />
               ))}
             </colgroup>
             <thead>
               <tr className="bg-gray-50">
-                <th className="px-2 py-1.5 text-left">
+                <th className="sticky left-0 z-10 bg-gray-50 px-2 py-1.5 text-left">
                   <Skeleton className="h-4 w-16 rounded" />
                 </th>
-                {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+                {DAY_COLUMN_INDEXES.map((col) => (
                   <th key={col} className="px-2 py-1.5 text-left">
                     <Skeleton className="h-4 w-14 rounded" />
                   </th>
@@ -67,17 +73,17 @@ function GridSkeletonBody() {
             </thead>
             <tbody>
               {Array.from({ length: 6 }, (_, row) => (
-                <tr key={row} className="border-t border-gray-100 bg-white">
-                  <td className="px-2 py-1.5 align-top">
+                <tr key={row} className="border-t border-gray-100">
+                  <th className="sticky left-0 z-10 bg-white px-2 py-1.5 text-left align-top font-normal">
                     <Skeleton className="h-4 w-32 rounded" />
-                  </td>
-                  {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+                  </th>
+                  {DAY_COLUMN_INDEXES.map((col) => (
                     <td
                       key={col}
                       className="border-l border-gray-100 px-1 py-1 align-top"
                     >
                       <Skeleton
-                        className={`${CELL_MIN_HEIGHT} w-full rounded-md`}
+                        className={`${RESOURCE_GRID_METRICS.cellMinHeightClass.days} w-full rounded-md`}
                       />
                     </td>
                   ))}
@@ -85,19 +91,13 @@ function GridSkeletonBody() {
               ))}
             </tbody>
             <tfoot>
-              <tr className="border-t border-gray-200 bg-gray-50">
-                <td className="px-2 py-1.5">
-                  <Skeleton className="h-4 w-28 rounded" />
-                </td>
-                {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
-                  <td
-                    key={col}
-                    className="border-l border-gray-100 px-2 py-1.5 text-center"
-                  >
-                    <Skeleton className="mx-auto h-4 w-8 rounded" />
-                  </td>
-                ))}
-              </tr>
+              <CapacityStrip
+                rowLabel={<Skeleton className="h-4 w-28 rounded" />}
+                cells={DAY_COLUMN_INDEXES.map((col) => ({
+                  key: String(col),
+                  content: <Skeleton className="mx-auto h-4 w-8 rounded" />,
+                }))}
+              />
             </tfoot>
           </table>
         </div>

--- a/frontend/src/components/staff/dienstplan-skeleton.tsx
+++ b/frontend/src/components/staff/dienstplan-skeleton.tsx
@@ -1,6 +1,17 @@
 "use client";
 
+import {
+  RESOURCE_GRID_METRICS,
+  resourceGridMinWidth,
+} from "~/components/ui/resource-grid";
 import { Skeleton } from "~/components/ui/skeleton";
+
+// Das Skelett rastert wie das echte Wochenraster: dieselbe Spaltenzahl,
+// dieselben Spaltenbreiten aus RESOURCE_GRID_METRICS und dieselbe
+// Zellen-Mindesthöhe (Issue #2026). Ändert sich die Metrik im ResourceGrid,
+// wandert sie automatisch mit.
+const SKELETON_DAY_COLUMNS = 5;
+const CELL_MIN_HEIGHT = RESOURCE_GRID_METRICS.cellMinHeightClass.days;
 
 // The PlanningContextBar header placeholder (title, week nav, view switcher,
 // "Schichtarten verwalten" action). Only used by the full-page skeleton — once
@@ -30,18 +41,44 @@ function HeaderSkeleton() {
 function GridSkeletonBody() {
   return (
     <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-      <div className="max-w-full overflow-hidden rounded-2xl border border-gray-100">
+      <div className="max-w-full overflow-clip rounded-2xl border border-gray-200">
         <div className="max-w-full overflow-x-auto">
-          <table className="w-full min-w-[960px] border-collapse text-sm">
-            <tbody className="divide-y divide-gray-100">
+          <table
+            className="w-full table-fixed border-collapse text-sm"
+            style={{ minWidth: resourceGridMinWidth(SKELETON_DAY_COLUMNS) }}
+          >
+            <colgroup>
+              <col style={{ width: RESOURCE_GRID_METRICS.rowHeaderWidth }} />
+              {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+                <col key={col} />
+              ))}
+            </colgroup>
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="px-2 py-1.5 text-left">
+                  <Skeleton className="h-4 w-16 rounded" />
+                </th>
+                {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+                  <th key={col} className="px-2 py-1.5 text-left">
+                    <Skeleton className="h-4 w-14 rounded" />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
               {Array.from({ length: 6 }, (_, row) => (
-                <tr key={row} className="bg-white">
-                  <td className="px-4 py-2">
+                <tr key={row} className="border-t border-gray-100 bg-white">
+                  <td className="px-2 py-1.5 align-top">
                     <Skeleton className="h-4 w-32 rounded" />
                   </td>
-                  {Array.from({ length: 5 }, (_, col) => (
-                    <td key={col} className="px-3 py-2">
-                      <Skeleton className="h-9 w-full rounded-md" />
+                  {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+                    <td
+                      key={col}
+                      className="border-l border-gray-100 px-1 py-1 align-top"
+                    >
+                      <Skeleton
+                        className={`${CELL_MIN_HEIGHT} w-full rounded-md`}
+                      />
                     </td>
                   ))}
                 </tr>
@@ -49,12 +86,15 @@ function GridSkeletonBody() {
             </tbody>
             <tfoot>
               <tr className="border-t border-gray-200 bg-gray-50">
-                <td className="px-4 py-2">
+                <td className="px-2 py-1.5">
                   <Skeleton className="h-4 w-28 rounded" />
                 </td>
-                {Array.from({ length: 5 }, (_, col) => (
-                  <td key={col} className="px-3 py-2">
-                    <Skeleton className="h-4 w-8 rounded" />
+                {Array.from({ length: SKELETON_DAY_COLUMNS }, (_, col) => (
+                  <td
+                    key={col}
+                    className="border-l border-gray-100 px-2 py-1.5 text-center"
+                  >
+                    <Skeleton className="mx-auto h-4 w-8 rounded" />
                   </td>
                 ))}
               </tr>

--- a/frontend/src/components/ui/capacity-strip.tsx
+++ b/frontend/src/components/ui/capacity-strip.tsx
@@ -77,10 +77,12 @@ interface CapacityStripProps {
    */
   readonly position?: "footer" | "header";
   /**
-   * Width utility class for the leading label cell. Default `min-w-[180px]`
-   * matches the ResourceGrid sticky person column. A narrow parent column
-   * (e.g. the 64px time gutter of the Betreuungsplan day header) overrides
-   * this so the label cell stops forcing extra width onto the grid.
+   * Width utility class for the leading label cell. Only relevant in `div`
+   * mode: a narrow parent column (e.g. the 64px time gutter of the
+   * Betreuungsplan day header) overrides the default so the label cell stops
+   * forcing extra width onto the grid. In `tr` mode the ResourceGrid runs a
+   * fixed table layout, where the <colgroup> owns every column width and a
+   * min-width on this cell has no effect.
    */
   readonly labelWidthClassName?: string;
 }

--- a/frontend/src/components/ui/resource-grid.test.tsx
+++ b/frontend/src/components/ui/resource-grid.test.tsx
@@ -131,7 +131,7 @@ describe("ResourceGrid", () => {
       DAY_COLUMNS.length + 1,
     );
     expect((table as HTMLTableElement).style.minWidth).toBe(
-      `calc(13rem + ${DAY_COLUMNS.length} * 7.5rem)`,
+      `${13 + DAY_COLUMNS.length * 7.5}rem`,
     );
   });
 
@@ -139,9 +139,7 @@ describe("ResourceGrid", () => {
     const { container } = renderGrid({ columnMode: "weeks" });
 
     const table = container.querySelector("table") as HTMLTableElement;
-    expect(table.style.minWidth).toBe(
-      `calc(13rem + ${DAY_COLUMNS.length} * 3.25rem)`,
-    );
+    expect(table.style.minWidth).toBe(`${13 + DAY_COLUMNS.length * 3.25}rem`);
   });
 
   it("gives empty, bare and filled cells the same height floor", () => {

--- a/frontend/src/components/ui/resource-grid.test.tsx
+++ b/frontend/src/components/ui/resource-grid.test.tsx
@@ -118,6 +118,62 @@ describe("ResourceGrid", () => {
     );
   });
 
+  // Issue #2026: an empty and a filled plan must raster identically. Column
+  // widths therefore come from a fixed table layout plus a colgroup, never from
+  // the cell content, and every cell carries the same height floor.
+  it("lays the table out with fixed columns from a colgroup, not from content", () => {
+    const { container } = renderGrid();
+
+    const table = container.querySelector("table");
+    expect(table).toHaveClass("table-fixed");
+    // One <col> for the sticky row header plus one per data column.
+    expect(container.querySelectorAll("colgroup col")).toHaveLength(
+      DAY_COLUMNS.length + 1,
+    );
+    expect((table as HTMLTableElement).style.minWidth).toBe(
+      `calc(13rem + ${DAY_COLUMNS.length} * 7.5rem)`,
+    );
+  });
+
+  it("scales the table min width with the narrower weeks columns", () => {
+    const { container } = renderGrid({ columnMode: "weeks" });
+
+    const table = container.querySelector("table") as HTMLTableElement;
+    expect(table.style.minWidth).toBe(
+      `calc(13rem + ${DAY_COLUMNS.length} * 3.25rem)`,
+    );
+  });
+
+  it("gives empty, bare and filled cells the same height floor", () => {
+    const { container } = renderGrid({
+      renderCell: (row, column) =>
+        column.key === "mo" ? <span>{`${row.name} früh`}</span> : null,
+      emptyCellLabel: (row, column) => `Anlegen, ${row.name}, ${column.label}`,
+      onEmptyCellClick: vi.fn(),
+    });
+
+    const filledWrapper = screen.getByText("A. Krause früh").parentElement;
+    const emptyWrapper = screen.getByRole("button", {
+      name: "Anlegen, A. Krause, Di 14.07.",
+    }).parentElement;
+
+    expect(filledWrapper).toHaveClass("min-h-16");
+    expect(emptyWrapper).toHaveClass("min-h-16");
+    // Every cell wrapper in the body carries the floor, including the ones
+    // without any empty-cell affordance.
+    for (const cell of container.querySelectorAll("tbody td")) {
+      expect(cell.firstElementChild).toHaveClass("min-h-16");
+    }
+  });
+
+  it("uses the shorter cell height floor in weeks mode", () => {
+    const { container } = renderGrid({ columnMode: "weeks" });
+
+    for (const cell of container.querySelectorAll("tbody td")) {
+      expect(cell.firstElementChild).toHaveClass("min-h-11");
+    }
+  });
+
   it("renders the footer slot inside a tfoot (CapacityStrip interplay)", () => {
     renderGrid({
       footer: (

--- a/frontend/src/components/ui/resource-grid.tsx
+++ b/frontend/src/components/ui/resource-grid.tsx
@@ -45,8 +45,9 @@ interface ResourceGridProps<TRow> {
    */
   readonly renderCell: (row: TRow, column: ResourceGridColumn) => ReactNode;
   /**
-   * Drives only the per-column minimum width: a handful of wide day columns vs.
-   * a couple dozen narrow week columns. Cell content itself is the caller's.
+   * Drives the per-column width and the uniform cell height: a handful of wide
+   * day columns vs. a couple dozen narrow week columns. Cell content itself is
+   * the caller's.
    */
   readonly columnMode?: ResourceGridColumnMode;
   /** Top-left corner header above the sticky row-header column. */
@@ -67,10 +68,56 @@ interface ResourceGridProps<TRow> {
   readonly className?: string;
 }
 
+// Declared per-column floor on the header cells. Under `table-layout: fixed`
+// the browser ignores min-width on table cells — the floor that actually binds
+// is the table's own minWidth below, computed from the same values.
 const COLUMN_MIN_WIDTH_CLASS: Record<ResourceGridColumnMode, string> = {
   days: "min-w-[7.5rem]",
   weeks: "min-w-[3.25rem]",
 };
+
+/**
+ * Raster metrics — the reason an empty and a filled plan look identical
+ * (issue #2026). The table runs in `table-layout: fixed`, so column widths come
+ * from the <colgroup> below and no longer from whatever a cell happens to
+ * contain. Fixed layout ignores `min-width` on cells, so the per-column floor
+ * has to be re-expressed as the table's own `minWidth` (row header + n columns)
+ * — below that the scroll container takes over. `cellMinHeightClass` is the
+ * matching floor for the row height: it applies to EVERY cell, empty or filled,
+ * and is sized so a cell holding one plain entry does not grow past it.
+ *
+ * The skeleton (dienstplan-skeleton.tsx) imports these so it keeps rastering
+ * like the real grid. `columnWidth` carries the same values as
+ * COLUMN_MIN_WIDTH_CLASS above as plain lengths — Tailwind only picks up class
+ * names written out as literals, hence the two shapes.
+ */
+export const RESOURCE_GRID_METRICS = {
+  // 13rem statt der alten Mindestbreite von 180px: die Spalte war im
+  // Auto-Layout je nach Inhalt 194–259px breit. Auf 180px (oder 192px)
+  // festgenagelt würden längere Namen ("Zimmermann, Frank") plötzlich
+  // abgeschnitten — gemessen im Dienstplan mit 21 Personen.
+  rowHeaderWidth: "13rem",
+  columnWidth: {
+    days: "7.5rem",
+    weeks: "3.25rem",
+  },
+  cellMinHeightClass: {
+    days: "min-h-16",
+    weeks: "min-h-11",
+  },
+} as const satisfies {
+  rowHeaderWidth: string;
+  columnWidth: Record<ResourceGridColumnMode, string>;
+  cellMinHeightClass: Record<ResourceGridColumnMode, string>;
+};
+
+/** Table width below which the grid scrolls instead of squeezing columns. */
+export function resourceGridMinWidth(
+  columnCount: number,
+  columnMode: ResourceGridColumnMode = "days",
+): string {
+  return `calc(${RESOURCE_GRID_METRICS.rowHeaderWidth} + ${columnCount} * ${RESOURCE_GRID_METRICS.columnWidth[columnMode]})`;
+}
 
 export function ResourceGrid<TRow>({
   columns,
@@ -88,6 +135,7 @@ export function ResourceGrid<TRow>({
   className,
 }: ResourceGridProps<TRow>) {
   const columnMinWidth = COLUMN_MIN_WIDTH_CLASS[columnMode];
+  const cellMinHeight = RESOURCE_GRID_METRICS.cellMinHeightClass[columnMode];
 
   return (
     // Radius, Rand und Ausschnitt sitzen auf der Fläche, gescrollt wird im
@@ -117,7 +165,20 @@ export function ResourceGrid<TRow>({
         }}
         className="max-w-full overflow-x-auto overscroll-x-contain focus-visible:outline-none"
       >
-        <table className="w-full border-collapse text-sm">
+        <table
+          className="w-full table-fixed border-collapse text-sm"
+          style={{ minWidth: resourceGridMinWidth(columns.length, columnMode) }}
+        >
+          {/* Fixed layout reads the column widths from here, so an empty and a
+              filled plan raster identically (issue #2026). Only the row header
+              is pinned; the data columns share the remaining width equally and
+              never fall below the floor baked into the table's minWidth. */}
+          <colgroup>
+            <col style={{ width: RESOURCE_GRID_METRICS.rowHeaderWidth }} />
+            {columns.map((column) => (
+              <col key={column.key} />
+            ))}
+          </colgroup>
           <thead>
             <tr className="bg-gray-50 text-left">
               <th
@@ -165,18 +226,24 @@ export function ResourceGrid<TRow>({
                           column.isCurrent ? "bg-gray-50" : ""
                         }`}
                       >
-                        {cell != null ? (
-                          cell
-                        ) : showEmptyButton ? (
-                          <button
-                            type="button"
-                            onClick={() => onEmptyCellClick(row, column)}
-                            aria-label={emptyCellLabel(row, column)}
-                            className="flex min-h-14 w-full items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
-                          >
-                            <Plus className="h-4 w-4" aria-hidden="true" />
-                          </button>
-                        ) : null}
+                        {/* The height floor sits on the wrapper, not on the
+                            cell content: an empty cell, a bare cell without an
+                            empty-cell affordance and a filled one all get the
+                            same row height (issue #2026). */}
+                        <div className={`flex ${cellMinHeight} flex-col`}>
+                          {cell != null ? (
+                            cell
+                          ) : showEmptyButton ? (
+                            <button
+                              type="button"
+                              onClick={() => onEmptyCellClick(row, column)}
+                              aria-label={emptyCellLabel(row, column)}
+                              className="flex w-full flex-1 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none"
+                            >
+                              <Plus className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                          ) : null}
+                        </div>
                       </td>
                     );
                   })}

--- a/frontend/src/components/ui/resource-grid.tsx
+++ b/frontend/src/components/ui/resource-grid.tsx
@@ -81,6 +81,12 @@ const COLUMN_MIN_WIDTH_CLASS: Record<ResourceGridColumnMode, string> = {
   weeks: "min-w-[3.25rem]",
 };
 
+const ROW_HEADER_WIDTH_REM = 13;
+const COLUMN_WIDTH_REM: Record<ResourceGridColumnMode, number> = {
+  days: 7.5,
+  weeks: 3.25,
+};
+
 /**
  * Raster metrics — the reason an empty and a filled plan look identical
  * (issue #2026). The table runs in `table-layout: fixed`, so column widths come
@@ -101,10 +107,10 @@ export const RESOURCE_GRID_METRICS = {
   // Auto-Layout je nach Inhalt 194–259px breit. Auf 180px (oder 192px)
   // festgenagelt würden längere Namen ("Zimmermann, Frank") plötzlich
   // abgeschnitten — gemessen im Dienstplan mit 21 Personen.
-  rowHeaderWidth: "13rem",
+  rowHeaderWidth: `${ROW_HEADER_WIDTH_REM}rem`,
   columnWidth: {
-    days: "7.5rem",
-    weeks: "3.25rem",
+    days: `${COLUMN_WIDTH_REM.days}rem`,
+    weeks: `${COLUMN_WIDTH_REM.weeks}rem`,
   },
   cellMinHeightClass: {
     days: "min-h-16",
@@ -121,7 +127,7 @@ export function resourceGridMinWidth(
   columnCount: number,
   columnMode: ResourceGridColumnMode = "days",
 ): string {
-  return `calc(${RESOURCE_GRID_METRICS.rowHeaderWidth} + ${columnCount} * ${RESOURCE_GRID_METRICS.columnWidth[columnMode]})`;
+  return `${ROW_HEADER_WIDTH_REM + columnCount * COLUMN_WIDTH_REM[columnMode]}rem`;
 }
 
 export function ResourceGrid<TRow>({

--- a/frontend/src/components/ui/resource-grid.tsx
+++ b/frontend/src/components/ui/resource-grid.tsx
@@ -42,6 +42,11 @@ interface ResourceGridProps<TRow> {
    * Cell content per (row, column). Returning null lets the grid render the
    * labelled empty-cell button (if `emptyCellLabel` + `onEmptyCellClick` are
    * given) — the caller decides emptiness, the grid owns the empty affordance.
+   *
+   * The returned node lands in a `flex flex-col` wrapper carrying the
+   * per-mode cell minimum height. Interactive content that should cover the
+   * whole cell (a click target, a hover surface) needs `flex-1` to fill that
+   * floor — otherwise it floats in the taller box.
    */
   readonly renderCell: (row: TRow, column: ResourceGridColumn) => ReactNode;
   /**
@@ -135,7 +140,7 @@ export function ResourceGrid<TRow>({
   className,
 }: ResourceGridProps<TRow>) {
   const columnMinWidth = COLUMN_MIN_WIDTH_CLASS[columnMode];
-  const cellMinHeight = RESOURCE_GRID_METRICS.cellMinHeightClass[columnMode];
+  const cellWrapperClass = `flex ${RESOURCE_GRID_METRICS.cellMinHeightClass[columnMode]} flex-col`;
 
   return (
     // Radius, Rand und Ausschnitt sitzen auf der Fläche, gescrollt wird im
@@ -183,7 +188,7 @@ export function ResourceGrid<TRow>({
             <tr className="bg-gray-50 text-left">
               <th
                 scope="col"
-                className="sticky left-0 z-10 min-w-[180px] bg-gray-50 px-2 py-1.5 text-xs font-medium text-gray-500"
+                className="sticky left-0 z-10 bg-gray-50 px-2 py-1.5 text-xs font-medium text-gray-500"
               >
                 {cornerHeader}
               </th>
@@ -211,7 +216,7 @@ export function ResourceGrid<TRow>({
                 <tr key={getRowKey(row)} className="border-t border-gray-100">
                   <th
                     scope="row"
-                    className="sticky left-0 z-10 min-w-[180px] bg-white px-2 py-1.5 text-left align-top font-normal"
+                    className="sticky left-0 z-10 bg-white px-2 py-1.5 text-left align-top font-normal"
                   >
                     {renderRowHeader(row)}
                   </th>
@@ -230,7 +235,7 @@ export function ResourceGrid<TRow>({
                             cell content: an empty cell, a bare cell without an
                             empty-cell affordance and a filled one all get the
                             same row height (issue #2026). */}
-                        <div className={`flex ${cellMinHeight} flex-col`}>
+                        <div className={cellWrapperClass}>
                           {cell != null ? (
                             cell
                           ) : showEmptyButton ? (


### PR DESCRIPTION
Schließt #2026.

## Problem

Ein leerer und ein gefüllter Dienstplan waren unterschiedlich gerastert. Die Tabelle im `ResourceGrid` lief im Auto-Layout, pro Spalte war nur eine Mindestbreite gesetzt — die tatsächliche Breite richtete sich also nach dem Inhalt. Dazu kam die Zeilenhöhe: eine leere Zelle rendert einen Plus-Button mit eigener Mindesthöhe, eine gefüllte kompakte `PlanBlock`-Elemente.

Nachgemessen im Wochenraster mit 21 Personen (Viewport 1440):

| | Personenspalte | Tagesspalten | Zeilenhöhe |
|---|---|---|---|
| leere Woche | 259px | 5x 160px | 65px |
| gefüllte Woche | 194px | 169/169/**192**/169/168px | 65px leer, **85px** gefüllt |

Halbjahresansicht: leere Zeilen 33px, Zeilen mit Wochensumme 52px.

## Lösung

- **`table-layout: fixed`** im `ResourceGrid`. Die Spaltenbreiten kommen aus einer `<colgroup>`: Personenspalte fest, Datenspalten teilen sich den Rest gleichmäßig. Die bisherige Spalten-Mindestbreite (7,5rem Tage / 3,25rem Wochen) wandert in die `minWidth` der Tabelle — darunter scrollt der Container weiterhin horizontal, genau wie vorher.
- **Einheitliche Zellen-Mindesthöhe** auf einem Wrapper um *jede* Zelle, leer wie gefüllt wie affordanzlos (Halbjahr). Bemessen so, dass eine Zelle mit einer schlichten Schicht nicht darüber hinauswächst (Tage 4rem, Wochen 2,75rem — die Wochenzelle muss die zweizeilig umbrechende Summe fassen).
- Das **Skelett** (`dienstplan-skeleton.tsx`) importiert die Metriken aus dem `ResourceGrid` und rastert damit weiterhin wie das echte Raster (vorher: `min-w-[960px]`, andere Paddings, keine Kopfzeile).

Nachgemessen nach der Änderung: Wochenansicht leer wie gefüllt **208px + 5x 170px, Zeilen je 73px**; Halbjahresansicht **alle Zeilen 53px**. Mobil (390px) greift der Boden: Tabelle 808px = 208 + 5x 120, Scrollbereich 314px.

## Bewusste Abwägungen

- **Personenspalte 13rem statt der alten Mindestbreite von 180px.** Fest auf 180px hätten längere Namen ("Zimmermann, Frank") plötzlich abgeschnitten — im Auto-Layout war die Spalte je nach Inhalt 194–259px breit. Mit 13rem wird bei den 21 Testpersonen kein Name gekürzt.
- **Schichtart-Label kann jetzt kürzen** ("Schi…"), weil eine Spalte mit Inhalt sich nicht mehr auf Kosten der leeren Nachbarspalten verbreitern darf. Genau das war der gemeldete Fehler; der vollständige Text steckt weiterhin im `aria-label` des Blocks.
- Zeilen mit zusätzlichen Notizzeilen (Pause, Vertretung, Fällt aus) bleiben höher als der Boden. Das ist echter Inhalt, keine Rasterabweichung.

## Tests

- 4 neue Fälle in `resource-grid.test.tsx`: fixes Layout + `<colgroup>`, `minWidth`-Formel je Spaltenmodus, gleicher Höhenboden für leere/inhaltslose/gefüllte Zellen, schmalerer Boden im Wochenmodus.
- `pnpm run check` grün, `pnpm vitest run` grün bis auf die drei vorbestehenden `chart.test.tsx`-Fehler (auch auf `development` rot, unabhängig von dieser Änderung).
- End-to-end im lokalen Stack verifiziert: Wochenansicht leer/gefüllt, Halbjahresansicht, Ladeskelett, Kapazitätsfuß, Mobil-Viewport.

## Screenshots

Vorher/Nachher-Paare liegen lokal und werden separat angehängt.
