### PR TITLE
Vertretung: Bearbeiten-Button als Hauptaktion hervorheben

### DIFF
--- a/frontend/src/components/timetable/vertretung-day-list.tsx
+++ b/frontend/src/components/timetable/vertretung-day-list.tsx
@@ -345,10 +345,14 @@ function VertretungDayListRow({
         {/* Auch Lesenutzer brauchen ein Klickziel: unterhalb lg gibt es keine
             Kalenderspalte, und der Verlauf muss ohne schedules:manage lesbar
             bleiben (Kriterium 8). Der Editor selbst rendert ohne canManage
-            nur Lese-Inhalte. */}
+            nur Lese-Inhalte.
+            Mit Verwaltungsrechten ist "Bearbeiten" die Hauptaktion der Zeile
+            und trägt deshalb die weiße Kit-Fläche mit Rahmen (#2029). Ohne die
+            Rechte bleibt "Details" die ruhigere Ghost-Variante, damit ein
+            reiner Lesezugriff nicht wie eine Aufforderung zum Ändern wirkt. */}
         <Button
           type="button"
-          variant="ghost"
+          variant={canManage ? "outline" : "ghost"}
           size="compact"
           onClick={() => onEdit(instance.id)}
         >


### PR DESCRIPTION
Closes #2029.

Der Branch war auf `feat/2030-vertretung-wochenansicht` gestapelt; PR #2041 ist inzwischen gemergt, deshalb geht dieser PR direkt gegen `development` und enthält nur den einen Commit.

## Problem

Der Bearbeiten-Button in der Vertretungsliste war eine rahmenlose Ghost-Fläche und damit optisch kaum von der Beschriftung daneben zu unterscheiden, obwohl er die Hauptaktion der Seite ist. In einer Liste aus grauem Fließtext liest sich reiner Text nicht als Klickziel.

Der zweite Punkt des Issues, der zu hohe Kopfbereich, ist bereits durch PR #2041 erledigt: die Kontextleiste misst jetzt 111px statt 135px, der Filter `Nur Störungen | Ganzer Tag` sitzt auf der Liste statt im Kopf, und Wochenwechsel, Tagesauswahl, Lückenzähler und Tag/Woche-Umschalter sind wie gefordert dort geblieben.

## Änderung

`vertretung-day-list.tsx`, eine Zeile:

- Mit `schedules:manage` trägt der Button die weiße Kit-Fläche mit Rahmen (`Button variant="outline"`). Die Größe bleibt `compact` (h-8), die Zeilenhöhe ändert sich also nicht.
- Ohne die Rechte bleibt `Details` die ruhigere Ghost-Variante, damit ein reiner Lesezugriff nicht wie eine Aufforderung zum Ändern wirkt.

Die Wochenansicht rendert dieselbe Zeile (`vertretung-week-list.tsx`) und erbt die Änderung mit.

## Akzeptanzkriterien

- [x] Der Bearbeiten-Button ist als Hauptaktion der Zeile erkennbar.
- [x] Der Kopfbereich ist flacher und trägt weiterhin Wochenwechsel, Tagesauswahl, Lückenzähler und Umschaltung (über #2041).
- [x] Mobil bedienbar, Liste funktioniert weiterhin ohne Kalenderspalte: bei 390px geprüft. Der Button misst in beiden Zuständen 82,41 x 32px, weil `ring-1` als `box-shadow` zeichnet und Padding wie Höhe unverändert sind. Es gibt keine Layout-Verschiebung, nur eine andere Fläche.

## Geprüft

- `pnpm run check`, `depcruise` und `knip` grün.
- Komponententests grün, ohne Teständerung: die bestehenden Tests prüfen Rolle und Beschriftung, nicht die Variante.
- Visuell im Browser geprüft, 1440x900 (Tagesansicht mit beiden Filtern, Wochenansicht) und 390x844. Vorher und Nachher laufen gegen dieselben Daten.
- Der Lesefall `Details` ist nicht im Browser geprüft, weil der Demo-Bestand kein Konto ohne `schedules:manage` hat. Der Pfad ist unverändert und in `vertretung-day-list.test.tsx` abgedeckt.
- Die drei Fehlschläge in `src/components/ui/chart.test.tsx` bestehen unabhängig von diesem Branch auch auf `development`.
<img width="1440" height="900" alt="01-nachher-tag" src="https://github.com/user-attachments/assets/6440f9ff-9975-4cf1-8e36-9801d77bd2ae" />
