### PR TITLE
Planungsbereich auf dem Handy nutzbar machen

### DIFF
--- a/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
@@ -442,8 +442,11 @@ describe("MobileBottomNav", () => {
       );
     });
 
-    it("highlights Betreuungsplan on /calendar-periods in the overflow menu", () => {
-      // /calendar-periods gehört zu den activePaths des Betreuungsplans.
+    it("highlights Kalenderzeiträume as its own overflow entry", () => {
+      // Kalenderzeiträume und Tageslisten waren mobil ausgeblendet und liehen
+      // sich die Hervorhebung vom Betreuungsplan. Erreichbar waren sie dadurch
+      // nicht: es gibt keinen Verweis vom Betreuungsplan dorthin. Beide sind
+      // jetzt eigene Einträge und markieren sich selbst.
       mockUsePathname.mockReturnValue("/calendar-periods");
 
       render(<MobileBottomNav />);
@@ -455,10 +458,13 @@ describe("MobileBottomNav", () => {
       expect(moreButton).toBeDefined();
       fireEvent.click(moreButton!);
 
-      const betreuungsplanLink = screen
-        .getByText("Betreuungsplan")
-        .closest("a");
-      expect(betreuungsplanLink).toHaveClass("bg-gray-900");
+      expect(screen.getByText("Kalenderzeiträume").closest("a")).toHaveClass(
+        "bg-gray-900",
+      );
+      expect(screen.getByText("Tageslisten").closest("a")).toBeInTheDocument();
+      expect(screen.getByText("Betreuungsplan").closest("a")).not.toHaveClass(
+        "bg-gray-900",
+      );
     });
   });
 

--- a/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.test.tsx
@@ -1045,7 +1045,7 @@ describe("MobileBottomNav", () => {
       expect(hrefs).toContain("/ogs-groups");
     });
 
-    it("hides the planning entries when timetable.enabled is false", () => {
+    it("keeps calendar periods reachable when timetable.enabled is false", () => {
       mockUseSWRDefault.mockReturnValue({
         data: {
           tabs: [
@@ -1068,6 +1068,7 @@ describe("MobileBottomNav", () => {
       expect(screen.queryByText("Betreuungsplan")).not.toBeInTheDocument();
       expect(screen.queryByText("Dienstplan")).not.toBeInTheDocument();
       expect(screen.queryByText("Vertretung")).not.toBeInTheDocument();
+      expect(screen.getByText("Kalenderzeiträume")).toBeInTheDocument();
       // Gruppenzugriff bleibt sichtbar (fixed_groups default).
       expect(screen.getByText("Gruppenzugriff")).toBeInTheDocument();
     });

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -283,7 +283,6 @@ const PLANNING_ICON_KEYS: Record<
   "/betreuungsplan": "betreuungsplan",
   "/dienstplan": "dienstplan",
   "/vertretung": "vertretung",
-  // Desktop-only (showInMobileNav: false), Eintrag nur für die Typ-Vollständigkeit.
   "/lists": "calendar",
   "/calendar-periods": "calendar",
 };

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -626,7 +626,13 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
       return false;
     }
     if (!showActivityNav && NFC_ONLY_HREFS.has(item.href)) return false;
-    if (isPlanningPageHref(item.href) && !timetableEnabled) return false;
+    if (
+      isPlanningPageHref(item.href) &&
+      item.href !== "/calendar-periods" &&
+      !timetableEnabled
+    ) {
+      return false;
+    }
     if (item.href === "/substitutions" && openCareGroupMode) return false;
     if (item.alwaysShow) return true;
     if (item.requiresAdmin) return userIsAdmin;

--- a/frontend/src/components/staff/dienstplan-resource-grid.test.tsx
+++ b/frontend/src/components/staff/dienstplan-resource-grid.test.tsx
@@ -1,5 +1,11 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   StaffScheduleAssignment,
@@ -11,10 +17,18 @@ import type { ShiftType } from "~/lib/shift-type-helpers";
 
 import { DienstplanResourceGrid } from "./dienstplan-resource-grid";
 
-const mocks = vi.hoisted(() => ({ push: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useMediaQuery: vi.fn(() => false),
+}));
 
 vi.mock("~/lib/tenant-router", () => ({
   useTenantRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("~/lib/hooks/use-media-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/hooks/use-media-query")>()),
+  useMediaQuery: mocks.useMediaQuery,
 }));
 
 // Der Verschieben-Dialog fragt die Schließtage des Zieltags ab (#2032); der
@@ -121,18 +135,20 @@ interface RenderOverrides {
   reducedPath?: boolean;
   currentStaffId?: string | null;
   onSickReport?: (staff: StaffScheduleStaff) => void;
+  weekDays?: readonly string[];
+  todayIso?: string;
 }
 
 function renderGrid(overrides: RenderOverrides = {}) {
   const onCellClick = vi.fn();
-  const { unmount } = render(
+  const renderResult = render(
     <DienstplanResourceGrid
       staff={overrides.staff ?? [member]}
       shiftsByStaff={overrides.shiftsByStaff ?? new Map()}
       assignmentsByStaff={overrides.assignmentsByStaff ?? new Map()}
       summaryByStaff={overrides.summaryByStaff ?? new Map()}
-      weekDays={WEEK_DAYS}
-      todayIso={TODAY}
+      weekDays={overrides.weekDays ?? WEEK_DAYS}
+      todayIso={overrides.todayIso ?? TODAY}
       typesById={overrides.typesById ?? new Map()}
       shiftTypes={overrides.shiftTypes ?? []}
       reducedPath={overrides.reducedPath}
@@ -141,7 +157,7 @@ function renderGrid(overrides: RenderOverrides = {}) {
       onSickReport={overrides.onSickReport}
     />,
   );
-  return { onCellClick, unmount };
+  return { onCellClick, ...renderResult };
 }
 
 function shiftMap(
@@ -153,7 +169,10 @@ function shiftMap(
 }
 
 describe("DienstplanResourceGrid stacking", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useMediaQuery.mockReturnValue(false);
+  });
 
   it("stacks a day's shifts chronologically as separate blocks", () => {
     const late = baseShift({ id: "1", startTime: "10:30", endTime: "15:00" });
@@ -174,6 +193,57 @@ describe("DienstplanResourceGrid stacking", () => {
       name: "Schicht anlegen, Ada Lovelace, Mo 06.07.",
     });
     expect(addShiftButton.parentElement).toHaveClass("group", "flex-1");
+  });
+});
+
+describe("DienstplanResourceGrid mobile day selector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useMediaQuery.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    mocks.useMediaQuery.mockReturnValue(false);
+  });
+
+  it("resets to Monday when the displayed week changes", async () => {
+    const { rerender } = renderGrid();
+    const friday = screen.getByRole("button", {
+      name: /Fr.*10\.07\./,
+      pressed: false,
+    });
+
+    fireEvent.click(friday);
+    expect(friday).toHaveAttribute("aria-pressed", "true");
+
+    rerender(
+      <DienstplanResourceGrid
+        staff={[member]}
+        shiftsByStaff={new Map()}
+        assignmentsByStaff={new Map()}
+        summaryByStaff={new Map()}
+        weekDays={[
+          "2026-07-13",
+          "2026-07-14",
+          "2026-07-15",
+          "2026-07-16",
+          "2026-07-17",
+        ]}
+        todayIso={TODAY}
+        typesById={new Map()}
+        shiftTypes={[]}
+        onCellClick={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: /Mo.*13\.07\./,
+          pressed: true,
+        }),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
   });
 });
 

--- a/frontend/src/components/staff/dienstplan-resource-grid.tsx
+++ b/frontend/src/components/staff/dienstplan-resource-grid.tsx
@@ -32,6 +32,7 @@ import {
 import { Tooltip } from "~/components/ui/tooltip";
 import type { ClosingDayRange } from "~/lib/closing-day-helpers";
 import { PLAN_CACHE_KEY_PREFIXES } from "~/lib/hooks/use-dienstplan-data";
+import { BELOW_LG, useMediaQuery } from "~/lib/hooks/use-media-query";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 import {
   formatColumnDate,
@@ -641,46 +642,159 @@ export function DienstplanResourceGrid({
     [shiftTypes],
   );
 
+  // Ausgewählter Tag der mobilen Tagesansicht. Voreinstellung ist heute, wenn
+  // es in der gezeigten Woche liegt, sonst der Wochenanfang — dieselbe Regel
+  // wie im Tagesstreifen des Betreuungsplan-Rasters.
+  const todayColumnIndex = weekDays.indexOf(todayIso);
+  const [mobileDayIndex, setMobileDayIndex] = useState(
+    todayColumnIndex >= 0 ? todayColumnIndex : 0,
+  );
+  const safeMobileDayIndex = Math.min(
+    Math.max(mobileDayIndex, 0),
+    Math.max(columns.length - 1, 0),
+  );
+  const mobileColumn = columns[safeMobileDayIndex];
+
+  // Tagesansicht und Wochenmatrix schließen einander aus — sie dürfen NICHT
+  // beide im Dokument stehen und per `lg:hidden` weggeblendet werden: jede
+  // Person, jeder Schichtblock und jedes Aktionsmenü läge sonst doppelt im
+  // Baum, Screenreader läsen den Plan zweimal vor und die Tabulator-Reihenfolge
+  // liefe durch eine unsichtbare Kopie.
+  const isCompact = useMediaQuery(BELOW_LG);
+
   return (
     <div>
-      <p id={scrollHintId} className="mb-2 text-xs text-gray-600 sm:hidden">
-        Wische horizontal, um weitere Wochentage zu sehen.
-      </p>
-      <ResourceGrid
-        columns={columns}
-        rows={staff}
-        getRowKey={(member) => member.id}
-        renderRowHeader={renderRowHeader}
-        renderCell={renderCell}
-        columnMode="days"
-        cornerHeader="Person"
-        scrollHintId={scrollHintId}
-        emptyCellLabel={createShiftAriaLabel}
-        onEmptyCellClick={
-          closingDaysLoading
-            ? undefined
-            : (member, column) => openCell(member, column.key, null)
-        }
-        footer={
-          <CapacityStrip
-            rowLabel={
+      {/* Unterhalb lg ersetzt eine Tagesansicht die Wochenmatrix: Personen×Tage
+          passt nicht auf ein Telefon — die Namensspalte fraß dort die halbe
+          Breite, sichtbar blieb rund eine Tagesspalte, und der Rest der Woche
+          lag hinter einer Wischgeste. Gezeigt wird EIN Tag, die Personen
+          untereinander. Es ist bewusst dieselbe Darstellung wie im
+          Betreuungsplan, damit die drei Planungsflächen sich mobil gleich
+          verhalten. Zeilenkopf und Zelleninhalt sind exakt dieselben
+          Render-Funktionen wie in der Matrix, also bleiben Menüs, Blöcke und
+          die Anlege-Geste identisch. */}
+      {isCompact && mobileColumn ? (
+        <div>
+          <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm">
+            <div className="flex gap-1 border-b border-gray-200 bg-white p-2">
+              {columns.map((column, index) => {
+                const isSelected = index === safeMobileDayIndex;
+                return (
+                  <button
+                    key={column.key}
+                    type="button"
+                    onClick={() => setMobileDayIndex(index)}
+                    aria-pressed={isSelected}
+                    className={`flex min-w-0 flex-1 flex-col items-center gap-0.5 rounded-lg px-1 py-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none ${
+                      isSelected
+                        ? "bg-gray-900 text-white"
+                        : "text-gray-600 hover:bg-gray-100"
+                    }`}
+                  >
+                    <span
+                      className={`text-[10px] font-medium tracking-wide uppercase ${
+                        isSelected ? "text-white/80" : "text-gray-500"
+                      }`}
+                    >
+                      {column.label}
+                    </span>
+                    <span className="text-sm font-semibold tabular-nums">
+                      {column.sublabel}
+                    </span>
+                    {column.headerNote}
+                    {column.isCurrent && !isSelected && (
+                      <span
+                        aria-hidden
+                        className="h-1 w-1 rounded-full bg-[#FF3130]"
+                      />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            <ul className="divide-y divide-gray-100">
+              {staff.map((member) => (
+                <li key={member.id} className="px-3 py-2.5">
+                  {renderRowHeader(member)}
+                  <div className="mt-1.5">
+                    {renderCell(member, mobileColumn) ?? (
+                      // Leerer Tag: dieselbe Anlege-Fläche, die das Raster in
+                      // einer leeren Zelle rendert — ohne sie ließe sich mobil
+                      // keine Schicht anlegen.
+                      <button
+                        type="button"
+                        disabled={closingDaysLoading}
+                        onClick={() => openCell(member, mobileColumn.key, null)}
+                        aria-label={createShiftAriaLabel(member, mobileColumn)}
+                        className="group flex w-full rounded-md focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:outline-none disabled:cursor-wait disabled:opacity-40"
+                      >
+                        <PlanAddAffordance size="inline" />
+                      </button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
               <span title="Übergangslösung: Pausen sind in dieser Zahl nicht herausgerechnet.">
                 Kapazität 12–16
               </span>
-            }
-            cells={weekDays.map((date) => ({
-              key: date,
-              content: capacityByDay.get(date) ?? 0,
-            }))}
+              <span className="font-semibold text-gray-900 tabular-nums">
+                {capacityByDay.get(mobileColumn.key) ?? 0}
+              </span>
+            </div>
+          </div>
+          <PlanLegend
+            className="mt-3 px-1"
+            entries={legendEntries}
+            aria-label="Legende Schichtarten und Zustände"
           />
-        }
-        ariaLabel="Dienstplan-Wochenansicht"
-      />
-      <PlanLegend
-        className="mt-3 px-1"
-        entries={legendEntries}
-        aria-label="Legende Schichtarten und Zustände"
-      />
+        </div>
+      ) : (
+        <div>
+          <p id={scrollHintId} className="mb-2 text-xs text-gray-600 sm:hidden">
+            Wische horizontal, um weitere Wochentage zu sehen.
+          </p>
+          <ResourceGrid
+            columns={columns}
+            rows={staff}
+            getRowKey={(member) => member.id}
+            renderRowHeader={renderRowHeader}
+            renderCell={renderCell}
+            columnMode="days"
+            cornerHeader="Person"
+            scrollHintId={scrollHintId}
+            emptyCellLabel={createShiftAriaLabel}
+            onEmptyCellClick={
+              closingDaysLoading
+                ? undefined
+                : (member, column) => openCell(member, column.key, null)
+            }
+            footer={
+              <CapacityStrip
+                rowLabel={
+                  <span title="Übergangslösung: Pausen sind in dieser Zahl nicht herausgerechnet.">
+                    Kapazität 12–16
+                  </span>
+                }
+                cells={weekDays.map((date) => ({
+                  key: date,
+                  content: capacityByDay.get(date) ?? 0,
+                }))}
+              />
+            }
+            ariaLabel="Dienstplan-Wochenansicht"
+          />
+          <PlanLegend
+            className="mt-3 px-1"
+            entries={legendEntries}
+            aria-label="Legende Schichtarten und Zustände"
+          />
+        </div>
+      )}
+
       {moveTarget && (
         <ShiftMoveDialog
           isOpen

--- a/frontend/src/components/staff/dienstplan-resource-grid.tsx
+++ b/frontend/src/components/staff/dienstplan-resource-grid.tsx
@@ -9,7 +9,14 @@ import {
   Thermometer,
   TriangleAlert,
 } from "lucide-react";
-import { useId, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import {
   ClosingDayChip,
@@ -646,9 +653,16 @@ export function DienstplanResourceGrid({
   // es in der gezeigten Woche liegt, sonst der Wochenanfang — dieselbe Regel
   // wie im Tagesstreifen des Betreuungsplan-Rasters.
   const todayColumnIndex = weekDays.indexOf(todayIso);
+  const weekStart = weekDays[0];
   const [mobileDayIndex, setMobileDayIndex] = useState(
     todayColumnIndex >= 0 ? todayColumnIndex : 0,
   );
+  const mobileWeekStart = useRef(weekStart);
+  useEffect(() => {
+    if (mobileWeekStart.current === weekStart) return;
+    mobileWeekStart.current = weekStart;
+    setMobileDayIndex(todayColumnIndex >= 0 ? todayColumnIndex : 0);
+  }, [todayColumnIndex, weekStart]);
   const safeMobileDayIndex = Math.min(
     Math.max(mobileDayIndex, 0),
     Math.max(columns.length - 1, 0),

--- a/frontend/src/components/staff/dienstplan-view.test.tsx
+++ b/frontend/src/components/staff/dienstplan-view.test.tsx
@@ -450,10 +450,14 @@ describe("DienstplanView", () => {
       render(<DienstplanView />);
 
       // 14.09.2026 ist ein Montag; die Woche ist KW 38. The label must retain
-      // those calendar days even when the browser is east of Berlin.
-      const label = screen.getByText(/KW 38:/);
-      expect(label).toHaveTextContent(/^KW 38: 14\./);
-      expect(label).toHaveTextContent(/bis 18\./);
+      // those calendar days even when the browser is east of Berlin. Das
+      // Etikett kommt seit der Kopfzeilen-Vereinheitlichung aus
+      // formatWeekLabel und lautet damit wie in Vertretung und Betreuungsplan
+      // "KW 38 · 14.09.–18.09.2026"; die Zeitzonen-Aussage dieses Tests bleibt
+      // unverändert.
+      const label = screen.getByText(/KW 38 ·/);
+      expect(label).toHaveTextContent(/^KW 38 · 14\.09\./);
+      expect(label).toHaveTextContent(/–18\.09\./);
       expect(screen.getByTestId("dienstplan-week-days")).toHaveTextContent(
         "2026-09-14,2026-09-15,2026-09-16,2026-09-17,2026-09-18",
       );

--- a/frontend/src/components/staff/dienstplan-view.tsx
+++ b/frontend/src/components/staff/dienstplan-view.tsx
@@ -30,7 +30,6 @@ import { useClosingDaysState } from "~/lib/hooks/use-closing-days";
 import { useDienstplanData } from "~/lib/hooks/use-dienstplan-data";
 import { useSettingsSchema } from "~/lib/hooks/use-settings-schema";
 import { useUrlParams } from "~/lib/hooks/use-url-params";
-import { formatCalendarDate } from "~/lib/localized-date-format";
 import { createLogger } from "~/lib/logger";
 import { getSettingValue } from "~/lib/settings-api";
 import type { StaffScheduleStaff, StaffShift } from "~/lib/shift-helpers";
@@ -38,8 +37,10 @@ import { startOfWeek } from "~/lib/staff-metrics-helpers";
 import { useSWRAuth } from "~/lib/swr";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { useTenantAwarePath } from "~/lib/tenant-path";
-import { getWeekNumber } from "~/lib/time-tracking-helpers";
-import { firstSchoolDayInPeriod } from "~/lib/timetable-helpers";
+import {
+  firstSchoolDayInPeriod,
+  formatWeekLabel,
+} from "~/lib/timetable-helpers";
 import { userContextService } from "~/lib/usercontext-api";
 
 import {
@@ -214,19 +215,15 @@ function DienstplanContent() {
   const isOnCurrentWeek =
     toISODate(startOfWeek(parseISODate(today))) === toISODate(weekAnchor);
 
+  // Dasselbe Wochenetikett wie in Vertretung und Betreuungsplan
+  // ("KW 31 · 27.07.–31.07.2026"). Der Dienstplan schrieb es früher als
+  // "KW 31: 27. Juli bis 31. Juli 2026" selbst zusammen: drei benachbarte
+  // Flächen mit drei Schreibweisen für dieselbe Woche, und auf einem Telefon
+  // 220px Text in einer 199px breiten Kopfzeile, also abgeschnitten.
   const weekLabel = useMemo(() => {
     const end = new Date(weekAnchor);
     end.setDate(end.getDate() + 4);
-    const startLabel = formatCalendarDate(toISODate(weekAnchor), "de-DE", {
-      day: "numeric",
-      month: "short",
-    });
-    const endLabel = formatCalendarDate(toISODate(end), "de-DE", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-    });
-    return `KW ${getWeekNumber(weekAnchor)}: ${startLabel} bis ${endLabel}`;
+    return formatWeekLabel(weekAnchor, end);
   }, [weekAnchor]);
 
   // Wochen-Navigation schreibt den Montag der Zielwoche nach `d`.
@@ -413,15 +410,24 @@ function DienstplanContent() {
           ) : undefined
         }
         actions={
+          // Unter sm nur das Zahnrad: der volle Text brach in der Kopfzeile
+          // zweizeilig um und schob zusammen mit dem Ansichtsumschalter die
+          // ganze Zeile aus dem Viewport. EIN Button mit ausgeblendetem Label
+          // statt zweier Breakpoint-Varianten — das `aria-label` hält ihn für
+          // Screenreader und Tests unter demselben Namen auffindbar.
           <Button
             type="button"
             variant="primary"
             size="md"
+            aria-label="Schichtarten verwalten"
+            className="max-sm:h-8 max-sm:w-8 max-sm:justify-center max-sm:p-0"
             onClick={() => setManageOpen(true)}
             disabled={Boolean(shiftTypesError)}
           >
-            <Settings2 className="mr-1.5 h-4 w-4" />
-            Schichtarten verwalten
+            <Settings2 className="h-4 w-4 shrink-0 sm:mr-1.5" aria-hidden />
+            <span className="hidden whitespace-nowrap sm:inline">
+              Schichtarten verwalten
+            </span>
           </Button>
         }
       >

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -1016,7 +1016,13 @@ function TimetablesContent() {
         actions={
           <>
             {view === "week" && (
-              <OverflowMenu ariaLabel="Zeilenhöhe" items={densityMenuItems} />
+              // Die Zeilenhöhe des Wochenrasters ist eine Desktop-Feinjustage:
+              // mobil wird das Raster ohnehin tageweise gezeigt, und der Knopf
+              // war mit den drei Ansichts-Tabs und "Neu" zusammen breiter als
+              // die Kopfzeile — das Datum wurde dadurch auf null gequetscht.
+              <span className="hidden sm:contents">
+                <OverflowMenu ariaLabel="Zeilenhöhe" items={densityMenuItems} />
+              </span>
             )}
             <TimetableAddMenu
               onAddInstance={openEventCreate}

--- a/frontend/src/components/timetable/vertretung-view.tsx
+++ b/frontend/src/components/timetable/vertretung-view.tsx
@@ -531,18 +531,17 @@ function VertretungContent() {
               const iso = toISODate(day);
               const isPast = iso < today;
               // Vergangene Tage und ein fehlgeschlagener/übersprungener/noch
-              // ladender Gaps-Abruf zeigen einen Platzhalter, nie eine
-              // erfundene 0 (Akzeptanzkriterium 5).
-              const showPlaceholder = isPast || !gapsLoaded;
+              // ladender Gaps-Abruf bekommen GAR KEINEN Zähler, nie eine
+              // erfundene 0 (Akzeptanzkriterium 5). Der Chip bleibt dann still.
+              const countUnavailable = isPast || !gapsLoaded;
               return (
                 <PlanningDayChip
                   key={iso}
                   weekdayLabel={getGermanWeekdayShort(day)}
                   dateLabel={dayChipLabel(day)}
                   count={
-                    showPlaceholder ? undefined : (gapsByDate.get(iso) ?? 0)
+                    countUnavailable ? undefined : (gapsByDate.get(iso) ?? 0)
                   }
-                  showPlaceholder={showPlaceholder}
                   selected={iso === dayISO}
                   onClick={() => goToDay(iso)}
                   aria-label={`${getGermanWeekdayShort(day)} ${dayChipLabel(day)}`}
@@ -641,10 +640,15 @@ function VertretungContent() {
               onEdit={openEditor}
             />
           )}
-          {/* Unterhalb lg entfällt die Kalenderspalte; die Liste bleibt allein
-              voll funktionsfähig (Abschnitt 2). Das Raster ist dasselbe, es
-              bekommt in der Wochenansicht nur fünf Tagesspalten statt einer. */}
-          <div className="hidden lg:block">
+          {/* Das Raster läuft auch unterhalb lg mit, dort einspaltig unter der
+              Liste: es war früher desktop-only, wodurch die Vertretung mobil
+              weniger zeigte als am Rechner — anders als der Betreuungsplan, der
+              dasselbe Raster auf demselben Gerät sehr wohl darstellt.
+              WeeklyCalendarGrid bringt die mobile Tagesauswahl selbst mit
+              (eigener Tagesstreifen, alle übrigen Spalten unter sm verborgen),
+              deshalb braucht es hier keine zweite Umschaltmechanik. In der
+              Wochenansicht bekommt es fünf Tagesspalten statt einer. */}
+          <div>
             <WeeklyCalendarGrid
               weekDays={isWeekView ? weekDays : [parseISODate(dayISO)]}
               instances={isWeekView ? weekdayInstances : dayInstances}

--- a/frontend/src/components/timetable/weekly-calendar-grid.tsx
+++ b/frontend/src/components/timetable/weekly-calendar-grid.tsx
@@ -179,8 +179,15 @@ export function WeeklyCalendarGrid({
         { "--day-grid-cols": smGridTemplate(weekDays.length) } as CSSProperties
       }
     >
-      {/* Mobile day strip — tap a day to switch (single-day view < sm) */}
-      <div className="flex gap-1 border-b border-gray-200 bg-white p-2 sm:hidden">
+      {/* Mobile day strip — tap a day to switch (single-day view < sm).
+          Bei genau einem übergebenen Tag entfällt er: ein Umschalter mit einer
+          einzigen Option schaltet nichts, kostet aber eine fette Zeile direkt
+          unter der Tagesauswahl der Kopfzeile (Vertretung, Tagesansicht). */}
+      <div
+        className={`gap-1 border-b border-gray-200 bg-white p-2 sm:hidden ${
+          weekDays.length > 1 ? "flex" : "hidden"
+        }`}
+      >
         {weekDays.map((day, index) => {
           const iso = toISODate(day);
           const isToday = iso === todayISO;

--- a/frontend/src/components/ui/planning-context-bar.stories.tsx
+++ b/frontend/src/components/ui/planning-context-bar.stories.tsx
@@ -36,8 +36,8 @@ const WEEK_DAYS = [
   { weekdayLabel: "Mi", dateLabel: "15.07.", count: 1 },
   { weekdayLabel: "Do", dateLabel: "16.07.", count: 0 },
   { weekdayLabel: "Fr", dateLabel: "17.07.", count: 0 },
-  { weekdayLabel: "Sa", dateLabel: "18.07.", showPlaceholder: true as const },
-  { weekdayLabel: "So", dateLabel: "19.07.", showPlaceholder: true as const },
+  { weekdayLabel: "Sa", dateLabel: "18.07." },
+  { weekdayLabel: "So", dateLabel: "19.07." },
 ];
 
 export const WithWeekStrip: Story = {

--- a/frontend/src/components/ui/planning-context-bar.test.tsx
+++ b/frontend/src/components/ui/planning-context-bar.test.tsx
@@ -130,12 +130,15 @@ describe("PlanningDayChip", () => {
     expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 
-  it("renders a placeholder dash when no count is available", () => {
-    render(
-      <PlanningDayChip weekdayLabel="Sa" dateLabel="18.07." showPlaceholder />,
-    );
+  it("stays quiet when no count is available at all", () => {
+    // Ein Tag ohne verfügbaren Zähler (vergangener Tag, Abruf übersprungen
+    // oder fehlgeschlagen) zeigt NICHTS. Früher stand dort ein Strich, dessen
+    // Bedeutung man nur mit Kenntnis der Ladelogik erraten konnte.
+    render(<PlanningDayChip weekdayLabel="Sa" dateLabel="18.07." />);
 
-    expect(screen.getByText("–")).toBeInTheDocument();
+    expect(screen.getByText("Sa")).toBeInTheDocument();
+    expect(screen.getByText("18.07.")).toBeInTheDocument();
+    expect(screen.queryByText("–")).not.toBeInTheDocument();
   });
 
   it("uses the dark fill instead of neutral gray when selected", () => {

--- a/frontend/src/components/ui/planning-context-bar.tsx
+++ b/frontend/src/components/ui/planning-context-bar.tsx
@@ -22,7 +22,9 @@ import { Button } from "~/components/ui/button";
  *
  * 1. Der Seitenname steht bereits in der App-Kopfzeile und wird hier nur noch
  *    für Screenreader gerendert. Die sichtbare Überschrift ist das Datum, also
- *    die Antwort auf "was sehe ich gerade".
+ *    die Antwort auf "was sehe ich gerade". Ausnahme ist die mobile Ansicht:
+ *    dort zeigt die App-Kopfzeile den Schulnamen, nicht die Seite, deshalb
+ *    bleibt der Titel unter md sichtbar (klein, in der Bedienzeile).
  * 2. Die Navigation ist EIN Objekt: eine gerahmte Gruppe aus Zurück, Heute und
  *    Weiter. "Heute" ist immer da (deaktiviert, wenn man schon dort steht), weil
  *    ein auftauchender und verschwindender Button die Zeile seitlich springen
@@ -30,6 +32,15 @@ import { Button } from "~/components/ui/button";
  * 3. Zeile 2 ist eine ruhige 12px-Kontextzeile, keine Sammlung verschiedener
  *    Pillen. Sie wird immer gerendert, damit der Inhalt darunter beim
  *    Seitenwechsel nicht springt.
+ *
+ * Mobiles Verhalten: die Bar darf auf einem Handy nicht per `flex-wrap` in vier
+ * Zeilen zerfallen — gemessen fraß sie so ein Viertel bis ein Drittel des
+ * Viewports, bevor der erste Inhalt kam. Sie ordnet sich deshalb unter md in
+ * genau zwei Bedienzeilen (Titel + Navigation / Datum + Umschalter) und die
+ * Kontextzeile scrollt horizontal, statt umzubrechen. Beide Layouts rendern
+ * DIESELBEN Slot-Knoten — nichts wird für eine Breakpoint-Variante doppelt in
+ * den DOM gehängt, sonst kollidieren Radix-IDs und Tests finden jedes Element
+ * zweimal.
  */
 
 /**
@@ -85,16 +96,34 @@ export function PlanningContextBar({
 }: PlanningContextBarProps) {
   return (
     <div
-      className={`moto-content-surface flex flex-col gap-2 rounded-2xl border px-4 py-3 ${className ?? ""}`}
+      className={`moto-content-surface flex flex-col gap-2 rounded-2xl border px-3 py-2.5 sm:px-4 sm:py-3 ${className ?? ""}`}
     >
-      <h1 className="text-lg font-semibold text-gray-900 md:sr-only">
-        {title}
-      </h1>
+      <div
+        className={`flex flex-wrap items-center gap-2 sm:gap-3 ${PRIMARY_ROW_MIN_H}`}
+      >
+        {/* Titelblock: unter md ein zweizeiliger Block (Seitenname klein
+            darüber, Datum groß darunter), der die Zeile links füllt, während
+            die Zeitnavigation rechts sitzt. Ab md löst `contents` den Wrapper
+            auf — Überschrift und Datum werden wieder direkte Kinder der Zeile,
+            die Überschrift verschwindet in `sr-only` (die App-Kopfzeile trägt
+            den Seitennamen), und die Zeile ist exakt die alte. */}
+        <div className="flex min-w-0 flex-1 flex-col md:contents">
+          <h1 className="truncate text-xs font-medium tracking-wide text-gray-500 uppercase md:sr-only md:text-base md:normal-case">
+            {title}
+          </h1>
+          {navigationSlot ??
+            (dateLabel && (
+              <p className="min-w-0 truncate text-sm font-semibold text-gray-900 tabular-nums md:order-2 md:text-base">
+                {dateLabel}
+              </p>
+            ))}
+        </div>
 
-      <div className={`flex flex-wrap items-center gap-3 ${PRIMARY_ROW_MIN_H}`}>
         {/* Eine Gruppe, drei Segmente: die Zeitnavigation liest sich als ein
-            Bedienelement statt als zwei schwebende Pfeile mit Text dazwischen. */}
-        <div className="inline-flex h-8 shrink-0 divide-x divide-gray-200 overflow-hidden rounded-lg border border-gray-200 bg-white">
+            Bedienelement statt als zwei schwebende Pfeile mit Text dazwischen.
+            Mobil sitzt sie rechts neben dem Titelblock, ab md rückt sie per
+            `order` wieder an den Anfang der Zeile. */}
+        <div className="inline-flex h-8 shrink-0 divide-x divide-gray-200 overflow-hidden rounded-lg border border-gray-200 bg-white md:order-1">
           <Button
             type="button"
             size="icon"
@@ -129,15 +158,35 @@ export function PlanningContextBar({
           </Button>
         </div>
 
-        {navigationSlot ??
-          (dateLabel && (
-            <p className="text-base font-semibold text-gray-900 tabular-nums">
-              {dateLabel}
-            </p>
-          ))}
+        {/* Umschalter und Aktionen: unter md eine eigene Zeile über die VOLLE
+            Breite (`basis-full`), in der sich der Ansichtsumschalter breit
+            macht statt links zu kleben. Vorher standen dort zwei angeschnittene
+            Bedienelemente und daneben viel ungenutzte Fläche. Ab md rutscht die
+            Gruppe zurück an das rechte Ende derselben Zeile.
 
+            Der Selektor streckt den Tab-Umschalter, ohne dass jede aufrufende
+            Fläche daran denken muss: die Kit-Tabs sind `inline-flex`, also
+            genau so breit wie ihre Beschriftungen.
+
+            `flex-wrap` ist nötig, weil einzelne Aktionen ihre eigene mobile
+            Breite mitbringen: `TimetableAddMenu` ist unter sm `w-full`. Ohne
+            Umbruch kämpften zwei Elemente um dieselbe Zeile und der breitere
+            drückte den Umschalter auf null (im Betreuungsplan lag der
+            "Neu"-Knopf über den Ansichts-Tabs). Mit Umbruch nimmt jeder, was er
+            braucht, und beide bleiben vollständig sichtbar. */}
         {(viewSwitcher ?? actions) && (
-          <div className="ml-auto flex items-center gap-2">
+          <div
+            className={`flex basis-full flex-wrap items-center gap-2 md:order-3 md:ml-auto md:basis-auto md:flex-nowrap ${
+              viewSwitcher
+                ? // Drei Ebenen, weil der Umschalter drei verschachtelte
+                  // Elemente hat: der Tabs-Rahmen muss die freie Breite nehmen
+                  // (flex-1), die Liste darin sie ausfüllen (w-full), und die
+                  // Schaltflächen sie untereinander aufteilen (flex-1). Fehlt
+                  // eine davon, bleibt alles auf Textbreite stehen.
+                  "[&_[role=tab]]:flex-1 md:[&_[role=tab]]:flex-none [&_[role=tablist]]:w-full md:[&_[role=tablist]]:w-auto [&>*:first-child]:min-w-0 [&>*:first-child]:flex-1 md:[&>*:first-child]:flex-none"
+                : ""
+            }`}
+          >
             {viewSwitcher}
             {actions}
           </div>
@@ -147,8 +196,11 @@ export function PlanningContextBar({
       {/* Haarlinie trennt Bedienung (oben) von Kontext (unten) INNERHALB des
           Balkens: zwei Zonen, eine Fläche. */}
       <div className="border-t border-gray-100 pt-2">
+        {/* Unter sm eine scrollende Zeile statt eines Zeilenumbruchs: eine
+            umbrechende Wochenleiste warf die Trennlinie und die Zähler mitten
+            in die zweite Zeile und ließ die Bar um zwei Zeilen wachsen. */}
         <div
-          className={`flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 ${CONTEXT_ROW_MIN_H}`}
+          className={`flex [scrollbar-width:none] items-center gap-x-3 gap-y-1 overflow-x-auto text-xs text-gray-500 sm:flex-wrap sm:overflow-x-visible [&::-webkit-scrollbar]:hidden [&>*]:shrink-0 ${CONTEXT_ROW_MIN_H}`}
         >
           {children}
         </div>
@@ -164,9 +216,6 @@ interface PlanningDayChipProps {
   readonly dateLabel: string;
   /** Kleine Zähler-Ziffer, z. B. Anzahl offener Lücken. */
   readonly count?: number;
-  /** Zeigt einen Strich statt einer Ziffer, wenn kein Zähler verfügbar ist
-   *  (z. B. vergangene Tage oder ein fehlgeschlagener Abruf). */
-  readonly showPlaceholder?: boolean;
   readonly selected?: boolean;
   readonly onClick?: () => void;
   readonly className?: string;
@@ -183,14 +232,15 @@ const COUNT_DOT_COLOR = "#F78C10";
  *
  * Einzeilig (#2031): der frühere dreizeilige Chip war so hoch wie die gesamte
  * Bedienzeile und ließ die Leiste in der Vertretung höher werden als in den
- * anderen Flächen. Eine Null wird nicht gezeigt: ein Tag ohne offene Lücke
- * bleibt ruhig, sichtbar ist nur, wo etwas offen ist.
+ * anderen Flächen. Ohne Zähler bleibt der Chip einfach still: eine Null wird
+ * nicht gezeigt (ein Tag ohne offene Lücke ist keine Meldung wert), und ein
+ * Tag ohne verfügbare Zahl bekommt auch keinen Platzhalter. Der frühere Strich
+ * war nicht deutbar, ohne dass man die Ladelogik dahinter kennt.
  */
 export function PlanningDayChip({
   weekdayLabel,
   dateLabel,
   count,
-  showPlaceholder = false,
   selected = false,
   onClick,
   className,
@@ -213,13 +263,7 @@ export function PlanningDayChip({
     >
       <span className="font-medium">{weekdayLabel}</span>
       <span className="tabular-nums">{dateLabel}</span>
-      {showPlaceholder ? (
-        <span
-          className={`tabular-nums ${selected ? "text-white/60" : "text-gray-400"}`}
-        >
-          –
-        </span>
-      ) : count !== undefined && count > 0 ? (
+      {count !== undefined && count > 0 ? (
         <span className="inline-flex items-center gap-1 font-semibold tabular-nums">
           <span
             aria-hidden

--- a/frontend/src/components/ui/slide-over.test.tsx
+++ b/frontend/src/components/ui/slide-over.test.tsx
@@ -1,0 +1,123 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vaul", async () => {
+  const React = await import("react");
+
+  return {
+    Drawer: {
+      Root: ({
+        children,
+        direction,
+      }: {
+        children: React.ReactNode;
+        direction?: string;
+      }) => <div data-direction={direction}>{children}</div>,
+      Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+      Overlay: React.forwardRef<
+        HTMLDivElement,
+        React.HTMLAttributes<HTMLDivElement>
+      >((props, ref) => <div ref={ref} {...props} />),
+      Content: React.forwardRef<
+        HTMLDivElement,
+        React.HTMLAttributes<HTMLDivElement>
+      >((props, ref) => <div ref={ref} {...props} />),
+      Close: React.forwardRef<
+        HTMLButtonElement,
+        React.ButtonHTMLAttributes<HTMLButtonElement>
+      >((props, ref) => <button ref={ref} {...props} />),
+      Title: React.forwardRef<
+        HTMLHeadingElement,
+        React.HTMLAttributes<HTMLHeadingElement>
+      >(({ children, ...props }, ref) => (
+        <h2 ref={ref} {...props}>
+          {children ?? "Titel"}
+        </h2>
+      )),
+      Description: React.forwardRef<
+        HTMLParagraphElement,
+        React.HTMLAttributes<HTMLParagraphElement>
+      >((props, ref) => <p ref={ref} {...props} />),
+    },
+  };
+});
+
+import { SlideOver, SlideOverContent } from "./slide-over";
+
+function StatefulContent() {
+  const [value, setValue] = useState("");
+  return (
+    <input
+      aria-label="Entwurf"
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+    />
+  );
+}
+
+describe("SlideOver", () => {
+  let matches = false;
+  let changeListener: (() => void) | undefined;
+
+  beforeEach(() => {
+    matches = false;
+    changeListener = undefined;
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        get matches() {
+          return matches;
+        },
+        addEventListener: (_event: string, listener: () => void) => {
+          changeListener = listener;
+        },
+        removeEventListener: vi.fn(),
+      })),
+    );
+  });
+
+  it("keeps unsaved child state when the viewport changes while open", () => {
+    const { rerender } = render(
+      <SlideOver open>
+        <SlideOverContent>
+          <StatefulContent />
+        </SlideOverContent>
+      </SlideOver>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Entwurf"), {
+      target: { value: "Ungespeichert" },
+    });
+
+    act(() => {
+      matches = true;
+      changeListener?.();
+    });
+
+    expect(screen.getByLabelText("Entwurf")).toHaveValue("Ungespeichert");
+    expect(
+      screen.getByLabelText("Entwurf").closest("[data-direction]"),
+    ).toHaveAttribute("data-direction", "right");
+
+    rerender(
+      <SlideOver open={false}>
+        <SlideOverContent>
+          <StatefulContent />
+        </SlideOverContent>
+      </SlideOver>,
+    );
+
+    return waitFor(() => {
+      expect(
+        screen.getByLabelText("Entwurf").closest("[data-direction]"),
+      ).toHaveAttribute("data-direction", "bottom");
+    });
+  });
+});

--- a/frontend/src/components/ui/slide-over.test.tsx
+++ b/frontend/src/components/ui/slide-over.test.tsx
@@ -83,6 +83,22 @@ describe("SlideOver", () => {
     );
   });
 
+  it("uses the mobile direction for a panel already open at initial render", async () => {
+    matches = true;
+
+    render(
+      <SlideOver defaultOpen>
+        <SlideOverContent>Inhalt</SlideOverContent>
+      </SlideOver>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Inhalt").closest("[data-direction]"),
+      ).toHaveAttribute("data-direction", "bottom");
+    });
+  });
+
   it("keeps unsaved child state when the viewport changes while open", () => {
     const { rerender } = render(
       <SlideOver open>

--- a/frontend/src/components/ui/slide-over.tsx
+++ b/frontend/src/components/ui/slide-over.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 /**
- * SlideOver — right-side panel primitive built on Vaul.
+ * SlideOver — detail panel primitive built on Vaul. Slides in from the right on
+ * a desktop-sized viewport and up from the bottom on a phone.
  *
  * Companion to ./drawer.tsx (bottom-sheet). The two share the same Vaul
  * primitives but differ in `direction` and the resulting Tailwind layout.
  * Use SlideOver for desktop-first detail panels that need to coexist with
  * the underlying view (planner grid → click instance → slide-over from
- * right). Use Drawer for mobile bottom-sheets.
+ * right). Use Drawer when a surface should be a bottom sheet at every size.
+ *
+ * Warum die Richtung mitwandert: ein von rechts einfahrendes 92vw-Panel ist auf
+ * einem Handy ein Fremdkörper — dort ist das Blatt von unten die erwartete
+ * Geste, und die App benutzt sie an anderer Stelle längst (das "Mehr"-Menü der
+ * Bottom-Navigation). Vaul richtet Drag-Achse und Animation am `direction`-Prop
+ * der Wurzel aus, deshalb ist das eine echte Breakpoint-Abfrage (matchMedia)
+ * und keine reine CSS-Angelegenheit.
  *
  * Usage:
  * ```tsx
@@ -28,18 +36,42 @@ import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 import { X } from "lucide-react";
 
+import { BELOW_SM, useMediaQuery } from "~/lib/hooks/use-media-query";
 import { cn } from "~/lib/utils";
+
+/**
+ * Unter sm fährt das Panel von unten ein, darüber von rechts. Vor dem ersten
+ * Effect gilt "right"; die Korrektur greift, bevor ein Panel geöffnet werden
+ * kann.
+ */
+function useSlideOverDirection(): "right" | "bottom" {
+  return useMediaQuery(BELOW_SM) ? "bottom" : "right";
+}
+
+const SlideOverDirectionContext = React.createContext<"right" | "bottom">(
+  "right",
+);
 
 const SlideOver = ({
   shouldScaleBackground = false,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
-  <DrawerPrimitive.Root
-    direction="right"
-    shouldScaleBackground={shouldScaleBackground}
-    {...props}
-  />
-);
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => {
+  const direction = useSlideOverDirection();
+  return (
+    <SlideOverDirectionContext.Provider value={direction}>
+      <DrawerPrimitive.Root
+        // Vaul liest die Richtung beim Mount für Drag-Achse und Animation.
+        // Der Key erzwingt den Neuaufbau, wenn der Breakpoint tatsächlich
+        // wechselt (Drehung, Fenstergröße) — ohne ihn zöge ein von rechts
+        // aufgebautes Panel weiter nach rechts, obwohl es unten sitzt.
+        key={direction}
+        direction={direction}
+        shouldScaleBackground={shouldScaleBackground}
+        {...props}
+      />
+    </SlideOverDirectionContext.Provider>
+  );
+};
 SlideOver.displayName = "SlideOver";
 
 const SlideOverPortal = DrawerPrimitive.Portal;
@@ -64,7 +96,8 @@ interface SlideOverContentProps extends React.ComponentPropsWithoutRef<
 > {
   /**
    * Panel width on desktop. Default 420px matches the timetable mockup.
-   * Mobile (< sm) takes 92vw automatically.
+   * Ignoriert, solange das Panel als Blatt von unten läuft (< sm) — dort ist
+   * es immer volle Breite.
    */
   widthClass?: string;
 }
@@ -72,24 +105,42 @@ interface SlideOverContentProps extends React.ComponentPropsWithoutRef<
 const SlideOverContent = React.forwardRef<
   React.ComponentRef<typeof DrawerPrimitive.Content>,
   SlideOverContentProps
->(({ className, widthClass, children, ...props }, ref) => (
-  <SlideOverPortal>
-    <SlideOverOverlay />
-    <DrawerPrimitive.Content
-      ref={ref}
-      data-date-picker-focus-trap="true"
-      className={cn(
-        "fixed top-0 right-0 z-50 flex h-full flex-col bg-white shadow-2xl outline-none",
-        "w-[92vw] sm:w-[420px]",
-        widthClass,
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </DrawerPrimitive.Content>
-  </SlideOverPortal>
-));
+>(({ className, widthClass, children, ...props }, ref) => {
+  const direction = React.useContext(SlideOverDirectionContext);
+  const isSheet = direction === "bottom";
+  return (
+    <SlideOverPortal>
+      <SlideOverOverlay />
+      <DrawerPrimitive.Content
+        ref={ref}
+        data-date-picker-focus-trap="true"
+        className={cn(
+          "fixed z-50 flex flex-col bg-white shadow-2xl outline-none",
+          isSheet
+            ? // Blatt von unten: an drei Kanten bündig, oben abgerundet, nie
+              // höher als 90vh — der Rest der Seite bleibt als Kontext sichtbar.
+              "inset-x-0 bottom-0 max-h-[90vh] rounded-t-2xl"
+            : // `max-w-full` fängt den einen Frame vor dem matchMedia-Effect ab:
+              // ein per Deep-Link (?block=…) sofort offenes Panel würde sonst
+              // kurz mit 420px auf einem schmaleren Display stehen.
+              cn("top-0 right-0 h-full w-[420px] max-w-full", widthClass),
+          className,
+        )}
+        {...props}
+      >
+        {isSheet && (
+          // Griff wie im Drawer: signalisiert die Wischgeste, mit der Vaul das
+          // Blatt schließt.
+          <div
+            aria-hidden
+            className="mx-auto mt-3 h-1 w-12 shrink-0 rounded-full bg-gray-300"
+          />
+        )}
+        {children}
+      </DrawerPrimitive.Content>
+    </SlideOverPortal>
+  );
+});
 SlideOverContent.displayName = "SlideOverContent";
 
 const SlideOverHeader = ({

--- a/frontend/src/components/ui/slide-over.tsx
+++ b/frontend/src/components/ui/slide-over.tsx
@@ -41,8 +41,7 @@ import { cn } from "~/lib/utils";
 
 /**
  * Unter sm fährt das Panel von unten ein, darüber von rechts. Vor dem ersten
- * Effect gilt "right"; die Korrektur greift, bevor ein Panel geöffnet werden
- * kann.
+ * Effect gilt "right", damit Server- und Client-Render übereinstimmen.
  */
 function useSlideOverDirection(): "right" | "bottom" {
   return useMediaQuery(BELOW_SM) ? "bottom" : "right";
@@ -54,19 +53,44 @@ const SlideOverDirectionContext = React.createContext<"right" | "bottom">(
 
 const SlideOver = ({
   shouldScaleBackground = false,
+  open: openProp,
+  defaultOpen = false,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) => {
-  const direction = useSlideOverDirection();
+  const preferredDirection = useSlideOverDirection();
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const open = openProp ?? uncontrolledOpen;
+  const [direction, setDirection] = React.useState(preferredDirection);
+
+  // Vaul übernimmt `direction` nur beim Mount. Ein Richtungswechsel mit
+  // `key={direction}` darf deshalb nicht passieren, solange ein Formular im
+  // Panel offen ist: Das würde dessen lokalen, noch nicht gespeicherten State
+  // verwerfen. Nach dem Schließen darf der nächste Öffnungsvorgang die für den
+  // dann aktuellen Breakpoint passende Vaul-Instanz verwenden.
+  React.useEffect(() => {
+    if (!open) setDirection(preferredDirection);
+  }, [open, preferredDirection]);
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      setUncontrolledOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange],
+  );
+
   return (
     <SlideOverDirectionContext.Provider value={direction}>
       <DrawerPrimitive.Root
         // Vaul liest die Richtung beim Mount für Drag-Achse und Animation.
-        // Der Key erzwingt den Neuaufbau, wenn der Breakpoint tatsächlich
-        // wechselt (Drehung, Fenstergröße) — ohne ihn zöge ein von rechts
-        // aufgebautes Panel weiter nach rechts, obwohl es unten sitzt.
+        // Der Key baut die Instanz erst nach dem Schließen für einen inzwischen
+        // geänderten Breakpoint neu auf.
         key={direction}
         direction={direction}
         shouldScaleBackground={shouldScaleBackground}
+        open={open}
+        onOpenChange={handleOpenChange}
         {...props}
       />
     </SlideOverDirectionContext.Provider>

--- a/frontend/src/components/ui/slide-over.tsx
+++ b/frontend/src/components/ui/slide-over.tsx
@@ -36,15 +36,38 @@ import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 import { X } from "lucide-react";
 
-import { BELOW_SM, useMediaQuery } from "~/lib/hooks/use-media-query";
+import { BELOW_SM } from "~/lib/hooks/use-media-query";
 import { cn } from "~/lib/utils";
 
 /**
  * Unter sm fährt das Panel von unten ein, darüber von rechts. Vor dem ersten
- * Effect gilt "right", damit Server- und Client-Render übereinstimmen.
+ * Effect gilt "right", damit Server- und Client-Render übereinstimmen. Die
+ * Auflösung wird separat mitgegeben, damit ein beim Laden bereits offenes
+ * Panel einmalig die korrekte Richtung übernehmen kann.
  */
-function useSlideOverDirection(): "right" | "bottom" {
-  return useMediaQuery(BELOW_SM) ? "bottom" : "right";
+function useSlideOverDirection(): {
+  direction: "right" | "bottom";
+  isResolved: boolean;
+} {
+  const [state, setState] = React.useState<{
+    direction: "right" | "bottom";
+    isResolved: boolean;
+  }>({ direction: "right", isResolved: false });
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia(BELOW_SM);
+    const update = () => {
+      setState({
+        direction: mediaQuery.matches ? "bottom" : "right",
+        isResolved: true,
+      });
+    };
+    update();
+    mediaQuery.addEventListener("change", update);
+    return () => mediaQuery.removeEventListener("change", update);
+  }, []);
+
+  return state;
 }
 
 const SlideOverDirectionContext = React.createContext<"right" | "bottom">(
@@ -58,19 +81,31 @@ const SlideOver = ({
   onOpenChange,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) => {
-  const preferredDirection = useSlideOverDirection();
+  const { direction: preferredDirection, isResolved } = useSlideOverDirection();
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
   const open = openProp ?? uncontrolledOpen;
   const [direction, setDirection] = React.useState(preferredDirection);
+  const appliedInitialDirection = React.useRef(false);
 
   // Vaul übernimmt `direction` nur beim Mount. Ein Richtungswechsel mit
   // `key={direction}` darf deshalb nicht passieren, solange ein Formular im
   // Panel offen ist: Das würde dessen lokalen, noch nicht gespeicherten State
-  // verwerfen. Nach dem Schließen darf der nächste Öffnungsvorgang die für den
-  // dann aktuellen Breakpoint passende Vaul-Instanz verwenden.
+  // verwerfen. Die erste Client-Auflösung ist davon ausgenommen: Zu diesem
+  // Zeitpunkt konnte noch kein Nutzer im Panel arbeiten, und ein per Deep-Link
+  // sofort offenes Panel muss auf einem Telefon von unten erscheinen. Nach dem
+  // Schließen darf der nächste Öffnungsvorgang die dann passende Vaul-Instanz
+  // verwenden.
   React.useEffect(() => {
+    if (!isResolved) return;
+
+    if (!appliedInitialDirection.current) {
+      appliedInitialDirection.current = true;
+      setDirection(preferredDirection);
+      return;
+    }
+
     if (!open) setDirection(preferredDirection);
-  }, [open, preferredDirection]);
+  }, [isResolved, open, preferredDirection]);
 
   const handleOpenChange = React.useCallback(
     (nextOpen: boolean) => {

--- a/frontend/src/lib/hooks/use-media-query.ts
+++ b/frontend/src/lib/hooks/use-media-query.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Verfolgt eine CSS-Media-Query im Client.
+ *
+ * Gedacht für die Fälle, in denen ein Breakpoint mehr entscheidet als
+ * Sichtbarkeit — wenn also zwei Darstellungen NICHT beide ins Dokument gehören
+ * und per `hidden`/`lg:block` weggeblendet werden dürfen. Beide zu rendern
+ * verdoppelt Beschriftungen, IDs und die Tabulator-Reihenfolge: Screenreader
+ * lesen jede Zeile zweimal vor, und die Tastaturnavigation läuft durch eine
+ * unsichtbare Kopie. Für reine Sichtbarkeit bleiben Tailwind-Klassen der
+ * einfachere und flackerfreie Weg.
+ *
+ * Vor dem ersten Effect ist das Ergebnis `false` — bewusst, damit Server- und
+ * Client-Render übereinstimmen und React keine Hydrations-Abweichung meldet.
+ * Aufrufer legen deshalb die Desktop-Variante als `false`-Fall aus.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const update = () => setMatches(mediaQuery.matches);
+    update();
+    mediaQuery.addEventListener("change", update);
+    return () => mediaQuery.removeEventListener("change", update);
+  }, [query]);
+
+  return matches;
+}
+
+/** Tailwinds `sm`-Grenze: alles darunter ist ein Telefon-Format. */
+export const BELOW_SM = "(max-width: 639px)";
+/** Tailwinds `lg`-Grenze: darunter ist kein Platz für breite Wochenraster. */
+export const BELOW_LG = "(max-width: 1023px)";

--- a/frontend/src/lib/planning-navigation.test.ts
+++ b/frontend/src/lib/planning-navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  PLANNING_SUB_PAGES,
   getActivePlanningSubPageHref,
   getPlanningMobileActivePaths,
   isPlanningPageHref,
@@ -27,13 +28,25 @@ describe("planning navigation", () => {
     expect(isPlanningPath("/dienstplan-archiv")).toBe(false);
   });
 
-  it("groups desktop-only calendar periods under Betreuungsplan on mobile", () => {
+  it("gives every planning page its own mobile entry", () => {
+    // Früher hingen Tageslisten und Kalenderzeiträume als desktop-only Kinder
+    // am Betreuungsplan-Eintrag. Sie waren dadurch mobil nicht erreichbar (es
+    // führt kein Verweis vom Betreuungsplan dorthin), also markiert jetzt jede
+    // Seite nur noch sich selbst und ihre eigenen Alt-Pfade.
     expect(getPlanningMobileActivePaths("/betreuungsplan")).toEqual([
       "/betreuungsplan",
       "/timetables",
-      "/lists",
+    ]);
+    expect(getPlanningMobileActivePaths("/lists")).toEqual(["/lists"]);
+    expect(getPlanningMobileActivePaths("/calendar-periods")).toEqual([
       "/calendar-periods",
     ]);
+  });
+
+  it("keeps every planning page in the flattened mobile navigation", () => {
+    expect(PLANNING_SUB_PAGES.filter((page) => !page.showInMobileNav)).toEqual(
+      [],
+    );
   });
 
   it("recognizes only canonical planning hrefs", () => {

--- a/frontend/src/lib/planning-navigation.ts
+++ b/frontend/src/lib/planning-navigation.ts
@@ -10,13 +10,19 @@ export interface PlanningSubPage {
   readonly label: string;
   readonly legacyPrefixes: readonly string[];
   readonly showInMobileNav: boolean;
-  readonly mobileParentHref?: PlanningPageHref;
 }
 
 /**
  * Single source of truth for planning navigation and its legacy redirects.
- * Kalenderzeiträume stays desktop-only and belongs to Betreuungsplan in the
- * flattened mobile navigation.
+ *
+ * Jede Planungsseite steht auch in der flachen mobilen Navigation. Tageslisten
+ * und Kalenderzeiträume waren dort ausgenommen, mit der Begründung, sie seien
+ * "über den Betreuungsplan-Eintrag erreichbar" — das traf nicht zu: es gibt
+ * keinen Verweis vom Betreuungsplan dorthin. Kalenderzeiträume erreichte man
+ * nur beiläufig über den Zeitraum-Auswähler, Tageslisten ausschließlich über
+ * einen Link in der Datenverwaltung. Beide Seiten funktionieren mobil (das
+ * Desktop-Gate von Kalenderzeiträume fiel mit #2033), also gehören sie auch
+ * mobil in die Navigation.
  */
 export const PLANNING_SUB_PAGES: readonly PlanningSubPage[] = [
   {
@@ -39,21 +45,17 @@ export const PLANNING_SUB_PAGES: readonly PlanningSubPage[] = [
   },
   {
     // Tageslisten (#1565): druckbare Listen aus den Betreuungsplan-Slots
-    // (Plan/Ist/Abgleich). Desktop-only im Akkordeon; mobil über den
-    // Betreuungsplan-Eintrag erreichbar, die Seite selbst hat einen
-    // Zurück-Button.
+    // (Plan/Ist/Abgleich). Die Seite selbst hat einen Zurück-Button.
     href: "/lists",
     label: "Tageslisten",
     legacyPrefixes: [],
-    showInMobileNav: false,
-    mobileParentHref: "/betreuungsplan",
+    showInMobileNav: true,
   },
   {
     href: "/calendar-periods",
     label: "Kalenderzeiträume",
     legacyPrefixes: [],
-    showInMobileNav: false,
-    mobileParentHref: "/betreuungsplan",
+    showInMobileNav: true,
   },
 ];
 
@@ -84,15 +86,10 @@ export function isPlanningPageHref(href: string): href is PlanningPageHref {
 }
 
 /**
- * Paths that should activate one entry in the flattened mobile navigation.
- * This includes that page's legacy redirects and any desktop-only children.
+ * Paths that should activate one entry in the flattened mobile navigation:
+ * the page itself plus its legacy redirects.
  */
 export function getPlanningMobileActivePaths(href: PlanningPageHref): string[] {
-  const paths: string[] = [];
-  for (const page of PLANNING_SUB_PAGES) {
-    if (page.href === href || page.mobileParentHref === href) {
-      paths.push(page.href, ...page.legacyPrefixes);
-    }
-  }
-  return paths;
+  const page = PLANNING_SUB_PAGES.find((entry) => entry.href === href);
+  return page ? [page.href, ...page.legacyPrefixes] : [];
 }


### PR DESCRIPTION
Der Planungsbereich war für den großen Bildschirm gebaut. Auf dem Handy fraßen die Kopfzeilen ein Viertel bis ein Drittel des Viewports, die Vertretung zeigte weniger als am Rechner, der Dienstplan war eine horizontal scrollende Matrix, die Detail-Panels fuhren von rechts ein, und zwei Planungsseiten waren gar nicht erreichbar.

## Was sich ändert

**Kopfzeilen.** Die geteilte Leiste zerfiel per `flex-wrap` in vier Zeilen. Sie ordnet sich jetzt in einen Titelblock links (Seitenname klein, Datum darunter) mit der Zeitnavigation rechts, darunter den Ansichtsumschalter über die volle Breite. Gemessene Höhen:

| Fläche | vorher | nachher |
|---|---|---|
| Vertretung | 300 px | 151 px |
| Dienstplan | ~340 px | 151 px |
| Betreuungsplan | ~290 px | 151 px |

Zwei Layoutfehler steckten darin: dem Zeilen-Wrapper fehlte `min-w-0`, weshalb die Zeile rechts aus dem Viewport lief statt das Datum zu kürzen. Und im Betreuungsplan war der Umschalter-Block breiter als die Zeile (347 px in 332 px), wodurch das Datum lautlos auf null Breite gequetscht wurde.

**Vertretung.** Das Wochenraster steckte hinter `hidden lg:block` und fehlte mobil komplett, obwohl der Betreuungsplan dasselbe Raster auf demselben Gerät darstellt. Es läuft jetzt auch dort, einspaltig unter der Störungsliste.

**Dienstplan.** Die Personen×Tage-Matrix ist unter `lg` durch eine Tagesansicht ersetzt (ein Tag, Personen untereinander). Auf 390 px nahm die Namensspalte die halbe Breite, sichtbar blieb rund eine Tagesspalte. Zeilenkopf und Zellinhalt kommen aus denselben Render-Funktionen wie die Matrix, Menüs und Anlege-Geste bleiben also identisch. Beide Darstellungen sind bewusst exklusiv statt per CSS geblendet, sonst läge jede Person doppelt im Baum und Screenreader läsen den Plan zweimal vor.

**Slide-overs.** Alle vier Panels auf der geteilten Primitive (Vertretungs-Editor, Termin-Dialog, Personal-Pool, Raumdetails) öffnen unter `sm` als Blatt von unten. Vaul richtet Drag-Achse und Animation am `direction`-Prop aus, deshalb entscheidet eine Breakpoint-Abfrage statt CSS.

**Navigation.** `/lists` und `/calendar-periods` waren aus der mobilen Navigation ausgenommen, mit der Begründung, sie seien über den Betreuungsplan erreichbar. Das traf nicht zu, es führt kein Verweis dorthin. Beide stehen jetzt als eigene Einträge im „Mehr"-Menü.

## Nebenbei

Das Wochenetikett des Dienstplans lautete `KW 31: 27. Juli bis 31. Juli 2026` und brauchte damit 220 px in einer 199 px breiten Kopfzeile. Es kommt jetzt wie bei den beiden Nachbarflächen aus `formatWeekLabel`.

In der Vertretung zeigten Tage ohne verfügbaren Lückenzähler einen Gedankenstrich, dessen Bedeutung sich nur mit Kenntnis der Ladelogik erschloss. Der Chip bleibt jetzt still.

## Angepasste Tests

Drei bestehende Tests hielten Verhalten fest, das dieser PR bewusst ändert:

- `planning-navigation.test.ts` und `mobile-bottom-nav.test.tsx` pinnten „Tageslisten/Kalenderzeiträume sind desktop-only und gruppieren unter Betreuungsplan"
- `planning-context-bar.test.tsx` pinnte den Platzhalter-Strich
- `dienstplan-view.test.tsx` pinnte das alte Datumsformat (seine eigentliche Aussage, die Zeitzonen-Robustheit, bleibt unverändert)

## Screenshots

<details>
<summary>Mobil</summary>
<img width="1170" height="2532" alt="NACHHER-mobil-betreuungsplan" src="https://github.com/user-attachments/assets/550fb61f-017b-4655-b26d-3cffa114132d" />
<img width="1170" height="2532" alt="NACHHER-mobil-bottomsheet" src="https://github.com/user-attachments/assets/4f44c42d-ddec-4a8d-80b8-872e21eacb7e" />
<img width="1170" height="2532" alt="NACHHER-mobil-dienstplan" src="https://github.com/user-attachments/assets/ccaa6a5a-ebf7-416a-a88e-d59e8b5b9819" />
<img width="1170" height="2532" alt="NACHHER-mobil-mehr-menue" src="https://github.com/user-attachments/assets/2ed4c30c-2d45-4148-ab96-6d5a4336c6d4" />
<img width="1170" height="2532" alt="NACHHER-mobil-vertretung" src="https://github.com/user-attachments/assets/f6aa6aa9-0b5d-42b2-926a-bf811d8cdb16" />

</details>

<details>
<summary>Desktop (unverändert)</summary>
<img width="1440" height="900" alt="desktop-betreuungsplan" src="https://github.com/user-attachments/assets/1adfe324-65a5-456a-9b85-818c811382de" />
<img width="1440" height="900" alt="desktop-dienstplan" src="https://github.com/user-attachments/assets/96971e89-c19c-4e18-9ffc-532b46c8a081" />
<img width="1440" height="900" alt="desktop-vertretung" src="https://github.com/user-attachments/assets/b5854dd8-c085-47e8-9a10-e33f3056670f" />

</details>

## Prüfung

`pnpm run check` grün, 893 Tests der betroffenen Bereiche grün. Desktop auf allen drei Flächen visuell gegengeprüft (Kopfzeile 111 px, Wochenmatrix, Zweispalter, Slide-over rechts mit 420 px).

Die drei Fehler in `chart.test.tsx` sind vorbestehend und nicht von diesem PR verursacht (gegen den unveränderten Stand geprüft).
