### PR TITLE
Persönliche Benachrichtigungen: Zustimmung pro Person, Tick pro Person, Standard an

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -523,7 +523,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	})
 	api.Emergency = emergencyAPI.NewResource(api.Services.Emergency, db)
 	api.Reminders = remindersAPI.NewResource(api.Services.Reminders, api.Services.UserContext, db)
-	api.Notifications = notificationsAPI.NewResource(api.Services.Notifications, api.Services.PushSubscriptions, db)
+	api.Notifications = notificationsAPI.NewResource(api.Services.Notifications, api.Services.PushSubscriptions, api.Services.NotificationPreferences, db)
 
 	// Initialize operator dashboard resources
 	api.Operator = operatorAPI.NewResource(operatorAPI.ResourceConfig{
@@ -558,6 +558,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	)
 	api.Parent.SetCalendarService(api.Services.Calendar)
 	api.Parent.SetPushService(api.Services.PushSubscriptions)
+	api.Parent.SetPreferenceService(api.Services.NotificationPreferences)
 	api.Platform = platformAPI.NewResource(platformAPI.ResourceConfig{
 		AnnouncementsService: api.Services.Announcement,
 		TokenAuth:            nil, // Uses tenant auth middleware

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -431,6 +431,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		EnrollmentFormSchema:    api.Services.EnrollmentFormSchema,
 		Broadcaster:             api.Services.RealtimeHub,
 		ParentEventEmitter:      api.Services.ParentEventEmitter,
+		AbsenceNotifier:         api.Services.AbsenceNotifier,
 		StudentPhotos:           api.Services.StudentPhotos,
 		ListExportService:       api.Services.ListExport,
 		Logger:                  logger.With("handler", "students"),

--- a/backend/api/config/settings_broadcast_test.go
+++ b/backend/api/config/settings_broadcast_test.go
@@ -33,6 +33,10 @@ func (c *captureBroadcaster) BroadcastToTenant(tenantID int64, event realtime.Ev
 
 func (c *captureBroadcaster) BroadcastToTenantAdmins(_ int64, _ realtime.Event) error { return nil }
 
+func (c *captureBroadcaster) BroadcastToStaffAccounts(_ int64, _ []int64, _ realtime.Event) error {
+	return nil
+}
+
 func (c *captureBroadcaster) BroadcastToAll(_ realtime.Event) error { return nil }
 
 // TestScheduleSettingsBroadcast_FiresAfterCommit pins the contract: the

--- a/backend/api/notifications/api.go
+++ b/backend/api/notifications/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
@@ -72,9 +73,10 @@ func (rs *Resource) Router() chi.Router {
 	return r
 }
 
-// sendTestNotification fires a fixed, display-safe test event to the caller's
-// whole tenant so an admin can verify the notification setup (feature flag on,
-// SSE connected, toast rendering) without waiting for a real producer.
+// sendTestNotification fires a fixed, display-safe test event only to the
+// requesting admin. This verifies the notification setup (feature flag on, SSE
+// connected, toast rendering) without broadcasting an unsolicited test to
+// other staff.
 func (rs *Resource) sendTestNotification(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -88,10 +90,19 @@ func (rs *Resource) sendTestNotification(w http.ResponseWriter, r *http.Request)
 		common.RenderError(w, r, common.ErrorForbidden(errors.New("missing tenant context")))
 		return
 	}
+	accountID := jwt.ActorAccountIDFromCtx(ctx)
+	if accountID == nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(jwt.ErrTokenUnauthorized))
+		return
+	}
 
 	err := rs.NotificationsService.Notify(ctx, notificationsService.Event{
-		Type:     "test",
-		Audience: notificationsService.Audience{TenantID: tenantID, Scope: notificationsService.ScopeTenant},
+		Type: "test",
+		Audience: notificationsService.Audience{
+			TenantID:        tenantID,
+			Scope:           notificationsService.ScopeStaff,
+			StaffAccountIDs: []int64{*accountID},
+		},
 		Priority: notificationsService.PriorityNormal,
 		Title:    "Testbenachrichtigung",
 		Body:     "Die Benachrichtigungen sind korrekt eingerichtet.",

--- a/backend/api/notifications/api.go
+++ b/backend/api/notifications/api.go
@@ -22,12 +22,23 @@ import (
 type Resource struct {
 	NotificationsService notificationsService.Service
 	PushService          notificationsService.PushSubscriptionService
+	PreferenceService    notificationsService.PreferenceService
 	db                   *bun.DB
 }
 
 // NewResource builds the notifications HTTP resource.
-func NewResource(service notificationsService.Service, pushService notificationsService.PushSubscriptionService, db *bun.DB) *Resource {
-	return &Resource{NotificationsService: service, PushService: pushService, db: db}
+func NewResource(
+	service notificationsService.Service,
+	pushService notificationsService.PushSubscriptionService,
+	preferenceService notificationsService.PreferenceService,
+	db *bun.DB,
+) *Resource {
+	return &Resource{
+		NotificationsService: service,
+		PushService:          pushService,
+		PreferenceService:    preferenceService,
+		db:                   db,
+	}
 }
 
 // Router mounts the notification routes behind tenant JWT auth.
@@ -46,6 +57,15 @@ func (rs *Resource) Router() chi.Router {
 			r.Get("/public-key", rs.getPushPublicKey)
 			r.Post("/subscriptions", rs.subscribePush)
 			r.Delete("/subscriptions", rs.unsubscribePush)
+		})
+
+		// Which notifications the logged-in user agreed to receive. Own data,
+		// so no permission beyond a valid tenant session — the same reasoning
+		// as the push routes above.
+		r.With(withTx).Route("/preferences", func(r chi.Router) {
+			r.Get("/", rs.listPreferences)
+			r.Delete("/", rs.deleteAllPreferences)
+			r.Put("/{type}", rs.setPreference)
 		})
 	})
 

--- a/backend/api/notifications/api_internal_test.go
+++ b/backend/api/notifications/api_internal_test.go
@@ -47,10 +47,11 @@ func newTestRequest(tenantID int64) *http.Request {
 	if tenantID > 0 {
 		ctx = tenant.WithTenantID(ctx, tenantID)
 	}
+	ctx = context.WithValue(ctx, jwt.CtxClaims, jwt.AppClaims{ID: 73})
 	return httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx)
 }
 
-func TestSendTestNotificationDispatchesTenantEvent(t *testing.T) {
+func TestSendTestNotificationDispatchesOnlyToRequester(t *testing.T) {
 	svc := &captureService{}
 	rs := &Resource{NotificationsService: svc}
 
@@ -61,7 +62,8 @@ func TestSendTestNotificationDispatchesTenantEvent(t *testing.T) {
 	require.True(t, svc.called)
 	assert.Equal(t, "test", svc.gotEvent.Type)
 	assert.Equal(t, int64(41), svc.gotEvent.Audience.TenantID)
-	assert.Equal(t, notificationsService.ScopeTenant, svc.gotEvent.Audience.Scope)
+	assert.Equal(t, notificationsService.ScopeStaff, svc.gotEvent.Audience.Scope)
+	assert.Equal(t, []int64{73}, svc.gotEvent.Audience.StaffAccountIDs)
 	assert.NotEmpty(t, svc.gotEvent.Title)
 }
 
@@ -93,6 +95,19 @@ func TestSendTestNotificationMissingTenant(t *testing.T) {
 	rs.sendTestNotification(rec, newTestRequest(0))
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, svc.called)
+}
+
+func TestSendTestNotificationMissingAccount(t *testing.T) {
+	svc := &captureService{}
+	rs := &Resource{NotificationsService: svc}
+	ctx := tenant.WithTenantID(context.Background(), 41)
+	req := httptest.NewRequest(http.MethodPost, "/test", nil).WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	rs.sendTestNotification(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.False(t, svc.called)
 }
 

--- a/backend/api/notifications/preference_handlers.go
+++ b/backend/api/notifications/preference_handlers.go
@@ -1,0 +1,101 @@
+package notifications
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
+)
+
+// notificationTypePattern bounds the path segment before it reaches the
+// service. The catalogue validates the value itself; this only keeps obviously
+// malformed input out of the logs and the query.
+var notificationTypePattern = regexp.MustCompile(`^[a-z0-9_]{1,64}$`)
+
+// preferenceRequest is the body of a single toggle.
+type preferenceRequest struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// Bind implements render.Binder. Enabled is a pointer so a missing field is
+// rejected rather than silently read as false — switching something off by
+// omission would be a bad surprise.
+func (p *preferenceRequest) Bind(_ *http.Request) error {
+	if p.Enabled == nil {
+		return errors.New("enabled is required")
+	}
+	return nil
+}
+
+// listPreferences returns the staff catalogue with this account's decisions.
+func (rs *Resource) listPreferences(w http.ResponseWriter, r *http.Request) {
+	if rs.PreferenceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notification preferences are not configured")))
+		return
+	}
+
+	accountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	overview, err := rs.PreferenceService.GetForAccount(r.Context(), accountID, notificationsService.PortalStaff)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, overview, "Notification preferences retrieved successfully")
+}
+
+// setPreference records one decision for this account.
+func (rs *Resource) setPreference(w http.ResponseWriter, r *http.Request) {
+	if rs.PreferenceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notification preferences are not configured")))
+		return
+	}
+
+	notificationType := chi.URLParam(r, "type")
+	if !notificationTypePattern.MatchString(notificationType) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid notification type")))
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
+	req := &preferenceRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	accountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	err := rs.PreferenceService.SetForAccount(r.Context(), accountID, notificationType, *req.Enabled)
+	switch {
+	case errors.Is(err, notificationsService.ErrUnknownNotificationType):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	case err != nil:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusNoContent, nil, "")
+}
+
+// deleteAllPreferences switches every decision of this account off. It backs
+// the card's "Alle deaktivieren" action.
+func (rs *Resource) deleteAllPreferences(w http.ResponseWriter, r *http.Request) {
+	if rs.PreferenceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notification preferences are not configured")))
+		return
+	}
+
+	accountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	if err := rs.PreferenceService.DisableAllForAccount(r.Context(), accountID); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusNoContent, nil, "")
+}

--- a/backend/api/parent/api.go
+++ b/backend/api/parent/api.go
@@ -43,8 +43,14 @@ type Resource struct {
 	GuardianProfileLoader *usersService.GuardianProfileLoader
 	SchoolService         platformSvc.SchoolService
 	PushService           notificationsService.PushSubscriptionService
+	PreferenceService     notificationsService.PreferenceService
 	db                    *bun.DB
 	authRateLimiter       func(http.Handler) http.Handler
+}
+
+// SetPreferenceService injects the notification consent service.
+func (rs *Resource) SetPreferenceService(service notificationsService.PreferenceService) {
+	rs.PreferenceService = service
 }
 
 // SetPushService injects the Web Push subscription service (#2003).
@@ -118,6 +124,15 @@ func (rs *Resource) Router() chi.Router {
 			r.Get("/public-key", rs.getPushPublicKey)
 			r.Post("/subscriptions", rs.subscribePush)
 			r.Delete("/subscriptions", rs.unsubscribePush)
+		})
+
+		// Which notifications this guardian agreed to. Applied to every
+		// school the family belongs to, the same fan-out the push
+		// registration above uses.
+		r.Route("/me/notification-preferences", func(r chi.Router) {
+			r.Get("/", rs.listNotificationPreferences)
+			r.Delete("/", rs.deleteAllNotificationPreferences)
+			r.Put("/{type}", rs.setNotificationPreference)
 		})
 
 		r.Get("/me/profile", rs.getMyProfile)

--- a/backend/api/parent/notification_preference_handlers.go
+++ b/backend/api/parent/notification_preference_handlers.go
@@ -1,0 +1,93 @@
+package parent
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
+)
+
+var parentNotificationTypePattern = regexp.MustCompile(`^[a-z0-9_]{1,64}$`)
+
+type parentPreferenceRequest struct {
+	// Pointer so a missing field is rejected rather than read as false:
+	// switching something off by omission would be a bad surprise.
+	Enabled *bool `json:"enabled"`
+}
+
+// listNotificationPreferences returns the guardian catalogue with this
+// account's decisions merged across every school the family belongs to.
+func (rs *Resource) listNotificationPreferences(w http.ResponseWriter, r *http.Request) {
+	if rs.PreferenceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notification preferences are not configured")))
+		return
+	}
+
+	accountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	overview, err := rs.PreferenceService.GetForParent(r.Context(), accountID)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, overview, "Notification preferences retrieved successfully")
+}
+
+// setNotificationPreference applies one decision to every school of the family.
+func (rs *Resource) setNotificationPreference(w http.ResponseWriter, r *http.Request) {
+	if rs.PreferenceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notification preferences are not configured")))
+		return
+	}
+
+	notificationType := chi.URLParam(r, "type")
+	if !parentNotificationTypePattern.MatchString(notificationType) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid notification type")))
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
+	req := parentPreferenceRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if req.Enabled == nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("enabled is required")))
+		return
+	}
+
+	accountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	err := rs.PreferenceService.SetForParent(r.Context(), accountID, notificationType, *req.Enabled)
+	switch {
+	case errors.Is(err, notificationsService.ErrUnknownNotificationType):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	case err != nil:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusNoContent, nil, "")
+}
+
+// deleteAllNotificationPreferences switches every decision off at every school.
+func (rs *Resource) deleteAllNotificationPreferences(w http.ResponseWriter, r *http.Request) {
+	if rs.PreferenceService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("notification preferences are not configured")))
+		return
+	}
+
+	accountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	if err := rs.PreferenceService.DisableAllForParent(r.Context(), accountID); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	common.Respond(w, r, http.StatusNoContent, nil, "")
+}

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -150,10 +150,18 @@ func configureSchedulerRepos(sched *scheduler.Scheduler, api *API) {
 	if api.Services.RealtimeHub != nil {
 		sched.SetInstanceOverdueDeps(repos.ActivityInstance, repos.Room, api.Services.RealtimeHub)
 	}
-	// Reminder → notification bridge (#1624 follow-up): dispatches aggregated
-	// reminder notifications through the channel-agnostic abstraction. Gated
-	// per tenant by notifications.dispatch_enabled + the reminders.* settings.
-	sched.SetReminderNotificationDeps(api.Services.Reminders, api.Services.Notifications)
+	// Personal reminder notifications: dispatches one event per person and
+	// reminder kind through the channel-agnostic abstraction. Gated per tenant
+	// by notifications.dispatch_enabled and the reminders.* settings, and per
+	// person by their own consent plus notifications.on_duty_only.
+	sched.SetReminderNotificationDeps(scheduler.ReminderNotificationDeps{
+		Computer:     api.Services.Reminders,
+		Notifier:     api.Services.Notifications,
+		Preferences:  api.Services.NotificationPreferences,
+		Staff:        repos.Staff,
+		Accounts:     repos.Account,
+		WorkSessions: repos.WorkSession,
+	})
 	// Daily session-end bridge: closes schedule-side rows for ended
 	// active.groups via repositories (issue #585 layering).
 	sched.SetTimetableBridgeRepos(repos.InstanceStudent, repos.ActivityInstance, api.Services.TimetableBridge)

--- a/backend/api/sse/api.go
+++ b/backend/api/sse/api.go
@@ -56,6 +56,9 @@ func (rs *Resource) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	// Step 2: Extract tenant ID from JWT context (set by TenantMiddleware)
 	conn.tenantID = tenant.FromContext(ctx)
 	conn.isAdmin = authorize.HasEffectiveAdminScope(ctx)
+	// The login account, needed to address this person individually. Already in
+	// the claims, so no extra lookup.
+	conn.accountID = int64(jwt.ClaimsFromCtx(ctx).ID)
 
 	// Step 3: Resolve staff + subscription topics.
 	topics, staffID, err := rs.resolveSSESubscription(ctx, conn.tenantID)

--- a/backend/api/sse/sse_helpers.go
+++ b/backend/api/sse/sse_helpers.go
@@ -16,14 +16,18 @@ import (
 
 // sseConnection holds all state for an active SSE connection
 type sseConnection struct {
-	writer   http.ResponseWriter
-	flusher  http.Flusher
-	staffID  int64
-	tenantID int64
-	isAdmin  bool
-	client   *realtime.Client
-	topics   *sseTopics
-	logger   *slog.Logger
+	writer  http.ResponseWriter
+	flusher http.Flusher
+	staffID int64
+	// accountID is auth.accounts.id. Carried separately from staffID because
+	// personal notifications address accounts, and a staff-less effective admin
+	// has staffID 0.
+	accountID int64
+	tenantID  int64
+	isAdmin   bool
+	client    *realtime.Client
+	topics    *sseTopics
+	logger    *slog.Logger
 }
 
 // sseTopics holds subscription topic information
@@ -135,6 +139,7 @@ func (rs *Resource) createAndRegisterClient(conn *sseConnection) {
 	conn.client = &realtime.Client{
 		Channel:          make(chan realtime.Event, 32), // Buffer up to 32 events (issue #848: headroom for bursts, e.g. admin-overview clients subscribed to every group)
 		UserID:           conn.staffID,
+		AccountID:        conn.accountID,
 		TenantID:         conn.tenantID,
 		IsAdmin:          conn.isAdmin,
 		SubscribedGroups: make(map[string]bool),

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -20,6 +20,7 @@ import (
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
 	iotSvc "github.com/moto-nrw/project-phoenix/services/iot"
 	"github.com/moto-nrw/project-phoenix/services/listexport"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
@@ -77,6 +78,7 @@ type ResourceConfig struct {
 	// nil is a no-op (the guardian helper guards on it), so tests that build a
 	// bare Resource keep working.
 	ParentEventEmitter *parentmessaging.Emitter
+	AbsenceNotifier    notificationsService.AbsenceNotifier
 	StudentPhotos      userService.StudentPhotoService
 	ListExportService  *listexport.RendererService
 	Logger             *slog.Logger

--- a/backend/api/students/status_day_handlers.go
+++ b/backend/api/students/status_day_handlers.go
@@ -77,7 +77,7 @@ func (rs *Resource) createStudentStatusDays(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := rs.StudentStatusDayService.CreateForDates(r.Context(), rs.newStatusDayWriteContext(r, userPermissions), student.ID, req.Status, req.Reason, dates); err != nil {
+	if err := rs.StudentStatusDayService.CreateForDates(r.Context(), rs.newStatusDayCreateWriteContext(r, userPermissions, req.Status, dates), student.ID, req.Status, req.Reason, dates); err != nil {
 		if errors.Is(err, activeService.ErrStudentStatusDayReassigned) {
 			renderError(w, r, common.ErrorForbidden(err))
 			return
@@ -127,7 +127,7 @@ func (rs *Resource) bulkCreateStudentStatusDays(w http.ResponseWriter, r *http.R
 	dates := datesBetweenInclusive(from, to)
 
 	userPermissions := jwt.PermissionsFromCtx(r.Context())
-	if err := rs.StudentStatusDayService.BulkCreateForDates(r.Context(), rs.newStatusDayWriteContext(r, userPermissions), req.StudentIDs, req.Status, req.Reason, dates); err != nil {
+	if err := rs.StudentStatusDayService.BulkCreateForDates(r.Context(), rs.newStatusDayCreateWriteContext(r, userPermissions, req.Status, dates), req.StudentIDs, req.Status, req.Reason, dates); err != nil {
 		if errors.Is(err, activeService.ErrStudentStatusDayReassigned) {
 			renderError(w, r, common.ErrorForbidden(err))
 			return
@@ -202,6 +202,16 @@ func (rs *Resource) newStatusDayWriteContext(r *http.Request, userPermissions []
 			rs.wakeChildGuardians(tenantID, studentID)
 		},
 	}
+}
+
+func (rs *Resource) newStatusDayCreateWriteContext(r *http.Request, userPermissions []string, status string, dates []timezone.Date) activeService.StatusDayWriteContext {
+	writeContext := rs.newStatusDayWriteContext(r, userPermissions)
+	tenantID := tenant.FromContext(r.Context())
+	actorAccountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	writeContext.AfterCreateCommit = func(studentIDs []int64) {
+		rs.notifyAbsenceReported(tenantID, studentIDs, status, dates, false, actorAccountID)
+	}
+	return writeContext
 }
 
 func parseStatusDayRange(r *http.Request) (timezone.Date, timezone.Date, error) {

--- a/backend/api/students/status_day_internal_test.go
+++ b/backend/api/students/status_day_internal_test.go
@@ -23,6 +23,7 @@ import (
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -30,6 +31,70 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 )
+
+type recordingAbsenceNotifier struct {
+	reports []notificationsService.AbsenceReport
+}
+
+func (n *recordingAbsenceNotifier) NotifyAbsenceReported(_ context.Context, report notificationsService.AbsenceReport) {
+	n.reports = append(n.reports, report)
+}
+
+func TestStaffAbsenceNotificationCallbacks(t *testing.T) {
+	const tenantID int64 = 17
+	const actorID = 23
+	today := timezone.TodayDate()
+
+	t.Run("planned status write keeps the whole submission together", func(t *testing.T) {
+		notifier := &recordingAbsenceNotifier{}
+		resource := &Resource{ResourceConfig: ResourceConfig{AbsenceNotifier: notifier}}
+		ctx := tenant.WithTenantID(context.Background(), tenantID)
+		ctx = context.WithValue(ctx, jwt.CtxClaims, jwt.AppClaims{ID: actorID})
+		req := httptest.NewRequest(http.MethodPost, "/status-days", nil).WithContext(ctx)
+
+		writeContext := resource.newStatusDayCreateWriteContext(
+			req,
+			[]string{"users:update"},
+			active.StudentStatusDaySick,
+			[]timezone.Date{today},
+		)
+		writeContext.AfterCreateCommit([]int64{41, 42})
+
+		require.Len(t, notifier.reports, 1)
+		report := notifier.reports[0]
+		assert.Equal(t, tenantID, report.TenantID)
+		assert.Equal(t, []int64{41, 42}, report.StudentIDs)
+		assert.Equal(t, active.StudentStatusDaySick, report.Status)
+		assert.Equal(t, []timezone.Date{today}, report.Dates)
+		assert.False(t, report.FromParent)
+		assert.Equal(t, int64(actorID), report.ActorAccountID)
+	})
+
+	t.Run("manual status change notifies only after commit", func(t *testing.T) {
+		notifier := &recordingAbsenceNotifier{}
+		resource := &Resource{ResourceConfig: ResourceConfig{AbsenceNotifier: notifier}}
+		baseCtx := tenant.WithTenantID(context.Background(), tenantID)
+		baseCtx = context.WithValue(baseCtx, jwt.CtxClaims, jwt.AppClaims{ID: actorID})
+		ctx, commit := tenant.WithAfterCommitHooksForTest(baseCtx)
+		excused := true
+
+		resource.scheduleStudentUpdateWakes(
+			ctx,
+			tenantID,
+			41,
+			&UpdateStudentRequest{Excused: &excused},
+			false,
+			active.StudentStatusDayExcused,
+			today,
+		)
+		assert.Empty(t, notifier.reports)
+		commit()
+
+		require.Len(t, notifier.reports, 1)
+		assert.Equal(t, active.StudentStatusDayExcused, notifier.reports[0].Status)
+		assert.Equal(t, int64(actorID), notifier.reports[0].ActorAccountID)
+	})
+}
 
 func TestStatusDayRangeParsing(t *testing.T) {
 	req := httptest.NewRequest("GET", "/status-days?from=2026-05-25&to=2026-05-29", nil)

--- a/backend/api/students/status_day_internal_test.go
+++ b/backend/api/students/status_day_internal_test.go
@@ -324,6 +324,8 @@ func TestStudentStatusDayHandlers_TodayUpdatesLiveStatusAndClearsOpposite(t *tes
 	defer func() { _ = db.Close() }()
 
 	resource := newStatusDayTestResource(db)
+	notifier := &recordingAbsenceNotifier{}
+	resource.AbsenceNotifier = notifier
 	student := testpkg.CreateTestStudent(t, db, "StatusToday", "Student", "ST1")
 	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
 	router := statusDayTestRouter(resource)
@@ -335,6 +337,15 @@ func TestStudentStatusDayHandlers_TodayUpdatesLiveStatusAndClearsOpposite(t *tes
 	})
 	sickRR := executeStatusDayHandler(router, sickReq, testutil.AdminTestClaims(42), []string{"admin:*"})
 	require.Equal(t, http.StatusCreated, sickRR.Code)
+	require.Len(t, notifier.reports, 1)
+
+	repeatedSickReq := testutil.NewAuthenticatedRequest(t, "POST", fmt.Sprintf("/%d/status-days", student.ID), map[string]any{
+		"status": active.StudentStatusDaySick,
+		"dates":  []string{today},
+	})
+	repeatedSickRR := executeStatusDayHandler(router, repeatedSickReq, testutil.AdminTestClaims(42), []string{"admin:*"})
+	require.Equal(t, http.StatusCreated, repeatedSickRR.Code)
+	assert.Len(t, notifier.reports, 1, "re-saving the same absence must not notify twice")
 
 	fresh, err := resource.PersonService.GetStudentByID(testpkg.TenantContext(1), student.ID)
 	require.NoError(t, err)
@@ -348,6 +359,8 @@ func TestStudentStatusDayHandlers_TodayUpdatesLiveStatusAndClearsOpposite(t *tes
 	})
 	excusedRR := executeStatusDayHandler(router, excusedReq, testutil.AdminTestClaims(42), []string{"admin:*"})
 	require.Equal(t, http.StatusCreated, excusedRR.Code)
+	require.Len(t, notifier.reports, 2, "changing the absence type must notify")
+	assert.Equal(t, active.StudentStatusDayExcused, notifier.reports[1].Status)
 
 	rows, err := resource.StudentStatusDayService.GetActiveByStudentAndDateRange(testpkg.TenantContext(1), student.ID, timezone.TodayDate(), timezone.TodayDate())
 	require.NoError(t, err)

--- a/backend/api/students/status_history.go
+++ b/backend/api/students/status_history.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 )
 
 func boolPtrValue(v *bool) bool {
@@ -74,4 +75,18 @@ func (rs *Resource) logStatusHistoryError(studentID int64, err error) {
 		slog.Int64("student_id", studentID),
 		slog.String("error", err.Error()),
 	)
+}
+
+func (rs *Resource) notifyAbsenceReported(tenantID int64, studentIDs []int64, status string, dates []timezone.Date, fromParent bool, actorAccountID int64) {
+	if rs.AbsenceNotifier == nil {
+		return
+	}
+	rs.AbsenceNotifier.NotifyAbsenceReported(context.Background(), notificationsService.AbsenceReport{
+		TenantID:       tenantID,
+		StudentIDs:     studentIDs,
+		Status:         status,
+		Dates:          dates,
+		FromParent:     fromParent,
+		ActorAccountID: actorAccountID,
+	})
 }

--- a/backend/api/students/status_history.go
+++ b/backend/api/students/status_history.go
@@ -22,6 +22,16 @@ func statusReportedAt(now time.Time, existing *time.Time) time.Time {
 	return now
 }
 
+func newlyReportedAbsenceStatus(student *users.Student, wasSick, wasExcused bool) string {
+	if !wasSick && boolPtrValue(student.Sick) {
+		return active.StudentStatusDaySick
+	}
+	if !wasExcused && boolPtrValue(student.Excused) {
+		return active.StudentStatusDayExcused
+	}
+	return ""
+}
+
 func (rs *Resource) persistStudentStatusHistory(ctx context.Context, student *users.Student, wasSick, wasExcused bool, now time.Time, sickNote *string) error {
 	if rs.StudentStatusDayService == nil {
 		return nil

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -18,7 +18,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/strutil"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
@@ -1215,12 +1214,7 @@ func (rs *Resource) applyStudentUpdate(ctx context.Context, tenantID int64, stud
 	// leave a partial write behind either — checking first keeps the refusal
 	// cheap, the rollback makes it safe.
 	applyStudentFieldUpdates(req, fresh)
-	reportedStatus := ""
-	if !wasSick && boolPtrValue(fresh.Sick) {
-		reportedStatus = activeModel.StudentStatusDaySick
-	} else if !wasExcused && boolPtrValue(fresh.Excused) {
-		reportedStatus = activeModel.StudentStatusDayExcused
-	}
+	reportedStatus := newlyReportedAbsenceStatus(fresh, wasSick, wasExcused)
 	authorizedExtensions, err := rs.checkCompanionConflicts(ctx, fresh, req, userPermissions)
 	if err != nil {
 		return false, err

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/strutil"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
@@ -1082,8 +1083,9 @@ func (rs *Resource) wakeChildGuardians(tenantID, studentID int64) {
 // plain name/notes edit changes nothing parent-visible, so it wakes no one
 // (#1725). Runs after the OUTER tx commits so a woken client never reads the
 // pre-commit snapshot; tenantID is captured before the hook fires.
-func (rs *Resource) scheduleStudentUpdateWakes(ctx context.Context, tenantID, studentID int64, req *UpdateStudentRequest, companionsChanged bool) {
+func (rs *Resource) scheduleStudentUpdateWakes(ctx context.Context, tenantID, studentID int64, req *UpdateStudentRequest, companionsChanged bool, reportedStatus string, reportDate timezone.Date) {
 	statusChanged := req.Sick != nil || req.Excused != nil
+	actorAccountID := int64(jwt.ClaimsFromCtx(ctx).ID)
 	tenant.RegisterAfterCommit(ctx, func() {
 		rs.broadcastStudentUpdated(tenantID, studentID)
 		// Only when the write actually changed the links (or a linked child's
@@ -1096,6 +1098,9 @@ func (rs *Resource) scheduleStudentUpdateWakes(ctx context.Context, tenantID, st
 		}
 		if statusChanged {
 			rs.wakeChildGuardians(tenantID, studentID)
+		}
+		if reportedStatus != "" {
+			rs.notifyAbsenceReported(tenantID, []int64{studentID}, reportedStatus, []timezone.Date{reportDate}, false, actorAccountID)
 		}
 	})
 }
@@ -1210,6 +1215,12 @@ func (rs *Resource) applyStudentUpdate(ctx context.Context, tenantID int64, stud
 	// leave a partial write behind either — checking first keeps the refusal
 	// cheap, the rollback makes it safe.
 	applyStudentFieldUpdates(req, fresh)
+	reportedStatus := ""
+	if !wasSick && boolPtrValue(fresh.Sick) {
+		reportedStatus = activeModel.StudentStatusDaySick
+	} else if !wasExcused && boolPtrValue(fresh.Excused) {
+		reportedStatus = activeModel.StudentStatusDayExcused
+	}
 	authorizedExtensions, err := rs.checkCompanionConflicts(ctx, fresh, req, userPermissions)
 	if err != nil {
 		return false, err
@@ -1256,7 +1267,7 @@ func (rs *Resource) applyStudentUpdate(ctx context.Context, tenantID int64, stud
 
 	// Broadcast after the OUTER tx commits. Broadcasting now would race
 	// subscribers into refetching the still-pre-commit row.
-	rs.scheduleStudentUpdateWakes(ctx, tenantID, student.ID, req, companionsChanged)
+	rs.scheduleStudentUpdateWakes(ctx, tenantID, student.ID, req, companionsChanged, reportedStatus, timezone.DateFromTime(statusHistoryNow))
 	return companionsChanged, nil
 }
 

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -26,6 +26,7 @@ DELETE /api/iot/*/{id}
 DELETE /api/iot/staff/{staffId}/rfid
 DELETE /api/me/profile/avatar
 DELETE /api/meal-plan/{date}
+DELETE /api/notifications/preferences/
 DELETE /api/notifications/push/subscriptions
 DELETE /api/parent-announcements/{announcementId}
 DELETE /api/rooms/{id}
@@ -90,6 +91,7 @@ DELETE /operator/suggestions/{id}/comments/{commentId}
 DELETE /parent/me/children/{studentId}/care-exception
 DELETE /parent/me/children/{studentId}/excused-requests/{requestId}
 DELETE /parent/me/children/{studentId}/related-accounts/{guardianProfileId}
+DELETE /parent/me/notification-preferences/
 DELETE /parent/me/push/subscriptions
 GET /
 GET /api/active/analytics/dashboard
@@ -240,6 +242,7 @@ GET /api/messages/students/{studentId}/guardians
 GET /api/messages/students/{studentId}/threads
 GET /api/messages/threads/{threadId}
 GET /api/messages/unread-count
+GET /api/notifications/preferences/
 GET /api/notifications/push/public-key
 GET /api/parent-announcements/
 GET /api/parent-announcements/{announcementId}
@@ -457,6 +460,7 @@ GET /parent/me/messages/children/{studentId}/threads
 GET /parent/me/messages/unread-count
 GET /parent/me/news
 GET /parent/me/news/unread-count
+GET /parent/me/notification-preferences/
 GET /parent/me/profile
 GET /parent/me/push/public-key
 GET /public/calendar/{token}
@@ -759,6 +763,7 @@ PUT /api/iot/*/{id}
 PUT /api/iot/session/{sessionId}/supervisors
 PUT /api/me/profile
 PUT /api/meal-plan/{date}
+PUT /api/notifications/preferences/{type}
 PUT /api/parent-announcements/{announcementId}
 PUT /api/rooms/{id}
 PUT /api/schedules/dateframes/{id}
@@ -815,6 +820,7 @@ PUT /operator/suggestions/{id}/hidden
 PUT /operator/suggestions/{id}/status
 PUT /parent/me/children/{studentId}/guardians/{guardianProfileId}/contact
 PUT /parent/me/children/{studentId}/guardians/{guardianProfileId}/pickup
+PUT /parent/me/notification-preferences/{type}
 PUT /parent/me/profile
 QUERY /internal/metrics
 TRACE /internal/metrics

--- a/backend/database/migrations/001015239_notification_preferences.go
+++ b/backend/database/migrations/001015239_notification_preferences.go
@@ -1,0 +1,131 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	notificationPreferencesVersion     = "1.15.239"
+	notificationPreferencesDescription = "Create users.notification_preferences - per-account notification opt-in"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     notificationPreferencesVersion,
+		Description: notificationPreferencesDescription,
+		DependsOn: []string{
+			gradeTransitionHistoryRFIDTagVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return notificationPreferencesUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return notificationPreferencesDown(ctx, db)
+		},
+	)
+}
+
+// notificationPreferencesUp creates the per-account notification opt-in store.
+//
+// One row per (tenant, account, notification type). Notifications are delivered
+// only where a person has explicitly agreed to that type, so the absence of a
+// row means "off" and the whole table starts empty.
+//
+// account_id uses a PLAIN FK to auth.accounts, matching iot.push_subscriptions
+// (1.15.234): accounts are cross-tenant, guardians especially, so there is no
+// composite tenant FK for them. A guardian at two schools decides per school,
+// which is why the unique key carries tenant_id.
+//
+// notification_type is deliberately NOT constrained by a CHECK. The catalogue
+// of types lives in Go (services/notifications/types.go) and is validated by the
+// API; a CHECK would make every new type cost a migration and turn a rollback
+// into a data problem. An unknown type in this table is inert — nothing reads it.
+//
+// A row with enabled = false is meaningfully different from no row at all: it
+// records a deliberate opt-out, which a future change of defaults must not
+// silently overwrite.
+func notificationPreferencesUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.239: Creating users.notification_preferences...")
+	return ensureNotificationPreferences(ctx, db)
+}
+
+func ensureNotificationPreferences(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS users.notification_preferences (
+			id                BIGSERIAL PRIMARY KEY,
+			tenant_id         BIGINT      NOT NULL,
+			account_id        BIGINT      NOT NULL,
+			notification_type TEXT        NOT NULL,
+			enabled           BOOLEAN     NOT NULL DEFAULT FALSE,
+			created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT uq_notification_preferences
+				UNIQUE (tenant_id, account_id, notification_type),
+			CONSTRAINT fk_notification_preferences_tenant
+				FOREIGN KEY (tenant_id) REFERENCES platform.schools(id) ON DELETE CASCADE,
+			CONSTRAINT fk_notification_preferences_account
+				FOREIGN KEY (account_id) REFERENCES auth.accounts(id) ON DELETE CASCADE
+		);
+
+		-- The producers' hot question is "who in this school agreed to type X".
+		-- Partial on enabled because that query never wants the opt-out rows.
+		CREATE INDEX IF NOT EXISTS idx_notification_preferences_type
+			ON users.notification_preferences (tenant_id, notification_type)
+			WHERE enabled;
+
+		DROP TRIGGER IF EXISTS update_notification_preferences_updated_at
+			ON users.notification_preferences;
+		CREATE TRIGGER update_notification_preferences_updated_at
+		BEFORE UPDATE ON users.notification_preferences
+		FOR EACH ROW EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE users.notification_preferences ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE users.notification_preferences FORCE  ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_users_notification_preferences
+			ON users.notification_preferences;
+		CREATE POLICY tenant_isolation_users_notification_preferences
+			ON users.notification_preferences
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON users.notification_preferences TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE users.notification_preferences_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating users.notification_preferences: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// notificationPreferencesDown drops the table. Unlike 1.15.234's deliberate
+// no-op, the data here is a user's own choice that they can re-enter, and
+// nothing else references the rows.
+func notificationPreferencesDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back 1.15.239: Dropping users.notification_preferences...")
+	_, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS users.notification_preferences;`)
+	if err != nil {
+		return fmt.Errorf("error dropping users.notification_preferences: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015240_notification_preferences_backfill.go
+++ b/backend/database/migrations/001015240_notification_preferences_backfill.go
@@ -30,23 +30,61 @@ func init() {
 	)
 }
 
-// notificationPreferencesBackfillUp gives everyone who already registered a
-// device for Web Push the consent that matches what that device used to
-// deliver.
+// dispatchWasEnabledSQL restricts the backfill to schools that had switched
+// notifications.dispatch_enabled ON themselves, by carrying an explicit
+// override row in config.setting_values.
+//
+// This is the whole justification for writing consent on somebody's behalf: at
+// those schools the registered device really did receive these notifications,
+// so the consent already existed in practice and is only being written down. A
+// school that never switched dispatch on delivered nothing, so there is no
+// prior consent to record. Adding a row there would be invented consent, and
+// this release flips the registry default to true, so it would arrive together
+// with a switch that suddenly reads "on" for a person who never agreed to any
+// category.
+//
+// No override row and an explicit false are treated the same on purpose: both
+// mean the school was running with dispatch off, which is what the registry
+// default was until this release.
+//
+// The value comparison is 'true'::jsonb because config.setting_values.value is
+// jsonb (1.15.25) and the settings service stores booleans via json.Marshal, so
+// a boolean setting is the jsonb literal true, never the string "true". Same
+// form as 1.15.98 and 1.15.125.
+//
+// The key is a string literal, not models/config.KeyNotificationsDispatchEnabled,
+// for the same reason as the type strings below: migrations are frozen history.
+const dispatchWasEnabledSQL = `EXISTS (
+		SELECT 1
+		FROM config.setting_values AS "dispatch"
+		WHERE "dispatch".tenant_id = "sub".tenant_id
+		  AND "dispatch".setting_key = 'notifications.dispatch_enabled'
+		  AND "dispatch".value = 'true'::jsonb
+	)`
+
+// notificationPreferencesBackfillUp gives everyone whose registered Web Push
+// device was actually being delivered to the consent that matches what that
+// device used to deliver.
 //
 // Consent is stored as "a row means yes, no row means no" (1.15.239), and this
 // release switches notifications.dispatch_enabled on by default while routing
 // every producer through consent. Without this backfill, the two changes
-// together would silence every phone that is registered today, in the same
-// minute, with nothing on screen to explain it.
+// together would silence every phone that is receiving notifications today, in
+// the same minute, with nothing on screen to explain it.
 //
-// Guardians get the single parent type. Only active effective admins get the
-// four reminder types, because the old reminders_due event used ScopeAdmin;
-// another staff member's registered device never received it. The personal
-// types added by this epic (my_activity_starting, student_absence_reported) are
-// deliberately NOT backfilled: no existing registration says anything about
-// them, and inventing consent is worse than an empty switch the person can turn
-// on.
+// Both blocks are therefore limited to schools that had dispatch switched on
+// (see dispatchWasEnabledSQL) and to accounts that are still active members of
+// that school. A device belonging to a deactivated account or to a family that
+// has left the school never receives anything again, so a consent row for it
+// would be a claim about a person's wishes that nobody ever made, kept forever:
+// down() is a deliberate no-op, so nothing removes it later.
+//
+// Guardians get the single parent type. Only effective admins get the four
+// reminder types, because the old reminders_due event used ScopeAdmin; another
+// staff member's registered device never received it. The personal types added
+// by this epic (my_activity_starting, student_absence_reported) are deliberately
+// NOT backfilled: no existing registration says anything about them, and
+// inventing consent is worse than an empty switch the person can turn on.
 //
 // ON CONFLICT DO NOTHING because an explicit opt-out is a decision: a row with
 // enabled = false means somebody said no, and a backfill must never overwrite
@@ -59,13 +97,22 @@ func init() {
 func notificationPreferencesBackfillUp(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.240: Backfilling notification consent from existing push subscriptions...")
 
-	if _, err := db.ExecContext(ctx, `
+	guardianBackfillQuery := fmt.Sprintf(`
 		INSERT INTO users.notification_preferences (tenant_id, account_id, notification_type, enabled)
 		SELECT DISTINCT "sub".tenant_id, "sub".account_id, 'parent_announcement', TRUE
 		FROM iot.push_subscriptions AS "sub"
+		INNER JOIN auth.accounts AS "account"
+			ON "account".id = "sub".account_id
+		INNER JOIN auth.account_tenants AS "account_tenant"
+			ON "account_tenant".account_id = "sub".account_id
+			AND "account_tenant".tenant_id = "sub".tenant_id
 		WHERE "sub".portal = 'parent'
+		  AND "account".active = TRUE
+		  AND "account_tenant".status = 'active'
+		  AND %s
 		ON CONFLICT (tenant_id, account_id, notification_type) DO NOTHING;
-	`); err != nil {
+	`, dispatchWasEnabledSQL)
+	if _, err := db.ExecContext(ctx, guardianBackfillQuery); err != nil {
 		return fmt.Errorf("error backfilling guardian notification consent: %w", err)
 	}
 
@@ -97,8 +144,9 @@ func notificationPreferencesBackfillUp(ctx context.Context, db *bun.DB) error {
 			  AND LOWER("staff_role".name) <> 'guardian'
 		  )
 		  AND (%s)
+		  AND %s
 		ON CONFLICT (tenant_id, account_id, notification_type) DO NOTHING;
-	`, authRepository.EffectiveAdminExistsSQL(`"sub".account_id`, `"sub".tenant_id`))
+	`, authRepository.EffectiveAdminExistsSQL(`"sub".account_id`, `"sub".tenant_id`), dispatchWasEnabledSQL)
 	if _, err := db.ExecContext(ctx, staffBackfillQuery); err != nil {
 		return fmt.Errorf("error backfilling staff notification consent: %w", err)
 	}

--- a/backend/database/migrations/001015240_notification_preferences_backfill.go
+++ b/backend/database/migrations/001015240_notification_preferences_backfill.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	authRepository "github.com/moto-nrw/project-phoenix/database/repositories/auth"
 	"github.com/uptrace/bun"
 )
 
@@ -39,11 +40,13 @@ func init() {
 // together would silence every phone that is registered today, in the same
 // minute, with nothing on screen to explain it.
 //
-// Guardians get the single parent type; staff get the four reminder types their
-// device could already receive. The personal types added by this epic
-// (my_activity_starting, student_absence_reported) are deliberately NOT
-// backfilled: no existing registration says anything about them, and inventing
-// consent is worse than an empty switch the person can turn on.
+// Guardians get the single parent type. Only active effective admins get the
+// four reminder types, because the old reminders_due event used ScopeAdmin;
+// another staff member's registered device never received it. The personal
+// types added by this epic (my_activity_starting, student_absence_reported) are
+// deliberately NOT backfilled: no existing registration says anything about
+// them, and inventing consent is worse than an empty switch the person can turn
+// on.
 //
 // ON CONFLICT DO NOTHING because an explicit opt-out is a decision: a row with
 // enabled = false means somebody said no, and a backfill must never overwrite
@@ -66,10 +69,15 @@ func notificationPreferencesBackfillUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error backfilling guardian notification consent: %w", err)
 	}
 
-	if _, err := db.ExecContext(ctx, `
+	staffBackfillQuery := fmt.Sprintf(`
 		INSERT INTO users.notification_preferences (tenant_id, account_id, notification_type, enabled)
 		SELECT DISTINCT "sub".tenant_id, "sub".account_id, "type", TRUE
 		FROM iot.push_subscriptions AS "sub"
+		INNER JOIN auth.accounts AS "account"
+			ON "account".id = "sub".account_id
+		INNER JOIN auth.account_tenants AS "account_tenant"
+			ON "account_tenant".account_id = "sub".account_id
+			AND "account_tenant".tenant_id = "sub".tenant_id
 		CROSS JOIN unnest(ARRAY[
 			'pickup_upcoming',
 			'pickup_overdue',
@@ -77,8 +85,21 @@ func notificationPreferencesBackfillUp(ctx context.Context, db *bun.DB) error {
 			'activity_overdue'
 		]) AS "type"
 		WHERE "sub".portal = 'staff'
+		  AND "account".active = TRUE
+		  AND "account_tenant".status = 'active'
+		  AND EXISTS (
+			SELECT 1
+			FROM auth.account_roles AS "staff_account_role"
+			INNER JOIN auth.roles AS "staff_role"
+				ON "staff_role".id = "staff_account_role".role_id
+			WHERE "staff_account_role".account_id = "sub".account_id
+			  AND "staff_account_role".tenant_id = "sub".tenant_id
+			  AND LOWER("staff_role".name) <> 'guardian'
+		  )
+		  AND (%s)
 		ON CONFLICT (tenant_id, account_id, notification_type) DO NOTHING;
-	`); err != nil {
+	`, authRepository.EffectiveAdminExistsSQL(`"sub".account_id`, `"sub".tenant_id`))
+	if _, err := db.ExecContext(ctx, staffBackfillQuery); err != nil {
 		return fmt.Errorf("error backfilling staff notification consent: %w", err)
 	}
 

--- a/backend/database/migrations/001015240_notification_preferences_backfill.go
+++ b/backend/database/migrations/001015240_notification_preferences_backfill.go
@@ -1,0 +1,97 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	notificationPreferencesBackfillVersion     = "1.15.240"
+	notificationPreferencesBackfillDescription = "Backfill notification consent for devices that already registered for push"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     notificationPreferencesBackfillVersion,
+		Description: notificationPreferencesBackfillDescription,
+		DependsOn:   []string{notificationPreferencesVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return notificationPreferencesBackfillUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return notificationPreferencesBackfillDown(ctx, db)
+		},
+	)
+}
+
+// notificationPreferencesBackfillUp gives everyone who already registered a
+// device for Web Push the consent that matches what that device used to
+// deliver.
+//
+// Consent is stored as "a row means yes, no row means no" (1.15.239), and this
+// release switches notifications.dispatch_enabled on by default while routing
+// every producer through consent. Without this backfill, the two changes
+// together would silence every phone that is registered today, in the same
+// minute, with nothing on screen to explain it.
+//
+// Guardians get the single parent type; staff get the four reminder types their
+// device could already receive. The personal types added by this epic
+// (my_activity_starting, student_absence_reported) are deliberately NOT
+// backfilled: no existing registration says anything about them, and inventing
+// consent is worse than an empty switch the person can turn on.
+//
+// ON CONFLICT DO NOTHING because an explicit opt-out is a decision: a row with
+// enabled = false means somebody said no, and a backfill must never overwrite
+// that. (None can exist yet, but the guard states the intent.)
+//
+// The type strings are literals here rather than constants: migrations are
+// frozen history and must keep working after a rename. The catalogue lives in
+// services/notifications/types.go; a renamed key simply leaves these rows inert,
+// which 1.15.239 already documents.
+func notificationPreferencesBackfillUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.240: Backfilling notification consent from existing push subscriptions...")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO users.notification_preferences (tenant_id, account_id, notification_type, enabled)
+		SELECT DISTINCT "sub".tenant_id, "sub".account_id, 'parent_announcement', TRUE
+		FROM iot.push_subscriptions AS "sub"
+		WHERE "sub".portal = 'parent'
+		ON CONFLICT (tenant_id, account_id, notification_type) DO NOTHING;
+	`); err != nil {
+		return fmt.Errorf("error backfilling guardian notification consent: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO users.notification_preferences (tenant_id, account_id, notification_type, enabled)
+		SELECT DISTINCT "sub".tenant_id, "sub".account_id, "type", TRUE
+		FROM iot.push_subscriptions AS "sub"
+		CROSS JOIN unnest(ARRAY[
+			'pickup_upcoming',
+			'pickup_overdue',
+			'activity_start',
+			'activity_overdue'
+		]) AS "type"
+		WHERE "sub".portal = 'staff'
+		ON CONFLICT (tenant_id, account_id, notification_type) DO NOTHING;
+	`); err != nil {
+		return fmt.Errorf("error backfilling staff notification consent: %w", err)
+	}
+
+	return nil
+}
+
+// notificationPreferencesBackfillDown is a deliberate no-op, like 1.15.234's.
+//
+// Once the rows exist they are indistinguishable from a choice the person made
+// themselves in their profile, and deleting somebody's own switch to undo a
+// migration is the worse failure. Dropping the table entirely is what 1.15.239
+// is for.
+func notificationPreferencesBackfillDown(_ context.Context, _ *bun.DB) error {
+	fmt.Println("Rolling back 1.15.240: nothing to do (backfilled consent is indistinguishable from a user's own choice)")
+	return nil
+}

--- a/backend/database/migrations/001015240_notification_preferences_backfill_test.go
+++ b/backend/database/migrations/001015240_notification_preferences_backfill_test.go
@@ -1,0 +1,115 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// The backfill exists because two changes land together: consent becomes
+// mandatory for every producer, and the school-wide switch defaults to on.
+// Without it, every phone registered today would go silent in the same minute.
+//
+// It therefore has to give a registered device exactly the consent it used to
+// act on — and nothing beyond that, because inventing consent is the failure
+// this whole epic is built to avoid.
+func TestNotificationPreferencesBackfill(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	parentAccount := testpkg.CreateTestAccount(t, db, "backfill-parent@example.com")
+	staffAccount := testpkg.CreateTestAccount(t, db, "backfill-staff@example.com")
+	silentAccount := testpkg.CreateTestAccount(t, db, "backfill-silent@example.com")
+	optedOutAccount := testpkg.CreateTestAccount(t, db, "backfill-optout@example.com")
+
+	insertSubscription := func(accountID int64, portal, endpoint string) {
+		t.Helper()
+		sub := &iotModels.PushSubscription{
+			AccountID: accountID,
+			Portal:    portal,
+			Endpoint:  endpoint,
+			P256dh:    "test-p256dh",
+			Auth:      "test-auth",
+		}
+		sub.SetTenantID(1)
+		_, err := db.NewInsert().Model(sub).ModelTableExpr("iot.push_subscriptions").Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	insertSubscription(parentAccount.ID, iotModels.PushPortalParent, "https://fcm.googleapis.com/backfill-parent")
+	// Two devices of one person: the backfill must still produce one row per
+	// type, not one per device.
+	insertSubscription(staffAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-staff-1")
+	insertSubscription(staffAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-staff-2")
+	insertSubscription(optedOutAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-optout")
+
+	// Somebody who already said no. A backfill must never overwrite a decision.
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO users.notification_preferences (tenant_id, account_id, notification_type, enabled)
+		VALUES (1, ?, 'pickup_upcoming', FALSE)`, optedOutAccount.ID)
+	require.NoError(t, err)
+
+	accountIDs := []int64{parentAccount.ID, staffAccount.ID, silentAccount.ID, optedOutAccount.ID}
+	t.Cleanup(func() {
+		_, cerr := db.NewDelete().
+			Table("users.notification_preferences").
+			Where("account_id IN (?)", bun.List(accountIDs)).
+			Exec(context.Background())
+		require.NoError(t, cerr)
+		_, cerr = db.NewDelete().
+			Table("iot.push_subscriptions").
+			Where("account_id IN (?)", bun.List(accountIDs)).
+			Exec(context.Background())
+		require.NoError(t, cerr)
+		testpkg.CleanupAuthFixtures(t, db, accountIDs...)
+	})
+
+	require.NoError(t, notificationPreferencesBackfillUp(ctx, db))
+
+	consentOf := func(accountID int64) map[string]bool {
+		t.Helper()
+		var rows []struct {
+			NotificationType string `bun:"notification_type"`
+			Enabled          bool   `bun:"enabled"`
+		}
+		require.NoError(t, db.NewSelect().
+			TableExpr("users.notification_preferences").
+			ColumnExpr("notification_type, enabled").
+			Where("account_id = ?", accountID).
+			Scan(ctx, &rows))
+		out := make(map[string]bool, len(rows))
+		for _, row := range rows {
+			out[row.NotificationType] = row.Enabled
+		}
+		return out
+	}
+
+	assert.Equal(t, map[string]bool{"parent_announcement": true}, consentOf(parentAccount.ID),
+		"a guardian device delivered exactly one kind of notification")
+
+	assert.Equal(t, map[string]bool{
+		"pickup_upcoming":  true,
+		"pickup_overdue":   true,
+		"activity_start":   true,
+		"activity_overdue": true,
+	}, consentOf(staffAccount.ID),
+		"a staff device gets the four reminder kinds it could already receive, and nothing this epic invented")
+
+	assert.Empty(t, consentOf(silentAccount.ID),
+		"somebody who never registered a device is not opted into anything")
+
+	optedOut := consentOf(optedOutAccount.ID)
+	assert.False(t, optedOut["pickup_upcoming"], "an explicit no must survive the backfill")
+	assert.True(t, optedOut["pickup_overdue"], "the untouched kinds are still backfilled")
+
+	// Re-running must be a no-op rather than a duplicate-key failure: migrations
+	// are re-applied on restored databases often enough that this matters.
+	require.NoError(t, notificationPreferencesBackfillUp(ctx, db))
+	assert.False(t, consentOf(optedOutAccount.ID)["pickup_upcoming"])
+}

--- a/backend/database/migrations/001015240_notification_preferences_backfill_test.go
+++ b/backend/database/migrations/001015240_notification_preferences_backfill_test.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -57,6 +58,52 @@ func TestNotificationPreferencesBackfill(t *testing.T) {
 	}
 	grantAdmin(adminAccount.ID)
 	grantAdmin(optedOutAccount.ID)
+
+	// A guardian account in the real world always carries an active
+	// account_tenants mapping: it is created by the guardian invitation flow,
+	// which maps the account to the school. Verified in the seeded dev database,
+	// where every parent account has status = 'active' and accounts.active =
+	// true. The backfill filters on exactly that pair, so without these rows the
+	// fixture would describe a world that does not exist, a parent account
+	// belonging to no school at all. Cleaned up by CleanupAuthFixtures below,
+	// which deletes auth.account_tenants by account_id.
+	mapToTenant := func(accountID int64) {
+		t.Helper()
+		now := time.Now()
+		mapping := &authModels.AccountTenant{
+			AccountID:   accountID,
+			TenantID:    1,
+			Status:      authModels.AccountTenantStatusActive,
+			ActivatedAt: &now,
+		}
+		_, merr := db.NewInsert().Model(mapping).ModelTableExpr("auth.account_tenants").Exec(ctx)
+		require.NoError(t, merr)
+	}
+	mapToTenant(parentAccount.ID)
+	mapToTenant(staffAccount.ID)
+
+	// The backfill only writes consent for a school that had switched
+	// notifications.dispatch_enabled on itself, because only there was the
+	// registered device really being delivered to. This test's subject is what
+	// such a school gets, so the override has to exist; the two tests below cover
+	// the schools that never switched it on. Do not remove this line as an
+	// unmotivated setting: without it the backfill correctly does nothing and
+	// every positive assertion here goes empty.
+	//
+	// Registered with t.Cleanup immediately, so a failure further down still
+	// removes the row. A leftover true on the default tenant would silently
+	// change any other test that relies on the registry default.
+	_, derr := db.ExecContext(ctx, `
+		INSERT INTO config.setting_values (tenant_id, setting_key, value)
+		VALUES (1, 'notifications.dispatch_enabled', 'true'::jsonb)
+		ON CONFLICT (tenant_id, setting_key) DO UPDATE SET value = 'true'::jsonb`)
+	require.NoError(t, derr)
+	t.Cleanup(func() {
+		_, cerr := db.ExecContext(context.Background(), `
+			DELETE FROM config.setting_values
+			WHERE tenant_id = 1 AND setting_key = 'notifications.dispatch_enabled'`)
+		require.NoError(t, cerr)
+	})
 
 	insertSubscription := func(accountID int64, portal, endpoint string) {
 		t.Helper()
@@ -146,4 +193,266 @@ func TestNotificationPreferencesBackfill(t *testing.T) {
 	// are re-applied on restored databases often enough that this matters.
 	require.NoError(t, notificationPreferencesBackfillUp(ctx, db))
 	assert.False(t, consentOf(optedOutAccount.ID)["pickup_upcoming"])
+}
+
+// The backfill may only write consent where the school was actually delivering
+// notifications, which means it had switched notifications.dispatch_enabled on
+// itself. A school that never did received nothing, so there is no prior
+// consent to record, and because this release flips the registry default to
+// true, a row written there would arrive together with a switch that suddenly
+// reads "on" for somebody who never agreed to a single category. down() is a
+// no-op, so nothing takes it back.
+func TestNotificationPreferencesBackfillOnlyForSchoolsWithDispatchEnabled(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	env := setupBackfillTenants(t, db)
+
+	guardianOn := testpkg.CreateTestAccount(t, db, "backfill-dispatch-on-parent@example.com")
+	adminOn := testpkg.CreateTestAccount(t, db, "backfill-dispatch-on-admin@example.com")
+	guardianNoOverride := testpkg.CreateTestAccount(t, db, "backfill-dispatch-unset-parent@example.com")
+	adminNoOverride := testpkg.CreateTestAccount(t, db, "backfill-dispatch-unset-admin@example.com")
+	guardianOff := testpkg.CreateTestAccount(t, db, "backfill-dispatch-off-parent@example.com")
+
+	env.registerAccounts(guardianOn.ID, adminOn.ID, guardianNoOverride.ID, adminNoOverride.ID, guardianOff.ID)
+
+	env.mapAccount(guardianOn.ID, env.enabledTenantID, authModels.AccountTenantStatusActive)
+	env.mapAccount(guardianNoOverride.ID, env.noOverrideTenantID, authModels.AccountTenantStatusActive)
+	env.mapAccount(guardianOff.ID, env.disabledTenantID, authModels.AccountTenantStatusActive)
+	env.grantAdmin(adminOn.ID, env.enabledTenantID)
+	env.grantAdmin(adminNoOverride.ID, env.noOverrideTenantID)
+
+	env.insertSubscription(guardianOn.ID, env.enabledTenantID, iotModels.PushPortalParent)
+	env.insertSubscription(adminOn.ID, env.enabledTenantID, iotModels.PushPortalStaff)
+	env.insertSubscription(guardianNoOverride.ID, env.noOverrideTenantID, iotModels.PushPortalParent)
+	env.insertSubscription(adminNoOverride.ID, env.noOverrideTenantID, iotModels.PushPortalStaff)
+	env.insertSubscription(guardianOff.ID, env.disabledTenantID, iotModels.PushPortalParent)
+
+	require.NoError(t, notificationPreferencesBackfillUp(ctx, db))
+
+	assert.Equal(t, map[string]bool{"parent_announcement": true}, env.consentOf(guardianOn.ID),
+		"a school that switched dispatch on was really delivering, so the consent is recorded")
+	assert.Equal(t, map[string]bool{
+		"pickup_upcoming":  true,
+		"pickup_overdue":   true,
+		"activity_start":   true,
+		"activity_overdue": true,
+	}, env.consentOf(adminOn.ID),
+		"same for the admin reminder types at that school")
+
+	assert.Empty(t, env.consentOf(guardianNoOverride.ID),
+		"a school without a dispatch_enabled override never delivered, so there is no consent to write")
+	assert.Empty(t, env.consentOf(adminNoOverride.ID),
+		"the staff block is bound by the same condition as the guardian block")
+	assert.Empty(t, env.consentOf(guardianOff.ID),
+		"an explicit dispatch_enabled = false is treated exactly like no override at all")
+}
+
+// The guardian block must filter on account state the same way the staff block
+// does. A family that left the school keeps its old registration; a consent row
+// for it would be a permanent, untrue statement about what that person wants,
+// and delivery-time checks stopping the notification does not make the row less
+// wrong (data minimisation).
+func TestNotificationPreferencesBackfillSkipsInactiveGuardians(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	env := setupBackfillTenants(t, db)
+
+	activeGuardian := testpkg.CreateTestAccount(t, db, "backfill-guardian-active@example.com")
+	deactivatedGuardian := testpkg.CreateTestAccount(t, db, "backfill-guardian-deactivated@example.com")
+	leftSchoolGuardian := testpkg.CreateTestAccount(t, db, "backfill-guardian-left@example.com")
+	unmappedGuardian := testpkg.CreateTestAccount(t, db, "backfill-guardian-unmapped@example.com")
+
+	env.registerAccounts(activeGuardian.ID, deactivatedGuardian.ID, leftSchoolGuardian.ID, unmappedGuardian.ID)
+
+	env.mapAccount(activeGuardian.ID, env.enabledTenantID, authModels.AccountTenantStatusActive)
+	env.mapAccount(deactivatedGuardian.ID, env.enabledTenantID, authModels.AccountTenantStatusActive)
+	env.mapAccount(leftSchoolGuardian.ID, env.enabledTenantID, authModels.AccountTenantStatusInactive)
+	// unmappedGuardian deliberately gets no account_tenants row at all.
+
+	_, err := db.NewUpdate().
+		TableExpr("auth.accounts").
+		Set("active = FALSE").
+		Where("id = ?", deactivatedGuardian.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	env.insertSubscription(activeGuardian.ID, env.enabledTenantID, iotModels.PushPortalParent)
+	env.insertSubscription(deactivatedGuardian.ID, env.enabledTenantID, iotModels.PushPortalParent)
+	env.insertSubscription(leftSchoolGuardian.ID, env.enabledTenantID, iotModels.PushPortalParent)
+	env.insertSubscription(unmappedGuardian.ID, env.enabledTenantID, iotModels.PushPortalParent)
+
+	require.NoError(t, notificationPreferencesBackfillUp(ctx, db))
+
+	assert.Equal(t, map[string]bool{"parent_announcement": true}, env.consentOf(activeGuardian.ID),
+		"an active guardian at an active mapping is exactly who this backfill is for")
+	assert.Empty(t, env.consentOf(deactivatedGuardian.ID),
+		"a deactivated account cannot receive anything, so consent must not be invented for it")
+	assert.Empty(t, env.consentOf(leftSchoolGuardian.ID),
+		"a family that left the school keeps no consent row behind")
+	assert.Empty(t, env.consentOf(unmappedGuardian.ID),
+		"without a mapping to the school there is no membership the consent could belong to")
+}
+
+// backfillTenantEnv holds three throwaway schools that differ only in their
+// notifications.dispatch_enabled override, plus the fixture helpers the two
+// tests above share. Every ID is created here and read back, never written as a
+// literal, so the tests survive any database state.
+type backfillTenantEnv struct {
+	t                  *testing.T
+	db                 *bun.DB
+	enabledTenantID    int64
+	noOverrideTenantID int64
+	disabledTenantID   int64
+	adminRoleID        int64
+	accountIDs         []int64
+}
+
+func setupBackfillTenants(t *testing.T, db *bun.DB) *backfillTenantEnv {
+	t.Helper()
+	ctx := context.Background()
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	var orgID int64
+	_, err := db.NewRaw(`
+		INSERT INTO platform.organizations (name, slug, active, created_at, updated_at)
+		VALUES (?, ?, true, NOW(), NOW())
+		RETURNING id`, "Backfill Org "+suffix, "backfill-org-"+suffix).Exec(ctx, &orgID)
+	require.NoError(t, err)
+
+	createSchool := func(label string) int64 {
+		var id int64
+		slug := "backfill-" + label + "-" + suffix
+		_, serr := db.NewRaw(`
+			INSERT INTO platform.schools (name, slug, subdomain, organization_id, active, created_at, updated_at)
+			VALUES (?, ?, ?, ?, true, NOW(), NOW())
+			RETURNING id`, "Backfill School "+label+" "+suffix, slug, slug, orgID).Exec(ctx, &id)
+		require.NoError(t, serr)
+		return id
+	}
+
+	env := &backfillTenantEnv{
+		t:                  t,
+		db:                 db,
+		enabledTenantID:    createSchool("dispatch-on"),
+		noOverrideTenantID: createSchool("dispatch-unset"),
+		disabledTenantID:   createSchool("dispatch-off"),
+	}
+
+	require.NoError(t, db.NewSelect().
+		TableExpr("auth.roles").
+		ColumnExpr("id").
+		Where("name = ?", authModels.BaseRoleAdmin).
+		Limit(1).
+		Scan(ctx, &env.adminRoleID))
+
+	// The override is written as raw jsonb because that is the shape the
+	// settings service produces for a boolean (json.Marshal of a Go bool) and
+	// the shape the migration matches against.
+	setDispatch := func(tenantID int64, value string) {
+		_, serr := db.ExecContext(ctx, `
+			INSERT INTO config.setting_values (tenant_id, setting_key, value)
+			VALUES (?, 'notifications.dispatch_enabled', ?::jsonb)`, tenantID, value)
+		require.NoError(t, serr)
+	}
+	setDispatch(env.enabledTenantID, "true")
+	setDispatch(env.disabledTenantID, "false")
+	// noOverrideTenantID deliberately gets no row: that is the registry default.
+
+	tenantIDs := []int64{env.enabledTenantID, env.noOverrideTenantID, env.disabledTenantID}
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		if len(env.accountIDs) > 0 {
+			_, cerr := db.NewDelete().
+				Table("users.notification_preferences").
+				Where("account_id IN (?)", bun.List(env.accountIDs)).
+				Exec(cleanupCtx)
+			require.NoError(t, cerr)
+			_, cerr = db.NewDelete().
+				Table("iot.push_subscriptions").
+				Where("account_id IN (?)", bun.List(env.accountIDs)).
+				Exec(cleanupCtx)
+			require.NoError(t, cerr)
+			testpkg.CleanupAuthFixtures(t, db, env.accountIDs...)
+		}
+		_, cerr := db.NewDelete().
+			Table("config.setting_values").
+			Where("tenant_id IN (?)", bun.List(tenantIDs)).
+			Exec(cleanupCtx)
+		require.NoError(t, cerr)
+		_, cerr = db.NewDelete().
+			Table("platform.schools").
+			Where("id IN (?)", bun.List(tenantIDs)).
+			Exec(cleanupCtx)
+		require.NoError(t, cerr)
+		_, cerr = db.NewDelete().
+			Table("platform.organizations").
+			Where("id = ?", orgID).
+			Exec(cleanupCtx)
+		require.NoError(t, cerr)
+	})
+
+	return env
+}
+
+func (e *backfillTenantEnv) registerAccounts(ids ...int64) {
+	e.accountIDs = append(e.accountIDs, ids...)
+}
+
+func (e *backfillTenantEnv) mapAccount(accountID, tenantID int64, status string) {
+	e.t.Helper()
+	now := time.Now()
+	mapping := &authModels.AccountTenant{
+		AccountID:   accountID,
+		TenantID:    tenantID,
+		Status:      status,
+		ActivatedAt: &now,
+	}
+	_, err := e.db.NewInsert().Model(mapping).ModelTableExpr("auth.account_tenants").Exec(context.Background())
+	require.NoError(e.t, err)
+}
+
+func (e *backfillTenantEnv) grantAdmin(accountID, tenantID int64) {
+	e.t.Helper()
+	e.mapAccount(accountID, tenantID, authModels.AccountTenantStatusActive)
+
+	adminRole := &authModels.AccountRole{AccountID: accountID, RoleID: e.adminRoleID}
+	adminRole.SetTenantID(tenantID)
+	_, err := e.db.NewInsert().Model(adminRole).ModelTableExpr("auth.account_roles").Exec(context.Background())
+	require.NoError(e.t, err)
+}
+
+func (e *backfillTenantEnv) insertSubscription(accountID, tenantID int64, portal string) {
+	e.t.Helper()
+	sub := &iotModels.PushSubscription{
+		AccountID: accountID,
+		Portal:    portal,
+		Endpoint:  fmt.Sprintf("https://fcm.googleapis.com/backfill-%d-%d-%s", accountID, tenantID, portal),
+		P256dh:    "test-p256dh",
+		Auth:      "test-auth",
+	}
+	sub.SetTenantID(tenantID)
+	_, err := e.db.NewInsert().Model(sub).ModelTableExpr("iot.push_subscriptions").Exec(context.Background())
+	require.NoError(e.t, err)
+}
+
+func (e *backfillTenantEnv) consentOf(accountID int64) map[string]bool {
+	e.t.Helper()
+	var rows []struct {
+		NotificationType string `bun:"notification_type"`
+		Enabled          bool   `bun:"enabled"`
+	}
+	require.NoError(e.t, e.db.NewSelect().
+		TableExpr("users.notification_preferences").
+		ColumnExpr("notification_type, enabled").
+		Where("account_id = ?", accountID).
+		Scan(context.Background(), &rows))
+	out := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		out[row.NotificationType] = row.Enabled
+	}
+	return out
 }

--- a/backend/database/migrations/001015240_notification_preferences_backfill_test.go
+++ b/backend/database/migrations/001015240_notification_preferences_backfill_test.go
@@ -3,7 +3,9 @@ package migrations
 import (
 	"context"
 	"testing"
+	"time"
 
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -24,9 +26,37 @@ func TestNotificationPreferencesBackfill(t *testing.T) {
 	ctx := context.Background()
 
 	parentAccount := testpkg.CreateTestAccount(t, db, "backfill-parent@example.com")
+	adminAccount := testpkg.CreateTestAccount(t, db, "backfill-admin@example.com")
 	staffAccount := testpkg.CreateTestAccount(t, db, "backfill-staff@example.com")
 	silentAccount := testpkg.CreateTestAccount(t, db, "backfill-silent@example.com")
 	optedOutAccount := testpkg.CreateTestAccount(t, db, "backfill-optout@example.com")
+
+	var adminRoleID int64
+	require.NoError(t, db.NewSelect().
+		TableExpr("auth.roles").
+		ColumnExpr("id").
+		Where("name = ?", authModels.BaseRoleAdmin).
+		Limit(1).
+		Scan(ctx, &adminRoleID))
+	grantAdmin := func(accountID int64) {
+		t.Helper()
+		now := time.Now()
+		mapping := &authModels.AccountTenant{
+			AccountID:   accountID,
+			TenantID:    1,
+			Status:      authModels.AccountTenantStatusActive,
+			ActivatedAt: &now,
+		}
+		_, err := db.NewInsert().Model(mapping).ModelTableExpr("auth.account_tenants").Exec(ctx)
+		require.NoError(t, err)
+
+		adminRole := &authModels.AccountRole{AccountID: accountID, RoleID: adminRoleID}
+		adminRole.SetTenantID(1)
+		_, err = db.NewInsert().Model(adminRole).ModelTableExpr("auth.account_roles").Exec(ctx)
+		require.NoError(t, err)
+	}
+	grantAdmin(adminAccount.ID)
+	grantAdmin(optedOutAccount.ID)
 
 	insertSubscription := func(accountID int64, portal, endpoint string) {
 		t.Helper()
@@ -45,8 +75,9 @@ func TestNotificationPreferencesBackfill(t *testing.T) {
 	insertSubscription(parentAccount.ID, iotModels.PushPortalParent, "https://fcm.googleapis.com/backfill-parent")
 	// Two devices of one person: the backfill must still produce one row per
 	// type, not one per device.
-	insertSubscription(staffAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-staff-1")
-	insertSubscription(staffAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-staff-2")
+	insertSubscription(adminAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-admin-1")
+	insertSubscription(adminAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-admin-2")
+	insertSubscription(staffAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-staff")
 	insertSubscription(optedOutAccount.ID, iotModels.PushPortalStaff, "https://fcm.googleapis.com/backfill-optout")
 
 	// Somebody who already said no. A backfill must never overwrite a decision.
@@ -55,7 +86,7 @@ func TestNotificationPreferencesBackfill(t *testing.T) {
 		VALUES (1, ?, 'pickup_upcoming', FALSE)`, optedOutAccount.ID)
 	require.NoError(t, err)
 
-	accountIDs := []int64{parentAccount.ID, staffAccount.ID, silentAccount.ID, optedOutAccount.ID}
+	accountIDs := []int64{parentAccount.ID, adminAccount.ID, staffAccount.ID, silentAccount.ID, optedOutAccount.ID}
 	t.Cleanup(func() {
 		_, cerr := db.NewDelete().
 			Table("users.notification_preferences").
@@ -98,8 +129,11 @@ func TestNotificationPreferencesBackfill(t *testing.T) {
 		"pickup_overdue":   true,
 		"activity_start":   true,
 		"activity_overdue": true,
-	}, consentOf(staffAccount.ID),
-		"a staff device gets the four reminder kinds it could already receive, and nothing this epic invented")
+	}, consentOf(adminAccount.ID),
+		"an admin device gets the four reminder kinds it could already receive, and nothing this epic invented")
+
+	assert.Empty(t, consentOf(staffAccount.ID),
+		"a non-admin staff device did not receive the old admin-scoped reminder event")
 
 	assert.Empty(t, consentOf(silentAccount.ID),
 		"somebody who never registered a device is not opted into anything")

--- a/backend/database/repositories/active/bulk_readers_test.go
+++ b/backend/database/repositories/active/bulk_readers_test.go
@@ -1,0 +1,208 @@
+package active_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupSupervisorRepository_ListActiveSupervisedRooms pins the whole-tenant
+// (staff, room) projection that replaces the per-staff FindActiveByStaffID plus
+// GetActiveGroupsByIDs walk.
+func TestGroupSupervisorRepository_ListActiveSupervisedRooms(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).GroupSupervisor
+	ctx := testpkg.TenantContext(1)
+
+	room := testpkg.CreateTestRoom(t, db, "BulkSupervisedRoom")
+	otherRoom := testpkg.CreateTestRoom(t, db, "BulkSupervisedRoomOther")
+	activityGroup := testpkg.CreateTestActivityGroup(t, db, "BulkSupervisedActivity")
+	staff := testpkg.CreateTestStaff(t, db, "BulkSupervised", "Person")
+
+	openGroup := testpkg.CreateTestActiveGroup(t, db, activityGroup.ID, room.ID)
+	closedGroup := testpkg.CreateTestActiveGroup(t, db, activityGroup.ID, otherRoom.ID)
+
+	// Close the second session: a room whose session already ended has no
+	// presence left and must not surface as supervised.
+	endTime := time.Now()
+	_, err := db.NewUpdate().
+		TableExpr("active.groups").
+		Set("end_time = ?", endTime).
+		Where("id = ?", closedGroup.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	openSupervision := testpkg.CreateTestGroupSupervisor(t, db, staff.ID, openGroup.ID, "primary")
+	closedSupervision := testpkg.CreateTestGroupSupervisor(t, db, staff.ID, closedGroup.ID, "primary")
+
+	defer testpkg.CleanupActivityFixtures(t, db,
+		openSupervision.ID, closedSupervision.ID,
+		openGroup.ID, closedGroup.ID,
+		activityGroup.ID, room.ID, otherRoom.ID,
+	)
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+
+	t.Run("returns the room of an open supervised session", func(t *testing.T) {
+		rows, err := repo.ListActiveSupervisedRooms(ctx)
+		require.NoError(t, err)
+
+		var openFound, closedFound bool
+		for _, row := range rows {
+			if row.StaffID != staff.ID {
+				continue
+			}
+			if row.RoomID == room.ID {
+				openFound = true
+			}
+			if row.RoomID == otherRoom.ID {
+				closedFound = true
+			}
+		}
+
+		assert.True(t, openFound, "open supervision should surface its room")
+		assert.False(t, closedFound, "a session with end_time set must not surface its room")
+	})
+
+	t.Run("excludes a supervision that ended before today", func(t *testing.T) {
+		// end_date in the past mirrors IsSupervisorActive returning false.
+		yesterday := timezone.TodayDate().AddDays(-1)
+		_, err := db.NewUpdate().
+			TableExpr("active.group_supervisors").
+			Set("end_date = ?", yesterday).
+			Where("id = ?", openSupervision.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		defer func() {
+			_, resetErr := db.NewUpdate().
+				TableExpr("active.group_supervisors").
+				Set("end_date = NULL").
+				Where("id = ?", openSupervision.ID).
+				Exec(ctx)
+			require.NoError(t, resetErr)
+		}()
+
+		rows, err := repo.ListActiveSupervisedRooms(ctx)
+		require.NoError(t, err)
+
+		for _, row := range rows {
+			assert.False(t, row.StaffID == staff.ID && row.RoomID == room.ID,
+				"an expired supervision must not surface")
+		}
+	})
+
+	t.Run("does not leak another tenant's supervisions", func(t *testing.T) {
+		const otherTenant int64 = 99042
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreignRoom := testpkg.CreateTestRoomForTenant(t, db, otherTenant, "ForeignSupervisedRoom")
+		foreignActivity := testpkg.CreateTestActivityGroupForTenant(t, db, otherTenant, "ForeignSupervisedActivity")
+		foreignStaff := testpkg.CreateTestStaffForTenant(t, db, otherTenant, "Foreign", "Supervisor")
+		foreignGroup := testpkg.CreateTestActiveGroupWithIDsForTenant(t, db, otherTenant, foreignActivity.ID, foreignRoom.ID)
+
+		foreignSupervision := &active.GroupSupervisor{
+			StaffID:   foreignStaff.ID,
+			GroupID:   foreignGroup.ID,
+			Role:      "primary",
+			StartDate: timezone.TodayDate(),
+		}
+		foreignSupervision.SetTenantID(otherTenant)
+		_, err := db.NewInsert().
+			Model(foreignSupervision).
+			ModelTableExpr("active.group_supervisors").
+			Exec(ctx)
+		require.NoError(t, err)
+
+		defer testpkg.CleanupActivityFixturesForTenant(t, db, otherTenant,
+			foreignSupervision.ID, foreignGroup.ID, foreignActivity.ID, foreignRoom.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, foreignStaff.ID)
+
+		rows, err := repo.ListActiveSupervisedRooms(ctx)
+		require.NoError(t, err)
+
+		for _, row := range rows {
+			assert.NotEqual(t, foreignStaff.ID, row.StaffID,
+				"tenant 1 must not see another tenant's supervisions")
+		}
+	})
+}
+
+// TestVisitRepository_ListOpenVisitStudentIDsByRoom pins the whole-tenant
+// room -> present students projection that replaces the per-room query loop.
+func TestVisitRepository_ListOpenVisitStudentIDsByRoom(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ActiveVisit
+	ctx := testpkg.TenantContext(1)
+
+	room := testpkg.CreateTestRoom(t, db, "BulkVisitRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, db, "BulkVisitActivity")
+	openGroup := testpkg.CreateTestActiveGroup(t, db, activityGroup.ID, room.ID)
+
+	present := testpkg.CreateTestStudent(t, db, "Present", "Child", "1a")
+	departed := testpkg.CreateTestStudent(t, db, "Departed", "Child", "1a")
+
+	entry := time.Now().Add(-time.Hour)
+	exit := time.Now().Add(-10 * time.Minute)
+	openVisit := testpkg.CreateTestVisit(t, db, present.ID, openGroup.ID, entry, nil)
+	closedVisit := testpkg.CreateTestVisit(t, db, departed.ID, openGroup.ID, entry, &exit)
+
+	defer testpkg.CleanupActivityFixtures(t, db,
+		openVisit.ID, closedVisit.ID, openGroup.ID, activityGroup.ID, room.ID,
+		present.ID, departed.ID,
+	)
+
+	t.Run("groups open visits by room and drops checked-out children", func(t *testing.T) {
+		byRoom, err := repo.ListOpenVisitStudentIDsByRoom(ctx)
+		require.NoError(t, err)
+
+		assert.Contains(t, byRoom[room.ID], present.ID,
+			"a child with an open visit belongs to its room")
+		assert.NotContains(t, byRoom[room.ID], departed.ID,
+			"a child who already left must not be reported as present")
+	})
+
+	t.Run("agrees with the single-room reader it replaces", func(t *testing.T) {
+		byRoom, err := repo.ListOpenVisitStudentIDsByRoom(ctx)
+		require.NoError(t, err)
+
+		single, err := repo.ListActiveStudentIDsByRoomID(ctx, room.ID)
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, single, byRoom[room.ID],
+			"the bulk reader must return exactly what the per-room reader returns")
+	})
+
+	t.Run("reports nothing for a room whose session has ended", func(t *testing.T) {
+		_, err := db.NewUpdate().
+			TableExpr("active.groups").
+			Set("end_time = ?", time.Now()).
+			Where("id = ?", openGroup.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		defer func() {
+			_, resetErr := db.NewUpdate().
+				TableExpr("active.groups").
+				Set("end_time = NULL").
+				Where("id = ?", openGroup.ID).
+				Exec(ctx)
+			require.NoError(t, resetErr)
+		}()
+
+		byRoom, err := repo.ListOpenVisitStudentIDsByRoom(ctx)
+		require.NoError(t, err)
+
+		assert.NotContains(t, byRoom[room.ID], present.ID,
+			"a closed session leaves no presence behind")
+	})
+}

--- a/backend/database/repositories/active/bulk_readers_test.go
+++ b/backend/database/repositories/active/bulk_readers_test.go
@@ -1,15 +1,18 @@
 package active_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
 )
 
 // TestGroupSupervisorRepository_ListActiveSupervisedRooms pins the whole-tenant
@@ -97,6 +100,65 @@ func TestGroupSupervisorRepository_ListActiveSupervisedRooms(t *testing.T) {
 			assert.False(t, row.StaffID == staff.ID && row.RoomID == room.ID,
 				"an expired supervision must not surface")
 		}
+	})
+
+	t.Run("uses the Berlin date independently of the database timezone", func(t *testing.T) {
+		today := timezone.TodayDate()
+		err := tenant.WithTenantTx(context.Background(), db, 1, func(txCtx context.Context, tx bun.Tx) error {
+			var databaseDate string
+			for _, zone := range []string{"Pacific/Kiritimati", "Etc/GMT+12"} {
+				var configuredZone string
+				if err := tx.NewSelect().
+					ColumnExpr(`set_config('TimeZone', ?, true)`, zone).
+					Scan(txCtx, &configuredZone); err != nil {
+					return err
+				}
+				if err := tx.NewSelect().ColumnExpr("CURRENT_DATE::text").Scan(txCtx, &databaseDate); err != nil {
+					return err
+				}
+				if databaseDate != today.String() {
+					break
+				}
+			}
+			require.NotEqual(t, today.String(), databaseDate)
+
+			endDate := today
+			wantFound := false
+			if databaseDate > today.String() {
+				endDate = today.AddDays(1)
+				wantFound = true
+			}
+			if _, err := tx.NewUpdate().
+				TableExpr("active.group_supervisors").
+				Set("end_date = ?", endDate).
+				Where("id = ?", openSupervision.ID).
+				Exec(txCtx); err != nil {
+				return err
+			}
+
+			rows, err := repo.ListActiveSupervisedRooms(txCtx)
+			if err != nil {
+				return err
+			}
+			found := false
+			for _, row := range rows {
+				if row.StaffID == staff.ID && row.RoomID == room.ID {
+					found = true
+					break
+				}
+			}
+			assert.Equal(t, wantFound, found,
+				"database session date must not change Berlin supervision expiry")
+			return nil
+		})
+		require.NoError(t, err)
+
+		_, err = db.NewUpdate().
+			TableExpr("active.group_supervisors").
+			Set("end_date = NULL").
+			Where("id = ?", openSupervision.ID).
+			Exec(ctx)
+		require.NoError(t, err)
 	})
 
 	t.Run("does not leak another tenant's supervisions", func(t *testing.T) {

--- a/backend/database/repositories/active/group_supervisor.go
+++ b/backend/database/repositories/active/group_supervisor.go
@@ -75,7 +75,7 @@ func (r *GroupSupervisorRepository) ListActiveSupervisedRooms(ctx context.Contex
 		TableExpr(`active.group_supervisors AS "group_supervisor"`).
 		ColumnExpr(`"group_supervisor".staff_id, "group".room_id`).
 		Join(`JOIN active.groups AS "group" ON "group".id = "group_supervisor".group_id`).
-		Where(`"group_supervisor".end_date IS NULL OR "group_supervisor".end_date > CURRENT_DATE`).
+		Where(`"group_supervisor".end_date IS NULL OR "group_supervisor".end_date > ?`, timezone.TodayDate()).
 		Where(`"group".end_time IS NULL`)
 
 	query = base.WithTenantFilter(ctx, query, "group_supervisor")

--- a/backend/database/repositories/active/group_supervisor.go
+++ b/backend/database/repositories/active/group_supervisor.go
@@ -50,6 +50,46 @@ func (r *GroupSupervisorRepository) FindActiveByStaffID(ctx context.Context, sta
 	return supervisions, nil
 }
 
+// ListActiveSupervisedRooms returns the (staff_id, room_id) pairs of every
+// currently active supervision in the tenant.
+//
+// Custom method rather than a Repository[T] filter (backend-conventions Rule 2):
+// the result is a cross-table projection, not a slice of GroupSupervisor rows,
+// and it deliberately collapses the two-step FindActiveByStaffID +
+// GetActiveGroupsByIDs walk that callers otherwise repeat per staff member.
+//
+// The end_date predicate mirrors IsSupervisorActive
+// (services/active/session_lifecycle.go): open-ended supervisions are active,
+// a dated one stays active while today is strictly before end_date. Doing it in
+// SQL keeps the in-Go re-filter that FindActiveByStaffID's callers apply from
+// being duplicated (or forgotten) here.
+//
+// The `end_time IS NULL` on the active group is not redundant with that: a
+// closed session has no room presence left, so its room must not appear as
+// supervised.
+func (r *GroupSupervisorRepository) ListActiveSupervisedRooms(ctx context.Context) ([]active.StaffRoomSupervision, error) {
+	var rows []active.StaffRoomSupervision
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Distinct().
+		TableExpr(`active.group_supervisors AS "group_supervisor"`).
+		ColumnExpr(`"group_supervisor".staff_id, "group".room_id`).
+		Join(`JOIN active.groups AS "group" ON "group".id = "group_supervisor".group_id`).
+		Where(`"group_supervisor".end_date IS NULL OR "group_supervisor".end_date > CURRENT_DATE`).
+		Where(`"group".end_time IS NULL`)
+
+	query = base.WithTenantFilter(ctx, query, "group_supervisor")
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list active supervised rooms",
+			Err: err,
+		}
+	}
+
+	return rows, nil
+}
+
 // FindStaleOpen returns supervisor rows started before the given day that
 // still lack an end_date. Feeds the nightly stale-supervisor cleanup and its
 // preview (services/active/cleanup_service.go, session_service.go).

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -666,6 +666,49 @@ func (r *VisitRepository) ListActiveStudentIDsByRoomID(ctx context.Context, room
 	return ids, nil
 }
 
+// ListOpenVisitStudentIDsByRoom returns every student of the tenant who is
+// currently checked in, grouped by the room they are in. It is the whole-tenant
+// counterpart of ListActiveStudentIDsByRoomID.
+//
+// Deliberately parameterless: a caller resolving many supervised rooms would
+// otherwise issue one query per room, and a tenant only ever has a few hundred
+// open visits, so narrowing by a room IN-list buys nothing while forcing two
+// code paths.
+//
+// Student IDs are distinct per room: two open visits for the same child in two
+// groups sharing a room collapse to one entry, so callers can range over the
+// slice without building their own set.
+func (r *VisitRepository) ListOpenVisitStudentIDsByRoom(ctx context.Context) (map[int64][]int64, error) {
+	var rows []struct {
+		RoomID    int64 `bun:"room_id"`
+		StudentID int64 `bun:"student_id"`
+	}
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Distinct().
+		TableExpr(tableExprActiveVisitsAsVisit).
+		ColumnExpr(`"group".room_id, "visit".student_id`).
+		Join(`JOIN active.groups AS "group" ON "group".id = "visit".active_group_id`).
+		Where(`"group".end_time IS NULL`).
+		Where(`"visit".exit_time IS NULL`)
+
+	query = base.WithTenantFilter(ctx, query, "visit")
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list open visit student IDs by room",
+			Err: err,
+		}
+	}
+
+	byRoom := make(map[int64][]int64)
+	for _, row := range rows {
+		byRoom[row.RoomID] = append(byRoom[row.RoomID], row.StudentID)
+	}
+
+	return byRoom, nil
+}
+
 // CountActiveByGroupID counts active visits in the given active group.
 func (r *VisitRepository) CountActiveByGroupID(ctx context.Context, activeGroupID int64) (int, error) {
 	count, err := base.GetDB(ctx, r.db).NewSelect().

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -18,6 +18,48 @@ const (
 	accountTableAlias = `auth.accounts AS "account"`
 )
 
+// EffectiveAdminExistsSQL builds the SQL predicate that decides whether an
+// account holds effective admin scope within one tenant: the literal admin
+// role, or an admin:* / *:* permission granted either through a tenant role or
+// directly to the account.
+//
+// It takes the caller's qualified account and tenant columns so the same
+// predicate can be applied to auth.accounts and to any other table carrying an
+// (account_id, tenant_id) pair. The arguments are SQL identifiers written by
+// callers in this repository, never request input.
+//
+// There must stay exactly one definition of "effective admin" in SQL. It
+// decides who receives admin-scoped data, so a second, drifting copy is a
+// disclosure bug waiting to happen. The Go-side counterpart is
+// authorize.HasEffectiveAdminScope.
+func EffectiveAdminExistsSQL(accountColumn, tenantColumn string) string {
+	return fmt.Sprintf(`EXISTS (
+		SELECT 1
+		FROM auth.account_roles AS "ar"
+		INNER JOIN auth.roles AS "r" ON "r".id = "ar".role_id
+		LEFT JOIN auth.role_permissions AS "rp" ON "rp".role_id = "ar".role_id
+		LEFT JOIN auth.permissions AS "p" ON "p".id = "rp".permission_id
+		WHERE "ar".account_id = %[1]s
+		  AND "ar".tenant_id = %[2]s
+		  AND (
+		    LOWER("r".name) = 'admin'
+		    OR ("p".resource = 'admin' AND "p".action = '*')
+		    OR ("p".resource = '*' AND "p".action = '*')
+		  )
+	) OR EXISTS (
+		SELECT 1
+		FROM auth.account_permissions AS "ap"
+		INNER JOIN auth.permissions AS "p" ON "p".id = "ap".permission_id
+		WHERE "ap".account_id = %[1]s
+		  AND "ap".tenant_id = %[2]s
+		  AND "ap".granted = TRUE
+		  AND (
+		    ("p".resource = 'admin' AND "p".action = '*')
+		    OR ("p".resource = '*' AND "p".action = '*')
+		  )
+	)`, accountColumn, tenantColumn)
+}
+
 // AccountRepository implements auth.AccountRepository interface
 type AccountRepository struct {
 	*base.Repository[*auth.Account]
@@ -41,6 +83,37 @@ func (r *AccountRepository) FindByIDForUpdate(ctx context.Context, id int64) (*a
 		return nil, &modelBase.DatabaseError{Op: "find account by id for update", Err: err}
 	}
 	return account, nil
+}
+
+// ListEffectiveAdminAccountIDs returns the IDs of accounts holding effective
+// admin scope in the current tenant, restricted to accounts that are active and
+// whose tenant mapping is active.
+//
+// Callers that need to decide, for many people at once, whether someone sees
+// tenant-wide data use this instead of asking per account. The predicate is
+// shared with the push-subscription admin finder through
+// EffectiveAdminExistsSQL, so both agree by construction.
+func (r *AccountRepository) ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error) {
+	var ids []int64
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Distinct().
+		TableExpr(accountTableAlias).
+		ColumnExpr(`"account".id`).
+		Join(`INNER JOIN auth.account_tenants AS "account_tenant" ON "account_tenant".account_id = "account".id`).
+		Where(`"account".active = ?`, true).
+		Where(`"account_tenant".status = ?`, auth.AccountTenantStatusActive).
+		Where(EffectiveAdminExistsSQL(`"account".id`, `"account_tenant".tenant_id`))
+
+	// auth.accounts is cross-tenant, so the tenant predicate belongs on the
+	// mapping table rather than on the account itself.
+	query = base.WithTenantFilter(ctx, query, "account_tenant")
+
+	if err := query.Scan(ctx, &ids); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list effective admin account IDs", Err: err}
+	}
+
+	return ids, nil
 }
 
 // NewAccountRepository creates a new AccountRepository

--- a/backend/database/repositories/auth/effective_admins_test.go
+++ b/backend/database/repositories/auth/effective_admins_test.go
@@ -1,0 +1,124 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// grantTenantRole gives an account an active mapping to a tenant plus one
+// seeded base role, which is the minimum an account needs to count as a real
+// member of a school.
+func grantTenantRole(t *testing.T, db *bun.DB, ctx context.Context, accountID, tenantID int64, roleName string) {
+	t.Helper()
+
+	now := time.Now()
+	mapping := &authModels.AccountTenant{
+		AccountID:   accountID,
+		TenantID:    tenantID,
+		Status:      authModels.AccountTenantStatusActive,
+		ActivatedAt: &now,
+	}
+	_, err := db.NewInsert().Model(mapping).ModelTableExpr(`auth.account_tenants`).Exec(ctx)
+	require.NoError(t, err)
+
+	var roleID int64
+	err = db.NewSelect().
+		ColumnExpr("id").
+		TableExpr("auth.roles").
+		Where("name = ?", roleName).
+		Limit(1).
+		Scan(ctx, &roleID)
+	require.NoError(t, err, "seeded role %q must exist", roleName)
+
+	assignment := &authModels.AccountRole{AccountID: accountID, RoleID: roleID}
+	assignment.SetTenantID(tenantID)
+	_, err = db.NewInsert().Model(assignment).ModelTableExpr(`auth.account_roles`).Exec(ctx)
+	require.NoError(t, err)
+}
+
+// TestAccountRepository_ListEffectiveAdminAccountIDs pins who counts as an
+// effective admin. The result decides who receives tenant-wide data, so both
+// directions matter: missing an admin is an annoyance, including a non-admin is
+// a disclosure.
+func TestAccountRepository_ListEffectiveAdminAccountIDs(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Account
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("includes the admin role and excludes a plain user", func(t *testing.T) {
+		admin := testpkg.CreateTestAccount(t, db, "effective-admin@example.test")
+		plain := testpkg.CreateTestAccount(t, db, "effective-plain@example.test")
+
+		grantTenantRole(t, db, ctx, admin.ID, 1, authModels.BaseRoleAdmin)
+		grantTenantRole(t, db, ctx, plain.ID, 1, authModels.BaseRoleUser)
+
+		defer testpkg.CleanupAuthFixtures(t, db, admin.ID, plain.ID)
+
+		ids, err := repo.ListEffectiveAdminAccountIDs(ctx)
+		require.NoError(t, err)
+
+		assert.Contains(t, ids, admin.ID)
+		assert.NotContains(t, ids, plain.ID, "a plain user is not an effective admin")
+	})
+
+	t.Run("excludes a deactivated admin account", func(t *testing.T) {
+		admin := testpkg.CreateTestAccount(t, db, "effective-inactive@example.test")
+		grantTenantRole(t, db, ctx, admin.ID, 1, authModels.BaseRoleAdmin)
+		defer testpkg.CleanupAuthFixtures(t, db, admin.ID)
+
+		_, err := db.NewUpdate().
+			TableExpr("auth.accounts").
+			Set("active = false").
+			Where("id = ?", admin.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		ids, err := repo.ListEffectiveAdminAccountIDs(ctx)
+		require.NoError(t, err)
+
+		assert.NotContains(t, ids, admin.ID, "a deactivated account receives nothing")
+	})
+
+	t.Run("excludes an admin whose tenant mapping is not active", func(t *testing.T) {
+		admin := testpkg.CreateTestAccount(t, db, "effective-pending@example.test")
+		grantTenantRole(t, db, ctx, admin.ID, 1, authModels.BaseRoleAdmin)
+		defer testpkg.CleanupAuthFixtures(t, db, admin.ID)
+
+		_, err := db.NewUpdate().
+			TableExpr("auth.account_tenants").
+			Set("status = ?", authModels.AccountTenantStatusInactive).
+			Where("account_id = ? AND tenant_id = ?", admin.ID, 1).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		ids, err := repo.ListEffectiveAdminAccountIDs(ctx)
+		require.NoError(t, err)
+
+		assert.NotContains(t, ids, admin.ID, "membership must be active, not merely present")
+	})
+
+	t.Run("does not leak another tenant's admins", func(t *testing.T) {
+		const otherTenant int64 = 99045
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreignAdmin := testpkg.CreateTestAccount(t, db, "effective-foreign@example.test")
+		grantTenantRole(t, db, ctx, foreignAdmin.ID, otherTenant, authModels.BaseRoleAdmin)
+		defer testpkg.CleanupAuthFixtures(t, db, foreignAdmin.ID)
+
+		ids, err := repo.ListEffectiveAdminAccountIDs(ctx)
+		require.NoError(t, err)
+
+		assert.NotContains(t, ids, foreignAdmin.ID,
+			"admin scope is per school, not global")
+	})
+}

--- a/backend/database/repositories/config/setting_value.go
+++ b/backend/database/repositories/config/setting_value.go
@@ -50,6 +50,29 @@ func (r *SettingValueRepository) FindByTenantAndKey(ctx context.Context, tenantI
 	return sv, nil
 }
 
+// FindByTenantAndKeys retrieves the stored overrides for the named keys in one
+// query. Registry defaults remain a service-layer concern.
+func (r *SettingValueRepository) FindByTenantAndKeys(ctx context.Context, tenantID int64, keys []string) ([]*config.SettingValue, error) {
+	if tenantID <= 0 || len(keys) == 0 {
+		return nil, nil
+	}
+
+	var values []*config.SettingValue
+	err := repoBase.GetDB(ctx, r.db).NewSelect().
+		Model(&values).
+		ModelTableExpr(tableSettingValuesAlias).
+		Where(`"setting_value".tenant_id = ?`, tenantID).
+		Where(`"setting_value".setting_key IN (?)`, bun.List(keys)).
+		Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find setting values by tenant and keys",
+			Err: err,
+		}
+	}
+	return values, nil
+}
+
 // Upsert inserts or updates a setting value.
 func (r *SettingValueRepository) Upsert(ctx context.Context, sv *config.SettingValue) error {
 	if sv == nil {

--- a/backend/database/repositories/config/setting_value_test.go
+++ b/backend/database/repositories/config/setting_value_test.go
@@ -66,6 +66,35 @@ func TestSettingValueRepository_FindByTenantAndKey_NotFound(t *testing.T) {
 	assert.Nil(t, found)
 }
 
+func TestSettingValueRepository_FindByTenantAndKeys(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	repo := configRepo.NewSettingValueRepository(db)
+	ctx := testpkg.TenantContext(1)
+
+	require.NoError(t, repo.Upsert(ctx, newSV("test.batch_one", `true`)))
+	require.NoError(t, repo.Upsert(ctx, newSV("test.batch_two", `false`)))
+	t.Cleanup(func() {
+		_ = repo.Delete(ctx, 1, "test.batch_one")
+		_ = repo.Delete(ctx, 1, "test.batch_two")
+	})
+
+	found, err := repo.FindByTenantAndKeys(ctx, 1, []string{
+		"test.batch_one",
+		"test.batch_two",
+		"test.not_stored",
+	})
+	require.NoError(t, err)
+	require.Len(t, found, 2)
+
+	byKey := make(map[string]json.RawMessage, len(found))
+	for _, value := range found {
+		byKey[value.SettingKey] = value.Value
+	}
+	assert.Equal(t, json.RawMessage(`true`), byKey["test.batch_one"])
+	assert.Equal(t, json.RawMessage(`false`), byKey["test.batch_two"])
+}
+
 func TestSettingValueRepository_Delete(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/database/repositories/education/group.go
+++ b/backend/database/repositories/education/group.go
@@ -192,6 +192,73 @@ func (r *GroupRepository) ListSupervisedGroupIDsByStaff(ctx context.Context, sta
 	return pairs, nil
 }
 
+// ListStaffIDsByEducationGroupIDs returns the (staff, group) pairs supervising
+// the given groups on the given day.
+//
+// The mirror image of ListSupervisedGroupIDsByStaff, deliberately built from
+// the same two sources with the same predicates: teacher assignments plus
+// substitutions active on the day, inner joins throughout, soft-deleted staff
+// and teachers excluded. If the two ever disagree, one of them is granting
+// access the other denies.
+func (r *GroupRepository) ListStaffIDsByEducationGroupIDs(ctx context.Context, groupIDs []int64, on timezone.Date) ([]education.StaffGroupID, error) {
+	if len(groupIDs) == 0 {
+		return []education.StaffGroupID{}, nil
+	}
+
+	pairs := make([]education.StaffGroupID, 0, len(groupIDs))
+	seen := make(map[education.StaffGroupID]struct{}, len(groupIDs))
+
+	appendRows := func(rows []education.StaffGroupID) {
+		for _, row := range rows {
+			if _, dup := seen[row]; dup {
+				continue
+			}
+			seen[row] = struct{}{}
+			pairs = append(pairs, row)
+		}
+	}
+
+	var assigned []education.StaffGroupID
+	assignedQuery := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`education.groups AS "group"`).
+		ColumnExpr(`"staff".id AS staff_id, "group".id AS group_id`).
+		Join(`JOIN education.group_teacher AS "gt" ON "gt".group_id = "group".id`).
+		Join(`JOIN users.teachers AS "teacher" ON "teacher".id = "gt".teacher_id AND "teacher".deleted_at IS NULL`).
+		Join(`JOIN users.staff AS "staff" ON "staff".id = "teacher".staff_id AND "staff".deleted_at IS NULL`).
+		Where(`"group".id IN (?)`, bun.List(groupIDs))
+
+	assignedQuery = base.WithTenantFilter(ctx, assignedQuery, "group")
+
+	if err := assignedQuery.Scan(ctx, &assigned); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list staff IDs by education group IDs (assigned)",
+			Err: err,
+		}
+	}
+	appendRows(assigned)
+
+	var substituted []education.StaffGroupID
+	substitutedQuery := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`education.group_substitution AS "sub"`).
+		ColumnExpr(`"staff".id AS staff_id, "sub".group_id AS group_id`).
+		Join(`JOIN users.staff AS "staff" ON "staff".id = "sub".substitute_staff_id AND "staff".deleted_at IS NULL`).
+		Where(`"sub".group_id IN (?)`, bun.List(groupIDs)).
+		Where(`"sub".start_date <= ?`, on).
+		Where(`"sub".end_date >= ?`, on)
+
+	substitutedQuery = base.WithTenantFilter(ctx, substitutedQuery, "sub")
+
+	if err := substitutedQuery.Scan(ctx, &substituted); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list staff IDs by education group IDs (substitutions)",
+			Err: err,
+		}
+	}
+	appendRows(substituted)
+
+	return pairs, nil
+}
+
 // FindWithRoom retrieves a group with its associated room
 func (r *GroupRepository) FindWithRoom(ctx context.Context, groupID int64) (*education.Group, error) {
 	group := new(education.Group)

--- a/backend/database/repositories/education/group.go
+++ b/backend/database/repositories/education/group.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/education"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
@@ -101,6 +102,94 @@ func (r *GroupRepository) FindByTeacher(ctx context.Context, teacherID int64) ([
 	}
 
 	return groups, nil
+}
+
+// ListSupervisedGroupIDsByStaff returns the (staff, education group) pairs the
+// given staff members supervise on the given day.
+//
+// It mirrors usercontext.GetMyGroups exactly, in bulk and without needing JWT
+// claims in the context. GetMyGroups resolves person -> staff -> teacher ->
+// groups and unions that with the staff member's active substitutions; the two
+// branches below are the same two sources, so an equivalence test can pin them
+// against each other.
+//
+// Two queries rather than one UNION: the tenant predicate is applied per branch
+// through the standard helper, which a hand-written UNION would force us to
+// inline. The cost that matters is that neither branch scales with the number
+// of staff members, and both are IN-list lookups.
+//
+// Every join is an INNER join on purpose. A LEFT join here would emit rows with
+// a NULL group for a staff member who supervises nothing, and a caller reading
+// "no rows means no restriction" would turn this filter into full access.
+// Soft-deleted staff and teachers are excluded for the same reason GetMyGroups
+// returns nothing for them: their identity lookup fails, so they supervise
+// nothing.
+func (r *GroupRepository) ListSupervisedGroupIDsByStaff(ctx context.Context, staffIDs []int64, on timezone.Date) ([]education.StaffGroupID, error) {
+	if len(staffIDs) == 0 {
+		return []education.StaffGroupID{}, nil
+	}
+
+	pairs := make([]education.StaffGroupID, 0, len(staffIDs))
+	seen := make(map[education.StaffGroupID]struct{}, len(staffIDs))
+
+	appendRows := func(rows []education.StaffGroupID) {
+		for _, row := range rows {
+			if _, dup := seen[row]; dup {
+				continue
+			}
+			seen[row] = struct{}{}
+			pairs = append(pairs, row)
+		}
+	}
+
+	// Branch 1: groups the staff member is assigned to as a teacher. Mirrors
+	// GetCurrentStaff -> teacherRepo.FindByStaffID -> educationGroupRepo.FindByTeacher.
+	var assigned []education.StaffGroupID
+	assignedQuery := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`users.staff AS "staff"`).
+		ColumnExpr(`"staff".id AS staff_id, "group".id AS group_id`).
+		Join(`JOIN users.teachers AS "teacher" ON "teacher".staff_id = "staff".id AND "teacher".deleted_at IS NULL`).
+		Join(`JOIN education.group_teacher AS "gt" ON "gt".teacher_id = "teacher".id`).
+		Join(`JOIN education.groups AS "group" ON "group".id = "gt".group_id`).
+		Where(`"staff".deleted_at IS NULL`).
+		Where(`"staff".id IN (?)`, bun.List(staffIDs))
+
+	assignedQuery = base.WithTenantFilter(ctx, assignedQuery, "staff")
+
+	if err := assignedQuery.Scan(ctx, &assigned); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list supervised group IDs by staff (assigned)",
+			Err: err,
+		}
+	}
+	appendRows(assigned)
+
+	// Branch 2: groups covered through a substitution that is active on `on`.
+	// The date predicate is inclusive on both ends, matching Filter.DateBetween
+	// as used by FindActiveBySubstituteWithRelations. The join back to
+	// users.staff reproduces GetMyGroups' precondition that the substitute has
+	// a live staff row at all.
+	var substituted []education.StaffGroupID
+	substitutedQuery := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`education.group_substitution AS "sub"`).
+		ColumnExpr(`"sub".substitute_staff_id AS staff_id, "group".id AS group_id`).
+		Join(`JOIN users.staff AS "staff" ON "staff".id = "sub".substitute_staff_id AND "staff".deleted_at IS NULL`).
+		Join(`JOIN education.groups AS "group" ON "group".id = "sub".group_id`).
+		Where(`"sub".substitute_staff_id IN (?)`, bun.List(staffIDs)).
+		Where(`"sub".start_date <= ?`, on).
+		Where(`"sub".end_date >= ?`, on)
+
+	substitutedQuery = base.WithTenantFilter(ctx, substitutedQuery, "sub")
+
+	if err := substitutedQuery.Scan(ctx, &substituted); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "list supervised group IDs by staff (substitutions)",
+			Err: err,
+		}
+	}
+	appendRows(substituted)
+
+	return pairs, nil
 }
 
 // FindWithRoom retrieves a group with its associated room

--- a/backend/database/repositories/education/supervised_groups_test.go
+++ b/backend/database/repositories/education/supervised_groups_test.go
@@ -189,3 +189,88 @@ func TestGroupRepository_ListSupervisedGroupIDsByStaff(t *testing.T) {
 		assert.Empty(t, groupIDsFor(pairs, foreignStaff.ID))
 	})
 }
+
+// staffIDsFor collapses the flat pair list into the staff set of one group,
+// which is what a producer looking for "who is responsible for this child"
+// consumes.
+func staffIDsFor(pairs []education.StaffGroupID, groupID int64) map[int64]struct{} {
+	out := make(map[int64]struct{})
+	for _, pair := range pairs {
+		if pair.GroupID == groupID {
+			out[pair.StaffID] = struct{}{}
+		}
+	}
+	return out
+}
+
+// TestGroupRepository_ListStaffIDsByEducationGroupIDs pins the same relation
+// read in the other direction. Both directions decide who may learn something
+// about a child, so they must answer alike: whoever this reader names for a
+// group is exactly who the by-staff reader would hand that group to.
+func TestGroupRepository_ListStaffIDsByEducationGroupIDs(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Group
+	ctx := testpkg.TenantContext(1)
+	today := timezone.TodayDate()
+
+	t.Run("names the assigned teacher and the substitute of today", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "ByGroupAssigned")
+		teacher := testpkg.CreateTestTeacher(t, db, "ByGroup", "Teacher")
+		link := testpkg.CreateTestGroupTeacher(t, db, group.ID, teacher.ID)
+		substitute := testpkg.CreateTestStaff(t, db, "ByGroup", "Substitute")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, substitute.ID,
+			today.AddDays(-1), today.AddDays(1))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, link.ID, group.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID, substitute.ID)
+
+		pairs, err := repo.ListStaffIDsByEducationGroupIDs(ctx, []int64{group.ID}, today)
+		require.NoError(t, err)
+
+		staff := staffIDsFor(pairs, group.ID)
+		assert.Contains(t, staff, teacher.StaffID)
+		assert.Contains(t, staff, substitute.ID)
+
+		// The two directions must agree, or one of them is leaking.
+		byStaff, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{teacher.StaffID, substitute.ID}, today)
+		require.NoError(t, err)
+		assert.Contains(t, groupIDsFor(byStaff, teacher.StaffID), group.ID)
+		assert.Contains(t, groupIDsFor(byStaff, substitute.ID), group.ID)
+	})
+
+	t.Run("a substitution outside the day is not counted", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "ByGroupPastSub")
+		substitute := testpkg.CreateTestStaff(t, db, "Past", "Substitute")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, substitute.ID,
+			today.AddDays(-10), today.AddDays(-5))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, substitute.ID)
+
+		pairs, err := repo.ListStaffIDsByEducationGroupIDs(ctx, []int64{group.ID}, today)
+		require.NoError(t, err)
+		assert.NotContains(t, staffIDsFor(pairs, group.ID), substitute.ID,
+			"a substitution that ended last week says nothing about today")
+	})
+
+	t.Run("no groups means no staff", func(t *testing.T) {
+		pairs, err := repo.ListStaffIDsByEducationGroupIDs(ctx, nil, today)
+		require.NoError(t, err)
+		assert.Empty(t, pairs, "an empty request must not resolve to everybody")
+	})
+
+	t.Run("another school's group resolves to nobody", func(t *testing.T) {
+		const otherTenant int64 = 99046
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreignGroup := testpkg.CreateTestEducationGroupForTenant(t, db, otherTenant, "ByGroupForeign")
+		defer testpkg.CleanupActivityFixturesForTenant(t, db, otherTenant, foreignGroup.ID)
+
+		pairs, err := repo.ListStaffIDsByEducationGroupIDs(ctx, []int64{foreignGroup.ID}, today)
+		require.NoError(t, err)
+		assert.Empty(t, staffIDsFor(pairs, foreignGroup.ID))
+	})
+}

--- a/backend/database/repositories/education/supervised_groups_test.go
+++ b/backend/database/repositories/education/supervised_groups_test.go
@@ -1,0 +1,191 @@
+package education_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// groupIDsFor collapses the flat pair list into the group set of one staff
+// member, which is the shape every caller actually consumes.
+func groupIDsFor(pairs []education.StaffGroupID, staffID int64) map[int64]struct{} {
+	out := make(map[int64]struct{})
+	for _, pair := range pairs {
+		if pair.StaffID == staffID {
+			out[pair.GroupID] = struct{}{}
+		}
+	}
+	return out
+}
+
+// TestGroupRepository_ListSupervisedGroupIDsByStaff pins the read filter that
+// decides which children a staff member may see. Every case here is a case
+// where getting it wrong either hides a group from someone entitled to it or,
+// far worse, exposes one to someone who is not.
+func TestGroupRepository_ListSupervisedGroupIDsByStaff(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Group
+	ctx := testpkg.TenantContext(1)
+	today := timezone.TodayDate()
+
+	t.Run("returns groups the staff member teaches", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "SupervisedAssigned")
+		teacher := testpkg.CreateTestTeacher(t, db, "Assigned", "Teacher")
+		link := testpkg.CreateTestGroupTeacher(t, db, group.ID, teacher.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, link.ID, group.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{teacher.StaffID}, today)
+		require.NoError(t, err)
+
+		assert.Contains(t, groupIDsFor(pairs, teacher.StaffID), group.ID)
+	})
+
+	t.Run("returns groups covered by a substitution active today", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "SupervisedSubstituted")
+		substitute := testpkg.CreateTestStaff(t, db, "Active", "Substitute")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, substitute.ID,
+			today.AddDays(-1), today.AddDays(1))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, substitute.ID)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{substitute.ID}, today)
+		require.NoError(t, err)
+
+		assert.Contains(t, groupIDsFor(pairs, substitute.ID), group.ID)
+	})
+
+	t.Run("substitution boundaries are inclusive on both ends", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "SupervisedBoundary")
+		substitute := testpkg.CreateTestStaff(t, db, "Boundary", "Substitute")
+		// A one-day substitution that starts and ends today must count. The
+		// helper this mirrors (Filter.DateBetween) is inclusive, and an
+		// exclusive rewrite here would silently strip single-day cover.
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, substitute.ID, today, today)
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, substitute.ID)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{substitute.ID}, today)
+		require.NoError(t, err)
+
+		assert.Contains(t, groupIDsFor(pairs, substitute.ID), group.ID)
+	})
+
+	t.Run("excludes an expired substitution", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "SupervisedExpired")
+		substitute := testpkg.CreateTestStaff(t, db, "Expired", "Substitute")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, substitute.ID,
+			today.AddDays(-10), today.AddDays(-1))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, substitute.ID)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{substitute.ID}, today)
+		require.NoError(t, err)
+
+		assert.NotContains(t, groupIDsFor(pairs, substitute.ID), group.ID,
+			"cover that ended yesterday must not grant access today")
+	})
+
+	t.Run("a staff member without a teacher record supervises nothing", func(t *testing.T) {
+		// The dangerous failure mode: a join that yields no rows must mean
+		// "sees nothing", never "sees everything".
+		group := testpkg.CreateTestEducationGroup(t, db, "SupervisedUnrelated")
+		teacher := testpkg.CreateTestTeacher(t, db, "Unrelated", "Teacher")
+		link := testpkg.CreateTestGroupTeacher(t, db, group.ID, teacher.ID)
+		plainStaff := testpkg.CreateTestStaff(t, db, "Plain", "Staff")
+
+		defer testpkg.CleanupActivityFixtures(t, db, link.ID, group.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID, plainStaff.ID)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{plainStaff.ID}, today)
+		require.NoError(t, err)
+
+		assert.Empty(t, groupIDsFor(pairs, plainStaff.ID),
+			"no teacher record and no substitution means no groups at all")
+	})
+
+	t.Run("excludes a soft-deleted staff member", func(t *testing.T) {
+		group := testpkg.CreateTestEducationGroup(t, db, "SupervisedDeleted")
+		teacher := testpkg.CreateTestTeacher(t, db, "Deleted", "Teacher")
+		link := testpkg.CreateTestGroupTeacher(t, db, group.ID, teacher.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, link.ID, group.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+
+		_, err := db.NewUpdate().
+			TableExpr("users.staff").
+			Set("deleted_at = NOW()").
+			Where("id = ?", teacher.StaffID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{teacher.StaffID}, today)
+		require.NoError(t, err)
+
+		assert.Empty(t, groupIDsFor(pairs, teacher.StaffID),
+			"an offboarded staff member keeps no group access")
+	})
+
+	t.Run("keeps staff members apart within one batch", func(t *testing.T) {
+		groupA := testpkg.CreateTestEducationGroup(t, db, "SupervisedBatchA")
+		groupB := testpkg.CreateTestEducationGroup(t, db, "SupervisedBatchB")
+		teacherA := testpkg.CreateTestTeacher(t, db, "BatchA", "Teacher")
+		teacherB := testpkg.CreateTestTeacher(t, db, "BatchB", "Teacher")
+		linkA := testpkg.CreateTestGroupTeacher(t, db, groupA.ID, teacherA.ID)
+		linkB := testpkg.CreateTestGroupTeacher(t, db, groupB.ID, teacherB.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, linkA.ID, linkB.ID, groupA.ID, groupB.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacherA.ID, teacherB.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacherA.StaffID, teacherB.StaffID)
+
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx,
+			[]int64{teacherA.StaffID, teacherB.StaffID}, today)
+		require.NoError(t, err)
+
+		forA := groupIDsFor(pairs, teacherA.StaffID)
+		forB := groupIDsFor(pairs, teacherB.StaffID)
+
+		assert.Contains(t, forA, groupA.ID)
+		assert.NotContains(t, forA, groupB.ID, "batching must not merge two people's groups")
+		assert.Contains(t, forB, groupB.ID)
+		assert.NotContains(t, forB, groupA.ID, "batching must not merge two people's groups")
+	})
+
+	t.Run("empty input short-circuits", func(t *testing.T) {
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, nil, today)
+		require.NoError(t, err)
+		assert.Empty(t, pairs)
+	})
+
+	t.Run("does not leak another tenant's assignments", func(t *testing.T) {
+		const otherTenant int64 = 99043
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreignGroup := testpkg.CreateTestEducationGroupForTenant(t, db, otherTenant, "ForeignSupervised")
+		foreignStaff := testpkg.CreateTestStaffForTenant(t, db, otherTenant, "Foreign", "Teacher")
+
+		defer testpkg.CleanupActivityFixturesForTenant(t, db, otherTenant, foreignGroup.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, foreignStaff.ID)
+
+		// Asked from tenant 1, a foreign staff ID must resolve to nothing even
+		// though the row exists in another school.
+		pairs, err := repo.ListSupervisedGroupIDsByStaff(ctx, []int64{foreignStaff.ID}, today)
+		require.NoError(t, err)
+
+		assert.Empty(t, groupIDsFor(pairs, foreignStaff.ID))
+	})
+}

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -79,6 +79,8 @@ type Factory struct {
 	GuardianPhoneNumber userModels.GuardianPhoneNumberRepository
 	PrivacyConsent      userModels.PrivacyConsentRepository
 
+	NotificationPreference userModels.NotificationPreferenceRepository
+
 	// Facilities domain
 	Room facilityModels.RoomRepository
 
@@ -272,6 +274,8 @@ func NewFactory(db *bun.DB) *Factory {
 		GuardianProfile:     users.NewGuardianProfileRepository(db),
 		GuardianPhoneNumber: users.NewGuardianPhoneNumberRepository(db),
 		PrivacyConsent:      users.NewPrivacyConsentRepository(db),
+
+		NotificationPreference: users.NewNotificationPreferenceRepository(db),
 
 		// Facilities repositories
 		Room: facilities.NewRoomRepository(db),

--- a/backend/database/repositories/iot/push_staff_accounts_test.go
+++ b/backend/database/repositories/iot/push_staff_accounts_test.go
@@ -1,0 +1,133 @@
+package iot_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	iotRepo "github.com/moto-nrw/project-phoenix/database/repositories/iot"
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushSubscriptionRepository_FindForStaffAccounts pins the addressing
+// primitive for personal notifications: exactly the named recipients, and only
+// while they are still eligible to receive anything.
+func TestPushSubscriptionRepository_FindForStaffAccounts(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := iotRepo.NewPushSubscriptionRepository(db)
+	ctx := tenant.WithTenantID(context.Background(), 1)
+
+	suffix := time.Now().UnixNano()
+	addressed := testpkg.CreateTestAccount(t, db, fmt.Sprintf("push-addressed-%d@example.com", suffix))
+	bystander := testpkg.CreateTestAccount(t, db, fmt.Sprintf("push-bystander-%d@example.com", suffix))
+
+	defer testpkg.CleanupAuthFixtures(t, db, addressed.ID, bystander.ID)
+	defer cleanupPushSubscriptions(t, db, addressed.ID, bystander.ID)
+
+	createAccountTenantMapping(t, db, addressed.ID, 1)
+	createAccountTenantMapping(t, db, bystander.ID, 1)
+	assignSystemRole(t, db, addressed.ID, 1, authModels.BaseRoleUser)
+	assignSystemRole(t, db, bystander.ID, 1, authModels.BaseRoleUser)
+
+	addressedEndpoint := fmt.Sprintf("https://fcm.googleapis.com/fcm/send/addressed-%d", suffix)
+	bystanderEndpoint := fmt.Sprintf("https://fcm.googleapis.com/fcm/send/bystander-%d", suffix)
+
+	require.NoError(t, repo.Upsert(ctx, newSubscription(addressed.ID, iotModels.PushPortalStaff, addressedEndpoint)))
+	require.NoError(t, repo.Upsert(ctx, newSubscription(bystander.ID, iotModels.PushPortalStaff, bystanderEndpoint)))
+
+	t.Run("returns only the addressed account's devices", func(t *testing.T) {
+		subs, err := repo.FindForStaffAccounts(ctx, []int64{addressed.ID})
+		require.NoError(t, err)
+
+		assert.True(t, hasSubscriptionEndpoint(subs, addressedEndpoint),
+			"the named recipient's device must be returned")
+		assert.Empty(t, subscriptionsForAccount(subs, bystander.ID),
+			"a personal notification must not reach a bystander")
+	})
+
+	t.Run("empty input returns nothing rather than everything", func(t *testing.T) {
+		// The dangerous default: an empty recipient list must never widen into
+		// a tenant-wide send.
+		subs, err := repo.FindForStaffAccounts(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, subs)
+	})
+
+	t.Run("agrees with the tenant-wide staff finder on eligibility", func(t *testing.T) {
+		all, err := repo.FindForTenantStaff(ctx)
+		require.NoError(t, err)
+
+		narrowed, err := repo.FindForStaffAccounts(ctx, []int64{addressed.ID})
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t,
+			subscriptionsForAccount(all, addressed.ID),
+			narrowed,
+			"narrowing by account must not change which devices qualify")
+	})
+
+	t.Run("drops a device whose account was deactivated", func(t *testing.T) {
+		_, err := db.NewUpdate().
+			TableExpr("auth.accounts").
+			Set("active = false").
+			Where("id = ?", addressed.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		defer func() {
+			_, resetErr := db.NewUpdate().
+				TableExpr("auth.accounts").
+				Set("active = true").
+				Where("id = ?", addressed.ID).
+				Exec(ctx)
+			require.NoError(t, resetErr)
+		}()
+
+		subs, err := repo.FindForStaffAccounts(ctx, []int64{addressed.ID})
+		require.NoError(t, err)
+
+		assert.Empty(t, subs,
+			"eligibility is re-checked at delivery time, not inherited from the recipient list")
+	})
+
+	t.Run("drops a device whose tenant mapping is no longer active", func(t *testing.T) {
+		_, err := db.NewUpdate().
+			TableExpr("auth.account_tenants").
+			Set("status = ?", authModels.AccountTenantStatusInactive).
+			Where("account_id = ? AND tenant_id = ?", addressed.ID, 1).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		defer func() {
+			_, resetErr := db.NewUpdate().
+				TableExpr("auth.account_tenants").
+				Set("status = ?", authModels.AccountTenantStatusActive).
+				Where("account_id = ? AND tenant_id = ?", addressed.ID, 1).
+				Exec(ctx)
+			require.NoError(t, resetErr)
+		}()
+
+		subs, err := repo.FindForStaffAccounts(ctx, []int64{addressed.ID})
+		require.NoError(t, err)
+
+		assert.Empty(t, subs, "someone who left the school stops receiving its notifications")
+	})
+
+	t.Run("does not reach the same account from another tenant's context", func(t *testing.T) {
+		otherTenantCtx := tenant.WithTenantID(context.Background(), 2)
+
+		subs, err := repo.FindForStaffAccounts(otherTenantCtx, []int64{addressed.ID})
+		require.NoError(t, err)
+
+		assert.Empty(t, subs,
+			"a device registered at one school must not receive another school's payload")
+	})
+}

--- a/backend/database/repositories/iot/push_subscription.go
+++ b/backend/database/repositories/iot/push_subscription.go
@@ -152,11 +152,17 @@ func (r *PushSubscriptionRepository) DeleteStaffByAccountID(ctx context.Context,
 	return nil
 }
 
-// FindForTenantStaff returns all staff-portal subscriptions of the current tenant.
-func (r *PushSubscriptionRepository) FindForTenantStaff(ctx context.Context) ([]*iot.PushSubscription, error) {
-	var subs []*iot.PushSubscription
+// staffSubscriptionQuery builds the base query every staff-portal finder shares:
+// staff portal, active account, active tenant mapping, non-guardian role, and
+// the tenant predicate.
+//
+// Extracted so the eligibility rules cannot drift between finders. They are a
+// delivery-time authorization check, not a convenience filter: a subscription
+// must stop receiving pushes the moment the account is deactivated or its
+// mapping to this school ends, and that has to hold for every finder equally.
+func (r *PushSubscriptionRepository) staffSubscriptionQuery(ctx context.Context, subs *[]*iot.PushSubscription) *bun.SelectQuery {
 	query := base.GetDB(ctx, r.DB).NewSelect().
-		Model(&subs).
+		Model(subs).
 		ModelTableExpr(tablePushSubscriptions+` AS "push_subscription"`).
 		Join(activeAccountJoin).
 		Join(activeAccountTenantJoin).
@@ -164,9 +170,36 @@ func (r *PushSubscriptionRepository) FindForTenantStaff(ctx context.Context) ([]
 		Where(`"account".active = ?`, true).
 		Where(`"account_tenant".status = ?`, authModels.AccountTenantStatusActive).
 		Where(nonGuardianRoleFilter, authModels.BaseRoleGuardian)
-	query = base.WithTenantFilter(ctx, query, "push_subscription")
-	if err := query.Scan(ctx); err != nil {
+
+	return base.WithTenantFilter(ctx, query, "push_subscription")
+}
+
+// FindForTenantStaff returns all staff-portal subscriptions of the current tenant.
+func (r *PushSubscriptionRepository) FindForTenantStaff(ctx context.Context) ([]*iot.PushSubscription, error) {
+	var subs []*iot.PushSubscription
+	if err := r.staffSubscriptionQuery(ctx, &subs).Scan(ctx); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "find staff push subscriptions", Err: err}
+	}
+	return subs, nil
+}
+
+// FindForStaffAccounts returns the staff-portal subscriptions of the given
+// accounts in the current tenant. It is the addressing primitive for personal
+// notifications, where each recipient gets their own payload.
+//
+// The eligibility rules are re-checked here, at delivery time, rather than
+// inherited from whoever assembled the recipient list: that list is built in an
+// earlier transaction, and an account can be deactivated or unmapped from the
+// school in between.
+func (r *PushSubscriptionRepository) FindForStaffAccounts(ctx context.Context, accountIDs []int64) ([]*iot.PushSubscription, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	var subs []*iot.PushSubscription
+	query := r.staffSubscriptionQuery(ctx, &subs).
+		Where(`"push_subscription".account_id IN (?)`, bun.List(accountIDs))
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "find staff account push subscriptions", Err: err}
 	}
 	return subs, nil
 }

--- a/backend/database/repositories/users/notification_preference.go
+++ b/backend/database/repositories/users/notification_preference.go
@@ -1,0 +1,112 @@
+package users
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+const (
+	tableNotificationPreferences     = "users.notification_preferences"
+	tableExprNotificationPreferences = `users.notification_preferences AS "notification_preference"`
+	aliasNotificationPreference      = "notification_preference"
+)
+
+// NotificationPreferenceRepository implements users.NotificationPreferenceRepository.
+type NotificationPreferenceRepository struct {
+	*base.Repository[*users.NotificationPreference]
+	db *bun.DB
+}
+
+// NewNotificationPreferenceRepository creates a NotificationPreferenceRepository.
+func NewNotificationPreferenceRepository(db *bun.DB) users.NotificationPreferenceRepository {
+	repo := base.NewRepository[*users.NotificationPreference](db, tableNotificationPreferences, "NotificationPreference")
+	repo.TenantScoped = true
+	return &NotificationPreferenceRepository{Repository: repo, db: db}
+}
+
+// Upsert records one decision, overwriting the previous one for the same
+// (tenant, account, type).
+func (r *NotificationPreferenceRepository) Upsert(ctx context.Context, pref *users.NotificationPreference) error {
+	base.EnsureTenantID(ctx, pref)
+
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(pref).
+		ModelTableExpr(tableNotificationPreferences).
+		On("CONFLICT (tenant_id, account_id, notification_type) DO UPDATE").
+		Set("enabled = EXCLUDED.enabled").
+		Set("updated_at = NOW()").
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{Op: "upsert notification preference", Err: err}
+	}
+	return nil
+}
+
+// ListByAccount returns every stored decision of one account in the current tenant.
+func (r *NotificationPreferenceRepository) ListByAccount(ctx context.Context, accountID int64) ([]*users.NotificationPreference, error) {
+	var prefs []*users.NotificationPreference
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&prefs).
+		ModelTableExpr(tableExprNotificationPreferences).
+		Where(`"notification_preference".account_id = ?`, accountID)
+
+	query = base.WithTenantFilter(ctx, query, aliasNotificationPreference)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list notification preferences by account", Err: err}
+	}
+	return prefs, nil
+}
+
+// FilterOptedIn narrows candidate recipients to those who agreed to the type.
+//
+// The empty-input short circuit matters: a producer that resolved no candidates
+// must end up with no recipients, never with "everyone". Enforcing that here
+// rather than in each producer keeps one answer to "has this person agreed".
+func (r *NotificationPreferenceRepository) FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if notificationType == "" || len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	var optedIn []int64
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(tableExprNotificationPreferences).
+		ColumnExpr(`"notification_preference".account_id`).
+		Where(`"notification_preference".notification_type = ?`, notificationType).
+		Where(`"notification_preference".enabled`).
+		Where(`"notification_preference".account_id IN (?)`, bun.List(accountIDs))
+
+	query = base.WithTenantFilter(ctx, query, aliasNotificationPreference)
+
+	if err := query.Scan(ctx, &optedIn); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "filter opted-in accounts", Err: err}
+	}
+	return optedIn, nil
+}
+
+// DisableAllForAccount switches every stored decision of one account off.
+func (r *NotificationPreferenceRepository) DisableAllForAccount(ctx context.Context, accountID int64) error {
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*users.NotificationPreference)(nil)).
+		ModelTableExpr(tableNotificationPreferences).
+		Set("enabled = FALSE").
+		Set("updated_at = NOW()").
+		Where("account_id = ?", accountID).
+		Where("enabled")
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "disable all notification preferences", Err: err}
+	}
+	return nil
+}

--- a/backend/database/repositories/users/notification_preference.go
+++ b/backend/database/repositories/users/notification_preference.go
@@ -91,6 +91,63 @@ func (r *NotificationPreferenceRepository) FilterOptedIn(ctx context.Context, no
 	return optedIn, nil
 }
 
+// HasAnyOptedIn answers whether the current tenant has at least one enabled
+// decision for any named type. The partial notification-preference index makes
+// this the cheap gate used before a scheduler resolves its full audience.
+func (r *NotificationPreferenceRepository) HasAnyOptedIn(ctx context.Context, notificationTypes []string) (bool, error) {
+	if len(notificationTypes) == 0 {
+		return false, nil
+	}
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(tableExprNotificationPreferences).
+		Where(`"notification_preference".notification_type IN (?)`, bun.List(notificationTypes)).
+		Where(`"notification_preference".enabled`)
+	query = base.WithTenantFilter(ctx, query, aliasNotificationPreference)
+
+	exists, err := query.Exists(ctx)
+	if err != nil {
+		return false, &modelBase.DatabaseError{Op: "check for opted-in accounts", Err: err}
+	}
+	return exists, nil
+}
+
+// FilterOptedInByType narrows one candidate set for multiple notification types
+// in a single query.
+func (r *NotificationPreferenceRepository) FilterOptedInByType(
+	ctx context.Context,
+	notificationTypes []string,
+	accountIDs []int64,
+) (map[string][]int64, error) {
+	optedInByType := make(map[string][]int64)
+	if len(notificationTypes) == 0 || len(accountIDs) == 0 {
+		return optedInByType, nil
+	}
+
+	var rows []struct {
+		NotificationType string `bun:"notification_type"`
+		AccountID        int64  `bun:"account_id"`
+	}
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(tableExprNotificationPreferences).
+		ColumnExpr(`"notification_preference".notification_type`).
+		ColumnExpr(`"notification_preference".account_id`).
+		Where(`"notification_preference".notification_type IN (?)`, bun.List(notificationTypes)).
+		Where(`"notification_preference".enabled`).
+		Where(`"notification_preference".account_id IN (?)`, bun.List(accountIDs)).
+		OrderExpr(`"notification_preference".notification_type ASC`).
+		OrderExpr(`"notification_preference".account_id ASC`)
+	query = base.WithTenantFilter(ctx, query, aliasNotificationPreference)
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "filter opted-in accounts by type", Err: err}
+	}
+	for _, row := range rows {
+		optedInByType[row.NotificationType] = append(optedInByType[row.NotificationType], row.AccountID)
+	}
+	return optedInByType, nil
+}
+
 // FilterNotOptedOut removes only the candidates who explicitly declined the type.
 //
 // It reads the opt-out rows and subtracts them instead of selecting survivors in

--- a/backend/database/repositories/users/notification_preference.go
+++ b/backend/database/repositories/users/notification_preference.go
@@ -91,14 +91,18 @@ func (r *NotificationPreferenceRepository) FilterOptedIn(ctx context.Context, no
 	return optedIn, nil
 }
 
-// DisableAllForAccount switches every stored decision of one account off.
-func (r *NotificationPreferenceRepository) DisableAllForAccount(ctx context.Context, accountID int64) error {
+// DisableAllForAccount switches the named stored decisions of one account off.
+func (r *NotificationPreferenceRepository) DisableAllForAccount(ctx context.Context, accountID int64, notificationTypes []string) error {
+	if len(notificationTypes) == 0 {
+		return nil
+	}
 	query := base.GetDB(ctx, r.db).NewUpdate().
 		Model((*users.NotificationPreference)(nil)).
 		ModelTableExpr(tableNotificationPreferences).
 		Set("enabled = FALSE").
 		Set("updated_at = NOW()").
 		Where("account_id = ?", accountID).
+		Where("notification_type IN (?)", bun.List(notificationTypes)).
 		Where("enabled")
 
 	if tenantID := tenant.FromContext(ctx); tenantID > 0 {

--- a/backend/database/repositories/users/notification_preference.go
+++ b/backend/database/repositories/users/notification_preference.go
@@ -91,6 +91,46 @@ func (r *NotificationPreferenceRepository) FilterOptedIn(ctx context.Context, no
 	return optedIn, nil
 }
 
+// FilterNotOptedOut removes only the candidates who explicitly declined the type.
+//
+// It reads the opt-out rows and subtracts them instead of selecting survivors in
+// SQL: candidates without any row have nothing to join against, and the input
+// order is preserved so callers keep a stable recipient list.
+func (r *NotificationPreferenceRepository) FilterNotOptedOut(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if notificationType == "" || len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	var optedOut []int64
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(tableExprNotificationPreferences).
+		ColumnExpr(`"notification_preference".account_id`).
+		Where(`"notification_preference".notification_type = ?`, notificationType).
+		Where(`NOT "notification_preference".enabled`).
+		Where(`"notification_preference".account_id IN (?)`, bun.List(accountIDs))
+
+	query = base.WithTenantFilter(ctx, query, aliasNotificationPreference)
+
+	if err := query.Scan(ctx, &optedOut); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "filter opted-out accounts", Err: err}
+	}
+
+	declined := make(map[int64]struct{}, len(optedOut))
+	for _, accountID := range optedOut {
+		declined[accountID] = struct{}{}
+	}
+
+	remaining := make([]int64, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if _, ok := declined[accountID]; ok {
+			continue
+		}
+		remaining = append(remaining, accountID)
+	}
+	return remaining, nil
+}
+
 // DisableAllForAccount switches the named stored decisions of one account off.
 func (r *NotificationPreferenceRepository) DisableAllForAccount(ctx context.Context, accountID int64, notificationTypes []string) error {
 	if len(notificationTypes) == 0 {

--- a/backend/database/repositories/users/notification_preference_test.go
+++ b/backend/database/repositories/users/notification_preference_test.go
@@ -85,18 +85,25 @@ func TestNotificationPreferenceRepository(t *testing.T) {
 		assert.Empty(t, optedIn)
 	})
 
-	t.Run("disable all switches every decision off", func(t *testing.T) {
+	t.Run("disable all switches only the named decisions off", func(t *testing.T) {
 		upsert(t, account.ID, "pickup_overdue", true)
 		upsert(t, account.ID, "activity_overdue", true)
+		upsert(t, account.ID, "parent_announcement", true)
 
-		require.NoError(t, repo.DisableAllForAccount(ctx, account.ID))
+		require.NoError(t, repo.DisableAllForAccount(ctx, account.ID,
+			[]string{"pickup_overdue", "activity_overdue"}))
 
 		prefs, err := repo.ListByAccount(ctx, account.ID)
 		require.NoError(t, err)
 		require.NotEmpty(t, prefs)
+		enabledByType := make(map[string]bool, len(prefs))
 		for _, pref := range prefs {
-			assert.False(t, pref.Enabled, "type %s", pref.NotificationType)
+			enabledByType[pref.NotificationType] = pref.Enabled
 		}
+		assert.False(t, enabledByType["pickup_overdue"])
+		assert.False(t, enabledByType["activity_overdue"])
+		assert.True(t, enabledByType["parent_announcement"],
+			"a bulk action in one portal must preserve the other portal")
 	})
 
 	t.Run("does not leak another tenant's decisions", func(t *testing.T) {

--- a/backend/database/repositories/users/notification_preference_test.go
+++ b/backend/database/repositories/users/notification_preference_test.go
@@ -1,0 +1,124 @@
+package users_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotificationPreferenceRepository pins the store that decides whether a
+// notification may be delivered to a person at all.
+func TestNotificationPreferenceRepository(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).NotificationPreference
+	ctx := testpkg.TenantContext(1)
+
+	suffix := time.Now().UnixNano()
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("pref-%d@example.com", suffix))
+	other := testpkg.CreateTestAccount(t, db, fmt.Sprintf("pref-other-%d@example.com", suffix))
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID, other.ID)
+
+	upsert := func(t *testing.T, accountID int64, notificationType string, enabled bool) {
+		t.Helper()
+		pref := &userModels.NotificationPreference{
+			AccountID:        accountID,
+			NotificationType: notificationType,
+			Enabled:          enabled,
+		}
+		require.NoError(t, repo.Upsert(ctx, pref))
+	}
+
+	t.Run("upsert stores and then overwrites one decision", func(t *testing.T) {
+		upsert(t, account.ID, "pickup_upcoming", true)
+
+		prefs, err := repo.ListByAccount(ctx, account.ID)
+		require.NoError(t, err)
+		require.Len(t, prefs, 1)
+		assert.Equal(t, "pickup_upcoming", prefs[0].NotificationType)
+		assert.True(t, prefs[0].Enabled)
+
+		upsert(t, account.ID, "pickup_upcoming", false)
+
+		prefs, err = repo.ListByAccount(ctx, account.ID)
+		require.NoError(t, err)
+		require.Len(t, prefs, 1, "the same type must not create a second row")
+
+		// An explicit opt-out is kept as a row rather than deleted: it records a
+		// decision, which a later change of defaults must not silently overrule.
+		assert.False(t, prefs[0].Enabled)
+	})
+
+	t.Run("filter returns only accounts that agreed", func(t *testing.T) {
+		upsert(t, account.ID, "student_absence_reported", true)
+		upsert(t, other.ID, "student_absence_reported", false)
+
+		optedIn, err := repo.FilterOptedIn(ctx, "student_absence_reported",
+			[]int64{account.ID, other.ID})
+		require.NoError(t, err)
+
+		assert.Equal(t, []int64{account.ID}, optedIn)
+	})
+
+	t.Run("an account with no row at all is not opted in", func(t *testing.T) {
+		optedIn, err := repo.FilterOptedIn(ctx, "activity_start", []int64{account.ID, other.ID})
+		require.NoError(t, err)
+		assert.Empty(t, optedIn, "no row means no consent")
+	})
+
+	t.Run("empty input yields nothing rather than everything", func(t *testing.T) {
+		// The dangerous default: a producer that resolved no candidates must end
+		// up with no recipients, never with the whole school.
+		optedIn, err := repo.FilterOptedIn(ctx, "student_absence_reported", nil)
+		require.NoError(t, err)
+		assert.Empty(t, optedIn)
+
+		optedIn, err = repo.FilterOptedIn(ctx, "", []int64{account.ID})
+		require.NoError(t, err)
+		assert.Empty(t, optedIn)
+	})
+
+	t.Run("disable all switches every decision off", func(t *testing.T) {
+		upsert(t, account.ID, "pickup_overdue", true)
+		upsert(t, account.ID, "activity_overdue", true)
+
+		require.NoError(t, repo.DisableAllForAccount(ctx, account.ID))
+
+		prefs, err := repo.ListByAccount(ctx, account.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, prefs)
+		for _, pref := range prefs {
+			assert.False(t, pref.Enabled, "type %s", pref.NotificationType)
+		}
+	})
+
+	t.Run("does not leak another tenant's decisions", func(t *testing.T) {
+		const otherTenant int64 = 99047
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreignCtx := testpkg.TenantContext(otherTenant)
+		foreign := &userModels.NotificationPreference{
+			AccountID:        account.ID,
+			NotificationType: "pickup_upcoming",
+			Enabled:          true,
+		}
+		require.NoError(t, repo.Upsert(foreignCtx, foreign))
+
+		// The same account agreed at another school. Tenant 1 must neither see
+		// that decision nor act on it.
+		optedIn, err := repo.FilterOptedIn(ctx, "pickup_upcoming", []int64{account.ID})
+		require.NoError(t, err)
+		assert.Empty(t, optedIn, "consent is per school, not global")
+
+		prefs, err := repo.ListByAccount(foreignCtx, account.ID)
+		require.NoError(t, err)
+		require.Len(t, prefs, 1, "the other school keeps its own row")
+	})
+}

--- a/backend/database/repositories/users/notification_preference_test.go
+++ b/backend/database/repositories/users/notification_preference_test.go
@@ -73,6 +73,30 @@ func TestNotificationPreferenceRepository(t *testing.T) {
 		assert.Empty(t, optedIn, "no row means no consent")
 	})
 
+	t.Run("tenant gate and multi-type filter use enabled rows only", func(t *testing.T) {
+		upsert(t, account.ID, "my_activity_starting", true)
+		upsert(t, other.ID, "activity_start", true)
+		upsert(t, other.ID, "pickup_overdue", false)
+
+		hasAny, err := repo.HasAnyOptedIn(ctx, []string{"my_activity_starting", "activity_start"})
+		require.NoError(t, err)
+		assert.True(t, hasAny)
+
+		hasAny, err = repo.HasAnyOptedIn(ctx, []string{"pickup_overdue"})
+		require.NoError(t, err)
+		assert.False(t, hasAny, "an explicit opt-out must not open the scheduler gate")
+
+		byType, err := repo.FilterOptedInByType(
+			ctx,
+			[]string{"my_activity_starting", "activity_start", "pickup_overdue"},
+			[]int64{account.ID, other.ID},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{account.ID}, byType["my_activity_starting"])
+		assert.Equal(t, []int64{other.ID}, byType["activity_start"])
+		assert.NotContains(t, byType, "pickup_overdue")
+	})
+
 	// The mirror rule, for channels that already reached people before consent
 	// existed: only a stored "no" filters, a missing row does not.
 	t.Run("not-opted-out drops an explicit no and keeps a missing decision", func(t *testing.T) {
@@ -142,6 +166,18 @@ func TestNotificationPreferenceRepository(t *testing.T) {
 		optedIn, err := repo.FilterOptedIn(ctx, "pickup_upcoming", []int64{account.ID})
 		require.NoError(t, err)
 		assert.Empty(t, optedIn, "consent is per school, not global")
+
+		hasAny, err := repo.HasAnyOptedIn(ctx, []string{"pickup_upcoming"})
+		require.NoError(t, err)
+		assert.False(t, hasAny, "another tenant's consent must not open this tenant's gate")
+
+		byType, err := repo.FilterOptedInByType(
+			ctx,
+			[]string{"pickup_upcoming"},
+			[]int64{account.ID},
+		)
+		require.NoError(t, err)
+		assert.Empty(t, byType, "another tenant's consent must not enter a bulk audience")
 
 		prefs, err := repo.ListByAccount(foreignCtx, account.ID)
 		require.NoError(t, err)

--- a/backend/database/repositories/users/notification_preference_test.go
+++ b/backend/database/repositories/users/notification_preference_test.go
@@ -73,6 +73,25 @@ func TestNotificationPreferenceRepository(t *testing.T) {
 		assert.Empty(t, optedIn, "no row means no consent")
 	})
 
+	// The mirror rule, for channels that already reached people before consent
+	// existed: only a stored "no" filters, a missing row does not.
+	t.Run("not-opted-out drops an explicit no and keeps a missing decision", func(t *testing.T) {
+		// From the subtest above: account agreed to student_absence_reported,
+		// other declined it. Neither has a row for activity_start.
+		remaining, err := repo.FilterNotOptedOut(ctx, "student_absence_reported",
+			[]int64{account.ID, other.ID})
+		require.NoError(t, err)
+		assert.Equal(t, []int64{account.ID}, remaining)
+
+		remaining, err = repo.FilterNotOptedOut(ctx, "activity_start", []int64{account.ID, other.ID})
+		require.NoError(t, err)
+		assert.Equal(t, []int64{account.ID, other.ID}, remaining, "no row means no objection")
+
+		remaining, err = repo.FilterNotOptedOut(ctx, "activity_start", nil)
+		require.NoError(t, err)
+		assert.Empty(t, remaining)
+	})
+
 	t.Run("empty input yields nothing rather than everything", func(t *testing.T) {
 		// The dangerous default: a producer that resolved no candidates must end
 		// up with no recipients, never with the whole school.

--- a/backend/database/repositories/users/parent_announcement.go
+++ b/backend/database/repositories/users/parent_announcement.go
@@ -481,10 +481,10 @@ func reachedArgs(announcementID, tenantID, accountID int64) []any {
 // guardian profile's e-mail/name; the pending_enrollment target reads the
 // e-mail/name captured on the enrollment request (those guardians may not have
 // a profile yet). An outer GROUP BY collapses the UNION to one row per
-// normalized e-mail, so a guardian reached through BOTH a student target and
-// pending_enrollment — possibly with different captured vs profile names — is
-// enqueued (and e-mailed) only once; the retained name prefers a non-empty
-// value across the merged rows.
+// account and normalized e-mail, so a guardian reached through BOTH a student
+// target and pending_enrollment — possibly with different captured vs profile
+// names — is enqueued (and e-mailed) only once per address; the retained name
+// prefers a non-empty value across the merged rows.
 func (r *ParentAnnouncementRepository) ResolveAudienceEmails(ctx context.Context, tenantID, announcementID int64) ([]*users.AnnouncementRecipient, error) {
 	// Only guardians WITH a linked account receive the e-mail: the mail is a
 	// pointer into the parent portal (title + link, no body), which is useless
@@ -496,11 +496,11 @@ func (r *ParentAnnouncementRepository) ResolveAudienceEmails(ctx context.Context
 	// requests with no account at all.
 	var rows []*users.AnnouncementRecipient
 	sqlStr := fmt.Sprintf(`
-		SELECT email,
+		SELECT account_id, email,
 			COALESCE(min(NULLIF(first_name, '')), '') AS first_name,
 			COALESCE(min(NULLIF(last_name, '')), '') AS last_name
 		FROM (
-		SELECT DISTINCT lower(gp.email) AS email,
+		SELECT DISTINCT gp.account_id, lower(gp.email) AS email,
 			COALESCE(gp.first_name, '') AS first_name, COALESCE(gp.last_name, '') AS last_name
 		FROM users.parent_announcement_targets pt
 		JOIN users.students s ON s.tenant_id = ? AND (
@@ -526,7 +526,8 @@ func (r *ParentAnnouncementRepository) ResolveAudienceEmails(ctx context.Context
 
 		UNION
 
-		SELECT DISTINCT lower(req.guardian_email) AS email,
+		SELECT DISTINCT COALESCE(req.guardian_account_id, ea.id) AS account_id,
+			lower(req.guardian_email) AS email,
 			COALESCE(req.guardian_first_name, '') AS first_name, COALESCE(req.guardian_last_name, '') AS last_name
 		FROM users.parent_announcement_targets pt
 		JOIN enrollment.requests req ON req.tenant_id = ?
@@ -540,7 +541,7 @@ func (r *ParentAnnouncementRepository) ResolveAudienceEmails(ctx context.Context
 		WHERE pt.announcement_id = ? AND pt.tenant_id = ? AND pt.target_type = 'pending_enrollment'
 			AND (req.guardian_account_id IS NOT NULL OR ea.id IS NOT NULL)
 		) recips
-		GROUP BY email`,
+		GROUP BY account_id, email`,
 		activeActivityGroupExists("?"), pendingStatusList())
 	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr,
 		tenantID, tenantID, tenantID, tenantID, announcementID, tenantID, // student path

--- a/backend/database/repositories/users/parent_announcement_test.go
+++ b/backend/database/repositories/users/parent_announcement_test.go
@@ -645,6 +645,8 @@ func TestParentAnnouncementAudience_PendingEnrollmentEmailFallback(t *testing.T)
 	foundEmail := false
 	for _, e := range emails {
 		if strings.EqualFold(e.Email, chain.Email) {
+			assert.Equal(t, chain.AccountID, e.AccountID,
+				"the e-mail recipient keeps the account identity needed for consent filtering")
 			foundEmail = true
 		}
 	}

--- a/backend/database/repositories/users/staff.go
+++ b/backend/database/repositories/users/staff.go
@@ -224,6 +224,49 @@ func (r *StaffRepository) GetStaffContactInfo(ctx context.Context, staffID int64
 	return &result, nil
 }
 
+// ListAccountIDsByStaffIDs maps staff members to their login accounts.
+//
+// The bulk counterpart of the staff -> person -> account walk
+// GetStaffContactInfo does for one person, reduced to the two columns a caller
+// addressing people by account needs. Deliberately not FindWithPersonByIDs:
+// that hydrates whole staff and person rows for a lookup that is two integers.
+//
+// Staff without a login account are absent from the result rather than mapped
+// to zero, so a caller ranging over the map cannot accidentally address account
+// 0. Soft-deleted staff and persons are excluded.
+func (r *StaffRepository) ListAccountIDsByStaffIDs(ctx context.Context, staffIDs []int64) (map[int64]int64, error) {
+	if len(staffIDs) == 0 {
+		return map[int64]int64{}, nil
+	}
+
+	var rows []struct {
+		StaffID   int64 `bun:"staff_id"`
+		AccountID int64 `bun:"account_id"`
+	}
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		ModelTableExpr(`users.staff AS "staff"`).
+		ColumnExpr(`"staff".id AS staff_id`).
+		ColumnExpr(`"person".account_id`).
+		Join(`INNER JOIN users.persons AS "person" ON "person".id = "staff".person_id AND "person".deleted_at IS NULL`).
+		Where(`"staff".deleted_at IS NULL`).
+		Where(`"person".account_id IS NOT NULL`).
+		Where(`"staff".id IN (?)`, bun.List(staffIDs))
+
+	query = base.WithTenantFilter(ctx, query, "staff")
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list account IDs by staff IDs", Err: err}
+	}
+
+	accountsByStaff := make(map[int64]int64, len(rows))
+	for _, row := range rows {
+		accountsByStaff[row.StaffID] = row.AccountID
+	}
+
+	return accountsByStaff, nil
+}
+
 // ListStaffWithPermission returns all active staff whose effective permissions
 // (role-granted UNION directly-granted, tenant-scoped) match permissionName —
 // wildcard-aware via the same matcher route authorization uses. Used for the

--- a/backend/database/repositories/users/staff.go
+++ b/backend/database/repositories/users/staff.go
@@ -231,9 +231,10 @@ func (r *StaffRepository) GetStaffContactInfo(ctx context.Context, staffID int64
 // addressing people by account needs. Deliberately not FindWithPersonByIDs:
 // that hydrates whole staff and person rows for a lookup that is two integers.
 //
-// Staff without a login account are absent from the result rather than mapped
-// to zero, so a caller ranging over the map cannot accidentally address account
-// 0. Soft-deleted staff and persons are excluded.
+// Staff without an active login account and active tenant mapping are absent
+// from the result rather than mapped to zero, so a caller ranging over the map
+// cannot accidentally address account 0. Soft-deleted staff and persons are
+// excluded.
 func (r *StaffRepository) ListAccountIDsByStaffIDs(ctx context.Context, staffIDs []int64) (map[int64]int64, error) {
 	if len(staffIDs) == 0 {
 		return map[int64]int64{}, nil
@@ -247,10 +248,13 @@ func (r *StaffRepository) ListAccountIDsByStaffIDs(ctx context.Context, staffIDs
 	query := base.GetDB(ctx, r.db).NewSelect().
 		ModelTableExpr(`users.staff AS "staff"`).
 		ColumnExpr(`"staff".id AS staff_id`).
-		ColumnExpr(`"person".account_id`).
+		ColumnExpr(`"account".id AS account_id`).
 		Join(`INNER JOIN users.persons AS "person" ON "person".id = "staff".person_id AND "person".deleted_at IS NULL`).
+		Join(`INNER JOIN auth.accounts AS "account" ON "account".id = "person".account_id AND "account".active = TRUE`).
+		Join(`INNER JOIN auth.account_tenants AS "account_tenant" ON "account_tenant".account_id = "account".id
+			AND "account_tenant".tenant_id = "staff".tenant_id
+			AND "account_tenant".status = ?`, authModels.AccountTenantStatusActive).
 		Where(`"staff".deleted_at IS NULL`).
-		Where(`"person".account_id IS NOT NULL`).
 		Where(`"staff".id IN (?)`, bun.List(staffIDs))
 
 	query = base.WithTenantFilter(ctx, query, "staff")

--- a/backend/database/repositories/users/staff.go
+++ b/backend/database/repositories/users/staff.go
@@ -267,6 +267,49 @@ func (r *StaffRepository) ListAccountIDsByStaffIDs(ctx context.Context, staffIDs
 	return accountsByStaff, nil
 }
 
+// ListAllStaffAccountIDs maps every staff member of the current tenant who can
+// actually log in to their account.
+//
+// The candidate set for anything addressed at "the team": a caller narrows it
+// afterwards by whatever the feature requires. It is deliberately not
+// ListAccountIDsByStaffIDs with a wildcard — that one answers a question about
+// named people and returns nothing for an empty list, which is the correct
+// contract there and the wrong one here.
+//
+// Inactive accounts and inactive tenant mappings are excluded, so a departed
+// colleague is not addressed by a background job that has no request context to
+// notice it. Staff without an account are absent rather than mapped to zero.
+func (r *StaffRepository) ListAllStaffAccountIDs(ctx context.Context) (map[int64]int64, error) {
+	var rows []struct {
+		StaffID   int64 `bun:"staff_id"`
+		AccountID int64 `bun:"account_id"`
+	}
+
+	query := base.GetDB(ctx, r.db).NewSelect().
+		ModelTableExpr(`users.staff AS "staff"`).
+		ColumnExpr(`"staff".id AS staff_id`).
+		ColumnExpr(`"account".id AS account_id`).
+		Join(`INNER JOIN users.persons AS "person" ON "person".id = "staff".person_id AND "person".deleted_at IS NULL`).
+		Join(`INNER JOIN auth.accounts AS "account" ON "account".id = "person".account_id AND "account".active = TRUE`).
+		Join(`INNER JOIN auth.account_tenants AS "account_tenant" ON "account_tenant".account_id = "account".id
+			AND "account_tenant".tenant_id = "staff".tenant_id
+			AND "account_tenant".status = ?`, authModels.AccountTenantStatusActive).
+		Where(`"staff".deleted_at IS NULL`)
+
+	query = base.WithTenantFilter(ctx, query, "staff")
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list all staff account IDs", Err: err}
+	}
+
+	accountsByStaff := make(map[int64]int64, len(rows))
+	for _, row := range rows {
+		accountsByStaff[row.StaffID] = row.AccountID
+	}
+
+	return accountsByStaff, nil
+}
+
 // ListStaffWithPermission returns all active staff whose effective permissions
 // (role-granted UNION directly-granted, tenant-scoped) match permissionName —
 // wildcard-aware via the same matcher route authorization uses. Used for the

--- a/backend/database/repositories/users/staff_account_ids_test.go
+++ b/backend/database/repositories/users/staff_account_ids_test.go
@@ -1,0 +1,78 @@
+package users_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStaffRepository_ListAccountIDsByStaffIDs pins the staff -> login account
+// mapping used to address people by account instead of by staff row.
+func TestStaffRepository_ListAccountIDsByStaffIDs(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Staff
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("maps staff with an account and omits staff without one", func(t *testing.T) {
+		withAccount, account := testpkg.CreateTestStaffWithAccount(t, db, "Mapped", "Staff")
+		withoutAccount := testpkg.CreateTestStaff(t, db, "Accountless", "Staff")
+
+		defer testpkg.CleanupStaffFixtures(t, db, withAccount.ID, withoutAccount.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		result, err := repo.ListAccountIDsByStaffIDs(ctx, []int64{withAccount.ID, withoutAccount.ID})
+		require.NoError(t, err)
+
+		assert.Equal(t, account.ID, result[withAccount.ID])
+
+		// Absent rather than mapped to zero: a caller ranging over the map must
+		// never end up addressing account 0.
+		_, present := result[withoutAccount.ID]
+		assert.False(t, present, "staff without a login account must not appear")
+	})
+
+	t.Run("excludes a soft-deleted staff member", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "Offboarded", "Staff")
+
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		_, err := db.NewUpdate().
+			TableExpr("users.staff").
+			Set("deleted_at = NOW()").
+			Where("id = ?", staff.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		result, err := repo.ListAccountIDsByStaffIDs(ctx, []int64{staff.ID})
+		require.NoError(t, err)
+
+		_, present := result[staff.ID]
+		assert.False(t, present, "an offboarded staff member is not addressable")
+	})
+
+	t.Run("empty input short-circuits", func(t *testing.T) {
+		result, err := repo.ListAccountIDsByStaffIDs(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("does not resolve another tenant's staff", func(t *testing.T) {
+		const otherTenant int64 = 99044
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreignStaff := testpkg.CreateTestStaffForTenant(t, db, otherTenant, "Foreign", "Staff")
+		defer testpkg.CleanupStaffFixtures(t, db, foreignStaff.ID)
+
+		result, err := repo.ListAccountIDsByStaffIDs(ctx, []int64{foreignStaff.ID})
+		require.NoError(t, err)
+
+		_, present := result[foreignStaff.ID]
+		assert.False(t, present, "tenant 1 must not resolve another school's staff")
+	})
+}

--- a/backend/database/repositories/users/staff_account_ids_test.go
+++ b/backend/database/repositories/users/staff_account_ids_test.go
@@ -20,6 +20,7 @@ func TestStaffRepository_ListAccountIDsByStaffIDs(t *testing.T) {
 
 	t.Run("maps staff with an account and omits staff without one", func(t *testing.T) {
 		withAccount, account := testpkg.CreateTestStaffWithAccount(t, db, "Mapped", "Staff")
+		testpkg.MapAccountToTenant(t, db, account.ID, 1)
 		withoutAccount := testpkg.CreateTestStaff(t, db, "Accountless", "Staff")
 
 		defer testpkg.CleanupStaffFixtures(t, db, withAccount.ID, withoutAccount.ID)
@@ -38,6 +39,7 @@ func TestStaffRepository_ListAccountIDsByStaffIDs(t *testing.T) {
 
 	t.Run("excludes a soft-deleted staff member", func(t *testing.T) {
 		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "Offboarded", "Staff")
+		testpkg.MapAccountToTenant(t, db, account.ID, 1)
 
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
@@ -54,6 +56,34 @@ func TestStaffRepository_ListAccountIDsByStaffIDs(t *testing.T) {
 
 		_, present := result[staff.ID]
 		assert.False(t, present, "an offboarded staff member is not addressable")
+	})
+
+	t.Run("excludes inactive accounts and tenant mappings", func(t *testing.T) {
+		inactiveAccountStaff, inactiveAccount := testpkg.CreateTestStaffWithAccount(t, db, "Inactive", "Account")
+		testpkg.MapAccountToTenant(t, db, inactiveAccount.ID, 1)
+		inactiveMappingStaff, inactiveMappingAccount := testpkg.CreateTestStaffWithAccount(t, db, "Inactive", "Mapping")
+		testpkg.MapAccountToTenant(t, db, inactiveMappingAccount.ID, 1)
+
+		defer testpkg.CleanupStaffFixtures(t, db, inactiveAccountStaff.ID, inactiveMappingStaff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, inactiveAccount.ID, inactiveMappingAccount.ID)
+
+		_, err := db.NewUpdate().
+			TableExpr("auth.accounts").
+			Set("active = FALSE").
+			Where("id = ?", inactiveAccount.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+		_, err = db.NewUpdate().
+			TableExpr("auth.account_tenants").
+			Set("status = 'inactive'").
+			Where("account_id = ?", inactiveMappingAccount.ID).
+			Where("tenant_id = ?", 1).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		result, err := repo.ListAccountIDsByStaffIDs(ctx, []int64{inactiveAccountStaff.ID, inactiveMappingStaff.ID})
+		require.NoError(t, err)
+		assert.Empty(t, result)
 	})
 
 	t.Run("empty input short-circuits", func(t *testing.T) {

--- a/backend/database/repositories/users/staff_account_ids_test.go
+++ b/backend/database/repositories/users/staff_account_ids_test.go
@@ -76,3 +76,88 @@ func TestStaffRepository_ListAccountIDsByStaffIDs(t *testing.T) {
 		assert.False(t, present, "tenant 1 must not resolve another school's staff")
 	})
 }
+
+// TestStaffRepository_ListAllStaffAccountIDs pins the candidate set a
+// background job addresses when it means "the team of this school".
+//
+// The eligibility rules match the push-subscription finder deliberately: both
+// answer "may this person be addressed in this school right now", and two
+// answers to that question would drift.
+func TestStaffRepository_ListAllStaffAccountIDs(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).Staff
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("lists mapped staff and skips the rest", func(t *testing.T) {
+		mapped, mappedAccount := testpkg.CreateTestStaffWithAccount(t, db, "Mapped", "Colleague")
+		testpkg.MapAccountToTenant(t, db, mappedAccount.ID, 1)
+
+		unmapped, unmappedAccount := testpkg.CreateTestStaffWithAccount(t, db, "Unmapped", "Colleague")
+
+		deactivated, deactivatedAccount := testpkg.CreateTestStaffWithAccount(t, db, "Deactivated", "Colleague")
+		testpkg.MapAccountToTenant(t, db, deactivatedAccount.ID, 1)
+
+		accountless := testpkg.CreateTestStaff(t, db, "Accountless", "Colleague")
+
+		defer testpkg.CleanupStaffFixtures(t, db, mapped.ID, unmapped.ID, deactivated.ID, accountless.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, mappedAccount.ID, unmappedAccount.ID, deactivatedAccount.ID)
+
+		_, err := db.NewUpdate().
+			TableExpr("auth.accounts").
+			Set("active = FALSE").
+			Where("id = ?", deactivatedAccount.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		result, err := repo.ListAllStaffAccountIDs(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, mappedAccount.ID, result[mapped.ID])
+
+		_, hasUnmapped := result[unmapped.ID]
+		assert.False(t, hasUnmapped, "an account without an active mapping does not belong to this school")
+
+		_, hasDeactivated := result[deactivated.ID]
+		assert.False(t, hasDeactivated, "a deactivated account is not addressable")
+
+		_, hasAccountless := result[accountless.ID]
+		assert.False(t, hasAccountless, "staff without a login cannot receive anything")
+	})
+
+	t.Run("excludes a soft-deleted staff member", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "Offboarded", "Colleague")
+		testpkg.MapAccountToTenant(t, db, account.ID, 1)
+
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		_, err := db.NewUpdate().
+			TableExpr("users.staff").
+			Set("deleted_at = NOW()").
+			Where("id = ?", staff.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		result, err := repo.ListAllStaffAccountIDs(ctx)
+		require.NoError(t, err)
+
+		_, present := result[staff.ID]
+		assert.False(t, present, "an offboarded staff member is not addressable")
+	})
+
+	t.Run("does not list another school's staff", func(t *testing.T) {
+		const otherTenant int64 = 99045
+		testpkg.EnsureTestTenant(t, db, otherTenant)
+
+		foreign := testpkg.CreateTestStaffForTenant(t, db, otherTenant, "Foreign", "Colleague")
+		defer testpkg.CleanupStaffFixtures(t, db, foreign.ID)
+
+		result, err := repo.ListAllStaffAccountIDs(ctx)
+		require.NoError(t, err)
+
+		_, present := result[foreign.ID]
+		assert.False(t, present, "tenant 1 must not list another school's staff")
+	})
+}

--- a/backend/models/active/group_supervisor.go
+++ b/backend/models/active/group_supervisor.go
@@ -24,6 +24,15 @@ type GroupSupervisor struct {
 	ActiveGroup *Group       `bun:"rel:belongs-to,join:group_id=id" json:"active_group,omitempty"`
 }
 
+// StaffRoomSupervision is the (staff, room) projection of a currently active
+// supervision. It exists so a caller that needs "who supervises which room
+// right now" for every staff member of a tenant can ask once, instead of
+// pairing FindActiveByStaffID with GetActiveGroupsByIDs per staff member.
+type StaffRoomSupervision struct {
+	StaffID int64 `bun:"staff_id"`
+	RoomID  int64 `bun:"room_id"`
+}
+
 // Table name constants for BUN ORM schema qualification
 const ()
 

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -180,6 +180,12 @@ type VisitRepository interface {
 	// flows through TenantTxMiddleware.
 	ListActiveStudentIDsByRoomID(ctx context.Context, roomID int64) ([]int64, error)
 
+	// ListOpenVisitStudentIDsByRoom returns every currently checked-in student
+	// of the tenant grouped by the room they are in. It is the whole-tenant
+	// counterpart of ListActiveStudentIDsByRoomID: one query instead of one per
+	// room, which is what a caller iterating many supervised rooms needs.
+	ListOpenVisitStudentIDsByRoom(ctx context.Context) (map[int64][]int64, error)
+
 	// CountActiveByGroupID counts currently active visits in a single active group.
 	CountActiveByGroupID(ctx context.Context, activeGroupID int64) (int, error)
 
@@ -205,6 +211,13 @@ type GroupSupervisorRepository interface {
 
 	// FindActiveByStaffID finds all active supervisions for a specific staff member
 	FindActiveByStaffID(ctx context.Context, staffID int64) ([]*GroupSupervisor, error)
+
+	// ListActiveSupervisedRooms returns one (staff_id, room_id) pair per
+	// currently supervised room in the tenant, for every staff member at once.
+	// It answers in a single query what FindActiveByStaffID plus
+	// GetActiveGroupsByIDs answer per staff member, so a caller that needs the
+	// whole tenant does not pay a per-person round trip.
+	ListActiveSupervisedRooms(ctx context.Context) ([]StaffRoomSupervision, error)
 
 	// FindByActiveGroupID finds supervisors for a specific active group
 	// If activeOnly is true, only returns supervisors with end_date IS NULL (currently active)

--- a/backend/models/auth/repository.go
+++ b/backend/models/auth/repository.go
@@ -28,6 +28,10 @@ type AccountRepository interface {
 	UpdateAvatar(ctx context.Context, id int64, avatar string) error
 	SetActive(ctx context.Context, id int64, active bool) error
 	FindByRole(ctx context.Context, role string) ([]*Account, error)
+	// ListEffectiveAdminAccountIDs returns the IDs of active accounts with
+	// effective admin scope in the current tenant: the literal admin role, or
+	// an admin:* / *:* permission from a role or granted directly.
+	ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error)
 	FindAccountsWithRolesAndPermissions(ctx context.Context, filters map[string]interface{}) ([]*Account, error)
 	FindEmailsByAccountIDs(ctx context.Context, accountIDs []int64) (map[int64]string, error)
 	FindAvatarsByAccountIDs(ctx context.Context, accountIDs []int64) (map[int64]string, error)

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -180,9 +180,8 @@ const (
 	// exists on top of the per-person opt-in.
 	KeyNotificationsAbsenceReportedEnabled = "notifications.absence_reported_enabled"
 	// KeyNotificationsOnDutyOnly restricts personal notifications to staff who
-	// are currently checked in. Schools without time tracking see an empty
-	// presence map, in which case the filter is skipped rather than silencing
-	// everyone.
+	// are currently checked in. An empty presence map fails closed; schools
+	// without time tracking must disable this setting.
 	KeyNotificationsOnDutyOnly = "notifications.on_duty_only"
 )
 

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -169,6 +169,21 @@ const (
 	// abstraction (#1624). When off (the default), Notify(ctx, event) is a
 	// no-op and no channel delivers anything.
 	KeyNotificationsDispatchEnabled = "notifications.dispatch_enabled"
+	// KeyNotificationsActiveWindowStart / End bound the wall-clock window in
+	// which notifications may be delivered at all. Enforced once in the
+	// notification router, so it applies to every producer.
+	KeyNotificationsActiveWindowStart = "notifications.active_window_start"
+	KeyNotificationsActiveWindowEnd   = "notifications.active_window_end"
+	// KeyNotificationsAbsenceReportedEnabled lets a school switch off the
+	// sick/excused notification entirely. This is a data-minimisation decision
+	// about health information, not a matter of personal taste, which is why it
+	// exists on top of the per-person opt-in.
+	KeyNotificationsAbsenceReportedEnabled = "notifications.absence_reported_enabled"
+	// KeyNotificationsOnDutyOnly restricts personal notifications to staff who
+	// are currently checked in. Schools without time tracking see an empty
+	// presence map, in which case the filter is skipped rather than silencing
+	// everyone.
+	KeyNotificationsOnDutyOnly = "notifications.on_duty_only"
 )
 
 // PresenceMode option values for KeyPresenceMode.

--- a/backend/models/config/setting_value_repository.go
+++ b/backend/models/config/setting_value_repository.go
@@ -10,6 +10,10 @@ type SettingValueRepository interface {
 	// Returns (nil, nil) if not found.
 	FindByTenantAndKey(ctx context.Context, tenantID int64, key string) (*SettingValue, error)
 
+	// FindByTenantAndKeys retrieves the stored overrides for the named keys in
+	// one query. Keys without an override are absent from the result.
+	FindByTenantAndKeys(ctx context.Context, tenantID int64, keys []string) ([]*SettingValue, error)
+
 	// Upsert inserts or updates a setting value (INSERT ... ON CONFLICT ... DO UPDATE).
 	Upsert(ctx context.Context, sv *SettingValue) error
 

--- a/backend/models/education/repository.go
+++ b/backend/models/education/repository.go
@@ -21,6 +21,30 @@ type GroupRepository interface {
 	FindByTeacher(ctx context.Context, teacherID int64) ([]*Group, error)
 	FindWithRoom(ctx context.Context, groupID int64) (*Group, error)
 	CountWithOptions(ctx context.Context, options *base.QueryOptions) (int, error)
+
+	// ListSupervisedGroupIDsByStaff returns, for each of the given staff
+	// members, the education groups they supervise on the given day: groups
+	// they are assigned to as a teacher, plus groups they cover through an
+	// active substitution.
+	//
+	// This is the identity-free bulk form of what
+	// usercontext.GetMyGroups answers for one authenticated caller. It exists
+	// because GetMyGroups derives the staff member from JWT claims and so
+	// cannot be used from a background job, and because asking it per person
+	// would mean a per-person round trip.
+	//
+	// It is a read filter for child data: an over-permissive result widens
+	// who may see a student. Any change here must keep the equivalence test
+	// against GetMyGroups green.
+	ListSupervisedGroupIDsByStaff(ctx context.Context, staffIDs []int64, on timezone.Date) ([]StaffGroupID, error)
+}
+
+// StaffGroupID pairs a staff member with one education group they supervise.
+// It is the projection ListSupervisedGroupIDsByStaff returns: callers need the
+// group IDs to decide readability, never the group rows themselves.
+type StaffGroupID struct {
+	StaffID int64 `bun:"staff_id"`
+	GroupID int64 `bun:"group_id"`
 }
 
 // GroupTeacherRepository defines operations for managing group-teacher relationships

--- a/backend/models/education/repository.go
+++ b/backend/models/education/repository.go
@@ -37,6 +37,14 @@ type GroupRepository interface {
 	// who may see a student. Any change here must keep the equivalence test
 	// against GetMyGroups green.
 	ListSupervisedGroupIDsByStaff(ctx context.Context, staffIDs []int64, on timezone.Date) ([]StaffGroupID, error)
+
+	// ListStaffIDsByEducationGroupIDs is the same relation read in the other
+	// direction: who supervises these groups on the given day. Producers use it
+	// to find the people responsible for one child.
+	//
+	// Both directions must agree, so they share the join shape. Widening either
+	// one widens who may learn something about a child.
+	ListStaffIDsByEducationGroupIDs(ctx context.Context, groupIDs []int64, on timezone.Date) ([]StaffGroupID, error)
 }
 
 // StaffGroupID pairs a staff member with one education group they supervise.

--- a/backend/models/iot/push_subscription.go
+++ b/backend/models/iot/push_subscription.go
@@ -110,6 +110,12 @@ type PushSubscriptionRepository interface {
 	DeleteStaffByAccountID(ctx context.Context, accountID int64) error
 	// FindForTenantStaff returns all staff-portal subscriptions of the current tenant.
 	FindForTenantStaff(ctx context.Context) ([]*PushSubscription, error)
+
+	// FindForStaffAccounts returns the staff-portal subscriptions of the given
+	// accounts in the current tenant. Same eligibility rules as
+	// FindForTenantStaff, narrowed to named recipients — the addressing
+	// primitive for personal notifications.
+	FindForStaffAccounts(ctx context.Context, accountIDs []int64) ([]*PushSubscription, error)
 	// FindForTenantAdmins returns staff-portal subscriptions of accounts with
 	// effective admin scope in the current tenant.
 	FindForTenantAdmins(ctx context.Context) ([]*PushSubscription, error)

--- a/backend/models/users/notification_preference.go
+++ b/backend/models/users/notification_preference.go
@@ -50,6 +50,13 @@ type NotificationPreferenceRepository interface {
 	// returns an empty result and never the full list.
 	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
 
+	// FilterNotOptedOut is the mirror of FilterOptedIn: it returns the candidates
+	// MINUS those who explicitly declined the type (a row with Enabled=false).
+	// A missing row does not filter anybody out. This is for channels that were
+	// delivered before consent existed and must not be silenced by the absence
+	// of a decision; consent-first channels use FilterOptedIn.
+	FilterNotOptedOut(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
+
 	// DisableAllForAccount switches the named stored decisions of one account
 	// off. Types with no row stay absent — they are already off.
 	DisableAllForAccount(ctx context.Context, accountID int64, notificationTypes []string) error

--- a/backend/models/users/notification_preference.go
+++ b/backend/models/users/notification_preference.go
@@ -50,6 +50,16 @@ type NotificationPreferenceRepository interface {
 	// returns an empty result and never the full list.
 	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
 
+	// HasAnyOptedIn answers whether the current tenant has at least one enabled
+	// preference row for any named type. It is a cheap scheduling gate only;
+	// it does not establish that the stored account is still an eligible
+	// recipient.
+	HasAnyOptedIn(ctx context.Context, notificationTypes []string) (bool, error)
+
+	// FilterOptedInByType narrows the candidates for multiple types in one
+	// query, keyed by notification type.
+	FilterOptedInByType(ctx context.Context, notificationTypes []string, accountIDs []int64) (map[string][]int64, error)
+
 	// FilterNotOptedOut is the mirror of FilterOptedIn: it returns the candidates
 	// MINUS those who explicitly declined the type (a row with Enabled=false).
 	// A missing row does not filter anybody out. This is for channels that were

--- a/backend/models/users/notification_preference.go
+++ b/backend/models/users/notification_preference.go
@@ -50,7 +50,7 @@ type NotificationPreferenceRepository interface {
 	// returns an empty result and never the full list.
 	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
 
-	// DisableAllForAccount switches every stored decision of one account off.
-	// Types with no row stay absent — they are already off.
-	DisableAllForAccount(ctx context.Context, accountID int64) error
+	// DisableAllForAccount switches the named stored decisions of one account
+	// off. Types with no row stay absent — they are already off.
+	DisableAllForAccount(ctx context.Context, accountID int64, notificationTypes []string) error
 }

--- a/backend/models/users/notification_preference.go
+++ b/backend/models/users/notification_preference.go
@@ -1,0 +1,56 @@
+package users
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// NotificationPreference records that one account agreed (or explicitly
+// declined) to receive one type of notification at one school.
+//
+// Absence of a row means "not agreed". A row with Enabled=false is a deliberate
+// opt-out and is kept as such, so a later change of defaults cannot silently
+// overrule a decision someone already made.
+type NotificationPreference struct {
+	base.Model `bun:"schema:users,table:notification_preferences"`
+	base.TenantModel
+	AccountID        int64  `bun:"account_id,notnull" json:"account_id"`
+	NotificationType string `bun:"notification_type,notnull" json:"notification_type"`
+	Enabled          bool   `bun:"enabled,notnull" json:"enabled"`
+}
+
+// Validate ensures the preference identifies an account and a type.
+func (p *NotificationPreference) Validate() error {
+	if p.AccountID <= 0 {
+		return errors.New("account ID is required")
+	}
+	if p.NotificationType == "" {
+		return errors.New("notification type is required")
+	}
+	return nil
+}
+
+// NotificationPreferenceRepository stores per-account notification opt-ins.
+type NotificationPreferenceRepository interface {
+	base.CRUDRepository[*NotificationPreference]
+
+	// Upsert records one decision, overwriting any previous one for the same
+	// (tenant, account, type).
+	Upsert(ctx context.Context, pref *NotificationPreference) error
+
+	// ListByAccount returns every stored decision of one account in the current
+	// tenant. Types the account never touched are simply absent.
+	ListByAccount(ctx context.Context, accountID int64) ([]*NotificationPreference, error)
+
+	// FilterOptedIn narrows a producer's candidate recipients to those who
+	// agreed to the given type. This is the enforcement point for "nothing is
+	// delivered without consent": an empty input, or nobody having agreed,
+	// returns an empty result and never the full list.
+	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
+
+	// DisableAllForAccount switches every stored decision of one account off.
+	// Types with no row stay absent — they are already off.
+	DisableAllForAccount(ctx context.Context, accountID int64) error
+}

--- a/backend/models/users/parent_announcement.go
+++ b/backend/models/users/parent_announcement.go
@@ -138,6 +138,7 @@ type AnnouncementFeedItem struct {
 // AnnouncementRecipient is one guardian to e-mail when an announcement that
 // opted into e-mail is published: their address and name (for the greeting).
 type AnnouncementRecipient struct {
+	AccountID int64  `bun:"account_id"`
 	Email     string `bun:"email"`
 	FirstName string `bun:"first_name"`
 	LastName  string `bun:"last_name"`

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -268,6 +268,11 @@ type StaffRepository interface {
 	// (staff → person → account join). Used for absence-decision emails (#1419).
 	GetStaffContactInfo(ctx context.Context, staffID int64) (*StaffWithRoleInfo, error)
 
+	// ListAccountIDsByStaffIDs maps the given staff members to their login
+	// accounts. Staff without an account are omitted rather than mapped to
+	// zero. For callers that address people by account instead of by staff row.
+	ListAccountIDsByStaffIDs(ctx context.Context, staffIDs []int64) (map[int64]int64, error)
+
 	// ListStaffByRoles retrieves staff members who have any of the specified roles,
 	// including their person data, account ID, and email, using a single JOIN query.
 	ListStaffByRoles(ctx context.Context, roles []string) ([]*StaffWithRoleInfo, error)

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -273,6 +273,11 @@ type StaffRepository interface {
 	// zero. For callers that address people by account instead of by staff row.
 	ListAccountIDsByStaffIDs(ctx context.Context, staffIDs []int64) (map[int64]int64, error)
 
+	// ListAllStaffAccountIDs maps every staff member of the current tenant who
+	// can log in to their account: active account, active tenant mapping. The
+	// candidate set for anything addressed at the whole team.
+	ListAllStaffAccountIDs(ctx context.Context) (map[int64]int64, error)
+
 	// ListStaffByRoles retrieves staff members who have any of the specified roles,
 	// including their person data, account ID, and email, using a single JOIN query.
 	ListStaffByRoles(ctx context.Context, roles []string) ([]*StaffWithRoleInfo, error)

--- a/backend/realtime/broadcaster.go
+++ b/backend/realtime/broadcaster.go
@@ -20,6 +20,11 @@ type Broadcaster interface {
 	// Fire-and-forget.
 	BroadcastToTenantAdmins(tenantID int64, event Event) error
 
+	// BroadcastToStaffAccounts wakes only the addressed staff accounts' clients
+	// within one tenant. This is the transport for personal notifications,
+	// where each recipient gets their own payload. Fire-and-forget.
+	BroadcastToStaffAccounts(tenantID int64, accountIDs []int64, event Event) error
+
 	// BroadcastToAll sends an event to every connected client regardless of group subscriptions.
 	// Used for global dashboard count refreshes. Fire-and-forget.
 	BroadcastToAll(event Event) error

--- a/backend/realtime/hub.go
+++ b/backend/realtime/hub.go
@@ -23,6 +23,13 @@ type Client struct {
 	// match tenant/group broadcasts, only BroadcastParentMessage addressed to
 	// their guardian account.
 	IsParent bool
+	// AccountID is auth.accounts.id, carried explicitly because UserID is NOT
+	// interchangeable with it: for staff clients UserID is users.staff.id, for
+	// parent clients it is the account id, and for an effective admin without a
+	// staff record it is 0. Address account-scoped notifications through this
+	// field only — indexing on UserID would collide every staff-less admin
+	// under one key.
+	AccountID int64
 }
 
 // tenantGroupKey builds a composite map key for tenant-isolated group lookups.
@@ -56,8 +63,12 @@ type Hub struct {
 	// RegisterParent / Unregister.
 	guardianClients map[int64][]*Client
 	tenantClients   map[int64][]*Client
-	mu              sync.RWMutex
-	logger          *slog.Logger
+	// staffAccountClients indexes staff clients by auth.accounts.id so a
+	// personal notification reaches its recipient without scanning the tenant.
+	// Maintained in Register / Unregister alongside the other indexes.
+	staffAccountClients map[int64][]*Client
+	mu                  sync.RWMutex
+	logger              *slog.Logger
 }
 
 // getLogger returns a nil-safe logger, falling back to slog.Default() if logger is nil
@@ -68,11 +79,12 @@ func (h *Hub) getLogger() *slog.Logger {
 // NewHub creates a new SSE hub
 func NewHub(logger *slog.Logger) *Hub {
 	return &Hub{
-		clients:         make(map[*Client]bool),
-		groupClients:    make(map[string][]*Client),
-		guardianClients: make(map[int64][]*Client),
-		tenantClients:   make(map[int64][]*Client),
-		logger:          logger,
+		clients:             make(map[*Client]bool),
+		groupClients:        make(map[string][]*Client),
+		guardianClients:     make(map[int64][]*Client),
+		tenantClients:       make(map[int64][]*Client),
+		staffAccountClients: make(map[int64][]*Client),
+		logger:              logger,
 	}
 }
 
@@ -93,6 +105,12 @@ func (h *Hub) Register(client *Client, tenantID int64, activeGroupIDs []string) 
 	h.clients[client] = true
 	// Index staff clients by tenant for O(recipients) parent-message fan-out.
 	h.tenantClients[tenantID] = append(h.tenantClients[tenantID], client)
+	// Index by login account so a personal notification can address exactly one
+	// person. Guarded on > 0 because an effective admin without a staff record
+	// may connect before an account id is known.
+	if client.AccountID > 0 {
+		h.staffAccountClients[client.AccountID] = append(h.staffAccountClients[client.AccountID], client)
+	}
 
 	// Subscribe client to each active group using composite keys
 	for _, groupID := range activeGroupIDs {
@@ -153,6 +171,14 @@ func (h *Hub) Unregister(client *Client) {
 		h.tenantClients[client.TenantID] = removeClient(h.tenantClients[client.TenantID], client)
 		if len(h.tenantClients[client.TenantID]) == 0 {
 			delete(h.tenantClients, client.TenantID)
+		}
+		// Must be cleaned up here too: the channel is closed below, and an
+		// entry left behind would make a later broadcast send on it and panic.
+		if client.AccountID > 0 {
+			h.staffAccountClients[client.AccountID] = removeClient(h.staffAccountClients[client.AccountID], client)
+			if len(h.staffAccountClients[client.AccountID]) == 0 {
+				delete(h.staffAccountClients, client.AccountID)
+			}
 		}
 	}
 
@@ -300,6 +326,50 @@ func (h *Hub) BroadcastToTenantAdmins(tenantID int64, event Event) error {
 		slog.Int("recipient_count", recipients),
 	)
 	observability.RecordSSEBroadcast(tenantID, string(event.Type), "tenant_admin", droppedCount)
+	return nil
+}
+
+// BroadcastToStaffAccounts wakes only the addressed staff accounts' clients in
+// ONE tenant.
+//
+// The tenant check is load-bearing rather than defensive: an account can hold
+// staff sessions at several schools, and without it one school's personal
+// counts would land in another school's tab.
+func (h *Hub) BroadcastToStaffAccounts(tenantID int64, accountIDs []int64, event Event) error {
+	if len(accountIDs) == 0 {
+		return nil
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	recipients := 0
+	droppedCount := 0
+	for _, accountID := range accountIDs {
+		for _, client := range h.staffAccountClients[accountID] {
+			if client.TenantID != tenantID {
+				continue
+			}
+			recipients++
+			select {
+			case client.Channel <- event:
+			default:
+				droppedCount++
+				h.getLogger().Warn("SSE client channel full, skipping staff broadcast",
+					slog.Int64("account_id", accountID),
+					slog.Int64("tenant_id", tenantID),
+					slog.String("event_type", string(event.Type)),
+				)
+			}
+		}
+	}
+
+	h.getLogger().Debug("SSE event broadcast to staff accounts",
+		slog.Int64("tenant_id", tenantID),
+		slog.String("event_type", string(event.Type)),
+		slog.Int("recipient_count", recipients),
+	)
+	observability.RecordSSEBroadcast(tenantID, string(event.Type), "staff_account", droppedCount)
 	return nil
 }
 

--- a/backend/realtime/hub_broadcast_to_staff_accounts_test.go
+++ b/backend/realtime/hub_broadcast_to_staff_accounts_test.go
@@ -1,0 +1,121 @@
+package realtime
+
+import (
+	"testing"
+)
+
+func staffClient(accountID, tenantID int64, staffID int64) *Client {
+	return &Client{
+		Channel:          make(chan Event, 1),
+		UserID:           staffID,
+		AccountID:        accountID,
+		SubscribedGroups: make(map[string]bool),
+	}
+}
+
+func received(t *testing.T, client *Client) bool {
+	t.Helper()
+	select {
+	case <-client.Channel:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestBroadcastToStaffAccountsAddressesExactlyTheNamedAccounts pins the
+// transport for personal notifications. Every case here is one where reaching
+// the wrong tab would show someone a count derived from data they may not read.
+func TestBroadcastToStaffAccountsAddressesExactlyTheNamedAccounts(t *testing.T) {
+	hub := NewHub(nil)
+
+	addressed := staffClient(11, 100, 1)
+	bystander := staffClient(22, 100, 2)
+	hub.Register(addressed, 100, nil)
+	hub.Register(bystander, 100, nil)
+
+	require := func(cond bool, msg string) {
+		t.Helper()
+		if !cond {
+			t.Fatal(msg)
+		}
+	}
+
+	err := hub.BroadcastToStaffAccounts(100, []int64{11}, Event{Type: EventNotification})
+	require(err == nil, "broadcast must not error")
+
+	require(received(t, addressed), "the named account must receive the event")
+	require(!received(t, bystander), "a personal notification must not reach a bystander")
+}
+
+// TestBroadcastToStaffAccountsIsTenantScoped is the cross-tenant guard: one
+// person can hold staff sessions at several schools, and school A's counts must
+// never land in school B's tab.
+func TestBroadcastToStaffAccountsIsTenantScoped(t *testing.T) {
+	hub := NewHub(nil)
+
+	atSchoolA := staffClient(11, 100, 1)
+	atSchoolB := staffClient(11, 200, 2)
+	hub.Register(atSchoolA, 100, nil)
+	hub.Register(atSchoolB, 200, nil)
+
+	if err := hub.BroadcastToStaffAccounts(100, []int64{11}, Event{Type: EventNotification}); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+
+	if !received(t, atSchoolA) {
+		t.Fatal("the session at the addressed school must receive the event")
+	}
+	if received(t, atSchoolB) {
+		t.Fatal("the same account's session at another school must not receive it")
+	}
+}
+
+// TestBroadcastToStaffAccountsSkipsUnregisteredClients guards the panic path:
+// Unregister closes the channel, so an index entry left behind would make the
+// next broadcast send on a closed channel.
+func TestBroadcastToStaffAccountsSkipsUnregisteredClients(t *testing.T) {
+	hub := NewHub(nil)
+
+	client := staffClient(11, 100, 1)
+	hub.Register(client, 100, nil)
+	hub.Unregister(client)
+
+	if err := hub.BroadcastToStaffAccounts(100, []int64{11}, Event{Type: EventNotification}); err != nil {
+		t.Fatalf("broadcast after unregister must be a no-op, got %v", err)
+	}
+}
+
+// TestBroadcastToStaffAccountsEmptyRecipients pins that an empty recipient list
+// stays empty. Widening it into a tenant-wide send is the worst possible
+// interpretation of "nobody was addressed".
+func TestBroadcastToStaffAccountsEmptyRecipients(t *testing.T) {
+	hub := NewHub(nil)
+
+	client := staffClient(11, 100, 1)
+	hub.Register(client, 100, nil)
+
+	if err := hub.BroadcastToStaffAccounts(100, nil, Event{Type: EventNotification}); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+	if received(t, client) {
+		t.Fatal("an empty recipient list must reach nobody")
+	}
+}
+
+// TestRegisterIgnoresZeroAccountID covers the effective admin without a staff
+// record: their account id may be unknown, and bucketing them under 0 would
+// merge every such admin across every school into one recipient.
+func TestRegisterIgnoresZeroAccountID(t *testing.T) {
+	hub := NewHub(nil)
+
+	anonymous := staffClient(0, 100, 0)
+	hub.Register(anonymous, 100, nil)
+
+	if err := hub.BroadcastToStaffAccounts(100, []int64{0}, Event{Type: EventNotification}); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+	if received(t, anonymous) {
+		t.Fatal("account id 0 must not be addressable")
+	}
+}

--- a/backend/services/absence/excused_request_errorpath_test.go
+++ b/backend/services/absence/excused_request_errorpath_test.go
@@ -399,10 +399,12 @@ func TestDecide_ApprovalNotifiesAfterCommit(t *testing.T) {
 		tenantID  int64 = 31
 		studentID int64 = 9
 		reviewer  int64 = 77
+		submitter int64 = 88
 	)
 	today := timezone.TodayDate()
 	row := pendingRow(5, studentID, today)
 	row.TenantID = tenantID
+	row.SubmittedBy = submitter
 	student := &usersModels.Student{}
 	student.ID = studentID
 
@@ -443,4 +445,5 @@ func TestDecide_ApprovalNotifiesAfterCommit(t *testing.T) {
 	assert.Equal(t, []timezone.Date{today}, report.Dates)
 	assert.True(t, report.FromParent)
 	assert.Equal(t, reviewer, report.ActorAccountID)
+	assert.Equal(t, []int64{submitter}, report.ExcludedAccountIDs)
 }

--- a/backend/services/absence/excused_request_errorpath_test.go
+++ b/backend/services/absence/excused_request_errorpath_test.go
@@ -13,6 +13,8 @@ import (
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	absenceSvc "github.com/moto-nrw/project-phoenix/services/absence"
+	notificationsSvc "github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // errBoom is the injected repository failure used across the error-path tests.
@@ -106,10 +108,17 @@ func (r *fakeStudentRepo) Update(ctx context.Context, s *usersModels.Student) er
 type fakePersonRepo struct {
 	usersModels.PersonRepository
 	findByIDs func(context.Context, []int64) (map[int64]*usersModels.Person, error)
+	findByID  func(context.Context, any) (*usersModels.Person, error)
 }
 
 func (r *fakePersonRepo) FindByIDs(ctx context.Context, ids []int64) (map[int64]*usersModels.Person, error) {
 	return r.findByIDs(ctx, ids)
+}
+func (r *fakePersonRepo) FindByID(ctx context.Context, id any) (*usersModels.Person, error) {
+	if r.findByID == nil {
+		return nil, nil
+	}
+	return r.findByID(ctx, id)
 }
 
 type fakeStatusRepo struct {
@@ -375,4 +384,63 @@ func TestErrorPath_Decide_ReloadError(t *testing.T) {
 	_, err := svc.Decide(adminCtx(), absenceSvc.ExcusedRequestDecideInput{RequestID: 5, Approve: false, Reason: "abgelehnt"})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "boom")
+}
+
+type recordingAbsenceNotifier struct {
+	reports []notificationsSvc.AbsenceReport
+}
+
+func (n *recordingAbsenceNotifier) NotifyAbsenceReported(_ context.Context, report notificationsSvc.AbsenceReport) {
+	n.reports = append(n.reports, report)
+}
+
+func TestDecide_ApprovalNotifiesAfterCommit(t *testing.T) {
+	const (
+		tenantID  int64 = 31
+		studentID int64 = 9
+		reviewer  int64 = 77
+	)
+	today := timezone.TodayDate()
+	row := pendingRow(5, studentID, today)
+	row.TenantID = tenantID
+	student := &usersModels.Student{}
+	student.ID = studentID
+
+	svc := newFakeService(&fakeReqRepo{
+		findPending: func(context.Context, int64) (*activeModels.ExcusedAbsenceRequest, error) {
+			return row, nil
+		},
+		decide: func(context.Context, int64, string, *string, *int64, bool) error {
+			return nil
+		},
+		findByID: func(context.Context, any) (*activeModels.ExcusedAbsenceRequest, error) {
+			return row, nil
+		},
+	}, okStatusRepo(), &fakeStudentRepo{
+		findByID:          func(context.Context, any) (*usersModels.Student, error) { return student, nil },
+		findByIDForUpdate: func(context.Context, int64) (*usersModels.Student, error) { return student, nil },
+		update:            func(context.Context, *usersModels.Student) error { return nil },
+	}, &fakePersonRepo{})
+	notifier := &recordingAbsenceNotifier{}
+	svc.(absenceSvc.AbsenceNotifierSetter).SetAbsenceNotifier(notifier)
+
+	baseCtx := tenant.WithTenantID(adminCtx(), tenantID)
+	ctx, commit := tenant.WithAfterCommitHooksForTest(baseCtx)
+	_, err := svc.Decide(ctx, absenceSvc.ExcusedRequestDecideInput{
+		RequestID:  5,
+		Approve:    true,
+		ReviewedBy: reviewer,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, notifier.reports, "the notification must not run before the decision commits")
+
+	commit()
+	require.Len(t, notifier.reports, 1)
+	report := notifier.reports[0]
+	assert.Equal(t, tenantID, report.TenantID)
+	assert.Equal(t, []int64{studentID}, report.StudentIDs)
+	assert.Equal(t, activeModels.StudentStatusDayExcused, report.Status)
+	assert.Equal(t, []timezone.Date{today}, report.Dates)
+	assert.True(t, report.FromParent)
+	assert.Equal(t, reviewer, report.ActorAccountID)
 }

--- a/backend/services/absence/excused_request_service.go
+++ b/backend/services/absence/excused_request_service.go
@@ -25,6 +25,7 @@ import (
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	userContextService "github.com/moto-nrw/project-phoenix/services/usercontext"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -123,6 +124,12 @@ type ExcusedAbsenceRequestService interface {
 	Decide(ctx context.Context, input ExcusedRequestDecideInput) (*ExcusedRequestReviewItem, error)
 }
 
+// AbsenceNotifierSetter injects the notification producer after construction.
+// The notification stack is built after this service in the factory.
+type AbsenceNotifierSetter interface {
+	SetAbsenceNotifier(notifier notificationsService.AbsenceNotifier)
+}
+
 type excusedAbsenceRequestService struct {
 	requestRepo   activeModels.ExcusedAbsenceRequestRepository
 	statusDayRepo activeModels.StudentStatusDayRepository
@@ -131,6 +138,7 @@ type excusedAbsenceRequestService struct {
 	userContext   userContextService.UserContextService
 	emitter       *parentmessaging.Emitter
 	broadcaster   realtime.Broadcaster
+	absenceNotify notificationsService.AbsenceNotifier
 	logger        *slog.Logger
 }
 
@@ -158,6 +166,11 @@ func NewExcusedAbsenceRequestService(
 		broadcaster:   broadcaster,
 		logger:        logger,
 	}
+}
+
+// SetAbsenceNotifier implements AbsenceNotifierSetter.
+func (s *excusedAbsenceRequestService) SetAbsenceNotifier(notifier notificationsService.AbsenceNotifier) {
+	s.absenceNotify = notifier
 }
 
 func (s *excusedAbsenceRequestService) CreateRequest(ctx context.Context, studentID, guardianAccountID int64, dates []timezone.Date, note string) (*activeModels.ExcusedAbsenceRequest, error) {
@@ -497,6 +510,23 @@ func (s *excusedAbsenceRequestService) Decide(ctx context.Context, input Excused
 	}
 
 	if input.Approve {
+		if s.absenceNotify != nil {
+			tenantID := req.TenantID
+			if tenantID <= 0 {
+				tenantID = tenant.FromContext(ctx)
+			}
+			report := notificationsService.AbsenceReport{
+				TenantID:       tenantID,
+				StudentIDs:     []int64{req.StudentID},
+				Status:         activeModels.StudentStatusDayExcused,
+				Dates:          req.Dates,
+				FromParent:     true,
+				ActorAccountID: input.ReviewedBy,
+			}
+			tenant.RegisterAfterCommit(ctx, func() {
+				s.absenceNotify.NotifyAbsenceReported(context.Background(), report)
+			})
+		}
 		tenant.RegisterAfterCommit(ctx, func() {
 			s.logger.Info("excused request approved",
 				slog.Int64("request_id", req.ID),

--- a/backend/services/absence/excused_request_service.go
+++ b/backend/services/absence/excused_request_service.go
@@ -516,12 +516,13 @@ func (s *excusedAbsenceRequestService) Decide(ctx context.Context, input Excused
 				tenantID = tenant.FromContext(ctx)
 			}
 			report := notificationsService.AbsenceReport{
-				TenantID:       tenantID,
-				StudentIDs:     []int64{req.StudentID},
-				Status:         activeModels.StudentStatusDayExcused,
-				Dates:          req.Dates,
-				FromParent:     true,
-				ActorAccountID: input.ReviewedBy,
+				TenantID:           tenantID,
+				StudentIDs:         []int64{req.StudentID},
+				Status:             activeModels.StudentStatusDayExcused,
+				Dates:              req.Dates,
+				FromParent:         true,
+				ActorAccountID:     input.ReviewedBy,
+				ExcludedAccountIDs: []int64{req.SubmittedBy},
 			}
 			tenant.RegisterAfterCommit(ctx, func() {
 				s.absenceNotify.NotifyAbsenceReported(context.Background(), report)

--- a/backend/services/absence/excused_request_service_test.go
+++ b/backend/services/absence/excused_request_service_test.go
@@ -43,6 +43,10 @@ type countingBroadcaster struct {
 }
 
 func (b *countingBroadcaster) BroadcastToGroup(int64, string, realtime.Event) error { return nil }
+func (b *countingBroadcaster) BroadcastToStaffAccounts(_ int64, _ []int64, _ realtime.Event) error {
+	return nil
+}
+
 func (b *countingBroadcaster) BroadcastToTenant(_ int64, event realtime.Event) error {
 	b.tenantBroadcasts++
 	b.tenantEvents = append(b.tenantEvents, event.Type)

--- a/backend/services/active/end_session_unit_test.go
+++ b/backend/services/active/end_session_unit_test.go
@@ -344,6 +344,10 @@ func (m *mockVisitRepository) FindActiveVisits(ctx context.Context) ([]*active.V
 	return nil, nil
 }
 
+func (m *mockVisitRepository) ListOpenVisitStudentIDsByRoom(ctx context.Context) (map[int64][]int64, error) {
+	return nil, nil
+}
+
 func (m *mockVisitRepository) EndVisitsByActiveGroupIDs(ctx context.Context, activeGroupIDs []int64) (int64, error) {
 	if m.endVisitsByActiveGroupIDsFunc != nil {
 		return m.endVisitsByActiveGroupIDsFunc(ctx, activeGroupIDs)
@@ -402,6 +406,10 @@ func (m *mockGroupSupervisorRepository) List(ctx context.Context, options *base.
 }
 
 func (m *mockGroupSupervisorRepository) FindActiveByStaffID(ctx context.Context, staffID int64) ([]*active.GroupSupervisor, error) {
+	return nil, nil
+}
+
+func (m *mockGroupSupervisorRepository) ListActiveSupervisedRooms(ctx context.Context) ([]active.StaffRoomSupervision, error) {
 	return nil, nil
 }
 

--- a/backend/services/active/student_status_day_write.go
+++ b/backend/services/active/student_status_day_write.go
@@ -32,6 +32,10 @@ type StatusDayWriteContext struct {
 	StudentService users.StudentService
 	Authorize      func(ctx context.Context, student *userModels.Student) bool
 	AfterCommit    func(studentID int64)
+	// AfterCreateCommit receives the whole submission once after commit. It is
+	// separate from AfterCommit so bulk writes can emit one aggregate absence
+	// notification while retaining the per-student SSE fan-out.
+	AfterCreateCommit func(studentIDs []int64)
 }
 
 // CreateForDates records the reported status for one student across the given
@@ -47,6 +51,9 @@ func (s *StudentStatusDayService) CreateForDates(ctx context.Context, wc StatusD
 			return err
 		}
 		tenant.RegisterAfterCommit(ctx, func() { wc.AfterCommit(studentID) })
+		if wc.AfterCreateCommit != nil {
+			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCreateCommit([]int64{studentID}) })
+		}
 		return nil
 	})
 }
@@ -64,6 +71,9 @@ func (s *StudentStatusDayService) BulkCreateForDates(ctx context.Context, wc Sta
 			}
 			studentID := studentID
 			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCommit(studentID) })
+		}
+		if wc.AfterCreateCommit != nil {
+			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCreateCommit(studentIDs) })
 		}
 		return nil
 	})

--- a/backend/services/active/student_status_day_write.go
+++ b/backend/services/active/student_status_day_write.go
@@ -32,9 +32,10 @@ type StatusDayWriteContext struct {
 	StudentService users.StudentService
 	Authorize      func(ctx context.Context, student *userModels.Student) bool
 	AfterCommit    func(studentID int64)
-	// AfterCreateCommit receives the whole submission once after commit. It is
-	// separate from AfterCommit so bulk writes can emit one aggregate absence
-	// notification while retaining the per-student SSE fan-out.
+	// AfterCreateCommit receives the students whose current-day status newly
+	// became a reportable absence, once after commit. It is separate from
+	// AfterCommit so bulk writes can emit one aggregate absence notification
+	// while retaining the per-student SSE fan-out.
 	AfterCreateCommit func(studentIDs []int64)
 }
 
@@ -47,11 +48,12 @@ func (s *StudentStatusDayService) CreateForDates(ctx context.Context, wc StatusD
 	today := timezone.TodayDate()
 	notePtr := strutil.TrimPtrToNil(&reason)
 	return tenant.WithTenantTx(ctx, wc.DB, wc.TenantID, func(ctx context.Context, _ bun.Tx) error {
-		if err := s.writeStatusForStudent(ctx, wc, studentID, status, dates, notePtr, now, today); err != nil {
+		notifyAbsence, err := s.writeStatusForStudent(ctx, wc, studentID, status, dates, notePtr, now, today)
+		if err != nil {
 			return err
 		}
 		tenant.RegisterAfterCommit(ctx, func() { wc.AfterCommit(studentID) })
-		if wc.AfterCreateCommit != nil {
+		if notifyAbsence && wc.AfterCreateCommit != nil {
 			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCreateCommit([]int64{studentID}) })
 		}
 		return nil
@@ -66,15 +68,20 @@ func (s *StudentStatusDayService) BulkCreateForDates(ctx context.Context, wc Sta
 	today := timezone.TodayDate()
 	notePtr := strutil.TrimPtrToNil(&reason)
 	return tenant.WithTenantTx(ctx, wc.DB, wc.TenantID, func(ctx context.Context, _ bun.Tx) error {
+		absenceStudentIDs := make([]int64, 0, len(studentIDs))
 		for _, studentID := range studentIDs {
-			if err := s.writeStatusForStudent(ctx, wc, studentID, status, dates, notePtr, now, today); err != nil {
+			notifyAbsence, err := s.writeStatusForStudent(ctx, wc, studentID, status, dates, notePtr, now, today)
+			if err != nil {
 				return err
+			}
+			if notifyAbsence {
+				absenceStudentIDs = append(absenceStudentIDs, studentID)
 			}
 			studentID := studentID
 			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCommit(studentID) })
 		}
-		if wc.AfterCreateCommit != nil {
-			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCreateCommit(studentIDs) })
+		if len(absenceStudentIDs) > 0 && wc.AfterCreateCommit != nil {
+			tenant.RegisterAfterCommit(ctx, func() { wc.AfterCreateCommit(absenceStudentIDs) })
 		}
 		return nil
 	})
@@ -130,17 +137,18 @@ func (s *StudentStatusDayService) DeleteByID(ctx context.Context, wc StatusDayWr
 	})
 }
 
-func (s *StudentStatusDayService) writeStatusForStudent(ctx context.Context, wc StatusDayWriteContext, studentID int64, status string, dates []timezone.Date, notePtr *string, now time.Time, today timezone.Date) error {
+func (s *StudentStatusDayService) writeStatusForStudent(ctx context.Context, wc StatusDayWriteContext, studentID int64, status string, dates []timezone.Date, notePtr *string, now time.Time, today timezone.Date) (bool, error) {
 	fresh, err := wc.StudentService.GetByIDForUpdate(ctx, studentID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !wc.Authorize(ctx, fresh) {
-		return ErrStudentStatusDayReassigned
+		return false, ErrStudentStatusDayReassigned
 	}
 
+	notifyAbsence := isNewReportableAbsence(fresh, status, dates, today)
 	if err := s.clearOtherStatusDaysForDates(ctx, fresh.ID, status, dates, now); err != nil {
-		return err
+		return false, err
 	}
 	for _, date := range dates {
 		if err := s.repo.UpsertReported(ctx, &activeModels.StudentStatusDay{
@@ -151,16 +159,30 @@ func (s *StudentStatusDayService) writeStatusForStudent(ctx context.Context, wc 
 			Source:     activeModels.StudentStatusSourcePlanned,
 			Note:       notePtr,
 		}); err != nil {
-			return err
+			return false, err
 		}
 	}
 	if slices.Contains(dates, today) {
 		ApplyLiveStatusForToday(fresh, status, now)
 		if err := wc.StudentService.Update(ctx, fresh); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return notifyAbsence, nil
+}
+
+func isNewReportableAbsence(student *userModels.Student, status string, dates []timezone.Date, today timezone.Date) bool {
+	if !slices.Contains(dates, today) {
+		return false
+	}
+	switch status {
+	case activeModels.StudentStatusDaySick:
+		return student.Sick == nil || !*student.Sick
+	case activeModels.StudentStatusDayExcused:
+		return student.Excused == nil || !*student.Excused
+	default:
+		return false
+	}
 }
 
 func (s *StudentStatusDayService) clearOtherStatusDaysForDates(ctx context.Context, studentID int64, status string, dates []timezone.Date, now time.Time) error {

--- a/backend/services/active/student_status_day_write.go
+++ b/backend/services/active/student_status_day_write.go
@@ -61,6 +61,7 @@ func (s *StudentStatusDayService) CreateForDates(ctx context.Context, wc StatusD
 // BulkCreateForDates applies CreateForDates' orchestration to several students
 // within a single tenant transaction.
 func (s *StudentStatusDayService) BulkCreateForDates(ctx context.Context, wc StatusDayWriteContext, studentIDs []int64, status, reason string, dates []timezone.Date) error {
+	studentIDs = dedupeStudentIDs(studentIDs)
 	now := time.Now()
 	today := timezone.TodayDate()
 	notePtr := strutil.TrimPtrToNil(&reason)
@@ -77,6 +78,19 @@ func (s *StudentStatusDayService) BulkCreateForDates(ctx context.Context, wc Sta
 		}
 		return nil
 	})
+}
+
+func dedupeStudentIDs(studentIDs []int64) []int64 {
+	seen := make(map[int64]struct{}, len(studentIDs))
+	unique := make([]int64, 0, len(studentIDs))
+	for _, studentID := range studentIDs {
+		if _, exists := seen[studentID]; exists {
+			continue
+		}
+		seen[studentID] = struct{}{}
+		unique = append(unique, studentID)
+	}
+	return unique
 }
 
 // DeleteByID clears a single status-day row after ownership and locked-row

--- a/backend/services/active/student_status_day_write_internal_test.go
+++ b/backend/services/active/student_status_day_write_internal_test.go
@@ -1,0 +1,12 @@
+package active
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDedupeStudentIDsPreservesFirstOccurrenceOrder(t *testing.T) {
+	assert.Equal(t, []int64{7, 3, 9}, dedupeStudentIDs([]int64{7, 3, 7, 9, 3}))
+	assert.Empty(t, dedupeStudentIDs(nil))
+}

--- a/backend/services/active/student_status_day_write_internal_test.go
+++ b/backend/services/active/student_status_day_write_internal_test.go
@@ -3,10 +3,51 @@ package active
 import (
 	"testing"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDedupeStudentIDsPreservesFirstOccurrenceOrder(t *testing.T) {
 	assert.Equal(t, []int64{7, 3, 9}, dedupeStudentIDs([]int64{7, 3, 7, 9, 3}))
 	assert.Empty(t, dedupeStudentIDs(nil))
+}
+
+func TestIsNewReportableAbsence(t *testing.T) {
+	today := timezone.NewDate(2026, 7, 29)
+	yesterday := timezone.NewDate(2026, 7, 28)
+	trueValue := true
+	falseValue := false
+
+	assert.True(t, isNewReportableAbsence(
+		&userModels.Student{Sick: &falseValue},
+		activeModels.StudentStatusDaySick,
+		[]timezone.Date{today},
+		today,
+	))
+	assert.False(t, isNewReportableAbsence(
+		&userModels.Student{Sick: &trueValue},
+		activeModels.StudentStatusDaySick,
+		[]timezone.Date{today},
+		today,
+	), "re-saving the current status must not notify again")
+	assert.True(t, isNewReportableAbsence(
+		&userModels.Student{Sick: &trueValue, Excused: &falseValue},
+		activeModels.StudentStatusDayExcused,
+		[]timezone.Date{today},
+		today,
+	), "changing the reportable absence type must notify")
+	assert.False(t, isNewReportableAbsence(
+		&userModels.Student{},
+		activeModels.StudentStatusDayClassTrip,
+		[]timezone.Date{today},
+		today,
+	))
+	assert.False(t, isNewReportableAbsence(
+		&userModels.Student{},
+		activeModels.StudentStatusDaySick,
+		[]timezone.Date{yesterday},
+		today,
+	))
 }

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -564,6 +564,10 @@ func (m *wsMockGroupSupervisorRepository) FindActiveByStaffID(ctx context.Contex
 	return nil, nil
 }
 
+func (m *wsMockGroupSupervisorRepository) ListActiveSupervisedRooms(ctx context.Context) ([]activeModels.StaffRoomSupervision, error) {
+	return nil, nil
+}
+
 func (m *wsMockGroupSupervisorRepository) FindByActiveGroupID(ctx context.Context, activeGroupID int64, activeOnly bool) ([]*activeModels.GroupSupervisor, error) {
 	if m.findByActiveGroupIDFunc != nil {
 		return m.findByActiveGroupIDFunc(ctx, activeGroupID, activeOnly)

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -335,15 +335,15 @@ func (s *service) Publish(ctx context.Context, id int64) (*usersModels.ParentAnn
 				return nil, fmt.Errorf("announcement: draft expired concurrently during publish; rolled back")
 			}
 			s.logger.Info("parent announcement published", slog.Int64("announcement_id", id))
-			deliveryAllowed, err := s.notifyAnnouncementGuardians(ctx, fresh)
-			if err != nil {
+			if err := s.notifyAnnouncementGuardians(ctx, fresh); err != nil {
 				return nil, fmt.Errorf("announcement: publish push notifications: %w", err)
 			}
-			// The notification router is the single enforcement point for the
-			// tenant dispatch switch and active window. E-mail is another
-			// delivery channel for the same event, so it must follow the same
-			// decision instead of bypassing those gates.
-			if fresh.SendEmail && deliveryAllowed {
+			// E-mail is deliberately independent of the push decision. The
+			// dispatch switch and the active window exist so a phone does not
+			// ring at night; an e-mail does not ring, and a school that opted
+			// into e-mail for an announcement expects it to leave. The e-mail
+			// path applies its own consent rule (see enqueueAnnouncementEmails).
+			if fresh.SendEmail {
 				if err := s.enqueueAnnouncementEmails(ctx, fresh); err != nil {
 					return nil, fmt.Errorf("announcement: publish e-mails: %w", err)
 				}
@@ -353,13 +353,13 @@ func (s *service) Publish(ctx context.Context, id int64) (*usersModels.ParentAnn
 	return s.Get(ctx, id)
 }
 
-func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModels.ParentAnnouncement) (bool, error) {
+func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModels.ParentAnnouncement) error {
 	if s.notifier == nil {
-		return false, nil
+		return nil
 	}
 	recipients, err := s.repo.AudienceRecipients(ctx, a.GetTenantID(), a.ID)
 	if err != nil {
-		return false, fmt.Errorf("resolve guardian recipients: %w", err)
+		return fmt.Errorf("resolve guardian recipients: %w", err)
 	}
 	priority := notifications.PriorityNormal
 	if a.Priority == usersModels.ParentAnnouncementPriorityImportant {
@@ -378,8 +378,9 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 		accountIDs = append(accountIDs, recipient.AccountID)
 	}
 	if len(accountIDs) == 0 {
-		return false, nil
+		return nil
 	}
+	candidateCount := len(accountIDs)
 
 	// Consent narrows the audience the announcement itself defined. A nil
 	// preference service means the dependency was never wired, which the
@@ -389,10 +390,17 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	if s.preferences != nil {
 		accountIDs, err = s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
 		if err != nil {
-			return false, fmt.Errorf("filter opted-in guardians: %w", err)
+			return fmt.Errorf("filter opted-in guardians: %w", err)
+		}
+		if len(accountIDs) < candidateCount {
+			s.logger.Info("parent announcement push narrowed by consent",
+				slog.Int64("announcement_id", a.ID),
+				slog.Int("candidate_count", candidateCount),
+				slog.Int("recipient_count", len(accountIDs)),
+			)
 		}
 		if len(accountIDs) == 0 {
-			return false, nil
+			return nil
 		}
 	}
 
@@ -409,12 +417,17 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 		},
 	})
 	if errors.Is(err, notifications.ErrDisabled) || errors.Is(err, notifications.ErrOutsideActiveWindow) {
-		return false, nil
+		s.logger.Info("parent announcement push suppressed by tenant notification gate",
+			slog.Int64("announcement_id", a.ID),
+			slog.Int("recipient_count", len(accountIDs)),
+			slog.String("reason", err.Error()),
+		)
+		return nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("notify guardian audience: %w", err)
+		return fmt.Errorf("notify guardian audience: %w", err)
 	}
-	return true, nil
+	return nil
 }
 
 // enqueueAnnouncementEmails queues one outbox e-mail per targeted guardian with
@@ -455,12 +468,16 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 			seen[recipient.AccountID] = struct{}{}
 			accountIDs = append(accountIDs, recipient.AccountID)
 		}
-		optedIn, err := s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
+		// E-mail honours an explicit "no" but not a missing decision: guardians
+		// received announcement e-mails before the consent switches existed, and
+		// most families have no row at all. Requiring an opt-in here would stop
+		// the e-mails for practically everybody.
+		remaining, err := s.preferences.FilterNotOptedOut(ctx, notifications.TypeParentAnnouncement, accountIDs)
 		if err != nil {
-			return fmt.Errorf("announcement: filter opted-in e-mail recipients: %w", err)
+			return fmt.Errorf("announcement: filter opted-out e-mail recipients: %w", err)
 		}
-		allowed := make(map[int64]struct{}, len(optedIn))
-		for _, accountID := range optedIn {
+		allowed := make(map[int64]struct{}, len(remaining))
+		for _, accountID := range remaining {
 			allowed[accountID] = struct{}{}
 		}
 		filtered := make([]*usersModels.AnnouncementRecipient, 0, len(recipients))
@@ -468,6 +485,13 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 			if _, ok := allowed[recipient.AccountID]; ok {
 				filtered = append(filtered, recipient)
 			}
+		}
+		if len(filtered) < len(recipients) {
+			s.logger.Info("parent announcement e-mails narrowed by opt-outs",
+				slog.Int64("announcement_id", a.ID),
+				slog.Int("candidate_count", len(recipients)),
+				slog.Int("recipient_count", len(filtered)),
+			)
 		}
 		recipients = filtered
 		if len(recipients) == 0 {

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -437,6 +437,38 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 	if len(recipients) == 0 {
 		return nil
 	}
+	if s.preferences != nil {
+		accountIDs := make([]int64, 0, len(recipients))
+		seen := make(map[int64]struct{}, len(recipients))
+		for _, recipient := range recipients {
+			if recipient.AccountID <= 0 {
+				continue
+			}
+			if _, exists := seen[recipient.AccountID]; exists {
+				continue
+			}
+			seen[recipient.AccountID] = struct{}{}
+			accountIDs = append(accountIDs, recipient.AccountID)
+		}
+		optedIn, err := s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
+		if err != nil {
+			return fmt.Errorf("announcement: filter opted-in e-mail recipients: %w", err)
+		}
+		allowed := make(map[int64]struct{}, len(optedIn))
+		for _, accountID := range optedIn {
+			allowed[accountID] = struct{}{}
+		}
+		filtered := make([]*usersModels.AnnouncementRecipient, 0, len(recipients))
+		for _, recipient := range recipients {
+			if _, ok := allowed[recipient.AccountID]; ok {
+				filtered = append(filtered, recipient)
+			}
+		}
+		recipients = filtered
+		if len(recipients) == 0 {
+			return nil
+		}
+	}
 	schoolName, err := s.repo.SchoolName(ctx, tenantID)
 	if err != nil {
 		return fmt.Errorf("announcement: resolve school name: %w", err)

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -98,21 +98,25 @@ type Service interface {
 // ServiceConfig is the dependency bundle. Outbox, Notifier and ParentsURL are
 // optional: nil delivery dependencies leave the in-app feed working.
 type ServiceConfig struct {
-	Repo       usersModels.ParentAnnouncementRepository
-	Settings   configService.SettingsService
-	Outbox     OutboxEnqueuer
-	Notifier   notifications.Service
-	ParentsURL string
-	Logger     *slog.Logger
+	Repo     usersModels.ParentAnnouncementRepository
+	Settings configService.SettingsService
+	Outbox   OutboxEnqueuer
+	Notifier notifications.Service
+	// Preferences gates the push by the guardian's own consent. Optional; when
+	// absent no guardian is notified at all, which is the safe direction.
+	Preferences notifications.PreferenceService
+	ParentsURL  string
+	Logger      *slog.Logger
 }
 
 type service struct {
-	repo       usersModels.ParentAnnouncementRepository
-	settings   configService.SettingsService
-	outbox     OutboxEnqueuer
-	notifier   notifications.Service
-	parentsURL string
-	logger     *slog.Logger
+	repo        usersModels.ParentAnnouncementRepository
+	settings    configService.SettingsService
+	outbox      OutboxEnqueuer
+	notifier    notifications.Service
+	preferences notifications.PreferenceService
+	parentsURL  string
+	logger      *slog.Logger
 }
 
 // NewService wires the staff announcement service.
@@ -122,12 +126,13 @@ func NewService(cfg ServiceConfig) Service {
 		logger = slog.Default()
 	}
 	return &service{
-		repo:       cfg.Repo,
-		settings:   cfg.Settings,
-		outbox:     cfg.Outbox,
-		notifier:   cfg.Notifier,
-		parentsURL: cfg.ParentsURL,
-		logger:     logger,
+		repo:        cfg.Repo,
+		settings:    cfg.Settings,
+		outbox:      cfg.Outbox,
+		notifier:    cfg.Notifier,
+		preferences: cfg.Preferences,
+		parentsURL:  cfg.ParentsURL,
+		logger:      logger,
 	}
 }
 
@@ -370,6 +375,22 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	if len(accountIDs) == 0 {
 		return nil
 	}
+
+	// Consent narrows the audience the announcement itself defined. A nil
+	// preference service means the dependency was never wired, which the
+	// factory always does — the pre-consent behaviour is kept for that case so
+	// a partially constructed service does not silently stop notifying. When a
+	// service IS present, its answer is final: no consent, no push.
+	if s.preferences != nil {
+		accountIDs, err = s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
+		if err != nil {
+			return fmt.Errorf("filter opted-in guardians: %w", err)
+		}
+		if len(accountIDs) == 0 {
+			return nil
+		}
+	}
+
 	err = s.notifier.Notify(ctx, notifications.Event{
 		Type:     parentAnnouncementNotificationType,
 		Title:    parentAnnouncementNotificationTitle,

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -403,7 +403,7 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 			GuardianAccountIDs: accountIDs,
 		},
 	})
-	if errors.Is(err, notifications.ErrDisabled) {
+	if errors.Is(err, notifications.ErrDisabled) || errors.Is(err, notifications.ErrOutsideActiveWindow) {
 		return nil
 	}
 	if err != nil {

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -335,10 +335,15 @@ func (s *service) Publish(ctx context.Context, id int64) (*usersModels.ParentAnn
 				return nil, fmt.Errorf("announcement: draft expired concurrently during publish; rolled back")
 			}
 			s.logger.Info("parent announcement published", slog.Int64("announcement_id", id))
-			if err := s.notifyAnnouncementGuardians(ctx, fresh); err != nil {
+			deliveryAllowed, err := s.notifyAnnouncementGuardians(ctx, fresh)
+			if err != nil {
 				return nil, fmt.Errorf("announcement: publish push notifications: %w", err)
 			}
-			if fresh.SendEmail {
+			// The notification router is the single enforcement point for the
+			// tenant dispatch switch and active window. E-mail is another
+			// delivery channel for the same event, so it must follow the same
+			// decision instead of bypassing those gates.
+			if fresh.SendEmail && deliveryAllowed {
 				if err := s.enqueueAnnouncementEmails(ctx, fresh); err != nil {
 					return nil, fmt.Errorf("announcement: publish e-mails: %w", err)
 				}
@@ -348,13 +353,13 @@ func (s *service) Publish(ctx context.Context, id int64) (*usersModels.ParentAnn
 	return s.Get(ctx, id)
 }
 
-func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModels.ParentAnnouncement) error {
+func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModels.ParentAnnouncement) (bool, error) {
 	if s.notifier == nil {
-		return nil
+		return false, nil
 	}
 	recipients, err := s.repo.AudienceRecipients(ctx, a.GetTenantID(), a.ID)
 	if err != nil {
-		return fmt.Errorf("resolve guardian recipients: %w", err)
+		return false, fmt.Errorf("resolve guardian recipients: %w", err)
 	}
 	priority := notifications.PriorityNormal
 	if a.Priority == usersModels.ParentAnnouncementPriorityImportant {
@@ -373,7 +378,7 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 		accountIDs = append(accountIDs, recipient.AccountID)
 	}
 	if len(accountIDs) == 0 {
-		return nil
+		return false, nil
 	}
 
 	// Consent narrows the audience the announcement itself defined. A nil
@@ -384,10 +389,10 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	if s.preferences != nil {
 		accountIDs, err = s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
 		if err != nil {
-			return fmt.Errorf("filter opted-in guardians: %w", err)
+			return false, fmt.Errorf("filter opted-in guardians: %w", err)
 		}
 		if len(accountIDs) == 0 {
-			return nil
+			return false, nil
 		}
 	}
 
@@ -404,12 +409,12 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 		},
 	})
 	if errors.Is(err, notifications.ErrDisabled) || errors.Is(err, notifications.ErrOutsideActiveWindow) {
-		return nil
+		return false, nil
 	}
 	if err != nil {
-		return fmt.Errorf("notify guardian audience: %w", err)
+		return false, fmt.Errorf("notify guardian audience: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // enqueueAnnouncementEmails queues one outbox e-mail per targeted guardian with

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -474,6 +474,25 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 			return nil
 		}
 	}
+	uniqueRecipients := make([]*usersModels.AnnouncementRecipient, 0, len(recipients))
+	seenEmails := make(map[string]struct{}, len(recipients))
+	for _, recipient := range recipients {
+		normalizedEmail := strings.ToLower(strings.TrimSpace(recipient.Email))
+		if normalizedEmail == "" {
+			continue
+		}
+		if _, exists := seenEmails[normalizedEmail]; exists {
+			continue
+		}
+		seenEmails[normalizedEmail] = struct{}{}
+		normalizedRecipient := *recipient
+		normalizedRecipient.Email = normalizedEmail
+		uniqueRecipients = append(uniqueRecipients, &normalizedRecipient)
+	}
+	recipients = uniqueRecipients
+	if len(recipients) == 0 {
+		return nil
+	}
 	schoolName, err := s.repo.SchoolName(ctx, tenantID)
 	if err != nil {
 		return fmt.Errorf("announcement: resolve school name: %w", err)

--- a/backend/services/announcement/service_methods_internal_test.go
+++ b/backend/services/announcement/service_methods_internal_test.go
@@ -406,9 +406,12 @@ func TestService_Publish_WithEmail(t *testing.T) {
 		publishIfDraft: func(_ context.Context, _ int64, _ time.Time) (bool, error) { return true, nil },
 		listTargetsFn:  func(_ context.Context, _ int64) ([]*usersModels.ParentAnnouncementTarget, error) { return nil, nil },
 		resolveEmailsFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipient, error) {
-			return []*usersModels.AnnouncementRecipient{{Email: "a@b.de", FirstName: "Ada", LastName: "L"}}, nil
+			return []*usersModels.AnnouncementRecipient{{AccountID: 101, Email: "a@b.de", FirstName: "Ada", LastName: "L"}}, nil
 		},
 		schoolNameFn: func(_ context.Context, _ int64) (string, error) { return "OGS Am Berg", nil },
+		audienceFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipientStatus, error) {
+			return []*usersModels.AnnouncementRecipientStatus{{AccountID: 101}}, nil
+		},
 	}
 	outbox := &stubOutbox{enqueueFn: func(_ context.Context, req platformService.EnqueueRequest) (*platformModels.EmailOutbox, error) {
 		enqueued++
@@ -423,6 +426,7 @@ func TestService_Publish_WithEmail(t *testing.T) {
 	svc := NewService(ServiceConfig{
 		Repo:       repo,
 		Settings:   stubSettings{newsEnabled: true, loginImageURL: "logo.png"},
+		Notifier:   &fakeNotifier{},
 		Outbox:     outbox,
 		ParentsURL: "https://parents.example",
 	})
@@ -591,8 +595,15 @@ func TestService_Publish_EmailNoOutbox(t *testing.T) {
 		},
 		publishIfDraft: func(_ context.Context, _ int64, _ time.Time) (bool, error) { return true, nil },
 		listTargetsFn:  func(_ context.Context, _ int64) ([]*usersModels.ParentAnnouncementTarget, error) { return nil, nil },
+		audienceFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipientStatus, error) {
+			return []*usersModels.AnnouncementRecipientStatus{{AccountID: 101}}, nil
+		},
 	}
-	svc := NewService(ServiceConfig{Repo: repo, Settings: stubSettings{newsEnabled: true}})
+	svc := NewService(ServiceConfig{
+		Repo:     repo,
+		Settings: stubSettings{newsEnabled: true},
+		Notifier: &fakeNotifier{},
+	})
 	if _, err := svc.Publish(context.Background(), testAnnID); err != nil {
 		t.Fatalf("Publish without outbox: %v", err)
 	}
@@ -668,9 +679,12 @@ func TestService_Publish_LogoLookupError_StillEnqueues(t *testing.T) {
 		publishIfDraft: func(_ context.Context, _ int64, _ time.Time) (bool, error) { return true, nil },
 		listTargetsFn:  func(_ context.Context, _ int64) ([]*usersModels.ParentAnnouncementTarget, error) { return nil, nil },
 		resolveEmailsFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipient, error) {
-			return []*usersModels.AnnouncementRecipient{{Email: "a@b.de"}}, nil
+			return []*usersModels.AnnouncementRecipient{{AccountID: 101, Email: "a@b.de"}}, nil
 		},
 		schoolNameFn: func(_ context.Context, _ int64) (string, error) { return "OGS", nil },
+		audienceFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipientStatus, error) {
+			return []*usersModels.AnnouncementRecipientStatus{{AccountID: 101}}, nil
+		},
 	}
 	outbox := &stubOutbox{enqueueFn: func(_ context.Context, req platformService.EnqueueRequest) (*platformModels.EmailOutbox, error) {
 		enqueued++
@@ -682,6 +696,7 @@ func TestService_Publish_LogoLookupError_StillEnqueues(t *testing.T) {
 	svc := NewService(ServiceConfig{
 		Repo:     repo,
 		Settings: stubSettings{newsEnabled: true, loginImageErr: errors.New("no logo")},
+		Notifier: &fakeNotifier{},
 		Outbox:   outbox,
 	})
 	if _, err := svc.Publish(context.Background(), testAnnID); err != nil {
@@ -702,12 +717,20 @@ func TestService_Publish_EmptyAudience(t *testing.T) {
 		publishIfDraft:  func(_ context.Context, _ int64, _ time.Time) (bool, error) { return true, nil },
 		listTargetsFn:   func(_ context.Context, _ int64) ([]*usersModels.ParentAnnouncementTarget, error) { return nil, nil },
 		resolveEmailsFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipient, error) { return nil, nil },
+		audienceFn: func(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipientStatus, error) {
+			return nil, nil
+		},
 	}
 	outbox := &stubOutbox{enqueueFn: func(_ context.Context, _ platformService.EnqueueRequest) (*platformModels.EmailOutbox, error) {
 		t.Fatal("must not enqueue for empty audience")
 		return nil, nil
 	}}
-	svc := NewService(ServiceConfig{Repo: repo, Settings: stubSettings{newsEnabled: true}, Outbox: outbox})
+	svc := NewService(ServiceConfig{
+		Repo:     repo,
+		Settings: stubSettings{newsEnabled: true},
+		Notifier: &fakeNotifier{},
+		Outbox:   outbox,
+	})
 	if _, err := svc.Publish(context.Background(), testAnnID); err != nil {
 		t.Fatalf("Publish empty audience: %v", err)
 	}

--- a/backend/services/announcement/service_publish_consent_internal_test.go
+++ b/backend/services/announcement/service_publish_consent_internal_test.go
@@ -20,10 +20,12 @@ type fakePreferences struct {
 	// gotType records which notification type was asked about, so a test can
 	// prove the producer filters on its own type rather than someone else's.
 	gotType string
+	asked   []int64
 }
 
-func (f *fakePreferences) FilterOptedIn(_ context.Context, notificationType string, _ []int64) ([]int64, error) {
+func (f *fakePreferences) FilterOptedIn(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
 	f.gotType = notificationType
+	f.asked = append([]int64(nil), accountIDs...)
 	return f.optedIn, f.err
 }
 
@@ -88,6 +90,41 @@ func TestPublishNotifiesNobodyWithoutConsent(t *testing.T) {
 	}
 	if len(notifier.events) != 0 {
 		t.Fatalf("nobody agreed, so nothing may be pushed, got %d events", len(notifier.events))
+	}
+}
+
+func TestPublishEmailsOnlyGuardiansWhoAgreed(t *testing.T) {
+	repo := consentTestRepo()
+	repo.announcement = draftAnnouncement(true)
+	repo.recipients = []*usersModels.AnnouncementRecipient{
+		{AccountID: 101, Email: "one@example.test"},
+		{AccountID: 202, Email: "two@example.test"},
+	}
+	notifier := &fakeNotifier{}
+	outbox := &fakeOutbox{}
+	prefs := &fakePreferences{optedIn: []int64{202}}
+	svc := NewService(ServiceConfig{
+		Repo:        repo,
+		Settings:    &fakeSettings{enabled: true},
+		Notifier:    notifier,
+		Preferences: prefs,
+		Outbox:      outbox,
+		ParentsURL:  "https://parents.example.test",
+		Logger:      slog.Default(),
+	})
+
+	if _, err := svc.Publish(context.Background(), repo.announcement.ID); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	if len(outbox.requests) != 1 {
+		t.Fatalf("expected one opted-in e-mail, got %d", len(outbox.requests))
+	}
+	if got := outbox.requests[0].Payload[emailPayloadRecipient]; got != "two@example.test" {
+		t.Fatalf("expected the opted-in guardian's address, got %v", got)
+	}
+	if !slices.Equal(prefs.asked, []int64{101, 202}) {
+		t.Fatalf("expected the full e-mail audience to be filtered, got %v", prefs.asked)
 	}
 }
 

--- a/backend/services/announcement/service_publish_consent_internal_test.go
+++ b/backend/services/announcement/service_publish_consent_internal_test.go
@@ -1,0 +1,107 @@
+package announcement
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"testing"
+
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+)
+
+// fakePreferences is a stand-in for the consent service. optedIn is returned
+// verbatim, so a test can express "these people agreed" directly.
+type fakePreferences struct {
+	notifications.PreferenceService
+	optedIn []int64
+	err     error
+	// gotType records which notification type was asked about, so a test can
+	// prove the producer filters on its own type rather than someone else's.
+	gotType string
+}
+
+func (f *fakePreferences) FilterOptedIn(_ context.Context, notificationType string, _ []int64) ([]int64, error) {
+	f.gotType = notificationType
+	return f.optedIn, f.err
+}
+
+func consentTestService(repo *fakeAnnouncementRepo, notifier *fakeNotifier, prefs *fakePreferences) Service {
+	return NewService(ServiceConfig{
+		Repo:        repo,
+		Settings:    &fakeSettings{enabled: true},
+		Notifier:    notifier,
+		Preferences: prefs,
+		ParentsURL:  "https://parents.example.test",
+		Logger:      slog.Default(),
+	})
+}
+
+func consentTestRepo() *fakeAnnouncementRepo {
+	return &fakeAnnouncementRepo{
+		announcement: draftAnnouncement(false),
+		audience: []*usersModels.AnnouncementRecipientStatus{
+			{AccountID: 101},
+			{AccountID: 202},
+		},
+	}
+}
+
+// TestPublishNotifiesOnlyGuardiansWhoAgreed pins the consent gate on the
+// guardian push. The audience of an announcement says who it is FOR; consent
+// says who agreed to be pushed about it. The second must narrow the first.
+func TestPublishNotifiesOnlyGuardiansWhoAgreed(t *testing.T) {
+	repo := consentTestRepo()
+	notifier := &fakeNotifier{}
+	prefs := &fakePreferences{optedIn: []int64{202}}
+
+	if _, err := consentTestService(repo, notifier, prefs).Publish(context.Background(), repo.announcement.ID); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	if len(notifier.events) != 1 {
+		t.Fatalf("expected one guardian event, got %d", len(notifier.events))
+	}
+	if !slices.Equal(notifier.events[0].Audience.GuardianAccountIDs, []int64{202}) {
+		t.Fatalf("only the guardian who agreed may be addressed, got %v",
+			notifier.events[0].Audience.GuardianAccountIDs)
+	}
+	if prefs.gotType != notifications.TypeParentAnnouncement {
+		t.Fatalf("the producer must filter on its own type, asked for %q", prefs.gotType)
+	}
+}
+
+// TestPublishNotifiesNobodyWithoutConsent is the case that makes the default
+// flip safe: the announcement still publishes, it simply pushes to nobody.
+func TestPublishNotifiesNobodyWithoutConsent(t *testing.T) {
+	repo := consentTestRepo()
+	notifier := &fakeNotifier{}
+
+	published, err := consentTestService(repo, notifier, &fakePreferences{}).
+		Publish(context.Background(), repo.announcement.ID)
+	if err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+	if published == nil {
+		t.Fatal("the announcement must still be published")
+	}
+	if len(notifier.events) != 0 {
+		t.Fatalf("nobody agreed, so nothing may be pushed, got %d events", len(notifier.events))
+	}
+}
+
+// TestPublishFailsOnConsentLookupError keeps a broken consent read from being
+// read as "nobody agreed" — that would look identical to a working feature.
+func TestPublishFailsOnConsentLookupError(t *testing.T) {
+	repo := consentTestRepo()
+	notifier := &fakeNotifier{}
+	prefs := &fakePreferences{err: errors.New("boom")}
+
+	if _, err := consentTestService(repo, notifier, prefs).Publish(context.Background(), repo.announcement.ID); err == nil {
+		t.Fatal("a failed consent lookup must surface, not silently notify nobody")
+	}
+	if len(notifier.events) != 0 {
+		t.Fatalf("no event may be dispatched on a failed lookup, got %d", len(notifier.events))
+	}
+}

--- a/backend/services/announcement/service_publish_consent_internal_test.go
+++ b/backend/services/announcement/service_publish_consent_internal_test.go
@@ -91,6 +91,23 @@ func TestPublishNotifiesNobodyWithoutConsent(t *testing.T) {
 	}
 }
 
+// Quiet hours suppress delivery, not the announcement itself. Staff must be
+// able to publish at any time even when the notification window is closed.
+func TestPublishSucceedsOutsideNotificationWindow(t *testing.T) {
+	repo := consentTestRepo()
+	notifier := &fakeNotifier{err: notifications.ErrOutsideActiveWindow}
+	prefs := &fakePreferences{optedIn: []int64{202}}
+
+	published, err := consentTestService(repo, notifier, prefs).
+		Publish(context.Background(), repo.announcement.ID)
+	if err != nil {
+		t.Fatalf("quiet hours must not roll back publication: %v", err)
+	}
+	if published == nil {
+		t.Fatal("the announcement must still be published")
+	}
+}
+
 // TestPublishFailsOnConsentLookupError keeps a broken consent read from being
 // read as "nobody agreed" — that would look identical to a working feature.
 func TestPublishFailsOnConsentLookupError(t *testing.T) {

--- a/backend/services/announcement/service_publish_consent_internal_test.go
+++ b/backend/services/announcement/service_publish_consent_internal_test.go
@@ -128,20 +128,49 @@ func TestPublishEmailsOnlyGuardiansWhoAgreed(t *testing.T) {
 	}
 }
 
-// Quiet hours suppress delivery, not the announcement itself. Staff must be
-// able to publish at any time even when the notification window is closed.
-func TestPublishSucceedsOutsideNotificationWindow(t *testing.T) {
-	repo := consentTestRepo()
-	notifier := &fakeNotifier{err: notifications.ErrOutsideActiveWindow}
-	prefs := &fakePreferences{optedIn: []int64{202}}
-
-	published, err := consentTestService(repo, notifier, prefs).
-		Publish(context.Background(), repo.announcement.ID)
-	if err != nil {
-		t.Fatalf("quiet hours must not roll back publication: %v", err)
+// Tenant notification gates suppress every delivery channel, not the
+// announcement itself. Staff must still be able to publish while dispatch is
+// disabled or the notification window is closed.
+func TestPublishSuppressesEmailWhenNotificationsAreGated(t *testing.T) {
+	tests := []struct {
+		name        string
+		notifierErr error
+	}{
+		{name: "dispatch disabled", notifierErr: notifications.ErrDisabled},
+		{name: "outside notification window", notifierErr: notifications.ErrOutsideActiveWindow},
 	}
-	if published == nil {
-		t.Fatal("the announcement must still be published")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := consentTestRepo()
+			repo.announcement = draftAnnouncement(true)
+			repo.recipients = []*usersModels.AnnouncementRecipient{
+				{AccountID: 202, Email: "two@example.test"},
+			}
+			notifier := &fakeNotifier{err: tt.notifierErr}
+			prefs := &fakePreferences{optedIn: []int64{202}}
+			outbox := &fakeOutbox{}
+			svc := NewService(ServiceConfig{
+				Repo:        repo,
+				Settings:    &fakeSettings{enabled: true},
+				Notifier:    notifier,
+				Preferences: prefs,
+				Outbox:      outbox,
+				ParentsURL:  "https://parents.example.test",
+				Logger:      slog.Default(),
+			})
+
+			published, err := svc.Publish(context.Background(), repo.announcement.ID)
+			if err != nil {
+				t.Fatalf("notification gate must not roll back publication: %v", err)
+			}
+			if published == nil {
+				t.Fatal("the announcement must still be published")
+			}
+			if len(outbox.requests) != 0 {
+				t.Fatalf("notification gate must suppress e-mail too, got %d queued messages", len(outbox.requests))
+			}
+		})
 	}
 }
 

--- a/backend/services/announcement/service_publish_consent_internal_test.go
+++ b/backend/services/announcement/service_publish_consent_internal_test.go
@@ -128,6 +128,41 @@ func TestPublishEmailsOnlyGuardiansWhoAgreed(t *testing.T) {
 	}
 }
 
+func TestPublishDeduplicatesOptedInGuardiansByNormalizedEmail(t *testing.T) {
+	repo := consentTestRepo()
+	repo.announcement = draftAnnouncement(true)
+	repo.recipients = []*usersModels.AnnouncementRecipient{
+		{AccountID: 101, Email: " Family@Example.Test "},
+		{AccountID: 202, Email: "family@example.test"},
+	}
+	notifier := &fakeNotifier{}
+	outbox := &fakeOutbox{}
+	prefs := &fakePreferences{optedIn: []int64{101, 202}}
+	svc := NewService(ServiceConfig{
+		Repo:        repo,
+		Settings:    &fakeSettings{enabled: true},
+		Notifier:    notifier,
+		Preferences: prefs,
+		Outbox:      outbox,
+		ParentsURL:  "https://parents.example.test",
+		Logger:      slog.Default(),
+	})
+
+	if _, err := svc.Publish(context.Background(), repo.announcement.ID); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	if len(outbox.requests) != 1 {
+		t.Fatalf("expected one e-mail per normalized address, got %d", len(outbox.requests))
+	}
+	if got := outbox.requests[0].Payload[emailPayloadRecipient]; got != "family@example.test" {
+		t.Fatalf("expected the normalized address, got %v", got)
+	}
+	if !slices.Equal(prefs.asked, []int64{101, 202}) {
+		t.Fatalf("expected consent to be evaluated per account before address deduplication, got %v", prefs.asked)
+	}
+}
+
 // Tenant notification gates suppress every delivery channel, not the
 // announcement itself. Staff must still be able to publish while dispatch is
 // disabled or the notification window is closed.

--- a/backend/services/announcement/service_publish_consent_internal_test.go
+++ b/backend/services/announcement/service_publish_consent_internal_test.go
@@ -21,12 +21,39 @@ type fakePreferences struct {
 	// prove the producer filters on its own type rather than someone else's.
 	gotType string
 	asked   []int64
+
+	// optedOut lists the accounts that explicitly declined. Everyone else stays
+	// in, which is the whole point of the not-opted-out rule.
+	optedOut      []int64
+	optOutErr     error
+	optOutGotType string
+	askedOptOut   []int64
 }
 
 func (f *fakePreferences) FilterOptedIn(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
 	f.gotType = notificationType
 	f.asked = append([]int64(nil), accountIDs...)
 	return f.optedIn, f.err
+}
+
+func (f *fakePreferences) FilterNotOptedOut(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	f.optOutGotType = notificationType
+	f.askedOptOut = append([]int64(nil), accountIDs...)
+	if f.optOutErr != nil {
+		return nil, f.optOutErr
+	}
+	declined := make(map[int64]struct{}, len(f.optedOut))
+	for _, accountID := range f.optedOut {
+		declined[accountID] = struct{}{}
+	}
+	remaining := make([]int64, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if _, ok := declined[accountID]; ok {
+			continue
+		}
+		remaining = append(remaining, accountID)
+	}
+	return remaining, nil
 }
 
 func consentTestService(repo *fakeAnnouncementRepo, notifier *fakeNotifier, prefs *fakePreferences) Service {
@@ -93,7 +120,11 @@ func TestPublishNotifiesNobodyWithoutConsent(t *testing.T) {
 	}
 }
 
-func TestPublishEmailsOnlyGuardiansWhoAgreed(t *testing.T) {
+// E-mail honours an explicit "no" and nothing else: the guardian who declined
+// the type is dropped, the one who never decided still receives the mail. Push
+// consent (FilterOptedIn) must not decide this, since most families have no row at
+// all, so an opt-in rule here would silence the e-mail for nearly everybody.
+func TestPublishEmailsEveryGuardianWhoDidNotOptOut(t *testing.T) {
 	repo := consentTestRepo()
 	repo.announcement = draftAnnouncement(true)
 	repo.recipients = []*usersModels.AnnouncementRecipient{
@@ -102,7 +133,8 @@ func TestPublishEmailsOnlyGuardiansWhoAgreed(t *testing.T) {
 	}
 	notifier := &fakeNotifier{}
 	outbox := &fakeOutbox{}
-	prefs := &fakePreferences{optedIn: []int64{202}}
+	// 101 said no; 202 never touched the switch and is not opted in for push.
+	prefs := &fakePreferences{optedOut: []int64{101}}
 	svc := NewService(ServiceConfig{
 		Repo:        repo,
 		Settings:    &fakeSettings{enabled: true},
@@ -118,13 +150,80 @@ func TestPublishEmailsOnlyGuardiansWhoAgreed(t *testing.T) {
 	}
 
 	if len(outbox.requests) != 1 {
-		t.Fatalf("expected one opted-in e-mail, got %d", len(outbox.requests))
+		t.Fatalf("expected one e-mail for the guardian who did not decline, got %d", len(outbox.requests))
 	}
 	if got := outbox.requests[0].Payload[emailPayloadRecipient]; got != "two@example.test" {
-		t.Fatalf("expected the opted-in guardian's address, got %v", got)
+		t.Fatalf("expected the address of the guardian who did not decline, got %v", got)
 	}
-	if !slices.Equal(prefs.asked, []int64{101, 202}) {
-		t.Fatalf("expected the full e-mail audience to be filtered, got %v", prefs.asked)
+	if !slices.Equal(prefs.askedOptOut, []int64{101, 202}) {
+		t.Fatalf("expected the full e-mail audience to be checked for opt-outs, got %v", prefs.askedOptOut)
+	}
+	if prefs.optOutGotType != notifications.TypeParentAnnouncement {
+		t.Fatalf("the e-mail path must filter on its own type, asked for %q", prefs.optOutGotType)
+	}
+}
+
+// The regression this rule exists for: parent push is brand new, so a normal
+// school has no preference rows and no push subscriptions at all. That must not
+// stop the announcement e-mail, which schools have relied on all along.
+func TestPublishEmailsFamiliesWithoutAnyPreferenceRow(t *testing.T) {
+	repo := consentTestRepo()
+	repo.announcement = draftAnnouncement(true)
+	repo.recipients = []*usersModels.AnnouncementRecipient{
+		{AccountID: 101, Email: "one@example.test"},
+		{AccountID: 202, Email: "two@example.test"},
+	}
+	notifier := &fakeNotifier{}
+	outbox := &fakeOutbox{}
+	// Nobody opted in (no push) and nobody opted out (no stored decision).
+	prefs := &fakePreferences{}
+	svc := NewService(ServiceConfig{
+		Repo:        repo,
+		Settings:    &fakeSettings{enabled: true},
+		Notifier:    notifier,
+		Preferences: prefs,
+		Outbox:      outbox,
+		ParentsURL:  "https://parents.example.test",
+		Logger:      slog.Default(),
+	})
+
+	if _, err := svc.Publish(context.Background(), repo.announcement.ID); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	if len(notifier.events) != 0 {
+		t.Fatalf("nobody agreed to push, so nothing may be pushed, got %d events", len(notifier.events))
+	}
+	if len(outbox.requests) != 2 {
+		t.Fatalf("a missing decision must not silence the e-mail, got %d queued messages", len(outbox.requests))
+	}
+}
+
+// A broken opt-out read must not be interpreted as "everyone agreed" either:
+// the publish fails so staff can retry instead of guessing the audience.
+func TestPublishFailsOnEmailOptOutLookupError(t *testing.T) {
+	repo := consentTestRepo()
+	repo.announcement = draftAnnouncement(true)
+	repo.recipients = []*usersModels.AnnouncementRecipient{
+		{AccountID: 202, Email: "two@example.test"},
+	}
+	outbox := &fakeOutbox{}
+	prefs := &fakePreferences{optedIn: []int64{202}, optOutErr: errors.New("boom")}
+	svc := NewService(ServiceConfig{
+		Repo:        repo,
+		Settings:    &fakeSettings{enabled: true},
+		Notifier:    &fakeNotifier{},
+		Preferences: prefs,
+		Outbox:      outbox,
+		ParentsURL:  "https://parents.example.test",
+		Logger:      slog.Default(),
+	})
+
+	if _, err := svc.Publish(context.Background(), repo.announcement.ID); err == nil {
+		t.Fatal("a failed opt-out lookup must surface, not silently e-mail everyone")
+	}
+	if len(outbox.requests) != 0 {
+		t.Fatalf("no e-mail may be queued on a failed lookup, got %d", len(outbox.requests))
 	}
 }
 
@@ -163,10 +262,11 @@ func TestPublishDeduplicatesOptedInGuardiansByNormalizedEmail(t *testing.T) {
 	}
 }
 
-// Tenant notification gates suppress every delivery channel, not the
-// announcement itself. Staff must still be able to publish while dispatch is
-// disabled or the notification window is closed.
-func TestPublishSuppressesEmailWhenNotificationsAreGated(t *testing.T) {
+// The tenant dispatch switch and the active window govern push and in-app
+// hints, not e-mail: they exist so a phone does not ring at night, and an
+// e-mail does not ring. A gated push must therefore leave both the publication
+// and the e-mail untouched.
+func TestPublishStillEmailsWhenPushIsGated(t *testing.T) {
 	tests := []struct {
 		name        string
 		notifierErr error
@@ -202,8 +302,11 @@ func TestPublishSuppressesEmailWhenNotificationsAreGated(t *testing.T) {
 			if published == nil {
 				t.Fatal("the announcement must still be published")
 			}
-			if len(outbox.requests) != 0 {
-				t.Fatalf("notification gate must suppress e-mail too, got %d queued messages", len(outbox.requests))
+			if len(outbox.requests) != 1 {
+				t.Fatalf("the push gate must not suppress e-mail, got %d queued messages", len(outbox.requests))
+			}
+			if got := outbox.requests[0].Payload[emailPayloadRecipient]; got != "two@example.test" {
+				t.Fatalf("expected the audience address, got %v", got)
 			}
 		})
 	}

--- a/backend/services/announcement/service_publish_internal_test.go
+++ b/backend/services/announcement/service_publish_internal_test.go
@@ -73,7 +73,18 @@ func (f *fakeAnnouncementRepo) ResolveAudienceEmails(_ context.Context, _, _ int
 }
 
 func (f *fakeAnnouncementRepo) AudienceRecipients(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementRecipientStatus, error) {
-	return f.audience, nil
+	if f.audience != nil {
+		return f.audience, nil
+	}
+	recipients := make([]*usersModels.AnnouncementRecipientStatus, 0, len(f.recipients))
+	for i, recipient := range f.recipients {
+		accountID := recipient.AccountID
+		if accountID <= 0 {
+			accountID = int64(i + 1)
+		}
+		recipients = append(recipients, &usersModels.AnnouncementRecipientStatus{AccountID: accountID})
+	}
+	return recipients, nil
 }
 
 func (f *fakeAnnouncementRepo) SchoolName(_ context.Context, _ int64) (string, error) {
@@ -125,6 +136,7 @@ func newTestService(repo *fakeAnnouncementRepo, outbox *fakeOutbox) Service {
 	return NewService(ServiceConfig{
 		Repo:       repo,
 		Settings:   &fakeSettings{enabled: true},
+		Notifier:   &fakeNotifier{},
 		Outbox:     outbox,
 		ParentsURL: "https://parents.example.test",
 		Logger:     slog.Default(),
@@ -319,6 +331,7 @@ func TestPublish_EnqueuesBrandingLogos(t *testing.T) {
 	svc := NewService(ServiceConfig{
 		Repo:       repo,
 		Settings:   &fakeSettings{enabled: true, logoURL: "/uploads/login-images/2_abc.jpg"},
+		Notifier:   &fakeNotifier{},
 		Outbox:     outbox,
 		ParentsURL: "https://parents.example.test",
 		Logger:     slog.Default(),
@@ -482,6 +495,7 @@ func TestPublish_EmailEnqueueFailureIsFatal(t *testing.T) {
 	svc := NewService(ServiceConfig{
 		Repo:       repo,
 		Settings:   &fakeSettings{enabled: true},
+		Notifier:   &fakeNotifier{},
 		Outbox:     failingOutbox{},
 		ParentsURL: "https://parents.example.test",
 		Logger:     slog.Default(),

--- a/backend/services/auth/mfa_service_settings_test.go
+++ b/backend/services/auth/mfa_service_settings_test.go
@@ -55,15 +55,23 @@ func (r *mfaTestValueRepo) FindByTenantAndKey(_ context.Context, tenantID int64,
 	return nil, nil
 }
 
-func (r *mfaTestValueRepo) FindByTenant(_ context.Context, tenantID int64) ([]*configModel.SettingValue, error) {
+func (r *mfaTestValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int64, settingKeys []string) ([]*configModel.SettingValue, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	requested := make(map[string]struct{}, len(settingKeys))
+	for _, key := range settingKeys {
+		requested[key] = struct{}{}
+	}
 	prefix := fmt.Sprintf("%d:", tenantID)
 	out := []*configModel.SettingValue{}
 	for k, v := range r.values {
-		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
-			out = append(out, v)
+		if len(k) <= len(prefix) || k[:len(prefix)] != prefix {
+			continue
 		}
+		if _, ok := requested[v.SettingKey]; !ok {
+			continue
+		}
+		out = append(out, v)
 	}
 	return out, nil
 }

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -199,6 +199,10 @@ func (noopAccountRepository) FindByRole(context.Context, string) ([]*authModel.A
 	panic("FindByRole not implemented")
 }
 
+func (noopAccountRepository) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
+	panic("ListEffectiveAdminAccountIDs not implemented")
+}
+
 func (noopAccountRepository) FindAccountsWithRolesAndPermissions(context.Context, map[string]interface{}) ([]*authModel.Account, error) {
 	panic("FindAccountsWithRolesAndPermissions not implemented")
 }

--- a/backend/services/config/configtest/mock.go
+++ b/backend/services/config/configtest/mock.go
@@ -24,6 +24,7 @@ type Mock struct {
 	ResolveStringFn                func(ctx context.Context, key string) (string, error)
 	ResolveStringForTenantFn       func(ctx context.Context, tenantID int64, key string) (string, error)
 	ResolveBoolFn                  func(ctx context.Context, key string) (bool, error)
+	ResolveBoolsFn                 func(ctx context.Context, keys []string) (map[string]bool, error)
 	ResolveBoolForTenantFn         func(ctx context.Context, tenantID int64, key string) (bool, error)
 	ResolveIntFn                   func(ctx context.Context, key string) (int, error)
 	ResolveIntForTenantFn          func(ctx context.Context, tenantID int64, key string) (int, error)
@@ -81,6 +82,21 @@ func (m *Mock) ResolveBool(ctx context.Context, key string) (bool, error) {
 		return m.ResolveBoolFn(ctx, key)
 	}
 	return false, nil
+}
+
+func (m *Mock) ResolveBools(ctx context.Context, keys []string) (map[string]bool, error) {
+	if m.ResolveBoolsFn != nil {
+		return m.ResolveBoolsFn(ctx, keys)
+	}
+	resolved := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		value, err := m.ResolveBool(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		resolved[key] = value
+	}
+	return resolved, nil
 }
 
 func (m *Mock) ResolveBoolForTenant(ctx context.Context, tenantID int64, key string) (bool, error) {

--- a/backend/services/config/defaults/notifications.go
+++ b/backend/services/config/defaults/notifications.go
@@ -35,4 +35,64 @@ func init() {
 		Category:        "benachrichtigungen",
 		SortOrder:       1,
 	})
+
+	// Delivery window. Checked once in the notification router, so it bounds
+	// every producer rather than each one carrying its own quiet hours.
+	config.Register(config.Definition{
+		Key:             config.KeyNotificationsActiveWindowStart,
+		Label:           "Benachrichtigungen ab",
+		Description:     "Ab dieser Uhrzeit werden Benachrichtigungen zugestellt.",
+		Type:            config.FieldTime,
+		Default:         "06:00",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "benachrichtigungen",
+		SortOrder:       2,
+		DependsOn:       config.DependsOnEq(config.KeyNotificationsDispatchEnabled, true),
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyNotificationsActiveWindowEnd,
+		Label:           "Benachrichtigungen bis",
+		Description:     "Bis zu dieser Uhrzeit werden Benachrichtigungen zugestellt. Danach bleibt es still bis zum nächsten Morgen.",
+		Type:            config.FieldTime,
+		Default:         "18:00",
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "benachrichtigungen",
+		SortOrder:       3,
+		DependsOn:       config.DependsOnEq(config.KeyNotificationsDispatchEnabled, true),
+	})
+
+	config.Register(config.Definition{
+		Key:             config.KeyNotificationsOnDutyOnly,
+		Label:           "Nur im Dienst benachrichtigen",
+		Description:     "Persönliche Hinweise erreichen nur Personen, die gerade eingestempelt sind. Ohne Zeiterfassung greift diese Einschränkung nicht.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "operations",
+		Category:        "benachrichtigungen",
+		SortOrder:       4,
+		DependsOn:       config.DependsOnEq(config.KeyNotificationsDispatchEnabled, true),
+	})
+
+	// Health information about a child fanning out to a group's phones is a
+	// data-minimisation decision for the school, not a matter of personal
+	// taste, so it exists on top of the per-person opt-in.
+	config.Register(config.Definition{
+		Key:             config.KeyNotificationsAbsenceReportedEnabled,
+		Label:           "Krankmeldungen melden",
+		Description:     "Erlaubt Hinweise an die Gruppe und die Leitung, wenn für ein Kind eine Krankmeldung oder Entschuldigung eingetragen wird. Jede Person entscheidet zusätzlich im eigenen Profil.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:manage",
+		Tab:             "operations",
+		Category:        "benachrichtigungen",
+		SortOrder:       5,
+	})
 }

--- a/backend/services/config/defaults/notifications.go
+++ b/backend/services/config/defaults/notifications.go
@@ -73,7 +73,7 @@ func init() {
 	config.Register(config.Definition{
 		Key:             config.KeyNotificationsOnDutyOnly,
 		Label:           "Nur im Dienst benachrichtigen",
-		Description:     "Persönliche Hinweise erreichen nur Personen, die gerade eingestempelt sind. Ohne Zeiterfassung greift diese Einschränkung nicht.",
+		Description:     "Persönliche Hinweise erreichen nur Personen, die gerade eingestempelt sind. Schulen ohne Zeiterfassung müssen diese Einstellung ausschalten.",
 		Type:            config.FieldBoolean,
 		Default:         true,
 		ReadPermission:  "config:read",

--- a/backend/services/config/defaults/notifications.go
+++ b/backend/services/config/defaults/notifications.go
@@ -21,14 +21,18 @@ func init() {
 		SortOrder:       5,
 	})
 
-	// Feature flag for the notification abstraction (#1624). Default off:
-	// Notify(ctx, event) is a no-op until a school explicitly enables it.
+	// Feature flag for the notification abstraction (#1624). On by default
+	// since the personal-notification epic: every producer behind it now
+	// requires the recipient's own consent, and consent starts empty, so an
+	// enabled school still delivers nothing until someone asks for something.
+	// Off would only mean that a person's own choice in their profile is
+	// silently ignored.
 	config.Register(config.Definition{
 		Key:             config.KeyNotificationsDispatchEnabled,
 		Label:           "Benachrichtigungen aktivieren",
-		Description:     "Aktiviert die zentrale Benachrichtigungs-Funktion (In-App-Hinweise, Grundlage für spätere Erinnerungen und Push-Nachrichten). Standardmäßig deaktiviert.",
+		Description:     "Aktiviert die zentrale Benachrichtigungs-Funktion (In-App-Hinweise und Push-Nachrichten). Standardmäßig aktiv. Was tatsächlich ankommt, wählt jede Person im eigenen Profil.",
 		Type:            config.FieldBoolean,
-		Default:         false,
+		Default:         true,
 		ReadPermission:  "config:read",
 		WritePermission: "config:update",
 		Tab:             "operations",

--- a/backend/services/config/settings_interface.go
+++ b/backend/services/config/settings_interface.go
@@ -34,6 +34,11 @@ type SettingsService interface {
 	// ResolveBool resolves a setting as a bool.
 	ResolveBool(ctx context.Context, key string) (bool, error)
 
+	// ResolveBools resolves multiple boolean settings in one repository query.
+	// Every requested key is present in the result, using its registry default
+	// when the tenant has no stored override.
+	ResolveBools(ctx context.Context, keys []string) (map[string]bool, error)
+
 	// ResolveBoolForTenant resolves a setting as a bool for an explicitly
 	// provided tenant — required from call sites that run outside the
 	// TenantTxMiddleware (e.g. /auth/mfa/verify, which runs between the

--- a/backend/services/config/settings_service.go
+++ b/backend/services/config/settings_service.go
@@ -204,6 +204,72 @@ func (s *settingsService) ResolveBool(ctx context.Context, key string) (bool, er
 	return b, nil
 }
 
+// ResolveBools resolves multiple boolean settings while loading all tenant
+// overrides in one query. Registry defaults are filled first, then explicit
+// tenant values replace them.
+func (s *settingsService) ResolveBools(ctx context.Context, keys []string) (map[string]bool, error) {
+	resolved := make(map[string]bool, len(keys))
+	uniqueKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, seen := resolved[key]; seen {
+			continue
+		}
+		def := config.GetDefinition(key)
+		if def == nil {
+			return nil, &SettingsError{
+				Op:  "resolve_bools",
+				Err: &DefinitionNotFoundError{Key: key},
+			}
+		}
+		value, ok := def.Default.(bool)
+		if !ok {
+			return nil, &SettingsError{
+				Op:  "resolve_bools",
+				Err: fmt.Errorf("expected bool default for %s, got %T", key, def.Default),
+			}
+		}
+		resolved[key] = value
+		uniqueKeys = append(uniqueKeys, key)
+	}
+	if len(uniqueKeys) == 0 {
+		return resolved, nil
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return resolved, nil
+	}
+	stored, err := s.valueRepo.FindByTenantAndKeys(ctx, tenantID, uniqueKeys)
+	if err != nil {
+		return nil, &SettingsError{Op: "resolve_bools", Err: err}
+	}
+	for _, sv := range stored {
+		if _, requested := resolved[sv.SettingKey]; !requested {
+			continue
+		}
+		var value any
+		if err := json.Unmarshal(sv.Value, &value); err != nil {
+			return nil, &SettingsError{
+				Op:  "resolve_bools",
+				Err: fmt.Errorf("unmarshal value for %s: %w", sv.SettingKey, err),
+			}
+		}
+		if value == nil {
+			resolved[sv.SettingKey] = false
+			continue
+		}
+		boolean, ok := value.(bool)
+		if !ok {
+			return nil, &SettingsError{
+				Op:  "resolve_bools",
+				Err: fmt.Errorf("expected bool for %s, got %T", sv.SettingKey, value),
+			}
+		}
+		resolved[sv.SettingKey] = boolean
+	}
+	return resolved, nil
+}
+
 // ResolveInt resolves a setting as an int.
 func (s *settingsService) ResolveInt(ctx context.Context, key string) (int, error) {
 	val, err := s.Resolve(ctx, key)

--- a/backend/services/config/settings_service_tenant_test.go
+++ b/backend/services/config/settings_service_tenant_test.go
@@ -59,9 +59,19 @@ func (r *inMemoryValueRepo) FindByTenantAndKey(_ context.Context, tenantID int64
 	return r.rows[r.key(tenantID, settingKey)], nil
 }
 
-func (r *inMemoryValueRepo) FindByTenant(_ context.Context, _ int64) ([]*config.SettingValue, error) {
+func (r *inMemoryValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int64, settingKeys []string) ([]*config.SettingValue, error) {
+	requested := make(map[string]struct{}, len(settingKeys))
+	for _, key := range settingKeys {
+		requested[key] = struct{}{}
+	}
 	out := []*config.SettingValue{}
 	for _, v := range r.rows {
+		if v.GetTenantID() != tenantID {
+			continue
+		}
+		if _, ok := requested[v.SettingKey]; !ok {
+			continue
+		}
 		out = append(out, v)
 	}
 	return out, nil

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -22,8 +22,9 @@ import (
 // --- Mock repositories ---
 
 type mockValueRepo struct {
-	values map[string]*config.SettingValue // key: "tenantID:settingKey"
-	err    error
+	values        map[string]*config.SettingValue // key: "tenantID:settingKey"
+	err           error
+	findManyCalls int
 }
 
 func newMockValueRepo() *mockValueRepo {
@@ -45,12 +46,23 @@ func (m *mockValueRepo) FindByTenantAndKey(_ context.Context, tenantID int64, se
 	return sv, nil
 }
 
-func (m *mockValueRepo) FindByTenant(_ context.Context, _ int64) ([]*config.SettingValue, error) {
+func (m *mockValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int64, settingKeys []string) ([]*config.SettingValue, error) {
+	m.findManyCalls++
 	if m.err != nil {
 		return nil, m.err
 	}
+	requested := make(map[string]struct{}, len(settingKeys))
+	for _, key := range settingKeys {
+		requested[key] = struct{}{}
+	}
 	var result []*config.SettingValue
 	for _, v := range m.values {
+		if v.TenantID != tenantID {
+			continue
+		}
+		if _, ok := requested[v.SettingKey]; !ok {
+			continue
+		}
 		result = append(result, v)
 	}
 	return result, nil
@@ -189,6 +201,72 @@ func TestResolveBool(t *testing.T) {
 	val, err := svc.ResolveBool(tenantCtx(1), "test.enabled")
 	require.NoError(t, err)
 	assert.True(t, val)
+}
+
+func TestResolveBoolsLoadsOverridesOnceAndFillsDefaults(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.enabled", config.FieldBoolean, true)
+	registerTestSetting("test.disabled", config.FieldBoolean, false)
+
+	repo := newMockValueRepo()
+	repo.values["1:test.enabled"] = &config.SettingValue{
+		SettingKey: "test.enabled",
+		Value:      json.RawMessage(`false`),
+	}
+	repo.values["1:test.enabled"].TenantID = 1
+	repo.values["2:test.disabled"] = &config.SettingValue{
+		SettingKey: "test.disabled",
+		Value:      json.RawMessage(`true`),
+	}
+	repo.values["2:test.disabled"].TenantID = 2
+
+	svc := createService(repo, &mockAuditRepo{})
+	values, err := svc.ResolveBools(tenantCtx(1), []string{
+		"test.enabled",
+		"test.disabled",
+		"test.enabled",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]bool{
+		"test.enabled":  false,
+		"test.disabled": false,
+	}, values)
+	assert.Equal(t, 1, repo.findManyCalls, "all keys must share one repository query")
+}
+
+func TestResolveBoolsFailsClosedForInvalidDefinitionsAndValues(t *testing.T) {
+	t.Run("unknown key", func(t *testing.T) {
+		setupTest(t)
+		svc := createService(newMockValueRepo(), &mockAuditRepo{})
+
+		_, err := svc.ResolveBools(tenantCtx(1), []string{"test.unknown"})
+		require.Error(t, err)
+	})
+
+	t.Run("non-boolean default", func(t *testing.T) {
+		setupTest(t)
+		registerTestSetting("test.text", config.FieldText, "value")
+		svc := createService(newMockValueRepo(), &mockAuditRepo{})
+
+		_, err := svc.ResolveBools(tenantCtx(1), []string{"test.text"})
+		require.Error(t, err)
+	})
+
+	t.Run("non-boolean override", func(t *testing.T) {
+		setupTest(t)
+		registerTestSetting("test.enabled", config.FieldBoolean, true)
+		repo := newMockValueRepo()
+		repo.values["1:test.enabled"] = &config.SettingValue{
+			SettingKey: "test.enabled",
+			Value:      json.RawMessage(`"yes"`),
+		}
+		repo.values["1:test.enabled"].TenantID = 1
+		svc := createService(repo, &mockAuditRepo{})
+
+		_, err := svc.ResolveBools(tenantCtx(1), []string{"test.enabled"})
+		require.Error(t, err)
+	})
 }
 
 func TestResolveInt(t *testing.T) {

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -122,7 +122,7 @@ type Factory struct {
 	ListExport               *listexport.RendererService
 	Emergency                *emergency.Service
 	SlotLists                slotlists.Service
-	Reminders                reminders.Service
+	Reminders                reminders.Computer
 	Notifications            notifications.Service
 	PushSubscriptions        notifications.PushSubscriptionService
 	RealtimeHub              *realtime.Hub     // SSE event hub (shared by services and API)
@@ -1772,6 +1772,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Supervision: activeService,
 		Groups:      userContextService,
 		Logger:      logger.With("service", "reminders"),
+
+		// Bulk readers for ComputeBatch. They answer the three genuinely
+		// per-person facts for the whole tenant in one query each, which is what
+		// keeps the per-minute cost flat in the number of staff.
+		BulkSupervision: repos.GroupSupervisor,
+		BulkVisits:      repos.ActiveVisit,
+		BulkGroups:      repos.Group,
 	})
 
 	workTimeModelService := config.NewWorkTimeModelService(repos.WorkTimeModel)

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -123,7 +123,7 @@ type Factory struct {
 	Emergency                *emergency.Service
 	SlotLists                slotlists.Service
 	Reminders                reminders.Computer
-	Notifications            notifications.Service
+	Notifications            notifications.Notifier
 	PushSubscriptions        notifications.PushSubscriptionService
 	NotificationPreferences  notifications.PreferenceService
 	AbsenceNotifier          notifications.AbsenceNotifier

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1780,6 +1780,8 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.Group,
 		repos.Staff,
 		repos.Account,
+		settingsService,
+		repos.WorkSession,
 		db,
 		logger.With("producer", "absence_notifications"),
 	)

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -126,6 +126,7 @@ type Factory struct {
 	Notifications            notifications.Service
 	PushSubscriptions        notifications.PushSubscriptionService
 	NotificationPreferences  notifications.PreferenceService
+	AbsenceNotifier          notifications.AbsenceNotifier
 	RealtimeHub              *realtime.Hub     // SSE event hub (shared by services and API)
 	Tracker                  analytics.Tracker // Product analytics (PostHog; no-op without POSTHOG_API_KEY)
 	Mailer                   email.Mailer
@@ -1695,13 +1696,23 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		notifications.NewWebPushChannel(db, repos.PushSubscription, vapidConfig, logger.With("channel", "web_push")),
 	)
 
+	// Built here rather than next to the other notification services because
+	// the announcement producer below needs it to gate its guardian push.
+	notificationPreferencesService := notifications.NewPreferenceService(
+		repos.NotificationPreference,
+		settingsService,
+		db,
+		repos.AccountTenant,
+	)
+
 	parentAnnouncementService := announcement.NewService(announcement.ServiceConfig{
-		Repo:       repos.ParentAnnouncement,
-		Settings:   settingsService,
-		Outbox:     emailOutboxService,
-		Notifier:   notificationsService,
-		ParentsURL: parentsURL,
-		Logger:     logger.With("service", "announcement"),
+		Repo:        repos.ParentAnnouncement,
+		Settings:    settingsService,
+		Outbox:      emailOutboxService,
+		Notifier:    notificationsService,
+		Preferences: notificationPreferencesService,
+		ParentsURL:  parentsURL,
+		Logger:      logger.With("service", "announcement"),
 	})
 
 	operatorProvisioningService := platform.NewOperatorProvisioningService(platform.OperatorProvisioningServiceConfig{
@@ -1762,12 +1773,20 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		logger.With("service", "push_subscriptions"),
 	)
 
-	notificationPreferencesService := notifications.NewPreferenceService(
-		repos.NotificationPreference,
-		settingsService,
-		db,
-		repos.AccountTenant,
+	absenceNotifier := notifications.NewAbsenceNotifier(
+		notificationsService,
+		notificationPreferencesService,
+		repos.Student,
+		repos.Group,
+		repos.Staff,
+		repos.Account,
+		logger.With("producer", "absence_notifications"),
 	)
+	// Injected after the fact: the parent service is wired before the
+	// notification stack exists.
+	if setter, ok := parentService.(parent.AbsenceNotifierSetter); ok {
+		setter.SetAbsenceNotifier(absenceNotifier)
+	}
 
 	remindersService := reminders.NewService(reminders.Dependencies{
 		Settings:    settingsService,
@@ -1784,9 +1803,10 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		// Bulk readers for ComputeBatch. They answer the three genuinely
 		// per-person facts for the whole tenant in one query each, which is what
 		// keeps the per-minute cost flat in the number of staff.
-		BulkSupervision: repos.GroupSupervisor,
-		BulkVisits:      repos.ActiveVisit,
-		BulkGroups:      repos.Group,
+		BulkSupervision:   repos.GroupSupervisor,
+		BulkVisits:        repos.ActiveVisit,
+		BulkGroups:        repos.Group,
+		BulkInstanceStaff: repos.InstanceStaff,
 	})
 
 	workTimeModelService := config.NewWorkTimeModelService(repos.WorkTimeModel)
@@ -1859,6 +1879,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Notifications:            notificationsService,
 		PushSubscriptions:        pushSubscriptionsService,
 		NotificationPreferences:  notificationPreferencesService,
+		AbsenceNotifier:          absenceNotifier,
 		RealtimeHub:              realtimeHub, // Expose SSE hub for API layer
 		Tracker:                  tracker,     // Product analytics (PostHog)
 		Invitation:               invitationService,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1780,11 +1780,15 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.Group,
 		repos.Staff,
 		repos.Account,
+		db,
 		logger.With("producer", "absence_notifications"),
 	)
 	// Injected after the fact: the parent service is wired before the
 	// notification stack exists.
 	if setter, ok := parentService.(parent.AbsenceNotifierSetter); ok {
+		setter.SetAbsenceNotifier(absenceNotifier)
+	}
+	if setter, ok := excusedRequestService.(absence.AbsenceNotifierSetter); ok {
 		setter.SetAbsenceNotifier(absenceNotifier)
 	}
 

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -125,6 +125,7 @@ type Factory struct {
 	Reminders                reminders.Computer
 	Notifications            notifications.Service
 	PushSubscriptions        notifications.PushSubscriptionService
+	NotificationPreferences  notifications.PreferenceService
 	RealtimeHub              *realtime.Hub     // SSE event hub (shared by services and API)
 	Tracker                  analytics.Tracker // Product analytics (PostHog; no-op without POSTHOG_API_KEY)
 	Mailer                   email.Mailer
@@ -1761,6 +1762,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		logger.With("service", "push_subscriptions"),
 	)
 
+	notificationPreferencesService := notifications.NewPreferenceService(
+		repos.NotificationPreference,
+		settingsService,
+		db,
+		repos.AccountTenant,
+	)
+
 	remindersService := reminders.NewService(reminders.Dependencies{
 		Settings:    settingsService,
 		Attendance:  repos.Attendance,
@@ -1850,6 +1858,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Reminders:                remindersService,
 		Notifications:            notificationsService,
 		PushSubscriptions:        pushSubscriptionsService,
+		NotificationPreferences:  notificationPreferencesService,
 		RealtimeHub:              realtimeHub, // Expose SSE hub for API layer
 		Tracker:                  tracker,     // Product analytics (PostHog)
 		Invitation:               invitationService,

--- a/backend/services/import/relationship_resolver_test.go
+++ b/backend/services/import/relationship_resolver_test.go
@@ -364,6 +364,9 @@ func (m *mockGroupRepo) FindWithRoom(_ context.Context, _ int64) (*education.Gro
 func (m *mockGroupRepo) ListSupervisedGroupIDsByStaff(_ context.Context, _ []int64, _ timezone.Date) ([]education.StaffGroupID, error) {
 	return nil, nil
 }
+func (m *mockGroupRepo) ListStaffIDsByEducationGroupIDs(_ context.Context, _ []int64, _ timezone.Date) ([]education.StaffGroupID, error) {
+	return nil, nil
+}
 func (m *mockGroupRepo) CountWithOptions(_ context.Context, _ *base.QueryOptions) (int, error) {
 	return len(m.groups), nil
 }

--- a/backend/services/import/relationship_resolver_test.go
+++ b/backend/services/import/relationship_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -358,6 +359,9 @@ func (m *mockGroupRepo) FindByTeacher(_ context.Context, _ int64) ([]*education.
 	return nil, nil
 }
 func (m *mockGroupRepo) FindWithRoom(_ context.Context, _ int64) (*education.Group, error) {
+	return nil, nil
+}
+func (m *mockGroupRepo) ListSupervisedGroupIDsByStaff(_ context.Context, _ []int64, _ timezone.Date) ([]education.StaffGroupID, error) {
 	return nil, nil
 }
 func (m *mockGroupRepo) CountWithOptions(_ context.Context, _ *base.QueryOptions) (int, error) {

--- a/backend/services/import/staff_import_config_test.go
+++ b/backend/services/import/staff_import_config_test.go
@@ -114,6 +114,9 @@ func (r stubStaffAccountRepo) SetActive(context.Context, int64, bool) error { pa
 func (r stubStaffAccountRepo) FindByRole(context.Context, string) ([]*authModels.Account, error) {
 	panic("not implemented")
 }
+func (r stubStaffAccountRepo) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
+	panic("not implemented")
+}
 func (r stubStaffAccountRepo) FindAccountsWithRolesAndPermissions(context.Context, map[string]interface{}) ([]*authModels.Account, error) {
 	panic("not implemented")
 }

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -10,6 +10,8 @@ import (
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	educationModel "github.com/moto-nrw/project-phoenix/models/education"
 	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
 )
 
 // Copy for the sick/excused notification.
@@ -65,6 +67,7 @@ type absenceNotifier struct {
 	groups      educationModel.GroupRepository
 	staff       userModel.StaffRepository
 	accounts    authAccountReader
+	db          *bun.DB
 	logger      *slog.Logger
 }
 
@@ -81,6 +84,7 @@ func NewAbsenceNotifier(
 	groups educationModel.GroupRepository,
 	staff userModel.StaffRepository,
 	accounts authAccountReader,
+	db *bun.DB,
 	logger *slog.Logger,
 ) AbsenceNotifier {
 	return &absenceNotifier{
@@ -90,6 +94,7 @@ func NewAbsenceNotifier(
 		groups:      groups,
 		staff:       staff,
 		accounts:    accounts,
+		db:          db,
 		logger:      logger,
 	}
 }
@@ -102,7 +107,22 @@ func (n *absenceNotifier) getLogger() *slog.Logger {
 }
 
 func (n *absenceNotifier) NotifyAbsenceReported(ctx context.Context, report AbsenceReport) {
-	if err := n.notify(ctx, report); err != nil {
+	if report.TenantID <= 0 {
+		return
+	}
+
+	var err error
+	if n.db == nil {
+		err = n.notify(ctx, report)
+	} else {
+		// Every caller invokes the producer after the write transaction has
+		// committed. Open a new tenant transaction so all recipient, consent and
+		// delivery reads carry the PostgreSQL RLS context they require.
+		err = tenant.WithTenantTx(ctx, n.db, report.TenantID, func(txCtx context.Context, _ bun.Tx) error {
+			return n.notify(txCtx, report)
+		})
+	}
+	if err != nil {
 		if errors.Is(err, ErrDisabled) || errors.Is(err, ErrOutsideActiveWindow) {
 			return
 		}

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -21,11 +21,12 @@ import (
 // group tablet. The deep link leads into the authenticated app, where the
 // permission-filtered view shows who it is.
 const (
-	absenceReportedTitle       = "Krankmeldung"
-	absenceReportedBodyParent  = "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet."
-	absenceReportedBodyStaff   = "Für ein Kind aus Ihrer Gruppe wurde heute eine Krankmeldung eingetragen."
-	absenceReportedBodyMany    = "%d Kinder wurden für heute krankgemeldet."
-	absenceReportedBodyExcused = "Für ein Kind aus Ihrer Gruppe wurde heute eine Entschuldigung eingetragen."
+	absenceReportedTitle           = "Krankmeldung"
+	absenceReportedBodyParent      = "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet."
+	absenceReportedBodyStaff       = "Für ein Kind aus Ihrer Gruppe wurde heute eine Krankmeldung eingetragen."
+	absenceReportedBodySickMany    = "%d Kinder wurden für heute krankgemeldet."
+	absenceReportedBodyExcused     = "Für ein Kind aus Ihrer Gruppe wurde heute eine Entschuldigung eingetragen."
+	absenceReportedBodyExcusedMany = "%d Kinder wurden für heute entschuldigt."
 )
 
 // absenceAggregateThreshold is the point at which one entry covering many
@@ -255,8 +256,11 @@ func (n *absenceNotifier) groupIDsOfStudents(ctx context.Context, studentIDs []i
 }
 
 func absenceBody(report AbsenceReport) string {
-	if len(report.StudentIDs) > absenceAggregateThreshold {
-		return fmt.Sprintf(absenceReportedBodyMany, len(report.StudentIDs))
+	if len(report.StudentIDs) > 1 {
+		if report.Status == activeModel.StudentStatusDayExcused {
+			return fmt.Sprintf(absenceReportedBodyExcusedMany, len(report.StudentIDs))
+		}
+		return fmt.Sprintf(absenceReportedBodySickMany, len(report.StudentIDs))
 	}
 	if report.Status == activeModel.StudentStatusDayExcused {
 		return absenceReportedBodyExcused

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	educationModel "github.com/moto-nrw/project-phoenix/models/education"
 	userModel "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -66,19 +67,29 @@ type AbsenceNotifier interface {
 }
 
 type absenceNotifier struct {
-	notifier    Service
-	preferences PreferenceService
-	students    userModel.StudentRepository
-	groups      educationModel.GroupRepository
-	staff       userModel.StaffRepository
-	accounts    authAccountReader
-	db          *bun.DB
-	logger      *slog.Logger
+	notifier     Service
+	preferences  PreferenceService
+	students     userModel.StudentRepository
+	groups       educationModel.GroupRepository
+	staff        userModel.StaffRepository
+	accounts     authAccountReader
+	settings     settingsBoolReader
+	workSessions dutyReader
+	db           *bun.DB
+	logger       *slog.Logger
 }
 
 // authAccountReader is the slice of the account repository this producer needs.
 type authAccountReader interface {
 	ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error)
+}
+
+type settingsBoolReader interface {
+	ResolveBool(ctx context.Context, key string) (bool, error)
+}
+
+type dutyReader interface {
+	GetTodayPresenceMap(ctx context.Context) (map[int64]string, error)
 }
 
 // NewAbsenceNotifier builds the sick/excused producer.
@@ -89,18 +100,22 @@ func NewAbsenceNotifier(
 	groups educationModel.GroupRepository,
 	staff userModel.StaffRepository,
 	accounts authAccountReader,
+	settings settingsBoolReader,
+	workSessions dutyReader,
 	db *bun.DB,
 	logger *slog.Logger,
 ) AbsenceNotifier {
 	return &absenceNotifier{
-		notifier:    notifier,
-		preferences: preferences,
-		students:    students,
-		groups:      groups,
-		staff:       staff,
-		accounts:    accounts,
-		db:          db,
-		logger:      logger,
+		notifier:     notifier,
+		preferences:  preferences,
+		students:     students,
+		groups:       groups,
+		staff:        staff,
+		accounts:     accounts,
+		settings:     settings,
+		workSessions: workSessions,
+		db:           db,
+		logger:       logger,
 	}
 }
 
@@ -140,7 +155,7 @@ func (n *absenceNotifier) NotifyAbsenceReported(ctx context.Context, report Abse
 }
 
 func (n *absenceNotifier) notify(ctx context.Context, report AbsenceReport) error {
-	if n.notifier == nil || n.preferences == nil {
+	if n.notifier == nil || n.preferences == nil || n.settings == nil || n.workSessions == nil {
 		return nil
 	}
 	if report.TenantID <= 0 || len(report.StudentIDs) == 0 {
@@ -258,6 +273,10 @@ func (n *absenceNotifier) resolveDeliveries(ctx context.Context, report AbsenceR
 	if err != nil {
 		return nil, err
 	}
+	optedIn, err = n.filterOnDutyAccounts(ctx, optedIn)
+	if err != nil {
+		return nil, err
+	}
 
 	byScope := make(map[string]*absenceDelivery, len(optedIn))
 	keys := make([]string, 0, len(optedIn))
@@ -286,6 +305,51 @@ func (n *absenceNotifier) resolveDeliveries(ctx context.Context, report AbsenceR
 		deliveries = append(deliveries, *delivery)
 	}
 	return deliveries, nil
+}
+
+func (n *absenceNotifier) filterOnDutyAccounts(ctx context.Context, accountIDs []int64) ([]int64, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	onDutyOnly, err := n.settings.ResolveBool(ctx, configModel.KeyNotificationsOnDutyOnly)
+	if err != nil {
+		return nil, fmt.Errorf("resolve on-duty notification setting: %w", err)
+	}
+	if !onDutyOnly {
+		return accountIDs, nil
+	}
+
+	presence, err := n.workSessions.GetTodayPresenceMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load staff presence: %w", err)
+	}
+	onDutyStaffIDs := make([]int64, 0, len(presence))
+	for staffID, status := range presence {
+		if status == activeModel.WorkSessionStatusPresent || status == activeModel.WorkSessionStatusHomeOffice {
+			onDutyStaffIDs = append(onDutyStaffIDs, staffID)
+		}
+	}
+	if len(onDutyStaffIDs) == 0 {
+		return nil, nil
+	}
+	accountsByStaff, err := n.staff.ListAccountIDsByStaffIDs(ctx, onDutyStaffIDs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve staff accounts for duty filter: %w", err)
+	}
+	onDutyAccounts := make(map[int64]struct{}, len(accountsByStaff))
+	for _, staffID := range onDutyStaffIDs {
+		if accountID := accountsByStaff[staffID]; accountID > 0 {
+			onDutyAccounts[accountID] = struct{}{}
+		}
+	}
+
+	filtered := make([]int64, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if _, ok := onDutyAccounts[accountID]; ok {
+			filtered = append(filtered, accountID)
+		}
+	}
+	return filtered, nil
 }
 
 func addVisibleStudents(visibleByAccount map[int64]map[int64]struct{}, accountID int64, studentIDs []int64) {

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -51,6 +51,9 @@ type AbsenceReport struct {
 	// ActorAccountID is excluded from the recipients: nobody needs a push about
 	// their own keystroke.
 	ActorAccountID int64
+	// ExcludedAccountIDs covers other people who originated the same report,
+	// such as a guardian whose request was later approved by staff.
+	ExcludedAccountIDs []int64
 }
 
 // AbsenceNotifier turns a recorded absence into a notification for the people
@@ -238,6 +241,9 @@ func (n *absenceNotifier) resolveDeliveries(ctx context.Context, report AbsenceR
 	}
 
 	delete(visibleByAccount, report.ActorAccountID)
+	for _, accountID := range report.ExcludedAccountIDs {
+		delete(visibleByAccount, accountID)
+	}
 	if len(visibleByAccount) == 0 {
 		return nil, nil
 	}

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
@@ -152,39 +153,57 @@ func (n *absenceNotifier) notify(ctx context.Context, report AbsenceReport) erro
 		return nil
 	}
 
-	recipients, err := n.resolveRecipients(ctx, report)
+	deliveries, err := n.resolveDeliveries(ctx, report)
 	if err != nil {
 		return err
 	}
-	if len(recipients) == 0 {
+	if len(deliveries) == 0 {
 		return nil
 	}
 
-	event := Event{
-		Type:     TypeStudentAbsenceReported,
-		Priority: PriorityNormal,
-		Title:    absenceReportedTitle,
-		Body:     absenceBody(report),
-		DeepLink: absenceDeepLink(report),
-		Audience: Audience{
-			TenantID:        report.TenantID,
-			Scope:           ScopeStaff,
-			StaffAccountIDs: recipients,
-		},
+	events := make([]Event, 0, len(deliveries))
+	for _, delivery := range deliveries {
+		scopedReport := report
+		scopedReport.StudentIDs = delivery.studentIDs
+		events = append(events, Event{
+			Type:     TypeStudentAbsenceReported,
+			Priority: PriorityNormal,
+			Title:    absenceReportedTitle,
+			Body:     absenceBody(scopedReport),
+			DeepLink: absenceDeepLink(scopedReport),
+			Audience: Audience{
+				TenantID:        report.TenantID,
+				Scope:           ScopeStaff,
+				StaffAccountIDs: delivery.accountIDs,
+			},
+		})
 	}
-	return n.notifier.Notify(ctx, event)
+	if batch, ok := n.notifier.(BatchNotifier); ok {
+		return batch.NotifyBatch(ctx, events)
+	}
+	for _, event := range events {
+		if err := n.notifier.Notify(ctx, event); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// resolveRecipients builds the candidate set from the relation and then applies
-// consent. The order matters: consent narrows a relation-derived set, it never
-// stands in for one.
-func (n *absenceNotifier) resolveRecipients(ctx context.Context, report AbsenceReport) ([]int64, error) {
-	candidates := make(map[int64]struct{})
+type absenceDelivery struct {
+	studentIDs []int64
+	accountIDs []int64
+}
 
-	groupIDs, err := n.groupIDsOfStudents(ctx, report.StudentIDs)
+// resolveDeliveries builds each account's visible student subset from the
+// supervision relation, adds the full submission for effective admins, then
+// applies consent. Accounts with identical visibility share one event.
+func (n *absenceNotifier) resolveDeliveries(ctx context.Context, report AbsenceReport) ([]absenceDelivery, error) {
+	allStudentIDs := uniqueInt64s(report.StudentIDs)
+	studentsByGroup, groupIDs, err := n.studentIDsByGroup(ctx, allStudentIDs)
 	if err != nil {
 		return nil, err
 	}
+	visibleByAccount := make(map[int64]map[int64]struct{})
 	if len(groupIDs) > 0 {
 		pairs, perr := n.groups.ListStaffIDsByEducationGroupIDs(ctx, groupIDs, timezone.TodayDate())
 		if perr != nil {
@@ -198,8 +217,12 @@ func (n *absenceNotifier) resolveRecipients(ctx context.Context, report AbsenceR
 		if aerr != nil {
 			return nil, fmt.Errorf("resolve staff accounts: %w", aerr)
 		}
-		for _, accountID := range accountsByStaff {
-			candidates[accountID] = struct{}{}
+		for _, pair := range pairs {
+			accountID, ok := accountsByStaff[pair.StaffID]
+			if !ok {
+				continue
+			}
+			addVisibleStudents(visibleByAccount, accountID, studentsByGroup[pair.GroupID])
 		}
 	}
 
@@ -211,48 +234,115 @@ func (n *absenceNotifier) resolveRecipients(ctx context.Context, report AbsenceR
 		return nil, fmt.Errorf("resolve admin accounts: %w", err)
 	}
 	for _, accountID := range adminIDs {
-		candidates[accountID] = struct{}{}
+		addVisibleStudents(visibleByAccount, accountID, allStudentIDs)
 	}
 
-	delete(candidates, report.ActorAccountID)
-	if len(candidates) == 0 {
+	delete(visibleByAccount, report.ActorAccountID)
+	if len(visibleByAccount) == 0 {
 		return nil, nil
 	}
 
-	candidateIDs := make([]int64, 0, len(candidates))
-	for accountID := range candidates {
+	candidateIDs := make([]int64, 0, len(visibleByAccount))
+	for accountID := range visibleByAccount {
 		candidateIDs = append(candidateIDs, accountID)
 	}
+	sort.Slice(candidateIDs, func(i, j int) bool { return candidateIDs[i] < candidateIDs[j] })
 
 	optedIn, err := n.preferences.FilterOptedIn(ctx, TypeStudentAbsenceReported, candidateIDs)
 	if err != nil {
 		return nil, err
 	}
-	return optedIn, nil
+
+	byScope := make(map[string]*absenceDelivery, len(optedIn))
+	keys := make([]string, 0, len(optedIn))
+	for _, accountID := range optedIn {
+		studentIDs := sortedInt64Set(visibleByAccount[accountID])
+		if len(studentIDs) == 0 {
+			continue
+		}
+		key := fmt.Sprint(studentIDs)
+		delivery := byScope[key]
+		if delivery == nil {
+			delivery = &absenceDelivery{studentIDs: studentIDs}
+			byScope[key] = delivery
+			keys = append(keys, key)
+		}
+		delivery.accountIDs = append(delivery.accountIDs, accountID)
+	}
+	sort.Strings(keys)
+
+	deliveries := make([]absenceDelivery, 0, len(keys))
+	for _, key := range keys {
+		delivery := byScope[key]
+		sort.Slice(delivery.accountIDs, func(i, j int) bool {
+			return delivery.accountIDs[i] < delivery.accountIDs[j]
+		})
+		deliveries = append(deliveries, *delivery)
+	}
+	return deliveries, nil
 }
 
-// groupIDsOfStudents collects the education groups of the reported children.
-func (n *absenceNotifier) groupIDsOfStudents(ctx context.Context, studentIDs []int64) ([]int64, error) {
+func addVisibleStudents(visibleByAccount map[int64]map[int64]struct{}, accountID int64, studentIDs []int64) {
+	if accountID <= 0 || len(studentIDs) == 0 {
+		return
+	}
+	if visibleByAccount[accountID] == nil {
+		visibleByAccount[accountID] = make(map[int64]struct{}, len(studentIDs))
+	}
+	for _, studentID := range studentIDs {
+		visibleByAccount[accountID][studentID] = struct{}{}
+	}
+}
+
+func uniqueInt64s(ids []int64) []int64 {
+	seen := make(map[int64]struct{}, len(ids))
+	unique := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	return unique
+}
+
+func sortedInt64Set(ids map[int64]struct{}) []int64 {
+	sorted := make([]int64, 0, len(ids))
+	for id := range ids {
+		sorted = append(sorted, id)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted
+}
+
+// studentIDsByGroup retains which reported children belong to each education
+// group; flattening this relation would leak the total submission size across
+// group boundaries.
+func (n *absenceNotifier) studentIDsByGroup(ctx context.Context, studentIDs []int64) (map[int64][]int64, []int64, error) {
 	if n.students == nil {
-		return nil, nil
+		return map[int64][]int64{}, nil, nil
 	}
 	students, err := n.students.FindReadScopeByIDs(ctx, studentIDs)
 	if err != nil {
-		return nil, fmt.Errorf("load reported students: %w", err)
+		return nil, nil, fmt.Errorf("load reported students: %w", err)
 	}
+	studentsByGroup := make(map[int64][]int64)
 	seen := make(map[int64]struct{}, len(students))
 	groupIDs := make([]int64, 0, len(students))
-	for _, student := range students {
+	for _, studentID := range studentIDs {
+		student := students[studentID]
 		if student == nil || student.GroupID == nil {
 			continue
 		}
+		studentsByGroup[*student.GroupID] = append(studentsByGroup[*student.GroupID], studentID)
 		if _, dup := seen[*student.GroupID]; dup {
 			continue
 		}
 		seen[*student.GroupID] = struct{}{}
 		groupIDs = append(groupIDs, *student.GroupID)
 	}
-	return groupIDs, nil
+	return studentsByGroup, groupIDs, nil
 }
 
 func absenceBody(report AbsenceReport) string {

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -1,0 +1,270 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// Copy for the sick/excused notification.
+//
+// No child name, no class, no group name: Web Push renders Title and Body on a
+// lock screen and keeps them in the notification centre, possibly on a shared
+// group tablet. The deep link leads into the authenticated app, where the
+// permission-filtered view shows who it is.
+const (
+	absenceReportedTitle       = "Krankmeldung"
+	absenceReportedBodyParent  = "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet."
+	absenceReportedBodyStaff   = "Für ein Kind aus Ihrer Gruppe wurde heute eine Krankmeldung eingetragen."
+	absenceReportedBodyMany    = "%d Kinder wurden für heute krankgemeldet."
+	absenceReportedBodyExcused = "Für ein Kind aus Ihrer Gruppe wurde heute eine Entschuldigung eingetragen."
+)
+
+// absenceAggregateThreshold is the point at which one entry covering many
+// children collapses into a single count instead of one notification each.
+const absenceAggregateThreshold = 3
+
+// AbsenceReport describes one submitted absence, whatever path recorded it.
+type AbsenceReport struct {
+	TenantID int64
+	// StudentIDs are the children covered by this one submission.
+	StudentIDs []int64
+	// Status is active.StudentStatusDaySick or ...Excused. Anything else is
+	// ignored: a class trip is not news, and a cleared status is not either.
+	Status string
+	// Dates the submission covers. The notification only fires when today is
+	// among them — a note for next Tuesday is planning data, not an interrupt.
+	Dates []timezone.Date
+	// FromParent picks the wording. A family reporting is a different event
+	// from a colleague entering it.
+	FromParent bool
+	// ActorAccountID is excluded from the recipients: nobody needs a push about
+	// their own keystroke.
+	ActorAccountID int64
+}
+
+// AbsenceNotifier turns a recorded absence into a notification for the people
+// responsible for that child.
+type AbsenceNotifier interface {
+	// NotifyAbsenceReported is fire-and-forget by contract: it is called from
+	// after-commit hooks, and a failure must never roll back the absence that
+	// was already recorded. Errors are logged, not returned.
+	NotifyAbsenceReported(ctx context.Context, report AbsenceReport)
+}
+
+type absenceNotifier struct {
+	notifier    Service
+	preferences PreferenceService
+	students    userModel.StudentRepository
+	groups      educationModel.GroupRepository
+	staff       userModel.StaffRepository
+	accounts    authAccountReader
+	logger      *slog.Logger
+}
+
+// authAccountReader is the slice of the account repository this producer needs.
+type authAccountReader interface {
+	ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error)
+}
+
+// NewAbsenceNotifier builds the sick/excused producer.
+func NewAbsenceNotifier(
+	notifier Service,
+	preferences PreferenceService,
+	students userModel.StudentRepository,
+	groups educationModel.GroupRepository,
+	staff userModel.StaffRepository,
+	accounts authAccountReader,
+	logger *slog.Logger,
+) AbsenceNotifier {
+	return &absenceNotifier{
+		notifier:    notifier,
+		preferences: preferences,
+		students:    students,
+		groups:      groups,
+		staff:       staff,
+		accounts:    accounts,
+		logger:      logger,
+	}
+}
+
+func (n *absenceNotifier) getLogger() *slog.Logger {
+	if n.logger == nil {
+		return slog.Default()
+	}
+	return n.logger
+}
+
+func (n *absenceNotifier) NotifyAbsenceReported(ctx context.Context, report AbsenceReport) {
+	if err := n.notify(ctx, report); err != nil {
+		if errors.Is(err, ErrDisabled) || errors.Is(err, ErrOutsideActiveWindow) {
+			return
+		}
+		n.getLogger().Warn("absence notification failed",
+			slog.Int64("tenant_id", report.TenantID),
+			slog.Int("student_count", len(report.StudentIDs)),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func (n *absenceNotifier) notify(ctx context.Context, report AbsenceReport) error {
+	if n.notifier == nil || n.preferences == nil {
+		return nil
+	}
+	if report.TenantID <= 0 || len(report.StudentIDs) == 0 {
+		return nil
+	}
+	switch report.Status {
+	case activeModel.StudentStatusDaySick, activeModel.StudentStatusDayExcused:
+	default:
+		// A class trip is not news, and a cleared status even less so.
+		return nil
+	}
+	if !containsToday(report.Dates) {
+		return nil
+	}
+
+	recipients, err := n.resolveRecipients(ctx, report)
+	if err != nil {
+		return err
+	}
+	if len(recipients) == 0 {
+		return nil
+	}
+
+	event := Event{
+		Type:     TypeStudentAbsenceReported,
+		Priority: PriorityNormal,
+		Title:    absenceReportedTitle,
+		Body:     absenceBody(report),
+		DeepLink: absenceDeepLink(report),
+		Audience: Audience{
+			TenantID:        report.TenantID,
+			Scope:           ScopeStaff,
+			StaffAccountIDs: recipients,
+		},
+	}
+	return n.notifier.Notify(ctx, event)
+}
+
+// resolveRecipients builds the candidate set from the relation and then applies
+// consent. The order matters: consent narrows a relation-derived set, it never
+// stands in for one.
+func (n *absenceNotifier) resolveRecipients(ctx context.Context, report AbsenceReport) ([]int64, error) {
+	candidates := make(map[int64]struct{})
+
+	groupIDs, err := n.groupIDsOfStudents(ctx, report.StudentIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(groupIDs) > 0 {
+		pairs, perr := n.groups.ListStaffIDsByEducationGroupIDs(ctx, groupIDs, timezone.TodayDate())
+		if perr != nil {
+			return nil, fmt.Errorf("resolve supervising staff: %w", perr)
+		}
+		staffIDs := make([]int64, 0, len(pairs))
+		for _, pair := range pairs {
+			staffIDs = append(staffIDs, pair.StaffID)
+		}
+		accountsByStaff, aerr := n.staff.ListAccountIDsByStaffIDs(ctx, staffIDs)
+		if aerr != nil {
+			return nil, fmt.Errorf("resolve staff accounts: %w", aerr)
+		}
+		for _, accountID := range accountsByStaff {
+			candidates[accountID] = struct{}{}
+		}
+	}
+
+	// The office owns attendance bookkeeping and parent contact, so it hears
+	// about an absence regardless of which group the child is in. This is also
+	// what covers a child with no group at all.
+	adminIDs, err := n.accounts.ListEffectiveAdminAccountIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve admin accounts: %w", err)
+	}
+	for _, accountID := range adminIDs {
+		candidates[accountID] = struct{}{}
+	}
+
+	delete(candidates, report.ActorAccountID)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	candidateIDs := make([]int64, 0, len(candidates))
+	for accountID := range candidates {
+		candidateIDs = append(candidateIDs, accountID)
+	}
+
+	optedIn, err := n.preferences.FilterOptedIn(ctx, TypeStudentAbsenceReported, candidateIDs)
+	if err != nil {
+		return nil, err
+	}
+	return optedIn, nil
+}
+
+// groupIDsOfStudents collects the education groups of the reported children.
+func (n *absenceNotifier) groupIDsOfStudents(ctx context.Context, studentIDs []int64) ([]int64, error) {
+	if n.students == nil {
+		return nil, nil
+	}
+	students, err := n.students.FindReadScopeByIDs(ctx, studentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("load reported students: %w", err)
+	}
+	seen := make(map[int64]struct{}, len(students))
+	groupIDs := make([]int64, 0, len(students))
+	for _, student := range students {
+		if student == nil || student.GroupID == nil {
+			continue
+		}
+		if _, dup := seen[*student.GroupID]; dup {
+			continue
+		}
+		seen[*student.GroupID] = struct{}{}
+		groupIDs = append(groupIDs, *student.GroupID)
+	}
+	return groupIDs, nil
+}
+
+func absenceBody(report AbsenceReport) string {
+	if len(report.StudentIDs) > absenceAggregateThreshold {
+		return fmt.Sprintf(absenceReportedBodyMany, len(report.StudentIDs))
+	}
+	if report.Status == activeModel.StudentStatusDayExcused {
+		return absenceReportedBodyExcused
+	}
+	if report.FromParent {
+		return absenceReportedBodyParent
+	}
+	return absenceReportedBodyStaff
+}
+
+// absenceDeepLink points at the one child when there is exactly one, and at the
+// list otherwise. The ID is opaque and the page is permission-filtered.
+func absenceDeepLink(report AbsenceReport) string {
+	if len(report.StudentIDs) == 1 {
+		return fmt.Sprintf("/students/%d", report.StudentIDs[0])
+	}
+	if len(report.StudentIDs) > absenceAggregateThreshold {
+		return ""
+	}
+	return "/students"
+}
+
+func containsToday(dates []timezone.Date) bool {
+	today := timezone.TodayDate()
+	for _, d := range dates {
+		if d == today {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -23,8 +23,11 @@ const (
 	absenceStudentA  int64 = 71
 	absenceStudentB  int64 = 72
 	absenceGroupA    int64 = 81
+	absenceGroupB    int64 = 82
 	absenceStaffA    int64 = 91
+	absenceStaffB    int64 = 92
 	absenceAccountA  int64 = 101
+	absenceAccountB  int64 = 104
 	absenceAdmin     int64 = 102
 	absenceActorAcct int64 = 103
 )
@@ -188,6 +191,34 @@ func TestAbsenceNotifierReachesGroupAndOffice(t *testing.T) {
 	assert.NotContains(t, event.Body, "Felix", "no child name leaves the app")
 }
 
+func TestAbsenceNotifierPartitionsCountsByRecipientScope(t *testing.T) {
+	producer, w := newAbsenceWorld()
+	groupB := absenceGroupB
+	w.students.byID[absenceStudentB] = &userModel.Student{GroupID: &groupB}
+	w.groups.staffByGroup[absenceGroupB] = []int64{absenceStaffB}
+	w.staff.accounts[absenceStaffB] = absenceAccountB
+	w.consent.allowed[absenceAccountB] = struct{}{}
+
+	producer.NotifyAbsenceReported(
+		context.Background(),
+		sickToday(absenceStudentA, absenceStudentB),
+	)
+
+	require.Len(t, w.notifier.events, 3)
+	byRecipient := make(map[int64]notifications.Event)
+	for _, event := range w.notifier.events {
+		require.Len(t, event.Audience.StaffAccountIDs, 1)
+		byRecipient[event.Audience.StaffAccountIDs[0]] = event
+	}
+
+	assert.Equal(t, "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet.", byRecipient[absenceAccountA].Body)
+	assert.Equal(t, "/students/71", byRecipient[absenceAccountA].DeepLink)
+	assert.Equal(t, "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet.", byRecipient[absenceAccountB].Body)
+	assert.Equal(t, "/students/72", byRecipient[absenceAccountB].DeepLink)
+	assert.Equal(t, "2 Kinder wurden für heute krankgemeldet.", byRecipient[absenceAdmin].Body)
+	assert.Equal(t, "/students", byRecipient[absenceAdmin].DeepLink)
+}
+
 func TestAbsenceNotifierWording(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -248,11 +279,23 @@ func TestAbsenceNotifierWording(t *testing.T) {
 			producer, w := newAbsenceWorld()
 			producer.NotifyAbsenceReported(context.Background(), tc.report())
 
-			require.Len(t, w.notifier.events, 1)
-			assert.Equal(t, tc.wantBody, w.notifier.events[0].Body)
-			assert.Equal(t, tc.wantLink, w.notifier.events[0].DeepLink)
+			event := eventForAbsenceRecipient(w.notifier.events, absenceAdmin)
+			require.NotNil(t, event)
+			assert.Equal(t, tc.wantBody, event.Body)
+			assert.Equal(t, tc.wantLink, event.DeepLink)
 		})
 	}
+}
+
+func eventForAbsenceRecipient(events []notifications.Event, accountID int64) *notifications.Event {
+	for i := range events {
+		for _, recipientID := range events[i].Audience.StaffAccountIDs {
+			if recipientID == accountID {
+				return &events[i]
+			}
+		}
+	}
+	return nil
 }
 
 func TestAbsenceNotifierSilentCases(t *testing.T) {

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	educationModel "github.com/moto-nrw/project-phoenix/models/education"
 	userModel "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
@@ -19,17 +20,18 @@ import (
 
 // In-memory identities. None of these are database rows.
 const (
-	absenceTenant    int64 = 5
-	absenceStudentA  int64 = 71
-	absenceStudentB  int64 = 72
-	absenceGroupA    int64 = 81
-	absenceGroupB    int64 = 82
-	absenceStaffA    int64 = 91
-	absenceStaffB    int64 = 92
-	absenceAccountA  int64 = 101
-	absenceAccountB  int64 = 104
-	absenceAdmin     int64 = 102
-	absenceActorAcct int64 = 103
+	absenceTenant     int64 = 5
+	absenceStudentA   int64 = 71
+	absenceStudentB   int64 = 72
+	absenceGroupA     int64 = 81
+	absenceGroupB     int64 = 82
+	absenceStaffA     int64 = 91
+	absenceStaffB     int64 = 92
+	absenceAdminStaff int64 = 93
+	absenceAccountA   int64 = 101
+	absenceAccountB   int64 = 104
+	absenceAdmin      int64 = 102
+	absenceActorAcct  int64 = 103
 )
 
 type fakeStudentReader struct {
@@ -74,11 +76,17 @@ type fakeStaffAccountReader struct {
 	userModel.StaffRepository
 	accounts map[int64]int64
 	err      error
+	dutyErr  error
+	calls    int
 }
 
 func (f *fakeStaffAccountReader) ListAccountIDsByStaffIDs(_ context.Context, staffIDs []int64) (map[int64]int64, error) {
+	f.calls++
 	if f.err != nil {
 		return nil, f.err
+	}
+	if f.dutyErr != nil && f.calls > 1 {
+		return nil, f.dutyErr
 	}
 	out := make(map[int64]int64, len(staffIDs))
 	for _, staffID := range staffIDs {
@@ -96,6 +104,28 @@ type fakeAdminReader struct {
 
 func (f *fakeAdminReader) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
 	return f.ids, f.err
+}
+
+type fakeOnDutySetting struct {
+	enabled bool
+	err     error
+	asked   string
+}
+
+func (f *fakeOnDutySetting) ResolveBool(_ context.Context, key string) (bool, error) {
+	f.asked = key
+	return f.enabled, f.err
+}
+
+type fakeDutyReader struct {
+	presence map[int64]string
+	err      error
+	called   bool
+}
+
+func (f *fakeDutyReader) GetTodayPresenceMap(context.Context) (map[int64]string, error) {
+	f.called = true
+	return f.presence, f.err
 }
 
 // captureNotifier records what the producer decided to send.
@@ -141,6 +171,8 @@ type absenceWorld struct {
 	groups   *fakeGroupReader
 	staff    *fakeStaffAccountReader
 	admins   *fakeAdminReader
+	settings *fakeOnDutySetting
+	duty     *fakeDutyReader
 }
 
 // newAbsenceWorld wires one child in one group, supervised by one person, plus
@@ -155,11 +187,19 @@ func newAbsenceWorld() (notifications.AbsenceNotifier, *absenceWorld) {
 			absenceStudentB: {GroupID: &groupID},
 		}},
 		groups: &fakeGroupReader{staffByGroup: map[int64][]int64{absenceGroupA: {absenceStaffA}}},
-		staff:  &fakeStaffAccountReader{accounts: map[int64]int64{absenceStaffA: absenceAccountA}},
-		admins: &fakeAdminReader{ids: []int64{absenceAdmin}},
+		staff: &fakeStaffAccountReader{accounts: map[int64]int64{
+			absenceStaffA:     absenceAccountA,
+			absenceAdminStaff: absenceAdmin,
+		}},
+		admins:   &fakeAdminReader{ids: []int64{absenceAdmin}},
+		settings: &fakeOnDutySetting{enabled: true},
+		duty: &fakeDutyReader{presence: map[int64]string{
+			absenceStaffA:     activeModel.WorkSessionStatusPresent,
+			absenceAdminStaff: activeModel.WorkSessionStatusPresent,
+		}},
 	}
 	producer := notifications.NewAbsenceNotifier(
-		w.notifier, w.consent, w.students, w.groups, w.staff, w.admins, nil, nil)
+		w.notifier, w.consent, w.students, w.groups, w.staff, w.admins, w.settings, w.duty, nil, nil)
 	return producer, w
 }
 
@@ -198,6 +238,7 @@ func TestAbsenceNotifierPartitionsCountsByRecipientScope(t *testing.T) {
 	w.groups.staffByGroup[absenceGroupB] = []int64{absenceStaffB}
 	w.staff.accounts[absenceStaffB] = absenceAccountB
 	w.consent.allowed[absenceAccountB] = struct{}{}
+	w.duty.presence[absenceStaffB] = activeModel.WorkSessionStatusPresent
 
 	producer.NotifyAbsenceReported(
 		context.Background(),
@@ -405,19 +446,77 @@ func TestAbsenceNotifierRespectsConsent(t *testing.T) {
 	})
 }
 
+func TestAbsenceNotifierRespectsOnDutySetting(t *testing.T) {
+	t.Run("only checked-in staff are addressed", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.duty.presence[absenceStaffA] = "checked_out"
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		require.Len(t, w.notifier.events, 1)
+		assert.Equal(t, []int64{absenceAdmin}, w.notifier.events[0].Audience.StaffAccountIDs)
+		assert.Equal(t, configModel.KeyNotificationsOnDutyOnly, w.settings.asked)
+	})
+
+	t.Run("home office counts as on duty", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.duty.presence[absenceStaffA] = activeModel.WorkSessionStatusHomeOffice
+		w.duty.presence[absenceAdminStaff] = "checked_out"
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		require.Len(t, w.notifier.events, 1)
+		assert.Equal(t, []int64{absenceAccountA}, w.notifier.events[0].Audience.StaffAccountIDs)
+	})
+
+	t.Run("nobody checked in fails closed", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.duty.presence = nil
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		assert.Empty(t, w.notifier.events)
+	})
+
+	t.Run("staffless admins are excluded", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		delete(w.staff.accounts, absenceAdminStaff)
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		require.Len(t, w.notifier.events, 1)
+		assert.Equal(t, []int64{absenceAccountA}, w.notifier.events[0].Audience.StaffAccountIDs)
+	})
+
+	t.Run("disabled setting leaves consent as the final filter", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.settings.enabled = false
+		w.duty.err = errors.New("must not be read")
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		require.Len(t, w.notifier.events, 1)
+		assert.ElementsMatch(t, []int64{absenceAccountA, absenceAdmin}, w.notifier.events[0].Audience.StaffAccountIDs)
+		assert.False(t, w.duty.called)
+	})
+}
+
 // Every failure is swallowed by contract: the producer runs from after-commit
 // hooks, and a notification that cannot be built must never undo an absence
 // that was already recorded.
 func TestAbsenceNotifierSwallowsFailures(t *testing.T) {
 	cases := map[string]func(*absenceWorld){
-		"student read fails": func(w *absenceWorld) { w.students.err = errors.New("boom") },
-		"group read fails":   func(w *absenceWorld) { w.groups.err = errors.New("boom") },
-		"staff read fails":   func(w *absenceWorld) { w.staff.err = errors.New("boom") },
-		"admin read fails":   func(w *absenceWorld) { w.admins.err = errors.New("boom") },
-		"consent fails":      func(w *absenceWorld) { w.consent.err = errors.New("boom") },
-		"dispatch fails":     func(w *absenceWorld) { w.notifier.err = errors.New("boom") },
-		"notifications off":  func(w *absenceWorld) { w.notifier.err = notifications.ErrDisabled },
-		"outside the window": func(w *absenceWorld) { w.notifier.err = notifications.ErrOutsideActiveWindow },
+		"student read fails":  func(w *absenceWorld) { w.students.err = errors.New("boom") },
+		"group read fails":    func(w *absenceWorld) { w.groups.err = errors.New("boom") },
+		"staff read fails":    func(w *absenceWorld) { w.staff.err = errors.New("boom") },
+		"admin read fails":    func(w *absenceWorld) { w.admins.err = errors.New("boom") },
+		"consent fails":       func(w *absenceWorld) { w.consent.err = errors.New("boom") },
+		"setting read fails":  func(w *absenceWorld) { w.settings.err = errors.New("boom") },
+		"presence read fails": func(w *absenceWorld) { w.duty.err = errors.New("boom") },
+		"duty mapping fails":  func(w *absenceWorld) { w.staff.dutyErr = errors.New("boom") },
+		"dispatch fails":      func(w *absenceWorld) { w.notifier.err = errors.New("boom") },
+		"notifications off":   func(w *absenceWorld) { w.notifier.err = notifications.ErrDisabled },
+		"outside the window":  func(w *absenceWorld) { w.notifier.err = notifications.ErrOutsideActiveWindow },
 	}
 
 	for name, break_ := range cases {
@@ -437,7 +536,7 @@ func TestAbsenceNotifierSwallowsFailures(t *testing.T) {
 // fallback audience.
 func TestAbsenceNotifierWithoutDependencies(t *testing.T) {
 	notifier := &captureNotifier{}
-	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil, nil, nil, nil, nil)
+	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.NotPanics(t, func() {
 		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
 	})

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -361,6 +361,18 @@ func TestAbsenceNotifierExcludesTheActor(t *testing.T) {
 		"nobody needs a push about their own keystroke")
 }
 
+func TestAbsenceNotifierExcludesAdditionalOriginators(t *testing.T) {
+	producer, w := newAbsenceWorld()
+
+	report := sickToday(absenceStudentA)
+	report.ExcludedAccountIDs = []int64{absenceAccountA}
+	producer.NotifyAbsenceReported(context.Background(), report)
+
+	require.Len(t, w.notifier.events, 1)
+	assert.Equal(t, []int64{absenceAdmin}, w.notifier.events[0].Audience.StaffAccountIDs,
+		"a guardian with a staff role must not receive their own approved report")
+}
+
 func TestAbsenceNotifierRespectsConsent(t *testing.T) {
 	t.Run("only those who agreed are addressed", func(t *testing.T) {
 		producer, w := newAbsenceWorld()

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -220,7 +220,17 @@ func TestAbsenceNotifierWording(t *testing.T) {
 			report: func() notifications.AbsenceReport {
 				return sickToday(absenceStudentA, absenceStudentB)
 			},
-			wantBody: "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet.",
+			wantBody: "2 Kinder wurden für heute krankgemeldet.",
+			wantLink: "/students",
+		},
+		{
+			name: "three excused children use plural wording",
+			report: func() notifications.AbsenceReport {
+				r := sickToday(71, 72, 73)
+				r.Status = activeModel.StudentStatusDayExcused
+				return r
+			},
+			wantBody: "3 Kinder wurden für heute entschuldigt.",
 			wantLink: "/students",
 		},
 		{

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -1,0 +1,380 @@
+// Absence producer tests against fakes. The producer is pure orchestration —
+// relation, then consent, then one event — so every branch is reachable without
+// a database.
+package notifications_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// In-memory identities. None of these are database rows.
+const (
+	absenceTenant    int64 = 5
+	absenceStudentA  int64 = 71
+	absenceStudentB  int64 = 72
+	absenceGroupA    int64 = 81
+	absenceStaffA    int64 = 91
+	absenceAccountA  int64 = 101
+	absenceAdmin     int64 = 102
+	absenceActorAcct int64 = 103
+)
+
+type fakeStudentReader struct {
+	userModel.StudentRepository
+	byID map[int64]*userModel.Student
+	err  error
+}
+
+func (f *fakeStudentReader) FindReadScopeByIDs(_ context.Context, ids []int64) (map[int64]*userModel.Student, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make(map[int64]*userModel.Student, len(ids))
+	for _, id := range ids {
+		if s, ok := f.byID[id]; ok {
+			out[id] = s
+		}
+	}
+	return out, nil
+}
+
+type fakeGroupReader struct {
+	educationModel.GroupRepository
+	staffByGroup map[int64][]int64
+	err          error
+}
+
+func (f *fakeGroupReader) ListStaffIDsByEducationGroupIDs(_ context.Context, groupIDs []int64, _ timezone.Date) ([]educationModel.StaffGroupID, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	var out []educationModel.StaffGroupID
+	for _, groupID := range groupIDs {
+		for _, staffID := range f.staffByGroup[groupID] {
+			out = append(out, educationModel.StaffGroupID{StaffID: staffID, GroupID: groupID})
+		}
+	}
+	return out, nil
+}
+
+type fakeStaffAccountReader struct {
+	userModel.StaffRepository
+	accounts map[int64]int64
+	err      error
+}
+
+func (f *fakeStaffAccountReader) ListAccountIDsByStaffIDs(_ context.Context, staffIDs []int64) (map[int64]int64, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make(map[int64]int64, len(staffIDs))
+	for _, staffID := range staffIDs {
+		if accountID, ok := f.accounts[staffID]; ok {
+			out[staffID] = accountID
+		}
+	}
+	return out, nil
+}
+
+type fakeAdminReader struct {
+	ids []int64
+	err error
+}
+
+func (f *fakeAdminReader) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
+	return f.ids, f.err
+}
+
+// captureNotifier records what the producer decided to send.
+type captureNotifier struct {
+	events []notifications.Event
+	err    error
+}
+
+func (c *captureNotifier) Notify(_ context.Context, event notifications.Event) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.events = append(c.events, event)
+	return nil
+}
+
+// stubConsent answers the consent question without a repository.
+type stubConsent struct {
+	notifications.PreferenceService
+	allowed map[int64]struct{}
+	err     error
+	asked   []int64
+}
+
+func (s *stubConsent) FilterOptedIn(_ context.Context, _ string, accountIDs []int64) ([]int64, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.asked = append(s.asked, accountIDs...)
+	out := make([]int64, 0, len(accountIDs))
+	for _, id := range accountIDs {
+		if _, ok := s.allowed[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}
+
+type absenceWorld struct {
+	notifier *captureNotifier
+	consent  *stubConsent
+	students *fakeStudentReader
+	groups   *fakeGroupReader
+	staff    *fakeStaffAccountReader
+	admins   *fakeAdminReader
+}
+
+// newAbsenceWorld wires one child in one group, supervised by one person, plus
+// one admin. Both the supervisor and the admin have agreed.
+func newAbsenceWorld() (notifications.AbsenceNotifier, *absenceWorld) {
+	groupID := absenceGroupA
+	w := &absenceWorld{
+		notifier: &captureNotifier{},
+		consent:  &stubConsent{allowed: map[int64]struct{}{absenceAccountA: {}, absenceAdmin: {}}},
+		students: &fakeStudentReader{byID: map[int64]*userModel.Student{
+			absenceStudentA: {GroupID: &groupID},
+			absenceStudentB: {GroupID: &groupID},
+		}},
+		groups: &fakeGroupReader{staffByGroup: map[int64][]int64{absenceGroupA: {absenceStaffA}}},
+		staff:  &fakeStaffAccountReader{accounts: map[int64]int64{absenceStaffA: absenceAccountA}},
+		admins: &fakeAdminReader{ids: []int64{absenceAdmin}},
+	}
+	producer := notifications.NewAbsenceNotifier(
+		w.notifier, w.consent, w.students, w.groups, w.staff, w.admins, nil)
+	return producer, w
+}
+
+func sickToday(studentIDs ...int64) notifications.AbsenceReport {
+	return notifications.AbsenceReport{
+		TenantID:   absenceTenant,
+		StudentIDs: studentIDs,
+		Status:     activeModel.StudentStatusDaySick,
+		Dates:      []timezone.Date{timezone.TodayDate()},
+		FromParent: true,
+	}
+}
+
+func TestAbsenceNotifierReachesGroupAndOffice(t *testing.T) {
+	producer, w := newAbsenceWorld()
+
+	producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+	require.Len(t, w.notifier.events, 1)
+	event := w.notifier.events[0]
+	assert.Equal(t, notifications.TypeStudentAbsenceReported, event.Type)
+	assert.Equal(t, notifications.ScopeStaff, event.Audience.Scope)
+	assert.Equal(t, absenceTenant, event.Audience.TenantID)
+	assert.ElementsMatch(t, []int64{absenceAccountA, absenceAdmin}, event.Audience.StaffAccountIDs,
+		"the supervising person and the office, both of whom agreed")
+	assert.Equal(t, "Krankmeldung", event.Title)
+	assert.Contains(t, event.Body, "Eine Familie")
+	assert.Equal(t, "/students/71", event.DeepLink)
+	assert.NotContains(t, event.Body, "Felix", "no child name leaves the app")
+}
+
+func TestAbsenceNotifierWording(t *testing.T) {
+	cases := []struct {
+		name     string
+		report   func() notifications.AbsenceReport
+		wantBody string
+		wantLink string
+	}{
+		{
+			name: "reported by staff",
+			report: func() notifications.AbsenceReport {
+				r := sickToday(absenceStudentA)
+				r.FromParent = false
+				return r
+			},
+			wantBody: "Für ein Kind aus Ihrer Gruppe wurde heute eine Krankmeldung eingetragen.",
+			wantLink: "/students/71",
+		},
+		{
+			name: "an excuse reads differently",
+			report: func() notifications.AbsenceReport {
+				r := sickToday(absenceStudentA)
+				r.Status = activeModel.StudentStatusDayExcused
+				return r
+			},
+			wantBody: "Für ein Kind aus Ihrer Gruppe wurde heute eine Entschuldigung eingetragen.",
+			wantLink: "/students/71",
+		},
+		{
+			name: "two children point at the list",
+			report: func() notifications.AbsenceReport {
+				return sickToday(absenceStudentA, absenceStudentB)
+			},
+			wantBody: "Eine Familie hat ein Kind aus Ihrer Gruppe für heute krankgemeldet.",
+			wantLink: "/students",
+		},
+		{
+			name: "many children collapse into a count without a link",
+			report: func() notifications.AbsenceReport {
+				return sickToday(71, 72, 73, 74)
+			},
+			wantBody: "4 Kinder wurden für heute krankgemeldet.",
+			wantLink: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			producer, w := newAbsenceWorld()
+			producer.NotifyAbsenceReported(context.Background(), tc.report())
+
+			require.Len(t, w.notifier.events, 1)
+			assert.Equal(t, tc.wantBody, w.notifier.events[0].Body)
+			assert.Equal(t, tc.wantLink, w.notifier.events[0].DeepLink)
+		})
+	}
+}
+
+func TestAbsenceNotifierSilentCases(t *testing.T) {
+	cases := []struct {
+		name   string
+		report notifications.AbsenceReport
+		why    string
+	}{
+		{
+			name: "a class trip is not news",
+			report: func() notifications.AbsenceReport {
+				r := sickToday(absenceStudentA)
+				r.Status = activeModel.StudentStatusDayClassTrip
+				return r
+			}(),
+			why: "only sick and excused are reported",
+		},
+		{
+			name: "a note for another day is planning data",
+			report: func() notifications.AbsenceReport {
+				r := sickToday(absenceStudentA)
+				r.Dates = []timezone.Date{timezone.TodayDate().AddDays(3)}
+				return r
+			}(),
+			why: "a future note must not interrupt anybody today",
+		},
+		{
+			name:   "no children",
+			report: sickToday(),
+			why:    "nothing was reported",
+		},
+		{
+			name: "no tenant",
+			report: func() notifications.AbsenceReport {
+				r := sickToday(absenceStudentA)
+				r.TenantID = 0
+				return r
+			}(),
+			why: "an event without a school cannot be delivered",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			producer, w := newAbsenceWorld()
+			producer.NotifyAbsenceReported(context.Background(), tc.report)
+			assert.Empty(t, w.notifier.events, tc.why)
+		})
+	}
+}
+
+func TestAbsenceNotifierExcludesTheActor(t *testing.T) {
+	producer, w := newAbsenceWorld()
+	w.consent.allowed[absenceActorAcct] = struct{}{}
+	w.staff.accounts[absenceStaffA] = absenceActorAcct
+
+	report := sickToday(absenceStudentA)
+	report.ActorAccountID = absenceActorAcct
+	producer.NotifyAbsenceReported(context.Background(), report)
+
+	require.Len(t, w.notifier.events, 1)
+	assert.NotContains(t, w.notifier.events[0].Audience.StaffAccountIDs, absenceActorAcct,
+		"nobody needs a push about their own keystroke")
+}
+
+func TestAbsenceNotifierRespectsConsent(t *testing.T) {
+	t.Run("only those who agreed are addressed", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.consent.allowed = map[int64]struct{}{absenceAdmin: {}}
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		require.Len(t, w.notifier.events, 1)
+		assert.Equal(t, []int64{absenceAdmin}, w.notifier.events[0].Audience.StaffAccountIDs)
+		assert.ElementsMatch(t, []int64{absenceAccountA, absenceAdmin}, w.consent.asked,
+			"consent narrows the relation-derived set, it never replaces it")
+	})
+
+	t.Run("nobody agreed means no event", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.consent.allowed = nil
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+		assert.Empty(t, w.notifier.events)
+	})
+
+	t.Run("a child without a group still reaches the office", func(t *testing.T) {
+		producer, w := newAbsenceWorld()
+		w.students.byID[absenceStudentA] = &userModel.Student{}
+
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+
+		require.Len(t, w.notifier.events, 1)
+		assert.Equal(t, []int64{absenceAdmin}, w.notifier.events[0].Audience.StaffAccountIDs)
+	})
+}
+
+// Every failure is swallowed by contract: the producer runs from after-commit
+// hooks, and a notification that cannot be built must never undo an absence
+// that was already recorded.
+func TestAbsenceNotifierSwallowsFailures(t *testing.T) {
+	cases := map[string]func(*absenceWorld){
+		"student read fails": func(w *absenceWorld) { w.students.err = errors.New("boom") },
+		"group read fails":   func(w *absenceWorld) { w.groups.err = errors.New("boom") },
+		"staff read fails":   func(w *absenceWorld) { w.staff.err = errors.New("boom") },
+		"admin read fails":   func(w *absenceWorld) { w.admins.err = errors.New("boom") },
+		"consent fails":      func(w *absenceWorld) { w.consent.err = errors.New("boom") },
+		"dispatch fails":     func(w *absenceWorld) { w.notifier.err = errors.New("boom") },
+		"notifications off":  func(w *absenceWorld) { w.notifier.err = notifications.ErrDisabled },
+		"outside the window": func(w *absenceWorld) { w.notifier.err = notifications.ErrOutsideActiveWindow },
+	}
+
+	for name, break_ := range cases {
+		t.Run(name, func(t *testing.T) {
+			producer, w := newAbsenceWorld()
+			break_(w)
+
+			assert.NotPanics(t, func() {
+				producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+			})
+			assert.Empty(t, w.notifier.events)
+		})
+	}
+}
+
+// A partially constructed producer stays quiet rather than addressing a
+// fallback audience.
+func TestAbsenceNotifierWithoutDependencies(t *testing.T) {
+	notifier := &captureNotifier{}
+	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil, nil, nil, nil)
+	assert.NotPanics(t, func() {
+		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
+	})
+	assert.Empty(t, notifier.events)
+}

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -156,7 +156,7 @@ func newAbsenceWorld() (notifications.AbsenceNotifier, *absenceWorld) {
 		admins: &fakeAdminReader{ids: []int64{absenceAdmin}},
 	}
 	producer := notifications.NewAbsenceNotifier(
-		w.notifier, w.consent, w.students, w.groups, w.staff, w.admins, nil)
+		w.notifier, w.consent, w.students, w.groups, w.staff, w.admins, nil, nil)
 	return producer, w
 }
 
@@ -372,7 +372,7 @@ func TestAbsenceNotifierSwallowsFailures(t *testing.T) {
 // fallback audience.
 func TestAbsenceNotifierWithoutDependencies(t *testing.T) {
 	notifier := &captureNotifier{}
-	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil, nil, nil, nil)
+	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.NotPanics(t, func() {
 		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
 	})

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -57,6 +57,13 @@ type PreferenceService interface {
 	// round.
 	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
 
+	// FilterNotOptedOut is the mirror of FilterOptedIn for channels that already
+	// reached people before consent existed: it drops only the accounts that
+	// explicitly declined the type, and keeps the ones who never decided. Use it
+	// for e-mail, which is addressed to a person the school already writes to;
+	// push and in-app hints stay consent-first via FilterOptedIn.
+	FilterNotOptedOut(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
+
 	// GetForParent and SetForParent are the guardian-portal counterparts. The
 	// parents app has no tenant context of its own, so both resolve the
 	// account's active school mappings and act across all of them: one set of
@@ -210,6 +217,39 @@ func (s *preferenceService) FilterOptedIn(ctx context.Context, notificationType 
 		return nil, fmt.Errorf("filter opted-in accounts: %w", err)
 	}
 	return optedIn, nil
+}
+
+func (s *preferenceService) FilterNotOptedOut(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	def, known := GetType(notificationType)
+	if !known {
+		// Same reasoning as FilterOptedIn: a producer naming a type outside the
+		// catalogue is a bug, and this is not the place to guess an audience.
+		return nil, fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+	}
+
+	// The school-wide gate is applied like in FilterOptedIn. It says "this
+	// school does not want this notification at all", which is about the type
+	// and not about one delivery channel. TypeParentAnnouncement declares no
+	// gate, so today this branch never fires for the e-mail path.
+	if def.TenantGate != "" {
+		allowed, err := s.resolveBool(ctx, def.TenantGate)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			return nil, nil
+		}
+	}
+
+	remaining, err := s.repo.FilterNotOptedOut(ctx, notificationType, accountIDs)
+	if err != nil {
+		return nil, fmt.Errorf("filter opted-out accounts: %w", err)
+	}
+	return remaining, nil
 }
 
 // GetForParent merges the guardian's decisions across every active school.

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -345,7 +345,7 @@ func (s *preferenceService) forEachGuardianTenant(
 // must not silently widen or narrow who gets notified.
 func (s *preferenceService) resolveBool(ctx context.Context, key string) (bool, error) {
 	if s.settings == nil {
-		return false, nil
+		return false, errors.New("notification preferences service has no settings service configured")
 	}
 	v, err := s.settings.ResolveBool(ctx, key)
 	if err != nil {

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -57,6 +57,15 @@ type PreferenceService interface {
 	// round.
 	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
 
+	// HasAnyOptedIn is a cheap tenant-wide scheduling gate. It only reports
+	// stored consent and must never be used as the source of an audience.
+	HasAnyOptedIn(ctx context.Context, notificationTypes []string) (bool, error)
+
+	// FilterOptedInByType applies the same consent and tenant-gate rules as
+	// FilterOptedIn for multiple types, using one settings read and one
+	// preference read.
+	FilterOptedInByType(ctx context.Context, notificationTypes []string, accountIDs []int64) (map[string][]int64, error)
+
 	// FilterNotOptedOut is the mirror of FilterOptedIn for channels that already
 	// reached people before consent existed: it drops only the accounts that
 	// explicitly declined the type, and keeps the ones who never decided. Use it
@@ -194,29 +203,89 @@ func (s *preferenceService) FilterOptedIn(ctx context.Context, notificationType 
 		return nil, nil
 	}
 
-	def, known := GetType(notificationType)
-	if !known {
-		// Fail closed: an unknown type reaches nobody. A producer naming a type
-		// that is not in the catalogue is a bug, and delivering to everyone
-		// would be the worst possible interpretation of it.
-		return nil, fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+	optedInByType, err := s.FilterOptedInByType(ctx, []string{notificationType}, accountIDs)
+	if err != nil {
+		return nil, err
+	}
+	return optedInByType[notificationType], nil
+}
+
+func (s *preferenceService) HasAnyOptedIn(ctx context.Context, notificationTypes []string) (bool, error) {
+	if len(notificationTypes) == 0 {
+		return false, nil
+	}
+	for _, notificationType := range notificationTypes {
+		if _, known := GetType(notificationType); !known {
+			return false, fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+		}
+	}
+	hasAny, err := s.repo.HasAnyOptedIn(ctx, notificationTypes)
+	if err != nil {
+		return false, fmt.Errorf("check for opted-in accounts: %w", err)
+	}
+	return hasAny, nil
+}
+
+func (s *preferenceService) FilterOptedInByType(
+	ctx context.Context,
+	notificationTypes []string,
+	accountIDs []int64,
+) (map[string][]int64, error) {
+	filtered := make(map[string][]int64)
+	if len(notificationTypes) == 0 || len(accountIDs) == 0 {
+		return filtered, nil
 	}
 
-	if def.TenantGate != "" {
-		allowed, err := s.resolveBool(ctx, def.TenantGate)
+	gateKeys := make([]string, 0, len(notificationTypes))
+	gateByType := make(map[string]string, len(notificationTypes))
+	seenGates := make(map[string]struct{}, len(notificationTypes))
+	for _, notificationType := range notificationTypes {
+		def, known := GetType(notificationType)
+		if !known {
+			// Fail closed: an unknown type reaches nobody. A producer naming a
+			// type outside the catalogue is a bug.
+			return nil, fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+		}
+		gateByType[notificationType] = def.TenantGate
+		if def.TenantGate == "" {
+			continue
+		}
+		if _, seen := seenGates[def.TenantGate]; seen {
+			continue
+		}
+		seenGates[def.TenantGate] = struct{}{}
+		gateKeys = append(gateKeys, def.TenantGate)
+	}
+
+	allowedByGate := make(map[string]bool)
+	if len(gateKeys) > 0 {
+		if s.settings == nil {
+			return nil, errors.New("notification preferences service has no settings service configured")
+		}
+		var err error
+		allowedByGate, err = s.settings.ResolveBools(ctx, gateKeys)
 		if err != nil {
-			return nil, err
-		}
-		if !allowed {
-			return nil, nil
+			return nil, fmt.Errorf("resolve notification gates: %w", err)
 		}
 	}
 
-	optedIn, err := s.repo.FilterOptedIn(ctx, notificationType, accountIDs)
+	allowedTypes := make([]string, 0, len(notificationTypes))
+	for _, notificationType := range notificationTypes {
+		gate := gateByType[notificationType]
+		if gate != "" && !allowedByGate[gate] {
+			continue
+		}
+		allowedTypes = append(allowedTypes, notificationType)
+	}
+	if len(allowedTypes) == 0 {
+		return filtered, nil
+	}
+
+	optedInByType, err := s.repo.FilterOptedInByType(ctx, allowedTypes, accountIDs)
 	if err != nil {
 		return nil, fmt.Errorf("filter opted-in accounts: %w", err)
 	}
-	return optedIn, nil
+	return optedInByType, nil
 }
 
 func (s *preferenceService) FilterNotOptedOut(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error) {

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -153,7 +153,8 @@ func (s *preferenceService) SetForAccount(ctx context.Context, accountID int64, 
 	if accountID <= 0 {
 		return errors.New("account id is required")
 	}
-	if _, known := GetType(notificationType); !known {
+	def, known := GetType(notificationType)
+	if !known || def.Portal != PortalStaff {
 		return fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
 	}
 

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -47,7 +47,7 @@ type PreferenceService interface {
 	// SetForAccount records one decision.
 	SetForAccount(ctx context.Context, accountID int64, notificationType string, enabled bool) error
 
-	// DisableAllForAccount switches every stored decision off.
+	// DisableAllForAccount switches every stored staff-portal decision off.
 	DisableAllForAccount(ctx context.Context, accountID int64) error
 
 	// FilterOptedIn narrows a producer's candidate recipients to those who
@@ -176,7 +176,7 @@ func (s *preferenceService) DisableAllForAccount(ctx context.Context, accountID 
 	if accountID <= 0 {
 		return errors.New("account id is required")
 	}
-	if err := s.repo.DisableAllForAccount(ctx, accountID); err != nil {
+	if err := s.repo.DisableAllForAccount(ctx, accountID, typeKeysForPortal(PortalStaff)); err != nil {
 		return fmt.Errorf("disable notification preferences: %w", err)
 	}
 	return nil
@@ -291,17 +291,27 @@ func (s *preferenceService) SetForParent(ctx context.Context, accountID int64, n
 	})
 }
 
-// DisableAllForParent switches every stored decision off at every school.
+// DisableAllForParent switches every stored parent-portal decision off at
+// every school.
 func (s *preferenceService) DisableAllForParent(ctx context.Context, accountID int64) error {
 	if accountID <= 0 {
 		return errors.New("account id is required")
 	}
 	return s.forEachGuardianTenant(ctx, accountID, func(tenantCtx context.Context, tenantID int64) error {
-		if err := s.repo.DisableAllForAccount(tenantCtx, accountID); err != nil {
+		if err := s.repo.DisableAllForAccount(tenantCtx, accountID, typeKeysForPortal(PortalParent)); err != nil {
 			return fmt.Errorf("disable notification preferences for tenant %d: %w", tenantID, err)
 		}
 		return nil
 	})
+}
+
+func typeKeysForPortal(portal string) []string {
+	defs := TypesForPortal(portal)
+	keys := make([]string, 0, len(defs))
+	for _, def := range defs {
+		keys = append(keys, def.Key)
+	}
+	return keys
 }
 
 // forEachGuardianTenant runs fn once per active school mapping of the account,

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -1,0 +1,344 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	authModel "github.com/moto-nrw/project-phoenix/models/auth"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// ErrUnknownNotificationType is returned when a caller names a type that is not
+// in the catalogue. Handlers map it to 400.
+var ErrUnknownNotificationType = errors.New("unknown notification type")
+
+// PreferenceState is one row of the profile page: what the type is, whether the
+// person agreed, and whether the school currently allows it at all.
+type PreferenceState struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Group       string `json:"group"`
+	Enabled     bool   `json:"enabled"`
+	// Available reports whether the school allows this type right now. A type
+	// can be switched on personally while unavailable — see SetForAccount.
+	Available bool `json:"available"`
+}
+
+// PreferenceOverview is the payload behind the profile page's card.
+type PreferenceOverview struct {
+	// TenantEnabled mirrors notifications.dispatch_enabled. When false nothing
+	// is delivered no matter what the person chose, and the card says so.
+	TenantEnabled bool              `json:"tenant_enabled"`
+	Types         []PreferenceState `json:"types"`
+}
+
+// PreferenceService owns per-account notification consent.
+type PreferenceService interface {
+	// GetForAccount returns the full catalogue of one portal with the account's
+	// stored decisions merged in. Types the account never touched read as off.
+	GetForAccount(ctx context.Context, accountID int64, portal string) (*PreferenceOverview, error)
+
+	// SetForAccount records one decision.
+	SetForAccount(ctx context.Context, accountID int64, notificationType string, enabled bool) error
+
+	// DisableAllForAccount switches every stored decision off.
+	DisableAllForAccount(ctx context.Context, accountID int64) error
+
+	// FilterOptedIn narrows a producer's candidate recipients to those who
+	// agreed to the type AND whose school still allows it. This is the single
+	// enforcement point for "nothing without consent"; producers build the
+	// relation-based candidate set and then call this, never the other way
+	// round.
+	FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
+
+	// GetForParent and SetForParent are the guardian-portal counterparts. The
+	// parents app has no tenant context of its own, so both resolve the
+	// account's active school mappings and act across all of them: one set of
+	// switches, applied to every school the family belongs to.
+	GetForParent(ctx context.Context, accountID int64) (*PreferenceOverview, error)
+	SetForParent(ctx context.Context, accountID int64, notificationType string, enabled bool) error
+	DisableAllForParent(ctx context.Context, accountID int64) error
+}
+
+type preferenceService struct {
+	repo           userModel.NotificationPreferenceRepository
+	settings       configService.SettingsService
+	db             *bun.DB
+	accountTenants authModel.AccountTenantRepository
+}
+
+// NewPreferenceService builds the consent service. db and accountTenants are
+// needed only for the guardian portal, which is cross-tenant.
+func NewPreferenceService(
+	repo userModel.NotificationPreferenceRepository,
+	settings configService.SettingsService,
+	db *bun.DB,
+	accountTenants authModel.AccountTenantRepository,
+) PreferenceService {
+	return &preferenceService{
+		repo:           repo,
+		settings:       settings,
+		db:             db,
+		accountTenants: accountTenants,
+	}
+}
+
+func (s *preferenceService) GetForAccount(ctx context.Context, accountID int64, portal string) (*PreferenceOverview, error) {
+	if accountID <= 0 {
+		return nil, errors.New("account id is required")
+	}
+
+	stored, err := s.repo.ListByAccount(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("load notification preferences: %w", err)
+	}
+	enabledByType := make(map[string]bool, len(stored))
+	for _, pref := range stored {
+		enabledByType[pref.NotificationType] = pref.Enabled
+	}
+
+	tenantEnabled, err := s.resolveBool(ctx, configModel.KeyNotificationsDispatchEnabled)
+	if err != nil {
+		return nil, err
+	}
+
+	defs := TypesForPortal(portal)
+	overview := &PreferenceOverview{
+		TenantEnabled: tenantEnabled,
+		Types:         make([]PreferenceState, 0, len(defs)),
+	}
+
+	// Gate values are cached per settings key: several types share one gate,
+	// and the page is opened often enough that re-reading would be wasteful.
+	gateCache := make(map[string]bool, len(defs))
+	for _, def := range defs {
+		available := true
+		if def.TenantGate != "" {
+			cached, seen := gateCache[def.TenantGate]
+			if !seen {
+				cached, err = s.resolveBool(ctx, def.TenantGate)
+				if err != nil {
+					return nil, err
+				}
+				gateCache[def.TenantGate] = cached
+			}
+			available = cached
+		}
+
+		overview.Types = append(overview.Types, PreferenceState{
+			Key:         def.Key,
+			Label:       def.Label,
+			Description: def.Description,
+			Group:       def.Group,
+			Enabled:     enabledByType[def.Key],
+			Available:   available,
+		})
+	}
+
+	return overview, nil
+}
+
+// SetForAccount records one decision.
+//
+// A type the school currently blocks can still be switched on. The alternative
+// would lose a person's choice whenever an admin toggles the school setting off
+// and on again; the gate is applied at delivery time instead.
+func (s *preferenceService) SetForAccount(ctx context.Context, accountID int64, notificationType string, enabled bool) error {
+	if accountID <= 0 {
+		return errors.New("account id is required")
+	}
+	if _, known := GetType(notificationType); !known {
+		return fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+	}
+
+	pref := &userModel.NotificationPreference{
+		AccountID:        accountID,
+		NotificationType: notificationType,
+		Enabled:          enabled,
+	}
+	if err := pref.Validate(); err != nil {
+		return err
+	}
+	if err := s.repo.Upsert(ctx, pref); err != nil {
+		return fmt.Errorf("save notification preference: %w", err)
+	}
+	return nil
+}
+
+func (s *preferenceService) DisableAllForAccount(ctx context.Context, accountID int64) error {
+	if accountID <= 0 {
+		return errors.New("account id is required")
+	}
+	if err := s.repo.DisableAllForAccount(ctx, accountID); err != nil {
+		return fmt.Errorf("disable notification preferences: %w", err)
+	}
+	return nil
+}
+
+func (s *preferenceService) FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	def, known := GetType(notificationType)
+	if !known {
+		// Fail closed: an unknown type reaches nobody. A producer naming a type
+		// that is not in the catalogue is a bug, and delivering to everyone
+		// would be the worst possible interpretation of it.
+		return nil, fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+	}
+
+	if def.TenantGate != "" {
+		allowed, err := s.resolveBool(ctx, def.TenantGate)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			return nil, nil
+		}
+	}
+
+	optedIn, err := s.repo.FilterOptedIn(ctx, notificationType, accountIDs)
+	if err != nil {
+		return nil, fmt.Errorf("filter opted-in accounts: %w", err)
+	}
+	return optedIn, nil
+}
+
+// GetForParent merges the guardian's decisions across every active school.
+//
+// A type reads as enabled when it is enabled at any of them: the parents app
+// shows one set of switches, and a family that agreed at their school should
+// see that reflected rather than a mysterious "off" caused by a second,
+// dormant mapping.
+func (s *preferenceService) GetForParent(ctx context.Context, accountID int64) (*PreferenceOverview, error) {
+	if accountID <= 0 {
+		return nil, errors.New("account id is required")
+	}
+
+	defs := TypesForPortal(PortalParent)
+	overview := &PreferenceOverview{Types: make([]PreferenceState, 0, len(defs))}
+	enabledByType := make(map[string]bool, len(defs))
+
+	err := s.forEachGuardianTenant(ctx, accountID, func(tenantCtx context.Context, _ int64) error {
+		stored, err := s.repo.ListByAccount(tenantCtx, accountID)
+		if err != nil {
+			return fmt.Errorf("load notification preferences: %w", err)
+		}
+		for _, pref := range stored {
+			if pref.Enabled {
+				enabledByType[pref.NotificationType] = true
+			}
+		}
+		// Any school allowing dispatch is enough for the card to stop saying
+		// "your school switched this off".
+		tenantEnabled, err := s.resolveBool(tenantCtx, configModel.KeyNotificationsDispatchEnabled)
+		if err != nil {
+			return err
+		}
+		if tenantEnabled {
+			overview.TenantEnabled = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, def := range defs {
+		overview.Types = append(overview.Types, PreferenceState{
+			Key:         def.Key,
+			Label:       def.Label,
+			Description: def.Description,
+			Group:       def.Group,
+			Enabled:     enabledByType[def.Key],
+			Available:   true, // parent types carry no school-wide gate
+		})
+	}
+	return overview, nil
+}
+
+// SetForParent applies one decision to every school the guardian belongs to.
+func (s *preferenceService) SetForParent(ctx context.Context, accountID int64, notificationType string, enabled bool) error {
+	if accountID <= 0 {
+		return errors.New("account id is required")
+	}
+	def, known := GetType(notificationType)
+	if !known || def.Portal != PortalParent {
+		return fmt.Errorf("%w: %s", ErrUnknownNotificationType, notificationType)
+	}
+
+	return s.forEachGuardianTenant(ctx, accountID, func(tenantCtx context.Context, tenantID int64) error {
+		pref := &userModel.NotificationPreference{
+			AccountID:        accountID,
+			NotificationType: notificationType,
+			Enabled:          enabled,
+		}
+		// Set explicitly: the admin transaction carries no tenant in its
+		// context, so the row would otherwise land without one.
+		pref.SetTenantID(tenantID)
+		if err := s.repo.Upsert(tenantCtx, pref); err != nil {
+			return fmt.Errorf("save notification preference for tenant %d: %w", tenantID, err)
+		}
+		return nil
+	})
+}
+
+// DisableAllForParent switches every stored decision off at every school.
+func (s *preferenceService) DisableAllForParent(ctx context.Context, accountID int64) error {
+	if accountID <= 0 {
+		return errors.New("account id is required")
+	}
+	return s.forEachGuardianTenant(ctx, accountID, func(tenantCtx context.Context, tenantID int64) error {
+		if err := s.repo.DisableAllForAccount(tenantCtx, accountID); err != nil {
+			return fmt.Errorf("disable notification preferences for tenant %d: %w", tenantID, err)
+		}
+		return nil
+	})
+}
+
+// forEachGuardianTenant runs fn once per active school mapping of the account,
+// all inside one admin transaction so a multi-school change is atomic. Mirrors
+// the push-subscription flow, including the deliberate exclusion of
+// pending-enrollment-only schools.
+func (s *preferenceService) forEachGuardianTenant(
+	ctx context.Context,
+	accountID int64,
+	fn func(tenantCtx context.Context, tenantID int64) error,
+) error {
+	if s.db == nil || s.accountTenants == nil {
+		return errors.New("notification preferences are not configured for the guardian portal")
+	}
+
+	return tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, _ bun.Tx) error {
+		mappings, err := s.accountTenants.FindActiveGuardianByAccountID(txCtx, accountID)
+		if err != nil {
+			return fmt.Errorf("resolving guardian tenant mappings: %w", err)
+		}
+		for _, mapping := range mappings {
+			if err := fn(tenant.WithTenantID(txCtx, mapping.TenantID), mapping.TenantID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// resolveBool surfaces a settings failure rather than guessing. A broken read
+// must not silently widen or narrow who gets notified.
+func (s *preferenceService) resolveBool(ctx context.Context, key string) (bool, error) {
+	if s.settings == nil {
+		return false, nil
+	}
+	v, err := s.settings.ResolveBool(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("resolve %s: %w", key, err)
+	}
+	return v, nil
+}

--- a/backend/services/notifications/preferences.go
+++ b/backend/services/notifications/preferences.go
@@ -214,10 +214,10 @@ func (s *preferenceService) FilterOptedIn(ctx context.Context, notificationType 
 
 // GetForParent merges the guardian's decisions across every active school.
 //
-// A type reads as enabled when it is enabled at any of them: the parents app
-// shows one set of switches, and a family that agreed at their school should
-// see that reflected rather than a mysterious "off" caused by a second,
-// dormant mapping.
+// A type reads as enabled only when it is enabled at every active guardian
+// mapping. The parents app shows one set of switches and SetForParent applies a
+// change to all schools, so a mixed state must read as off rather than claiming
+// that a newly added school may deliver when it has no consent row.
 func (s *preferenceService) GetForParent(ctx context.Context, accountID int64) (*PreferenceOverview, error) {
 	if accountID <= 0 {
 		return nil, errors.New("account id is required")
@@ -225,16 +225,18 @@ func (s *preferenceService) GetForParent(ctx context.Context, accountID int64) (
 
 	defs := TypesForPortal(PortalParent)
 	overview := &PreferenceOverview{Types: make([]PreferenceState, 0, len(defs))}
-	enabledByType := make(map[string]bool, len(defs))
+	enabledTenantCount := make(map[string]int, len(defs))
+	tenantCount := 0
 
 	err := s.forEachGuardianTenant(ctx, accountID, func(tenantCtx context.Context, _ int64) error {
+		tenantCount++
 		stored, err := s.repo.ListByAccount(tenantCtx, accountID)
 		if err != nil {
 			return fmt.Errorf("load notification preferences: %w", err)
 		}
 		for _, pref := range stored {
 			if pref.Enabled {
-				enabledByType[pref.NotificationType] = true
+				enabledTenantCount[pref.NotificationType]++
 			}
 		}
 		// Any school allowing dispatch is enough for the card to stop saying
@@ -258,7 +260,7 @@ func (s *preferenceService) GetForParent(ctx context.Context, accountID int64) (
 			Label:       def.Label,
 			Description: def.Description,
 			Group:       def.Group,
-			Enabled:     enabledByType[def.Key],
+			Enabled:     tenantCount > 0 && enabledTenantCount[def.Key] == tenantCount,
 			Available:   true, // parent types carry no school-wide gate
 		})
 	}

--- a/backend/services/notifications/preferences_guardian_test.go
+++ b/backend/services/notifications/preferences_guardian_test.go
@@ -1,0 +1,125 @@
+// Guardian-portal consent, against a real database.
+//
+// The parents app carries no tenant of its own, so these paths resolve the
+// account's active school mappings and act across all of them inside one admin
+// transaction. That resolution, the RLS-guarded write it performs per school,
+// and the tenant stamped on the row are exactly what a fake cannot check.
+package notifications_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuardianPreferencesAcrossSchools(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	repos := repositories.NewFactory(db)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	t.Cleanup(func() {
+		_, err := db.NewDelete().
+			Table("users.notification_preferences").
+			Where("account_id = ?", chain.AccountID).
+			Exec(context.Background())
+		require.NoError(t, err)
+		testpkg.CleanupParentGuardianChain(t, db, chain)
+	})
+
+	settings := &configtest.Mock{
+		ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+			return key == configModel.KeyNotificationsDispatchEnabled, nil
+		},
+	}
+	svc := notifications.NewPreferenceService(repos.NotificationPreference, settings, db, repos.AccountTenant)
+
+	t.Run("starts empty", func(t *testing.T) {
+		overview, err := svc.GetForParent(ctx, chain.AccountID)
+		require.NoError(t, err)
+		require.Len(t, overview.Types, 1, "the guardian catalogue holds exactly one type today")
+		assert.Equal(t, notifications.TypeParentAnnouncement, overview.Types[0].Key)
+		assert.False(t, overview.Types[0].Enabled, "no row means off")
+		assert.True(t, overview.Types[0].Available, "parent types carry no school-wide gate")
+		assert.True(t, overview.TenantEnabled, "the family's school has dispatch on")
+	})
+
+	t.Run("a decision is stored per school and reads back", func(t *testing.T) {
+		require.NoError(t, svc.SetForParent(ctx, chain.AccountID, notifications.TypeParentAnnouncement, true))
+
+		overview, err := svc.GetForParent(ctx, chain.AccountID)
+		require.NoError(t, err)
+		assert.True(t, overview.Types[0].Enabled)
+
+		// The row must carry the school it was decided for: without it the
+		// tenant-scoped producer read would never find it again.
+		var tenantID int64
+		require.NoError(t, db.NewSelect().
+			TableExpr("users.notification_preferences").
+			ColumnExpr("tenant_id").
+			Where("account_id = ? AND notification_type = ?", chain.AccountID, notifications.TypeParentAnnouncement).
+			Scan(ctx, &tenantID))
+		assert.Equal(t, chain.TenantID, tenantID)
+	})
+
+	t.Run("the producer finds the guardian through the tenant-scoped filter", func(t *testing.T) {
+		tenantCtx := testpkg.TenantContext(chain.TenantID)
+		optedIn, err := svc.FilterOptedIn(tenantCtx, notifications.TypeParentAnnouncement, []int64{chain.AccountID})
+		require.NoError(t, err)
+		assert.Equal(t, []int64{chain.AccountID}, optedIn,
+			"what the parents app stored has to be what the announcement producer reads")
+	})
+
+	t.Run("switching everything off keeps the row as a deliberate no", func(t *testing.T) {
+		require.NoError(t, svc.DisableAllForParent(ctx, chain.AccountID))
+
+		overview, err := svc.GetForParent(ctx, chain.AccountID)
+		require.NoError(t, err)
+		assert.False(t, overview.Types[0].Enabled)
+
+		var count int
+		require.NoError(t, db.NewSelect().
+			TableExpr("users.notification_preferences").
+			ColumnExpr("count(*)").
+			Where("account_id = ?", chain.AccountID).
+			Scan(ctx, &count))
+		assert.Equal(t, 1, count, "the opt-out is recorded, not deleted")
+
+		tenantCtx := testpkg.TenantContext(chain.TenantID)
+		optedIn, err := svc.FilterOptedIn(tenantCtx, notifications.TypeParentAnnouncement, []int64{chain.AccountID})
+		require.NoError(t, err)
+		assert.Empty(t, optedIn, "an opt-out reaches nobody")
+	})
+
+	t.Run("an unknown type is rejected before any write", func(t *testing.T) {
+		err := svc.SetForParent(ctx, chain.AccountID, "not_a_type", true)
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+	})
+
+	t.Run("an account with no school mapping changes nothing", func(t *testing.T) {
+		orphan := testpkg.CreateTestAccount(t, db, "guardian-without-school@example.com")
+		t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, orphan.ID) })
+
+		require.NoError(t, svc.SetForParent(ctx, orphan.ID, notifications.TypeParentAnnouncement, true))
+
+		var count int
+		require.NoError(t, db.NewSelect().
+			TableExpr("users.notification_preferences").
+			ColumnExpr("count(*)").
+			Where("account_id = ?", orphan.ID).
+			Scan(ctx, &count))
+		assert.Zero(t, count, "without a school there is nowhere to store a decision")
+
+		overview, err := svc.GetForParent(ctx, orphan.ID)
+		require.NoError(t, err)
+		assert.False(t, overview.TenantEnabled, "no school means no school that enabled dispatch")
+	})
+}

--- a/backend/services/notifications/preferences_guardian_test.go
+++ b/backend/services/notifications/preferences_guardian_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
@@ -78,6 +79,34 @@ func TestGuardianPreferencesAcrossSchools(t *testing.T) {
 			"what the parents app stored has to be what the announcement producer reads")
 	})
 
+	t.Run("a new school mapping keeps the shared switch off until consent covers it", func(t *testing.T) {
+		const secondTenantID int64 = 2
+		testpkg.EnsureTestTenant(t, db, secondTenantID)
+		testpkg.MapAccountToTenant(t, db, chain.AccountID, secondTenantID)
+
+		var guardianRoleID int64
+		require.NoError(t, db.NewSelect().
+			TableExpr("auth.roles").
+			ColumnExpr("id").
+			Where("name = ?", authModel.BaseRoleGuardian).
+			Scan(ctx, &guardianRoleID))
+		role := &authModel.AccountRole{AccountID: chain.AccountID, RoleID: guardianRoleID}
+		role.SetTenantID(secondTenantID)
+		_, err := db.NewInsert().Model(role).ModelTableExpr("auth.account_roles").Exec(ctx)
+		require.NoError(t, err)
+
+		overview, err := svc.GetForParent(ctx, chain.AccountID)
+		require.NoError(t, err)
+		assert.False(t, overview.Types[0].Enabled,
+			"a missing consent row at the new school must not read as enabled")
+
+		require.NoError(t, svc.SetForParent(ctx, chain.AccountID, notifications.TypeParentAnnouncement, true))
+		overview, err = svc.GetForParent(ctx, chain.AccountID)
+		require.NoError(t, err)
+		assert.True(t, overview.Types[0].Enabled,
+			"one shared change must record consent at every active school")
+	})
+
 	t.Run("switching everything off keeps the row as a deliberate no", func(t *testing.T) {
 		require.NoError(t, svc.DisableAllForParent(ctx, chain.AccountID))
 
@@ -91,7 +120,7 @@ func TestGuardianPreferencesAcrossSchools(t *testing.T) {
 			ColumnExpr("count(*)").
 			Where("account_id = ?", chain.AccountID).
 			Scan(ctx, &count))
-		assert.Equal(t, 1, count, "the opt-out is recorded, not deleted")
+		assert.Equal(t, 2, count, "the opt-out is recorded once per active school, not deleted")
 
 		tenantCtx := testpkg.TenantContext(chain.TenantID)
 		optedIn, err := svc.FilterOptedIn(tenantCtx, notifications.TypeParentAnnouncement, []int64{chain.AccountID})

--- a/backend/services/notifications/preferences_mock_test.go
+++ b/backend/services/notifications/preferences_mock_test.go
@@ -22,15 +22,16 @@ import (
 type fakePreferenceRepo struct {
 	userModel.NotificationPreferenceRepository
 
-	stored     []*userModel.NotificationPreference
-	optedIn    map[string][]int64
-	upserted   []*userModel.NotificationPreference
-	disabled   []int64
-	listErr    error
-	upsertErr  error
-	filterErr  error
-	disableErr error
-	filterArgs []int64
+	stored        []*userModel.NotificationPreference
+	optedIn       map[string][]int64
+	upserted      []*userModel.NotificationPreference
+	disabled      []int64
+	disabledTypes [][]string
+	listErr       error
+	upsertErr     error
+	filterErr     error
+	disableErr    error
+	filterArgs    []int64
 }
 
 func (f *fakePreferenceRepo) ListByAccount(_ context.Context, _ int64) ([]*userModel.NotificationPreference, error) {
@@ -53,11 +54,12 @@ func (f *fakePreferenceRepo) FilterOptedIn(_ context.Context, notificationType s
 	return f.optedIn[notificationType], nil
 }
 
-func (f *fakePreferenceRepo) DisableAllForAccount(_ context.Context, accountID int64) error {
+func (f *fakePreferenceRepo) DisableAllForAccount(_ context.Context, accountID int64, notificationTypes []string) error {
 	if f.disableErr != nil {
 		return f.disableErr
 	}
 	f.disabled = append(f.disabled, accountID)
+	f.disabledTypes = append(f.disabledTypes, notificationTypes)
 	return nil
 }
 
@@ -202,6 +204,10 @@ func TestDisableAllForAccount(t *testing.T) {
 
 	require.NoError(t, svc.DisableAllForAccount(context.Background(), prefAccountA))
 	assert.Equal(t, []int64{prefAccountA}, repo.disabled)
+	require.Len(t, repo.disabledTypes, 1)
+	assert.Contains(t, repo.disabledTypes[0], notifications.TypePickupUpcoming)
+	assert.NotContains(t, repo.disabledTypes[0], notifications.TypeParentAnnouncement,
+		"the staff action must not disable parent-portal consent")
 
 	require.Error(t, svc.DisableAllForAccount(context.Background(), 0))
 

--- a/backend/services/notifications/preferences_mock_test.go
+++ b/backend/services/notifications/preferences_mock_test.go
@@ -175,6 +175,15 @@ func TestSetForAccount(t *testing.T) {
 		assert.Empty(t, repo.upserted)
 	})
 
+	t.Run("a parent type is rejected on the staff portal", func(t *testing.T) {
+		repo := &fakePreferenceRepo{}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		err := svc.SetForAccount(context.Background(), prefAccountA, notifications.TypeParentAnnouncement, true)
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+		assert.Empty(t, repo.upserted)
+	})
+
 	t.Run("account id is required", func(t *testing.T) {
 		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
 		require.Error(t, svc.SetForAccount(context.Background(), 0, notifications.TypePickupUpcoming, true))

--- a/backend/services/notifications/preferences_mock_test.go
+++ b/backend/services/notifications/preferences_mock_test.go
@@ -1,0 +1,293 @@
+// Consent service tests against fakes. The staff-portal paths are pure — a
+// repository double and a settings double are enough — which is why they live
+// here rather than in the database-backed file next to them.
+package notifications_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePreferenceRepo implements the four methods the service actually calls.
+// The embedded interface is nil on purpose: if the service ever reaches for
+// another method, the test panics instead of quietly passing.
+type fakePreferenceRepo struct {
+	userModel.NotificationPreferenceRepository
+
+	stored     []*userModel.NotificationPreference
+	optedIn    map[string][]int64
+	upserted   []*userModel.NotificationPreference
+	disabled   []int64
+	listErr    error
+	upsertErr  error
+	filterErr  error
+	disableErr error
+	filterArgs []int64
+}
+
+func (f *fakePreferenceRepo) ListByAccount(_ context.Context, _ int64) ([]*userModel.NotificationPreference, error) {
+	return f.stored, f.listErr
+}
+
+func (f *fakePreferenceRepo) Upsert(_ context.Context, pref *userModel.NotificationPreference) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upserted = append(f.upserted, pref)
+	return nil
+}
+
+func (f *fakePreferenceRepo) FilterOptedIn(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if f.filterErr != nil {
+		return nil, f.filterErr
+	}
+	f.filterArgs = accountIDs
+	return f.optedIn[notificationType], nil
+}
+
+func (f *fakePreferenceRepo) DisableAllForAccount(_ context.Context, accountID int64) error {
+	if f.disableErr != nil {
+		return f.disableErr
+	}
+	f.disabled = append(f.disabled, accountID)
+	return nil
+}
+
+// allSettingsOn answers every boolean setting with true: dispatch is on and no
+// type is gated off school-wide.
+func allSettingsOn() *configtest.Mock {
+	return &configtest.Mock{
+		ResolveBoolFn: func(_ context.Context, _ string) (bool, error) { return true, nil },
+	}
+}
+
+// The account IDs here are in-memory arguments to fakes, not database rows.
+const (
+	prefAccountA int64 = 41
+	prefAccountB int64 = 42
+)
+
+func TestGetForAccountMergesStoredDecisions(t *testing.T) {
+	repo := &fakePreferenceRepo{stored: []*userModel.NotificationPreference{
+		{AccountID: prefAccountA, NotificationType: notifications.TypePickupUpcoming, Enabled: true},
+		{AccountID: prefAccountA, NotificationType: notifications.TypePickupOverdue, Enabled: false},
+	}}
+	svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+	overview, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
+	require.NoError(t, err)
+
+	assert.True(t, overview.TenantEnabled)
+	byKey := make(map[string]bool, len(overview.Types))
+	for _, state := range overview.Types {
+		byKey[state.Key] = state.Enabled
+		assert.NotEmpty(t, state.Label, "%s renders on the profile page and needs copy", state.Key)
+		assert.True(t, state.Available, "no gate is off in this setup")
+	}
+
+	assert.True(t, byKey[notifications.TypePickupUpcoming])
+	assert.False(t, byKey[notifications.TypePickupOverdue], "an explicit no reads as off")
+	assert.False(t, byKey[notifications.TypeMyActivityStarting], "a type never touched reads as off")
+	assert.NotContains(t, byKey, notifications.TypeParentAnnouncement,
+		"a parent type must not surface in the staff catalogue")
+}
+
+// A type the school switched off is still listed and still switchable — the
+// person's choice has to survive an admin toggling the school setting.
+func TestGetForAccountMarksSchoolGatedTypesUnavailable(t *testing.T) {
+	settings := &configtest.Mock{
+		ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+			return key != configModel.KeyRemindersPickupUpcomingEnabled, nil
+		},
+	}
+	svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, settings, nil, nil)
+
+	overview, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
+	require.NoError(t, err)
+
+	for _, state := range overview.Types {
+		if state.Key == notifications.TypePickupUpcoming {
+			assert.False(t, state.Available)
+			return
+		}
+	}
+	t.Fatal("pickup_upcoming missing from the staff catalogue")
+}
+
+func TestGetForAccountFailures(t *testing.T) {
+	t.Run("account id is required", func(t *testing.T) {
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
+		_, err := svc.GetForAccount(context.Background(), 0, notifications.PortalStaff)
+		require.Error(t, err)
+	})
+
+	t.Run("a failing repository surfaces", func(t *testing.T) {
+		repo := &fakePreferenceRepo{listErr: errors.New("boom")}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+		_, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
+		require.Error(t, err)
+	})
+
+	t.Run("a failing settings read surfaces", func(t *testing.T) {
+		settings := &configtest.Mock{
+			ResolveBoolFn: func(_ context.Context, _ string) (bool, error) { return false, errors.New("boom") },
+		}
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, settings, nil, nil)
+		_, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
+		require.Error(t, err, "a broken read must not silently widen or narrow who gets notified")
+	})
+
+	t.Run("without a settings service nothing is enabled", func(t *testing.T) {
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, nil, nil, nil)
+		overview, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
+		require.NoError(t, err)
+		assert.False(t, overview.TenantEnabled)
+	})
+}
+
+func TestSetForAccount(t *testing.T) {
+	t.Run("records the decision", func(t *testing.T) {
+		repo := &fakePreferenceRepo{}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		require.NoError(t, svc.SetForAccount(context.Background(), prefAccountA, notifications.TypePickupUpcoming, true))
+
+		require.Len(t, repo.upserted, 1)
+		assert.Equal(t, prefAccountA, repo.upserted[0].AccountID)
+		assert.Equal(t, notifications.TypePickupUpcoming, repo.upserted[0].NotificationType)
+		assert.True(t, repo.upserted[0].Enabled)
+	})
+
+	t.Run("an unknown type is rejected", func(t *testing.T) {
+		repo := &fakePreferenceRepo{}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		err := svc.SetForAccount(context.Background(), prefAccountA, "not_a_type", true)
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+		assert.Empty(t, repo.upserted)
+	})
+
+	t.Run("account id is required", func(t *testing.T) {
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
+		require.Error(t, svc.SetForAccount(context.Background(), 0, notifications.TypePickupUpcoming, true))
+	})
+
+	t.Run("a failing write surfaces", func(t *testing.T) {
+		repo := &fakePreferenceRepo{upsertErr: errors.New("boom")}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+		require.Error(t, svc.SetForAccount(context.Background(), prefAccountA, notifications.TypePickupUpcoming, true))
+	})
+}
+
+func TestDisableAllForAccount(t *testing.T) {
+	repo := &fakePreferenceRepo{}
+	svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+	require.NoError(t, svc.DisableAllForAccount(context.Background(), prefAccountA))
+	assert.Equal(t, []int64{prefAccountA}, repo.disabled)
+
+	require.Error(t, svc.DisableAllForAccount(context.Background(), 0))
+
+	failing := notifications.NewPreferenceService(&fakePreferenceRepo{disableErr: errors.New("boom")}, allSettingsOn(), nil, nil)
+	require.Error(t, failing.DisableAllForAccount(context.Background(), prefAccountA))
+}
+
+// FilterOptedIn is the single enforcement point for "nothing without consent",
+// so each of its answers is pinned separately.
+func TestFilterOptedIn(t *testing.T) {
+	candidates := []int64{prefAccountA, prefAccountB}
+
+	t.Run("returns only those who agreed", func(t *testing.T) {
+		repo := &fakePreferenceRepo{optedIn: map[string][]int64{
+			notifications.TypePickupUpcoming: {prefAccountA},
+		}}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		got, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, candidates)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{prefAccountA}, got)
+		assert.Equal(t, candidates, repo.filterArgs, "the whole candidate set is offered to the filter")
+	})
+
+	t.Run("no candidates means nobody", func(t *testing.T) {
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
+		got, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("an unknown type fails closed", func(t *testing.T) {
+		repo := &fakePreferenceRepo{optedIn: map[string][]int64{"": candidates}}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		got, err := svc.FilterOptedIn(context.Background(), "not_a_type", candidates)
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+		assert.Empty(t, got, "a producer naming a type that does not exist must reach nobody, not everybody")
+	})
+
+	t.Run("a type the school switched off reaches nobody", func(t *testing.T) {
+		settings := &configtest.Mock{
+			ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+				return key != configModel.KeyRemindersPickupUpcomingEnabled, nil
+			},
+		}
+		repo := &fakePreferenceRepo{optedIn: map[string][]int64{
+			notifications.TypePickupUpcoming: candidates,
+		}}
+		svc := notifications.NewPreferenceService(repo, settings, nil, nil)
+
+		got, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, candidates)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("a failing gate read surfaces", func(t *testing.T) {
+		settings := &configtest.Mock{
+			ResolveBoolFn: func(_ context.Context, _ string) (bool, error) { return false, errors.New("boom") },
+		}
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, settings, nil, nil)
+		_, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, candidates)
+		require.Error(t, err)
+	})
+
+	t.Run("a failing repository surfaces", func(t *testing.T) {
+		repo := &fakePreferenceRepo{filterErr: errors.New("boom")}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+		_, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, candidates)
+		require.Error(t, err)
+	})
+}
+
+// The guardian portal is cross-tenant and needs the database handle plus the
+// mapping repository. Without them the service must refuse rather than act on
+// the request context's tenant, which for a parent request is nobody's school.
+func TestGuardianPathsRequireTheirDependencies(t *testing.T) {
+	svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
+	ctx := context.Background()
+
+	_, err := svc.GetForParent(ctx, prefAccountA)
+	require.Error(t, err)
+
+	require.Error(t, svc.SetForParent(ctx, prefAccountA, notifications.TypeParentAnnouncement, true))
+	require.Error(t, svc.DisableAllForParent(ctx, prefAccountA))
+
+	t.Run("account id is required", func(t *testing.T) {
+		_, err := svc.GetForParent(ctx, 0)
+		require.Error(t, err)
+		require.Error(t, svc.SetForParent(ctx, 0, notifications.TypeParentAnnouncement, true))
+		require.Error(t, svc.DisableAllForParent(ctx, 0))
+	})
+
+	t.Run("a staff type cannot be set through the parent portal", func(t *testing.T) {
+		err := svc.SetForParent(ctx, prefAccountA, notifications.TypePickupUpcoming, true)
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+	})
+}

--- a/backend/services/notifications/preferences_mock_test.go
+++ b/backend/services/notifications/preferences_mock_test.go
@@ -24,6 +24,7 @@ type fakePreferenceRepo struct {
 
 	stored        []*userModel.NotificationPreference
 	optedIn       map[string][]int64
+	optedOut      map[string][]int64
 	upserted      []*userModel.NotificationPreference
 	disabled      []int64
 	disabledTypes [][]string
@@ -52,6 +53,25 @@ func (f *fakePreferenceRepo) FilterOptedIn(_ context.Context, notificationType s
 	}
 	f.filterArgs = accountIDs
 	return f.optedIn[notificationType], nil
+}
+
+func (f *fakePreferenceRepo) FilterNotOptedOut(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if f.filterErr != nil {
+		return nil, f.filterErr
+	}
+	f.filterArgs = accountIDs
+	declined := make(map[int64]struct{}, len(f.optedOut[notificationType]))
+	for _, accountID := range f.optedOut[notificationType] {
+		declined[accountID] = struct{}{}
+	}
+	remaining := make([]int64, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if _, ok := declined[accountID]; ok {
+			continue
+		}
+		remaining = append(remaining, accountID)
+	}
+	return remaining, nil
 }
 
 func (f *fakePreferenceRepo) DisableAllForAccount(_ context.Context, accountID int64, notificationTypes []string) error {
@@ -277,6 +297,58 @@ func TestFilterOptedIn(t *testing.T) {
 		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
 		_, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, candidates)
 		require.Error(t, err)
+	})
+}
+
+// FilterNotOptedOut is the mirror rule for channels that predate consent: only
+// an explicit no filters, a missing decision does not.
+func TestFilterNotOptedOut(t *testing.T) {
+	candidates := []int64{prefAccountA, prefAccountB}
+
+	t.Run("keeps everyone who did not decline", func(t *testing.T) {
+		repo := &fakePreferenceRepo{optedOut: map[string][]int64{
+			notifications.TypeParentAnnouncement: {prefAccountA},
+		}}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		got, err := svc.FilterNotOptedOut(context.Background(), notifications.TypeParentAnnouncement, candidates)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{prefAccountB}, got,
+			"the account with no stored decision stays in, the one that declined does not")
+	})
+
+	t.Run("no candidates means nobody", func(t *testing.T) {
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
+		got, err := svc.FilterNotOptedOut(context.Background(), notifications.TypeParentAnnouncement, nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("an unknown type fails closed", func(t *testing.T) {
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, allSettingsOn(), nil, nil)
+		got, err := svc.FilterNotOptedOut(context.Background(), "not_a_type", candidates)
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+		assert.Empty(t, got)
+	})
+
+	t.Run("a type the school switched off reaches nobody", func(t *testing.T) {
+		settings := &configtest.Mock{
+			ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+				return key != configModel.KeyRemindersPickupUpcomingEnabled, nil
+			},
+		}
+		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, settings, nil, nil)
+
+		got, err := svc.FilterNotOptedOut(context.Background(), notifications.TypePickupUpcoming, candidates)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("a failing repository surfaces", func(t *testing.T) {
+		repo := &fakePreferenceRepo{filterErr: errors.New("boom")}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+		_, err := svc.FilterNotOptedOut(context.Background(), notifications.TypeParentAnnouncement, candidates)
+		require.Error(t, err, "a broken read must not read as consent")
 	})
 }
 

--- a/backend/services/notifications/preferences_mock_test.go
+++ b/backend/services/notifications/preferences_mock_test.go
@@ -147,11 +147,10 @@ func TestGetForAccountFailures(t *testing.T) {
 		require.Error(t, err, "a broken read must not silently widen or narrow who gets notified")
 	})
 
-	t.Run("without a settings service nothing is enabled", func(t *testing.T) {
+	t.Run("a missing settings service surfaces", func(t *testing.T) {
 		svc := notifications.NewPreferenceService(&fakePreferenceRepo{}, nil, nil, nil)
-		overview, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
-		require.NoError(t, err)
-		assert.False(t, overview.TenantEnabled)
+		_, err := svc.GetForAccount(context.Background(), prefAccountA, notifications.PortalStaff)
+		require.ErrorContains(t, err, "no settings service configured")
 	})
 }
 

--- a/backend/services/notifications/preferences_mock_test.go
+++ b/backend/services/notifications/preferences_mock_test.go
@@ -33,6 +33,9 @@ type fakePreferenceRepo struct {
 	filterErr     error
 	disableErr    error
 	filterArgs    []int64
+	filterTypes   []string
+	hasCalls      int
+	bulkCalls     int
 }
 
 func (f *fakePreferenceRepo) ListByAccount(_ context.Context, _ int64) ([]*userModel.NotificationPreference, error) {
@@ -53,6 +56,45 @@ func (f *fakePreferenceRepo) FilterOptedIn(_ context.Context, notificationType s
 	}
 	f.filterArgs = accountIDs
 	return f.optedIn[notificationType], nil
+}
+
+func (f *fakePreferenceRepo) HasAnyOptedIn(_ context.Context, notificationTypes []string) (bool, error) {
+	f.hasCalls++
+	if f.filterErr != nil {
+		return false, f.filterErr
+	}
+	for _, notificationType := range notificationTypes {
+		if len(f.optedIn[notificationType]) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakePreferenceRepo) FilterOptedInByType(
+	_ context.Context,
+	notificationTypes []string,
+	accountIDs []int64,
+) (map[string][]int64, error) {
+	f.bulkCalls++
+	if f.filterErr != nil {
+		return nil, f.filterErr
+	}
+	f.filterArgs = accountIDs
+	f.filterTypes = notificationTypes
+	candidates := make(map[int64]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		candidates[accountID] = struct{}{}
+	}
+	result := make(map[string][]int64)
+	for _, notificationType := range notificationTypes {
+		for _, accountID := range f.optedIn[notificationType] {
+			if _, ok := candidates[accountID]; ok {
+				result[notificationType] = append(result[notificationType], accountID)
+			}
+		}
+	}
+	return result, nil
 }
 
 func (f *fakePreferenceRepo) FilterNotOptedOut(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
@@ -249,6 +291,7 @@ func TestFilterOptedIn(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []int64{prefAccountA}, got)
 		assert.Equal(t, candidates, repo.filterArgs, "the whole candidate set is offered to the filter")
+		assert.Equal(t, 1, repo.bulkCalls)
 	})
 
 	t.Run("no candidates means nobody", func(t *testing.T) {
@@ -298,6 +341,82 @@ func TestFilterOptedIn(t *testing.T) {
 		_, err := svc.FilterOptedIn(context.Background(), notifications.TypePickupUpcoming, candidates)
 		require.Error(t, err)
 	})
+}
+
+func TestHasAnyOptedIn(t *testing.T) {
+	t.Run("reports stored consent without inventing an audience", func(t *testing.T) {
+		repo := &fakePreferenceRepo{optedIn: map[string][]int64{
+			notifications.TypePickupUpcoming: {prefAccountA},
+		}}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		hasAny, err := svc.HasAnyOptedIn(context.Background(), []string{
+			notifications.TypePickupUpcoming,
+			notifications.TypeActivityStart,
+		})
+		require.NoError(t, err)
+		assert.True(t, hasAny)
+		assert.Equal(t, 1, repo.hasCalls)
+	})
+
+	t.Run("unknown types fail closed before the repository", func(t *testing.T) {
+		repo := &fakePreferenceRepo{}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		hasAny, err := svc.HasAnyOptedIn(context.Background(), []string{"not_a_type"})
+		require.ErrorIs(t, err, notifications.ErrUnknownNotificationType)
+		assert.False(t, hasAny)
+		assert.Zero(t, repo.hasCalls)
+	})
+
+	t.Run("repository failure surfaces", func(t *testing.T) {
+		repo := &fakePreferenceRepo{filterErr: errors.New("boom")}
+		svc := notifications.NewPreferenceService(repo, allSettingsOn(), nil, nil)
+
+		_, err := svc.HasAnyOptedIn(context.Background(), []string{notifications.TypePickupUpcoming})
+		require.Error(t, err)
+	})
+}
+
+func TestFilterOptedInByTypeBatchesGatesAndPreferences(t *testing.T) {
+	candidates := []int64{prefAccountA, prefAccountB}
+	var gateCalls int
+	settings := &configtest.Mock{
+		ResolveBoolsFn: func(_ context.Context, keys []string) (map[string]bool, error) {
+			gateCalls++
+			assert.ElementsMatch(t, []string{
+				configModel.KeyRemindersPickupUpcomingEnabled,
+				configModel.KeyRemindersActivityStartEnabled,
+			}, keys)
+			return map[string]bool{
+				configModel.KeyRemindersPickupUpcomingEnabled: true,
+				configModel.KeyRemindersActivityStartEnabled:  false,
+			}, nil
+		},
+	}
+	repo := &fakePreferenceRepo{optedIn: map[string][]int64{
+		notifications.TypePickupUpcoming:     {prefAccountA},
+		notifications.TypeActivityStart:      {prefAccountB},
+		notifications.TypeMyActivityStarting: {prefAccountB},
+	}}
+	svc := notifications.NewPreferenceService(repo, settings, nil, nil)
+
+	got, err := svc.FilterOptedInByType(context.Background(), []string{
+		notifications.TypePickupUpcoming,
+		notifications.TypeActivityStart,
+		notifications.TypeMyActivityStarting,
+	}, candidates)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, gateCalls, "all tenant gates must share one settings read")
+	assert.Equal(t, 1, repo.bulkCalls, "all allowed types must share one preference read")
+	assert.ElementsMatch(t, []string{
+		notifications.TypePickupUpcoming,
+		notifications.TypeMyActivityStarting,
+	}, repo.filterTypes, "a school-gated type must not reach the preference query")
+	assert.Equal(t, []int64{prefAccountA}, got[notifications.TypePickupUpcoming])
+	assert.Equal(t, []int64{prefAccountB}, got[notifications.TypeMyActivityStarting])
+	assert.NotContains(t, got, notifications.TypeActivityStart)
 }
 
 // FilterNotOptedOut is the mirror rule for channels that predate consent: only

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -353,8 +353,8 @@ func staffAccountIDs(audience Audience) []int64 {
 // withinActiveWindow reports whether the tenant currently accepts delivery.
 //
 // The check lives here rather than in each producer so quiet hours hold for
-// everything by construction. An unparseable or empty setting means "no
-// restriction": a broken time value must not silence a school outright.
+// everything by construction. An unparseable or empty setting closes the
+// window: corrupt configuration must never widen delivery into quiet hours.
 func (r *router) withinActiveWindow(ctx context.Context, tenantID int64) (bool, error) {
 	start, err := r.resolveWindowBound(ctx, tenantID, configModel.KeyNotificationsActiveWindowStart)
 	if err != nil {
@@ -364,9 +364,11 @@ func (r *router) withinActiveWindow(ctx context.Context, tenantID int64) (bool, 
 	if err != nil {
 		return false, err
 	}
-	// Empty/malformed bounds and equal bounds retain the historic unrestricted
-	// behaviour. The dispatch flag is the explicit way to silence all delivery.
-	if start < 0 || end < 0 || start == end {
+	if start < 0 || end < 0 {
+		return false, nil
+	}
+	// Equal valid bounds explicitly represent an unrestricted 24-hour window.
+	if start == end {
 		return true, nil
 	}
 
@@ -385,8 +387,8 @@ func withinWindow(nowMin, start, end int) bool {
 	return nowMin >= start && nowMin < end
 }
 
-// resolveWindowBound reads one "HH:MM" setting as a minute of day, or -1 when
-// it is unset or malformed.
+// resolveWindowBound reads one "HH:MM" setting as a minute of day. Invalid
+// values return -1 so the shared window check fails closed.
 func (r *router) resolveWindowBound(ctx context.Context, tenantID int64, key string) (int, error) {
 	raw, err := r.settings.ResolveStringForTenant(ctx, tenantID, key)
 	if err != nil {
@@ -394,11 +396,15 @@ func (r *router) resolveWindowBound(ctx context.Context, tenantID int64, key str
 	}
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
+		r.getLogger().Warn("blank notification window bound; treating window as closed",
+			"key", key,
+			"tenant_id", tenantID,
+		)
 		return -1, nil
 	}
 	parsed, err := time.Parse("15:04", raw)
 	if err != nil {
-		r.getLogger().Warn("ignoring malformed notification window bound",
+		r.getLogger().Warn("malformed notification window bound; treating window as closed",
 			"key", key,
 			"tenant_id", tenantID,
 			"value", raw,

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -28,11 +28,15 @@ package notifications
 import (
 	"context"
 	"errors"
+
 	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
 	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
@@ -60,6 +64,10 @@ const (
 	ScopeGuardian AudienceScope = "guardian"
 	// ScopeGroup delivers to clients subscribed to one active group.
 	ScopeGroup AudienceScope = "group"
+	// ScopeStaff delivers to one or more named staff accounts' own clients and
+	// devices. This is the scope for personal notifications, where each
+	// recipient gets their own payload.
+	ScopeStaff AudienceScope = "staff"
 )
 
 // Audience describes the recipients of an event. TenantID is always required;
@@ -70,6 +78,7 @@ type Audience struct {
 	GuardianAccountID  int64   // one recipient for ScopeGuardian
 	GuardianAccountIDs []int64 // batched recipients for ScopeGuardian
 	ActiveGroupID      string  // required for ScopeGroup
+	StaffAccountIDs    []int64 // recipients for ScopeStaff (auth.accounts.id)
 }
 
 // Event is a channel-agnostic notification. Title/Body/DeepLink are
@@ -90,12 +99,40 @@ type Event struct {
 // effect should treat it as a silent no-op; the test endpoint surfaces it.
 var ErrDisabled = errors.New("notifications are disabled for this tenant")
 
+// ErrOutsideActiveWindow is returned when a tenant's delivery window has
+// closed for the day. Producers treat it like ErrDisabled: a silent no-op.
+var ErrOutsideActiveWindow = errors.New("outside the tenant's notification window")
+
 // Channel delivers an event over one transport. Implementations must be
 // fire-and-forget-safe: a returned error is logged by the router and never
 // propagated to the feature that triggered the event.
 type Channel interface {
 	Name() string
 	Deliver(ctx context.Context, event Event) error
+}
+
+// BatchChannel is implemented by channels that can serve many events at once
+// more cheaply than one at a time. The router uses it when available and loops
+// Deliver otherwise, so implementing it is always optional.
+type BatchChannel interface {
+	Channel
+	DeliverBatch(ctx context.Context, events []Event) error
+}
+
+// BatchNotifier dispatches many events sharing one tenant in one pass.
+//
+// Kept separate from Service because several test doubles implement Service and
+// have no business growing a batch method.
+type BatchNotifier interface {
+	NotifyBatch(ctx context.Context, events []Event) error
+}
+
+// Notifier is the full surface the concrete service provides. It is assignable
+// to Service, so consumers that only notify one audience keep their narrower
+// type.
+type Notifier interface {
+	Service
+	BatchNotifier
 }
 
 // Service is the entry point features use to trigger notifications.
@@ -114,8 +151,14 @@ type router struct {
 	logger   *slog.Logger
 }
 
+// TypeTest is the notification an admin can fire to verify the setup. It is
+// the one type exempt from the delivery window.
+const TypeTest = "test"
+
 // NewService builds the channel router. Channels are fixed at wiring time.
-func NewService(settings configService.SettingsService, logger *slog.Logger, channels ...Channel) Service {
+// It returns Notifier so wiring can reach NotifyBatch; the value stays
+// assignable to Service for consumers that only notify one audience.
+func NewService(settings configService.SettingsService, logger *slog.Logger, channels ...Channel) Notifier {
 	return &router{settings: settings, channels: channels, logger: logger}
 }
 
@@ -159,6 +202,15 @@ func validate(event Event) error {
 		if event.Audience.ActiveGroupID == "" {
 			return errors.New("group-scoped notification requires an active group id")
 		}
+	case ScopeStaff:
+		if len(event.Audience.StaffAccountIDs) == 0 {
+			return errors.New("staff-scoped notification requires at least one staff account id")
+		}
+		for _, accountID := range event.Audience.StaffAccountIDs {
+			if accountID <= 0 {
+				return errors.New("staff-scoped notification requires positive staff account ids")
+			}
+		}
 	default:
 		return fmt.Errorf("unknown audience scope %q", event.Audience.Scope)
 	}
@@ -196,13 +248,85 @@ func (r *router) Notify(ctx context.Context, event Event) error {
 		return ErrDisabled
 	}
 
+	// The test notification is exempt from the delivery window on purpose: an
+	// admin verifying the setup in the evening must get an answer, not silence
+	// that looks like a broken configuration.
+	if event.Type != TypeTest {
+		within, werr := r.withinActiveWindow(ctx, event.Audience.TenantID)
+		if werr != nil {
+			return werr
+		}
+		if !within {
+			return ErrOutsideActiveWindow
+		}
+	}
+
 	// Channels run after commit, so they must not inherit the closed transaction.
 	// Snapshot the mutable payload before the callback outlives this call.
 	dispatchCtx := modelBase.ContextWithoutTx(ctx)
 	event.Data = maps.Clone(event.Data)
 	event.Audience.GuardianAccountIDs = slices.Clone(event.Audience.GuardianAccountIDs)
+	event.Audience.StaffAccountIDs = slices.Clone(event.Audience.StaffAccountIDs)
 	tenant.RegisterAfterCommit(ctx, func() {
 		r.deliver(dispatchCtx, event)
+	})
+	return nil
+}
+
+// NotifyBatch dispatches many events that share one tenant in a single
+// after-commit hook.
+//
+// It exists because the per-recipient shape of personal notifications would
+// otherwise multiply the fixed cost of Notify: one feature-flag read and one
+// delivery pass per event. Here the flag is resolved once, and a channel that
+// can group its own work gets the whole batch through DeliverBatch.
+//
+// Validation is all-or-nothing: one malformed event fails the batch rather than
+// silently dropping a recipient.
+func (r *router) NotifyBatch(ctx context.Context, events []Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	tenantID := events[0].Audience.TenantID
+	prepared := make([]Event, 0, len(events))
+	for _, event := range events {
+		if err := validate(event); err != nil {
+			return err
+		}
+		if event.Audience.TenantID != tenantID {
+			return errors.New("notification batch must not mix tenants")
+		}
+		if event.Priority == "" {
+			event.Priority = PriorityNormal
+		}
+		event.Data = maps.Clone(event.Data)
+		event.Audience.GuardianAccountIDs = slices.Clone(event.Audience.GuardianAccountIDs)
+		event.Audience.StaffAccountIDs = slices.Clone(event.Audience.StaffAccountIDs)
+		prepared = append(prepared, event)
+	}
+
+	if r.settings == nil {
+		return errors.New("notifications service has no settings service configured")
+	}
+	enabled, err := r.settings.ResolveBoolForTenant(ctx, tenantID, configModel.KeyNotificationsDispatchEnabled)
+	if err != nil {
+		return fmt.Errorf("resolving notification feature flag: %w", err)
+	}
+	if !enabled {
+		return ErrDisabled
+	}
+	within, err := r.withinActiveWindow(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if !within {
+		return ErrOutsideActiveWindow
+	}
+
+	dispatchCtx := modelBase.ContextWithoutTx(ctx)
+	tenant.RegisterAfterCommit(ctx, func() {
+		r.deliverBatch(dispatchCtx, prepared)
 	})
 	return nil
 }
@@ -215,6 +339,84 @@ func guardianAccountIDs(audience Audience) []int64 {
 		return []int64{audience.GuardianAccountID}
 	}
 	return nil
+}
+
+// staffAccountIDs returns the recipients of a staff-scoped event.
+func staffAccountIDs(audience Audience) []int64 {
+	return audience.StaffAccountIDs
+}
+
+// withinActiveWindow reports whether the tenant currently accepts delivery.
+//
+// The check lives here rather than in each producer so quiet hours hold for
+// everything by construction. An unparseable or empty setting means "no
+// restriction": a broken time value must not silence a school outright.
+func (r *router) withinActiveWindow(ctx context.Context, tenantID int64) (bool, error) {
+	start, err := r.resolveWindowBound(ctx, tenantID, configModel.KeyNotificationsActiveWindowStart)
+	if err != nil {
+		return false, err
+	}
+	end, err := r.resolveWindowBound(ctx, tenantID, configModel.KeyNotificationsActiveWindowEnd)
+	if err != nil {
+		return false, err
+	}
+	if start < 0 || end < 0 || start >= end {
+		return true, nil
+	}
+
+	now := timezone.Now()
+	nowMin := now.Hour()*60 + now.Minute()
+	return nowMin >= start && nowMin < end, nil
+}
+
+// resolveWindowBound reads one "HH:MM" setting as a minute of day, or -1 when
+// it is unset or malformed.
+func (r *router) resolveWindowBound(ctx context.Context, tenantID int64, key string) (int, error) {
+	raw, err := r.settings.ResolveStringForTenant(ctx, tenantID, key)
+	if err != nil {
+		return 0, fmt.Errorf("resolving %s: %w", key, err)
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return -1, nil
+	}
+	parsed, err := time.Parse("15:04", raw)
+	if err != nil {
+		r.getLogger().Warn("ignoring malformed notification window bound",
+			"key", key,
+			"tenant_id", tenantID,
+			"value", raw,
+		)
+		return -1, nil
+	}
+	return parsed.Hour()*60 + parsed.Minute(), nil
+}
+
+// deliverBatch hands the whole batch to channels that can group their work and
+// falls back to one Deliver per event for the others.
+func (r *router) deliverBatch(ctx context.Context, events []Event) {
+	for _, ch := range r.channels {
+		if batch, ok := ch.(BatchChannel); ok {
+			if err := batch.DeliverBatch(ctx, events); err != nil {
+				r.getLogger().Error("notification channel batch delivery failed",
+					"channel", ch.Name(),
+					"event_count", len(events),
+					"error", err.Error(),
+				)
+			}
+			continue
+		}
+		for _, event := range events {
+			if err := ch.Deliver(ctx, event); err != nil {
+				r.getLogger().Error("notification channel delivery failed",
+					"channel", ch.Name(),
+					"notification_type", event.Type,
+					"tenant_id", event.Audience.TenantID,
+					"error", err.Error(),
+				)
+			}
+		}
+	}
 }
 
 func (r *router) deliver(ctx context.Context, event Event) {

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -360,13 +360,25 @@ func (r *router) withinActiveWindow(ctx context.Context, tenantID int64) (bool, 
 	if err != nil {
 		return false, err
 	}
-	if start < 0 || end < 0 || start >= end {
+	// Empty/malformed bounds and equal bounds retain the historic unrestricted
+	// behaviour. The dispatch flag is the explicit way to silence all delivery.
+	if start < 0 || end < 0 || start == end {
 		return true, nil
 	}
 
 	now := timezone.Now()
 	nowMin := now.Hour()*60 + now.Minute()
-	return nowMin >= start && nowMin < end, nil
+	return withinWindow(nowMin, start, end), nil
+}
+
+func withinWindow(nowMin, start, end int) bool {
+	if start == end {
+		return true
+	}
+	if start > end {
+		return nowMin >= start || nowMin < end
+	}
+	return nowMin >= start && nowMin < end
 }
 
 // resolveWindowBound reads one "HH:MM" setting as a minute of day, or -1 when

--- a/backend/services/notifications/service.go
+++ b/backend/services/notifications/service.go
@@ -316,12 +316,16 @@ func (r *router) NotifyBatch(ctx context.Context, events []Event) error {
 	if !enabled {
 		return ErrDisabled
 	}
-	within, err := r.withinActiveWindow(ctx, tenantID)
-	if err != nil {
-		return err
-	}
-	if !within {
-		return ErrOutsideActiveWindow
+	// As in Notify, test notifications deliberately bypass quiet hours. A
+	// batch containing real deliveries still observes the window as one unit.
+	if slices.ContainsFunc(prepared, func(event Event) bool { return event.Type != TypeTest }) {
+		within, werr := r.withinActiveWindow(ctx, tenantID)
+		if werr != nil {
+			return werr
+		}
+		if !within {
+			return ErrOutsideActiveWindow
+		}
 	}
 
 	dispatchCtx := modelBase.ContextWithoutTx(ctx)

--- a/backend/services/notifications/service_window_internal_test.go
+++ b/backend/services/notifications/service_window_internal_test.go
@@ -1,0 +1,29 @@
+package notifications
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithinWindow(t *testing.T) {
+	tests := []struct {
+		name            string
+		now, start, end int
+		want            bool
+	}{
+		{name: "normal before", now: 5 * 60, start: 6 * 60, end: 18 * 60, want: false},
+		{name: "normal start inclusive", now: 6 * 60, start: 6 * 60, end: 18 * 60, want: true},
+		{name: "normal end exclusive", now: 18 * 60, start: 6 * 60, end: 18 * 60, want: false},
+		{name: "overnight evening", now: 22 * 60, start: 18 * 60, end: 6 * 60, want: true},
+		{name: "overnight morning", now: 2 * 60, start: 18 * 60, end: 6 * 60, want: true},
+		{name: "overnight daytime", now: 12 * 60, start: 18 * 60, end: 6 * 60, want: false},
+		{name: "equal bounds mean all day", now: 12 * 60, start: 6 * 60, end: 6 * 60, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, withinWindow(tt.now, tt.start, tt.end))
+		})
+	}
+}

--- a/backend/services/notifications/sse_channel.go
+++ b/backend/services/notifications/sse_channel.go
@@ -49,6 +49,8 @@ func (c *sseChannel) Deliver(ctx context.Context, event Event) error {
 		return nil
 	case ScopeGroup:
 		return c.broadcaster.BroadcastToGroup(event.Audience.TenantID, event.Audience.ActiveGroupID, sseEvent)
+	case ScopeStaff:
+		return c.broadcaster.BroadcastToStaffAccounts(event.Audience.TenantID, staffAccountIDs(event.Audience), sseEvent)
 	default:
 		return fmt.Errorf("sse channel cannot route audience scope %q (tenant %s)",
 			event.Audience.Scope, strconv.FormatInt(event.Audience.TenantID, 10))

--- a/backend/services/notifications/staff_scope_test.go
+++ b/backend/services/notifications/staff_scope_test.go
@@ -1,0 +1,238 @@
+package notifications_test
+
+import (
+	"context"
+	"testing"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// settingsWithWindow builds a settings double with the dispatch flag on and an
+// explicit delivery window.
+func settingsWithWindow(start, end string) *configtest.Mock {
+	return &configtest.Mock{
+		ResolveBoolForTenantFn: func(_ context.Context, _ int64, key string) (bool, error) {
+			return key == configModel.KeyNotificationsDispatchEnabled, nil
+		},
+		ResolveStringForTenantFn: func(_ context.Context, _ int64, key string) (string, error) {
+			switch key {
+			case configModel.KeyNotificationsActiveWindowStart:
+				return start, nil
+			case configModel.KeyNotificationsActiveWindowEnd:
+				return end, nil
+			}
+			return "", nil
+		},
+	}
+}
+
+// testTenantID is the school every event in this file belongs to. These tests
+// are pure in-memory (recording broadcaster, settings double, no database), so
+// there is no fixture to derive an ID from.
+const testTenantID int64 = 7
+
+// dispatch runs fn inside an after-commit scope and then drains the hooks, so
+// the assertions see what delivery actually did rather than what was queued.
+func dispatch(t *testing.T, fn func(ctx context.Context) error) error {
+	t.Helper()
+	ctx, drain := tenant.WithAfterCommitHooksForTest(context.Background())
+	err := fn(ctx)
+	drain()
+	return err
+}
+
+func staffEvent(tenantID int64, accountIDs ...int64) notifications.Event {
+	return notifications.Event{
+		Type: notifications.TypePickupUpcoming,
+		Audience: notifications.Audience{
+			TenantID:        tenantID,
+			Scope:           notifications.ScopeStaff,
+			StaffAccountIDs: accountIDs,
+		},
+		Title:    "Abholung steht an",
+		Body:     "Ein Kind aus Ihrer Gruppe wird bald abgeholt.",
+		DeepLink: "/reminders",
+	}
+}
+
+// TestStaffScopeValidation pins that a staff-scoped event must name real
+// recipients. An event that addresses nobody must be rejected rather than
+// delivered to a fallback audience.
+func TestStaffScopeValidation(t *testing.T) {
+	svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		notifications.NewSSEChannel(testpkg.NewRecordingBroadcaster()))
+
+	t.Run("no recipients is rejected", func(t *testing.T) {
+		err := svc.Notify(context.Background(), staffEvent(7))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one staff account id")
+	})
+
+	t.Run("a non-positive recipient is rejected", func(t *testing.T) {
+		err := svc.Notify(context.Background(), staffEvent(7, 11, 0))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "positive staff account ids")
+	})
+}
+
+// TestStaffScopeRoutesToNamedAccounts pins that the SSE channel addresses
+// exactly the named accounts and no other audience.
+func TestStaffScopeRoutesToNamedAccounts(t *testing.T) {
+	bc := testpkg.NewRecordingBroadcaster()
+	svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		notifications.NewSSEChannel(bc))
+
+	err := dispatch(t, func(ctx context.Context) error {
+		return svc.Notify(ctx, staffEvent(7, 11, 22))
+	})
+	require.NoError(t, err)
+
+	calls := bc.CallsByMethod("staff")
+	require.Len(t, calls, 1)
+	assert.Equal(t, testTenantID, calls[0].TenantID)
+	assert.Equal(t, []int64{11, 22}, calls[0].AccountIDs)
+
+	// A personal notification must not also reach the tenant, the admins or a
+	// group: those are the audiences a mis-routed staff event would fall back
+	// to, and each of them is a disclosure.
+	assert.Empty(t, bc.CallsByMethod("tenant"))
+	assert.Empty(t, bc.CallsByMethod("admin"))
+	assert.Empty(t, bc.CallsByMethod("group"))
+	assert.Empty(t, bc.CallsByMethod("guardian"))
+}
+
+// TestStaffAccountIDsAreSnapshotted pins that the recipient list survives the
+// after-commit boundary unchanged. Delivery runs after Notify returns, so a
+// caller reusing its slice would otherwise redirect a notification.
+func TestStaffAccountIDsAreSnapshotted(t *testing.T) {
+	bc := testpkg.NewRecordingBroadcaster()
+	svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		notifications.NewSSEChannel(bc))
+
+	recipients := []int64{11, 22}
+	event := staffEvent(7, recipients...)
+
+	err := dispatch(t, func(ctx context.Context) error {
+		if nerr := svc.Notify(ctx, event); nerr != nil {
+			return nerr
+		}
+		// Mutate the caller's slice before the hook runs.
+		recipients[0] = 999
+		return nil
+	})
+	require.NoError(t, err)
+
+	calls := bc.CallsByMethod("staff")
+	require.Len(t, calls, 1)
+	assert.Equal(t, []int64{11, 22}, calls[0].AccountIDs,
+		"the recipient list must be snapshotted, not aliased")
+}
+
+// TestDeliveryWindow pins the quiet-hours gate that lives in the router, so it
+// holds for every producer rather than each carrying its own.
+func TestDeliveryWindow(t *testing.T) {
+	t.Run("outside the window nothing is dispatched", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		// A window that has already closed for every possible current time.
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:01"), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.Notify(ctx, staffEvent(7, 11))
+		})
+		require.ErrorIs(t, err, notifications.ErrOutsideActiveWindow)
+		assert.Empty(t, bc.Calls())
+	})
+
+	t.Run("the test notification ignores the window", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:01"), nil,
+			notifications.NewSSEChannel(bc))
+
+		// An admin verifying the setup in the evening must get an answer, not
+		// silence that looks like a broken configuration.
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.Notify(ctx, tenantEvent(7))
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, bc.Calls())
+	})
+
+	t.Run("a malformed window does not silence the school", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("nonsense", "18:00"), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.Notify(ctx, staffEvent(7, 11))
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, bc.Calls())
+	})
+}
+
+// TestNotifyBatch pins the batched entry point.
+func TestNotifyBatch(t *testing.T) {
+	t.Run("delivers one event per recipient", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.NotifyBatch(ctx, []notifications.Event{
+				staffEvent(7, 11),
+				staffEvent(7, 22),
+			})
+		})
+		require.NoError(t, err)
+
+		calls := bc.CallsByMethod("staff")
+		require.Len(t, calls, 2)
+		assert.Equal(t, []int64{11}, calls[0].AccountIDs)
+		assert.Equal(t, []int64{22}, calls[1].AccountIDs)
+	})
+
+	t.Run("a mixed-tenant batch is rejected", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := svc.NotifyBatch(context.Background(), []notifications.Event{
+			staffEvent(7, 11),
+			staffEvent(8, 22),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not mix tenants")
+		assert.Empty(t, bc.Calls())
+	})
+
+	t.Run("one malformed event fails the whole batch", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+			notifications.NewSSEChannel(bc))
+
+		// Dropping the bad event silently would lose a recipient without a
+		// trace; failing loudly lets the caller retry the whole tick.
+		err := svc.NotifyBatch(context.Background(), []notifications.Event{
+			staffEvent(7, 11),
+			staffEvent(7),
+		})
+		require.Error(t, err)
+		assert.Empty(t, bc.Calls())
+	})
+
+	t.Run("an empty batch is a no-op", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+			notifications.NewSSEChannel(bc))
+
+		require.NoError(t, svc.NotifyBatch(context.Background(), nil))
+		assert.Empty(t, bc.Calls())
+	})
+}

--- a/backend/services/notifications/staff_scope_test.go
+++ b/backend/services/notifications/staff_scope_test.go
@@ -198,6 +198,18 @@ func TestNotifyBatch(t *testing.T) {
 		assert.Equal(t, []int64{22}, calls[1].AccountIDs)
 	})
 
+	t.Run("test notifications ignore the delivery window", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:01"), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.NotifyBatch(ctx, []notifications.Event{tenantEvent(7)})
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, bc.Calls())
+	})
+
 	t.Run("a mixed-tenant batch is rejected", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
 		svc := notifications.NewService(settingsWithWindow("", ""), nil,

--- a/backend/services/notifications/staff_scope_test.go
+++ b/backend/services/notifications/staff_scope_test.go
@@ -65,7 +65,7 @@ func staffEvent(tenantID int64, accountIDs ...int64) notifications.Event {
 // recipients. An event that addresses nobody must be rejected rather than
 // delivered to a fallback audience.
 func TestStaffScopeValidation(t *testing.T) {
-	svc := notifications.NewService(settingsWithWindow("", ""), nil,
+	svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 		notifications.NewSSEChannel(testpkg.NewRecordingBroadcaster()))
 
 	t.Run("no recipients is rejected", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestStaffScopeValidation(t *testing.T) {
 // exactly the named accounts and no other audience.
 func TestStaffScopeRoutesToNamedAccounts(t *testing.T) {
 	bc := testpkg.NewRecordingBroadcaster()
-	svc := notifications.NewService(settingsWithWindow("", ""), nil,
+	svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 		notifications.NewSSEChannel(bc))
 
 	err := dispatch(t, func(ctx context.Context) error {
@@ -112,7 +112,7 @@ func TestStaffScopeRoutesToNamedAccounts(t *testing.T) {
 // caller reusing its slice would otherwise redirect a notification.
 func TestStaffAccountIDsAreSnapshotted(t *testing.T) {
 	bc := testpkg.NewRecordingBroadcaster()
-	svc := notifications.NewService(settingsWithWindow("", ""), nil,
+	svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 		notifications.NewSSEChannel(bc))
 
 	recipients := []int64{11, 22}
@@ -164,7 +164,7 @@ func TestDeliveryWindow(t *testing.T) {
 		assert.NotEmpty(t, bc.Calls())
 	})
 
-	t.Run("a malformed window does not silence the school", func(t *testing.T) {
+	t.Run("a malformed window fails closed", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
 		svc := notifications.NewService(settingsWithWindow("nonsense", "18:00"), nil,
 			notifications.NewSSEChannel(bc))
@@ -172,8 +172,20 @@ func TestDeliveryWindow(t *testing.T) {
 		err := dispatch(t, func(ctx context.Context) error {
 			return svc.Notify(ctx, staffEvent(7, 11))
 		})
-		require.NoError(t, err)
-		assert.NotEmpty(t, bc.Calls())
+		require.ErrorIs(t, err, notifications.ErrOutsideActiveWindow)
+		assert.Empty(t, bc.Calls())
+	})
+
+	t.Run("a blank window fails closed", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("", "18:00"), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.Notify(ctx, staffEvent(7, 11))
+		})
+		require.ErrorIs(t, err, notifications.ErrOutsideActiveWindow)
+		assert.Empty(t, bc.Calls())
 	})
 }
 
@@ -181,7 +193,7 @@ func TestDeliveryWindow(t *testing.T) {
 func TestNotifyBatch(t *testing.T) {
 	t.Run("delivers one event per recipient", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
-		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 			notifications.NewSSEChannel(bc))
 
 		err := dispatch(t, func(ctx context.Context) error {
@@ -210,9 +222,24 @@ func TestNotifyBatch(t *testing.T) {
 		assert.NotEmpty(t, bc.Calls())
 	})
 
+	t.Run("a malformed window rejects the whole batch", func(t *testing.T) {
+		bc := testpkg.NewRecordingBroadcaster()
+		svc := notifications.NewService(settingsWithWindow("06:00", "invalid"), nil,
+			notifications.NewSSEChannel(bc))
+
+		err := dispatch(t, func(ctx context.Context) error {
+			return svc.NotifyBatch(ctx, []notifications.Event{
+				staffEvent(7, 11),
+				staffEvent(7, 22),
+			})
+		})
+		require.ErrorIs(t, err, notifications.ErrOutsideActiveWindow)
+		assert.Empty(t, bc.Calls())
+	})
+
 	t.Run("a mixed-tenant batch is rejected", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
-		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 			notifications.NewSSEChannel(bc))
 
 		err := svc.NotifyBatch(context.Background(), []notifications.Event{
@@ -226,7 +253,7 @@ func TestNotifyBatch(t *testing.T) {
 
 	t.Run("one malformed event fails the whole batch", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
-		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 			notifications.NewSSEChannel(bc))
 
 		// Dropping the bad event silently would lose a recipient without a
@@ -241,7 +268,7 @@ func TestNotifyBatch(t *testing.T) {
 
 	t.Run("an empty batch is a no-op", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
-		svc := notifications.NewService(settingsWithWindow("", ""), nil,
+		svc := notifications.NewService(settingsWithWindow("00:00", "00:00"), nil,
 			notifications.NewSSEChannel(bc))
 
 		require.NoError(t, svc.NotifyBatch(context.Background(), nil))

--- a/backend/services/notifications/types.go
+++ b/backend/services/notifications/types.go
@@ -1,0 +1,203 @@
+// Notification type catalogue.
+//
+// Every notification a person can agree to is declared here once: its key, the
+// German label and description the profile page shows, the group it appears
+// under, which portal it belongs to, and the tenant setting (if any) that can
+// switch it off school-wide.
+//
+// The catalogue lives in Go rather than in the database so adding a type costs
+// no migration, and so the labels sit next to the code that produces the
+// notification. It mirrors the settings registry (models/config/registry.go):
+// a mutex-guarded map filled from init(), panicking on a duplicate key so a
+// collision surfaces at process start rather than at runtime.
+package notifications
+
+import (
+	"sort"
+	"sync"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+)
+
+// Portals a notification type can belong to.
+const (
+	PortalStaff  = "staff"
+	PortalParent = "parent"
+)
+
+// Groups the profile page renders as headings, in this order.
+const (
+	GroupPickup     = "abholung"
+	GroupActivities = "aktivitaeten"
+	GroupChildren   = "kinder"
+	GroupMessages   = "mitteilungen"
+)
+
+// groupOrder fixes the order of the headings independently of registration
+// order, so the profile page never reshuffles between releases.
+var groupOrder = map[string]int{
+	GroupPickup:     1,
+	GroupActivities: 2,
+	GroupChildren:   3,
+	GroupMessages:   4,
+}
+
+// Notification type keys.
+//
+// The four reminder keys are the same strings services/reminders emits as
+// Reminder.Type and the frontend switches on. They are declared separately
+// rather than imported to keep this package free of a dependency on reminders;
+// TestNotificationTypeKeysMatchReminders pins them against each other.
+const (
+	TypePickupUpcoming         = "pickup_upcoming"
+	TypePickupOverdue          = "pickup_overdue"
+	TypeActivityStart          = "activity_start"
+	TypeActivityOverdue        = "activity_overdue"
+	TypeMyActivityStarting     = "my_activity_starting"
+	TypeStudentAbsenceReported = "student_absence_reported"
+	TypeParentAnnouncement     = "parent_announcement"
+)
+
+// TypeDefinition describes one notification a person can agree to.
+type TypeDefinition struct {
+	Key         string
+	Label       string // German, shown as the row title
+	Description string // German, shown under the title
+	Group       string
+	Portal      string
+	// TenantGate is the settings key a school can use to switch this type off
+	// for everyone. Empty means the type has no school-wide gate, because
+	// whether a person wants to hear about their own shift is nobody else's
+	// decision.
+	TenantGate string
+	SortOrder  int
+}
+
+var (
+	typeMu       sync.RWMutex
+	typeRegistry = make(map[string]TypeDefinition)
+)
+
+// RegisterType adds a definition to the catalogue. It panics on a duplicate
+// key or an incomplete definition: both are programming errors that must not
+// survive process start.
+func RegisterType(def TypeDefinition) {
+	if def.Key == "" || def.Label == "" || def.Group == "" || def.Portal == "" {
+		panic("notifications: incomplete type definition for key " + def.Key)
+	}
+	if def.Portal != PortalStaff && def.Portal != PortalParent {
+		panic("notifications: unknown portal " + def.Portal + " for key " + def.Key)
+	}
+	if _, ok := groupOrder[def.Group]; !ok {
+		panic("notifications: unknown group " + def.Group + " for key " + def.Key)
+	}
+
+	typeMu.Lock()
+	defer typeMu.Unlock()
+	if _, exists := typeRegistry[def.Key]; exists {
+		panic("notifications: duplicate type key " + def.Key)
+	}
+	typeRegistry[def.Key] = def
+}
+
+// GetType returns one definition.
+func GetType(key string) (TypeDefinition, bool) {
+	typeMu.RLock()
+	defer typeMu.RUnlock()
+	def, ok := typeRegistry[key]
+	return def, ok
+}
+
+// TypesForPortal returns the catalogue of one portal, ordered by group and
+// then by SortOrder.
+func TypesForPortal(portal string) []TypeDefinition {
+	typeMu.RLock()
+	defs := make([]TypeDefinition, 0, len(typeRegistry))
+	for _, def := range typeRegistry {
+		if def.Portal == portal {
+			defs = append(defs, def)
+		}
+	}
+	typeMu.RUnlock()
+
+	sort.Slice(defs, func(i, j int) bool {
+		if groupOrder[defs[i].Group] != groupOrder[defs[j].Group] {
+			return groupOrder[defs[i].Group] < groupOrder[defs[j].Group]
+		}
+		if defs[i].SortOrder != defs[j].SortOrder {
+			return defs[i].SortOrder < defs[j].SortOrder
+		}
+		return defs[i].Key < defs[j].Key
+	})
+	return defs
+}
+
+func init() {
+	RegisterType(TypeDefinition{
+		Key:         TypePickupUpcoming,
+		Label:       "Anstehende Abholung",
+		Description: "Kurz bevor ein Kind abgeholt wird, das Sie gerade betreuen.",
+		Group:       GroupPickup,
+		Portal:      PortalStaff,
+		TenantGate:  configModel.KeyRemindersPickupUpcomingEnabled,
+		SortOrder:   1,
+	})
+	RegisterType(TypeDefinition{
+		Key:         TypePickupOverdue,
+		Label:       "Überfällige Abholung",
+		Description: "Wenn ein Kind nach seiner Abholzeit noch da ist.",
+		Group:       GroupPickup,
+		Portal:      PortalStaff,
+		TenantGate:  configModel.KeyRemindersPickupOverdueEnabled,
+		SortOrder:   2,
+	})
+
+	// The two activity types read almost alike, so their labels name the
+	// relation rather than the event: one is about the room you are watching,
+	// the other about the slot you are assigned to.
+	RegisterType(TypeDefinition{
+		Key:         TypeActivityStart,
+		Label:       "Aktivität in Ihrem Raum",
+		Description: "Kurz bevor eine geplante Aktivität in einem Raum startet, den Sie gerade beaufsichtigen.",
+		Group:       GroupActivities,
+		Portal:      PortalStaff,
+		TenantGate:  configModel.KeyRemindersActivityStartEnabled,
+		SortOrder:   1,
+	})
+	RegisterType(TypeDefinition{
+		Key:         TypeActivityOverdue,
+		Label:       "Aktivität nicht gestartet",
+		Description: "Wenn eine geplante Aktivität überfällig ist und noch niemand sie gestartet hat.",
+		Group:       GroupActivities,
+		Portal:      PortalStaff,
+		TenantGate:  configModel.KeyRemindersActivityOverdueEnabled,
+		SortOrder:   2,
+	})
+	RegisterType(TypeDefinition{
+		Key:         TypeMyActivityStarting,
+		Label:       "Ihr nächster Einsatz",
+		Description: "Kurz bevor ein Einsatz aus Ihrem Betreuungsplan beginnt, auch wenn Sie gerade keine Aufsicht führen.",
+		Group:       GroupActivities,
+		Portal:      PortalStaff,
+		SortOrder:   3,
+	})
+
+	RegisterType(TypeDefinition{
+		Key:         TypeStudentAbsenceReported,
+		Label:       "Krankmeldung eines Kindes",
+		Description: "Wenn für ein Kind aus Ihren Gruppen eine Krankmeldung oder Entschuldigung für heute eingetragen wird.",
+		Group:       GroupChildren,
+		Portal:      PortalStaff,
+		TenantGate:  configModel.KeyNotificationsAbsenceReportedEnabled,
+		SortOrder:   1,
+	})
+
+	RegisterType(TypeDefinition{
+		Key:         TypeParentAnnouncement,
+		Label:       "Neue Mitteilung der Schule",
+		Description: "Wenn die Schule eine neue Mitteilung im Elternportal veröffentlicht.",
+		Group:       GroupMessages,
+		Portal:      PortalParent,
+		SortOrder:   1,
+	})
+}

--- a/backend/services/notifications/types_test.go
+++ b/backend/services/notifications/types_test.go
@@ -1,0 +1,94 @@
+package notifications_test
+
+import (
+	"testing"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/moto-nrw/project-phoenix/services/reminders"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotificationTypeKeysMatchReminders pins the four reminder keys against
+// their source of truth.
+//
+// The strings are declared twice on purpose — services/notifications must not
+// depend on services/reminders — but they are one wire contract: the frontend
+// switches on Reminder.Type and stores consent under the same string. A silent
+// rename on either side would leave people opted into a type that no longer
+// exists, which looks exactly like a working opt-in.
+func TestNotificationTypeKeysMatchReminders(t *testing.T) {
+	assert.Equal(t, reminders.TypePickupUpcoming, notifications.TypePickupUpcoming)
+	assert.Equal(t, reminders.TypePickupOverdue, notifications.TypePickupOverdue)
+	assert.Equal(t, reminders.TypeActivityStart, notifications.TypeActivityStart)
+	assert.Equal(t, reminders.TypeActivityOverdue, notifications.TypeActivityOverdue)
+}
+
+func TestNotificationTypeCatalogue(t *testing.T) {
+	t.Run("staff catalogue is grouped and ordered", func(t *testing.T) {
+		defs := notifications.TypesForPortal(notifications.PortalStaff)
+		require.Len(t, defs, 6)
+
+		keys := make([]string, len(defs))
+		for i, def := range defs {
+			keys[i] = def.Key
+		}
+		assert.Equal(t, []string{
+			notifications.TypePickupUpcoming,
+			notifications.TypePickupOverdue,
+			notifications.TypeActivityStart,
+			notifications.TypeActivityOverdue,
+			notifications.TypeMyActivityStarting,
+			notifications.TypeStudentAbsenceReported,
+		}, keys, "order is fixed by group then SortOrder, not by registration order")
+	})
+
+	t.Run("parent catalogue is separate", func(t *testing.T) {
+		defs := notifications.TypesForPortal(notifications.PortalParent)
+		require.Len(t, defs, 1)
+		assert.Equal(t, notifications.TypeParentAnnouncement, defs[0].Key)
+
+		// A staff type must never surface in the parent portal and vice versa:
+		// the catalogue is what the preference page renders, so a leak here
+		// would offer someone consent to a notification they cannot receive.
+		for _, def := range notifications.TypesForPortal(notifications.PortalStaff) {
+			assert.NotEqual(t, notifications.TypeParentAnnouncement, def.Key)
+		}
+	})
+
+	t.Run("every definition carries German copy", func(t *testing.T) {
+		for _, portal := range []string{notifications.PortalStaff, notifications.PortalParent} {
+			for _, def := range notifications.TypesForPortal(portal) {
+				assert.NotEmpty(t, def.Label, "label for %s", def.Key)
+				assert.NotEmpty(t, def.Description, "description for %s", def.Key)
+			}
+		}
+	})
+
+	t.Run("tenant gates point at registered settings", func(t *testing.T) {
+		gated := map[string]string{
+			notifications.TypePickupUpcoming:         configModel.KeyRemindersPickupUpcomingEnabled,
+			notifications.TypePickupOverdue:          configModel.KeyRemindersPickupOverdueEnabled,
+			notifications.TypeActivityStart:          configModel.KeyRemindersActivityStartEnabled,
+			notifications.TypeActivityOverdue:        configModel.KeyRemindersActivityOverdueEnabled,
+			notifications.TypeStudentAbsenceReported: configModel.KeyNotificationsAbsenceReportedEnabled,
+		}
+		for key, expected := range gated {
+			def, ok := notifications.GetType(key)
+			require.True(t, ok, "type %s must be registered", key)
+			assert.Equal(t, expected, def.TenantGate, "gate for %s", key)
+		}
+
+		// Whether a person wants to hear about their own shift is nobody
+		// else's decision, so this one deliberately has no school-wide gate.
+		def, ok := notifications.GetType(notifications.TypeMyActivityStarting)
+		require.True(t, ok)
+		assert.Empty(t, def.TenantGate)
+	})
+
+	t.Run("unknown key is not registered", func(t *testing.T) {
+		_, ok := notifications.GetType("does_not_exist")
+		assert.False(t, ok)
+	})
+}

--- a/backend/services/notifications/webpush_channel.go
+++ b/backend/services/notifications/webpush_channel.go
@@ -106,18 +106,9 @@ func (c *webPushChannel) Deliver(ctx context.Context, event Event) error {
 		return nil
 	}
 
-	payload, err := json.Marshal(webPushPayload{
-		Title:    event.Title,
-		Body:     event.Body,
-		DeepLink: event.DeepLink,
-		Type:     event.Type,
-		Priority: event.Priority,
-	})
+	payload, err := marshalPushPayload(event)
 	if err != nil {
-		return fmt.Errorf("marshaling web push payload: %w", err)
-	}
-	if len(payload) > maxPushPayloadBytes {
-		return fmt.Errorf("web push payload exceeds %d bytes (%d)", maxPushPayloadBytes, len(payload))
+		return err
 	}
 
 	// Read subscriptions under RLS, then commit before any network request.
@@ -143,6 +134,117 @@ func (c *webPushChannel) Deliver(ctx context.Context, event Event) error {
 	return nil
 }
 
+// DeliverBatch resolves the devices of every recipient in ONE transaction and
+// then sends each recipient their own payload.
+//
+// Looping Deliver would open one tenant transaction per event, each with its
+// own SET LOCAL ROLE round trip. With a per-minute tick addressing every staff
+// member of a school that is the difference between a handful of transactions
+// and one per person.
+//
+// Only staff-scoped events are grouped; anything else falls back to Deliver,
+// because the other scopes resolve their devices from the scope alone and gain
+// nothing from batching.
+func (c *webPushChannel) DeliverBatch(ctx context.Context, events []Event) error {
+	if !c.vapid.Configured() || len(events) == 0 {
+		return nil
+	}
+
+	staffEvents := make([]Event, 0, len(events))
+	for _, event := range events {
+		if event.Audience.Scope == ScopeStaff {
+			staffEvents = append(staffEvents, event)
+			continue
+		}
+		if err := c.Deliver(ctx, event); err != nil {
+			c.getLogger().Error("web push delivery failed inside batch",
+				"notification_type", event.Type,
+				"tenant_id", event.Audience.TenantID,
+				"error", err.Error(),
+			)
+		}
+	}
+	if len(staffEvents) == 0 {
+		return nil
+	}
+
+	tenantID := staffEvents[0].Audience.TenantID
+	recipientSet := make(map[int64]struct{})
+	for _, event := range staffEvents {
+		for _, accountID := range event.Audience.StaffAccountIDs {
+			recipientSet[accountID] = struct{}{}
+		}
+	}
+	recipients := make([]int64, 0, len(recipientSet))
+	for accountID := range recipientSet {
+		recipients = append(recipients, accountID)
+	}
+
+	// Read under RLS, then commit before any network request — the same
+	// ordering Deliver keeps, for the same reason.
+	var subs []*iot.PushSubscription
+	err := tenant.WithTenantTx(ctx, c.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		resolved, err := c.repo.FindForStaffAccounts(txCtx, recipients)
+		if err != nil {
+			return err
+		}
+		subs = resolved
+		return nil
+	})
+	if err != nil || len(subs) == 0 {
+		return err
+	}
+
+	byAccount := make(map[int64][]*iot.PushSubscription, len(recipients))
+	for _, sub := range subs {
+		byAccount[sub.AccountID] = append(byAccount[sub.AccountID], sub)
+	}
+
+	dispatchCtx := context.WithoutCancel(ctx)
+	for _, event := range staffEvents {
+		targets := make([]*iot.PushSubscription, 0, len(event.Audience.StaffAccountIDs))
+		for _, accountID := range event.Audience.StaffAccountIDs {
+			targets = append(targets, byAccount[accountID]...)
+		}
+		if len(targets) == 0 {
+			continue
+		}
+		payload, marshalErr := marshalPushPayload(event)
+		if marshalErr != nil {
+			c.getLogger().Error("skipping web push event with unusable payload",
+				"notification_type", event.Type,
+				"tenant_id", event.Audience.TenantID,
+				"error", marshalErr.Error(),
+			)
+			continue
+		}
+		go func(event Event, payload []byte, targets []*iot.PushSubscription) {
+			c.sendAll(dispatchCtx, event, payload, targets)
+		}(event, payload, targets)
+	}
+	return nil
+}
+
+// marshalPushPayload renders one event into the wire payload and enforces the
+// size bound. Shared by the single and batched paths so the GDPR-safe field
+// set and the cap cannot drift apart.
+func marshalPushPayload(event Event) ([]byte, error) {
+	payload, err := json.Marshal(webPushPayload{
+		Title:    event.Title,
+		Body:     event.Body,
+		DeepLink: event.DeepLink,
+		Type:     event.Type,
+		Priority: event.Priority,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling web push payload: %w", err)
+	}
+	if len(payload) > maxPushPayloadBytes {
+		return nil, fmt.Errorf("web push payload exceeds %d bytes (%d)", maxPushPayloadBytes, len(payload))
+	}
+	return payload, nil
+}
+
 // resolveSubscriptions maps the audience scope to registered devices.
 // ScopeGroup is deliberately unsupported: unlike SSE there is no persisted
 // device-to-group membership, and no producer targets groups with
@@ -155,6 +257,11 @@ func (c *webPushChannel) resolveSubscriptions(ctx context.Context, audience Audi
 		return c.repo.FindForTenantAdmins(ctx)
 	case ScopeGuardian:
 		return c.repo.FindForGuardians(ctx, guardianAccountIDs(audience))
+	case ScopeStaff:
+		// Eligibility is re-checked here rather than trusted from the recipient
+		// list: that list was assembled in an earlier transaction, and an
+		// account can be deactivated or unmapped from the school in between.
+		return c.repo.FindForStaffAccounts(ctx, staffAccountIDs(audience))
 	case ScopeGroup:
 		c.getLogger().Debug("web push does not support group scope, skipping",
 			"tenant_id", audience.TenantID,

--- a/backend/services/notifications/webpush_channel_internal_test.go
+++ b/backend/services/notifications/webpush_channel_internal_test.go
@@ -26,14 +26,17 @@ import (
 // embedded interface panics on anything else (nothing else may be called).
 type fakePushRepo struct {
 	iot.PushSubscriptionRepository
-	staff          []*iot.PushSubscription
-	admins         []*iot.PushSubscription
-	guardians      map[int64][]*iot.PushSubscription
-	deleted        []any
-	deleteAttempts []*iot.PushSubscription
-	keepExpired    bool
-	deleteErr      error
-	mu             sync.Mutex
+	staff              []*iot.PushSubscription
+	admins             []*iot.PushSubscription
+	guardians          map[int64][]*iot.PushSubscription
+	deleted            []any
+	deleteAttempts     []*iot.PushSubscription
+	keepExpired        bool
+	staffAccounts      map[int64][]*iot.PushSubscription
+	staffAccountsAsked []int64
+	staffAccountsErr   error
+	deleteErr          error
+	mu                 sync.Mutex
 }
 
 func (f *fakePushRepo) FindForTenantStaff(context.Context) ([]*iot.PushSubscription, error) {
@@ -439,4 +442,165 @@ func TestWebPushDeliverCommitsBeforeAsyncSend(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("web push send did not finish")
 	}
+}
+
+// findForStaffAccounts is the batch path's finder. Kept next to the other
+// finders on the same double so both delivery paths see one fake repository.
+func (f *fakePushRepo) FindForStaffAccounts(_ context.Context, accountIDs []int64) ([]*iot.PushSubscription, error) {
+	if f.staffAccountsErr != nil {
+		return nil, f.staffAccountsErr
+	}
+	f.mu.Lock()
+	f.staffAccountsAsked = append(f.staffAccountsAsked, accountIDs...)
+	f.mu.Unlock()
+	var out []*iot.PushSubscription
+	for _, accountID := range accountIDs {
+		out = append(out, f.staffAccounts[accountID]...)
+	}
+	return out, nil
+}
+
+// mockTenantTx primes a sqlmock for exactly one tenant transaction.
+func mockTenantTx(t *testing.T) (*bun.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	db := bun.NewDB(sqlDB, pgdialect.New())
+	t.Cleanup(func() {
+		_ = db.Close()
+		_ = sqlDB.Close()
+	})
+	mock.ExpectBegin()
+	mock.ExpectExec("SET LOCAL ROLE phoenix_tenant").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SELECT set_config").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+	return db, mock
+}
+
+func staffEventFor(accountID int64, title string) Event {
+	return Event{
+		Type:     TypePickupUpcoming,
+		Audience: Audience{TenantID: 41, Scope: ScopeStaff, StaffAccountIDs: []int64{accountID}},
+		Priority: PriorityNormal,
+		Title:    title,
+	}
+}
+
+// DeliverBatch exists to resolve every recipient's devices in ONE transaction
+// and still send each person their own payload. Both halves of that sentence
+// are load-bearing: one transaction is the whole point, and a shared payload
+// would hand one person another's message.
+func TestWebPushDeliverBatchResolvesOnceAndSendsPerRecipient(t *testing.T) {
+	subA := testSub(1, 41, "https://fcm.googleapis.com/a")
+	subA.AccountID = 11
+	subB := testSub(2, 41, "https://fcm.googleapis.com/b")
+	subB.AccountID = 12
+	repo := &fakePushRepo{staffAccounts: map[int64][]*iot.PushSubscription{
+		11: {subA},
+		12: {subB},
+	}}
+	sender := &fakeSender{}
+	channel := testChannel(repo, sender)
+	db, mock := mockTenantTx(t)
+	channel.db = db
+
+	require.NoError(t, channel.DeliverBatch(context.Background(), []Event{
+		staffEventFor(11, "Abholung steht an"),
+		staffEventFor(12, "Aktivität beginnt"),
+	}))
+
+	require.Eventually(t, func() bool {
+		sender.mu.Lock()
+		defer sender.mu.Unlock()
+		return len(sender.sent) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	assert.NoError(t, mock.ExpectationsWereMet(), "one transaction for the whole batch")
+	assert.ElementsMatch(t, []int64{11, 12}, repo.staffAccountsAsked,
+		"every recipient is resolved in the same read")
+
+	byEndpoint := map[string]string{}
+	sender.mu.Lock()
+	for _, push := range sender.sent {
+		byEndpoint[push.endpoint] = string(push.payload)
+	}
+	sender.mu.Unlock()
+	assert.Contains(t, byEndpoint[subA.Endpoint], "Abholung steht an")
+	assert.Contains(t, byEndpoint[subB.Endpoint], "Aktivität beginnt")
+	assert.NotContains(t, byEndpoint[subA.Endpoint], "Aktivität beginnt",
+		"each recipient gets their own payload")
+}
+
+func TestWebPushDeliverBatchEdgeCases(t *testing.T) {
+	t.Run("no events is a no-op", func(t *testing.T) {
+		channel := testChannel(&fakePushRepo{}, &fakeSender{})
+		require.NoError(t, channel.DeliverBatch(context.Background(), nil))
+	})
+
+	t.Run("without VAPID keys the channel stays inert", func(t *testing.T) {
+		channel := testChannel(&fakePushRepo{}, &fakeSender{})
+		channel.vapid = VAPIDConfig{}
+		require.NoError(t, channel.DeliverBatch(context.Background(), []Event{staffEventFor(11, "x")}))
+	})
+
+	t.Run("a recipient without a device is skipped", func(t *testing.T) {
+		withDevice := testSub(1, 41, "https://fcm.googleapis.com/a")
+		withDevice.AccountID = 11
+		repo := &fakePushRepo{staffAccounts: map[int64][]*iot.PushSubscription{
+			11: {withDevice},
+		}}
+		sender := &fakeSender{}
+		channel := testChannel(repo, sender)
+		db, _ := mockTenantTx(t)
+		channel.db = db
+
+		require.NoError(t, channel.DeliverBatch(context.Background(), []Event{
+			staffEventFor(11, "erreicht"),
+			staffEventFor(12, "kein Gerät"),
+		}))
+
+		require.Eventually(t, func() bool {
+			sender.mu.Lock()
+			defer sender.mu.Unlock()
+			return len(sender.sent) == 1
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("nobody has a device", func(t *testing.T) {
+		channel := testChannel(&fakePushRepo{}, &fakeSender{})
+		db, _ := mockTenantTx(t)
+		channel.db = db
+		require.NoError(t, channel.DeliverBatch(context.Background(), []Event{staffEventFor(11, "x")}))
+	})
+
+	t.Run("a failing read is returned", func(t *testing.T) {
+		channel := testChannel(&fakePushRepo{staffAccountsErr: errors.New("boom")}, &fakeSender{})
+		db, _ := mockTenantTx(t)
+		channel.db = db
+		require.Error(t, channel.DeliverBatch(context.Background(), []Event{staffEventFor(11, "x")}))
+	})
+}
+
+// Only staff-scoped events are grouped; the other scopes resolve their devices
+// from the scope alone and go through the single path.
+func TestWebPushDeliverBatchFallsBackForOtherScopes(t *testing.T) {
+	repo := &fakePushRepo{staff: []*iot.PushSubscription{
+		testSub(1, 41, "https://fcm.googleapis.com/tenant"),
+	}}
+	sender := &fakeSender{}
+	channel := testChannel(repo, sender)
+	db, _ := mockTenantTx(t)
+	channel.db = db
+
+	require.NoError(t, channel.DeliverBatch(context.Background(), []Event{{
+		Type:     "test",
+		Audience: Audience{TenantID: 41, Scope: ScopeTenant},
+		Title:    "An alle",
+	}}))
+
+	require.Eventually(t, func() bool {
+		sender.mu.Lock()
+		defer sender.mu.Unlock()
+		return len(sender.sent) == 1
+	}, time.Second, 10*time.Millisecond)
 }

--- a/backend/services/parent/parent_service.go
+++ b/backend/services/parent/parent_service.go
@@ -30,6 +30,7 @@ import (
 	absenceSvc "github.com/moto-nrw/project-phoenix/services/absence"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
 	configService "github.com/moto-nrw/project-phoenix/services/config"
+	notificationsSvc "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
@@ -360,6 +361,10 @@ type ServiceConfig struct {
 	// submission becomes a pending request here instead of a direct status day.
 	ExcusedRequests absenceSvc.ExcusedAbsenceRequestService
 
+	// AbsenceNotifier informs the child's group and the office that an absence
+	// was reported. Optional and best-effort, after-commit only.
+	AbsenceNotifier notificationsSvc.AbsenceNotifier
+
 	// Emitter posts notification pills into the child's parent-OGS thread for
 	// self-service actions (sick note, one-day pickup change) and master-data
 	// request submissions. Best-effort, after-commit only.
@@ -408,6 +413,20 @@ func NewService(cfg ServiceConfig) Service {
 		cfg.Logger = slog.Default()
 	}
 	return &service{ServiceConfig: cfg}
+}
+
+// AbsenceNotifierSetter injects the sick/excused producer after construction.
+//
+// Deliberately a standalone interface rather than a method on Service: the
+// notification stack is wired later than this service, and widening Service
+// would force every test double to grow a method none of them call.
+type AbsenceNotifierSetter interface {
+	SetAbsenceNotifier(notifier notificationsSvc.AbsenceNotifier)
+}
+
+// SetAbsenceNotifier implements AbsenceNotifierSetter.
+func (s *service) SetAbsenceNotifier(notifier notificationsSvc.AbsenceNotifier) {
+	s.AbsenceNotifier = notifier
 }
 
 func (s *service) GetProfile(ctx context.Context, accountID int64) (*Profile, error) {

--- a/backend/services/parent/parent_write_service.go
+++ b/backend/services/parent/parent_write_service.go
@@ -245,6 +245,17 @@ func (s *service) SubmitSickNote(ctx context.Context, accountID, studentID int64
 
 	var result []*activeModels.StudentStatusDay
 	txErr := tenant.WithTenantTx(ctx, s.DB, child.tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		var fresh *usersModels.Student
+		notifyAbsence := false
+		if slices.Contains(dates, today) {
+			var err error
+			fresh, err = s.StudentRepo.FindByIDForUpdate(txCtx, studentID)
+			if err != nil {
+				return err
+			}
+			notifyAbsence = isNewParentReportableAbsence(fresh, status)
+		}
+
 		for _, other := range activeModels.StudentStatusDayStatusesExcept(status) {
 			if err := s.StatusDayRepo.MarkClearedForDates(txCtx, studentID, other, dates, now, activeModels.StudentStatusSourceParent); err != nil {
 				return err
@@ -263,11 +274,7 @@ func (s *service) SubmitSickNote(ctx context.Context, accountID, studentID int64
 			}
 		}
 
-		if slices.Contains(dates, today) {
-			fresh, err := s.StudentRepo.FindByIDForUpdate(txCtx, studentID)
-			if err != nil {
-				return err
-			}
+		if fresh != nil {
 			applyLiveStatusForParentToday(fresh, status, now)
 			if err := s.StudentRepo.Update(txCtx, fresh); err != nil {
 				return err
@@ -313,7 +320,7 @@ func (s *service) SubmitSickNote(ctx context.Context, accountID, studentID int64
 			// check-in path also writes a status row before immediately
 			// clearing it, and a repository hook would announce a sick note
 			// exactly when the child walks in.
-			if s.AbsenceNotifier != nil {
+			if notifyAbsence && s.AbsenceNotifier != nil {
 				s.AbsenceNotifier.NotifyAbsenceReported(context.Background(), notificationsSvc.AbsenceReport{
 					TenantID:       capturedTenant,
 					StudentIDs:     []int64{studentID},
@@ -339,6 +346,17 @@ func (s *service) SubmitSickNote(ctx context.Context, accountID, studentID int64
 		slog.Bool("has_reason", notePtr != nil),
 	)
 	return &SickNoteResult{StatusDays: result}, nil
+}
+
+func isNewParentReportableAbsence(student *usersModels.Student, status string) bool {
+	switch status {
+	case activeModels.StudentStatusDaySick:
+		return student.Sick == nil || !*student.Sick
+	case activeModels.StudentStatusDayExcused:
+		return student.Excused == nil || !*student.Excused
+	default:
+		return false
+	}
 }
 
 // submitExcusedRequest turns an excused report into a pending office-approval

--- a/backend/services/parent/parent_write_service.go
+++ b/backend/services/parent/parent_write_service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/realtime"
 	absenceSvc "github.com/moto-nrw/project-phoenix/services/absence"
 	mealplanService "github.com/moto-nrw/project-phoenix/services/mealplan"
+	notificationsSvc "github.com/moto-nrw/project-phoenix/services/notifications"
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
@@ -307,6 +308,21 @@ func (s *service) SubmitSickNote(ctx context.Context, accountID, studentID int64
 			// just the acting guardian's thread; fan out to EVERY guardian so a
 			// co-guardian's open tab drops the stale presence too (#1725 review).
 			s.wakeChildGuardians(capturedTenant, studentID)
+			// The child's group and the office learn that the family reported
+			// an absence. Hooked here rather than in the repository: the
+			// check-in path also writes a status row before immediately
+			// clearing it, and a repository hook would announce a sick note
+			// exactly when the child walks in.
+			if s.AbsenceNotifier != nil {
+				s.AbsenceNotifier.NotifyAbsenceReported(context.Background(), notificationsSvc.AbsenceReport{
+					TenantID:       capturedTenant,
+					StudentIDs:     []int64{studentID},
+					Status:         status,
+					Dates:          dates,
+					FromParent:     true,
+					ActorAccountID: accountID,
+				})
+			}
 		})
 		return nil
 	})

--- a/backend/services/parent/parent_write_service_test.go
+++ b/backend/services/parent/parent_write_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
+	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	parentService "github.com/moto-nrw/project-phoenix/services/parent"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
@@ -30,6 +31,17 @@ func tenantBroadcastIDs(bc *testpkg.RecordingBroadcaster) []int64 {
 		ids[i] = c.TenantID
 	}
 	return ids
+}
+
+type recordingParentAbsenceNotifier struct {
+	reports []notificationsService.AbsenceReport
+}
+
+func (n *recordingParentAbsenceNotifier) NotifyAbsenceReported(
+	_ context.Context,
+	report notificationsService.AbsenceReport,
+) {
+	n.reports = append(n.reports, report)
 }
 
 func buildWriteService(t *testing.T, sickEnabled, notesEnabled bool) (parentService.Service, *testpkg.RecordingBroadcaster, *bun.DB) {
@@ -111,6 +123,31 @@ func TestSubmitSickNote_TodayFlipsLiveFlagAndStoresReason(t *testing.T) {
 	assert.True(t, sick, "today's sick note must flip the live sick flag")
 
 	assert.Contains(t, tenantBroadcastIDs(bc), chain.TenantID, "SSE broadcast must fire for the tenant")
+}
+
+func TestSubmitSickNote_ResubmitDoesNotNotifyAgain(t *testing.T) {
+	svc, _, db := buildWriteService(t, true, true)
+	notifier := &recordingParentAbsenceNotifier{}
+	require.Implements(t, (*parentService.AbsenceNotifierSetter)(nil), svc)
+	svc.(parentService.AbsenceNotifierSetter).SetAbsenceNotifier(notifier)
+
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	for range 2 {
+		_, err := svc.SubmitSickNote(
+			context.Background(),
+			chain.AccountID,
+			chain.StudentID,
+			[]timezone.Date{timezone.TodayDate()},
+			"Fieber",
+			activeModels.StudentStatusDaySick,
+		)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, notifier.reports, 1)
+	assert.Equal(t, activeModels.StudentStatusDaySick, notifier.reports[0].Status)
 }
 
 // TestChildMessaging_RequiresNotesWritePermission is the regression guard for the

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -146,27 +146,24 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 
 		var activityPart []Reminder
 		if cfg.anyActivity() {
-			// The batch additionally counts the slots this person is planned
-			// on: at ten minutes before the start they supervise nothing yet,
-			// so the room filter alone would reach everyone except the one
-			// person who has to show up.
-			scope := activityScopeFilter(
-				activityRoomFilter(sc.Scope, in.roomsByStaff[sc.StaffID]),
-				in.assignedInstances[sc.StaffID],
-			)
+			roomFilter := activityRoomFilter(sc.Scope, in.roomsByStaff[sc.StaffID])
 			part, next := buildActivityReminders(in.instances, in.schulhofRoomIDs,
-				scope, activityWindow{
+				activityScopeFilter(roomFilter, nil), activityWindow{
 					nowMin:           in.nowMin,
 					lead:             cfg.activityLead,
 					overdueThreshold: cfg.overdueThreshold,
 					upcoming:         cfg.activityStart,
 					overdue:          cfg.activityOverdue,
 				})
-			if !cfg.activityStart && sc.IncludeAssignedActivityStart {
+			if sc.IncludeAssignedActivityStart {
 				assignedPart, assignedNext := buildActivityReminders(
 					in.instances,
 					in.schulhofRoomIDs,
-					assignedActivityFilter(in.assignedInstances[sc.StaffID]),
+					assignedUpcomingFilter(
+						in.assignedInstances[sc.StaffID],
+						roomFilter,
+						cfg.activityStart,
+					),
 					activityWindow{
 						nowMin:   in.nowMin,
 						lead:     cfg.activityLead,
@@ -493,6 +490,29 @@ func assignedActivityFilter(instanceIDs map[int64]struct{}) func(*scheduleModel.
 	return func(inst *scheduleModel.ActivityInstance) bool {
 		_, assigned := instanceIDs[inst.ID]
 		return assigned
+	}
+}
+
+// assignedUpcomingFilter adds only personal starts the room-scoped pass did
+// not already include. Assignments never widen overdue reminders.
+func assignedUpcomingFilter(
+	instanceIDs map[int64]struct{},
+	roomFilter map[int64]struct{},
+	roomUpcomingEnabled bool,
+) func(*scheduleModel.ActivityInstance) bool {
+	assigned := assignedActivityFilter(instanceIDs)
+	return func(inst *scheduleModel.ActivityInstance) bool {
+		if !assigned(inst) {
+			return false
+		}
+		if !roomUpcomingEnabled {
+			return true
+		}
+		if roomFilter == nil {
+			return false
+		}
+		_, alreadyIncluded := roomFilter[inst.RoomID]
+		return !alreadyIncluded
 	}
 }
 

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -58,6 +58,9 @@ type batchInputs struct {
 	students        map[int64]*userModel.Student
 	pickupTimes     map[int64]*scheduleService.EffectivePickupTime
 	presenceByStaff map[int64][]int64
+	// assignedInstances holds, per staff member, the activity instances they
+	// are planned on and not absent from.
+	assignedInstances map[int64]map[int64]struct{}
 }
 
 func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[int64]*Result, error) {
@@ -137,8 +140,16 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 
 		var activityPart []Reminder
 		if cfg.anyActivity() {
+			// The batch additionally counts the slots this person is planned
+			// on: at ten minutes before the start they supervise nothing yet,
+			// so the room filter alone would reach everyone except the one
+			// person who has to show up.
+			scope := activityScopeFilter(
+				activityRoomFilter(sc.Scope, in.roomsByStaff[sc.StaffID]),
+				in.assignedInstances[sc.StaffID],
+			)
 			part, next := buildActivityReminders(in.instances, in.schulhofRoomIDs,
-				activityRoomFilter(sc.Scope, in.roomsByStaff[sc.StaffID]), activityWindow{
+				scope, activityWindow{
 					nowMin:           in.nowMin,
 					lead:             cfg.activityLead,
 					overdueThreshold: cfg.overdueThreshold,
@@ -265,15 +276,16 @@ func (s *service) resolveToggle(ctx context.Context, key string) (bool, error) {
 // per-person presence sets in memory.
 func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipients []BatchScope) (*batchInputs, error) {
 	in := &batchInputs{
-		today:           timezone.TodayDate(),
-		nowMin:          minutesOfDay(timezone.Now()),
-		visitsByRoom:    map[int64][]int64{},
-		roomsByStaff:    map[int64][]int64{},
-		groupsByStaff:   map[int64]map[int64]struct{}{},
-		schulhofRoomIDs: map[int64]struct{}{},
-		students:        map[int64]*userModel.Student{},
-		pickupTimes:     map[int64]*scheduleService.EffectivePickupTime{},
-		presenceByStaff: map[int64][]int64{},
+		today:             timezone.TodayDate(),
+		nowMin:            minutesOfDay(timezone.Now()),
+		visitsByRoom:      map[int64][]int64{},
+		roomsByStaff:      map[int64][]int64{},
+		groupsByStaff:     map[int64]map[int64]struct{}{},
+		schulhofRoomIDs:   map[int64]struct{}{},
+		students:          map[int64]*userModel.Student{},
+		pickupTimes:       map[int64]*scheduleService.EffectivePickupTime{},
+		presenceByStaff:   map[int64][]int64{},
+		assignedInstances: map[int64]map[int64]struct{}{},
 	}
 
 	caregivers := hasCaregiver(recipients)
@@ -388,6 +400,35 @@ func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipien
 				return nil, resolveErr
 			}
 			in.schulhofRoomIDs = schulhof
+		}
+
+		// Planned assignments, one query for the whole day. Absent rows are
+		// skipped: someone who called in sick must not be pinged about the
+		// slot they were relieved of. Substitutes are kept — they are the ones
+		// who have to show up.
+		if caregivers && s.BulkInstanceStaff != nil {
+			instanceIDs := make([]int64, 0, len(instances))
+			for _, inst := range instances {
+				if inst != nil && inst.Status == scheduleModel.InstanceStatusPlanned {
+					instanceIDs = append(instanceIDs, inst.ID)
+				}
+			}
+			rows, staffErr := s.BulkInstanceStaff.FindByInstanceIDs(ctx, instanceIDs)
+			if staffErr != nil {
+				return nil, fmt.Errorf("load planned activity staff: %w", staffErr)
+			}
+			for _, row := range rows {
+				if row == nil || row.IsAbsent {
+					continue
+				}
+				if _, wanted := in.roomsByStaff[row.StaffID]; !wanted {
+					continue
+				}
+				if in.assignedInstances[row.StaffID] == nil {
+					in.assignedInstances[row.StaffID] = map[int64]struct{}{}
+				}
+				in.assignedInstances[row.StaffID][row.InstanceID] = struct{}{}
+			}
 		}
 	}
 

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -18,6 +18,7 @@ package reminders
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
@@ -160,10 +161,27 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 			nextChange = minFuture(nextChange, next)
 		}
 
-		results[sc.StaffID] = assembleResult(pickupPart, activityPart, nextChange)
+		result := assembleResult(pickupPart, activityPart, nextChange)
+		result.AssignedActivityInstanceIDs = assignedIDStrings(in.assignedInstances[sc.StaffID])
+		results[sc.StaffID] = result
 	}
 
 	return results, nil
+}
+
+// assignedIDStrings renders an instance-ID set in the same string form the
+// reminders themselves carry, so a consumer can match the two without knowing
+// how IDs are formatted. Nil for a person with no assignment, which reads as
+// "nothing of mine" rather than as an empty restriction.
+func assignedIDStrings(instanceIDs map[int64]struct{}) map[string]struct{} {
+	if len(instanceIDs) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(instanceIDs))
+	for id := range instanceIDs {
+		out[strconv.FormatInt(id, 10)] = struct{}{}
+	}
+	return out
 }
 
 // dedupeBatchScopes drops unusable scopes and collapses repeats.

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -27,14 +27,16 @@ import (
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
 )
 
-// batchConfig is the tenant-wide configuration of one batch run, resolved once.
-// Compute re-reads these per request; here they are shared, which is most of the
-// reason the query count stays flat.
+// batchConfig combines the tenant-wide settings resolved once per batch with
+// whether any recipient requested the ungated personal-assignment type.
+// Compute re-reads tenant settings per request; sharing them here is most of
+// the reason the query count stays flat.
 type batchConfig struct {
 	pickupUpcoming   bool
 	pickupOverdue    bool
 	activityStart    bool
 	activityOverdue  bool
+	assignedStart    bool
 	pickupLead       int
 	activityLead     int
 	overdueThreshold int
@@ -42,9 +44,11 @@ type batchConfig struct {
 	allStaffScope    bool
 }
 
-func (c batchConfig) anyPickup() bool   { return c.pickupUpcoming || c.pickupOverdue }
-func (c batchConfig) anyActivity() bool { return c.activityStart || c.activityOverdue }
-func (c batchConfig) anyEnabled() bool  { return c.anyPickup() || c.anyActivity() }
+func (c batchConfig) anyPickup() bool { return c.pickupUpcoming || c.pickupOverdue }
+func (c batchConfig) anyActivity() bool {
+	return c.activityStart || c.activityOverdue || c.assignedStart
+}
+func (c batchConfig) anyEnabled() bool { return c.anyPickup() || c.anyActivity() }
 
 // batchInputs is everything read once for the whole tenant.
 type batchInputs struct {
@@ -157,6 +161,20 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 					upcoming:         cfg.activityStart,
 					overdue:          cfg.activityOverdue,
 				})
+			if !cfg.activityStart && sc.IncludeAssignedActivityStart {
+				assignedPart, assignedNext := buildActivityReminders(
+					in.instances,
+					in.schulhofRoomIDs,
+					assignedActivityFilter(in.assignedInstances[sc.StaffID]),
+					activityWindow{
+						nowMin:   in.nowMin,
+						lead:     cfg.activityLead,
+						upcoming: true,
+					},
+				)
+				part = append(part, assignedPart...)
+				next = minFuture(next, assignedNext)
+			}
 			activityPart = part
 			nextChange = minFuture(nextChange, next)
 		}
@@ -190,16 +208,17 @@ func assignedIDStrings(instanceIDs map[int64]struct{}) map[string]struct{} {
 // and combined with a bulk lookup that returns no row for it, an empty result
 // would be indistinguishable from "no restriction".
 func dedupeBatchScopes(scopes []BatchScope) []BatchScope {
-	seen := make(map[int64]struct{}, len(scopes))
+	positions := make(map[int64]int, len(scopes))
 	out := make([]BatchScope, 0, len(scopes))
 	for _, sc := range scopes {
 		if sc.StaffID <= 0 {
 			continue
 		}
-		if _, dup := seen[sc.StaffID]; dup {
+		if pos, dup := positions[sc.StaffID]; dup {
+			out[pos].IncludeAssignedActivityStart = out[pos].IncludeAssignedActivityStart || sc.IncludeAssignedActivityStart
 			continue
 		}
-		seen[sc.StaffID] = struct{}{}
+		positions[sc.StaffID] = len(out)
 		out = append(out, sc)
 	}
 	return out
@@ -227,12 +246,20 @@ func hasCaregiver(recipients []BatchScope) bool {
 	return false
 }
 
+func hasAssignedActivityStart(recipients []BatchScope) bool {
+	for _, sc := range recipients {
+		if sc.IncludeAssignedActivityStart {
+			return true
+		}
+	}
+	return false
+}
+
 // loadBatchConfig resolves the tenant settings in the same order and with the
-// same error contract as Compute, and only the ones Compute would have read:
-// resolving a lead time for a disabled branch would surface an error where
-// Compute reports success.
+// same error contract as Compute. The personal assignment type additionally
+// needs the activity lead time even when the room-scoped start gate is off.
 func (s *service) loadBatchConfig(ctx context.Context, recipients []BatchScope) (batchConfig, error) {
-	var cfg batchConfig
+	cfg := batchConfig{assignedStart: hasAssignedActivityStart(recipients)}
 	var err error
 
 	if cfg.pickupUpcoming, err = s.resolveToggle(ctx, configModel.KeyRemindersPickupUpcomingEnabled); err != nil {
@@ -269,10 +296,12 @@ func (s *service) loadBatchConfig(ctx context.Context, recipients []BatchScope) 
 		}
 	}
 
-	if cfg.anyActivity() {
+	if cfg.activityStart || cfg.assignedStart {
 		if cfg.activityLead, err = s.leadMinutes(ctx, configModel.KeyRemindersActivityStartLeadMinutes); err != nil {
 			return cfg, err
 		}
+	}
+	if cfg.activityOverdue {
 		if cfg.overdueThreshold, err = s.overdueThresholdMinutes(ctx); err != nil {
 			return cfg, err
 		}
@@ -454,6 +483,13 @@ func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipien
 	}
 
 	return in, nil
+}
+
+func assignedActivityFilter(instanceIDs map[int64]struct{}) func(*scheduleModel.ActivityInstance) bool {
+	return func(inst *scheduleModel.ActivityInstance) bool {
+		_, assigned := instanceIDs[inst.ID]
+		return assigned
+	}
 }
 
 // batchPresence reproduces pickupScopeStudentIDs for one recipient, from

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -101,12 +101,13 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 		dues       []duePickup
 		nextChange int
 	}
-	pickupsByStaff := make(map[int64]staffPickups, len(recipients))
+	pickupsByRecipient := make(map[int64]staffPickups, len(recipients))
 	dueIDSet := make(map[int64]struct{})
 
 	for _, sc := range recipients {
+		resultKey := sc.resultKey()
 		if !cfg.anyPickup() {
-			pickupsByStaff[sc.StaffID] = staffPickups{nextChange: -1}
+			pickupsByRecipient[resultKey] = staffPickups{nextChange: -1}
 			continue
 		}
 		readable, rerr := s.batchReadableStudents(sc, cfg, in)
@@ -119,7 +120,7 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 			upcoming: cfg.pickupUpcoming,
 			overdue:  cfg.pickupOverdue,
 		})
-		pickupsByStaff[sc.StaffID] = staffPickups{dues: dues, nextChange: next}
+		pickupsByRecipient[resultKey] = staffPickups{dues: dues, nextChange: next}
 		for _, d := range dues {
 			dueIDSet[d.id] = struct{}{}
 		}
@@ -137,7 +138,7 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 
 	// Per-staff pass two: render.
 	for _, sc := range recipients {
-		sp := pickupsByStaff[sc.StaffID]
+		sp := pickupsByRecipient[sc.resultKey()]
 
 		pickupPart, dropped := buildPickupReminders(sp.dues, names)
 		s.logDroppedPickups(dropped)
@@ -181,7 +182,7 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 
 		result := assembleResult(pickupPart, activityPart, nextChange)
 		result.AssignedActivityInstanceIDs = assignedIDStrings(in.assignedInstances[sc.StaffID])
-		results[sc.StaffID] = result
+		results[sc.resultKey()] = result
 	}
 
 	return results, nil
@@ -204,21 +205,22 @@ func assignedIDStrings(instanceIDs map[int64]struct{}) map[string]struct{} {
 
 // dedupeBatchScopes drops unusable scopes and collapses repeats.
 //
-// A non-positive StaffID is dropped rather than computed: it addresses nobody,
-// and combined with a bulk lookup that returns no row for it, an empty result
-// would be indistinguishable from "no restriction".
+// A staff-less admin is valid when the caller supplies an explicit result key:
+// admin visibility does not depend on a staff row. Non-admins still require a
+// positive StaffID so an absent bulk row can never widen their read scope.
 func dedupeBatchScopes(scopes []BatchScope) []BatchScope {
 	positions := make(map[int64]int, len(scopes))
 	out := make([]BatchScope, 0, len(scopes))
 	for _, sc := range scopes {
-		if sc.StaffID <= 0 {
+		key := sc.resultKey()
+		if key == 0 || sc.StaffID < 0 || (sc.StaffID == 0 && !sc.IsAdmin) {
 			continue
 		}
-		if pos, dup := positions[sc.StaffID]; dup {
+		if pos, dup := positions[key]; dup {
 			out[pos].IncludeAssignedActivityStart = out[pos].IncludeAssignedActivityStart || sc.IncludeAssignedActivityStart
 			continue
 		}
-		positions[sc.StaffID] = len(out)
+		positions[key] = len(out)
 		out = append(out, sc)
 	}
 	return out
@@ -230,7 +232,7 @@ func dedupeBatchScopes(scopes []BatchScope) []BatchScope {
 func disabledResults(recipients []BatchScope) map[int64]*Result {
 	results := make(map[int64]*Result, len(recipients))
 	for _, sc := range recipients {
-		results[sc.StaffID] = &Result{Reminders: []Reminder{}}
+		results[sc.resultKey()] = &Result{Reminders: []Reminder{}}
 	}
 	return results
 }
@@ -337,7 +339,9 @@ func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipien
 	caregivers := hasCaregiver(recipients)
 	recipientStaffIDs := make(map[int64]struct{}, len(recipients))
 	for _, sc := range recipients {
-		recipientStaffIDs[sc.StaffID] = struct{}{}
+		if sc.StaffID > 0 {
+			recipientStaffIDs[sc.StaffID] = struct{}{}
+		}
 	}
 
 	// Seed an empty entry for every caregiver BEFORE the bulk reads. The readers

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -1,0 +1,458 @@
+// Batch computation (epic "persönliche Benachrichtigungen"): ComputeBatch
+// answers the same question as Compute for many staff members at once, with a
+// number of queries that does not grow with the number of staff.
+//
+// Two properties make it worth a separate entry point rather than a loop over
+// Compute. First, Compute's read gate resolves the caller from JWT claims, so a
+// background job cannot use it at all. Second, of the ~28 queries Compute issues
+// for one caregiver, only three facts are genuinely per-person; everything else
+// is identical for the whole tenant.
+//
+// The actual reminder rules are NOT reimplemented here. Both entry points call
+// the same pure cores in service.go (duePickups, buildPickupReminders,
+// resolveActivityRooms, buildActivityReminders, assembleResult), and an
+// equivalence test asserts that ComputeBatch and Compute agree scope by scope.
+// If you are about to add a rule here, it belongs in a pure core instead.
+package reminders
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+// batchConfig is the tenant-wide configuration of one batch run, resolved once.
+// Compute re-reads these per request; here they are shared, which is most of the
+// reason the query count stays flat.
+type batchConfig struct {
+	pickupUpcoming   bool
+	pickupOverdue    bool
+	activityStart    bool
+	activityOverdue  bool
+	pickupLead       int
+	activityLead     int
+	overdueThreshold int
+	binaryPresence   bool
+	allStaffScope    bool
+}
+
+func (c batchConfig) anyPickup() bool   { return c.pickupUpcoming || c.pickupOverdue }
+func (c batchConfig) anyActivity() bool { return c.activityStart || c.activityOverdue }
+func (c batchConfig) anyEnabled() bool  { return c.anyPickup() || c.anyActivity() }
+
+// batchInputs is everything read once for the whole tenant.
+type batchInputs struct {
+	today           timezone.Date
+	nowMin          int
+	attendanceIDs   []int64
+	visitsByRoom    map[int64][]int64
+	roomsByStaff    map[int64][]int64
+	groupsByStaff   map[int64]map[int64]struct{}
+	instances       []*scheduleModel.ActivityInstance
+	schulhofRoomIDs map[int64]struct{}
+	students        map[int64]*userModel.Student
+	pickupTimes     map[int64]*scheduleService.EffectivePickupTime
+	presenceByStaff map[int64][]int64
+}
+
+func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[int64]*Result, error) {
+	recipients := dedupeBatchScopes(scopes)
+	results := make(map[int64]*Result, len(recipients))
+	if len(recipients) == 0 {
+		return results, nil
+	}
+
+	// Mirrors Compute's nil-settings guard: an empty, disabled result rather
+	// than a failure, so a partially wired service degrades the same way.
+	if s.Settings == nil {
+		return disabledResults(recipients), nil
+	}
+
+	cfg, err := s.loadBatchConfig(ctx, recipients)
+	if err != nil {
+		return nil, err
+	}
+	if !cfg.anyEnabled() {
+		return disabledResults(recipients), nil
+	}
+
+	in, err := s.loadBatchInputs(ctx, cfg, recipients)
+	if err != nil {
+		return nil, err
+	}
+
+	// Per-staff pass one: which pickups are due, and the soonest boundary. Both
+	// are per person by construction — a shared next-change would leak the
+	// earliest pickup minute in the school to everyone.
+	type staffPickups struct {
+		dues       []duePickup
+		nextChange int
+	}
+	pickupsByStaff := make(map[int64]staffPickups, len(recipients))
+	dueIDSet := make(map[int64]struct{})
+
+	for _, sc := range recipients {
+		if !cfg.anyPickup() {
+			pickupsByStaff[sc.StaffID] = staffPickups{nextChange: -1}
+			continue
+		}
+		readable, rerr := s.batchReadableStudents(sc, cfg, in)
+		if rerr != nil {
+			return nil, rerr
+		}
+		dues, next := duePickups(in.presenceByStaff[sc.StaffID], in.pickupTimes, readable, pickupWindow{
+			nowMin:   in.nowMin,
+			lead:     cfg.pickupLead,
+			upcoming: cfg.pickupUpcoming,
+			overdue:  cfg.pickupOverdue,
+		})
+		pickupsByStaff[sc.StaffID] = staffPickups{dues: dues, nextChange: next}
+		for _, d := range dues {
+			dueIDSet[d.id] = struct{}{}
+		}
+	}
+
+	// One name hydration for the union of everyone's due students. Deliberately
+	// not derived from the admin set: in detailed mode a caregiver's presence
+	// comes from active.visits while an admin's comes from active.attendance,
+	// and those two are not in a subset relation, so an admin-derived set would
+	// silently drop a child that is in the caregiver's own room.
+	names, err := s.hydrateNames(ctx, in.students, sortedIDs(dueIDSet))
+	if err != nil {
+		return nil, err
+	}
+
+	// Per-staff pass two: render.
+	for _, sc := range recipients {
+		sp := pickupsByStaff[sc.StaffID]
+
+		pickupPart, dropped := buildPickupReminders(sp.dues, names)
+		s.logDroppedPickups(dropped)
+		nextChange := sp.nextChange
+
+		var activityPart []Reminder
+		if cfg.anyActivity() {
+			part, next := buildActivityReminders(in.instances, in.schulhofRoomIDs,
+				activityRoomFilter(sc.Scope, in.roomsByStaff[sc.StaffID]), activityWindow{
+					nowMin:           in.nowMin,
+					lead:             cfg.activityLead,
+					overdueThreshold: cfg.overdueThreshold,
+					upcoming:         cfg.activityStart,
+					overdue:          cfg.activityOverdue,
+				})
+			activityPart = part
+			nextChange = minFuture(nextChange, next)
+		}
+
+		results[sc.StaffID] = assembleResult(pickupPart, activityPart, nextChange)
+	}
+
+	return results, nil
+}
+
+// dedupeBatchScopes drops unusable scopes and collapses repeats.
+//
+// A non-positive StaffID is dropped rather than computed: it addresses nobody,
+// and combined with a bulk lookup that returns no row for it, an empty result
+// would be indistinguishable from "no restriction".
+func dedupeBatchScopes(scopes []BatchScope) []BatchScope {
+	seen := make(map[int64]struct{}, len(scopes))
+	out := make([]BatchScope, 0, len(scopes))
+	for _, sc := range scopes {
+		if sc.StaffID <= 0 {
+			continue
+		}
+		if _, dup := seen[sc.StaffID]; dup {
+			continue
+		}
+		seen[sc.StaffID] = struct{}{}
+		out = append(out, sc)
+	}
+	return out
+}
+
+// disabledResults gives every recipient its own empty, disabled result. Each
+// gets a distinct Result and a distinct slice: sharing one would couple two
+// people's lists.
+func disabledResults(recipients []BatchScope) map[int64]*Result {
+	results := make(map[int64]*Result, len(recipients))
+	for _, sc := range recipients {
+		results[sc.StaffID] = &Result{Reminders: []Reminder{}}
+	}
+	return results
+}
+
+// hasCaregiver reports whether any recipient needs the per-person reads at all.
+// A batch of admins only — which is what the notification tick sends today —
+// skips all three bulk staff reads.
+func hasCaregiver(recipients []BatchScope) bool {
+	for _, sc := range recipients {
+		if !sc.IsAdmin {
+			return true
+		}
+	}
+	return false
+}
+
+// loadBatchConfig resolves the tenant settings in the same order and with the
+// same error contract as Compute, and only the ones Compute would have read:
+// resolving a lead time for a disabled branch would surface an error where
+// Compute reports success.
+func (s *service) loadBatchConfig(ctx context.Context, recipients []BatchScope) (batchConfig, error) {
+	var cfg batchConfig
+	var err error
+
+	if cfg.pickupUpcoming, err = s.resolveToggle(ctx, configModel.KeyRemindersPickupUpcomingEnabled); err != nil {
+		return cfg, err
+	}
+	if cfg.pickupOverdue, err = s.resolveToggle(ctx, configModel.KeyRemindersPickupOverdueEnabled); err != nil {
+		return cfg, err
+	}
+	if cfg.activityStart, err = s.resolveToggle(ctx, configModel.KeyRemindersActivityStartEnabled); err != nil {
+		return cfg, err
+	}
+	if cfg.activityOverdue, err = s.resolveToggle(ctx, configModel.KeyRemindersActivityOverdueEnabled); err != nil {
+		return cfg, err
+	}
+	if !cfg.anyEnabled() {
+		return cfg, nil
+	}
+
+	caregivers := hasCaregiver(recipients)
+
+	if cfg.anyPickup() {
+		if cfg.pickupLead, err = s.leadMinutes(ctx, configModel.KeyRemindersPickupUpcomingLeadMinutes); err != nil {
+			return cfg, err
+		}
+		if caregivers {
+			if cfg.binaryPresence, err = s.binaryMode(ctx); err != nil {
+				return cfg, err
+			}
+			var scopeVal string
+			if scopeVal, err = s.Settings.ResolveString(ctx, configModel.KeyStudentDataScope); err != nil {
+				return cfg, fmt.Errorf("resolve %s: %w", configModel.KeyStudentDataScope, err)
+			}
+			cfg.allStaffScope = scopeVal == configModel.StudentDataScopeAllStaff
+		}
+	}
+
+	if cfg.anyActivity() {
+		if cfg.activityLead, err = s.leadMinutes(ctx, configModel.KeyRemindersActivityStartLeadMinutes); err != nil {
+			return cfg, err
+		}
+		if cfg.overdueThreshold, err = s.overdueThresholdMinutes(ctx); err != nil {
+			return cfg, err
+		}
+	}
+
+	return cfg, nil
+}
+
+func (s *service) resolveToggle(ctx context.Context, key string) (bool, error) {
+	v, err := s.Settings.ResolveBool(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("resolve %s: %w", key, err)
+	}
+	return v, nil
+}
+
+// loadBatchInputs performs every tenant-wide read exactly once, then derives the
+// per-person presence sets in memory.
+func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipients []BatchScope) (*batchInputs, error) {
+	in := &batchInputs{
+		today:           timezone.TodayDate(),
+		nowMin:          minutesOfDay(timezone.Now()),
+		visitsByRoom:    map[int64][]int64{},
+		roomsByStaff:    map[int64][]int64{},
+		groupsByStaff:   map[int64]map[int64]struct{}{},
+		schulhofRoomIDs: map[int64]struct{}{},
+		students:        map[int64]*userModel.Student{},
+		pickupTimes:     map[int64]*scheduleService.EffectivePickupTime{},
+		presenceByStaff: map[int64][]int64{},
+	}
+
+	caregivers := hasCaregiver(recipients)
+
+	// Seed an empty entry for every caregiver BEFORE the bulk reads. The readers
+	// only return rows for people who have something, and a missing key that is
+	// later read as "no restriction" is exactly how a room filter turns into
+	// full access.
+	for _, sc := range recipients {
+		if !sc.IsAdmin {
+			in.roomsByStaff[sc.StaffID] = nil
+			in.groupsByStaff[sc.StaffID] = map[int64]struct{}{}
+		}
+	}
+
+	needsAttendance := cfg.anyPickup() && (!caregivers || cfg.binaryPresence || hasAdmin(recipients))
+	if needsAttendance {
+		ids, err := s.presentStudentIDsFromAttendance(ctx, in.today)
+		if err != nil {
+			return nil, err
+		}
+		in.attendanceIDs = ids
+	}
+
+	if caregivers && cfg.anyPickup() && !cfg.binaryPresence {
+		if s.BulkVisits != nil {
+			byRoom, err := s.BulkVisits.ListOpenVisitStudentIDsByRoom(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("load open visits by room: %w", err)
+			}
+			in.visitsByRoom = byRoom
+		}
+	}
+
+	if caregivers && (cfg.anyActivity() || (cfg.anyPickup() && !cfg.binaryPresence)) {
+		if s.BulkSupervision != nil {
+			rows, err := s.BulkSupervision.ListActiveSupervisedRooms(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("load supervised rooms: %w", err)
+			}
+			for _, row := range rows {
+				if _, wanted := in.roomsByStaff[row.StaffID]; wanted {
+					in.roomsByStaff[row.StaffID] = append(in.roomsByStaff[row.StaffID], row.RoomID)
+				}
+			}
+		}
+	}
+
+	if caregivers && cfg.anyPickup() && !cfg.allStaffScope {
+		if s.BulkGroups != nil {
+			staffIDs := make([]int64, 0, len(in.groupsByStaff))
+			for staffID := range in.groupsByStaff {
+				staffIDs = append(staffIDs, staffID)
+			}
+			pairs, err := s.BulkGroups.ListSupervisedGroupIDsByStaff(ctx, staffIDs, in.today)
+			if err != nil {
+				return nil, fmt.Errorf("load supervised groups: %w", err)
+			}
+			for _, pair := range pairs {
+				if groups, wanted := in.groupsByStaff[pair.StaffID]; wanted {
+					groups[pair.GroupID] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// Presence per person, reproducing pickupScopeStudentIDs branch for branch.
+	if cfg.anyPickup() {
+		for _, sc := range recipients {
+			in.presenceByStaff[sc.StaffID] = s.batchPresence(sc, cfg, in)
+		}
+	}
+
+	if cfg.anyPickup() {
+		union := unionOf(in.presenceByStaff)
+		if len(union) > 0 {
+			if s.Student != nil {
+				students, err := s.Student.FindReadScopeByIDs(ctx, union)
+				if err != nil {
+					return nil, fmt.Errorf("load students: %w", err)
+				}
+				in.students = students
+			}
+			if s.Pickup != nil {
+				times, err := s.Pickup.GetBulkEffectivePickupTimesForDate(ctx, union, in.today)
+				if err != nil {
+					return nil, err
+				}
+				in.pickupTimes = times
+			}
+		}
+	}
+
+	if cfg.anyActivity() && s.Instance != nil {
+		instances, err := s.Instance.FindByTenantAndDate(ctx, in.today)
+		if err != nil {
+			return nil, err
+		}
+		in.instances = instances
+
+		if cfg.activityOverdue {
+			if s.Room == nil {
+				return nil, errActivityRoomReaderMissing
+			}
+			wanted := plannedInstanceRoomIDs(instances)
+			rooms, roomErr := s.Room.FindByIDs(ctx, sortedIDs(wanted))
+			if roomErr != nil {
+				return nil, fmt.Errorf("load activity reminder rooms: %w", roomErr)
+			}
+			schulhof, resolveErr := resolveActivityRooms(rooms, wanted)
+			if resolveErr != nil {
+				return nil, resolveErr
+			}
+			in.schulhofRoomIDs = schulhof
+		}
+	}
+
+	return in, nil
+}
+
+// batchPresence reproduces pickupScopeStudentIDs for one recipient, from
+// already-loaded data.
+func (s *service) batchPresence(sc BatchScope, cfg batchConfig, in *batchInputs) []int64 {
+	if sc.IsAdmin || cfg.binaryPresence {
+		return in.attendanceIDs
+	}
+	present := make(map[int64]struct{})
+	for _, roomID := range in.roomsByStaff[sc.StaffID] {
+		for _, studentID := range in.visitsByRoom[roomID] {
+			present[studentID] = struct{}{}
+		}
+	}
+	return sortedIDs(present)
+}
+
+// batchReadableStudents applies the gdpr.student_data_scope gate for one
+// recipient. The loaded student rows are shared across the batch, but the gate
+// is recomputed per person — sharing a gated map would hand one caregiver the
+// children another may read.
+func (s *service) batchReadableStudents(sc BatchScope, cfg batchConfig, in *batchInputs) (map[int64]*userModel.Student, error) {
+	allowAll := sc.IsAdmin || cfg.allStaffScope
+	groups := in.groupsByStaff[sc.StaffID]
+
+	readable := make(map[int64]*userModel.Student)
+	for _, id := range in.presenceByStaff[sc.StaffID] {
+		st := in.students[id]
+		if st == nil {
+			continue
+		}
+		if !allowAll {
+			if st.GroupID == nil {
+				continue
+			}
+			if _, ok := groups[*st.GroupID]; !ok {
+				continue
+			}
+		}
+		readable[id] = st
+	}
+	return readable, nil
+}
+
+func hasAdmin(recipients []BatchScope) bool {
+	for _, sc := range recipients {
+		if sc.IsAdmin {
+			return true
+		}
+	}
+	return false
+}
+
+// unionOf collapses the per-person presence sets into one ascending ID list, so
+// the shared student and pickup-time reads happen once.
+func unionOf(byStaff map[int64][]int64) []int64 {
+	set := make(map[int64]struct{})
+	for _, ids := range byStaff {
+		for _, id := range ids {
+			set[id] = struct{}{}
+		}
+	}
+	return sortedIDs(set)
+}

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -216,9 +216,8 @@ func disabledResults(recipients []BatchScope) map[int64]*Result {
 	return results
 }
 
-// hasCaregiver reports whether any recipient needs the per-person reads at all.
-// A batch of admins only — which is what the notification tick sends today —
-// skips all three bulk staff reads.
+// hasCaregiver reports whether any recipient needs the supervision and group
+// reads. Planned assignments are loaded for every recipient, including admins.
 func hasCaregiver(recipients []BatchScope) bool {
 	for _, sc := range recipients {
 		if !sc.IsAdmin {
@@ -307,6 +306,10 @@ func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipien
 	}
 
 	caregivers := hasCaregiver(recipients)
+	recipientStaffIDs := make(map[int64]struct{}, len(recipients))
+	for _, sc := range recipients {
+		recipientStaffIDs[sc.StaffID] = struct{}{}
+	}
 
 	// Seed an empty entry for every caregiver BEFORE the bulk reads. The readers
 	// only return rows for people who have something, and a missing key that is
@@ -424,7 +427,7 @@ func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipien
 		// skipped: someone who called in sick must not be pinged about the
 		// slot they were relieved of. Substitutes are kept — they are the ones
 		// who have to show up.
-		if caregivers && s.BulkInstanceStaff != nil {
+		if s.BulkInstanceStaff != nil {
 			instanceIDs := make([]int64, 0, len(instances))
 			for _, inst := range instances {
 				if inst != nil && inst.Status == scheduleModel.InstanceStatusPlanned {
@@ -439,7 +442,7 @@ func (s *service) loadBatchInputs(ctx context.Context, cfg batchConfig, recipien
 				if row == nil || row.IsAbsent {
 					continue
 				}
-				if _, wanted := in.roomsByStaff[row.StaffID]; !wanted {
+				if _, wanted := recipientStaffIDs[row.StaffID]; !wanted {
 					continue
 				}
 				if in.assignedInstances[row.StaffID] == nil {

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -52,8 +52,9 @@ type world struct {
 	roomsByStaff  map[int64][]int64
 	groupsByStaff map[int64][]int64
 
-	instances []*scheduleModel.ActivityInstance
-	roomNames map[int64]string
+	instances     []*scheduleModel.ActivityInstance
+	instanceStaff []*scheduleModel.InstanceStaff
+	roomNames     map[int64]string
 
 	// failGetMyGroups makes the JWT-bound path loud instead of silently empty,
 	// so a batch regression that falls back to it cannot pass unnoticed.
@@ -167,20 +168,47 @@ func (w *world) addInstance(id int64, title string, roomID int64, startMin, endM
 	return w
 }
 
+// assignsInstance plans a staff member onto an activity instance, the relation
+// the Betreuungsplan records.
+func (w *world) assignsInstance(staffID, instanceID int64, absent bool) *world {
+	w.instanceStaff = append(w.instanceStaff, &scheduleModel.InstanceStaff{
+		InstanceID: instanceID,
+		StaffID:    staffID,
+		IsAbsent:   absent,
+	})
+	return w
+}
+
+func (w *world) FindByInstanceIDs(_ context.Context, instanceIDs []int64) ([]*scheduleModel.InstanceStaff, error) {
+	w.hit("FindByInstanceIDs")
+	wanted := make(map[int64]struct{}, len(instanceIDs))
+	for _, id := range instanceIDs {
+		wanted[id] = struct{}{}
+	}
+	out := make([]*scheduleModel.InstanceStaff, 0, len(w.instanceStaff))
+	for _, row := range w.instanceStaff {
+		if _, ok := wanted[row.InstanceID]; ok {
+			out = append(out, row)
+		}
+	}
+	return out, nil
+}
+
 func (w *world) service() *service {
 	return &service{Dependencies: Dependencies{
-		Settings:        w,
-		Attendance:      w,
-		Pickup:          w,
-		Instance:        w,
-		Room:            worldRooms{w},
-		Student:         w,
-		Person:          worldPersons{w},
-		Supervision:     w,
-		Groups:          w,
-		BulkSupervision: w,
-		BulkVisits:      w,
-		BulkGroups:      w,
+		Settings:          w,
+		Attendance:        w,
+		Pickup:            w,
+		Instance:          w,
+		Room:              worldRooms{w},
+		Student:           w,
+		Person:            worldPersons{w},
+		Supervision:       w,
+		Groups:            w,
+		BulkSupervision:   w,
+		BulkVisits:        w,
+		BulkGroups:        w,
+		BulkInstanceStaff: w,
 	}}
 }
 
@@ -540,6 +568,58 @@ func TestComputeBatchMatchesCompute(t *testing.T) {
 		w := baseWorld()
 		w.pickupAtMinute(1, far)
 		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
+	})
+
+	t.Run("planned assignment widens the batch and never narrows it", func(t *testing.T) {
+		// The batch deliberately diverges from Compute here: it also counts the
+		// slots a person is planned on, because ten minutes before the start
+		// they supervise nothing yet and the room filter alone would reach
+		// everyone except the one person who has to show up.
+		w := baseWorld()
+		// Staff 7 supervises room 10; instance 102 runs in room 20, which they
+		// do not supervise, but they are planned on it.
+		w.assignsInstance(7, 102, false)
+
+		single, err := w.service().Compute(ctxForStaff(7), Scope{StaffID: 7})
+		require.NoError(t, err)
+		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7)})
+		require.NoError(t, err)
+
+		hasInstance := func(rs []Reminder, id string) bool {
+			for _, r := range rs {
+				if r.ActivityInstanceID != nil && *r.ActivityInstanceID == id {
+					return true
+				}
+			}
+			return false
+		}
+
+		assert.False(t, hasInstance(single.Reminders, "102"),
+			"Compute stays room-scoped and must not change")
+		assert.True(t, hasInstance(batch[7].Reminders, "102"),
+			"the batch must reach the person planned on the slot")
+		assert.GreaterOrEqual(t, len(batch[7].Reminders), len(single.Reminders),
+			"the batch may show more, never fewer")
+	})
+
+	t.Run("an absent assignment is ignored", func(t *testing.T) {
+		// Someone who called in sick must not be pinged about the slot they
+		// were relieved of.
+		w := baseWorld()
+		w.assignsInstance(7, 102, true)
+
+		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7)})
+		require.NoError(t, err)
+
+		for _, r := range batch[7].Reminders {
+			if r.ActivityInstanceID != nil {
+				assert.NotEqual(t, "102", *r.ActivityInstanceID)
+			}
+		}
+	})
+
+	t.Run("without assignments both paths stay identical", func(t *testing.T) {
+		assertBatchMatchesCompute(t, baseWorld(), []BatchScope{caregiver(7), caregiver(8), admin(1)})
 	})
 
 	t.Run("toggle combinations", func(t *testing.T) {

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -713,6 +713,15 @@ func TestComputeBatchScopeHandling(t *testing.T) {
 		assert.Empty(t, out, "a scope that addresses nobody must not be computed")
 	})
 
+	t.Run("staff-less admins use an explicit result key", func(t *testing.T) {
+		out, err := svc.ComputeBatch(ctx, []BatchScope{
+			{Scope: Scope{IsAdmin: true}, ResultKey: -41},
+		})
+		require.NoError(t, err)
+		require.Contains(t, out, int64(-41))
+		assert.NotNil(t, out[-41])
+	})
+
 	t.Run("repeated staff IDs collapse", func(t *testing.T) {
 		out, err := svc.ComputeBatch(ctx, []BatchScope{caregiver(7), caregiver(7)})
 		require.NoError(t, err)

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -438,6 +438,13 @@ func caregiver(staffID int64) BatchScope {
 	return BatchScope{Scope: Scope{IsAdmin: false, StaffID: staffID}}
 }
 
+func personalCaregiver(staffID int64) BatchScope {
+	return BatchScope{
+		Scope:                        Scope{IsAdmin: false, StaffID: staffID},
+		IncludeAssignedActivityStart: true,
+	}
+}
+
 func admin(staffID int64) BatchScope {
 	return BatchScope{Scope: Scope{IsAdmin: true, StaffID: staffID}}
 }
@@ -602,6 +609,23 @@ func TestComputeBatchMatchesCompute(t *testing.T) {
 			"the batch may show more, never fewer")
 	})
 
+	t.Run("personal assignment is independent of the room activity gate", func(t *testing.T) {
+		w := baseWorld()
+		w.settingBools[configModel.KeyRemindersPickupUpcomingEnabled] = false
+		w.settingBools[configModel.KeyRemindersPickupOverdueEnabled] = false
+		w.settingBools[configModel.KeyRemindersActivityStartEnabled] = false
+		w.settingBools[configModel.KeyRemindersActivityOverdueEnabled] = false
+		w.addInstance(103, "Unassigned", 10, start, start+60)
+		w.assignsInstance(7, 101, false)
+
+		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{personalCaregiver(7)})
+		require.NoError(t, err)
+		require.Len(t, batch[7].Reminders, 1)
+		require.NotNil(t, batch[7].Reminders[0].ActivityInstanceID)
+		assert.Equal(t, "101", *batch[7].Reminders[0].ActivityInstanceID)
+		assert.Equal(t, TypeActivityStart, batch[7].Reminders[0].Type)
+	})
+
 	t.Run("an absent assignment is ignored", func(t *testing.T) {
 		// Someone who called in sick must not be pinged about the slot they
 		// were relieved of.
@@ -693,6 +717,12 @@ func TestComputeBatchScopeHandling(t *testing.T) {
 		out, err := svc.ComputeBatch(ctx, []BatchScope{caregiver(7), caregiver(7)})
 		require.NoError(t, err)
 		assert.Len(t, out, 1)
+	})
+
+	t.Run("repeated scopes preserve personal assignment requests", func(t *testing.T) {
+		scopes := dedupeBatchScopes([]BatchScope{caregiver(7), personalCaregiver(7)})
+		require.Len(t, scopes, 1)
+		assert.True(t, scopes[0].IncludeAssignedActivityStart)
 	})
 
 	t.Run("every recipient gets its own result", func(t *testing.T) {

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -787,3 +787,45 @@ func TestComputeBatchQueryCountIsFlatInStaffCount(t *testing.T) {
 	assert.Zero(t, manyCalls["GetStaffActiveSupervisions"],
 		"no per-staff supervision lookup")
 }
+
+// TestBatchReportsPersonalAssignments pins the one piece of per-person context
+// the batch reports beyond the reminder list itself.
+//
+// A consumer that addresses people individually has to tell "an activity in the
+// room you are watching" from "the slot you are planned on" — the assignment is
+// exactly what the batch already knows and Compute does not. Without it the
+// distinction would have to be re-derived from supervision data, which is how
+// two answers to one question start drifting apart.
+func TestBatchReportsPersonalAssignments(t *testing.T) {
+	nowMin := minutesOfDay(timezone.Now())
+	start := nowMin + 5
+
+	w := newWorld()
+	w.addInstance(201, "Schach", 10, start, start+60)
+	w.addInstance(202, "Fußball", 20, start, start+60)
+	w.supervises(7, 10) // watches room 10 only
+	w.supervises(8, 10) // same room, no assignment
+	w.assignsInstance(7, 202, false)
+
+	batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7), caregiver(8), admin(1)})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]struct{}{"202": {}}, batch[7].AssignedActivityInstanceIDs,
+		"only the slot this person is planned on, not the room they supervise")
+	assert.Nil(t, batch[8].AssignedActivityInstanceIDs,
+		"no assignment means nil, which reads as 'nothing of mine' rather than an empty restriction")
+	assert.Nil(t, batch[1].AssignedActivityInstanceIDs,
+		"an admin sees every activity anyway; none of them is personally theirs")
+
+	// The field describes the list, so it has to be usable as a key into it.
+	var matched bool
+	for _, r := range batch[7].Reminders {
+		if r.ActivityInstanceID == nil {
+			continue
+		}
+		if _, ok := batch[7].AssignedActivityInstanceIDs[*r.ActivityInstanceID]; ok {
+			matched = true
+		}
+	}
+	assert.True(t, matched, "the assigned instance must appear in the reminder list too")
+}

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -806,6 +806,7 @@ func TestBatchReportsPersonalAssignments(t *testing.T) {
 	w.supervises(7, 10) // watches room 10 only
 	w.supervises(8, 10) // same room, no assignment
 	w.assignsInstance(7, 202, false)
+	w.assignsInstance(1, 201, false)
 
 	batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7), caregiver(8), admin(1)})
 	require.NoError(t, err)
@@ -814,8 +815,8 @@ func TestBatchReportsPersonalAssignments(t *testing.T) {
 		"only the slot this person is planned on, not the room they supervise")
 	assert.Nil(t, batch[8].AssignedActivityInstanceIDs,
 		"no assignment means nil, which reads as 'nothing of mine' rather than an empty restriction")
-	assert.Nil(t, batch[1].AssignedActivityInstanceIDs,
-		"an admin sees every activity anyway; none of them is personally theirs")
+	assert.Equal(t, map[string]struct{}{"201": {}}, batch[1].AssignedActivityInstanceIDs,
+		"an admin's personal assignment must remain distinguishable from room-wide activities")
 
 	// The field describes the list, so it has to be usable as a key into it.
 	var matched bool

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -1,0 +1,709 @@
+package reminders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"sync"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+	facilitiesModel "github.com/moto-nrw/project-phoenix/models/facilities"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// The world
+//
+// One fixture object serves BOTH the per-caller readers Compute uses and the
+// bulk readers ComputeBatch uses, deriving every answer from the same fields.
+// That is the point: hand-writing separate bulk fixtures would only test the
+// fixture writing, not whether the two code paths agree.
+// =============================================================================
+
+type ctxStaffKey struct{}
+
+// ctxForStaff carries the caller identity that GetMyGroups resolves from the
+// context, standing in for JWT claims. ComputeBatch is deliberately called
+// WITHOUT it — that it works anyway is half the point of this package.
+func ctxForStaff(staffID int64) context.Context {
+	return context.WithValue(context.Background(), ctxStaffKey{}, staffID)
+}
+
+type world struct {
+	settingBools   map[string]bool
+	settingInts    map[string]int
+	settingStrings map[string]string
+
+	students    map[int64]*userModel.Student
+	persons     map[int64]*userModel.Person
+	pickupTimes map[int64]*scheduleService.EffectivePickupTime
+
+	attendanceIDs []int64
+	visitsByRoom  map[int64][]int64
+	roomsByStaff  map[int64][]int64
+	groupsByStaff map[int64][]int64
+
+	instances []*scheduleModel.ActivityInstance
+	roomNames map[int64]string
+
+	// failGetMyGroups makes the JWT-bound path loud instead of silently empty,
+	// so a batch regression that falls back to it cannot pass unnoticed.
+	failGetMyGroups bool
+
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func newWorld() *world {
+	return &world{
+		settingBools: map[string]bool{
+			configModel.KeyRemindersPickupUpcomingEnabled:  true,
+			configModel.KeyRemindersPickupOverdueEnabled:   true,
+			configModel.KeyRemindersActivityStartEnabled:   true,
+			configModel.KeyRemindersActivityOverdueEnabled: true,
+		},
+		settingInts: map[string]int{
+			configModel.KeyRemindersPickupUpcomingLeadMinutes: 10,
+			configModel.KeyRemindersActivityStartLeadMinutes:  10,
+			configModel.KeyTimetableOverdueThresholdMinutes:   5,
+		},
+		settingStrings: map[string]string{
+			configModel.KeyPresenceMode:     configModel.PresenceModeDetailed,
+			configModel.KeyStudentDataScope: configModel.StudentDataScopeGroupSupervisorsOnly,
+		},
+		students:      map[int64]*userModel.Student{},
+		persons:       map[int64]*userModel.Person{},
+		pickupTimes:   map[int64]*scheduleService.EffectivePickupTime{},
+		visitsByRoom:  map[int64][]int64{},
+		roomsByStaff:  map[int64][]int64{},
+		groupsByStaff: map[int64][]int64{},
+		roomNames:     map[int64]string{},
+		calls:         map[string]int{},
+	}
+}
+
+func (w *world) hit(op string) {
+	w.mu.Lock()
+	w.calls[op]++
+	w.mu.Unlock()
+}
+
+func (w *world) resetCalls() {
+	w.mu.Lock()
+	w.calls = map[string]int{}
+	w.mu.Unlock()
+}
+
+func (w *world) snapshot() map[string]int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make(map[string]int, len(w.calls))
+	maps.Copy(out, w.calls)
+	return out
+}
+
+// addStudent registers a child with a name, a class and an education group.
+func (w *world) addStudent(id int64, group int64, name, class string) *world {
+	st := &userModel.Student{SchoolClass: class}
+	st.ID = id
+	st.PersonID = id
+	if group > 0 {
+		g := group
+		st.GroupID = &g
+	}
+	w.students[id] = st
+
+	p := &userModel.Person{FirstName: name, LastName: fmt.Sprintf("Nr%d", id)}
+	p.ID = id
+	w.persons[id] = p
+	return w
+}
+
+func (w *world) presentInRoom(roomID int64, studentIDs ...int64) *world {
+	w.visitsByRoom[roomID] = append(w.visitsByRoom[roomID], studentIDs...)
+	w.attendanceIDs = append(w.attendanceIDs, studentIDs...)
+	return w
+}
+
+// presentOnlyInRoom checks a child into a room WITHOUT an attendance row. That
+// combination is the reason a batch may never derive its hydration sets from
+// the admin (attendance-based) set.
+func (w *world) presentOnlyInRoom(roomID int64, studentIDs ...int64) *world {
+	w.visitsByRoom[roomID] = append(w.visitsByRoom[roomID], studentIDs...)
+	return w
+}
+
+func (w *world) pickupAtMinute(studentID int64, minuteOfDay int) *world {
+	w.pickupTimes[studentID] = pickupAt(minuteOfDay)
+	return w
+}
+
+func (w *world) supervises(staffID int64, roomIDs ...int64) *world {
+	w.roomsByStaff[staffID] = append(w.roomsByStaff[staffID], roomIDs...)
+	return w
+}
+
+func (w *world) teaches(staffID int64, groupIDs ...int64) *world {
+	w.groupsByStaff[staffID] = append(w.groupsByStaff[staffID], groupIDs...)
+	return w
+}
+
+func (w *world) addInstance(id int64, title string, roomID int64, startMin, endMin int) *world {
+	inst := plannedInstance(title, roomID, startMin, endMin)
+	inst.ID = id
+	w.instances = append(w.instances, inst)
+	if _, ok := w.roomNames[roomID]; !ok {
+		w.roomNames[roomID] = "Lernraum"
+	}
+	return w
+}
+
+func (w *world) service() *service {
+	return &service{Dependencies: Dependencies{
+		Settings:        w,
+		Attendance:      w,
+		Pickup:          w,
+		Instance:        w,
+		Room:            worldRooms{w},
+		Student:         w,
+		Person:          worldPersons{w},
+		Supervision:     w,
+		Groups:          w,
+		BulkSupervision: w,
+		BulkVisits:      w,
+		BulkGroups:      w,
+	}}
+}
+
+// --- settingsResolver ---------------------------------------------------------
+
+func (w *world) ResolveBool(_ context.Context, key string) (bool, error) {
+	w.hit("ResolveBool")
+	return w.settingBools[key], nil
+}
+
+func (w *world) ResolveInt(_ context.Context, key string) (int, error) {
+	w.hit("ResolveInt")
+	return w.settingInts[key], nil
+}
+
+func (w *world) ResolveString(_ context.Context, key string) (string, error) {
+	w.hit("ResolveString")
+	return w.settingStrings[key], nil
+}
+
+// --- attendanceReader ---------------------------------------------------------
+
+func (w *world) ListOpenStudentIDsForDate(_ context.Context, _ timezone.Date) ([]int64, error) {
+	w.hit("ListOpenStudentIDsForDate")
+	return append([]int64(nil), w.attendanceIDs...), nil
+}
+
+// --- pickupReader -------------------------------------------------------------
+
+// Narrows to the requested IDs, unlike the older fake in service_internal_test.go.
+// The batch asks over a union, so a fake that ignores its argument would hide a
+// missing student.
+func (w *world) GetBulkEffectivePickupTimesForDate(_ context.Context, ids []int64, _ timezone.Date) (map[int64]*scheduleService.EffectivePickupTime, error) {
+	w.hit("GetBulkEffectivePickupTimesForDate")
+	out := make(map[int64]*scheduleService.EffectivePickupTime, len(ids))
+	for _, id := range ids {
+		if t, ok := w.pickupTimes[id]; ok {
+			out[id] = t
+		}
+	}
+	return out, nil
+}
+
+// --- instanceReader -----------------------------------------------------------
+
+func (w *world) FindByTenantAndDate(_ context.Context, _ timezone.Date) ([]*scheduleModel.ActivityInstance, error) {
+	w.hit("FindByTenantAndDate")
+	return w.instances, nil
+}
+
+// --- studentReader ------------------------------------------------------------
+
+func (w *world) FindReadScopeByIDs(_ context.Context, ids []int64) (map[int64]*userModel.Student, error) {
+	w.hit("FindReadScopeByIDs")
+	out := make(map[int64]*userModel.Student, len(ids))
+	for _, id := range ids {
+		if st, ok := w.students[id]; ok {
+			out[id] = st
+		}
+	}
+	return out, nil
+}
+
+// --- supervisionReader --------------------------------------------------------
+//
+// The test world identifies an active group with the room it runs in, so a
+// supervision row carries the room ID as its GroupID.
+
+func (w *world) GetStaffActiveSupervisions(_ context.Context, staffID int64) ([]*activeModel.GroupSupervisor, error) {
+	w.hit("GetStaffActiveSupervisions")
+	out := make([]*activeModel.GroupSupervisor, 0, len(w.roomsByStaff[staffID]))
+	for _, roomID := range w.roomsByStaff[staffID] {
+		out = append(out, &activeModel.GroupSupervisor{StaffID: staffID, GroupID: roomID})
+	}
+	return out, nil
+}
+
+func (w *world) GetActiveGroupsByIDs(_ context.Context, groupIDs []int64) (map[int64]*activeModel.Group, error) {
+	w.hit("GetActiveGroupsByIDs")
+	out := make(map[int64]*activeModel.Group, len(groupIDs))
+	for _, id := range groupIDs {
+		out[id] = &activeModel.Group{RoomID: id}
+	}
+	return out, nil
+}
+
+func (w *world) ListStudentsPresentInRoom(_ context.Context, roomID int64) ([]int64, error) {
+	w.hit("ListStudentsPresentInRoom")
+	return w.visitsByRoom[roomID], nil
+}
+
+// --- groupReader (JWT-bound) --------------------------------------------------
+
+func (w *world) GetMyGroups(ctx context.Context) ([]*educationModel.Group, error) {
+	w.hit("GetMyGroups")
+	if w.failGetMyGroups {
+		return nil, errors.New("GetMyGroups must not be reached from the batch path")
+	}
+	staffID, _ := ctx.Value(ctxStaffKey{}).(int64)
+	out := make([]*educationModel.Group, 0, len(w.groupsByStaff[staffID]))
+	for _, gid := range w.groupsByStaff[staffID] {
+		out = append(out, eduGroup(gid))
+	}
+	return out, nil
+}
+
+// --- bulk readers -------------------------------------------------------------
+
+func (w *world) ListActiveSupervisedRooms(_ context.Context) ([]activeModel.StaffRoomSupervision, error) {
+	w.hit("ListActiveSupervisedRooms")
+	var out []activeModel.StaffRoomSupervision
+	for staffID, rooms := range w.roomsByStaff {
+		for _, roomID := range rooms {
+			out = append(out, activeModel.StaffRoomSupervision{StaffID: staffID, RoomID: roomID})
+		}
+	}
+	return out, nil
+}
+
+func (w *world) ListOpenVisitStudentIDsByRoom(_ context.Context) (map[int64][]int64, error) {
+	w.hit("ListOpenVisitStudentIDsByRoom")
+	return w.visitsByRoom, nil
+}
+
+func (w *world) ListSupervisedGroupIDsByStaff(_ context.Context, staffIDs []int64, _ timezone.Date) ([]educationModel.StaffGroupID, error) {
+	w.hit("ListSupervisedGroupIDsByStaff")
+	wanted := make(map[int64]struct{}, len(staffIDs))
+	for _, id := range staffIDs {
+		wanted[id] = struct{}{}
+	}
+	var out []educationModel.StaffGroupID
+	for staffID, groups := range w.groupsByStaff {
+		if _, ok := wanted[staffID]; !ok {
+			continue
+		}
+		for _, gid := range groups {
+			out = append(out, educationModel.StaffGroupID{StaffID: staffID, GroupID: gid})
+		}
+	}
+	return out, nil
+}
+
+// --- adapters for the two colliding FindByIDs signatures ----------------------
+
+type worldRooms struct{ w *world }
+
+func (r worldRooms) FindByIDs(_ context.Context, ids []int64) ([]*facilitiesModel.Room, error) {
+	r.w.hit("Room.FindByIDs")
+	out := make([]*facilitiesModel.Room, 0, len(ids))
+	for _, id := range ids {
+		name, ok := r.w.roomNames[id]
+		if !ok {
+			name = "Lernraum"
+		}
+		room := &facilitiesModel.Room{Name: name}
+		room.ID = id
+		out = append(out, room)
+	}
+	return out, nil
+}
+
+type worldPersons struct{ w *world }
+
+func (p worldPersons) FindByIDs(_ context.Context, ids []int64) (map[int64]*userModel.Person, error) {
+	p.w.hit("Person.FindByIDs")
+	out := make(map[int64]*userModel.Person, len(ids))
+	for _, id := range ids {
+		if person, ok := p.w.persons[id]; ok {
+			out[id] = person
+		}
+	}
+	return out, nil
+}
+
+// =============================================================================
+// Equivalence
+// =============================================================================
+
+// assertBatchMatchesCompute is the core assertion of this package: for every
+// scope, ComputeBatch must produce exactly what Compute produces.
+//
+// Both entry points read the clock themselves, so a minute tick between the two
+// calls would shift every MinutesAway by one. The pair is therefore retried once
+// if the wall-clock minute moved.
+func assertBatchMatchesCompute(t *testing.T, w *world, scopes []BatchScope) {
+	t.Helper()
+
+	svc := w.service()
+	ctx := context.Background()
+
+	for attempt := 0; attempt < 2; attempt++ {
+		before := minutesOfDay(timezone.Now())
+
+		batch, err := svc.ComputeBatch(ctx, scopes)
+		require.NoError(t, err)
+
+		singles := make(map[int64]*Result, len(scopes))
+		for _, sc := range scopes {
+			single, serr := svc.Compute(ctxForStaff(sc.StaffID), sc.Scope)
+			require.NoError(t, serr)
+			singles[sc.StaffID] = single
+		}
+
+		if minutesOfDay(timezone.Now()) != before {
+			if attempt == 0 {
+				continue // the minute rolled over mid-comparison, redo the pair
+			}
+			t.Skip("wall-clock minute kept changing during the comparison")
+		}
+
+		require.Len(t, batch, len(scopes), "every requested scope needs an entry")
+		for _, sc := range scopes {
+			single := singles[sc.StaffID]
+			got := batch[sc.StaffID]
+			require.NotNil(t, got, "staff %d must have a result", sc.StaffID)
+
+			assert.Equal(t, single.Enabled, got.Enabled, "staff %d: Enabled", sc.StaffID)
+			assert.Equal(t, single.Count, got.Count, "staff %d: Count", sc.StaffID)
+			assert.Equal(t, single.NextChangeAt, got.NextChangeAt, "staff %d: NextChangeAt", sc.StaffID)
+			assert.Equal(t, single.Reminders, got.Reminders, "staff %d: Reminders", sc.StaffID)
+		}
+		return
+	}
+}
+
+func caregiver(staffID int64) BatchScope {
+	return BatchScope{Scope: Scope{IsAdmin: false, StaffID: staffID}}
+}
+
+func admin(staffID int64) BatchScope {
+	return BatchScope{Scope: Scope{IsAdmin: true, StaffID: staffID}}
+}
+
+func TestComputeBatchMatchesCompute(t *testing.T) {
+	nowMin := minutesOfDay(timezone.Now())
+	if nowMin < 60 || nowMin > 1380 {
+		t.Skip("skipping near midnight: fixtures would wrap the day boundary")
+	}
+
+	soon := nowMin + 5  // inside the 10 minute lead window
+	late := nowMin - 15 // overdue
+	far := nowMin + 120 // outside every window, contributes only a boundary
+	start := nowMin + 5 // activity starting soon
+	overdue := nowMin - 20
+
+	// baseWorld: two rooms, two education groups, one child each, plus a child
+	// nobody supervises.
+	baseWorld := func() *world {
+		w := newWorld()
+		w.addStudent(1, 100, "Anna", "1a").addStudent(2, 200, "Ben", "2b").addStudent(3, 300, "Cem", "3c")
+		w.pickupAtMinute(1, soon).pickupAtMinute(2, late).pickupAtMinute(3, soon)
+		w.presentInRoom(10, 1).presentInRoom(20, 2).presentInRoom(30, 3)
+		w.supervises(7, 10).teaches(7, 100)
+		w.supervises(8, 20).teaches(8, 200)
+		w.addInstance(101, "Schach", 10, start, start+60)
+		w.addInstance(102, "Fußball", 20, overdue, overdue+90)
+		return w
+	}
+
+	t.Run("admin sees everything", func(t *testing.T) {
+		assertBatchMatchesCompute(t, baseWorld(), []BatchScope{admin(1)})
+	})
+
+	t.Run("caregiver with one room and one group", func(t *testing.T) {
+		assertBatchMatchesCompute(t, baseWorld(), []BatchScope{caregiver(7)})
+	})
+
+	t.Run("all_staff scope widens the gate for everyone", func(t *testing.T) {
+		w := baseWorld()
+		w.settingStrings[configModel.KeyStudentDataScope] = configModel.StudentDataScopeAllStaff
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
+	})
+
+	t.Run("caregiver without supervision or groups sees nothing", func(t *testing.T) {
+		w := baseWorld()
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(99)})
+
+		// Asserted in absolute terms as well, not only against Compute: an
+		// equivalence check compares the two paths with each other and is blind
+		// to a bug they share. "Supervises nothing" turning into "sees
+		// everything" is the worst such bug, so it gets its own claim.
+		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(99)})
+		require.NoError(t, err)
+		assert.Empty(t, batch[99].Reminders,
+			"a caregiver without a live supervision must see no activity and no child")
+	})
+
+	t.Run("caregiver supervising a room but teaching no group", func(t *testing.T) {
+		w := baseWorld()
+		w.supervises(9, 10)
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(9)})
+	})
+
+	t.Run("caregiver teaching a group but supervising no room", func(t *testing.T) {
+		w := baseWorld()
+		w.teaches(9, 100)
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(9)})
+	})
+
+	t.Run("binary mode reads presence from attendance", func(t *testing.T) {
+		w := baseWorld()
+		w.settingStrings[configModel.KeyPresenceMode] = configModel.PresenceModeBinary
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
+	})
+
+	t.Run("binary mode with all_staff scope", func(t *testing.T) {
+		w := baseWorld()
+		w.settingStrings[configModel.KeyPresenceMode] = configModel.PresenceModeBinary
+		w.settingStrings[configModel.KeyStudentDataScope] = configModel.StudentDataScopeAllStaff
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
+	})
+
+	t.Run("two caregivers must not contaminate each other", func(t *testing.T) {
+		assertBatchMatchesCompute(t, baseWorld(), []BatchScope{caregiver(7), caregiver(8)})
+	})
+
+	t.Run("admin and caregiver in one batch", func(t *testing.T) {
+		assertBatchMatchesCompute(t, baseWorld(), []BatchScope{admin(1), caregiver(7)})
+	})
+
+	t.Run("two rooms sharing a child are deduplicated", func(t *testing.T) {
+		w := baseWorld()
+		w.supervises(7, 20)
+		w.teaches(7, 200)
+		w.presentInRoom(20, 1) // the same child is present in both rooms
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
+	})
+
+	t.Run("child present in a room but missing from attendance", func(t *testing.T) {
+		// The case that breaks any design deriving hydration sets from the
+		// admin (attendance-based) set: the caregiver must still see the child
+		// standing in their own room.
+		w := baseWorld()
+		w.addStudent(4, 100, "Dana", "1a")
+		w.pickupAtMinute(4, soon)
+		w.presentOnlyInRoom(10, 4)
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7), admin(1)})
+
+		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7)})
+		require.NoError(t, err)
+		var found bool
+		for _, r := range batch[7].Reminders {
+			if r.StudentID != nil && *r.StudentID == "4" {
+				found = true
+			}
+		}
+		assert.True(t, found, "the visit-only child must produce a reminder for its room supervisor")
+	})
+
+	t.Run("due child without a person record is dropped identically", func(t *testing.T) {
+		w := baseWorld()
+		delete(w.persons, 1)
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7), admin(1)})
+	})
+
+	t.Run("child outside every window contributes only a boundary", func(t *testing.T) {
+		w := baseWorld()
+		w.pickupAtMinute(1, far)
+		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
+	})
+
+	t.Run("toggle combinations", func(t *testing.T) {
+		combos := []struct {
+			name                                string
+			pickUp, pickOver, actStart, actOver bool
+		}{
+			{"pickups only", true, true, false, false},
+			{"activities only", false, false, true, true},
+			{"upcoming pickup only", true, false, false, false},
+			{"overdue activity only", false, false, false, true},
+			{"all off", false, false, false, false},
+		}
+		for _, c := range combos {
+			t.Run(c.name, func(t *testing.T) {
+				w := baseWorld()
+				w.settingBools[configModel.KeyRemindersPickupUpcomingEnabled] = c.pickUp
+				w.settingBools[configModel.KeyRemindersPickupOverdueEnabled] = c.pickOver
+				w.settingBools[configModel.KeyRemindersActivityStartEnabled] = c.actStart
+				w.settingBools[configModel.KeyRemindersActivityOverdueEnabled] = c.actOver
+				assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7), admin(1)})
+			})
+		}
+	})
+}
+
+// TestActivityRoomFilterNilOnlyForAdmins pins the nil-versus-empty rule
+// directly. Both entry points share this helper, so the equivalence test cannot
+// see a mistake in it — they would simply be wrong together.
+func TestActivityRoomFilterNilOnlyForAdmins(t *testing.T) {
+	t.Run("admin gets no restriction", func(t *testing.T) {
+		assert.Nil(t, activityRoomFilter(Scope{IsAdmin: true}, nil))
+		assert.Nil(t, activityRoomFilter(Scope{IsAdmin: true}, []int64{10}))
+	})
+
+	t.Run("caregiver without rooms is restricted to nothing", func(t *testing.T) {
+		filter := activityRoomFilter(Scope{StaffID: 7}, nil)
+		require.NotNil(t, filter, "an empty room list must restrict, never widen")
+		assert.Empty(t, filter)
+	})
+
+	t.Run("caregiver is restricted to their rooms", func(t *testing.T) {
+		filter := activityRoomFilter(Scope{StaffID: 7}, []int64{10, 20})
+		require.NotNil(t, filter)
+		assert.Len(t, filter, 2)
+		assert.Contains(t, filter, int64(10))
+		assert.Contains(t, filter, int64(20))
+	})
+}
+
+func TestComputeBatchScopeHandling(t *testing.T) {
+	w := newWorld()
+	svc := w.service()
+	ctx := context.Background()
+
+	t.Run("empty input costs nothing", func(t *testing.T) {
+		w.resetCalls()
+		out, err := svc.ComputeBatch(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+		assert.Empty(t, w.snapshot(), "an empty batch must not touch a single reader")
+	})
+
+	t.Run("non-positive staff IDs are dropped", func(t *testing.T) {
+		out, err := svc.ComputeBatch(ctx, []BatchScope{caregiver(0), caregiver(-1)})
+		require.NoError(t, err)
+		assert.Empty(t, out, "a scope that addresses nobody must not be computed")
+	})
+
+	t.Run("repeated staff IDs collapse", func(t *testing.T) {
+		out, err := svc.ComputeBatch(ctx, []BatchScope{caregiver(7), caregiver(7)})
+		require.NoError(t, err)
+		assert.Len(t, out, 1)
+	})
+
+	t.Run("every recipient gets its own result", func(t *testing.T) {
+		out, err := svc.ComputeBatch(ctx, []BatchScope{caregiver(7), caregiver(8)})
+		require.NoError(t, err)
+		require.Len(t, out, 2)
+		assert.NotSame(t, out[7], out[8], "results must not share a pointer")
+	})
+
+	t.Run("nil dependencies yield empty disabled results, not a panic", func(t *testing.T) {
+		bare := &service{}
+		out, err := bare.ComputeBatch(ctx, []BatchScope{caregiver(7), admin(1)})
+		require.NoError(t, err)
+		require.Len(t, out, 2)
+		for id, res := range out {
+			assert.False(t, res.Enabled, "staff %d", id)
+			assert.Empty(t, res.Reminders, "staff %d", id)
+		}
+	})
+}
+
+// =============================================================================
+// Query count
+// =============================================================================
+
+func TestComputeBatchQueryCountIsFlatInStaffCount(t *testing.T) {
+	nowMin := minutesOfDay(timezone.Now())
+	if nowMin < 60 || nowMin > 1380 {
+		t.Skip("skipping near midnight")
+	}
+
+	// A world with many staff, each supervising their own room and teaching
+	// their own group, with a child due for pickup in it.
+	build := func(staffCount int) (*world, []BatchScope) {
+		w := newWorld()
+		// The batch must never reach the JWT-bound path; make that loud.
+		w.failGetMyGroups = true
+
+		scopes := make([]BatchScope, 0, staffCount)
+		for n := range staffCount {
+			i := n + 1
+			staffID := int64(i)
+			roomID := int64(100 + i)
+			groupID := int64(200 + i)
+			studentID := int64(1000 + i)
+
+			w.addStudent(studentID, groupID, fmt.Sprintf("Kind%d", i), "1a")
+			w.pickupAtMinute(studentID, nowMin+5)
+			w.presentInRoom(roomID, studentID)
+			w.supervises(staffID, roomID)
+			w.teaches(staffID, groupID)
+			w.addInstance(int64(500+i), fmt.Sprintf("AG%d", i), roomID, nowMin+5, nowMin+65)
+
+			scopes = append(scopes, caregiver(staffID))
+		}
+		return w, scopes
+	}
+
+	run := func(staffCount int) (map[string]int, map[int64]*Result) {
+		w, scopes := build(staffCount)
+		w.resetCalls()
+		out, err := w.service().ComputeBatch(context.Background(), scopes)
+		require.NoError(t, err)
+		return w.snapshot(), out
+	}
+
+	oneCalls, oneOut := run(1)
+	manyCalls, manyOut := run(50)
+
+	require.Len(t, oneOut, 1)
+	require.Len(t, manyOut, 50)
+
+	// A degenerate early return would also produce a flat count, so prove the
+	// batch actually computed something first.
+	require.NotEmpty(t, manyOut[1].Reminders, "the batch must produce real reminders")
+
+	assert.Equal(t, oneCalls, manyCalls,
+		"the number of reads must not grow with the number of staff")
+
+	assert.Equal(t, 1, manyCalls["ListSupervisedGroupIDsByStaff"],
+		"supervised groups are resolved for all staff in one call")
+	assert.Equal(t, 1, manyCalls["ListActiveSupervisedRooms"])
+	assert.Equal(t, 1, manyCalls["ListOpenVisitStudentIDsByRoom"])
+	assert.Equal(t, 1, manyCalls["FindReadScopeByIDs"])
+	assert.Equal(t, 1, manyCalls["GetBulkEffectivePickupTimesForDate"])
+	assert.Equal(t, 1, manyCalls["Person.FindByIDs"])
+
+	assert.Zero(t, manyCalls["GetMyGroups"],
+		"the batch must never fall back to the JWT-bound group lookup")
+	assert.Zero(t, manyCalls["ListStudentsPresentInRoom"],
+		"no per-room query loop")
+	assert.Zero(t, manyCalls["GetStaffActiveSupervisions"],
+		"no per-staff supervision lookup")
+}

--- a/backend/services/reminders/batch_internal_test.go
+++ b/backend/services/reminders/batch_internal_test.go
@@ -577,19 +577,20 @@ func TestComputeBatchMatchesCompute(t *testing.T) {
 		assertBatchMatchesCompute(t, w, []BatchScope{caregiver(7)})
 	})
 
-	t.Run("planned assignment widens the batch and never narrows it", func(t *testing.T) {
+	t.Run("planned upcoming assignment widens the batch and never narrows it", func(t *testing.T) {
 		// The batch deliberately diverges from Compute here: it also counts the
 		// slots a person is planned on, because ten minutes before the start
 		// they supervise nothing yet and the room filter alone would reach
 		// everyone except the one person who has to show up.
 		w := baseWorld()
-		// Staff 7 supervises room 10; instance 102 runs in room 20, which they
+		// Staff 7 supervises room 10; instance 103 runs in room 20, which they
 		// do not supervise, but they are planned on it.
-		w.assignsInstance(7, 102, false)
+		w.addInstance(103, "Theater", 20, start, start+60)
+		w.assignsInstance(7, 103, false)
 
 		single, err := w.service().Compute(ctxForStaff(7), Scope{StaffID: 7})
 		require.NoError(t, err)
-		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7)})
+		batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{personalCaregiver(7)})
 		require.NoError(t, err)
 
 		hasInstance := func(rs []Reminder, id string) bool {
@@ -601,9 +602,9 @@ func TestComputeBatchMatchesCompute(t *testing.T) {
 			return false
 		}
 
-		assert.False(t, hasInstance(single.Reminders, "102"),
+		assert.False(t, hasInstance(single.Reminders, "103"),
 			"Compute stays room-scoped and must not change")
-		assert.True(t, hasInstance(batch[7].Reminders, "102"),
+		assert.True(t, hasInstance(batch[7].Reminders, "103"),
 			"the batch must reach the person planned on the slot")
 		assert.GreaterOrEqual(t, len(batch[7].Reminders), len(single.Reminders),
 			"the batch may show more, never fewer")
@@ -847,7 +848,7 @@ func TestBatchReportsPersonalAssignments(t *testing.T) {
 	w.assignsInstance(7, 202, false)
 	w.assignsInstance(1, 201, false)
 
-	batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{caregiver(7), caregiver(8), admin(1)})
+	batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{personalCaregiver(7), caregiver(8), admin(1)})
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]struct{}{"202": {}}, batch[7].AssignedActivityInstanceIDs,
@@ -868,4 +869,31 @@ func TestBatchReportsPersonalAssignments(t *testing.T) {
 		}
 	}
 	assert.True(t, matched, "the assigned instance must appear in the reminder list too")
+}
+
+func TestAssignedActivitiesExpandOnlyUpcomingScope(t *testing.T) {
+	nowMin := minutesOfDay(timezone.Now())
+	if nowMin < 60 || nowMin > 1380 {
+		t.Skip("skipping near midnight: fixtures would wrap the day boundary")
+	}
+
+	w := newWorld()
+	w.supervises(7, 10)
+	w.addInstance(201, "Überfällig außerhalb der Aufsicht", 20, nowMin-20, nowMin+40)
+	w.addInstance(202, "Nächster Einsatz außerhalb der Aufsicht", 20, nowMin+5, nowMin+65)
+	w.assignsInstance(7, 201, false)
+	w.assignsInstance(7, 202, false)
+
+	batch, err := w.service().ComputeBatch(context.Background(), []BatchScope{personalCaregiver(7)})
+	require.NoError(t, err)
+	require.Contains(t, batch, int64(7))
+
+	var reminderIDs []string
+	for _, reminder := range batch[7].Reminders {
+		if reminder.ActivityInstanceID != nil {
+			reminderIDs = append(reminderIDs, *reminder.ActivityInstanceID)
+		}
+	}
+	assert.Contains(t, reminderIDs, "202", "an upcoming personal assignment must be included")
+	assert.NotContains(t, reminderIDs, "201", "an assignment outside supervised rooms must not widen overdue scope")
 }

--- a/backend/services/reminders/room_scope_equivalence_test.go
+++ b/backend/services/reminders/room_scope_equivalence_test.go
@@ -1,0 +1,99 @@
+package reminders_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSupervisedRoomScopeAgreesWithBulkReader documents where the two ways of
+// answering "which rooms does this person supervise right now" agree and where
+// they deliberately do not.
+//
+// Compute walks active.group_supervisors -> active.groups and never checks
+// whether the session is still open, because the underlying FindByIDs has no
+// end_time predicate. ComputeBatch uses ListActiveSupervisedRooms, which does
+// check it. A room whose session already ended therefore surfaces on the single
+// path and not on the batch path.
+//
+// The batch is the stricter and more correct side: a closed session holds no
+// children, so an activity reminder for its room is noise. The divergence is
+// accepted rather than fixed, because aligning it would change Compute's
+// production behaviour with no test coverage on either side. This test pins the
+// DIRECTION so nobody flips it by accident: whatever the bulk reader returns
+// must always be a subset of what the single path returns.
+//
+// The in-memory equivalence suite cannot see any of this — its fixtures serve
+// both paths from one field, so SQL predicate drift is invisible there. That is
+// exactly why this test talks to a real database.
+func TestSupervisedRoomScopeAgreesWithBulkReader(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).GroupSupervisor
+	ctx := testpkg.TenantContext(1)
+
+	staff := testpkg.CreateTestStaff(t, db, "RoomScope", "Supervisor")
+	activity := testpkg.CreateTestActivityGroup(t, db, "RoomScopeActivity")
+
+	openRoom := testpkg.CreateTestRoom(t, db, "RoomScopeOpen")
+	closedRoom := testpkg.CreateTestRoom(t, db, "RoomScopeClosed")
+	expiredRoom := testpkg.CreateTestRoom(t, db, "RoomScopeExpired")
+
+	openGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, openRoom.ID)
+	closedGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, closedRoom.ID)
+	expiredGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, expiredRoom.ID)
+
+	openSup := testpkg.CreateTestGroupSupervisor(t, db, staff.ID, openGroup.ID, "primary")
+	closedSup := testpkg.CreateTestGroupSupervisor(t, db, staff.ID, closedGroup.ID, "primary")
+	expiredSup := testpkg.CreateTestGroupSupervisor(t, db, staff.ID, expiredGroup.ID, "primary")
+
+	defer testpkg.CleanupActivityFixtures(t, db,
+		openSup.ID, closedSup.ID, expiredSup.ID,
+		openGroup.ID, closedGroup.ID, expiredGroup.ID,
+		activity.ID, openRoom.ID, closedRoom.ID, expiredRoom.ID,
+	)
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+
+	// The session in closedRoom is over, but the supervision row is still open —
+	// the state the nightly stale-supervisor cleanup exists to resolve.
+	_, err := db.NewUpdate().
+		TableExpr("active.groups").
+		Set("end_time = ?", time.Now()).
+		Where("id = ?", closedGroup.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// The supervision in expiredRoom ended yesterday.
+	_, err = db.NewUpdate().
+		TableExpr("active.group_supervisors").
+		Set("end_date = ?", timezone.TodayDate().AddDays(-1)).
+		Where("id = ?", expiredSup.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	rows, err := repo.ListActiveSupervisedRooms(ctx)
+	require.NoError(t, err)
+
+	bulkRooms := make(map[int64]struct{})
+	for _, row := range rows {
+		if row.StaffID == staff.ID {
+			bulkRooms[row.RoomID] = struct{}{}
+		}
+	}
+
+	// What both paths agree on.
+	assert.Contains(t, bulkRooms, openRoom.ID,
+		"a live supervision on an open session is supervised on either path")
+	assert.NotContains(t, bulkRooms, expiredRoom.ID,
+		"a supervision that ended yesterday is gone on either path")
+
+	// The accepted divergence. Compute still sees this room; the batch does not.
+	assert.NotContains(t, bulkRooms, closedRoom.ID,
+		"the bulk reader drops the room of an ended session — deliberate, and stricter than Compute")
+}

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -115,6 +115,10 @@ type Computer interface {
 // assertion, exactly as with Scope — the service does not verify it.
 type BatchScope struct {
 	Scope
+	// IncludeAssignedActivityStart enables upcoming reminders for activity
+	// instances this person is planned on. Unlike room-scoped activity
+	// reminders, this personal type has no tenant-level reminder gate.
+	IncludeAssignedActivityStart bool
 }
 
 type settingsResolver interface {

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -97,10 +97,10 @@ type Service interface {
 // It is deliberately separate from Service: Service is implemented by several
 // test doubles that have no business growing a batch method.
 type BatchComputer interface {
-	// ComputeBatch returns one result per requested scope, keyed by StaffID
-	// (admins are keyed by their own StaffID too). Every requested scope gets an
-	// entry, so callers may index the map without checking. Any read failure
-	// fails the whole batch, matching Compute's all-or-nothing contract.
+	// ComputeBatch returns one result per requested scope, keyed by ResultKey
+	// when set and otherwise by StaffID. Every requested scope gets an entry, so
+	// callers may index the map without checking. Any read failure fails the
+	// whole batch, matching Compute's all-or-nothing contract.
 	ComputeBatch(ctx context.Context, scopes []BatchScope) (map[int64]*Result, error)
 }
 
@@ -115,10 +115,21 @@ type Computer interface {
 // assertion, exactly as with Scope — the service does not verify it.
 type BatchScope struct {
 	Scope
+	// ResultKey lets callers address an effective admin who has no staff row.
+	// It is an opaque, non-zero map key; ordinary staff scopes leave it unset
+	// and remain keyed by StaffID.
+	ResultKey int64
 	// IncludeAssignedActivityStart enables upcoming reminders for activity
 	// instances this person is planned on. Unlike room-scoped activity
 	// reminders, this personal type has no tenant-level reminder gate.
 	IncludeAssignedActivityStart bool
+}
+
+func (s BatchScope) resultKey() int64 {
+	if s.ResultKey != 0 {
+		return s.ResultKey
+	}
+	return s.StaffID
 }
 
 type settingsResolver interface {

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -65,6 +65,15 @@ type Result struct {
 	// pending (the poll then remains the only cadence). Data-driven changes
 	// (check-ins, edits) are still delivered via the SSE-stale event, not this.
 	NextChangeAt string `json:"next_change_at,omitempty"`
+	// AssignedActivityInstanceIDs names the activity instances this person is
+	// personally planned on, keyed exactly like Reminder.ActivityInstanceID.
+	//
+	// Set by ComputeBatch only and never serialized: the /reminders page shows
+	// one activity list and does not care where an entry came from. A consumer
+	// that addresses people individually does care — "an activity in the room
+	// you are watching" and "the slot you have to show up for" are two
+	// different messages, and a person may want to hear one and not the other.
+	AssignedActivityInstanceIDs map[string]struct{} `json:"-"`
 }
 
 // Scope describes whose reminders to compute. Admins see all present children

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -75,9 +75,37 @@ type Scope struct {
 	StaffID int64
 }
 
-// Service is the reminder computation entry point.
+// Service is the reminder computation entry point for one caller.
 type Service interface {
 	Compute(ctx context.Context, scope Scope) (*Result, error)
+}
+
+// BatchComputer computes personally-scoped reminder lists for many staff
+// members with a number of queries that does not grow with the number of staff.
+// It exists for callers with no authenticated user (the scheduler), which is
+// also why it takes staff IDs rather than deriving the person from the context.
+//
+// It is deliberately separate from Service: Service is implemented by several
+// test doubles that have no business growing a batch method.
+type BatchComputer interface {
+	// ComputeBatch returns one result per requested scope, keyed by StaffID
+	// (admins are keyed by their own StaffID too). Every requested scope gets an
+	// entry, so callers may index the map without checking. Any read failure
+	// fails the whole batch, matching Compute's all-or-nothing contract.
+	ComputeBatch(ctx context.Context, scopes []BatchScope) (map[int64]*Result, error)
+}
+
+// Computer is the full surface the concrete service provides. It is assignable
+// to Service, so consumers that only need Compute keep their narrower type.
+type Computer interface {
+	Service
+	BatchComputer
+}
+
+// BatchScope is one recipient of a batch computation. IsAdmin is the caller's
+// assertion, exactly as with Scope — the service does not verify it.
+type BatchScope struct {
+	Scope
 }
 
 type settingsResolver interface {
@@ -143,14 +171,43 @@ type Dependencies struct {
 	Supervision supervisionReader
 	Groups      groupReader
 	Logger      *slog.Logger
+
+	// The bulk readers below are used only by ComputeBatch. They are optional so
+	// every existing Dependencies literal keeps compiling; a nil one fails
+	// closed (empty room set, empty presence, nobody readable), never open.
+	BulkSupervision bulkSupervisionReader
+	BulkVisits      bulkVisitReader
+	BulkGroups      bulkGroupReader
+}
+
+// bulkSupervisionReader answers "who supervises which room right now" for the
+// whole tenant in one query.
+type bulkSupervisionReader interface {
+	ListActiveSupervisedRooms(ctx context.Context) ([]activeModel.StaffRoomSupervision, error)
+}
+
+// bulkVisitReader answers "which children are present in which room" for the
+// whole tenant in one query.
+type bulkVisitReader interface {
+	ListOpenVisitStudentIDsByRoom(ctx context.Context) (map[int64][]int64, error)
+}
+
+// bulkGroupReader is the identity-free counterpart of groupReader: it resolves
+// supervised education groups by staff ID instead of from JWT claims. Its
+// agreement with GetMyGroups is pinned by an equivalence test in
+// services/usercontext.
+type bulkGroupReader interface {
+	ListSupervisedGroupIDsByStaff(ctx context.Context, staffIDs []int64, on timezone.Date) ([]educationModel.StaffGroupID, error)
 }
 
 type service struct {
 	Dependencies
 }
 
-// NewService builds the reminder service.
-func NewService(deps Dependencies) Service {
+// NewService builds the reminder service. It returns Computer so wiring can
+// reach ComputeBatch; the value stays assignable to Service for the consumers
+// that only compute for one caller.
+func NewService(deps Dependencies) Computer {
 	if deps.Room == nil {
 		panic("reminders.NewService: Room is required")
 	}
@@ -194,7 +251,7 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 	today := timezone.TodayDate()
 	nowMin := minutesOfDay(timezone.Now())
 
-	reminders := make([]Reminder, 0)
+	var pickupPart, activityPart []Reminder
 	// -1 = no future time-based change pending. Both branches feed their soonest
 	// boundary in; the earliest across pickups and activities wins.
 	nextChange := -1
@@ -215,7 +272,7 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 		if perr != nil {
 			return nil, perr
 		}
-		reminders = append(reminders, pickupReminders...)
+		pickupPart = pickupReminders
 		nextChange = minFuture(nextChange, pickupNext)
 	}
 
@@ -242,9 +299,28 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 		if aerr != nil {
 			return nil, aerr
 		}
-		reminders = append(reminders, activityReminders...)
+		activityPart = activityReminders
 		nextChange = minFuture(nextChange, activityNext)
 	}
+
+	return assembleResult(pickupPart, activityPart, nextChange), nil
+}
+
+// errActivityRoomReaderMissing is returned when overdue activity reminders are
+// enabled but no room reader is wired: the Schulhof exemption cannot be decided
+// without it, and guessing would either invent or suppress reminders.
+var errActivityRoomReaderMissing = errors.New("activity reminder room reader is not configured")
+
+// assembleResult builds the response from the two reminder groups. Shared by
+// both entry points so ordering, counting and the next-change field cannot
+// differ between them.
+//
+// Pickups are appended before activities and the sort is stable, so the two
+// groups keep their relative order when they tie on urgency.
+func assembleResult(pickupPart, activityPart []Reminder, nextChange int) *Result {
+	reminders := make([]Reminder, 0, len(pickupPart)+len(activityPart))
+	reminders = append(reminders, pickupPart...)
+	reminders = append(reminders, activityPart...)
 
 	// Most urgent first (overdue is negative, soonest upcoming next).
 	sort.SliceStable(reminders, func(i, j int) bool {
@@ -255,7 +331,7 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 	if nextChange >= 0 {
 		result.NextChangeAt = formatMinutes(nextChange)
 	}
-	return result, nil
+	return result
 }
 
 // pickupScopeStudentIDs returns the IDs of currently present students whose
@@ -409,13 +485,68 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 		return nil, nextChange, nil
 	}
 
-	type duePickup struct {
-		id        int64
-		pickupMin int
-		diff      int
-		isOverdue bool
+	dues, nextChange := duePickups(studentIDs, times, readable, pickupWindow{
+		nowMin:   nowMin,
+		lead:     lead,
+		upcoming: upcoming,
+		overdue:  overdue,
+	})
+	if len(dues) == 0 {
+		return nil, nextChange, nil
 	}
+
+	dueIDs := make([]int64, len(dues))
+	for i, d := range dues {
+		dueIDs[i] = d.id
+	}
+
+	// Hydrate display names for the due students only (all already read-gated).
+	infos, err := s.hydrateNames(ctx, readable, dueIDs)
+	if err != nil {
+		return nil, nextChange, err
+	}
+
+	out, dropped := buildPickupReminders(dues, infos)
+	s.logDroppedPickups(dropped)
+	return out, nextChange, nil
+}
+
+// pickupWindow bundles the time-window parameters of one pickup evaluation.
+// Grouping them keeps the pure core from growing another pair of adjacent
+// positional bools, which is how the single and batch paths would start to
+// drift.
+type pickupWindow struct {
+	nowMin   int
+	lead     int
+	upcoming bool
+	overdue  bool
+}
+
+// duePickup is one student whose pickup currently qualifies for a reminder.
+type duePickup struct {
+	id        int64
+	pickupMin int
+	diff      int
+	isOverdue bool
+}
+
+// duePickups decides which of the given students currently have a due pickup and
+// what the soonest future state change is. It is pure: both Compute and
+// ComputeBatch call it with their own inputs, so the actual rule lives in one
+// place and cannot diverge between the two entry points.
+//
+// `readable` is the read-gated set. A student missing from it contributes
+// neither a reminder nor a boundary — see the caller's comment on why the gate
+// must run before any boundary is derived.
+func duePickups(
+	studentIDs []int64,
+	times map[int64]*scheduleService.EffectivePickupTime,
+	readable map[int64]*userModel.Student,
+	w pickupWindow,
+) ([]duePickup, int) {
+	nextChange := -1
 	dues := make([]duePickup, 0)
+
 	for _, id := range studentIDs {
 		if _, ok := readable[id]; !ok {
 			// Not readable under gdpr.student_data_scope — must contribute neither
@@ -440,42 +571,45 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 		// boundary — leaving the overdue reminder to surface only on the next 60s
 		// poll. This is what lets the frontend time the first appearance of a
 		// reminder that isn't in this response yet.
-		if upcoming {
-			nextChange = minFuture(nextChange, futureBoundary(pickupMin-lead, nowMin))
+		if w.upcoming {
+			nextChange = minFuture(nextChange, futureBoundary(pickupMin-w.lead, w.nowMin))
 		}
-		if upcoming || overdue {
-			nextChange = minFuture(nextChange, futureBoundary(pickupMin+1, nowMin))
+		if w.upcoming || w.overdue {
+			nextChange = minFuture(nextChange, futureBoundary(pickupMin+1, w.nowMin))
 		}
 
-		diff := pickupMin - nowMin
+		diff := pickupMin - w.nowMin
 		switch {
-		case diff < 0 && overdue:
+		case diff < 0 && w.overdue:
 			dues = append(dues, duePickup{id: id, pickupMin: pickupMin, diff: diff, isOverdue: true})
-		case diff >= 0 && diff <= lead && upcoming:
+		case diff >= 0 && diff <= w.lead && w.upcoming:
 			dues = append(dues, duePickup{id: id, pickupMin: pickupMin, diff: diff, isOverdue: false})
 		}
 	}
-	if len(dues) == 0 {
-		return nil, nextChange, nil
-	}
 
-	dueIDs := make([]int64, len(dues))
-	for i, d := range dues {
-		dueIDs[i] = d.id
-	}
+	// Sort by student ID so reminders that tie on urgency come out in a stable
+	// order. The caregiver paths collect student IDs through a map, so without
+	// this the final stable sort by MinutesAway would hand ties to whichever
+	// order the map happened to produce — the list would reshuffle between two
+	// polls of an endpoint the header hits every 60 seconds, and the single and
+	// batch paths could never be compared for equality.
+	sort.Slice(dues, func(i, j int) bool { return dues[i].id < dues[j].id })
 
-	// Hydrate display names for the due students only (all already read-gated).
-	infos, err := s.hydrateNames(ctx, readable, dueIDs)
-	if err != nil {
-		return nil, nextChange, err
-	}
+	return dues, nextChange
+}
 
+// buildPickupReminders renders due pickups into reminders. Pure: it neither
+// reads nor logs, and returns the students it had to drop so the caller can emit
+// the log line. Both entry points share it, so the drop rule cannot diverge.
+func buildPickupReminders(dues []duePickup, names map[int64]studentNameInfo) ([]Reminder, []int64) {
 	out := make([]Reminder, 0, len(dues))
+	var dropped []int64
+
 	for _, d := range dues {
 		// dueIDs is a subset of the read-gated `readable` set and hydrateNames
-		// populates an entry for every one of them, so infos[d.id] is always
+		// populates an entry for every one of them, so names[d.id] is always
 		// present here — no missing-key guard is needed.
-		info := infos[d.id]
+		info := names[d.id]
 		if info.name == "" {
 			// The student passed the read gate but its person record could not be
 			// resolved (a not-found row rather than a read error — e.g. the person
@@ -483,9 +617,7 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 			// attendance row). A reminder with a blank title is an unidentifiable
 			// card, so skip it: this upholds the same "no unusable empty-title
 			// reminders" guarantee the person-read-error path enforces by failing.
-			if s.Logger != nil {
-				s.Logger.Debug("skipping pickup reminder with unresolved name", "student_id", d.id)
-			}
+			dropped = append(dropped, d.id)
 			continue
 		}
 		reminderType := TypePickupUpcoming
@@ -501,7 +633,18 @@ func (s *service) pickupReminders(ctx context.Context, scope Scope, studentIDs [
 			MinutesAway: d.diff,
 		})
 	}
-	return out, nextChange, nil
+	return out, dropped
+}
+
+// logDroppedPickups emits the Debug line for students whose name could not be
+// resolved. GDPR: IDs only, never names, and only at Debug level.
+func (s *service) logDroppedPickups(dropped []int64) {
+	if s.Logger == nil {
+		return
+	}
+	for _, id := range dropped {
+		s.Logger.Debug("skipping pickup reminder with unresolved name", "student_id", id)
+	}
 }
 
 func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []int64, today timezone.Date, nowMin, lead, overdueThreshold int, upcoming, overdue bool) ([]Reminder, int, error) {
@@ -514,51 +657,121 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 		return nil, nextChange, err
 	}
 
-	var roomFilter map[int64]struct{}
-	if !scope.IsAdmin {
-		roomFilter = make(map[int64]struct{}, len(roomIDs))
-		for _, id := range roomIDs {
-			roomFilter[id] = struct{}{}
-		}
-	}
+	roomFilter := activityRoomFilter(scope, roomIDs)
 
 	schulhofRoomIDs := make(map[int64]struct{})
 	if overdue {
 		if s.Room == nil {
-			return nil, nextChange, errors.New("activity reminder room reader is not configured")
+			return nil, nextChange, errActivityRoomReaderMissing
 		}
-		uniqueRoomIDs := make(map[int64]struct{})
-		for _, inst := range instances {
-			if inst != nil && inst.Status == scheduleModel.InstanceStatusPlanned {
-				uniqueRoomIDs[inst.RoomID] = struct{}{}
-			}
-		}
-		roomIDsToLoad := make([]int64, 0, len(uniqueRoomIDs))
-		for roomID := range uniqueRoomIDs {
-			roomIDsToLoad = append(roomIDsToLoad, roomID)
-		}
-		rooms, roomErr := s.Room.FindByIDs(ctx, roomIDsToLoad)
+		wanted := plannedInstanceRoomIDs(instances)
+		rooms, roomErr := s.Room.FindByIDs(ctx, sortedIDs(wanted))
 		if roomErr != nil {
 			return nil, nextChange, fmt.Errorf("load activity reminder rooms: %w", roomErr)
 		}
-		resolvedRoomIDs := make(map[int64]struct{}, len(rooms))
-		for _, room := range rooms {
-			if room == nil {
-				continue
-			}
-			resolvedRoomIDs[room.ID] = struct{}{}
-			if room.Name == constants.SchulhofRoomName {
-				schulhofRoomIDs[room.ID] = struct{}{}
-			}
-		}
-		for roomID := range uniqueRoomIDs {
-			if _, found := resolvedRoomIDs[roomID]; !found {
-				return nil, nextChange, fmt.Errorf("load activity reminder rooms: room %d not found", roomID)
-			}
+		schulhofRoomIDs, err = resolveActivityRooms(rooms, wanted)
+		if err != nil {
+			return nil, nextChange, err
 		}
 	}
 
+	out, nextChange := buildActivityReminders(instances, schulhofRoomIDs, roomFilter, activityWindow{
+		nowMin:           nowMin,
+		lead:             lead,
+		overdueThreshold: overdueThreshold,
+		upcoming:         upcoming,
+		overdue:          overdue,
+	})
+	return out, nextChange, nil
+}
+
+// activityWindow bundles the time-window parameters of one activity evaluation.
+type activityWindow struct {
+	nowMin           int
+	lead             int
+	overdueThreshold int
+	upcoming         bool
+	overdue          bool
+}
+
+// activityRoomFilter builds the room restriction for one caller.
+//
+// The nil-versus-empty distinction is load-bearing and is decided by the scope
+// alone, never by how many rooms came back: nil means "every room" and is
+// correct only for admins, an empty map means "no room at all" and is what a
+// caregiver without a live supervision must get. Deriving nil from an empty
+// room list would hand that caregiver every activity in the school.
+func activityRoomFilter(scope Scope, roomIDs []int64) map[int64]struct{} {
+	if scope.IsAdmin {
+		return nil
+	}
+	filter := make(map[int64]struct{}, len(roomIDs))
+	for _, id := range roomIDs {
+		filter[id] = struct{}{}
+	}
+	return filter
+}
+
+// plannedInstanceRoomIDs collects the rooms of today's planned instances, which
+// is the set that has to be resolvable before overdue reminders can be judged.
+func plannedInstanceRoomIDs(instances []*scheduleModel.ActivityInstance) map[int64]struct{} {
+	wanted := make(map[int64]struct{})
+	for _, inst := range instances {
+		if inst != nil && inst.Status == scheduleModel.InstanceStatusPlanned {
+			wanted[inst.RoomID] = struct{}{}
+		}
+	}
+	return wanted
+}
+
+// sortedIDs renders an ID set as an ascending slice, so both the query argument
+// and any error message derived from it are reproducible.
+func sortedIDs(set map[int64]struct{}) []int64 {
+	ids := make([]int64, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// resolveActivityRooms classifies the loaded rooms and enforces that every
+// wanted room actually resolved. Pure, and shared by both entry points: the
+// Schulhof exemption and the "a missing room is a hard error" contract belong
+// together and must not drift apart.
+func resolveActivityRooms(rooms []*facilitiesModel.Room, wanted map[int64]struct{}) (map[int64]struct{}, error) {
+	schulhof := make(map[int64]struct{})
+	resolved := make(map[int64]struct{}, len(rooms))
+	for _, room := range rooms {
+		if room == nil {
+			continue
+		}
+		resolved[room.ID] = struct{}{}
+		if room.Name == constants.SchulhofRoomName {
+			schulhof[room.ID] = struct{}{}
+		}
+	}
+	for _, roomID := range sortedIDs(wanted) {
+		if _, found := resolved[roomID]; !found {
+			return nil, fmt.Errorf("load activity reminder rooms: room %d not found", roomID)
+		}
+	}
+	return schulhof, nil
+}
+
+// buildActivityReminders decides which instances currently deserve a reminder
+// and what the soonest future state change is. Pure, shared by Compute and
+// ComputeBatch.
+//
+// A nil roomFilter means every room; see activityRoomFilter.
+func buildActivityReminders(
+	instances []*scheduleModel.ActivityInstance,
+	schulhofRoomIDs, roomFilter map[int64]struct{},
+	w activityWindow,
+) ([]Reminder, int) {
+	nextChange := -1
 	out := make([]Reminder, 0)
+
 	for _, inst := range instances {
 		// Only planned instances are relevant: started/completed/cancelled rows
 		// are neither "starting soon" nor "not started in time".
@@ -572,7 +785,7 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 		}
 		startMin := minutesOfDay(inst.StartTime)
 		endMin := minutesOfDay(inst.EndTime)
-		diff := startMin - nowMin
+		diff := startMin - w.nowMin
 		_, isSchulhof := schulhofRoomIDs[inst.RoomID]
 
 		// Track the boundaries at which this instance's reminder state flips, so
@@ -584,20 +797,20 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 		// disappears the first minute startMin is in the past. Scheduling startMin
 		// would refetch a minute early (nothing changed) and drop the real
 		// startMin+1 boundary — same reasoning as the pickup flip below.
-		if upcoming {
-			nextChange = minFuture(nextChange, futureBoundary(startMin-lead, nowMin))
-			nextChange = minFuture(nextChange, futureBoundary(startMin+1, nowMin))
+		if w.upcoming {
+			nextChange = minFuture(nextChange, futureBoundary(startMin-w.lead, w.nowMin))
+			nextChange = minFuture(nextChange, futureBoundary(startMin+1, w.nowMin))
 		}
-		if overdue && !isSchulhof {
-			overdueStart := startMin + overdueThreshold
+		if w.overdue && !isSchulhof {
+			overdueStart := startMin + w.overdueThreshold
 			if overdueStart < endMin {
-				nextChange = minFuture(nextChange, futureBoundary(overdueStart, nowMin))
-				nextChange = minFuture(nextChange, futureBoundary(endMin, nowMin))
+				nextChange = minFuture(nextChange, futureBoundary(overdueStart, w.nowMin))
+				nextChange = minFuture(nextChange, futureBoundary(endMin, w.nowMin))
 			}
 		}
 
 		switch {
-		case upcoming && diff >= 0 && diff <= lead:
+		case w.upcoming && diff >= 0 && diff <= w.lead:
 			out = append(out, Reminder{
 				Type:               TypeActivityStart,
 				ActivityInstanceID: int64String(inst.ID),
@@ -607,7 +820,7 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 			})
 		// Overdue: planned, started late by at least the threshold, and the
 		// slot is not over yet (after end_time a reminder is pointless).
-		case overdue && !isSchulhof && diff < 0 && -diff >= overdueThreshold && nowMin < endMin:
+		case w.overdue && !isSchulhof && diff < 0 && -diff >= w.overdueThreshold && w.nowMin < endMin:
 			out = append(out, Reminder{
 				Type:               TypeActivityOverdue,
 				ActivityInstanceID: int64String(inst.ID),
@@ -617,7 +830,7 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 			})
 		}
 	}
-	return out, nextChange, nil
+	return out, nextChange
 }
 
 type studentNameInfo struct {

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -178,6 +178,15 @@ type Dependencies struct {
 	BulkSupervision bulkSupervisionReader
 	BulkVisits      bulkVisitReader
 	BulkGroups      bulkGroupReader
+	// BulkInstanceStaff resolves the planned staff of today's activity
+	// instances. Without it the batch falls back to room supervision alone,
+	// which never reaches the person who is supposed to START a slot.
+	BulkInstanceStaff bulkInstanceStaffReader
+}
+
+// bulkInstanceStaffReader answers who is planned on which activity instance.
+type bulkInstanceStaffReader interface {
+	FindByInstanceIDs(ctx context.Context, instanceIDs []int64) ([]*scheduleModel.InstanceStaff, error)
 }
 
 // bulkSupervisionReader answers "who supervises which room right now" for the
@@ -675,7 +684,9 @@ func (s *service) activityReminders(ctx context.Context, scope Scope, roomIDs []
 		}
 	}
 
-	out, nextChange := buildActivityReminders(instances, schulhofRoomIDs, roomFilter, activityWindow{
+	// The single path knows nothing about planned assignments: Compute answers
+	// for the caller in front of it, and its scope is unchanged.
+	out, nextChange := buildActivityReminders(instances, schulhofRoomIDs, activityScopeFilter(roomFilter, nil), activityWindow{
 		nowMin:           nowMin,
 		lead:             lead,
 		overdueThreshold: overdueThreshold,
@@ -692,6 +703,25 @@ type activityWindow struct {
 	overdueThreshold int
 	upcoming         bool
 	overdue          bool
+}
+
+// activityScopeFilter extends a room restriction with the instances a person is
+// planned on.
+//
+// The room filter alone answers "what is happening where I am watching", which
+// systematically misses the slot someone is about to start: at that moment they
+// supervise nothing yet. A nil room filter (admin) still means "everything".
+func activityScopeFilter(roomFilter map[int64]struct{}, assignedInstanceIDs map[int64]struct{}) func(*scheduleModel.ActivityInstance) bool {
+	if roomFilter == nil {
+		return nil
+	}
+	return func(inst *scheduleModel.ActivityInstance) bool {
+		if _, ok := roomFilter[inst.RoomID]; ok {
+			return true
+		}
+		_, assigned := assignedInstanceIDs[inst.ID]
+		return assigned
+	}
 }
 
 // activityRoomFilter builds the room restriction for one caller.
@@ -766,7 +796,8 @@ func resolveActivityRooms(rooms []*facilitiesModel.Room, wanted map[int64]struct
 // A nil roomFilter means every room; see activityRoomFilter.
 func buildActivityReminders(
 	instances []*scheduleModel.ActivityInstance,
-	schulhofRoomIDs, roomFilter map[int64]struct{},
+	schulhofRoomIDs map[int64]struct{},
+	inScope func(*scheduleModel.ActivityInstance) bool,
 	w activityWindow,
 ) ([]Reminder, int) {
 	nextChange := -1
@@ -778,10 +809,8 @@ func buildActivityReminders(
 		if inst == nil || inst.Status != scheduleModel.InstanceStatusPlanned {
 			continue
 		}
-		if roomFilter != nil {
-			if _, ok := roomFilter[inst.RoomID]; !ok {
-				continue
-			}
+		if inScope != nil && !inScope(inst) {
+			continue
 		}
 		startMin := minutesOfDay(inst.StartTime)
 		endMin := minutesOfDay(inst.EndTime)

--- a/backend/services/schedule/staff_shift_service_mock_test.go
+++ b/backend/services/schedule/staff_shift_service_mock_test.go
@@ -148,6 +148,10 @@ func (m *shiftMockStaffRepo) ListAccountIDsByStaffIDs(_ context.Context, _ []int
 	return map[int64]int64{}, nil
 }
 
+func (m *shiftMockStaffRepo) ListAllStaffAccountIDs(_ context.Context) (map[int64]int64, error) {
+	return map[int64]int64{}, nil
+}
+
 // The remaining StaffRepository methods are unused by the shift service.
 func (m *shiftMockStaffRepo) Create(context.Context, *usersModels.Staff) error { return nil }
 func (m *shiftMockStaffRepo) FindByIDForUpdate(ctx context.Context, id int64) (*usersModels.Staff, error) {

--- a/backend/services/schedule/staff_shift_service_mock_test.go
+++ b/backend/services/schedule/staff_shift_service_mock_test.go
@@ -144,6 +144,10 @@ func (m *shiftMockStaffRepo) FindByID(ctx context.Context, id interface{}) (*use
 	return &usersModels.Staff{}, nil
 }
 
+func (m *shiftMockStaffRepo) ListAccountIDsByStaffIDs(_ context.Context, _ []int64) (map[int64]int64, error) {
+	return map[int64]int64{}, nil
+}
+
 // The remaining StaffRepository methods are unused by the shift service.
 func (m *shiftMockStaffRepo) Create(context.Context, *usersModels.Staff) error { return nil }
 func (m *shiftMockStaffRepo) FindByIDForUpdate(ctx context.Context, id int64) (*usersModels.Staff, error) {

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -161,6 +161,15 @@ type reminderRecipient struct {
 	consent   map[string]struct{}
 }
 
+func (r reminderRecipient) resultKey() int64 {
+	if r.staffID > 0 {
+		return r.staffID
+	}
+	// Account and staff IDs come from different sequences. Keeping staff-less
+	// admins in the negative half makes their opaque batch keys collision-free.
+	return -r.accountID
+}
+
 // runReminderNotificationsForTenant resolves the audience, computes everybody's
 // personal list in one batch and dispatches what is new. `now` is injected for
 // deterministic tests.
@@ -184,6 +193,7 @@ func (s *Scheduler) runReminderNotificationsForTenant(ctx context.Context, tenan
 		_, includeAssignedStart := r.consent[notifications.TypeMyActivityStarting]
 		scopes = append(scopes, reminders.BatchScope{
 			Scope:                        reminders.Scope{IsAdmin: r.isAdmin, StaffID: r.staffID},
+			ResultKey:                    r.resultKey(),
 			IncludeAssignedActivityStart: includeAssignedStart,
 		})
 	}
@@ -236,8 +246,8 @@ func (s *Scheduler) runReminderNotificationsForTenant(ctx context.Context, tenan
 }
 
 // resolveReminderRecipients builds the audience: every staff member with a
-// login, narrowed by their own consent and, when the school asks for it, by
-// whether they are currently on duty.
+// login plus every effective admin account, narrowed by their own consent and,
+// when the school asks for it, by whether staff-backed recipients are on duty.
 //
 // The order is the one the consent service prescribes — a relation first, then
 // consent narrowing it. Consent is never the source of the audience, it is the
@@ -250,12 +260,40 @@ func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRe
 	if err != nil {
 		return nil, fmt.Errorf("list staff accounts: %w", err)
 	}
-	if len(accountsByStaff) == 0 {
+
+	adminIDs, err := deps.Accounts.ListEffectiveAdminAccountIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list admin accounts: %w", err)
+	}
+
+	staffByAccount := make(map[int64]int64, len(accountsByStaff))
+	accountSet := make(map[int64]struct{}, len(accountsByStaff)+len(adminIDs))
+	for staffID, accountID := range accountsByStaff {
+		if accountID <= 0 {
+			continue
+		}
+		// An account should map to one staff row. Choosing the smaller ID keeps
+		// resolution deterministic if inconsistent legacy data says otherwise.
+		current, exists := staffByAccount[accountID]
+		if !exists || staffID < current {
+			staffByAccount[accountID] = staffID
+		}
+		accountSet[accountID] = struct{}{}
+	}
+	admins := make(map[int64]struct{}, len(adminIDs))
+	for _, accountID := range adminIDs {
+		if accountID <= 0 {
+			continue
+		}
+		admins[accountID] = struct{}{}
+		accountSet[accountID] = struct{}{}
+	}
+	if len(accountSet) == 0 {
 		return nil, nil
 	}
 
-	accountIDs := make([]int64, 0, len(accountsByStaff))
-	for _, accountID := range accountsByStaff {
+	accountIDs := make([]int64, 0, len(accountSet))
+	for accountID := range accountSet {
 		accountIDs = append(accountIDs, accountID)
 	}
 	sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
@@ -285,27 +323,22 @@ func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRe
 		return nil, err
 	}
 
-	adminIDs, err := deps.Accounts.ListEffectiveAdminAccountIDs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list admin accounts: %w", err)
-	}
-	admins := make(map[int64]struct{}, len(adminIDs))
-	for _, accountID := range adminIDs {
-		admins[accountID] = struct{}{}
-	}
-
 	recipients := make([]reminderRecipient, 0, len(consentByAccount))
-	for staffID, accountID := range accountsByStaff {
+	for _, accountID := range accountIDs {
 		consent := consentByAccount[accountID]
 		if len(consent) == 0 {
 			continue
 		}
-		if onDuty != nil {
+		staffID := staffByAccount[accountID]
+		_, isAdmin := admins[accountID]
+		if staffID <= 0 && !isAdmin {
+			continue
+		}
+		if onDuty != nil && staffID > 0 {
 			if _, working := onDuty[staffID]; !working {
 				continue
 			}
 		}
-		_, isAdmin := admins[accountID]
 		recipients = append(recipients, reminderRecipient{
 			staffID:   staffID,
 			accountID: accountID,
@@ -315,7 +348,7 @@ func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRe
 	}
 	// Map iteration is random; a stable order keeps the dispatched batch (and
 	// therefore the logs and the tests) reproducible.
-	sort.Slice(recipients, func(i, j int) bool { return recipients[i].staffID < recipients[j].staffID })
+	sort.Slice(recipients, func(i, j int) bool { return recipients[i].accountID < recipients[j].accountID })
 
 	return recipients, nil
 }
@@ -370,7 +403,7 @@ func buildPersonalReminderEvents(
 	)
 
 	for _, r := range recipients {
-		result := results[r.staffID]
+		result := results[r.resultKey()]
 		if result == nil || !result.Enabled || len(result.Reminders) == 0 {
 			continue
 		}

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -1,57 +1,112 @@
-// Reminder → notification bridge (#1624 follow-up): the first real consumer
-// of the notification abstraction. Every minute, per tenant, the tick
-// computes the current reminder list (issue #1457 — pickups, activity
-// starts, overdue variants) and dispatches ONE aggregated, display-safe
-// notification for reminders that became due since the last tick.
+// Reminder → notification bridge (epic "persönliche Benachrichtigungen"): the
+// producer that turns the #1457 reminder list into notifications for the people
+// it actually concerns.
 //
-// Deliberately generic: the tick knows nothing about channels — it builds a
-// notifications.Event and calls Notify. Whatever channels the abstraction
-// grows (Web Push, e-mail) automatically apply here.
+// Every minute, per tenant, the tick asks who agreed to hear about which kind
+// of reminder, computes those people's personal reminder lists in one batch,
+// and dispatches one event per person and kind. Nobody is addressed who did not
+// switch that kind on in their own profile.
 //
-// GDPR: reminder rows carry student names, but the dispatched notification
-// NEVER does. Title/body only say how many reminders of which kind are due;
-// the deep link points to /reminders where the names are shown to the
-// authenticated, permission-filtered viewer.
+// The producer lives in the scheduler rather than in services/notifications
+// because it needs both packages, and those two deliberately do not know each
+// other (see TestNotificationTypeKeysMatchReminders). It knows nothing about
+// channels either — it builds events and calls NotifyBatch, so every channel the
+// abstraction grows applies here automatically.
 //
-// Re-fire guard: an in-memory sync.Map keyed by (tenant, reminder identity),
-// rotated on civil-date rollover — the same shape as the instance-overdue
-// tick. A mid-day restart re-fires currently-due reminders once; toasts are
-// ephemeral, that cost is acceptable for zero disk state.
+// GDPR: reminder rows carry student names, the dispatched notifications never
+// do. Title and body only say how many reminders of which kind are due; the deep
+// link leads to /reminders, where the names are shown to the authenticated,
+// permission-filtered viewer.
+//
+// Re-fire guard: an in-memory sync.Map keyed by (tenant, account, reminder
+// identity), rotated on civil-date rollover — the same shape as the
+// instance-overdue tick. A mid-day restart re-fires currently-due reminders
+// once; toasts are ephemeral, that cost is acceptable for zero disk state.
 package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
+	"sort"
+	"strconv"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/reminders"
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
-// reminderNotificationKey identifies one dispatched reminder occurrence.
+// reminderNotificationKey identifies one dispatched reminder occurrence for one
+// person. The account is part of the key because the same pickup legitimately
+// reaches several people, and each of them must hear about it once.
 type reminderNotificationKey struct {
-	tenantID int64
-	reminder string // type + entity id + due time
+	tenantID  int64
+	accountID int64
+	reminder  string // type + entity id + due time
 }
 
-// SetReminderNotificationDeps wires the reminder-notification tick. Both nil
-// (or either nil) → the task does not register, matching the scheduler's
-// opt-in setter pattern.
-func (s *Scheduler) SetReminderNotificationDeps(computer reminders.Service, notifier notifications.Service) {
-	s.reminderComputer = computer
-	s.reminderNotifier = notifier
+// The three reads the producer needs beyond its two services. Narrow interfaces
+// rather than the full repositories: they say exactly what this tick reads, and
+// a test double stays three methods long.
+type (
+	staffAccountReader interface {
+		ListAllStaffAccountIDs(ctx context.Context) (map[int64]int64, error)
+	}
+	adminAccountReader interface {
+		ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error)
+	}
+	dutyReader interface {
+		GetTodayPresenceMap(ctx context.Context) (map[int64]string, error)
+	}
+	// consentFilter is the one method this producer uses of the consent
+	// service; notifications.PreferenceService satisfies it.
+	consentFilter interface {
+		FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
+	}
+)
+
+// ReminderNotificationDeps bundles what the tick needs. All of it or none: a
+// partially wired producer would resolve a narrower audience for a reason
+// nobody intended, so an incomplete set disables the task instead.
+type ReminderNotificationDeps struct {
+	Computer     reminders.BatchComputer
+	Notifier     notifications.BatchNotifier
+	Preferences  consentFilter
+	Staff        staffAccountReader
+	Accounts     adminAccountReader
+	WorkSessions dutyReader
 }
 
-// scheduleReminderNotificationTask registers the minute tick when both
-// dependencies are wired.
+func (d ReminderNotificationDeps) complete() bool {
+	return d.Computer != nil && d.Notifier != nil && d.Preferences != nil &&
+		d.Staff != nil && d.Accounts != nil && d.WorkSessions != nil
+}
+
+// personalReminderTypes are the notification types this producer can send, in
+// the order the consent lookup runs.
+var personalReminderTypes = []string{
+	notifications.TypePickupUpcoming,
+	notifications.TypePickupOverdue,
+	notifications.TypeActivityStart,
+	notifications.TypeActivityOverdue,
+	notifications.TypeMyActivityStarting,
+}
+
+// SetReminderNotificationDeps wires the reminder-notification tick.
+func (s *Scheduler) SetReminderNotificationDeps(deps ReminderNotificationDeps) {
+	s.reminderNotifications = deps
+}
+
+// scheduleReminderNotificationTask registers the minute tick when the producer
+// is completely wired.
 func (s *Scheduler) scheduleReminderNotificationTask() {
-	if s.reminderComputer == nil || s.reminderNotifier == nil {
-		s.getLogger().Info("reminder notification tick not configured (missing reminders or notifications service)")
+	if !s.reminderNotifications.complete() {
+		s.getLogger().Info("reminder notification tick not configured (incomplete dependencies)")
 		return
 	}
 	s.registerTask("reminder-notifications", "1m-poll", s.runReminderNotificationTaskPolling)
@@ -86,9 +141,9 @@ func (s *Scheduler) checkAndRunReminderNotifications(task *ScheduledTask) {
 	defer cancel()
 
 	s.forEachTenantSettings(ctx, "reminder-notifications", func(tenantCtx context.Context, tenantID int64) error {
-		// Cheap gate first: skip the reminder computation entirely while the
-		// notification feature flag is off for this tenant. Notify would also
-		// refuse (ErrDisabled), but there is no point computing the list.
+		// Cheap gate first: skip the whole resolution while the notification
+		// feature flag is off for this tenant. NotifyBatch would also refuse
+		// (ErrDisabled), but there is no point resolving anybody.
 		if !s.resolveBoolSetting(tenantCtx, configModel.KeyNotificationsDispatchEnabled, "", false) {
 			return nil
 		}
@@ -97,14 +152,41 @@ func (s *Scheduler) checkAndRunReminderNotifications(task *ScheduledTask) {
 	})
 }
 
-// runReminderNotificationsForTenant computes the tenant-wide reminder list
-// and dispatches one aggregated notification for occurrences not yet seen
-// today. `now` is injected for deterministic tests.
+// reminderRecipient is one person the tick may address, with the kinds of
+// reminder they agreed to hear about.
+type reminderRecipient struct {
+	staffID   int64
+	accountID int64
+	isAdmin   bool
+	consent   map[string]struct{}
+}
+
+// runReminderNotificationsForTenant resolves the audience, computes everybody's
+// personal list in one batch and dispatches what is new. `now` is injected for
+// deterministic tests.
 func (s *Scheduler) runReminderNotificationsForTenant(ctx context.Context, tenantID int64, now time.Time) {
-	// Admin scope = all present children and all activities: the notification
-	// is tenant-wide, so it must reflect the full list, not one staffer's
-	// supervision slice. It carries no per-child data either way.
-	result, err := s.reminderComputer.Compute(ctx, reminders.Scope{IsAdmin: true})
+	deps := s.reminderNotifications
+
+	recipients, err := s.resolveReminderRecipients(ctx)
+	if err != nil {
+		s.getLogger().Warn("reminder notification tick: audience resolution failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	if len(recipients) == 0 {
+		return
+	}
+
+	scopes := make([]reminders.BatchScope, 0, len(recipients))
+	for _, r := range recipients {
+		scopes = append(scopes, reminders.BatchScope{
+			Scope: reminders.Scope{IsAdmin: r.isAdmin, StaffID: r.staffID},
+		})
+	}
+
+	results, err := deps.Computer.ComputeBatch(ctx, scopes)
 	if err != nil {
 		s.getLogger().Warn("reminder notification tick: compute failed",
 			slog.Int64("tenant_id", tenantID),
@@ -112,48 +194,242 @@ func (s *Scheduler) runReminderNotificationsForTenant(ctx context.Context, tenan
 		)
 		return
 	}
-	if result == nil || !result.Enabled || len(result.Reminders) == 0 {
+
+	events, freshKeys := buildPersonalReminderEvents(tenantID, recipients, results, func(key reminderNotificationKey) bool {
+		_, seen := s.reminderNotified.Load(key)
+		return seen
+	})
+	if len(events) == 0 {
 		return
 	}
 
-	fresh := make([]reminders.Reminder, 0, len(result.Reminders))
-	freshKeys := make([]reminderNotificationKey, 0, len(result.Reminders))
-	for _, r := range result.Reminders {
-		key := reminderNotificationKey{tenantID: tenantID, reminder: reminderIdentity(r)}
-		if _, seen := s.reminderNotified.Load(key); seen {
-			continue
+	if err := deps.Notifier.NotifyBatch(ctx, events); err != nil {
+		// A closed delivery window and a flipped feature flag are ordinary
+		// answers, not failures: quiet hours would otherwise produce one warning
+		// per tenant per minute all evening. Either way the occurrences stay
+		// unmarked and fire on the next tick once dispatch is possible again.
+		if !errors.Is(err, notifications.ErrDisabled) && !errors.Is(err, notifications.ErrOutsideActiveWindow) {
+			s.getLogger().Warn("reminder notification tick: notify failed",
+				slog.Int64("tenant_id", tenantID),
+				slog.String("error", err.Error()),
+			)
 		}
-		fresh = append(fresh, r)
-		freshKeys = append(freshKeys, key)
-	}
-	if len(fresh) == 0 {
 		return
 	}
 
-	event := buildReminderNotificationEvent(tenantID, fresh)
-	if err := s.reminderNotifier.Notify(ctx, event); err != nil {
-		// ErrDisabled can still race the settings gate above (flag flipped
-		// between checks); leave the occurrences unmarked so they fire on the
-		// next tick once dispatch is possible.
-		s.getLogger().Warn("reminder notification tick: notify failed",
-			slog.Int64("tenant_id", tenantID),
-			slog.String("error", err.Error()),
-		)
-		return
-	}
-	// Notify registered delivery first, so this hook runs after delivery and
-	// only after the surrounding tenant transaction commits. A rollback or
+	// NotifyBatch registered delivery first, so this hook runs after delivery
+	// and only after the surrounding tenant transaction commits. A rollback or
 	// commit failure drops both hooks and leaves the occurrences eligible for
 	// the next tick.
 	tenant.RegisterAfterCommit(ctx, func() {
 		for _, key := range freshKeys {
 			s.reminderNotified.Store(key, now)
 		}
-		s.getLogger().Info("reminder notification dispatched",
+		s.getLogger().Info("personal reminder notifications dispatched",
 			slog.Int64("tenant_id", tenantID),
-			slog.Int("reminder_count", len(fresh)),
+			slog.Int("recipient_count", len(recipients)),
+			slog.Int("event_count", len(events)),
 		)
 	})
+}
+
+// resolveReminderRecipients builds the audience: every staff member with a
+// login, narrowed by their own consent and, when the school asks for it, by
+// whether they are currently on duty.
+//
+// The order is the one the consent service prescribes — a relation first, then
+// consent narrowing it. Consent is never the source of the audience, it is the
+// filter on top; that is also why an empty consent result ends the tick before
+// any reminder is computed.
+func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRecipient, error) {
+	deps := s.reminderNotifications
+
+	accountsByStaff, err := deps.Staff.ListAllStaffAccountIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list staff accounts: %w", err)
+	}
+	if len(accountsByStaff) == 0 {
+		return nil, nil
+	}
+
+	accountIDs := make([]int64, 0, len(accountsByStaff))
+	for _, accountID := range accountsByStaff {
+		accountIDs = append(accountIDs, accountID)
+	}
+	sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
+
+	// FilterOptedIn also applies each type's school-wide gate (the matching
+	// reminders.* setting), so a reminder kind the school switched off reaches
+	// nobody without this tick having to know which setting that is.
+	consentByAccount := make(map[int64]map[string]struct{}, len(accountIDs))
+	for _, notificationType := range personalReminderTypes {
+		optedIn, ferr := deps.Preferences.FilterOptedIn(ctx, notificationType, accountIDs)
+		if ferr != nil {
+			return nil, fmt.Errorf("filter opted-in accounts for %s: %w", notificationType, ferr)
+		}
+		for _, accountID := range optedIn {
+			if consentByAccount[accountID] == nil {
+				consentByAccount[accountID] = make(map[string]struct{}, len(personalReminderTypes))
+			}
+			consentByAccount[accountID][notificationType] = struct{}{}
+		}
+	}
+	if len(consentByAccount) == 0 {
+		return nil, nil
+	}
+
+	onDuty, err := s.resolveOnDutyStaff(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	adminIDs, err := deps.Accounts.ListEffectiveAdminAccountIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list admin accounts: %w", err)
+	}
+	admins := make(map[int64]struct{}, len(adminIDs))
+	for _, accountID := range adminIDs {
+		admins[accountID] = struct{}{}
+	}
+
+	recipients := make([]reminderRecipient, 0, len(consentByAccount))
+	for staffID, accountID := range accountsByStaff {
+		consent := consentByAccount[accountID]
+		if len(consent) == 0 {
+			continue
+		}
+		if onDuty != nil {
+			if _, working := onDuty[staffID]; !working {
+				continue
+			}
+		}
+		_, isAdmin := admins[accountID]
+		recipients = append(recipients, reminderRecipient{
+			staffID:   staffID,
+			accountID: accountID,
+			isAdmin:   isAdmin,
+			consent:   consent,
+		})
+	}
+	// Map iteration is random; a stable order keeps the dispatched batch (and
+	// therefore the logs and the tests) reproducible.
+	sort.Slice(recipients, func(i, j int) bool { return recipients[i].staffID < recipients[j].staffID })
+
+	return recipients, nil
+}
+
+// resolveOnDutyStaff answers who may be addressed under
+// notifications.on_duty_only. A nil map means "no restriction".
+//
+// An empty presence map is read as "this school does not clock in" rather than
+// as "nobody is working", which is what the setting's own description promises.
+// A school that does use time tracking and has everybody stamped out gets a
+// non-empty map with nobody in it, and stays quiet — which is the point.
+func (s *Scheduler) resolveOnDutyStaff(ctx context.Context) (map[int64]struct{}, error) {
+	if !s.resolveBoolSetting(ctx, configModel.KeyNotificationsOnDutyOnly, "", true) {
+		return nil, nil
+	}
+
+	presence, err := s.reminderNotifications.WorkSessions.GetTodayPresenceMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load staff presence: %w", err)
+	}
+	if len(presence) == 0 {
+		return nil, nil
+	}
+
+	onDuty := make(map[int64]struct{}, len(presence))
+	for staffID, status := range presence {
+		// Matched positively against the two real statuses: the map also carries
+		// a synthetic "checked out" value, and an unknown future status must not
+		// silently count as working.
+		if status == activeModel.WorkSessionStatusPresent || status == activeModel.WorkSessionStatusHomeOffice {
+			onDuty[staffID] = struct{}{}
+		}
+	}
+	return onDuty, nil
+}
+
+// buildPersonalReminderEvents turns the batch results into one event per person
+// and notification type, skipping everything the person did not agree to and
+// everything they already heard about today.
+//
+// Pure apart from the injected seen-check, so the whole mapping — consent,
+// classification, aggregation — is testable without a scheduler.
+func buildPersonalReminderEvents(
+	tenantID int64,
+	recipients []reminderRecipient,
+	results map[int64]*reminders.Result,
+	seen func(reminderNotificationKey) bool,
+) ([]notifications.Event, []reminderNotificationKey) {
+	var (
+		events    []notifications.Event
+		freshKeys []reminderNotificationKey
+	)
+
+	for _, r := range recipients {
+		result := results[r.staffID]
+		if result == nil || !result.Enabled || len(result.Reminders) == 0 {
+			continue
+		}
+
+		counts := make(map[string]int, len(personalReminderTypes))
+		order := make([]string, 0, len(personalReminderTypes))
+
+		for _, reminder := range result.Reminders {
+			notificationType, wanted := notificationTypeFor(reminder, result.AssignedActivityInstanceIDs, r.consent)
+			if !wanted {
+				continue
+			}
+			key := reminderNotificationKey{
+				tenantID:  tenantID,
+				accountID: r.accountID,
+				reminder:  reminderIdentity(reminder),
+			}
+			if seen(key) {
+				continue
+			}
+			if counts[notificationType] == 0 {
+				order = append(order, notificationType)
+			}
+			counts[notificationType]++
+			freshKeys = append(freshKeys, key)
+		}
+
+		for _, notificationType := range order {
+			events = append(events, buildPersonalReminderEvent(
+				tenantID, r.accountID, notificationType, counts[notificationType]))
+		}
+	}
+
+	return events, freshKeys
+}
+
+// notificationTypeFor decides which notification type a reminder belongs to for
+// one person, and whether that person wants it.
+//
+// The only non-obvious case is an activity the person is personally planned on.
+// It is reported as "Ihr nächster Einsatz" even when they also happen to
+// supervise the room, because that is what the two catalogue descriptions
+// promise: the room type is about "a room you are watching", the assignment type
+// about your own slot "auch wenn Sie gerade keine Aufsicht führen". Each switch
+// therefore means exactly what it says, and the same activity never arrives
+// twice.
+func notificationTypeFor(
+	reminder reminders.Reminder,
+	assigned map[string]struct{},
+	consent map[string]struct{},
+) (string, bool) {
+	notificationType := reminder.Type
+	if reminder.Type == reminders.TypeActivityStart && reminder.ActivityInstanceID != nil {
+		if _, mine := assigned[*reminder.ActivityInstanceID]; mine {
+			notificationType = notifications.TypeMyActivityStarting
+		}
+	}
+	if _, agreed := consent[notificationType]; !agreed {
+		return "", false
+	}
+	return notificationType, true
 }
 
 // reminderIdentity builds the dedup identity of one reminder occurrence:
@@ -170,64 +446,82 @@ func reminderIdentity(r reminders.Reminder) string {
 	return r.Type + "|" + entity + "|" + r.DueTime
 }
 
-// reminderTypeLabels maps reminder types to display-safe German fragments.
-// Singular/plural chosen by count at build time.
-var reminderTypeLabels = map[string]struct{ singular, plural string }{
-	reminders.TypePickupUpcoming:  {"anstehende Abholung", "anstehende Abholungen"},
-	reminders.TypePickupOverdue:   {"überfällige Abholung", "überfällige Abholungen"},
-	reminders.TypeActivityStart:   {"beginnende Aktivität", "beginnende Aktivitäten"},
-	reminders.TypeActivityOverdue: {"überfällige Aktivität", "überfällige Aktivitäten"},
+// personalReminderCopy is the display-safe German wording per notification
+// type. Counts only: these strings end up on a lock screen, and the reminder
+// rows they summarise carry child names.
+type personalReminderCopy struct {
+	title    string
+	singular string
+	plural   string // one %d
+	urgent   bool
 }
 
-// buildReminderNotificationEvent aggregates fresh reminders into ONE
-// display-safe event: counts per type, no student names, deep link to the
-// reminders page. Overdue reminders raise the priority.
-func buildReminderNotificationEvent(tenantID int64, fresh []reminders.Reminder) notifications.Event {
-	counts := make(map[string]int, len(reminderTypeLabels))
-	order := make([]string, 0, len(reminderTypeLabels))
-	overdue := false
-	for _, r := range fresh {
-		if counts[r.Type] == 0 {
-			order = append(order, r.Type)
-		}
-		counts[r.Type]++
-		if r.Type == reminders.TypePickupOverdue || r.Type == reminders.TypeActivityOverdue {
-			overdue = true
+var reminderCopyByType = map[string]personalReminderCopy{
+	notifications.TypePickupUpcoming: {
+		title:    "Abholung steht an",
+		singular: "Ein Kind aus Ihrer Aufsicht wird bald abgeholt.",
+		plural:   "%d Kinder aus Ihrer Aufsicht werden bald abgeholt.",
+	},
+	notifications.TypePickupOverdue: {
+		title:    "Abholung überfällig",
+		singular: "Ein Kind ist noch da, obwohl die Abholzeit vorbei ist.",
+		plural:   "%d Kinder sind noch da, obwohl ihre Abholzeit vorbei ist.",
+		urgent:   true,
+	},
+	notifications.TypeActivityStart: {
+		title:    "Aktivität beginnt",
+		singular: "In einem Raum Ihrer Aufsicht beginnt gleich eine Aktivität.",
+		plural:   "In Ihren Räumen beginnen gleich %d Aktivitäten.",
+	},
+	notifications.TypeActivityOverdue: {
+		title:    "Aktivität nicht gestartet",
+		singular: "Eine geplante Aktivität ist überfällig und wurde noch nicht gestartet.",
+		plural:   "%d geplante Aktivitäten sind überfällig und wurden noch nicht gestartet.",
+		urgent:   true,
+	},
+	notifications.TypeMyActivityStarting: {
+		title:    "Ihr Einsatz beginnt",
+		singular: "Einer Ihrer geplanten Einsätze beginnt gleich.",
+		plural:   "%d Ihrer geplanten Einsätze beginnen gleich.",
+	},
+}
+
+// buildPersonalReminderEvent renders one person's due count of one kind.
+func buildPersonalReminderEvent(tenantID, accountID int64, notificationType string, count int) notifications.Event {
+	copyFor, known := reminderCopyByType[notificationType]
+	if !known {
+		// Unreachable while personalReminderTypes and the copy table agree,
+		// which a test pins. A generic wording still beats an empty title,
+		// which validation would reject and which would drop the whole batch.
+		copyFor = personalReminderCopy{
+			title:    "Erinnerung",
+			singular: "Eine Erinnerung ist fällig.",
+			plural:   "%d Erinnerungen sind fällig.",
 		}
 	}
 
-	parts := make([]string, 0, len(order))
-	data := make(map[string]string, len(order))
-	for _, typ := range order {
-		n := counts[typ]
-		label, known := reminderTypeLabels[typ]
-		if !known {
-			label = struct{ singular, plural string }{"fällige Erinnerung", "fällige Erinnerungen"}
-		}
-		if n == 1 {
-			parts = append(parts, fmt.Sprintf("1 %s", label.singular))
-		} else {
-			parts = append(parts, fmt.Sprintf("%d %s", n, label.plural))
-		}
-		data[typ] = fmt.Sprintf("%d", n)
+	body := copyFor.singular
+	if count > 1 {
+		body = fmt.Sprintf(copyFor.plural, count)
 	}
 
 	priority := notifications.PriorityNormal
-	if overdue {
+	if copyFor.urgent {
 		priority = notifications.PriorityHigh
 	}
 
 	return notifications.Event{
-		Type: "reminders_due",
-		// The counts come from Compute(IsAdmin: true), so only clients with the
-		// same effective admin scope may receive them. Caregivers fetch their
-		// own supervision-filtered counts from /reminders.
-		Audience: notifications.Audience{TenantID: tenantID, Scope: notifications.ScopeAdmin},
+		Type: notificationType,
+		Audience: notifications.Audience{
+			TenantID:        tenantID,
+			Scope:           notifications.ScopeStaff,
+			StaffAccountIDs: []int64{accountID},
+		},
 		Priority: priority,
-		Title:    "Erinnerungen",
-		Body:     strings.Join(parts, ", ") + ".",
+		Title:    copyFor.title,
+		Body:     body,
 		DeepLink: "/reminders",
-		Data:     data,
+		Data:     map[string]string{"count": strconv.Itoa(count)},
 	}
 }
 

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -143,13 +143,41 @@ func (s *Scheduler) checkAndRunReminderNotifications(task *ScheduledTask) {
 	s.forEachTenantSettings(ctx, "reminder-notifications", func(tenantCtx context.Context, tenantID int64) error {
 		// Cheap gate first: skip the whole resolution while the notification
 		// feature flag is off for this tenant. NotifyBatch would also refuse
-		// (ErrDisabled), but there is no point resolving anybody.
-		if !s.resolveBoolSetting(tenantCtx, configModel.KeyNotificationsDispatchEnabled, "", false) {
+		// (ErrDisabled), but there is no point resolving anybody. That mirroring
+		// only holds while both sides read the flag the same way, hence
+		// notificationDispatchEnabled instead of the scheduler's
+		// literal-default helpers.
+		if !s.notificationDispatchEnabled(tenantCtx, tenantID) {
 			return nil
 		}
 		s.runReminderNotificationsForTenant(tenantCtx, tenantID, time.Now())
 		return nil
 	})
+}
+
+// notificationDispatchEnabled answers the notification feature flag exactly the
+// way the notification router does (services/notifications/service.go): the
+// tenant override when one exists, otherwise the value registered in the
+// settings registry. ResolveBool already returns the registry default, so this
+// gate carries no default of its own. A literal here would be a second source of
+// truth beside the registry: a registry default of "on" against a literal "off"
+// silenced the whole tick for every school without an explicit override.
+//
+// Fails closed when the flag cannot be read and when no settings service is
+// wired: without one the router cannot dispatch either.
+func (s *Scheduler) notificationDispatchEnabled(ctx context.Context, tenantID int64) bool {
+	if s.settings == nil {
+		return false
+	}
+	enabled, err := s.settings.ResolveBool(ctx, configModel.KeyNotificationsDispatchEnabled)
+	if err != nil {
+		s.getLogger().Warn("reminder notification tick: notification feature flag unreadable, skipping tenant",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+		return false
+	}
+	return enabled
 }
 
 // reminderRecipient is one person the tick may address, with the kinds of

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -181,8 +181,10 @@ func (s *Scheduler) runReminderNotificationsForTenant(ctx context.Context, tenan
 
 	scopes := make([]reminders.BatchScope, 0, len(recipients))
 	for _, r := range recipients {
+		_, includeAssignedStart := r.consent[notifications.TypeMyActivityStarting]
 		scopes = append(scopes, reminders.BatchScope{
-			Scope: reminders.Scope{IsAdmin: r.isAdmin, StaffID: r.staffID},
+			Scope:                        reminders.Scope{IsAdmin: r.isAdmin, StaffID: r.staffID},
+			IncludeAssignedActivityStart: includeAssignedStart,
 		})
 	}
 

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -20,8 +20,12 @@
 //
 // Re-fire guard: an in-memory sync.Map keyed by (tenant, account, reminder
 // identity), rotated on civil-date rollover — the same shape as the
-// instance-overdue tick. A mid-day restart re-fires currently-due reminders
-// once; toasts are ephemeral, that cost is acceptable for zero disk state.
+// instance-overdue tick. This is deliberately a single-scheduler-instance
+// guarantee: two active backend scheduler instances have independent maps and
+// may both emit the same reminder. Deployments must run one scheduler instance
+// until the guard is moved to shared durable state. A mid-day restart likewise
+// re-fires currently-due reminders once; toasts are ephemeral, that cost is
+// acceptable for zero disk state.
 package scheduler
 
 import (
@@ -50,9 +54,8 @@ type reminderNotificationKey struct {
 	reminder  string // type + entity id + due time
 }
 
-// The three reads the producer needs beyond its two services. Narrow interfaces
-// rather than the full repositories: they say exactly what this tick reads, and
-// a test double stays three methods long.
+// Narrow interfaces expose only the reads this tick needs and keep its test
+// doubles small.
 type (
 	staffAccountReader interface {
 		ListAllStaffAccountIDs(ctx context.Context) (map[int64]int64, error)
@@ -63,10 +66,12 @@ type (
 	dutyReader interface {
 		GetTodayPresenceMap(ctx context.Context) (map[int64]string, error)
 	}
-	// consentFilter is the one method this producer uses of the consent
-	// service; notifications.PreferenceService satisfies it.
+	// consentFilter is the narrow subset of the consent service used here.
+	// HasAnyOptedIn is only a cheap gate; FilterOptedInByType still narrows the
+	// relation-derived audience.
 	consentFilter interface {
-		FilterOptedIn(ctx context.Context, notificationType string, accountIDs []int64) ([]int64, error)
+		HasAnyOptedIn(ctx context.Context, notificationTypes []string) (bool, error)
+		FilterOptedInByType(ctx context.Context, notificationTypes []string, accountIDs []int64) (map[string][]int64, error)
 	}
 )
 
@@ -204,6 +209,21 @@ func (r reminderRecipient) resultKey() int64 {
 func (s *Scheduler) runReminderNotificationsForTenant(ctx context.Context, tenantID int64, now time.Time) {
 	deps := s.reminderNotifications
 
+	// This is a gate, never an audience source. Stale consent rows can survive
+	// offboarding, so a positive answer only justifies paying for the canonical
+	// staff/admin relationship lookup below.
+	hasAnyConsent, err := deps.Preferences.HasAnyOptedIn(ctx, personalReminderTypes)
+	if err != nil {
+		s.getLogger().Warn("reminder notification tick: consent gate failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	if !hasAnyConsent {
+		return
+	}
+
 	recipients, err := s.resolveReminderRecipients(ctx)
 	if err != nil {
 		s.getLogger().Warn("reminder notification tick: audience resolution failed",
@@ -326,15 +346,15 @@ func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRe
 	}
 	sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
 
-	// FilterOptedIn also applies each type's school-wide gate (the matching
-	// reminders.* setting), so a reminder kind the school switched off reaches
-	// nobody without this tick having to know which setting that is.
+	// FilterOptedInByType also applies every type's school-wide gate (the
+	// matching reminders.* setting). The consent service resolves the gates in
+	// one settings query and the preferences in one IN query.
 	consentByAccount := make(map[int64]map[string]struct{}, len(accountIDs))
-	for _, notificationType := range personalReminderTypes {
-		optedIn, ferr := deps.Preferences.FilterOptedIn(ctx, notificationType, accountIDs)
-		if ferr != nil {
-			return nil, fmt.Errorf("filter opted-in accounts for %s: %w", notificationType, ferr)
-		}
+	optedInByType, err := deps.Preferences.FilterOptedInByType(ctx, personalReminderTypes, accountIDs)
+	if err != nil {
+		return nil, fmt.Errorf("filter opted-in accounts: %w", err)
+	}
+	for notificationType, optedIn := range optedInByType {
 		for _, accountID := range optedIn {
 			if consentByAccount[accountID] == nil {
 				consentByAccount[accountID] = make(map[string]struct{}, len(personalReminderTypes))

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -354,12 +354,8 @@ func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRe
 }
 
 // resolveOnDutyStaff answers who may be addressed under
-// notifications.on_duty_only. A nil map means "no restriction".
-//
-// An empty presence map is read as "this school does not clock in" rather than
-// as "nobody is working", which is what the setting's own description promises.
-// A school that does use time tracking and has everybody stamped out gets a
-// non-empty map with nobody in it, and stays quiet — which is the point.
+// notifications.on_duty_only. A nil map means "no restriction"; an empty,
+// non-nil map means nobody is currently on duty.
 func (s *Scheduler) resolveOnDutyStaff(ctx context.Context) (map[int64]struct{}, error) {
 	if !s.resolveBoolSetting(ctx, configModel.KeyNotificationsOnDutyOnly, "", true) {
 		return nil, nil
@@ -369,10 +365,6 @@ func (s *Scheduler) resolveOnDutyStaff(ctx context.Context) (map[int64]struct{},
 	if err != nil {
 		return nil, fmt.Errorf("load staff presence: %w", err)
 	}
-	if len(presence) == 0 {
-		return nil, nil
-	}
-
 	onDuty := make(map[int64]struct{}, len(presence))
 	for staffID, status := range presence {
 		// Matched positively against the two real statuses: the map also carries

--- a/backend/services/scheduler/reminder_notifications.go
+++ b/backend/services/scheduler/reminder_notifications.go
@@ -334,7 +334,10 @@ func (s *Scheduler) resolveReminderRecipients(ctx context.Context) ([]reminderRe
 		if staffID <= 0 && !isAdmin {
 			continue
 		}
-		if onDuty != nil && staffID > 0 {
+		if onDuty != nil {
+			if staffID <= 0 {
+				continue
+			}
 			if _, working := onDuty[staffID]; !working {
 				continue
 			}

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -151,8 +151,8 @@ type reminderTestSetup struct {
 }
 
 // buildReminderSched wires a scheduler with the given batch results and consent
-// map. The duty gate is off by default (empty presence map = the school does
-// not clock in), so tests that do not care about it are unaffected.
+// map. Both staff are on duty by default so tests that do not care about the
+// duty gate are unaffected.
 func buildReminderSched(results map[int64]*reminders.Result, consent map[string][]int64) *reminderTestSetup {
 	setup := &reminderTestSetup{
 		computer: &fakeBatchComputer{results: results},
@@ -161,8 +161,11 @@ func buildReminderSched(results map[int64]*reminders.Result, consent map[string]
 			caregiverStaffID: caregiverAccountID,
 			adminStaffID:     adminAccountID,
 		}},
-		admins:   &fakeAdminAccounts{ids: []int64{adminAccountID}},
-		duty:     &fakeDuty{},
+		admins: &fakeAdminAccounts{ids: []int64{adminAccountID}},
+		duty: &fakeDuty{presence: map[int64]string{
+			caregiverStaffID: activeModel.WorkSessionStatusPresent,
+			adminStaffID:     activeModel.WorkSessionStatusPresent,
+		}},
 		notifier: &captureBatchNotifier{},
 	}
 	setup.sched = &Scheduler{
@@ -383,14 +386,15 @@ func TestPersonalRemindersOnDutyGate(t *testing.T) {
 		assert.Equal(t, []int64{caregiverAccountID}, setup.notifier.events[0].Audience.StaffAccountIDs)
 	})
 
-	t.Run("a school without time tracking is not restricted", func(t *testing.T) {
+	t.Run("nobody clocked in fails closed", func(t *testing.T) {
 		setup := buildReminderSched(results, consent)
 		setup.duty.presence = nil
 
 		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
 
-		assert.Len(t, setup.notifier.events, 2,
-			"no work sessions at all means the school does not clock in, not that nobody works")
+		assert.Empty(t, setup.notifier.events)
+		assert.Zero(t, setup.computer.calls,
+			"an empty work-session day must not widen the recipient set")
 	})
 
 	t.Run("everybody stamped out stays quiet", func(t *testing.T) {

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -57,42 +57,70 @@ type fakeConsent struct {
 	err    error
 	// asked records the candidate list the producer offered, so a test can
 	// assert that consent narrowed a relation instead of inventing one.
-	asked []int64
+	asked       []int64
+	askedTypes  []string
+	hasCalls    int
+	filterCalls int
 }
 
-func (f *fakeConsent) FilterOptedIn(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+func (f *fakeConsent) HasAnyOptedIn(_ context.Context, notificationTypes []string) (bool, error) {
+	f.hasCalls++
+	if f.err != nil {
+		return false, f.err
+	}
+	for _, notificationType := range notificationTypes {
+		if len(f.byType[notificationType]) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeConsent) FilterOptedInByType(
+	_ context.Context,
+	notificationTypes []string,
+	accountIDs []int64,
+) (map[string][]int64, error) {
+	f.filterCalls++
 	if f.err != nil {
 		return nil, f.err
 	}
 	f.asked = accountIDs
-	allowed := make(map[int64]struct{}, len(f.byType[notificationType]))
-	for _, id := range f.byType[notificationType] {
-		allowed[id] = struct{}{}
-	}
-	out := make([]int64, 0, len(allowed))
-	for _, id := range accountIDs {
-		if _, ok := allowed[id]; ok {
-			out = append(out, id)
+	f.askedTypes = notificationTypes
+	result := make(map[string][]int64)
+	for _, notificationType := range notificationTypes {
+		allowed := make(map[int64]struct{}, len(f.byType[notificationType]))
+		for _, id := range f.byType[notificationType] {
+			allowed[id] = struct{}{}
+		}
+		for _, id := range accountIDs {
+			if _, ok := allowed[id]; ok {
+				result[notificationType] = append(result[notificationType], id)
+			}
 		}
 	}
-	return out, nil
+	return result, nil
 }
 
 type fakeStaffAccounts struct {
 	accounts map[int64]int64
 	err      error
+	calls    int
 }
 
 func (f *fakeStaffAccounts) ListAllStaffAccountIDs(context.Context) (map[int64]int64, error) {
+	f.calls++
 	return f.accounts, f.err
 }
 
 type fakeAdminAccounts struct {
-	ids []int64
-	err error
+	ids   []int64
+	err   error
+	calls int
 }
 
 func (f *fakeAdminAccounts) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
+	f.calls++
 	return f.ids, f.err
 }
 
@@ -215,6 +243,7 @@ func TestPersonalRemindersReachOnlyTheConsenting(t *testing.T) {
 	// The consent filter was offered the whole team, not just the one who said
 	// yes: consent narrows a relation, it is never the source of the audience.
 	assert.ElementsMatch(t, []int64{caregiverAccountID, adminAccountID}, setup.consent.asked)
+	assert.Equal(t, 1, setup.consent.filterCalls, "all reminder types must share one consent filter call")
 
 	// The computation was scoped per person, with the admin marked as one.
 	require.Len(t, setup.computer.scopes, 1, "only people with consent are computed")
@@ -283,6 +312,27 @@ func TestPersonalRemindersSkipComputationWithoutConsent(t *testing.T) {
 	assert.Empty(t, setup.notifier.events)
 	assert.Zero(t, setup.computer.calls,
 		"with nobody to address, the tick must not compute reminders at all")
+	assert.Zero(t, setup.staff.calls, "the tenant-wide consent gate must run before staff resolution")
+	assert.Zero(t, setup.admins.calls, "the tenant-wide consent gate must run before admin resolution")
+	assert.Equal(t, 1, setup.consent.hasCalls)
+	assert.Zero(t, setup.consent.filterCalls)
+}
+
+func TestPersonalRemindersTreatStoredConsentAsGateNotAudience(t *testing.T) {
+	const staleAccountID int64 = 999
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+		map[string][]int64{notifications.TypePickupUpcoming: {staleAccountID}},
+	)
+
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+	assert.Equal(t, 1, setup.staff.calls, "a positive gate justifies canonical audience resolution")
+	assert.Equal(t, 1, setup.admins.calls)
+	assert.Equal(t, 1, setup.consent.filterCalls)
+	assert.Zero(t, setup.computer.calls,
+		"a stale preference row must not turn its account into a recipient")
+	assert.Empty(t, setup.notifier.events)
 }
 
 func TestPersonalRemindersAggregatePerTypeAndDedupPerPerson(t *testing.T) {

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -210,6 +210,7 @@ func TestPersonalRemindersReachOnlyTheConsenting(t *testing.T) {
 	require.Len(t, setup.computer.scopes, 1, "only people with consent are computed")
 	assert.Equal(t, caregiverStaffID, setup.computer.scopes[0].StaffID)
 	assert.False(t, setup.computer.scopes[0].IsAdmin)
+	assert.False(t, setup.computer.scopes[0].IncludeAssignedActivityStart)
 }
 
 func TestPersonalRemindersMarkAdminScope(t *testing.T) {
@@ -295,6 +296,8 @@ func TestPersonalRemindersClassifyAssignedActivities(t *testing.T) {
 		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
 
 		require.Len(t, setup.notifier.events, 1)
+		require.Len(t, setup.computer.scopes, 1)
+		assert.True(t, setup.computer.scopes[0].IncludeAssignedActivityStart)
 		assert.Equal(t, notifications.TypeMyActivityStarting, setup.notifier.events[0].Type)
 		assert.Equal(t, "Ihr Einsatz beginnt", setup.notifier.events[0].Title)
 	})
@@ -309,6 +312,8 @@ func TestPersonalRemindersClassifyAssignedActivities(t *testing.T) {
 
 		assert.Empty(t, setup.notifier.events,
 			"somebody who switched their own slots off must not receive them under another name")
+		require.Len(t, setup.computer.scopes, 1)
+		assert.False(t, setup.computer.scopes[0].IncludeAssignedActivityStart)
 	})
 
 	t.Run("an unassigned activity stays a room activity", func(t *testing.T) {

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -25,6 +25,7 @@ const (
 	caregiverAccountID int64 = 10
 	adminStaffID       int64 = 2
 	adminAccountID     int64 = 20
+	stafflessAdminID   int64 = 30
 	testTenant         int64 = 7
 )
 
@@ -225,6 +226,25 @@ func TestPersonalRemindersMarkAdminScope(t *testing.T) {
 	assert.Equal(t, adminStaffID, setup.computer.scopes[0].StaffID)
 	assert.True(t, setup.computer.scopes[0].IsAdmin,
 		"effective admin scope decides what the batch may see")
+}
+
+func TestPersonalRemindersIncludeStafflessEffectiveAdmins(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{-stafflessAdminID: resultOf(pickupFixture("11", "14:00"))},
+		map[string][]int64{notifications.TypePickupUpcoming: {stafflessAdminID}},
+	)
+	setup.staff.accounts = map[int64]int64{caregiverStaffID: caregiverAccountID}
+	setup.admins.ids = []int64{stafflessAdminID}
+	setup.duty.presence = map[int64]string{caregiverStaffID: "checked_out"}
+
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+	require.Len(t, setup.computer.scopes, 1)
+	assert.Zero(t, setup.computer.scopes[0].StaffID)
+	assert.True(t, setup.computer.scopes[0].IsAdmin)
+	assert.Equal(t, -stafflessAdminID, setup.computer.scopes[0].ResultKey)
+	require.Len(t, setup.notifier.events, 1)
+	assert.Equal(t, []int64{stafflessAdminID}, setup.notifier.events[0].Audience.StaffAccountIDs)
 }
 
 func TestPersonalRemindersSkipComputationWithoutConsent(t *testing.T) {

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -1,5 +1,5 @@
-// Reminder → notification bridge tests (#1624 follow-up). Pure in-memory:
-// the reminders computer and the notifications service are faked, and the
+// Personal reminder notification tests. Pure in-memory: the batch computer,
+// the consent filter, the three readers and the notifier are all fakes, and the
 // tests drive runReminderNotificationsForTenant directly — the tenant/settings
 // plumbing around it is exercised by the shared scheduler loop tests.
 package scheduler
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/reminders"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -17,209 +18,558 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeReminderComputer struct {
-	result *reminders.Result
+// The two people every test works with. Staff 1 (account 10) is a caregiver,
+// staff 2 (account 20) an admin.
+const (
+	caregiverStaffID   int64 = 1
+	caregiverAccountID int64 = 10
+	adminStaffID       int64 = 2
+	adminAccountID     int64 = 20
+	testTenant         int64 = 7
+)
+
+type fakeBatchComputer struct {
+	results map[int64]*reminders.Result
+	err     error
+	calls   int
+	scopes  []reminders.BatchScope
+}
+
+func (f *fakeBatchComputer) ComputeBatch(_ context.Context, scopes []reminders.BatchScope) (map[int64]*reminders.Result, error) {
+	f.calls++
+	f.scopes = scopes
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.results, nil
+}
+
+// fakeConsent answers "who agreed to X" from a per-type account list.
+type fakeConsent struct {
+	byType map[string][]int64
 	err    error
+	// asked records the candidate list the producer offered, so a test can
+	// assert that consent narrowed a relation instead of inventing one.
+	asked []int64
 }
 
-func (f *fakeReminderComputer) Compute(context.Context, reminders.Scope) (*reminders.Result, error) {
-	return f.result, f.err
+func (f *fakeConsent) FilterOptedIn(_ context.Context, notificationType string, accountIDs []int64) ([]int64, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.asked = accountIDs
+	allowed := make(map[int64]struct{}, len(f.byType[notificationType]))
+	for _, id := range f.byType[notificationType] {
+		allowed[id] = struct{}{}
+	}
+	out := make([]int64, 0, len(allowed))
+	for _, id := range accountIDs {
+		if _, ok := allowed[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return out, nil
 }
 
-type captureNotifier struct {
+type fakeStaffAccounts struct {
+	accounts map[int64]int64
+	err      error
+}
+
+func (f *fakeStaffAccounts) ListAllStaffAccountIDs(context.Context) (map[int64]int64, error) {
+	return f.accounts, f.err
+}
+
+type fakeAdminAccounts struct {
+	ids []int64
+	err error
+}
+
+func (f *fakeAdminAccounts) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
+	return f.ids, f.err
+}
+
+type fakeDuty struct {
+	presence map[int64]string
+	err      error
+}
+
+func (f *fakeDuty) GetTodayPresenceMap(context.Context) (map[int64]string, error) {
+	return f.presence, f.err
+}
+
+type captureBatchNotifier struct {
 	events []notifications.Event
 	err    error
 }
 
-func (c *captureNotifier) Notify(ctx context.Context, event notifications.Event) error {
+func (c *captureBatchNotifier) NotifyBatch(ctx context.Context, events []notifications.Event) error {
 	if c.err != nil {
 		return c.err
 	}
 	tenant.RegisterAfterCommit(ctx, func() {
-		c.events = append(c.events, event)
+		c.events = append(c.events, events...)
 	})
 	return nil
 }
 
 func str(s string) *string { return &s }
 
-func reminderFixture(typ, studentID, due string) reminders.Reminder {
+func pickupFixture(studentID, due string) reminders.Reminder {
 	return reminders.Reminder{
-		Type:      typ,
+		Type:      reminders.TypePickupUpcoming,
 		StudentID: str(studentID),
-		Title:     "Kind Name", // must never surface in the notification
+		Title:     "Kind Name", // must never surface in a notification
 		DueTime:   due,
 	}
 }
 
-func buildReminderSched(computer reminders.Service, notifier notifications.Service) *Scheduler {
-	return &Scheduler{
-		tasks:            make(map[string]*ScheduledTask),
-		logger:           slog.Default(),
-		reminderComputer: computer,
-		reminderNotifier: notifier,
+func activityFixture(instanceID, due string) reminders.Reminder {
+	return reminders.Reminder{
+		Type:               reminders.TypeActivityStart,
+		ActivityInstanceID: str(instanceID),
+		Title:              "Bastel-AG",
+		DueTime:            due,
 	}
 }
 
-func TestReminderNotificationsAggregateAndDedup(t *testing.T) {
-	notifier := &captureNotifier{}
-	computer := &fakeReminderComputer{result: &reminders.Result{
-		Enabled: true,
-		Reminders: []reminders.Reminder{
-			reminderFixture(reminders.TypePickupUpcoming, "11", "14:00"),
-			reminderFixture(reminders.TypePickupUpcoming, "12", "14:05"),
-			reminderFixture(reminders.TypeActivityStart, "13", "14:10"),
+func resultOf(rems ...reminders.Reminder) *reminders.Result {
+	return &reminders.Result{Enabled: true, Reminders: rems, Count: len(rems)}
+}
+
+// reminderTestSetup is the wiring of one test, with every part reachable for
+// assertions afterwards.
+type reminderTestSetup struct {
+	sched    *Scheduler
+	computer *fakeBatchComputer
+	consent  *fakeConsent
+	staff    *fakeStaffAccounts
+	admins   *fakeAdminAccounts
+	duty     *fakeDuty
+	notifier *captureBatchNotifier
+}
+
+// buildReminderSched wires a scheduler with the given batch results and consent
+// map. The duty gate is off by default (empty presence map = the school does
+// not clock in), so tests that do not care about it are unaffected.
+func buildReminderSched(results map[int64]*reminders.Result, consent map[string][]int64) *reminderTestSetup {
+	setup := &reminderTestSetup{
+		computer: &fakeBatchComputer{results: results},
+		consent:  &fakeConsent{byType: consent},
+		staff: &fakeStaffAccounts{accounts: map[int64]int64{
+			caregiverStaffID: caregiverAccountID,
+			adminStaffID:     adminAccountID,
+		}},
+		admins:   &fakeAdminAccounts{ids: []int64{adminAccountID}},
+		duty:     &fakeDuty{},
+		notifier: &captureBatchNotifier{},
+	}
+	setup.sched = &Scheduler{
+		tasks:  make(map[string]*ScheduledTask),
+		logger: slog.Default(),
+		reminderNotifications: ReminderNotificationDeps{
+			Computer:     setup.computer,
+			Notifier:     setup.notifier,
+			Preferences:  setup.consent,
+			Staff:        setup.staff,
+			Accounts:     setup.admins,
+			WorkSessions: setup.duty,
 		},
-	}}
-	sched := buildReminderSched(computer, notifier)
-	now := time.Now()
+	}
+	return setup
+}
 
-	sched.runReminderNotificationsForTenant(context.Background(), 7, now)
-	require.Len(t, notifier.events, 1, "fresh reminders aggregate into ONE event")
+func TestPersonalRemindersReachOnlyTheConsenting(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{
+			caregiverStaffID: resultOf(pickupFixture("11", "14:00")),
+			adminStaffID:     resultOf(pickupFixture("11", "14:00")),
+		},
+		// Only the caregiver switched pickups on.
+		map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+	)
 
-	event := notifier.events[0]
-	assert.Equal(t, "reminders_due", event.Type)
-	assert.Equal(t, int64(7), event.Audience.TenantID)
-	assert.Equal(t, notifications.ScopeAdmin, event.Audience.Scope)
-	assert.Equal(t, notifications.PriorityNormal, event.Priority)
-	assert.Equal(t, "Erinnerungen", event.Title)
-	assert.Equal(t, "2 anstehende Abholungen, 1 beginnende Aktivität.", event.Body)
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+	require.Len(t, setup.notifier.events, 1, "the admin never agreed, so nothing is addressed to them")
+	event := setup.notifier.events[0]
+	assert.Equal(t, notifications.TypePickupUpcoming, event.Type)
+	assert.Equal(t, notifications.ScopeStaff, event.Audience.Scope)
+	assert.Equal(t, []int64{caregiverAccountID}, event.Audience.StaffAccountIDs)
+	assert.Equal(t, testTenant, event.Audience.TenantID)
+	assert.Equal(t, "Abholung steht an", event.Title)
+	assert.Equal(t, "Ein Kind aus Ihrer Aufsicht wird bald abgeholt.", event.Body)
 	assert.Equal(t, "/reminders", event.DeepLink)
-	assert.Equal(t, map[string]string{"pickup_upcoming": "2", "activity_start": "1"}, event.Data)
 	assert.NotContains(t, event.Body, "Kind Name", "student names must never leave the reminder list")
 
-	// Second tick with the identical list: everything already notified.
-	sched.runReminderNotificationsForTenant(context.Background(), 7, now)
-	assert.Len(t, notifier.events, 1, "already-notified reminders must not re-fire")
+	// The consent filter was offered the whole team, not just the one who said
+	// yes: consent narrows a relation, it is never the source of the audience.
+	assert.ElementsMatch(t, []int64{caregiverAccountID, adminAccountID}, setup.consent.asked)
 
-	// A new occurrence joins: only IT is dispatched.
-	computer.result.Reminders = append(computer.result.Reminders,
-		reminderFixture(reminders.TypePickupOverdue, "14", "13:30"))
-	sched.runReminderNotificationsForTenant(context.Background(), 7, now)
-	require.Len(t, notifier.events, 2)
-	assert.Equal(t, "1 überfällige Abholung.", notifier.events[1].Body)
-	assert.Equal(t, notifications.PriorityHigh, notifier.events[1].Priority, "overdue raises priority")
+	// The computation was scoped per person, with the admin marked as one.
+	require.Len(t, setup.computer.scopes, 1, "only people with consent are computed")
+	assert.Equal(t, caregiverStaffID, setup.computer.scopes[0].StaffID)
+	assert.False(t, setup.computer.scopes[0].IsAdmin)
 }
 
-func TestReminderNotificationsSkipConditions(t *testing.T) {
-	notifier := &captureNotifier{}
+func TestPersonalRemindersMarkAdminScope(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{adminStaffID: resultOf(pickupFixture("11", "14:00"))},
+		map[string][]int64{notifications.TypePickupUpcoming: {adminAccountID}},
+	)
 
-	disabled := buildReminderSched(&fakeReminderComputer{result: &reminders.Result{
-		Enabled:   false,
-		Reminders: []reminders.Reminder{reminderFixture(reminders.TypePickupUpcoming, "11", "14:00")},
-	}}, notifier)
-	disabled.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Empty(t, notifier.events, "reminder feature off → nothing dispatched")
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
 
-	empty := buildReminderSched(&fakeReminderComputer{result: &reminders.Result{Enabled: true}}, notifier)
-	empty.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Empty(t, notifier.events, "no reminders → nothing dispatched")
-
-	failing := buildReminderSched(&fakeReminderComputer{err: assert.AnError}, notifier)
-	failing.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Empty(t, notifier.events, "compute error → skip, no dispatch")
+	require.Len(t, setup.computer.scopes, 1)
+	assert.Equal(t, adminStaffID, setup.computer.scopes[0].StaffID)
+	assert.True(t, setup.computer.scopes[0].IsAdmin,
+		"effective admin scope decides what the batch may see")
 }
 
-func TestReminderNotificationsNotifyFailureLeavesUnmarked(t *testing.T) {
-	notifier := &captureNotifier{err: notifications.ErrDisabled}
-	computer := &fakeReminderComputer{result: &reminders.Result{
-		Enabled:   true,
-		Reminders: []reminders.Reminder{reminderFixture(reminders.TypePickupUpcoming, "11", "14:00")},
-	}}
-	sched := buildReminderSched(computer, notifier)
+func TestPersonalRemindersSkipComputationWithoutConsent(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+		nil, // nobody agreed to anything
+	)
 
-	sched.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Empty(t, notifier.events)
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+	assert.Empty(t, setup.notifier.events)
+	assert.Zero(t, setup.computer.calls,
+		"with nobody to address, the tick must not compute reminders at all")
+}
+
+func TestPersonalRemindersAggregatePerTypeAndDedupPerPerson(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{
+			caregiverStaffID: resultOf(
+				pickupFixture("11", "14:00"),
+				pickupFixture("12", "14:05"),
+				activityFixture("31", "14:10"),
+			),
+			adminStaffID: resultOf(pickupFixture("11", "14:00")),
+		},
+		map[string][]int64{
+			notifications.TypePickupUpcoming: {caregiverAccountID, adminAccountID},
+			notifications.TypeActivityStart:  {caregiverAccountID},
+		},
+	)
+	now := time.Now()
+
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, now)
+
+	require.Len(t, setup.notifier.events, 3, "two kinds for the caregiver, one for the admin")
+	assert.Equal(t, "2 Kinder aus Ihrer Aufsicht werden bald abgeholt.", setup.notifier.events[0].Body)
+	assert.Equal(t, notifications.TypeActivityStart, setup.notifier.events[1].Type)
+	assert.Equal(t, []int64{adminAccountID}, setup.notifier.events[2].Audience.StaffAccountIDs)
+
+	// The same pickup reached both people — and each of them only once.
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, now)
+	assert.Len(t, setup.notifier.events, 3, "already-notified occurrences must not re-fire")
+
+	// A newly due overdue pickup for the caregiver alone.
+	setup.computer.results[caregiverStaffID] = resultOf(
+		pickupFixture("11", "14:00"),
+		reminders.Reminder{Type: reminders.TypePickupOverdue, StudentID: str("14"), DueTime: "13:30"},
+	)
+	setup.consent.byType[notifications.TypePickupOverdue] = []int64{caregiverAccountID}
+
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, now)
+	require.Len(t, setup.notifier.events, 4)
+	assert.Equal(t, notifications.PriorityHigh, setup.notifier.events[3].Priority,
+		"overdue raises the priority")
+}
+
+// An activity someone is personally planned on is their own slot, not "an
+// activity in the room I am watching". The two switches must not overlap.
+func TestPersonalRemindersClassifyAssignedActivities(t *testing.T) {
+	assigned := resultOf(activityFixture("31", "14:10"))
+	assigned.AssignedActivityInstanceIDs = map[string]struct{}{"31": {}}
+
+	t.Run("assigned slot needs the assignment consent", func(t *testing.T) {
+		setup := buildReminderSched(
+			map[int64]*reminders.Result{caregiverStaffID: assigned},
+			map[string][]int64{notifications.TypeMyActivityStarting: {caregiverAccountID}},
+		)
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		require.Len(t, setup.notifier.events, 1)
+		assert.Equal(t, notifications.TypeMyActivityStarting, setup.notifier.events[0].Type)
+		assert.Equal(t, "Ihr Einsatz beginnt", setup.notifier.events[0].Title)
+	})
+
+	t.Run("the room consent does not cover an own slot", func(t *testing.T) {
+		setup := buildReminderSched(
+			map[int64]*reminders.Result{caregiverStaffID: assigned},
+			map[string][]int64{notifications.TypeActivityStart: {caregiverAccountID}},
+		)
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		assert.Empty(t, setup.notifier.events,
+			"somebody who switched their own slots off must not receive them under another name")
+	})
+
+	t.Run("an unassigned activity stays a room activity", func(t *testing.T) {
+		setup := buildReminderSched(
+			map[int64]*reminders.Result{caregiverStaffID: resultOf(activityFixture("31", "14:10"))},
+			map[string][]int64{notifications.TypeActivityStart: {caregiverAccountID}},
+		)
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		require.Len(t, setup.notifier.events, 1)
+		assert.Equal(t, notifications.TypeActivityStart, setup.notifier.events[0].Type)
+	})
+}
+
+func TestPersonalRemindersOnDutyGate(t *testing.T) {
+	results := map[int64]*reminders.Result{
+		caregiverStaffID: resultOf(pickupFixture("11", "14:00")),
+		adminStaffID:     resultOf(pickupFixture("11", "14:00")),
+	}
+	consent := map[string][]int64{
+		notifications.TypePickupUpcoming: {caregiverAccountID, adminAccountID},
+	}
+
+	t.Run("only stamped-in people are addressed", func(t *testing.T) {
+		setup := buildReminderSched(results, consent)
+		setup.duty.presence = map[int64]string{
+			caregiverStaffID: activeModel.WorkSessionStatusPresent,
+			adminStaffID:     "checked_out",
+		}
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		require.Len(t, setup.notifier.events, 1)
+		assert.Equal(t, []int64{caregiverAccountID}, setup.notifier.events[0].Audience.StaffAccountIDs)
+	})
+
+	t.Run("home office counts as on duty", func(t *testing.T) {
+		setup := buildReminderSched(results, consent)
+		setup.duty.presence = map[int64]string{
+			caregiverStaffID: activeModel.WorkSessionStatusHomeOffice,
+		}
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		require.Len(t, setup.notifier.events, 1)
+		assert.Equal(t, []int64{caregiverAccountID}, setup.notifier.events[0].Audience.StaffAccountIDs)
+	})
+
+	t.Run("a school without time tracking is not restricted", func(t *testing.T) {
+		setup := buildReminderSched(results, consent)
+		setup.duty.presence = nil
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		assert.Len(t, setup.notifier.events, 2,
+			"no work sessions at all means the school does not clock in, not that nobody works")
+	})
+
+	t.Run("everybody stamped out stays quiet", func(t *testing.T) {
+		setup := buildReminderSched(results, consent)
+		setup.duty.presence = map[int64]string{
+			caregiverStaffID: "checked_out",
+			adminStaffID:     "checked_out",
+		}
+
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+		assert.Empty(t, setup.notifier.events)
+		assert.Zero(t, setup.computer.calls)
+	})
+}
+
+func TestPersonalRemindersSkipConditions(t *testing.T) {
+	consent := map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}}
+	reminder := pickupFixture("11", "14:00")
+
+	t.Run("reminder feature off", func(t *testing.T) {
+		setup := buildReminderSched(map[int64]*reminders.Result{
+			caregiverStaffID: {Enabled: false, Reminders: []reminders.Reminder{reminder}},
+		}, consent)
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+		assert.Empty(t, setup.notifier.events)
+	})
+
+	t.Run("nothing due", func(t *testing.T) {
+		setup := buildReminderSched(map[int64]*reminders.Result{
+			caregiverStaffID: {Enabled: true},
+		}, consent)
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+		assert.Empty(t, setup.notifier.events)
+	})
+
+	t.Run("compute error", func(t *testing.T) {
+		setup := buildReminderSched(nil, consent)
+		setup.computer.err = assert.AnError
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+		assert.Empty(t, setup.notifier.events)
+	})
+
+	t.Run("no staff at all", func(t *testing.T) {
+		setup := buildReminderSched(nil, consent)
+		setup.staff.accounts = nil
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+		assert.Empty(t, setup.notifier.events)
+		assert.Zero(t, setup.computer.calls)
+	})
+
+	t.Run("a failing reader aborts the tick", func(t *testing.T) {
+		setup := buildReminderSched(nil, consent)
+		setup.admins.err = assert.AnError
+		setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+		assert.Empty(t, setup.notifier.events)
+		assert.Zero(t, setup.computer.calls,
+			"an unknown admin set would silently change what people are allowed to see")
+	})
+}
+
+func TestPersonalRemindersNotifyFailureLeavesUnmarked(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+		map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+	)
+	setup.notifier.err = notifications.ErrDisabled
+
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+	assert.Empty(t, setup.notifier.events)
 
 	// Dispatch becomes possible again → the SAME occurrence fires now.
-	notifier.err = nil
-	sched.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Len(t, notifier.events, 1, "a failed dispatch must not consume the occurrence")
+	setup.notifier.err = nil
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+	assert.Len(t, setup.notifier.events, 1, "a failed dispatch must not consume the occurrence")
 }
 
-func TestReminderNotificationsMarksOccurrencesAfterCommit(t *testing.T) {
-	reminder := reminderFixture(reminders.TypePickupUpcoming, "11", "14:00")
-	notifier := &captureNotifier{}
-	sched := buildReminderSched(&fakeReminderComputer{result: &reminders.Result{
-		Enabled:   true,
-		Reminders: []reminders.Reminder{reminder},
-	}}, notifier)
-	key := reminderNotificationKey{tenantID: 7, reminder: reminderIdentity(reminder)}
+func TestPersonalRemindersMarkOccurrencesAfterCommit(t *testing.T) {
+	reminder := pickupFixture("11", "14:00")
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{caregiverStaffID: resultOf(reminder)},
+		map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+	)
+	key := reminderNotificationKey{
+		tenantID:  testTenant,
+		accountID: caregiverAccountID,
+		reminder:  reminderIdentity(reminder),
+	}
 	ctx, commit := tenant.WithAfterCommitHooksForTest(context.Background())
 
-	sched.runReminderNotificationsForTenant(ctx, 7, time.Now())
+	setup.sched.runReminderNotificationsForTenant(ctx, testTenant, time.Now())
 
-	assert.Empty(t, notifier.events, "delivery must wait for commit")
-	_, markedBeforeCommit := sched.reminderNotified.Load(key)
+	assert.Empty(t, setup.notifier.events, "delivery must wait for commit")
+	_, markedBeforeCommit := setup.sched.reminderNotified.Load(key)
 	assert.False(t, markedBeforeCommit, "dedup key must wait for commit")
 
 	commit()
 
-	assert.Len(t, notifier.events, 1)
-	_, markedAfterCommit := sched.reminderNotified.Load(key)
+	assert.Len(t, setup.notifier.events, 1)
+	_, markedAfterCommit := setup.sched.reminderNotified.Load(key)
 	assert.True(t, markedAfterCommit, "successful commit must consume the occurrence")
 
-	sched.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Len(t, notifier.events, 1, "committed occurrence must not re-fire")
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+	assert.Len(t, setup.notifier.events, 1, "committed occurrence must not re-fire")
 }
 
-func TestReminderNotificationsRollbackLeavesOccurrencesUnmarked(t *testing.T) {
-	reminder := reminderFixture(reminders.TypePickupUpcoming, "11", "14:00")
-	notifier := &captureNotifier{}
-	sched := buildReminderSched(&fakeReminderComputer{result: &reminders.Result{
-		Enabled:   true,
-		Reminders: []reminders.Reminder{reminder},
-	}}, notifier)
-	key := reminderNotificationKey{tenantID: 7, reminder: reminderIdentity(reminder)}
+func TestPersonalRemindersRollbackLeavesOccurrencesUnmarked(t *testing.T) {
+	reminder := pickupFixture("11", "14:00")
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{caregiverStaffID: resultOf(reminder)},
+		map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+	)
+	key := reminderNotificationKey{
+		tenantID:  testTenant,
+		accountID: caregiverAccountID,
+		reminder:  reminderIdentity(reminder),
+	}
 	rolledBackCtx, _ := tenant.WithAfterCommitHooksForTest(context.Background())
 
-	sched.runReminderNotificationsForTenant(rolledBackCtx, 7, time.Now())
+	setup.sched.runReminderNotificationsForTenant(rolledBackCtx, testTenant, time.Now())
 
-	assert.Empty(t, notifier.events, "rollback must drop queued delivery")
-	_, marked := sched.reminderNotified.Load(key)
+	assert.Empty(t, setup.notifier.events, "rollback must drop queued delivery")
+	_, marked := setup.sched.reminderNotified.Load(key)
 	assert.False(t, marked, "rollback must leave the occurrence eligible")
 
-	sched.runReminderNotificationsForTenant(context.Background(), 7, time.Now())
-	assert.Len(t, notifier.events, 1, "the next successful tick must retry the occurrence")
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+	assert.Len(t, setup.notifier.events, 1, "the next successful tick must retry the occurrence")
 }
 
-func TestReminderNotificationsTenantIsolationAndDayRotation(t *testing.T) {
-	notifier := &captureNotifier{}
-	computer := &fakeReminderComputer{result: &reminders.Result{
-		Enabled:   true,
-		Reminders: []reminders.Reminder{reminderFixture(reminders.TypePickupUpcoming, "11", "14:00")},
-	}}
-	sched := buildReminderSched(computer, notifier)
+func TestPersonalRemindersTenantIsolationAndDayRotation(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+		map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+	)
 	now := time.Now()
 
 	// Production rotates at the top of every tick; initialize the day first so
 	// the later same-day rotation call is a genuine no-op check.
-	sched.rotateReminderNotificationCacheIfNewDay(now)
-	sched.runReminderNotificationsForTenant(context.Background(), 7, now)
-	sched.runReminderNotificationsForTenant(context.Background(), 8, now)
-	assert.Len(t, notifier.events, 2, "the guard is per tenant")
+	setup.sched.rotateReminderNotificationCacheIfNewDay(now)
+	setup.sched.runReminderNotificationsForTenant(context.Background(), 7, now)
+	setup.sched.runReminderNotificationsForTenant(context.Background(), 8, now)
+	assert.Len(t, setup.notifier.events, 2, "the guard is per tenant")
 
 	// Same civil date → rotation is a no-op, guard intact.
-	sched.rotateReminderNotificationCacheIfNewDay(now)
-	sched.runReminderNotificationsForTenant(context.Background(), 7, now)
-	assert.Len(t, notifier.events, 2)
+	setup.sched.rotateReminderNotificationCacheIfNewDay(now)
+	setup.sched.runReminderNotificationsForTenant(context.Background(), 7, now)
+	assert.Len(t, setup.notifier.events, 2)
 
 	// Next civil date → guard cleared, identical schedule fires again.
-	sched.rotateReminderNotificationCacheIfNewDay(now.Add(24 * time.Hour))
-	sched.runReminderNotificationsForTenant(context.Background(), 7, now)
-	assert.Len(t, notifier.events, 3)
+	setup.sched.rotateReminderNotificationCacheIfNewDay(now.Add(24 * time.Hour))
+	setup.sched.runReminderNotificationsForTenant(context.Background(), 7, now)
+	assert.Len(t, setup.notifier.events, 3)
 }
 
-func TestScheduleReminderNotificationTaskRequiresBothDeps(t *testing.T) {
-	sched := buildReminderSched(nil, nil)
-	sched.scheduleReminderNotificationTask()
-	assert.Empty(t, sched.tasks, "missing deps → task must not register")
+func TestScheduleReminderNotificationTaskRequiresEveryDep(t *testing.T) {
+	complete := buildReminderSched(nil, nil).sched.reminderNotifications
 
-	sched = buildReminderSched(&fakeReminderComputer{}, nil)
-	sched.scheduleReminderNotificationTask()
-	assert.Empty(t, sched.tasks)
+	t.Run("nothing wired", func(t *testing.T) {
+		sched := &Scheduler{tasks: make(map[string]*ScheduledTask), logger: slog.Default()}
+		sched.scheduleReminderNotificationTask()
+		assert.Empty(t, sched.tasks)
+	})
 
-	sched = buildReminderSched(&fakeReminderComputer{}, &captureNotifier{})
-	sched.scheduleReminderNotificationTask()
-	assert.Contains(t, sched.tasks, "reminder-notifications")
+	// Every single missing dependency must disable the task: a producer that
+	// resolves a narrower audience because one reader is absent would look like
+	// it works.
+	partials := map[string]ReminderNotificationDeps{
+		"no computer":     {Notifier: complete.Notifier, Preferences: complete.Preferences, Staff: complete.Staff, Accounts: complete.Accounts, WorkSessions: complete.WorkSessions},
+		"no notifier":     {Computer: complete.Computer, Preferences: complete.Preferences, Staff: complete.Staff, Accounts: complete.Accounts, WorkSessions: complete.WorkSessions},
+		"no preferences":  {Computer: complete.Computer, Notifier: complete.Notifier, Staff: complete.Staff, Accounts: complete.Accounts, WorkSessions: complete.WorkSessions},
+		"no staff reader": {Computer: complete.Computer, Notifier: complete.Notifier, Preferences: complete.Preferences, Accounts: complete.Accounts, WorkSessions: complete.WorkSessions},
+		"no admin reader": {Computer: complete.Computer, Notifier: complete.Notifier, Preferences: complete.Preferences, Staff: complete.Staff, WorkSessions: complete.WorkSessions},
+		"no duty reader":  {Computer: complete.Computer, Notifier: complete.Notifier, Preferences: complete.Preferences, Staff: complete.Staff, Accounts: complete.Accounts},
+	}
+	for name, deps := range partials {
+		t.Run(name, func(t *testing.T) {
+			sched := &Scheduler{tasks: make(map[string]*ScheduledTask), logger: slog.Default()}
+			sched.SetReminderNotificationDeps(deps)
+			sched.scheduleReminderNotificationTask()
+			assert.Empty(t, sched.tasks)
+		})
+	}
+
+	t.Run("fully wired", func(t *testing.T) {
+		sched := &Scheduler{tasks: make(map[string]*ScheduledTask), logger: slog.Default()}
+		sched.SetReminderNotificationDeps(complete)
+		sched.scheduleReminderNotificationTask()
+		assert.Contains(t, sched.tasks, "reminder-notifications")
+	})
+}
+
+// The copy table and the type list are two halves of one contract: a type
+// without wording would dispatch the generic fallback, which reads like a bug.
+func TestEveryPersonalReminderTypeHasCopy(t *testing.T) {
+	for _, notificationType := range personalReminderTypes {
+		copyFor, ok := reminderCopyByType[notificationType]
+		require.True(t, ok, "missing copy for %s", notificationType)
+		assert.NotEmpty(t, copyFor.title)
+		assert.NotEmpty(t, copyFor.singular)
+		assert.Contains(t, copyFor.plural, "%d")
+
+		// And the type has to exist in the catalogue the profile page renders,
+		// or people could never agree to it.
+		_, known := notifications.GetType(notificationType)
+		assert.True(t, known, "%s is not in the notification catalogue", notificationType)
+	}
 }

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -231,7 +231,7 @@ func TestPersonalRemindersMarkAdminScope(t *testing.T) {
 		"effective admin scope decides what the batch may see")
 }
 
-func TestPersonalRemindersIncludeStafflessEffectiveAdmins(t *testing.T) {
+func TestPersonalRemindersIncludeStafflessEffectiveAdminsWhenDutyGateDisabled(t *testing.T) {
 	setup := buildReminderSched(
 		map[int64]*reminders.Result{-stafflessAdminID: resultOf(pickupFixture("11", "14:00"))},
 		map[string][]int64{notifications.TypePickupUpcoming: {stafflessAdminID}},
@@ -239,6 +239,7 @@ func TestPersonalRemindersIncludeStafflessEffectiveAdmins(t *testing.T) {
 	setup.staff.accounts = map[int64]int64{caregiverStaffID: caregiverAccountID}
 	setup.admins.ids = []int64{stafflessAdminID}
 	setup.duty.presence = map[int64]string{caregiverStaffID: "checked_out"}
+	setup.sched.settings = &stubSettingsResolver{hasOverride: true, boolVal: false}
 
 	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
 
@@ -248,6 +249,21 @@ func TestPersonalRemindersIncludeStafflessEffectiveAdmins(t *testing.T) {
 	assert.Equal(t, -stafflessAdminID, setup.computer.scopes[0].ResultKey)
 	require.Len(t, setup.notifier.events, 1)
 	assert.Equal(t, []int64{stafflessAdminID}, setup.notifier.events[0].Audience.StaffAccountIDs)
+}
+
+func TestPersonalRemindersExcludeStafflessEffectiveAdminsWhenDutyGateEnabled(t *testing.T) {
+	setup := buildReminderSched(
+		map[int64]*reminders.Result{-stafflessAdminID: resultOf(pickupFixture("11", "14:00"))},
+		map[string][]int64{notifications.TypePickupUpcoming: {stafflessAdminID}},
+	)
+	setup.staff.accounts = map[int64]int64{caregiverStaffID: caregiverAccountID}
+	setup.admins.ids = []int64{stafflessAdminID}
+
+	setup.sched.runReminderNotificationsForTenant(context.Background(), testTenant, time.Now())
+
+	assert.Zero(t, setup.computer.calls,
+		"an account without a staff identity cannot satisfy the duty gate")
+	assert.Empty(t, setup.notifier.events)
 }
 
 func TestPersonalRemindersSkipComputationWithoutConsent(t *testing.T) {

--- a/backend/services/scheduler/reminder_notifications_test.go
+++ b/backend/services/scheduler/reminder_notifications_test.go
@@ -6,12 +6,18 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
 
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
+
+	// Populates the settings registry, so the tick test can assert against the
+	// registered default instead of a literal copy of it.
+	_ "github.com/moto-nrw/project-phoenix/services/config/defaults"
 	"github.com/moto-nrw/project-phoenix/services/reminders"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/stretchr/testify/assert"
@@ -563,6 +569,107 @@ func TestPersonalRemindersTenantIsolationAndDayRotation(t *testing.T) {
 	setup.sched.rotateReminderNotificationCacheIfNewDay(now.Add(24 * time.Hour))
 	setup.sched.runReminderNotificationsForTenant(context.Background(), 7, now)
 	assert.Len(t, setup.notifier.events, 3)
+}
+
+// registrySettingsResolver behaves like the real settings service for a school
+// that never touched a setting: no tenant override, and Resolve* answers with
+// the value registered in the settings registry. The other doubles in this
+// package invent their own "no value" behaviour, which is exactly what would let
+// a registry-default regression pass unnoticed.
+type registrySettingsResolver struct{}
+
+func (registrySettingsResolver) HasTenantOverride(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (registrySettingsResolver) ResolveBool(_ context.Context, key string) (bool, error) {
+	def := configModel.GetDefinition(key)
+	if def == nil {
+		return false, fmt.Errorf("no definition registered for %s", key)
+	}
+	value, ok := def.Default.(bool)
+	if !ok {
+		return false, fmt.Errorf("%s is not a boolean setting", key)
+	}
+	return value, nil
+}
+
+func (registrySettingsResolver) ResolveInt(_ context.Context, key string) (int, error) {
+	def := configModel.GetDefinition(key)
+	if def == nil {
+		return 0, fmt.Errorf("no definition registered for %s", key)
+	}
+	value, ok := def.Default.(int)
+	if !ok {
+		return 0, fmt.Errorf("%s is not an integer setting", key)
+	}
+	return value, nil
+}
+
+func (registrySettingsResolver) ResolveString(_ context.Context, key string) (string, error) {
+	def := configModel.GetDefinition(key)
+	if def == nil {
+		return "", fmt.Errorf("no definition registered for %s", key)
+	}
+	value, ok := def.Default.(string)
+	if !ok {
+		return "", fmt.Errorf("%s is not a string setting", key)
+	}
+	return value, nil
+}
+
+// The tick's feature gate has to answer what the notification router answers.
+// While the gate carried its own literal default, every school without an
+// explicit override was silently skipped even though the setting reads "on" in
+// the UI and the router would have delivered.
+func TestReminderNotificationTickHonoursRegistryDefault(t *testing.T) {
+	definition := configModel.GetDefinition(configModel.KeyNotificationsDispatchEnabled)
+	require.NotNil(t, definition, "the dispatch flag must be registered")
+	require.Equal(t, true, definition.Default,
+		"premise of this test: the registry default of the dispatch flag is on")
+
+	t.Run("no tenant override runs the tick", func(t *testing.T) {
+		setup := buildReminderSched(
+			map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+			map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+		)
+		setup.sched.settings = registrySettingsResolver{}
+
+		// No db/schoolRepo wired, so forEachTenantSettings runs the body once
+		// without tenant context, which is enough to exercise the gate.
+		setup.sched.checkAndRunReminderNotifications(&ScheduledTask{Name: "reminder-notifications"})
+
+		require.Len(t, setup.notifier.events, 1,
+			"a school that never touched the setting must be served the registry default")
+		assert.Equal(t, []int64{caregiverAccountID}, setup.notifier.events[0].Audience.StaffAccountIDs)
+	})
+
+	t.Run("an explicit off override still stops the tick", func(t *testing.T) {
+		setup := buildReminderSched(
+			map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+			map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+		)
+		setup.sched.settings = &stubSettingsResolver{hasOverride: true, boolVal: false}
+
+		setup.sched.checkAndRunReminderNotifications(&ScheduledTask{Name: "reminder-notifications"})
+
+		assert.Empty(t, setup.notifier.events)
+		assert.Zero(t, setup.computer.calls,
+			"a school that switched notifications off must not even resolve an audience")
+	})
+
+	t.Run("no settings service fails closed", func(t *testing.T) {
+		setup := buildReminderSched(
+			map[int64]*reminders.Result{caregiverStaffID: resultOf(pickupFixture("11", "14:00"))},
+			map[string][]int64{notifications.TypePickupUpcoming: {caregiverAccountID}},
+		)
+
+		setup.sched.checkAndRunReminderNotifications(&ScheduledTask{Name: "reminder-notifications"})
+
+		assert.Empty(t, setup.notifier.events,
+			"without a settings service the router could not dispatch either")
+		assert.Zero(t, setup.computer.calls)
+	})
 }
 
 func TestScheduleReminderNotificationTaskRequiresEveryDep(t *testing.T) {

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -23,8 +23,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/services/active"
 	"github.com/moto-nrw/project-phoenix/services/config"
 	enrollmentSvc "github.com/moto-nrw/project-phoenix/services/enrollment"
-	"github.com/moto-nrw/project-phoenix/services/notifications"
-	"github.com/moto-nrw/project-phoenix/services/reminders"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -163,12 +161,11 @@ type Scheduler struct {
 	// SetRolloverDeadlineRunner. Nil → task does not register.
 	rolloverDeadlineRunner RolloverDeadlineRunner
 
-	// Reminder → notification bridge (#1624 follow-up). Wired via
-	// SetReminderNotificationDeps; either nil → task does not register.
-	// reminderNotified is the once-per-day re-fire guard, rotated on
-	// civil-date rollover like overdueEmitted.
-	reminderComputer      reminders.Service
-	reminderNotifier      notifications.Service
+	// Personal reminder notifications. Wired via SetReminderNotificationDeps;
+	// anything missing → task does not register. reminderNotified is the
+	// once-per-day re-fire guard (now per person), rotated on civil-date
+	// rollover like overdueEmitted.
+	reminderNotifications ReminderNotificationDeps
 	reminderNotified      sync.Map // reminderNotificationKey → time.Time
 	reminderNotifiedDay   timezone.Date
 	reminderNotifiedDayMu sync.Mutex

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -164,7 +164,8 @@ type Scheduler struct {
 	// Personal reminder notifications. Wired via SetReminderNotificationDeps;
 	// anything missing → task does not register. reminderNotified is the
 	// once-per-day re-fire guard (now per person), rotated on civil-date
-	// rollover like overdueEmitted.
+	// rollover like overdueEmitted. It is process-local, so production must run
+	// only one scheduler instance until this state is shared.
 	reminderNotifications ReminderNotificationDeps
 	reminderNotified      sync.Map // reminderNotificationKey → time.Time
 	reminderNotifiedDay   timezone.Date

--- a/backend/services/usercontext/interface.go
+++ b/backend/services/usercontext/interface.go
@@ -30,7 +30,13 @@ type UserContextService interface {
 	// GetCurrentTeacher retrieves the teacher linked to the currently authenticated user
 	GetCurrentTeacher(ctx context.Context) (*users.Teacher, error)
 
-	// GetMyGroups retrieves educational groups associated with the current user
+	// GetMyGroups retrieves educational groups associated with the current user.
+	//
+	// The identity-free bulk counterpart is
+	// education.GroupRepository.ListSupervisedGroupIDsByStaff: same two sources
+	// (teacher assignments plus active substitutions), keyed by staff ID, for
+	// callers with no authenticated user. The two are pinned against each other
+	// by an equivalence test.
 	GetMyGroups(ctx context.Context) ([]*education.Group, error)
 
 	// GetSubstitutedGroupIDs returns the set of education group IDs the current

--- a/backend/services/usercontext/supervised_groups_equivalence_test.go
+++ b/backend/services/usercontext/supervised_groups_equivalence_test.go
@@ -1,0 +1,172 @@
+package usercontext_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSupervisedGroupsEquivalence is the guard for the read filter that decides
+// which children a staff member may see.
+//
+// There are two implementations of "which education groups does this person
+// supervise": usercontext.GetMyGroups, which resolves the person from JWT
+// claims and is used on every request, and
+// education.GroupRepository.ListSupervisedGroupIDsByStaff, which answers the
+// same question by staff ID and without an authenticated user, for callers that
+// need many people at once.
+//
+// Two implementations of one authorization rule is exactly the shape that drifts
+// silently, and the direction it drifts matters: a wider bulk result exposes
+// children to staff who may not read them. So the two are compared directly,
+// over the cases where they could plausibly disagree, instead of each being
+// checked against a hand-written expectation.
+func TestSupervisedGroupsEquivalence(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+	groupRepo := repositories.NewFactory(db).Group
+	tenantCtx := testpkg.TenantContext(1)
+	today := timezone.TodayDate()
+
+	// assertAgrees compares both implementations for one staff member and
+	// reports the group sets on failure.
+	assertAgrees := func(t *testing.T, accountID int64, staffID int64, what string) {
+		t.Helper()
+
+		groups, err := service.GetMyGroups(contextWithClaims(int(accountID)))
+		require.NoError(t, err)
+
+		viaClaims := make(map[int64]struct{}, len(groups))
+		for _, group := range groups {
+			viaClaims[group.ID] = struct{}{}
+		}
+
+		pairs, err := groupRepo.ListSupervisedGroupIDsByStaff(tenantCtx, []int64{staffID}, today)
+		require.NoError(t, err)
+
+		viaBulk := make(map[int64]struct{}, len(pairs))
+		for _, pair := range pairs {
+			if pair.StaffID == staffID {
+				viaBulk[pair.GroupID] = struct{}{}
+			}
+		}
+
+		assert.Equal(t, viaClaims, viaBulk,
+			"%s: the bulk read filter must resolve exactly the groups GetMyGroups resolves", what)
+	}
+
+	t.Run("teacher with assigned groups", func(t *testing.T) {
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "EquivAssigned", "Teacher")
+		groupOne := testpkg.CreateTestEducationGroup(t, db, "EquivAssignedOne")
+		groupTwo := testpkg.CreateTestEducationGroup(t, db, "EquivAssignedTwo")
+		linkOne := testpkg.CreateTestGroupTeacher(t, db, groupOne.ID, teacher.ID)
+		linkTwo := testpkg.CreateTestGroupTeacher(t, db, groupTwo.ID, teacher.ID)
+
+		defer testpkg.CleanupActivityFixtures(t, db, linkOne.ID, linkTwo.ID, groupOne.ID, groupTwo.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, teacher.StaffID, "teacher with two groups")
+	})
+
+	t.Run("staff member without a teacher record", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "EquivPlain", "Staff")
+
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, staff.ID, "staff without teacher record")
+	})
+
+	t.Run("active substitute", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "EquivActiveSub", "Staff")
+		group := testpkg.CreateTestEducationGroup(t, db, "EquivActiveSubGroup")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, staff.ID,
+			today.AddDays(-1), today.AddDays(3))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, staff.ID, "active substitute")
+	})
+
+	t.Run("expired substitute", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "EquivExpiredSub", "Staff")
+		group := testpkg.CreateTestEducationGroup(t, db, "EquivExpiredSubGroup")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, staff.ID,
+			today.AddDays(-10), today.AddDays(-2))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, staff.ID, "expired substitute")
+	})
+
+	t.Run("substitution starting and ending today", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "EquivOneDaySub", "Staff")
+		group := testpkg.CreateTestEducationGroup(t, db, "EquivOneDaySubGroup")
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, staff.ID, today, today)
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, group.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, staff.ID, "one-day substitution")
+	})
+
+	t.Run("teacher who is also an active substitute elsewhere", func(t *testing.T) {
+		// The union case: both branches contribute, and the bulk reader must
+		// neither drop nor duplicate either source.
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "EquivBoth", "Teacher")
+		ownGroup := testpkg.CreateTestEducationGroup(t, db, "EquivBothOwn")
+		coveredGroup := testpkg.CreateTestEducationGroup(t, db, "EquivBothCovered")
+		link := testpkg.CreateTestGroupTeacher(t, db, ownGroup.ID, teacher.ID)
+		sub := testpkg.CreateTestGroupSubstitution(t, db, coveredGroup.ID, nil, teacher.StaffID,
+			today.AddDays(-1), today.AddDays(1))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, link.ID, ownGroup.ID, coveredGroup.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, teacher.StaffID, "teacher and substitute at once")
+	})
+
+	t.Run("teacher substituting in a group they already teach", func(t *testing.T) {
+		// Both branches yield the same group. GetMyGroups dedupes through a map;
+		// the bulk reader must not report the pair twice.
+		teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "EquivOverlap", "Teacher")
+		group := testpkg.CreateTestEducationGroup(t, db, "EquivOverlapGroup")
+		link := testpkg.CreateTestGroupTeacher(t, db, group.ID, teacher.ID)
+		sub := testpkg.CreateTestGroupSubstitution(t, db, group.ID, nil, teacher.StaffID,
+			today.AddDays(-1), today.AddDays(1))
+
+		defer testpkg.CleanupActivityFixtures(t, db, sub.ID, link.ID, group.ID)
+		defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+		defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		assertAgrees(t, account.ID, teacher.StaffID, "overlapping sources")
+
+		pairs, err := groupRepo.ListSupervisedGroupIDsByStaff(tenantCtx,
+			[]int64{teacher.StaffID}, today)
+		require.NoError(t, err)
+
+		matches := 0
+		for _, pair := range pairs {
+			if pair.StaffID == teacher.StaffID && pair.GroupID == group.ID {
+				matches++
+			}
+		}
+		assert.Equal(t, 1, matches, "an overlapping group must be reported exactly once")
+	})
+}

--- a/backend/test/broadcaster.go
+++ b/backend/test/broadcaster.go
@@ -8,10 +8,11 @@ import (
 
 // BroadcastCall records one realtime.Broadcaster invocation.
 type BroadcastCall struct {
-	Method     string // "group", "tenant", "admin", "all", "parent" or "guardian"
+	Method     string // "group", "tenant", "admin", "all", "parent", "guardian" or "staff"
 	TenantID   int64
-	Topic      string // active-group topic (BroadcastToGroup only)
-	GuardianID int64  // guardian account ID (BroadcastParentMessage / BroadcastToGuardian)
+	Topic      string  // active-group topic (BroadcastToGroup only)
+	GuardianID int64   // guardian account ID (BroadcastParentMessage / BroadcastToGuardian)
+	AccountIDs []int64 // staff account IDs (BroadcastToStaffAccounts only)
 	Event      realtime.Event
 }
 
@@ -46,6 +47,11 @@ func (b *RecordingBroadcaster) BroadcastToGroup(tenantID int64, topic string, ev
 // BroadcastToTenant implements realtime.Broadcaster.
 func (b *RecordingBroadcaster) BroadcastToTenant(tenantID int64, event realtime.Event) error {
 	return b.record(BroadcastCall{Method: "tenant", TenantID: tenantID, Event: event})
+}
+
+// BroadcastToStaffAccounts implements realtime.Broadcaster.
+func (b *RecordingBroadcaster) BroadcastToStaffAccounts(tenantID int64, accountIDs []int64, event realtime.Event) error {
+	return b.record(BroadcastCall{Method: "staff", TenantID: tenantID, AccountIDs: accountIDs, Event: event})
 }
 
 // BroadcastToTenantAdmins implements realtime.Broadcaster.

--- a/backend/test/repo_mocks.go
+++ b/backend/test/repo_mocks.go
@@ -164,6 +164,7 @@ type StaffRepoMock struct {
 	GetStaffContactInfoFn           func(ctx context.Context, staffID int64) (*users.StaffWithRoleInfo, error)
 	FindReachableCalendarStaffIDsFn func(ctx context.Context, ids []int64) (map[int64]bool, error)
 	ListAccountIDsByStaffIDsFn      func(ctx context.Context, staffIDs []int64) (map[int64]int64, error)
+	ListAllStaffAccountIDsFn        func(ctx context.Context) (map[int64]int64, error)
 }
 
 var _ users.StaffRepository = (*StaffRepoMock)(nil)
@@ -262,6 +263,13 @@ func (m *StaffRepoMock) GetStaffContactInfo(ctx context.Context, staffID int64) 
 func (m *StaffRepoMock) ListAccountIDsByStaffIDs(ctx context.Context, staffIDs []int64) (map[int64]int64, error) {
 	if m.ListAccountIDsByStaffIDsFn != nil {
 		return m.ListAccountIDsByStaffIDsFn(ctx, staffIDs)
+	}
+	return map[int64]int64{}, nil
+}
+
+func (m *StaffRepoMock) ListAllStaffAccountIDs(ctx context.Context) (map[int64]int64, error) {
+	if m.ListAllStaffAccountIDsFn != nil {
+		return m.ListAllStaffAccountIDsFn(ctx)
 	}
 	return map[int64]int64{}, nil
 }

--- a/backend/test/repo_mocks.go
+++ b/backend/test/repo_mocks.go
@@ -163,6 +163,7 @@ type StaffRepoMock struct {
 	ListStaffWithPermissionFn       func(ctx context.Context, permissionName string) ([]*users.StaffWithRoleInfo, error)
 	GetStaffContactInfoFn           func(ctx context.Context, staffID int64) (*users.StaffWithRoleInfo, error)
 	FindReachableCalendarStaffIDsFn func(ctx context.Context, ids []int64) (map[int64]bool, error)
+	ListAccountIDsByStaffIDsFn      func(ctx context.Context, staffIDs []int64) (map[int64]int64, error)
 }
 
 var _ users.StaffRepository = (*StaffRepoMock)(nil)
@@ -256,6 +257,13 @@ func (m *StaffRepoMock) GetStaffContactInfo(ctx context.Context, staffID int64) 
 		return m.GetStaffContactInfoFn(ctx, staffID)
 	}
 	return nil, nil
+}
+
+func (m *StaffRepoMock) ListAccountIDsByStaffIDs(ctx context.Context, staffIDs []int64) (map[int64]int64, error) {
+	if m.ListAccountIDsByStaffIDsFn != nil {
+		return m.ListAccountIDsByStaffIDsFn(ctx, staffIDs)
+	}
+	return map[int64]int64{}, nil
 }
 
 func (m *StaffRepoMock) ListStaffWithPermission(ctx context.Context, permissionName string) ([]*users.StaffWithRoleInfo, error) {

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -207,9 +207,8 @@ closed/locked devices.
    Nobody opted in → the tick ends **before** any reminder is computed, which
    is the normal case and keeps the per-minute cost at six cheap queries.
 3. **On duty** — with `notifications.on_duty_only` (default on) only people
-   with an open work session today remain. An empty presence map means the
-   school does not clock in at all and lifts the restriction, matching the
-   setting's own description.
+   with an open work session today remain. An empty presence map reaches
+   nobody; schools without time tracking must switch this setting off.
 4. **Compute** — one `reminders.ComputeBatch` for all recipients: the
    tenant-wide reads happen once, only the per-person slice is derived in
    memory (see the package comment in `services/reminders/batch.go`).

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -21,7 +21,7 @@ they are checked in this order:
 | 2 | Delivery window `notifications.active_window_start`/`_end` (`test` events exempt) | `router.withinActiveWindow` |
 | 3 | The type's school-wide gate, if it has one (`TypeDefinition.TenantGate`) | `PreferenceService.FilterOptedIn` |
 | 4 | The recipient's own consent for that type | `PreferenceService.FilterOptedIn` |
-| 5 | `notifications.on_duty_only`, for personal staff reminders | the reminder tick |
+| 5 | `notifications.on_duty_only`, for personal staff notifications | the reminder tick / absence producer |
 
 Gate 1 defaults to **on** since the personal-notification epic. That is only
 safe because gates 3–5 exist: every producer routes through consent, consent
@@ -233,8 +233,10 @@ do not know each other.
 `NotifyAbsenceReported` turns a recorded sick note or excuse for **today** into
 a `student_absence_reported` notification for the supervising staff of the
 child's group plus the office (effective admins), minus the person who entered
-it. Gated additionally by `notifications.absence_reported_enabled`. Wired into
-the parent write path and all three staff-side entry points
+it. Gated additionally by `notifications.absence_reported_enabled` and
+`notifications.on_duty_only`; with the latter enabled, only accounts mapped to
+staff who are currently checked in remain. Wired into the parent write path and
+all three staff-side entry points
 (`student_status_day_write.go`, `api/students/status_history.go`,
 `excused_request_service.go`). Every call runs after the absence transaction
 commits; the producer opens a fresh tenant transaction for its RLS-scoped

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,16 +1,35 @@
 # Notification Abstraction (#1624)
 
 A single technical interface through which features trigger user-facing
-notifications without knowing the delivery channels. This is deliberately an
-abstraction, not a user feature: it is the foundation the "Erinnerungen" page
-(#669) and later bell/push features build on.
+notifications without knowing the delivery channels.
 
-## Feature flag
+It started as an abstraction with no user-visible surface (#1624). With the
+personal-notification epic it also became a feature: people choose in their own
+profile what they want to hear about, and notifications are addressed to
+individuals rather than broadcast to a school. Two things follow from that and
+run through this whole document — **no consent, no delivery**, and **the
+payload never carries a child's name**.
 
-Everything is gated by the tenant setting `notifications.dispatch_enabled`
-(boolean, **default off**, tab "Betrieb", permission `config:update`). While
-off, `Notify` returns `notifications.ErrDisabled` and no channel delivers
-anything.
+## Gates
+
+Five gates stand between a producer and a phone. All of them must pass, and
+they are checked in this order:
+
+| # | Gate | Where |
+|---|---|---|
+| 1 | `notifications.dispatch_enabled` (tenant setting, **default on**) | `router.Notify` / `NotifyBatch` |
+| 2 | Delivery window `notifications.active_window_start`/`_end` (`test` events exempt) | `router.withinActiveWindow` |
+| 3 | The type's school-wide gate, if it has one (`TypeDefinition.TenantGate`) | `PreferenceService.FilterOptedIn` |
+| 4 | The recipient's own consent for that type | `PreferenceService.FilterOptedIn` |
+| 5 | `notifications.on_duty_only`, for personal staff reminders | the reminder tick |
+
+Gate 1 defaults to **on** since the personal-notification epic. That is only
+safe because gates 3–5 exist: every producer routes through consent, consent
+starts empty, and an enabled school therefore still delivers nothing until
+somebody asks for something in their profile. Off now only means that a
+person's own choice is silently ignored. While off, `Notify` returns
+`notifications.ErrDisabled`; outside the window, `ErrOutsideActiveWindow`.
+Producers treat both as a silent no-op.
 
 ## Triggering a notification (backend)
 
@@ -42,8 +61,16 @@ Audience scopes map to the existing SSE routing:
 |---|---|
 | `ScopeTenant` | every connected staff client of the tenant |
 | `ScopeAdmin` | connected staff clients with effective admin scope in the tenant |
-| `ScopeGuardian` | one guardian account's own clients (`GuardianAccountID` required) |
+| `ScopeGuardian` | guardian accounts' own clients (`GuardianAccountID` or `GuardianAccountIDs`) |
 | `ScopeGroup` | clients subscribed to one active group (`ActiveGroupID` required) |
+| `ScopeStaff` | named staff accounts' own clients and devices (`StaffAccountIDs`) |
+
+`ScopeStaff` is the scope of personal notifications: each recipient gets their
+own event, so the payload can differ per person. `NotifyBatch(ctx, events)`
+dispatches many such events of one tenant in one after-commit hook — it
+resolves the feature flag and the window once, and hands the whole batch to
+channels that implement `BatchChannel` (Web Push does; it resolves every
+recipient's devices in ONE tenant transaction).
 
 ## GDPR contract
 
@@ -60,6 +87,51 @@ Display safety does not replace recipient authorization. Producers must choose
 an audience that matches the visibility of the data used to build the event.
 For example, an aggregate derived from an admin-wide view must use
 `ScopeAdmin`, not `ScopeTenant`.
+
+## Consent (per account, per type)
+
+Nothing is delivered to a person who did not ask for it. The rule is
+mechanical: **no row means off**.
+
+- **Catalogue** — `services/notifications/types.go`. One `TypeDefinition` per
+  notification a person can agree to: key, German label and description (the
+  profile page renders them verbatim), display group, portal (`staff` /
+  `parent`), and the optional `TenantGate` setting a school can use to switch
+  the type off for everybody. Registered from `init()` like the settings
+  registry, panicking on a duplicate key. Adding a type costs no migration.
+- **Storage** — `users.notification_preferences` (migration 1.15.239):
+  `UNIQUE (tenant_id, account_id, notification_type)`, RLS-isolated, partial
+  index on `(tenant_id, notification_type) WHERE enabled` because the producers'
+  hot question is "who in this school agreed to X". A row with
+  `enabled = false` is deliberately different from no row: it records a decision
+  a later change of defaults must not overwrite. `notification_type` carries no
+  CHECK constraint — an unknown type is inert, nothing reads it.
+- **Service** — `services/notifications/preferences.go`. `GetForAccount` /
+  `SetForAccount` for the staff portal; `GetForParent` / `SetForParent` act
+  across every active school of a guardian at once (the parents app has no
+  tenant context of its own). A type the school currently blocks can still be
+  switched on: the gate is applied at delivery time, so an admin toggling the
+  school setting off and on again does not erase anybody's choice.
+- **Enforcement** — `FilterOptedIn(ctx, type, accountIDs)` is the single point
+  where consent is applied, and it also checks the type's `TenantGate`. The
+  order matters: **a producer builds its candidate set from the relation
+  (whose group, whose team, whose child) and then narrows it with
+  `FilterOptedIn`** — never the other way round. An unknown type fails closed
+  and reaches nobody.
+- **Endpoints** — staff: `GET /api/notifications/preferences`,
+  `PUT /api/notifications/preferences/{type}`,
+  `DELETE /api/notifications/preferences` (switch everything off). Parents:
+  the same shapes under `/parent/me/notification-preferences`. The UI is
+  `components/settings/notification-preferences-section.tsx`, rendered on the
+  staff profile page and in the parents dashboard above the per-device push
+  card — this one answers "what do I want to hear about", the other "on which
+  device".
+- **Backfill** — migration 1.15.240 gives every account with an existing push
+  registration the consent that device already acted on: `parent_announcement`
+  for guardian devices, the four reminder types for staff devices. Without it,
+  flipping `dispatch_enabled` on by default would have silenced every
+  registered phone in the same minute. It is `ON CONFLICT DO NOTHING` (never
+  overwrite a decision) and its `down` is a deliberate no-op.
 
 ## Channels
 
@@ -121,25 +193,78 @@ closed/locked devices.
 - Unlike all other SSE events, `notification` events are rendered directly,
   not used as refetch triggers.
 
-## First consumer: reminder notifications
+## Producers
 
-The scheduler task `reminder-notifications`
-(`services/scheduler/reminder_notifications.go`) is the first real producer.
-Every minute, per tenant, it computes the #1457 reminder list (pickups,
-activity starts, overdue variants) and dispatches ONE aggregated event
-(`Type: "reminders_due"`) for occurrences that newly became due — priority
-`high` when something is overdue, deep link `/reminders`. Double gate:
-`notifications.dispatch_enabled` AND at least one `reminders.*` type enabled.
-The notification carries counts only, never student names (GDPR); a once-per-
-day in-memory guard (rotated at midnight, refires once after a restart)
-prevents repeats. The producer only builds an Event and calls `Notify` — new
-channels apply to it automatically.
+### Personal reminders (scheduler task `reminder-notifications`)
+
+`services/scheduler/reminder_notifications.go`. Every minute, per tenant:
+
+1. **Candidates** — `StaffRepository.ListAllStaffAccountIDs`: every staff
+   member of the school with an active account and an active tenant mapping.
+2. **Consent** — `FilterOptedIn` per type (`pickup_upcoming`,
+   `pickup_overdue`, `activity_start`, `activity_overdue`,
+   `my_activity_starting`), which also applies each type's `reminders.*` gate.
+   Nobody opted in → the tick ends **before** any reminder is computed, which
+   is the normal case and keeps the per-minute cost at six cheap queries.
+3. **On duty** — with `notifications.on_duty_only` (default on) only people
+   with an open work session today remain. An empty presence map means the
+   school does not clock in at all and lifts the restriction, matching the
+   setting's own description.
+4. **Compute** — one `reminders.ComputeBatch` for all recipients: the
+   tenant-wide reads happen once, only the per-person slice is derived in
+   memory (see the package comment in `services/reminders/batch.go`).
+5. **Dispatch** — one event per person and type, aggregated by count, through
+   a single `NotifyBatch`. An activity the person is personally planned on is
+   reported as `my_activity_starting` (the batch reports the assignment in
+   `Result.AssignedActivityInstanceIDs`), everything else in a supervised room
+   as `activity_start`; the two switches therefore never overlap and the same
+   activity never arrives twice.
+
+Copy is count-only ("2 Kinder aus Ihrer Aufsicht werden bald abgeholt"), never
+a name — the reminder rows behind it carry names, the notification must not.
+Deep link `/reminders`, priority `high` for the two overdue types. A re-fire
+guard keyed by `(tenant, account, reminder identity)` and rotated at midnight
+prevents repeats; a failed dispatch leaves the occurrence eligible for the next
+tick. The producer lives in the scheduler because it needs both
+`services/reminders` and `services/notifications`, and those two deliberately
+do not know each other.
+
+### Absences (`services/notifications/absence_producer.go`)
+
+`NotifyAbsenceReported` turns a recorded sick note or excuse for **today** into
+a `student_absence_reported` notification for the supervising staff of the
+child's group plus the office (effective admins), minus the person who entered
+it. Gated additionally by `notifications.absence_reported_enabled`. Wired into
+the parent write path; the three staff-side entry points
+(`student_status_day_write.go`, `api/students/status_history.go`,
+`excused_request_service.go`) still need the same injection — the producer is
+finished and tested, only the call sites are missing.
+
+### Parent announcements (`services/announcement/service.go`)
+
+A published announcement notifies its guardian audience as
+`parent_announcement`, narrowed by consent. A nil preference service keeps the
+pre-consent behaviour (it is always wired in the factory); a wired one has the
+final say.
 
 ## Verifying a tenant's setup
 
 `POST /api/notifications/test` (tenant JWT, `config:update`) dispatches a
 fixed display-safe test event to the whole tenant. Returns `409` while the
 feature flag is off. The frontend proxies it at `/api/notifications/test`.
+
+## Adding a new notification type
+
+1. Add the key and a `RegisterType(TypeDefinition{...})` call in
+   `services/notifications/types.go` — German label and description (the
+   profile page renders them as they are), a group from the existing set, the
+   portal, and a `TenantGate` only if a school should be able to switch the
+   type off for everybody. No migration.
+2. Build the candidate set in the producer from the relation the notification
+   is about, then narrow it with `FilterOptedIn(ctx, yourType, candidates)`.
+3. Write display-safe copy: counts and roles, never names.
+4. Nothing on the frontend: the preference card is generated from the
+   catalogue.
 
 ## Adding a new channel
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -24,12 +24,31 @@ they are checked in this order:
 | 5 | `notifications.on_duty_only`, for personal staff notifications | the reminder tick / absence producer |
 
 Gate 1 defaults to **on** since the personal-notification epic. That is only
-safe because gates 3–5 exist: every producer routes through consent, consent
-starts empty, and an enabled school therefore still delivers nothing until
-somebody asks for something in their profile. Off now only means that a
-person's own choice is silently ignored. While off, `Notify` returns
-`notifications.ErrDisabled`; outside the window, `ErrOutsideActiveWindow`.
-Producers treat both as a silent no-op.
+safe because gates 3–5 exist: every producer routes through consent, and an
+enabled school therefore still delivers nothing until somebody asks for
+something in their profile. Off now only means that a person's own choice is
+silently ignored. While off, `Notify` returns `notifications.ErrDisabled`;
+outside the window, `ErrOutsideActiveWindow`. Producers treat both as a silent
+no-op.
+
+Consent starts empty for everybody except the accounts migration 1.15.240
+backfills. That backfill is deliberately narrow: it only writes rows for
+schools that had already switched `dispatch_enabled` on themselves, and only
+for accounts still active in that school. At those schools the registered
+device really was receiving these notifications, so the row records a consent
+that already existed in practice rather than inventing one. Everywhere else the
+switch starts off.
+
+### E-mail is not routed through these gates
+
+Gates 1 and 2 govern push and in-app hints: they exist so a phone does not ring
+at night, and an e-mail does not ring. Announcement e-mails therefore leave
+regardless of the dispatch switch and the delivery window, and they apply the
+opposite consent rule, `FilterNotOptedOut` instead of `FilterOptedIn`. Only an
+explicit "no" removes a recipient; a family that never touched the switch keeps
+receiving the mail it received before consent existed. Tying e-mail to
+`FilterOptedIn` would have made the reach of a backfill decide whether a
+long-standing channel works at all.
 
 ## Triggering a notification (backend)
 
@@ -126,12 +145,18 @@ mechanical: **no row means off**.
   staff profile page and in the parents dashboard above the per-device push
   card — this one answers "what do I want to hear about", the other "on which
   device".
-- **Backfill** — migration 1.15.240 gives every account with an existing push
+- **Backfill** — migration 1.15.240 gives an account with an existing push
   registration the consent that device already acted on: `parent_announcement`
   for guardian devices, the four reminder types for staff devices. Without it,
-  flipping `dispatch_enabled` on by default would have silenced every
-  registered phone in the same minute. It is `ON CONFLICT DO NOTHING` (never
-  overwrite a decision) and its `down` is a deliberate no-op.
+  flipping `dispatch_enabled` on by default would have silenced every phone
+  that is receiving notifications today, in the same minute. Two conditions
+  keep it from inventing consent instead of recording it: the school must have
+  switched `dispatch_enabled` on itself (an explicit override row), because a
+  school that never did delivered nothing and therefore has no prior consent to
+  record; and the account must still be active in that school. It is
+  `ON CONFLICT DO NOTHING` (never overwrite a decision) and its `down` is a
+  deliberate no-op, which is exactly why both conditions matter: a wrong row
+  written here stays forever.
 
 ## Channels
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -235,10 +235,11 @@ do not know each other.
 a `student_absence_reported` notification for the supervising staff of the
 child's group plus the office (effective admins), minus the person who entered
 it. Gated additionally by `notifications.absence_reported_enabled`. Wired into
-the parent write path; the three staff-side entry points
+the parent write path and all three staff-side entry points
 (`student_status_day_write.go`, `api/students/status_history.go`,
-`excused_request_service.go`) still need the same injection — the producer is
-finished and tested, only the call sites are missing.
+`excused_request_service.go`). Every call runs after the absence transaction
+commits; the producer opens a fresh tenant transaction for its RLS-scoped
+recipient and consent reads.
 
 ### Parent announcements (`services/announcement/service.go`)
 

--- a/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
@@ -146,6 +146,10 @@ vi.mock("lucide-react", () => ({
   BellRing: (props: Record<string, unknown>) => (
     <svg data-testid="bell-ring-icon" {...props} />
   ),
+  // Used by the NotificationPreferencesSection next to it.
+  Bell: (props: Record<string, unknown>) => (
+    <svg data-testid="bell-icon" {...props} />
+  ),
 }));
 
 // Mock Next.js Image component

--- a/frontend/src/app/[tenant]/(protected)/profile/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.tsx
@@ -18,6 +18,7 @@ import { PasswordChangeModal } from "~/components/ui/password-change-modal";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { TrustedDevicesSection } from "~/components/settings/trusted-devices-section";
 import { PasskeySettingsSection } from "~/components/settings/passkey-settings-section";
+import { NotificationPreferencesSection } from "~/components/settings/notification-preferences-section";
 import { PushNotificationSection } from "~/components/settings/push-notification-section";
 import { getInitials } from "~/lib/format-utils";
 
@@ -272,6 +273,8 @@ function ProfileContent() {
 
         {/* Trusted Devices Section — personal device management.
             Mirrors the Operator profile page (app/operator/settings/page.tsx). */}
+        {/* "Was" before "wo": pick the topics first, then the device. */}
+        <NotificationPreferencesSection />
         <PushNotificationSection />
         <PasskeySettingsSection />
         <TrustedDevicesSection />

--- a/frontend/src/app/api/notifications/preferences/[type]/route.ts
+++ b/frontend/src/app/api/notifications/preferences/[type]/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+
+import { apiPut } from "~/lib/api-helpers.server";
+import { createPutHandler } from "~/lib/route-wrapper.server";
+
+/** Bounds the path segment before it reaches the backend. */
+const VALID_TYPE_PATTERN = /^[a-z0-9_]{1,64}$/;
+
+/**
+ * PUT /api/notifications/preferences/{type} — record one decision.
+ */
+export const PUT = createPutHandler(
+  async (
+    _request: NextRequest,
+    body: unknown,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const type = params.type as string;
+    if (!VALID_TYPE_PATTERN.test(type)) {
+      throw new Error("API error (400): Invalid notification type format");
+    }
+    return apiPut(`/api/notifications/preferences/${type}`, token, body);
+  },
+);

--- a/frontend/src/app/api/notifications/preferences/route.test.ts
+++ b/frontend/src/app/api/notifications/preferences/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockApiDelete, mockProxyGet } = vi.hoisted(() => ({
+  mockApiDelete: vi.fn(),
+  mockProxyGet: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("~/lib/api-helpers.server", () => ({
+  apiDelete: mockApiDelete,
+}));
+vi.mock("~/lib/route-proxy.server", () => ({
+  proxyGet: mockProxyGet,
+}));
+vi.mock("~/lib/route-wrapper.server", () => ({
+  createDeleteHandler: (handler: Function) => handler,
+}));
+
+const { DELETE } = await import("./route");
+
+describe("/api/notifications/preferences proxy", () => {
+  it("uses the backend collection route with its required trailing slash", async () => {
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      "/api/notifications/preferences/",
+    );
+
+    await (DELETE as Function)({}, "test-token");
+
+    expect(mockApiDelete).toHaveBeenCalledWith(
+      "/api/notifications/preferences/",
+      "test-token",
+    );
+  });
+});

--- a/frontend/src/app/api/notifications/preferences/route.ts
+++ b/frontend/src/app/api/notifications/preferences/route.ts
@@ -1,0 +1,32 @@
+import { apiDelete } from "~/lib/api-helpers.server";
+import { proxyGet } from "~/lib/route-proxy.server";
+import { createDeleteHandler } from "~/lib/route-wrapper.server";
+
+interface NotificationPreferencesResponse {
+  tenant_enabled: boolean;
+  types: {
+    key: string;
+    label: string;
+    description: string;
+    group: string;
+    enabled: boolean;
+    available: boolean;
+  }[];
+}
+
+/**
+ * GET /api/notifications/preferences — which notifications the logged-in user
+ * agreed to, plus the school-wide state of each type.
+ */
+export const GET = proxyGet<NotificationPreferencesResponse>(
+  "/api/notifications/preferences",
+);
+
+/**
+ * DELETE /api/notifications/preferences — switch every type off at once
+ * ("Alle deaktivieren").
+ */
+export const DELETE = createDeleteHandler<null>(async (_request, token) => {
+  await apiDelete("/api/notifications/preferences", token);
+  return null;
+});

--- a/frontend/src/app/api/notifications/preferences/route.ts
+++ b/frontend/src/app/api/notifications/preferences/route.ts
@@ -19,7 +19,7 @@ interface NotificationPreferencesResponse {
  * agreed to, plus the school-wide state of each type.
  */
 export const GET = proxyGet<NotificationPreferencesResponse>(
-  "/api/notifications/preferences",
+  "/api/notifications/preferences/",
 );
 
 /**
@@ -27,6 +27,6 @@ export const GET = proxyGet<NotificationPreferencesResponse>(
  * ("Alle deaktivieren").
  */
 export const DELETE = createDeleteHandler<null>(async (_request, token) => {
-  await apiDelete("/api/notifications/preferences", token);
+  await apiDelete("/api/notifications/preferences/", token);
   return null;
 });

--- a/frontend/src/app/api/parent/me/notification-preferences/[type]/route.ts
+++ b/frontend/src/app/api/parent/me/notification-preferences/[type]/route.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from "next/server";
+
+import {
+  createParentPutHandler,
+  parentApiPut,
+} from "~/lib/parent/route-wrapper.server";
+
+/** Bounds the path segment before it reaches the backend. */
+const VALID_TYPE_PATTERN = /^[a-z0-9_]{1,64}$/;
+
+/**
+ * PUT /api/parent/me/notification-preferences/{type} — record one decision,
+ * applied to every school the family belongs to.
+ */
+export const PUT = createParentPutHandler(
+  async (
+    _request: NextRequest,
+    body: unknown,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const type = params.type as string;
+    if (!VALID_TYPE_PATTERN.test(type)) {
+      throw new Error("API error (400): Invalid notification type format");
+    }
+    return parentApiPut(
+      `/parent/me/notification-preferences/${type}`,
+      token,
+      body,
+    );
+  },
+);

--- a/frontend/src/app/api/parent/me/notification-preferences/route.test.ts
+++ b/frontend/src/app/api/parent/me/notification-preferences/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockParentApiDelete, mockProxyGet } = vi.hoisted(() => ({
+  mockParentApiDelete: vi.fn(),
+  mockProxyGet: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("~/lib/parent/route-wrapper.server", () => ({
+  createParentDeleteHandler: (handler: Function) => handler,
+  parentApiDelete: mockParentApiDelete,
+  proxyGet: mockProxyGet,
+}));
+
+const { DELETE } = await import("./route");
+
+describe("/api/parent/me/notification-preferences proxy", () => {
+  it("uses the backend collection route with its required trailing slash", async () => {
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      "/parent/me/notification-preferences/",
+    );
+
+    await (DELETE as Function)({}, "test-token");
+
+    expect(mockParentApiDelete).toHaveBeenCalledWith(
+      "/parent/me/notification-preferences/",
+      "test-token",
+    );
+  });
+});

--- a/frontend/src/app/api/parent/me/notification-preferences/route.ts
+++ b/frontend/src/app/api/parent/me/notification-preferences/route.ts
@@ -21,7 +21,7 @@ interface NotificationPreferencesResponse {
  * guardian agreed to, merged across every school the family belongs to.
  */
 export const GET = proxyGet<NotificationPreferencesResponse>(
-  "/parent/me/notification-preferences",
+  "/parent/me/notification-preferences/",
 );
 
 /**
@@ -29,7 +29,7 @@ export const GET = proxyGet<NotificationPreferencesResponse>(
  */
 export const DELETE = createParentDeleteHandler<null>(
   async (_request, token) => {
-    await parentApiDelete<null>("/parent/me/notification-preferences", token);
+    await parentApiDelete<null>("/parent/me/notification-preferences/", token);
     return null;
   },
 );

--- a/frontend/src/app/api/parent/me/notification-preferences/route.ts
+++ b/frontend/src/app/api/parent/me/notification-preferences/route.ts
@@ -1,0 +1,35 @@
+import {
+  createParentDeleteHandler,
+  parentApiDelete,
+  proxyGet,
+} from "~/lib/parent/route-wrapper.server";
+
+interface NotificationPreferencesResponse {
+  tenant_enabled: boolean;
+  types: {
+    key: string;
+    label: string;
+    description: string;
+    group: string;
+    enabled: boolean;
+    available: boolean;
+  }[];
+}
+
+/**
+ * GET /api/parent/me/notification-preferences — which notifications this
+ * guardian agreed to, merged across every school the family belongs to.
+ */
+export const GET = proxyGet<NotificationPreferencesResponse>(
+  "/parent/me/notification-preferences",
+);
+
+/**
+ * DELETE /api/parent/me/notification-preferences — switch every type off.
+ */
+export const DELETE = createParentDeleteHandler<null>(
+  async (_request, token) => {
+    await parentApiDelete<null>("/parent/me/notification-preferences", token);
+    return null;
+  },
+);

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1685,7 +1685,7 @@ export const appChapters: readonly GuideChapter[] = [
           "`Einstellungen` -> `Betrieb` öffnen und zur Sektion `Benachrichtigungen` scrollen.",
           "`Benachrichtigungen aktivieren` ist im Auslieferungszustand an. Ausgeschaltet bleibt die ganze Schule still, unabhängig davon, was einzelne Personen in ihrem Profil ausgewählt haben.",
           "`Benachrichtigungen ab` und `bis` begrenzen den Versand auf die Betreuungszeiten (Standard 06:00 bis 18:00). Außerhalb bleibt es still bis zum nächsten Morgen.",
-          "`Nur im Dienst benachrichtigen` beschränkt persönliche Hinweise auf Personen, die gerade eingestempelt sind. Ohne Zeiterfassung greift die Einschränkung nicht.",
+          "`Nur im Dienst benachrichtigen` beschränkt persönliche Hinweise auf Personen, die gerade eingestempelt sind. Solange noch niemand eingestempelt ist, bleibt es still. Schulen ohne Zeiterfassung schalten diese Einstellung aus.",
           "`Krankmeldungen melden` erlaubt Hinweise an die Gruppe und die Leitung, wenn für ein Kind eine Krankmeldung oder Entschuldigung eingetragen wird. Diese Einstellung ist Admins vorbehalten.",
         ],
         callout: {

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  Bell,
   BellRing,
   Building2,
   CalendarDays,
@@ -1587,16 +1588,38 @@ export const appChapters: readonly GuideChapter[] = [
           "Teilen-Menü in Safari mit dem Eintrag Zum Home-Bildschirm.",
       },
       {
+        id: "benachrichtigungen-auswaehlen",
+        title: "Auswählen, worüber moto informiert",
+        icon: Bell,
+        printCompact: true,
+        summary:
+          "Jede Person entscheidet selbst, worüber sie Bescheid bekommt. Ohne diese Auswahl wird nichts verschickt, auch nicht als Push. Die Auswahl gilt für alle Geräte.",
+        steps: [
+          "Im eigenen Profil den Abschnitt `Benachrichtigungen` öffnen.",
+          "Die gewünschten Arten einschalten. Sie sind nach Themen sortiert: `Abholungen` (anstehend, überfällig), `Aktivitäten` (Aktivität im eigenen Aufsichtsraum, nicht gestartete Aktivität, eigener Einsatz aus dem Betreuungsplan) und `Kinder` (Krankmeldung eines Kindes aus den eigenen Gruppen).",
+          "Jeder Schalter speichert sofort. `Alle deaktivieren` oben rechts schaltet alles auf einmal ab.",
+          "Steht unter einer Art `Von Ihrer Schule derzeit deaktiviert`, bleibt sie still. Der eigene Schalter darf trotzdem an bleiben und greift wieder, sobald die Schule die Art einschaltet.",
+        ],
+        callout: {
+          title: "Erst auswählen, dann Gerät freischalten",
+          body: "Diese Auswahl beantwortet `worüber`, der nächste Schritt `auf welchem Gerät`. Ohne Push-Freigabe erscheinen die Hinweise weiterhin in der geöffneten App; ohne Auswahl hier kommt auf keinem Weg etwas an.",
+          tone: "blue",
+        },
+        screenshot:
+          "Profilseite mit dem Abschnitt Benachrichtigungen: Schalter je Art, gruppiert nach Abholungen, Aktivitäten und Kinder, mit der Schaltfläche Alle deaktivieren.",
+      },
+      {
         id: "push-benachrichtigungen-aktivieren",
         title: "Push-Benachrichtigungen aktivieren",
         icon: BellRing,
         printCompact: true,
         summary:
-          "Erinnerungen (z. B. anstehende Abholungen) kommen auf Wunsch als Systembenachrichtigung an, auch wenn die App geschlossen ist. Aktiviert wird das pro Gerät im eigenen Profil.",
+          "Damit die ausgewählten Hinweise auch bei geschlossener App ankommen, wird jedes Gerät einmal freigeschaltet. Die Freigabe gilt nur für dieses eine Gerät.",
         steps: [
-          "Im eigenen Profil den Abschnitt `Push-Benachrichtigungen` öffnen.",
+          "Zuerst im Profil unter `Benachrichtigungen` auswählen, worüber informiert werden soll (siehe Schritt davor).",
+          "Im selben Profil den Abschnitt `Push-Benachrichtigungen` öffnen.",
           "`Aktivieren` antippen und die Browser-Nachfrage mit `Erlauben` bestätigen.",
-          "Fertig: Neue Erinnerungen erscheinen jetzt als Benachrichtigung auf diesem Gerät.",
+          "Fertig: Die ausgewählten Hinweise erscheinen jetzt als Benachrichtigung auf diesem Gerät.",
         ],
         callout: {
           title: "iPhone/iPad: erst installieren",
@@ -1651,6 +1674,27 @@ export const appChapters: readonly GuideChapter[] = [
         screenshot:
           "Sektion Indikatoren im Reiter Betrieb mit eingeschalteten Aktivitäts-Indikatoren und den Begriffen Mensa und Hausaufgaben.",
         image: "/help/screens/einstellungen.webp",
+      },
+      {
+        id: "einstellungen-benachrichtigungen",
+        title: "Benachrichtigungen der Schule steuern",
+        icon: Bell,
+        summary:
+          "Die Schule legt den Rahmen fest: ob überhaupt benachrichtigt wird, in welchem Zeitfenster und ob Krankmeldungen an die Gruppe gehen dürfen. Was eine einzelne Person davon bekommt, wählt sie weiterhin selbst im eigenen Profil.",
+        steps: [
+          "`Einstellungen` -> `Betrieb` öffnen und zur Sektion `Benachrichtigungen` scrollen.",
+          "`Benachrichtigungen aktivieren` ist im Auslieferungszustand an. Ausgeschaltet bleibt die ganze Schule still, unabhängig davon, was einzelne Personen in ihrem Profil ausgewählt haben.",
+          "`Benachrichtigungen ab` und `bis` begrenzen den Versand auf die Betreuungszeiten (Standard 06:00 bis 18:00). Außerhalb bleibt es still bis zum nächsten Morgen.",
+          "`Nur im Dienst benachrichtigen` beschränkt persönliche Hinweise auf Personen, die gerade eingestempelt sind. Ohne Zeiterfassung greift die Einschränkung nicht.",
+          "`Krankmeldungen melden` erlaubt Hinweise an die Gruppe und die Leitung, wenn für ein Kind eine Krankmeldung oder Entschuldigung eingetragen wird. Diese Einstellung ist Admins vorbehalten.",
+        ],
+        callout: {
+          title: "Niemand wird ungefragt benachrichtigt",
+          body: "Diese Einstellungen erlauben etwas, sie verordnen nichts. Solange eine Person im eigenen Profil nichts eingeschaltet hat, bekommt sie auch nichts. Wer nach dem Einschalten nichts erhält, prüft also zuerst das eigene Profil.",
+          tone: "blue",
+        },
+        screenshot:
+          "Sektion Benachrichtigungen im Reiter Betrieb mit dem Hauptschalter, dem Zeitfenster von und bis, Nur im Dienst benachrichtigen und Krankmeldungen melden.",
       },
       {
         id: "einstellungen-zustaendigkeit",

--- a/frontend/src/components/parent/parent-dashboard.tsx
+++ b/frontend/src/components/parent/parent-dashboard.tsx
@@ -18,6 +18,7 @@ import {
   NewsCard,
   NewsDetailModal,
 } from "~/components/parent/news/news-components";
+import { NotificationPreferencesSection } from "~/components/settings/notification-preferences-section";
 import { PushNotificationSection } from "~/components/settings/push-notification-section";
 import { createLogger } from "~/lib/logger";
 import { formatLocalizedDate } from "~/lib/localized-date-format";
@@ -229,6 +230,7 @@ export function ParentDashboard() {
 
       <StartNewsPanel />
 
+      <NotificationPreferencesSection portal="parent" />
       <PushNotificationSection portal="parent" />
     </div>
   );

--- a/frontend/src/components/settings/notification-preferences-section.stories.tsx
+++ b/frontend/src/components/settings/notification-preferences-section.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { NotificationPreferencesSection } from "./notification-preferences-section";
+
+const meta = {
+  title: "components/settings/NotificationPreferencesSection",
+  component: NotificationPreferencesSection,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Per-account notification consent. Sits above the per-device push card: this one answers what to hear about, the other on which device.",
+      },
+    },
+  },
+} satisfies Meta<typeof NotificationPreferencesSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Staff: Story = {
+  args: { portal: "tenant" },
+};
+
+export const Parent: Story = {
+  args: { portal: "parent" },
+};

--- a/frontend/src/components/settings/notification-preferences-section.test.tsx
+++ b/frontend/src/components/settings/notification-preferences-section.test.tsx
@@ -83,6 +83,26 @@ describe("NotificationPreferencesSection", () => {
     ).toHaveAttribute("aria-checked", "false");
   });
 
+  it("disables switches only while a preference save is in flight", async () => {
+    let finishSave: (() => void) | undefined;
+    api.setNotificationPreference.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSave = resolve;
+        }),
+    );
+    render(<NotificationPreferencesSection />);
+
+    const preferenceSwitch = await screen.findByRole("switch", {
+      name: "Anstehende Abholung",
+    });
+    fireEvent.click(preferenceSwitch);
+
+    await waitFor(() => expect(preferenceSwitch).toBeDisabled());
+    finishSave?.();
+    await waitFor(() => expect(preferenceSwitch).not.toBeDisabled());
+  });
+
   it("explains a type the school currently blocks but keeps it choosable", async () => {
     api.fetchNotificationPreferences.mockResolvedValue(
       preferences({ available: false }),
@@ -99,7 +119,7 @@ describe("NotificationPreferencesSection", () => {
     ).not.toBeDisabled();
   });
 
-  it("disables every switch when the school switched the feature off", async () => {
+  it("keeps preferences editable when the school switched delivery off", async () => {
     api.fetchNotificationPreferences.mockResolvedValue({
       ...preferences(),
       tenant_enabled: false,
@@ -109,9 +129,19 @@ describe("NotificationPreferencesSection", () => {
     expect(
       await screen.findByText(/Ihre Schule hat Benachrichtigungen derzeit/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("switch", { name: "Anstehende Abholung" }),
-    ).toBeDisabled();
+    const preferenceSwitch = screen.getByRole("switch", {
+      name: "Anstehende Abholung",
+    });
+    expect(preferenceSwitch).not.toBeDisabled();
+
+    fireEvent.click(preferenceSwitch);
+    await waitFor(() =>
+      expect(api.setNotificationPreference).toHaveBeenCalledWith(
+        "pickup_upcoming",
+        true,
+        "tenant",
+      ),
+    );
   });
 
   it("offers to switch everything off only when something is on", async () => {

--- a/frontend/src/components/settings/notification-preferences-section.test.tsx
+++ b/frontend/src/components/settings/notification-preferences-section.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationPreferencesSection } from "./notification-preferences-section";
+
+const api = vi.hoisted(() => ({
+  fetchNotificationPreferences: vi.fn(),
+  setNotificationPreference: vi.fn(),
+  disableAllNotificationPreferences: vi.fn(),
+}));
+
+vi.mock("~/lib/notification-preferences-api", () => api);
+
+function preferences(overrides?: { enabled?: boolean; available?: boolean }) {
+  return {
+    tenant_enabled: true,
+    types: [
+      {
+        key: "pickup_upcoming",
+        label: "Anstehende Abholung",
+        description: "Kurz bevor ein Kind abgeholt wird.",
+        group: "abholung",
+        enabled: overrides?.enabled ?? false,
+        available: overrides?.available ?? true,
+      },
+    ],
+  };
+}
+
+describe("NotificationPreferencesSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.fetchNotificationPreferences.mockResolvedValue(preferences());
+    api.setNotificationPreference.mockResolvedValue(undefined);
+    api.disableAllNotificationPreferences.mockResolvedValue(undefined);
+  });
+
+  it("renders the catalogue grouped under German headings", async () => {
+    render(<NotificationPreferencesSection />);
+
+    expect(await screen.findByText("Anstehende Abholung")).toBeInTheDocument();
+    expect(screen.getByText("Abholungen")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Anstehende Abholung" }),
+    ).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("saves a decision when a switch is flipped", async () => {
+    render(<NotificationPreferencesSection />);
+
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Anstehende Abholung" }),
+    );
+
+    await waitFor(() =>
+      expect(api.setNotificationPreference).toHaveBeenCalledWith(
+        "pickup_upcoming",
+        true,
+        "tenant",
+      ),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Anstehende Abholung" }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("rolls the switch back when saving fails", async () => {
+    api.setNotificationPreference.mockRejectedValue(new Error("boom"));
+    render(<NotificationPreferencesSection />);
+
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Anstehende Abholung" }),
+    );
+
+    // The optimistic flip must not survive a failed save: otherwise the card
+    // claims a consent the server never recorded.
+    expect(
+      await screen.findByText(
+        "Die Einstellung konnte nicht gespeichert werden.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Anstehende Abholung" }),
+    ).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("explains a type the school currently blocks but keeps it choosable", async () => {
+    api.fetchNotificationPreferences.mockResolvedValue(
+      preferences({ available: false }),
+    );
+    render(<NotificationPreferencesSection />);
+
+    expect(
+      await screen.findByText("Von Ihrer Schule derzeit deaktiviert."),
+    ).toBeInTheDocument();
+    // The choice belongs to the person and must survive the school toggling
+    // its own setting off and on again.
+    expect(
+      screen.getByRole("switch", { name: "Anstehende Abholung" }),
+    ).not.toBeDisabled();
+  });
+
+  it("disables every switch when the school switched the feature off", async () => {
+    api.fetchNotificationPreferences.mockResolvedValue({
+      ...preferences(),
+      tenant_enabled: false,
+    });
+    render(<NotificationPreferencesSection />);
+
+    expect(
+      await screen.findByText(/Ihre Schule hat Benachrichtigungen derzeit/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Anstehende Abholung" }),
+    ).toBeDisabled();
+  });
+
+  it("offers to switch everything off only when something is on", async () => {
+    api.fetchNotificationPreferences.mockResolvedValue(
+      preferences({ enabled: true }),
+    );
+    render(<NotificationPreferencesSection />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Alle deaktivieren" }),
+    );
+
+    await waitFor(() =>
+      expect(api.disableAllNotificationPreferences).toHaveBeenCalledWith(
+        "tenant",
+      ),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Alle deaktivieren" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the parent portal when asked to", async () => {
+    render(<NotificationPreferencesSection portal="parent" />);
+
+    await waitFor(() =>
+      expect(api.fetchNotificationPreferences).toHaveBeenCalledWith("parent"),
+    );
+  });
+});

--- a/frontend/src/components/settings/notification-preferences-section.tsx
+++ b/frontend/src/components/settings/notification-preferences-section.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Bell } from "lucide-react";
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { Skeleton } from "~/components/ui/skeleton";
+import { BooleanField } from "~/components/settings/fields/boolean-field";
+import { createLogger } from "~/lib/logger";
+import {
+  disableAllNotificationPreferences,
+  fetchNotificationPreferences,
+  setNotificationPreference,
+  type NotificationPreferenceType,
+  type PreferencePortal,
+} from "~/lib/notification-preferences-api";
+
+const logger = createLogger({ component: "NotificationPreferencesSection" });
+
+/** German headings for the registry groups, in display order. */
+const GROUP_LABELS: Record<string, string> = {
+  abholung: "Abholungen",
+  aktivitaeten: "Aktivitäten",
+  kinder: "Kinder",
+  mitteilungen: "Mitteilungen",
+};
+
+const GROUP_ORDER = ["abholung", "aktivitaeten", "kinder", "mitteilungen"];
+
+interface NotificationPreferencesSectionProps {
+  readonly portal?: PreferencePortal;
+}
+
+/**
+ * Per-account notification consent. Sits above the per-device push card: this
+ * one answers "what do I want to hear about", the other "on which device".
+ *
+ * Nothing is delivered without an explicit switch here, so every type starts
+ * off.
+ */
+export function NotificationPreferencesSection({
+  portal = "tenant",
+}: NotificationPreferencesSectionProps) {
+  const [types, setTypes] = useState<NotificationPreferenceType[]>([]);
+  const [tenantEnabled, setTenantEnabled] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchNotificationPreferences(portal);
+      setTypes(data.types);
+      setTenantEnabled(data.tenant_enabled);
+      setError(null);
+    } catch (err) {
+      logger.error("notification_preferences_load_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError("Die Einstellungen konnten nicht geladen werden.");
+    } finally {
+      setLoading(false);
+    }
+  }, [portal]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = async (type: NotificationPreferenceType, enabled: boolean) => {
+    // Optimistic: the switch answers immediately and rolls back on failure.
+    setTypes((current) =>
+      current.map((t) => (t.key === type.key ? { ...t, enabled } : t)),
+    );
+    setError(null);
+    try {
+      await setNotificationPreference(type.key, enabled, portal);
+    } catch (err) {
+      logger.error("notification_preference_save_failed", {
+        type: type.key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setTypes((current) =>
+        current.map((t) =>
+          t.key === type.key ? { ...t, enabled: !enabled } : t,
+        ),
+      );
+      setError("Die Einstellung konnte nicht gespeichert werden.");
+    }
+  };
+
+  const disableAll = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await disableAllNotificationPreferences(portal);
+      setTypes((current) => current.map((t) => ({ ...t, enabled: false })));
+    } catch (err) {
+      logger.error("notification_preferences_disable_all_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError("Die Einstellungen konnten nicht geändert werden.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const anyEnabled = types.some((t) => t.enabled);
+  const groups = GROUP_ORDER.map((group) => ({
+    group,
+    label: GROUP_LABELS[group] ?? group,
+    items: types.filter((t) => t.group === group),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 backdrop-blur-sm md:p-6">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5 text-gray-800" aria-hidden="true" />
+          <h3 className="text-base font-semibold text-gray-900">
+            Benachrichtigungen
+          </h3>
+        </div>
+        {anyEnabled && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => void disableAll()}
+          >
+            Alle deaktivieren
+          </Button>
+        )}
+      </div>
+
+      <p className="mb-4 text-sm text-gray-600">
+        Wählen Sie, worüber moto Sie informieren soll. Es wird nur verschickt,
+        was Sie hier einschalten.
+      </p>
+
+      {error && (
+        <div className="mb-3">
+          <Alert type="error" message={error} />
+        </div>
+      )}
+
+      {!loading && !tenantEnabled && (
+        <div className="mb-3">
+          <Alert
+            type="info"
+            message="Ihre Schule hat Benachrichtigungen derzeit deaktiviert. Ihre Auswahl wird gespeichert und gilt, sobald die Schule sie wieder einschaltet."
+          />
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {groups.map(({ group, label, items }) => (
+            <div key={group}>
+              <h4 className="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase">
+                {label}
+              </h4>
+              <div className="divide-y divide-gray-100">
+                {items.map((type) => (
+                  <div
+                    key={type.key}
+                    className="flex items-start justify-between gap-4 py-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900">
+                        {type.label}
+                      </p>
+                      <p className="text-sm text-gray-600">
+                        {type.description}
+                      </p>
+                      {!type.available && (
+                        // The switch stays usable on purpose: the choice
+                        // belongs to the person and must survive the school
+                        // toggling its own setting off and on again.
+                        <p className="mt-1 text-xs text-gray-500">
+                          Von Ihrer Schule derzeit deaktiviert.
+                        </p>
+                      )}
+                    </div>
+                    <BooleanField
+                      value={type.enabled}
+                      onChange={(next) => void toggle(type, next)}
+                      disabled={!tenantEnabled}
+                      ariaLabel={type.label}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/notification-preferences-section.tsx
+++ b/frontend/src/components/settings/notification-preferences-section.tsx
@@ -69,6 +69,7 @@ export function NotificationPreferencesSection({
 
   const toggle = async (type: NotificationPreferenceType, enabled: boolean) => {
     // Optimistic: the switch answers immediately and rolls back on failure.
+    setBusy(true);
     setTypes((current) =>
       current.map((t) => (t.key === type.key ? { ...t, enabled } : t)),
     );
@@ -86,6 +87,8 @@ export function NotificationPreferencesSection({
         ),
       );
       setError("Die Einstellung konnte nicht gespeichert werden.");
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -192,7 +195,7 @@ export function NotificationPreferencesSection({
                     <BooleanField
                       value={type.enabled}
                       onChange={(next) => void toggle(type, next)}
-                      disabled={!tenantEnabled}
+                      disabled={busy}
                       ariaLabel={type.label}
                     />
                   </div>

--- a/frontend/src/lib/notification-preferences-api.test.ts
+++ b/frontend/src/lib/notification-preferences-api.test.ts
@@ -71,12 +71,23 @@ describe("notification preferences API client", () => {
     expect(result.types).toHaveLength(1);
   });
 
-  it("falls back to an empty, disabled state on a bodyless answer", async () => {
+  it("rejects a successful response without a preference payload", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({}));
 
-    const result = await fetchNotificationPreferences();
+    await expect(fetchNotificationPreferences()).rejects.toThrow();
+  });
 
-    expect(result).toEqual({ tenant_enabled: false, types: [] });
+  it("rejects malformed preference rows", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: {
+          tenant_enabled: true,
+          types: [{ key: "pickup_upcoming", enabled: "yes" }],
+        },
+      }),
+    );
+
+    await expect(fetchNotificationPreferences()).rejects.toThrow();
   });
 
   it("sends one decision as a PUT on the encoded type", async () => {

--- a/frontend/src/lib/notification-preferences-api.test.ts
+++ b/frontend/src/lib/notification-preferences-api.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  disableAllNotificationPreferences,
+  fetchNotificationPreferences,
+  setNotificationPreference,
+} from "./notification-preferences-api";
+
+/**
+ * The two portals speak to different paths and wrap their payloads
+ * differently. Both details are invisible in the card and would fail silently:
+ * a wrong path 404s into a generic error, and a missed envelope renders an
+ * empty list that looks exactly like "no notification types exist".
+ */
+describe("notification preferences API client", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: () => Promise.resolve(JSON.stringify(body)),
+    };
+  }
+
+  const payload = {
+    tenant_enabled: true,
+    types: [
+      {
+        key: "pickup_upcoming",
+        label: "Anstehende Abholung",
+        description: "…",
+        group: "abholung",
+        enabled: true,
+        available: true,
+      },
+    ],
+  };
+
+  it("reads the staff catalogue from the tenant path", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: payload }));
+
+    const result = await fetchNotificationPreferences();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/notifications/preferences",
+      expect.objectContaining({ credentials: "include" }),
+    );
+    expect(result.tenant_enabled).toBe(true);
+    expect(result.types).toHaveLength(1);
+    expect(result.types[0]?.key).toBe("pickup_upcoming");
+  });
+
+  it("accepts an unwrapped payload from the parent path", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(payload));
+
+    const result = await fetchNotificationPreferences("parent");
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/parent/me/notification-preferences",
+    );
+    expect(result.types).toHaveLength(1);
+  });
+
+  it("falls back to an empty, disabled state on a bodyless answer", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+
+    const result = await fetchNotificationPreferences();
+
+    expect(result).toEqual({ tenant_enabled: false, types: [] });
+  });
+
+  it("sends one decision as a PUT on the encoded type", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 204 });
+
+    await setNotificationPreference("pickup_upcoming", true);
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("/api/notifications/preferences/pickup_upcoming");
+    expect(init).toMatchObject({
+      method: "PUT",
+      body: JSON.stringify({ enabled: true }),
+    });
+  });
+
+  it("routes a parent decision to the parent path", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 204 });
+
+    await setNotificationPreference("parent_announcement", false, "parent");
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/parent/me/notification-preferences/parent_announcement",
+    );
+  });
+
+  it("switches everything off with a DELETE", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 204 });
+
+    await disableAllNotificationPreferences("parent");
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("/api/parent/me/notification-preferences");
+    expect(init).toMatchObject({ method: "DELETE" });
+  });
+
+  it("surfaces the backend's message on failure", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "unknown notification type" }, 400),
+    );
+
+    await expect(setNotificationPreference("nope", true)).rejects.toThrow(
+      "unknown notification type",
+    );
+  });
+
+  it("falls back to a German message when the error carries no body", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve(""),
+    });
+
+    await expect(fetchNotificationPreferences()).rejects.toThrow(
+      /Einstellung konnte nicht geladen werden \(500\)/,
+    );
+  });
+});

--- a/frontend/src/lib/notification-preferences-api.ts
+++ b/frontend/src/lib/notification-preferences-api.ts
@@ -6,6 +6,8 @@
  * The two cards sit next to each other, so they behave the same way.
  */
 
+import { z } from "zod";
+
 export type PreferencePortal = "tenant" | "parent";
 
 export interface NotificationPreferenceType {
@@ -23,6 +25,23 @@ export interface NotificationPreferences {
   tenant_enabled: boolean;
   types: NotificationPreferenceType[];
 }
+
+const notificationPreferencesSchema = z.object({
+  tenant_enabled: z.boolean(),
+  types: z.array(
+    z.object({
+      key: z.string(),
+      label: z.string(),
+      description: z.string(),
+      group: z.string(),
+      enabled: z.boolean(),
+      available: z.boolean(),
+    }),
+  ),
+});
+const notificationPreferencesEnvelopeSchema = z.object({
+  data: notificationPreferencesSchema,
+});
 
 class PreferencesApiError extends Error {
   constructor(
@@ -72,17 +91,13 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
 export async function fetchNotificationPreferences(
   portal: PreferencePortal = "tenant",
 ): Promise<NotificationPreferences> {
-  const response = await requestJson<
-    { data?: NotificationPreferences } & Partial<NotificationPreferences>
-  >(basePath(portal));
+  const response = await requestJson<unknown>(basePath(portal));
 
   // The tenant proxy unwraps the envelope, the parent proxy may not — accept
   // either shape rather than depending on which layer stripped it.
-  const payload = response.data ?? (response as NotificationPreferences);
-  return {
-    tenant_enabled: payload.tenant_enabled ?? false,
-    types: payload.types ?? [],
-  };
+  const direct = notificationPreferencesSchema.safeParse(response);
+  if (direct.success) return direct.data;
+  return notificationPreferencesEnvelopeSchema.parse(response).data;
 }
 
 export async function setNotificationPreference(

--- a/frontend/src/lib/notification-preferences-api.ts
+++ b/frontend/src/lib/notification-preferences-api.ts
@@ -1,0 +1,105 @@
+/**
+ * Client for the per-account notification consent API.
+ *
+ * Mirrors push-api.ts: it throws on failure and the card renders an Alert,
+ * rather than the settings-page convention of returning a German error string.
+ * The two cards sit next to each other, so they behave the same way.
+ */
+
+export type PreferencePortal = "tenant" | "parent";
+
+export interface NotificationPreferenceType {
+  key: string;
+  label: string;
+  description: string;
+  group: string;
+  enabled: boolean;
+  /** False when the school currently blocks this type for everyone. */
+  available: boolean;
+}
+
+export interface NotificationPreferences {
+  /** Mirrors the school-wide switch. False means nothing is delivered at all. */
+  tenant_enabled: boolean;
+  types: NotificationPreferenceType[];
+}
+
+export const NOTIFICATION_PREFERENCES_SWR_KEY = "notification-preferences";
+
+class PreferencesApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PreferencesApiError";
+  }
+}
+
+function basePath(portal: PreferencePortal): string {
+  return portal === "parent"
+    ? "/api/parent/me/notification-preferences"
+    : "/api/notifications/preferences";
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    credentials: "include",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+  if (response.status === 204) return undefined as T;
+
+  const text = await response.text();
+  let data: unknown = null;
+  try {
+    data = text ? (JSON.parse(text) as unknown) : null;
+  } catch {
+    data = null;
+  }
+
+  if (!response.ok) {
+    const message =
+      data && typeof data === "object" && "error" in data
+        ? String((data as { error: unknown }).error)
+        : `Einstellung konnte nicht geladen werden (${response.status}).`;
+    throw new PreferencesApiError(response.status, message);
+  }
+  return data as T;
+}
+
+export async function fetchNotificationPreferences(
+  portal: PreferencePortal = "tenant",
+): Promise<NotificationPreferences> {
+  const response = await requestJson<
+    { data?: NotificationPreferences } & Partial<NotificationPreferences>
+  >(basePath(portal));
+
+  // The tenant proxy unwraps the envelope, the parent proxy may not — accept
+  // either shape rather than depending on which layer stripped it.
+  const payload = response.data ?? (response as NotificationPreferences);
+  return {
+    tenant_enabled: payload.tenant_enabled ?? false,
+    types: payload.types ?? [],
+  };
+}
+
+export async function setNotificationPreference(
+  type: string,
+  enabled: boolean,
+  portal: PreferencePortal = "tenant",
+): Promise<void> {
+  await requestJson<void>(`${basePath(portal)}/${encodeURIComponent(type)}`, {
+    method: "PUT",
+    body: JSON.stringify({ enabled }),
+  });
+}
+
+export async function disableAllNotificationPreferences(
+  portal: PreferencePortal = "tenant",
+): Promise<void> {
+  await requestJson<void>(basePath(portal), { method: "DELETE" });
+}

--- a/frontend/src/lib/notification-preferences-api.ts
+++ b/frontend/src/lib/notification-preferences-api.ts
@@ -24,8 +24,6 @@ export interface NotificationPreferences {
   types: NotificationPreferenceType[];
 }
 
-export const NOTIFICATION_PREFERENCES_SWR_KEY = "notification-preferences";
-
 class PreferencesApiError extends Error {
   constructor(
     public status: number,

--- a/frontend/src/lib/parent/route-wrapper.server.ts
+++ b/frontend/src/lib/parent/route-wrapper.server.ts
@@ -106,7 +106,9 @@ export function parentApiDelete<T>(
   return parentServerFetch<T>(endpoint, token, { method: "DELETE" });
 }
 
-function parentApiPut<T, B = unknown>(
+// Exported for parent routes with a dynamic path segment, which the static
+// proxy factories below cannot express.
+export function parentApiPut<T, B = unknown>(
   endpoint: string,
   token: string,
   body?: B,
@@ -220,7 +222,7 @@ export function createParentDeleteHandler<T>(handler: NoBodyHandler<T>) {
   return createParentNoBodyHandler(handler, jsonResponse);
 }
 
-function createParentPutHandler<T, B = unknown>(
+export function createParentPutHandler<T, B = unknown>(
   handler: WithBodyHandler<T, B>,
 ) {
   return createParentWithBodyHandler(handler);


### PR DESCRIPTION
Persönliche Benachrichtigungen: statt einer Sammelmeldung an alle Admins bekommt jede Person genau das, was sie im eigenen Profil eingeschaltet hat. Der Branch baut die Kette von unten auf und schaltet sie im letzten Commit scharf.

Zwei Sätze, die durch alles hindurchgehen: **ohne Zustimmung keine Zustellung**, und **kein Kindername verlässt die App**. Titel und Text einer Benachrichtigung nennen nur Anzahl und Art; die Namen stehen hinter dem Deep-Link in der angemeldeten, berechtigungsgefilterten Ansicht.

## Commit für Commit

| Commit | Was darin passiert |
|---|---|
| `46b981f8` **Bulk-Reader** | Leser, die eine Frage für die ganze Schule in einer Abfrage beantworten statt pro Person: Räume je Aufsicht, offene Besuche je Raum, betreute Gruppen je Person, Personal je Gruppe, Konto je Person, effektive Admins, Push-Abos je Konto. Ohne sie skaliert nichts davon im Minutentakt. |
| `d9275bc1` **Geteilte Kerne + ComputeBatch** | `Compute` konnte aus einem Hintergrundjob gar nicht laufen (Lesefilter über JWT-Claims), und von ~28 Abfragen je Person waren nur drei wirklich personenabhängig. Die Regeln stehen jetzt in reinen Funktionen, die beide Einstiegspunkte teilen; `ComputeBatch` rechnet für viele Personen mit gleichbleibender Abfragezahl. Ein Äquivalenztest hält beide Wege deckungsgleich. |
| `39f924c9` **Zustimmung pro Konto und Typ** | Tabelle `users.notification_preferences` (Migration 1.15.239, RLS, keine Zeile = aus), Typregistry in Go (Schlüssel, deutsche Texte, Portal, optionales Schul-Tor), Service mit `FilterOptedIn` als einzigem Durchsetzungspunkt, vier Einstellungen, Endpunkte für beide Portale. |
| `30001180` **Zustellung an einzelne Personen** | `ScopeStaff` (jede Person bekommt ihre eigene Nutzlast), `NotifyBatch` (ein Feature-Flag-Lesen und eine Zustellrunde für den ganzen Mandanten), Zeitfenster im Router statt in jedem Producer, Konto-Index im SSE-Hub, Push-Finder für benannte Konten. |
| `3349539e` **Präferenzkarte** | Die Karte im Profil und im Eltern-Dashboard. Sie wird aus dem Katalog erzeugt, ein neuer Typ braucht also keine Frontend-Änderung. |
| `d0e7b717` **Krankmeldungs-Producer** | Producer für Krankmeldung/Entschuldigung an die betreuenden Personen der Gruppe plus die Leitung, Zustimmungsfilter für Elternmitteilungen, `instance_staff` im Batch-Scope. |
| `5509ae6f` **Tick + Standard an** (dieser PR) | Der Minuten-Tick liefert personenbezogen, `dispatch_enabled` steht standardmäßig auf an, Migration 1.15.240 trägt bestehenden Push-Geräten die passende Zustimmung nach, Hilfe-Guide und `docs/notifications.md` beschreiben den Stand. |
| `40cf9539` **Aufräumen** | Ungenutzter SWR-Key aus `39f924c9`, den knip beim Push angemahnt hat. |

### Was der letzte Commit am Tick ändert

Vorher: ein Ereignis `reminders_due` je Mandant an alle Admins, ohne Zustimmung, mit Zählern über die ganze Schule.

Nachher, je Mandant und Minute:

1. Kandidaten sind alle Mitarbeitenden mit aktivem Konto und aktivem Schul-Mapping.
2. `FilterOptedIn` je Typ verengt auf die, die zugestimmt haben, und zieht das Schul-Tor des Typs gleich mit. Hat niemand zugestimmt, endet der Tick **vor** jeder Erinnerungsberechnung.
3. `notifications.on_duty_only` lässt nur Eingestempelte übrig. Gibt es heute überhaupt keine Arbeitssitzung, stempelt die Schule nicht, und die Einschränkung greift nicht.
4. Ein `ComputeBatch` für alle Empfänger, dann ein Ereignis je Person und Art in einem `NotifyBatch`.

Eine Aktivität, auf die eine Person persönlich geplant ist, ist `Ihr nächster Einsatz` und nicht `Aktivität in Ihrem Raum` — auch dann, wenn sie den Raum beaufsichtigt. So bedeutet jeder Schalter genau das, was danebensteht, und dieselbe Aktivität kommt nie doppelt an.

## Wer bekommt was, und woran hängt es

| Benachrichtigung | Wer | Schul-Tor | Zusätzliche Bedingung | Auslöser |
|---|---|---|---|---|
| Anstehende Abholung | Personal | `Einstellungen → Erinnerungen → Anstehende Abholung` | Kind in der eigenen Aufsicht, Abholzeit innerhalb der Vorlaufzeit | Minuten-Tick |
| Überfällige Abholung | Personal | `… → Überfällige Abholung` | Kind nach seiner Abholzeit noch da | Minuten-Tick |
| Aktivität in Ihrem Raum | Personal | `… → Aktivitätsbeginn` | Aktivität startet in einem gerade beaufsichtigten Raum | Minuten-Tick |
| Aktivität nicht gestartet | Personal | `… → Überfällige Aktivität` | geplante Aktivität überfällig, niemand hat sie gestartet | Minuten-Tick |
| Ihr nächster Einsatz | Personal | keins | Einsatz aus dem Betreuungsplan beginnt gleich | Minuten-Tick |
| Krankmeldung eines Kindes | Personal der Gruppe + Leitung | `Einstellungen → Betrieb → Krankmeldungen melden` | Eintrag betrifft heute; wer ihn selbst eingetragen hat, bekommt nichts | Schreibpfad Krankmeldung |
| Neue Mitteilung der Schule | Eltern | keins | Mitteilung veröffentlicht, Konto gehört zur Zielgruppe | Elternmitteilung |

Über allem stehen zwei Tore, die für jede Zeile gelten: `Benachrichtigungen aktivieren` (Standard **an**) und das Zeitfenster `Benachrichtigungen ab/bis` (Standard 06:00–18:00). Für persönliche Erinnerungen kommt `Nur im Dienst benachrichtigen` (Standard an) dazu.

## Was zu tun ist

| Rolle | Automatisch erledigt | Selbst zu tun |
|---|---|---|
| **Schul-Admin** | `Benachrichtigungen aktivieren` steht ohne Zutun auf an. Zeitfenster, Dienstfilter und `Krankmeldungen melden` haben brauchbare Standardwerte. | **Erinnerungsarten einschalten** unter `Einstellungen → Erinnerungen` — die sind im Auslieferungszustand alle aus, und solange sie aus sind, erreichen Abhol- und Aktivitätshinweise niemanden, egal was einzelne Personen gewählt haben. Danach ggf. Zeitfenster und `Nur im Dienst benachrichtigen` anpassen. |
| **Mitarbeitende** | Wer vorher schon ein Gerät für Push registriert hatte, ist für die vier Erinnerungsarten bereits zugestimmt (Migration 1.15.240). | `Profil → Benachrichtigungen` öffnen und die gewünschten Arten einschalten. Ohne das kommt nichts an. Optional darunter `Push-Benachrichtigungen` für dieses Gerät freischalten (braucht VAPID-Schlüssel auf dem Server). |
| **Eltern** | Wer vorher schon Push im Eltern-Portal aktiviert hatte, ist für `Neue Mitteilung der Schule` bereits zugestimmt (Migration 1.15.240). | Auf der Startseite des Eltern-Portals unter `Benachrichtigungen` den Schalter setzen. Optional Push pro Gerät. |
| **Betrieb / Deployment** | Migrationen 1.15.239 und 1.15.240 laufen beim Deploy mit. Kein Env-Var, kein SOPS-Eintrag, keine Konfiguration nötig. | Nichts. Ohne VAPID-Schlüssel bleibt Web Push inert, In-App-Hinweise funktionieren trotzdem. |

Die Nachtrags-Migration existiert genau deshalb: Zustimmung wird Pflicht und der Schalter geht gleichzeitig standardmäßig an — ohne sie wären alle heute registrierten Telefone in derselben Minute verstummt. Sie schreibt `ON CONFLICT DO NOTHING`, überschreibt also nie ein ausdrückliches Nein, und trägt nur die Arten nach, die das jeweilige Gerät schon bekommen konnte. Die zwei Arten, die dieser Epic neu hinzufügt (`Ihr nächster Einsatz`, `Krankmeldung eines Kindes`), bleiben bewusst leer.

## Verifikation

Backend: Build, Vet, `golangci-lint` sauber, **gesamte Suite grün** (`go test ./...`), alle Ratchets grün, Migrationen auf Test- und Dev-Datenbank eingespielt.
Frontend: `pnpm run check` sauber, **912 Testdateien / 12456 Tests grün**, knip sauber.

Manuell im laufenden Stack mit drei Personas durchgespielt (Screenshots unten):

- **Admin** — Einstellungen zeigen den Hauptschalter ohne Override auf an, die abhängigen Felder sind sichtbar (was den aufgelösten Wert beweist).
- **Betreuerin** — Profilkarte zunächst mit `Von Ihrer Schule derzeit deaktiviert` bei allen vier Erinnerungsarten; nachdem der Admin sie eingeschaltet hat, verschwindet der Hinweis. Drei Arten eingeschaltet, nach Reload noch da, genau drei Zeilen in der Datenbank.
- **Eltern** — Karte im Dashboard, Schalter an/aus/an, jedes Mal korrekt in der Datenbank, Zeile trägt den richtigen Mandanten.
- **Zustellung** — Testbenachrichtigung des Admins erreicht die Betreuerin als Toast. Das beweist den umgestellten Standard von der Einstellung bis zum Bildschirm, denn vor diesem PR hätte derselbe Aufruf 409 geliefert.
- **Tick** — registriert sich beim Serverstart mit allen sechs Abhängigkeiten und läuft im Minutentakt ohne Warnung gegen die echte Datenbank.

Ehrlich dazugesagt: eine **echte Abhol-Erinnerung** habe ich nicht live ausgelöst. Dafür bräuchte es ein anwesendes Kind in einer laufenden Aufsicht mit Abholzeit in den nächsten Minuten; die Dev-Datenbank hat heute weder Anwesenheiten noch offene Besuche. Dieser Pfad ist über die Unit-Tests abgedeckt (Zustimmung verengt, Sperre pro Person, Dienstfilter, Typ-Zuordnung, Batch-Zustellung).

## Screenshots

Werden separat angehängt:

1. Admin: `Einstellungen → Betrieb → Benachrichtigungen`, Hauptschalter an mit Abzeichen `Standard`
2. Profil: Präferenzkarte, solange die Schule die Erinnerungsarten aus hat
3. Betreuerin: dieselbe Karte mit drei eingeschalteten Arten, Hinweis verschwunden
4. Eltern-Portal: Karte auf der Startseite
5. Toast der Testbenachrichtigung beim Personal
6. Hilfe-Guide: neuer Schritt `Auswählen, worüber moto informiert`
7. Hilfe-Guide: neuer Admin-Schritt `Benachrichtigungen der Schule steuern`

## Offen

Drei Einhängepunkte für Krankmeldungen fehlen noch: der geplante Status durch Personal (`student_status_day_write.go`), die manuelle Umschaltung in der Kinderakte (`api/students/status_history.go`) und die genehmigte Entschuldigung (`excused_request_service.go`). Verdrahtet ist der Eltern-Schreibpfad. Der Producer selbst ist fertig und getestet, es fehlt jeweils nur die Injektion. Steht so auch in `docs/notifications.md`.
