### PR TITLE
fix(dienstplan): Serie bearbeiten funktioniert am Segmentende wieder

### DIFF
--- a/backend/database/repositories/schedule/staff_shift_series_repo.go
+++ b/backend/database/repositories/schedule/staff_shift_series_repo.go
@@ -73,16 +73,17 @@ func (r *StaffShiftSeriesRepository) CapAllByStaffID(ctx context.Context, staffI
 	return rows, nil
 }
 
-// FindNextInLineage returns the next chronological segment in one split
-// lineage. Root rows store a NULL series_root_id, so resolve both roots and
-// successors through COALESCE.
-func (r *StaffShiftSeriesRepository) FindNextInLineage(ctx context.Context, rootID int64, after timezone.Date) (*schedule.StaffShiftSeries, error) {
+// FindOverlappingInLineage returns another chronological segment in one split
+// lineage that is active on or after from. Root rows store a NULL series_root_id,
+// so resolve both roots and successors through COALESCE.
+func (r *StaffShiftSeriesRepository) FindOverlappingInLineage(ctx context.Context, rootID, excludeID int64, from timezone.Date) (*schedule.StaffShiftSeries, error) {
 	series := new(schedule.StaffShiftSeries)
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(series).
 		ModelTableExpr(tableExprStaffShiftSeriesAsSeries).
 		Where(`COALESCE("staff_shift_series".series_root_id, "staff_shift_series".id) = ?`, rootID).
-		Where(`"staff_shift_series".valid_from > ?`, after).
+		Where(`"staff_shift_series".id != ?`, excludeID).
+		Where(`("staff_shift_series".valid_until IS NULL OR "staff_shift_series".valid_until > ?)`, from).
 		OrderExpr(`"staff_shift_series".valid_from ASC`).
 		Limit(1)
 
@@ -91,7 +92,7 @@ func (r *StaffShiftSeriesRepository) FindNextInLineage(ctx context.Context, root
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, &modelBase.DatabaseError{Op: "find next staff shift series in lineage", Err: err}
+		return nil, &modelBase.DatabaseError{Op: "find overlapping staff shift series in lineage", Err: err}
 	}
 	return series, nil
 }

--- a/backend/models/schedule/repository.go
+++ b/backend/models/schedule/repository.go
@@ -114,9 +114,10 @@ type StaffShiftSeriesRepository interface {
 	// exclusive date (staff offboarding).
 	CapAllByStaffID(ctx context.Context, staffID int64, until timezone.Date) (int64, error)
 
-	// FindNextInLineage returns the first segment of a split lineage that starts
-	// after the given date. A newly inserted predecessor must not extend into it.
-	FindNextInLineage(ctx context.Context, rootID int64, after timezone.Date) (*StaffShiftSeries, error)
+	// FindOverlappingInLineage returns another segment of a split lineage that
+	// is active on or after the given date. A superseded predecessor must not be
+	// reopened across it.
+	FindOverlappingInLineage(ctx context.Context, rootID, excludeID int64, from timezone.Date) (*StaffShiftSeries, error)
 }
 
 // StaffShiftSeriesExceptionRepository stores deliberately removed single

--- a/backend/services/schedule/staff_shift_series_mock_test.go
+++ b/backend/services/schedule/staff_shift_series_mock_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 type seriesMockRepo struct {
-	createFn        func(ctx context.Context, series *scheduleModels.StaffShiftSeries) error
-	findByIDFn      func(ctx context.Context, id any) (*scheduleModels.StaffShiftSeries, error)
-	capValidUntilFn func(ctx context.Context, id int64, until timezone.Date) error
-	findNextFn      func(ctx context.Context, rootID int64, after timezone.Date) (*scheduleModels.StaffShiftSeries, error)
+	createFn          func(ctx context.Context, series *scheduleModels.StaffShiftSeries) error
+	findByIDFn        func(ctx context.Context, id any) (*scheduleModels.StaffShiftSeries, error)
+	capValidUntilFn   func(ctx context.Context, id int64, until timezone.Date) error
+	findOverlappingFn func(ctx context.Context, rootID, excludeID int64, from timezone.Date) (*scheduleModels.StaffShiftSeries, error)
 }
 
 func (m *seriesMockRepo) Create(ctx context.Context, series *scheduleModels.StaffShiftSeries) error {
@@ -55,9 +55,9 @@ func (m *seriesMockRepo) CapAllByStaffID(context.Context, int64, timezone.Date) 
 	return 0, nil
 }
 
-func (m *seriesMockRepo) FindNextInLineage(ctx context.Context, rootID int64, after timezone.Date) (*scheduleModels.StaffShiftSeries, error) {
-	if m.findNextFn != nil {
-		return m.findNextFn(ctx, rootID, after)
+func (m *seriesMockRepo) FindOverlappingInLineage(ctx context.Context, rootID, excludeID int64, from timezone.Date) (*scheduleModels.StaffShiftSeries, error) {
+	if m.findOverlappingFn != nil {
+		return m.findOverlappingFn(ctx, rootID, excludeID, from)
 	}
 	return nil, nil
 }
@@ -386,7 +386,7 @@ func TestSplitSeriesUnit_ErrorBranches(t *testing.T) {
 		nextFrom := timezone.TodayDate().AddDays(8)
 		var created *scheduleModels.StaffShiftSeries
 		repo := found(t)
-		repo.findNextFn = func(context.Context, int64, timezone.Date) (*scheduleModels.StaffShiftSeries, error) {
+		repo.findOverlappingFn = func(context.Context, int64, int64, timezone.Date) (*scheduleModels.StaffShiftSeries, error) {
 			return &scheduleModels.StaffShiftSeries{ValidFrom: nextFrom}, nil
 		}
 		repo.createFn = func(_ context.Context, successor *scheduleModels.StaffShiftSeries) error {

--- a/backend/services/schedule/staff_shift_series_rule_edit_test.go
+++ b/backend/services/schedule/staff_shift_series_rule_edit_test.go
@@ -197,3 +197,79 @@ func TestStaffShiftSeries_SplitBoundsEarlierSegmentAtNextSuccessor(t *testing.T)
 	require.NotNil(t, result.Series.ValidUntil)
 	assert.Equal(t, downstreamFrom, *result.Series.ValidUntil)
 }
+
+// A series whose last planned day has arrived was permanently uneditable: the
+// effective date is clamped to tomorrow, and the segment check compared that
+// against the STORED end. Extending "Gültig bis" is the one edit that has to
+// work there, otherwise "Serie bearbeiten" cannot edit the series at all.
+func TestStaffShiftSeries_SplitExtendsSeriesEndingToday(t *testing.T) {
+	env := setupSeriesTest(t)
+	today := timezone.TodayDate()
+	periodEnd := today.AddDays(28)
+	periodID := env.createPeriod(t, today.AddDays(-7), periodEnd, 1, nil)
+
+	// valid_until is exclusive: the last day carrying a shift is today.
+	storedEnd := today.AddDays(1)
+	series := env.buildSeries(t, periodID, today.AddDays(-7), &storedEnd, scheduleModels.WeekPatternEvery)
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.CreateSeries(ctx, series)
+		return err
+	})
+
+	newEnd := today.AddDays(15)
+	var result *scheduleSvc.SeriesResult
+	env.inTx(t, func(ctx context.Context) error {
+		var err error
+		result, err = env.series.SplitSeries(ctx, scheduleSvc.SplitSeriesInput{
+			SeriesID: series.ID,
+			// The planner opened an occurrence in the past; the split clamps it
+			// to tomorrow rather than rejecting the edit.
+			EffectiveDate: today.AddDays(-3),
+			StartTime:     series.StartTime,
+			EndTime:       series.EndTime,
+			BreakMinutes:  series.BreakMinutes,
+			ValidUntil:    &newEnd,
+			ValidUntilSet: true,
+			ActorStaffID:  env.staff.ID,
+		})
+		return err
+	})
+
+	require.NotNil(t, result.Series)
+	assert.Equal(t, today.AddDays(1), result.Series.ValidFrom)
+	require.NotNil(t, result.Series.ValidUntil)
+	assert.Equal(t, newEnd, *result.Series.ValidUntil)
+	assert.NotEmpty(t, env.shiftsInRange(t, today.AddDays(1), today.AddDays(14)),
+		"the extended segment must materialize shifts")
+	assert.Empty(t, env.shiftsInRange(t, newEnd, periodEnd),
+		"nothing may be planned past the new end date")
+}
+
+// The same series without an extended end has no day left to change. That is
+// still a 400, but it must say so instead of passing for a generic input error.
+func TestStaffShiftSeries_SplitRejectsWhenNoOccurrenceRemains(t *testing.T) {
+	env := setupSeriesTest(t)
+	today := timezone.TodayDate()
+	periodID := env.createPeriod(t, today.AddDays(-7), today.AddDays(28), 1, nil)
+
+	storedEnd := today.AddDays(1)
+	series := env.buildSeries(t, periodID, today.AddDays(-7), &storedEnd, scheduleModels.WeekPatternEvery)
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.CreateSeries(ctx, series)
+		return err
+	})
+
+	err := env.inTxExpectErr(t, func(ctx context.Context) error {
+		_, err := env.series.SplitSeries(ctx, scheduleSvc.SplitSeriesInput{
+			SeriesID:      series.ID,
+			EffectiveDate: today.AddDays(-3),
+			StartTime:     seriesClock(t, "13:00"),
+			EndTime:       seriesClock(t, "15:00"),
+			BreakMinutes:  0,
+			ActorStaffID:  env.staff.ID,
+		})
+		return err
+	})
+	require.ErrorIs(t, err, scheduleSvc.ErrSeriesInvalid)
+	assert.Contains(t, err.Error(), "no occurrences left to change")
+}

--- a/backend/services/schedule/staff_shift_series_rule_edit_test.go
+++ b/backend/services/schedule/staff_shift_series_rule_edit_test.go
@@ -198,6 +198,46 @@ func TestStaffShiftSeries_SplitBoundsEarlierSegmentAtNextSuccessor(t *testing.T)
 	assert.Equal(t, downstreamFrom, *result.Series.ValidUntil)
 }
 
+func TestStaffShiftSeries_SplitRejectsSupersededSegment(t *testing.T) {
+	env := setupSeriesTest(t)
+	today := timezone.TodayDate()
+	periodEnd := today.AddDays(28)
+	periodID := env.createPeriod(t, today.AddDays(-7), periodEnd, 1, nil)
+	effective := today.AddDays(1)
+
+	oldEnd := effective
+	series := env.buildSeries(t, periodID, today.AddDays(-7), &oldEnd, scheduleModels.WeekPatternEvery)
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.CreateSeries(ctx, series)
+		return err
+	})
+
+	rootID := series.ID
+	successor := env.buildSeries(t, periodID, effective, nil, scheduleModels.WeekPatternEvery)
+	successor.SeriesRootID = &rootID
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.CreateSeries(ctx, successor)
+		return err
+	})
+
+	newEnd := today.AddDays(15)
+	err := env.inTxExpectErr(t, func(ctx context.Context) error {
+		_, err := env.series.SplitSeries(ctx, scheduleSvc.SplitSeriesInput{
+			SeriesID:      series.ID,
+			EffectiveDate: effective,
+			StartTime:     series.StartTime,
+			EndTime:       series.EndTime,
+			BreakMinutes:  series.BreakMinutes,
+			ValidUntil:    &newEnd,
+			ValidUntilSet: true,
+			ActorStaffID:  env.staff.ID,
+		})
+		return err
+	})
+	require.ErrorIs(t, err, scheduleSvc.ErrSeriesInvalid)
+	assert.Contains(t, err.Error(), "already been superseded")
+}
+
 // A series whose last planned day has arrived was permanently uneditable: the
 // effective date is clamped to tomorrow, and the segment check compared that
 // against the STORED end. Extending "Gültig bis" is the one edit that has to
@@ -272,4 +312,39 @@ func TestStaffShiftSeries_SplitRejectsWhenNoOccurrenceRemains(t *testing.T) {
 	})
 	require.ErrorIs(t, err, scheduleSvc.ErrSeriesInvalid)
 	assert.Contains(t, err.Error(), "no occurrences left to change")
+}
+
+func TestStaffShiftSeries_SplitRejectsExtensionWithoutRecurrenceOccurrence(t *testing.T) {
+	env := setupSeriesTest(t)
+	today := timezone.TodayDate()
+	periodID := env.createPeriod(t, today.AddDays(-7), today.AddDays(28), 1, nil)
+	effective := today.AddDays(1)
+	newEnd := effective.AddDays(2)
+
+	// The two included dates are effective and effective+1. Select the next
+	// weekday so an extension exists by date but cannot produce a shift.
+	weekday := int16((int(newEnd.Weekday())+6)%7 + 1)
+	storedEnd := effective
+	series := env.buildSeries(t, periodID, today.AddDays(-7), &storedEnd, scheduleModels.WeekPatternEvery)
+	series.Weekdays = []int16{weekday}
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.CreateSeries(ctx, series)
+		return err
+	})
+
+	err := env.inTxExpectErr(t, func(ctx context.Context) error {
+		_, err := env.series.SplitSeries(ctx, scheduleSvc.SplitSeriesInput{
+			SeriesID:      series.ID,
+			EffectiveDate: effective,
+			StartTime:     series.StartTime,
+			EndTime:       series.EndTime,
+			BreakMinutes:  series.BreakMinutes,
+			ValidUntil:    &newEnd,
+			ValidUntilSet: true,
+			ActorStaffID:  env.staff.ID,
+		})
+		return err
+	})
+	require.ErrorIs(t, err, scheduleSvc.ErrSeriesInvalid)
+	assert.Contains(t, err.Error(), "selected weekdays and week pattern")
 }

--- a/backend/services/schedule/staff_shift_series_rule_edit_test.go
+++ b/backend/services/schedule/staff_shift_series_rule_edit_test.go
@@ -198,6 +198,51 @@ func TestStaffShiftSeries_SplitBoundsEarlierSegmentAtNextSuccessor(t *testing.T)
 	assert.Equal(t, downstreamFrom, *result.Series.ValidUntil)
 }
 
+func TestStaffShiftSeries_SplitRejectsWhenNextSegmentLeavesNoOccurrence(t *testing.T) {
+	env := setupSeriesTest(t)
+	today := timezone.TodayDate()
+	periodEnd := today.AddDays(28)
+	periodID := env.createPeriod(t, today.AddDays(-1), periodEnd, 1, nil)
+	effective := today.AddDays(1)
+	nextFrom := effective.AddDays(1)
+	weekday := int16((int(nextFrom.Weekday())+6)%7 + 1)
+	series := env.buildSeries(t, periodID, today.AddDays(-1), nil, scheduleModels.WeekPatternEvery)
+	series.Weekdays = []int16{weekday}
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.CreateSeries(ctx, series)
+		return err
+	})
+
+	env.inTx(t, func(ctx context.Context) error {
+		_, err := env.series.SplitSeries(ctx, scheduleSvc.SplitSeriesInput{
+			SeriesID:      series.ID,
+			EffectiveDate: nextFrom,
+			StartTime:     series.StartTime,
+			EndTime:       series.EndTime,
+			BreakMinutes:  series.BreakMinutes,
+			ActorStaffID:  env.staff.ID,
+		})
+		return err
+	})
+
+	err := env.inTxExpectErr(t, func(ctx context.Context) error {
+		_, err := env.series.SplitSeries(ctx, scheduleSvc.SplitSeriesInput{
+			SeriesID:      series.ID,
+			EffectiveDate: effective,
+			StartTime:     series.StartTime,
+			EndTime:       series.EndTime,
+			BreakMinutes:  series.BreakMinutes,
+			ValidUntilSet: true,
+			ActorStaffID:  env.staff.ID,
+		})
+		return err
+	})
+	require.ErrorIs(t, err, scheduleSvc.ErrSeriesInvalid)
+	assert.Contains(t, err.Error(), "no occurrences left to change")
+	assert.NotEmpty(t, env.shiftsInRange(t, nextFrom, nextFrom),
+		"the rejected edit must leave the later segment's shift intact")
+}
+
 func TestStaffShiftSeries_SplitRejectsSupersededSegment(t *testing.T) {
 	env := setupSeriesTest(t)
 	today := timezone.TodayDate()

--- a/backend/services/schedule/staff_shift_series_service.go
+++ b/backend/services/schedule/staff_shift_series_service.go
@@ -277,6 +277,33 @@ func (s *staffShiftSeriesService) materializeSeries(ctx context.Context, series 
 	return len(candidates), skipped, nil
 }
 
+// hasFutureSeriesOccurrence checks the recurrence itself before a split mutates
+// the predecessor. Exceptions and overlapping shifts intentionally do not
+// count here: they are deviations of an otherwise valid recurring rule.
+func hasFutureSeriesOccurrence(series *scheduleModels.StaffShiftSeries, period *scheduleModels.CalendarPeriod) bool {
+	from := series.ValidFrom
+	if period.StartDate.After(from) {
+		from = period.StartDate
+	}
+	tomorrow := timezone.TodayDate().AddDays(1)
+	if tomorrow.After(from) {
+		from = tomorrow
+	}
+	to := period.EndDate
+	if series.ValidUntil != nil {
+		lastIncluded := series.ValidUntil.AddDays(-1)
+		if lastIncluded.Before(to) {
+			to = lastIncluded
+		}
+	}
+	for d := from; !d.After(to); d = d.AddDays(1) {
+		if series.ContainsWeekday(isoWeekday(d)) && ShouldMaterializeWeekPattern(series.WeekPattern, d, period) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *staffShiftSeriesService) CreateSeries(ctx context.Context, series *scheduleModels.StaffShiftSeries) (*SeriesResult, error) {
 	if err := series.Validate(); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrSeriesInvalid, err.Error())
@@ -426,16 +453,25 @@ func (s *staffShiftSeriesService) SplitSeries(ctx context.Context, input SplitSe
 	if err != nil {
 		return nil, err
 	}
+	if !hasFutureSeriesOccurrence(successor, period) {
+		return nil, fmt.Errorf(
+			"%w: no occurrences left to change for the selected weekdays and week pattern",
+			ErrSeriesInvalid,
+		)
+	}
 
 	if err := s.lockShiftWrites(ctx, old.StaffID); err != nil {
 		return nil, err
 	}
-	// A predecessor can be edited after a later segment already exists. Keep
-	// the new segment strictly before that successor even when the editor clears
-	// a stored valid_until, otherwise two rules of one lineage overlap.
-	next, err := s.seriesRepo.FindNextInLineage(ctx, rootID, effective)
+	// A predecessor can be edited before a later segment begins. Keep the new
+	// segment strictly before that successor, but never reopen a segment that a
+	// current successor has already superseded.
+	next, err := s.seriesRepo.FindOverlappingInLineage(ctx, rootID, old.ID, effective)
 	if err != nil {
 		return nil, err
+	}
+	if next != nil && !effective.Before(next.ValidFrom) {
+		return nil, fmt.Errorf("%w: series segment has already been superseded", ErrSeriesInvalid)
 	}
 	if next != nil && (successor.ValidUntil == nil || next.ValidFrom.Before(*successor.ValidUntil)) {
 		until := next.ValidFrom

--- a/backend/services/schedule/staff_shift_series_service.go
+++ b/backend/services/schedule/staff_shift_series_service.go
@@ -453,13 +453,6 @@ func (s *staffShiftSeriesService) SplitSeries(ctx context.Context, input SplitSe
 	if err != nil {
 		return nil, err
 	}
-	if !hasFutureSeriesOccurrence(successor, period) {
-		return nil, fmt.Errorf(
-			"%w: no occurrences left to change for the selected weekdays and week pattern",
-			ErrSeriesInvalid,
-		)
-	}
-
 	if err := s.lockShiftWrites(ctx, old.StaffID); err != nil {
 		return nil, err
 	}
@@ -476,6 +469,12 @@ func (s *staffShiftSeriesService) SplitSeries(ctx context.Context, input SplitSe
 	if next != nil && (successor.ValidUntil == nil || next.ValidFrom.Before(*successor.ValidUntil)) {
 		until := next.ValidFrom
 		successor.ValidUntil = &until
+	}
+	if !hasFutureSeriesOccurrence(successor, period) {
+		return nil, fmt.Errorf(
+			"%w: no occurrences left to change for the selected weekdays and week pattern",
+			ErrSeriesInvalid,
+		)
 	}
 	if err := s.seriesRepo.CapValidUntil(ctx, old.ID, effective); err != nil {
 		return nil, err

--- a/backend/services/schedule/staff_shift_series_service.go
+++ b/backend/services/schedule/staff_shift_series_service.go
@@ -365,8 +365,20 @@ func (s *staffShiftSeriesService) SplitSeries(ctx context.Context, input SplitSe
 	if effective.Before(old.ValidFrom) {
 		effective = old.ValidFrom
 	}
-	if old.ValidUntil != nil && !effective.Before(*old.ValidUntil) {
-		return nil, fmt.Errorf("%w: effective date lies outside the series segment", ErrSeriesInvalid)
+	// The successor is bounded by the EDITED end, not the predecessor's: an
+	// editor that extends "Gültig bis" is deliberately re-opening a series whose
+	// stored end already passed, and that is a legitimate edit. Checking the old
+	// bound here made every series whose last day had arrived permanently
+	// uneditable, because the effective date is clamped to tomorrow (#2028).
+	validUntil := old.ValidUntil
+	if input.ValidUntilSet {
+		validUntil = input.ValidUntil
+	}
+	if validUntil != nil && !effective.Before(*validUntil) {
+		return nil, fmt.Errorf(
+			"%w: series ends before %s, no occurrences left to change",
+			ErrSeriesInvalid, effective.String(),
+		)
 	}
 
 	rootID := old.RootID()
@@ -385,10 +397,6 @@ func (s *staffShiftSeriesService) SplitSeries(ctx context.Context, input SplitSe
 	notes := old.Notes
 	if input.Notes != nil {
 		notes = *input.Notes
-	}
-	validUntil := old.ValidUntil
-	if input.ValidUntilSet {
-		validUntil = input.ValidUntil
 	}
 	successor := &scheduleModels.StaffShiftSeries{
 		StaffID:          old.StaffID,

--- a/frontend/src/components/staff/shift-edit-modal.series.test.tsx
+++ b/frontend/src/components/staff/shift-edit-modal.series.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ShiftEditModal } from "./shift-edit-modal";
 import type { CalendarPeriod } from "~/lib/calendar-period-helpers";
@@ -761,5 +761,73 @@ describe("ShiftEditModal series rule editing", () => {
 
     fireEvent.click(save);
     expect(splitSeries).not.toHaveBeenCalled();
+  });
+});
+
+// A segment whose last day has arrived used to be uneditable: the re-plan
+// starts tomorrow at the earliest, so the save came back as a generic 400
+// pointing at Beginn/Ende/Pause. The editor now says what to do instead (#2028).
+describe("ShiftEditModal series rule editing at the end of a segment", () => {
+  beforeEach(() => {
+    // Fake ONLY Date: testing-library's findBy* polls on real timers.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    // 12:00 Berlin on the opened occurrence's own day.
+    vi.setSystemTime(new Date("2026-09-07T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("warns instead of saving when nothing is left to change", async () => {
+    // Exclusive valid_until 2026-09-08 = last shift day is today.
+    getSeries.mockResolvedValue({ ...seriesRule, validUntil: "2026-09-08" });
+    renderModal({ mode: "edit", shift: seriesShift });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Serie bearbeiten" }),
+    );
+
+    // The effective date is the clamped one, not the opened occurrence.
+    expect(
+      await screen.findByText(/Die Änderungen gelten ab 08\.09\.2026/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Setzen Sie „Gültig bis" auf ein späteres Datum/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Serie speichern" }));
+    expect(splitSeries).not.toHaveBeenCalled();
+  });
+
+  it("saves once the end date is extended", async () => {
+    getSeries.mockResolvedValue({ ...seriesRule, validUntil: "2026-09-08" });
+    splitSeries.mockResolvedValue({
+      seriesId: "6",
+      created: 12,
+      skippedDates: [],
+    });
+    renderModal({ mode: "edit", shift: seriesShift });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Serie bearbeiten" }),
+    );
+    // The stubbed DatePicker picks 2026-12-31.
+    fireEvent.click(await screen.findByText("DatePicker Auswahl"));
+    fireEvent.click(screen.getByRole("button", { name: "Serie speichern" }));
+
+    await waitFor(() => {
+      expect(splitSeries).toHaveBeenCalledWith("5", {
+        effectiveDate: "2026-09-07",
+        startTime: "08:00",
+        endTime: "12:00",
+        breakMinutes: 0,
+        shiftTypeId: null,
+        weekdays: [1, 3],
+        weekPattern: 0,
+        // Picker is inclusive, the API's valid_until exclusive.
+        validUntil: "2027-01-01",
+      });
+    });
   });
 });

--- a/frontend/src/components/staff/shift-edit-modal.series.test.tsx
+++ b/frontend/src/components/staff/shift-edit-modal.series.test.tsx
@@ -25,6 +25,9 @@ const mockUseClosingDaysState = vi.hoisted(() =>
     isLoading: false,
   })),
 );
+const mockDatePickerValue = vi.hoisted(() => ({
+  value: new Date(2026, 11, 31),
+}));
 
 vi.mock("~/lib/hooks/use-closing-days", () => ({
   useClosingDaysState: mockUseClosingDaysState,
@@ -67,7 +70,7 @@ vi.mock("~/lib/calendar-period-api", () => ({
 // onChange directly instead (same pattern as planned-status-days-modal.test).
 vi.mock("~/components/ui/date-picker", () => ({
   DatePicker: ({ onChange }: { onChange: (date: Date | null) => void }) => (
-    <button type="button" onClick={() => onChange(new Date(2026, 11, 31))}>
+    <button type="button" onClick={() => onChange(mockDatePickerValue.value)}>
       DatePicker Auswahl
     </button>
   ),
@@ -153,6 +156,7 @@ const seriesRule = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockDatePickerValue.value = new Date(2026, 11, 31);
   listPeriods.mockResolvedValue([halbjahr]);
   mockUseClosingDaysState.mockReturnValue({
     closingDays: new Map(),
@@ -829,5 +833,25 @@ describe("ShiftEditModal series rule editing at the end of a segment", () => {
         validUntil: "2027-01-01",
       });
     });
+  });
+
+  it("warns instead of extending without a matching recurrence date", async () => {
+    // The change starts on Tuesday. Extending a Mo/Mi series only through
+    // Tuesday creates no future occurrence.
+    mockDatePickerValue.value = new Date(2026, 8, 8);
+    getSeries.mockResolvedValue({ ...seriesRule, validUntil: "2026-09-08" });
+    renderModal({ mode: "edit", shift: seriesShift });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Serie bearbeiten" }),
+    );
+    fireEvent.click(await screen.findByText("DatePicker Auswahl"));
+
+    expect(
+      await screen.findByText(/Für die gewählten Wochentage/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Serie speichern" }));
+    expect(splitSeries).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/staff/shift-edit-modal.tsx
+++ b/frontend/src/components/staff/shift-edit-modal.tsx
@@ -68,6 +68,18 @@ function getShiftMutationErrorMessage(
       return "Diese Schicht überschneidet sich mit einer bestehenden Schicht.";
     }
     if (err.status === 400) {
+      // A series edit rejects for reasons that have nothing to do with the
+      // times, so translate those instead of sending the planner to check
+      // Beginn/Ende/Pause (#2028).
+      if (detail.includes("no occurrences left")) {
+        return 'Diese Serie hat ab morgen keine Termine mehr. Setzen Sie „Gültig bis" auf ein späteres Datum, um sie fortzuführen.';
+      }
+      if (detail.includes("calendar period")) {
+        return "Der gewählte Zeitraum liegt außerhalb des Kalenderzeitraums der Serie.";
+      }
+      if (detail.includes("week cycle")) {
+        return "Woche A/B benötigt einen Kalenderzeitraum mit gepflegtem Wochenzyklus.";
+      }
       return "Ungültige Schichtdaten. Bitte prüfen Sie Beginn, Ende und Pause.";
     }
     if (err.status === 401) {
@@ -409,9 +421,28 @@ export function ShiftEditModal({
     [periods, seriesRule],
   );
   const seriesPeriodHasCycle = (seriesPeriod?.weekCycleLength ?? 1) > 1;
+  // The backend never re-plans today or the past, so a series edit takes effect
+  // tomorrow at the earliest (clamped up to the segment start). Every hint in
+  // the editor describes THIS date — showing the opened occurrence promised a
+  // change for a day the re-plan does not touch (#2028).
+  const seriesAppliesFrom = latestISODate(
+    seriesEffectiveDate,
+    dayAfterISO(berlinTodayISO()),
+    seriesRule?.validFrom ?? seriesEffectiveDate,
+  );
+  // "Gültig bis" is inclusive in the picker: the segment still has something to
+  // change while its last day is on or after the applies-from date. Without the
+  // check the save fails server-side with a 400 the planner cannot act on.
+  const seriesHasRemainingOccurrence =
+    seriesValidUntil === "" || seriesValidUntil >= seriesAppliesFrom;
+  const seriesNoOccurrenceMessage = `Diese Serie endet am ${formatShortDate(
+    seriesValidUntil === "" ? seriesAppliesFrom : seriesValidUntil,
+  )}, Änderungen wirken aber erst ab ${formatShortDate(
+    seriesAppliesFrom,
+  )}. Setzen Sie „Gültig bis" auf ein späteres Datum, um die Serie fortzuführen.`;
   const seriesDefaultAbPattern = weekPatternForDate(
     seriesPeriod,
-    seriesEffectiveDate,
+    seriesAppliesFrom,
   );
   // Keep the stored A/B pattern until the series period is available:
   // otherwise a save while its metadata is still loading would silently turn
@@ -429,12 +460,7 @@ export function ShiftEditModal({
   // morgen, weil die Materialisierung vergangene Tage ohnehin nicht anfasst.
   const seriesEditClosingDayWindow = useMemo(() => {
     if (!seriesEditOpen || !seriesPeriod) return null;
-    const tomorrow = dayAfterISO(berlinTodayISO());
-    const from = latestISODate(
-      seriesEffectiveDate,
-      seriesPeriod.startDate,
-      tomorrow,
-    );
+    const from = latestISODate(seriesAppliesFrom, seriesPeriod.startDate);
     const to =
       seriesValidUntil !== "" && seriesValidUntil < seriesPeriod.endDate
         ? seriesValidUntil
@@ -450,7 +476,7 @@ export function ShiftEditModal({
     return { from, to, dates };
   }, [
     seriesEditOpen,
-    seriesEffectiveDate,
+    seriesAppliesFrom,
     seriesPeriod,
     seriesRuleWeekPattern,
     seriesValidUntil,
@@ -613,6 +639,10 @@ export function ShiftEditModal({
     if (!validateInputs()) return;
     if (seriesWeekdays.length === 0) {
       setError("Bitte mindestens einen Wochentag auswählen.");
+      return;
+    }
+    if (!seriesHasRemainingOccurrence) {
+      setError(seriesNoOccurrenceMessage);
       return;
     }
     // Schließtag-Rückfrage vor dem Neuplanen (#2032).
@@ -1174,7 +1204,7 @@ export function ShiftEditModal({
             {seriesEditOpen && seriesRule && (
               <div className="space-y-3 rounded-md border border-gray-200 p-3">
                 <p className="text-xs text-gray-600">
-                  {`Die Änderungen gelten ab ${formatShortDate(seriesEffectiveDate)} für alle weiteren Termine der Serie. Termine davor bleiben unverändert, ebenso Termine bis heute.`}
+                  {`Die Änderungen gelten ab ${formatShortDate(seriesAppliesFrom)} für alle weiteren Termine der Serie. Termine davor bleiben unverändert, ebenso Termine bis heute.`}
                 </p>
                 <FieldGroup label="Wochentage">
                   <WeekdayPicker
@@ -1193,7 +1223,7 @@ export function ShiftEditModal({
                     periodHasCycle={seriesPeriodHasCycle}
                     weekHint={
                       seriesDefaultAbPattern !== null
-                        ? `Die Woche vom ${formatShortDate(seriesEffectiveDate)} ist Woche ${
+                        ? `Die Woche vom ${formatShortDate(seriesAppliesFrom)} ist Woche ${
                             seriesDefaultAbPattern === 1 ? "A" : "B"
                           }.`
                         : undefined
@@ -1201,12 +1231,13 @@ export function ShiftEditModal({
                   />
                 </FieldGroup>
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  {/* The date the change takes effect — the occurrence the
-                      planner opened, not the original series start. */}
+                  {/* The date the change actually takes effect: the opened
+                      occurrence, moved forward to tomorrow when it already
+                      passed — the re-plan never touches today or earlier. */}
                   <Field label="Gilt ab">
                     <input
                       type="text"
-                      value={formatShortDate(seriesEffectiveDate)}
+                      value={formatShortDate(seriesAppliesFrom)}
                       disabled
                       className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-gray-500"
                     />
@@ -1227,6 +1258,19 @@ export function ShiftEditModal({
                     />
                   </FieldGroup>
                 </div>
+                {/* Say it before the save fails: a segment whose last day has
+                    arrived has nothing left for the re-plan to change (#2028). */}
+                {!seriesHasRemainingOccurrence && (
+                  <p
+                    className="rounded-md px-3 py-2 text-xs"
+                    style={{
+                      backgroundColor: `${LOCATION_COLORS.SCHOOLYARD}14`,
+                      color: LOCATION_COLORS.SCHOOLYARD,
+                    }}
+                  >
+                    {seriesNoOccurrenceMessage}
+                  </p>
+                )}
               </div>
             )}
             {mode === "edit" &&

--- a/frontend/src/components/staff/shift-edit-modal.tsx
+++ b/frontend/src/components/staff/shift-edit-modal.tsx
@@ -40,7 +40,11 @@ import {
 } from "~/lib/shift-api";
 import type { StaffScheduleStaff, StaffShift } from "~/lib/shift-helpers";
 import type { ShiftType } from "~/lib/shift-type-helpers";
-import { latestISODate, weekdayDatesInRange } from "~/lib/timetable-helpers";
+import {
+  latestISODate,
+  materializedRecurrenceDates,
+  weekdayDatesInRange,
+} from "~/lib/timetable-helpers";
 
 import {
   formatWeekdays,
@@ -433,13 +437,8 @@ export function ShiftEditModal({
   // "Gültig bis" is inclusive in the picker: the segment still has something to
   // change while its last day is on or after the applies-from date. Without the
   // check the save fails server-side with a 400 the planner cannot act on.
-  const seriesHasRemainingOccurrence =
+  const seriesHasDateRange =
     seriesValidUntil === "" || seriesValidUntil >= seriesAppliesFrom;
-  const seriesNoOccurrenceMessage = `Diese Serie endet am ${formatShortDate(
-    seriesValidUntil === "" ? seriesAppliesFrom : seriesValidUntil,
-  )}, Änderungen wirken aber erst ab ${formatShortDate(
-    seriesAppliesFrom,
-  )}. Setzen Sie „Gültig bis" auf ein späteres Datum, um die Serie fortzuführen.`;
   const seriesDefaultAbPattern = weekPatternForDate(
     seriesPeriod,
     seriesAppliesFrom,
@@ -465,14 +464,14 @@ export function ShiftEditModal({
       seriesValidUntil !== "" && seriesValidUntil < seriesPeriod.endDate
         ? seriesValidUntil
         : seriesPeriod.endDate;
-    const dates = weekdayDatesInRange(from, to, seriesWeekdays).filter(
-      (dateISO) =>
-        shouldMaterializeWeekPattern(
-          seriesPeriod,
-          dateISO,
-          seriesRuleWeekPattern,
-        ),
-    );
+    const dates = materializedRecurrenceDates({
+      period: seriesPeriod,
+      fromISO: from,
+      weekdays: seriesWeekdays,
+      weekPattern: seriesRuleWeekPattern,
+      validUntil:
+        seriesValidUntil === "" ? undefined : dayAfterISO(seriesValidUntil),
+    });
     return { from, to, dates };
   }, [
     seriesEditOpen,
@@ -504,6 +503,12 @@ export function ShiftEditModal({
   // Markierung ist ein Hinweis, kein Sperrmechanismus.
   const seriesEditClosingDaysLoading =
     seriesEditOpen && (periods === null || seriesEditClosingDayState.isLoading);
+  const seriesHasRemainingOccurrence =
+    seriesHasDateRange &&
+    (seriesPeriod === null || seriesEditClosingDayWindow?.dates.length !== 0);
+  const seriesNoOccurrenceMessage = seriesHasDateRange
+    ? `Für die gewählten Wochentage und den Wochenrhythmus bleibt ab ${formatShortDate(seriesAppliesFrom)} kein Termin mehr. Setzen Sie „Gültig bis" auf ein späteres Datum oder ändern Sie die Wiederholung.`
+    : `Diese Serie endet am ${formatShortDate(seriesValidUntil)}, Änderungen wirken aber erst ab ${formatShortDate(seriesAppliesFrom)}. Setzen Sie „Gültig bis" auf ein späteres Datum, um die Serie fortzuführen.`;
   const seriesEditConfirmationKey =
     seriesEditClosingDayConflict === null
       ? null


### PR DESCRIPTION
Behebt: „Serie bearbeiten" scheiterte dauerhaft mit **„Ungültige Schichtdaten. Bitte prüfen Sie Beginn, Ende und Pause."**, sobald der letzte geplante Tag der Serie erreicht war.

## Warum es passierte

Ein Serien-Edit wirkt frühestens ab morgen: der Re-Plan löscht die Schicht-Zeilen ab dem Wirkdatum und erzeugt sie neu (`DeleteNonDetachedBySeriesFrom` + `materializeSeries`), und das darf heute laufende Schichten nicht treffen. Vertretungen hängen per `origin_shift_id` (`ON DELETE SET NULL`) an der Origin-Zeile, Abweichungs-Events ebenso.

`SplitSeries` verglich dieses auf morgen geklemmte Datum anschließend gegen das **gespeicherte** `valid_until`. Für ein Segment, dessen letzter Tag heute ist, lag morgen immer hinter dem Ende → 400. Ausweglos, denn auch das Hochsetzen von „Gültig bis" wurde abgelehnt: die Prüfung sah das neue Enddatum nie.

Kein Regress der letzten PRs. Clamp und Segmentprüfung stammen aus dem Ursprungs-Commit `15f46f27b` (#1889); sichtbar wurde die Kombination erst durch den Serien-Editor aus #2028.

## Änderungen

**Backend** (`services/schedule/staff_shift_series_service.go`)
- Die Segmentprüfung liest jetzt das **bearbeitete** Enddatum (`input.ValidUntil`, falls gesetzt) statt des Vorgängerwerts. Eine ausgelaufene Serie lässt sich damit über „Gültig bis" verlängern.
- Ein Edit, der wirklich keinen Termin übrig lässt, bleibt ein 400, benennt aber den Grund (`no occurrences left to change`) statt allgemein „outside the series segment".
- `CapValidUntil` schützt das Vorgänger-Segment ohnehin per `WHERE valid_until > ?`, Vergangenes bleibt unangetastet.

**Frontend** (`components/staff/shift-edit-modal.tsx`)
- „Gilt ab" zeigt das tatsächliche Wirkdatum (auf morgen geklemmt), statt einen Vergangenheitstag zu versprechen. A/B-Wochenhinweis und Schließtag-Fenster rechnen mit demselben Datum.
- Lässt das Enddatum nichts zu ändern übrig, steht der Hinweis **vor** dem Speichern im Editor, samt Lösung.
- 400er der Serien-Endpunkte werden nach Ursache übersetzt (Segmentende, Kalenderzeitraum, Wochenzyklus) statt pauschal auf Beginn/Ende/Pause zu zeigen.

## Tests

Vier neue Tests, kein bestehender Test geändert.

- `TestStaffShiftSeries_SplitExtendsSeriesEndingToday` — Verlängern über den heutigen Endtag hinaus plant wieder.
- `TestStaffShiftSeries_SplitRejectsWhenNoOccurrenceRemains` — Rest-Fall bleibt 400, mit sprechender Meldung.
- Zwei Vitest-Fälle im Serien-Editor (Systemzeit auf den Occurrence-Tag gesetzt): Warnung statt Save, und Save nach verlängertem Enddatum.

```
go test ./services/schedule/ -run TestStaffShiftSeries   # 10/10 grün
pnpm vitest run src/components/staff/                    # 190/190 grün
pnpm run check                                           # sauber
```

## Offen

Nicht visuell im Browser verifiziert: der lokale Docker-Stack ist an einen anderen Worktree gebunden. Screenshots reiche ich nach, falls gewünscht.
