### PR TITLE
fix: batch scheduler settings polling

### DIFF
--- a/backend/api/auth/tenant_handlers.go
+++ b/backend/api/auth/tenant_handlers.go
@@ -112,16 +112,44 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 
 func (rs *Resource) resolveTenantShellSettings(ctx context.Context, tenantID int64) tenantShellSettings {
 	resolved := tenantShellSettings{
-		presenceMode:         configSvc.ResolvePresenceModeForTenant(ctx, rs.SettingsService, tenantID, nil),
-		careOfferingsEnabled: true,
-		groupMode:            configModel.GroupModeFixedGroups,
-		showTimetableCounts:  true,
-		waitlistEnabled:      true,
+		presenceMode:           configModel.PresenceModeDetailed,
+		parentMessagingEnabled: true,
+		careOfferingsEnabled:   true,
+		groupMode:              configModel.GroupModeFixedGroups,
+		showTimetableCounts:    true,
+		waitlistEnabled:        true,
 	}
 	if rs.SettingsService == nil {
 		return resolved
 	}
 
+	keys := []string{
+		configModel.KeyPresenceMode,
+		configModel.KeyStudentPhotosEnabled,
+		configModel.KeyAttendanceNFCEnabled,
+		configModel.KeyDisplayEnabled,
+		configModel.KeyEnrollmentCareOfferingsEnabled,
+		configModel.KeyAttendanceWebEnabled,
+		configModel.KeyAttendanceLogEnabled,
+		configModel.KeyTimetableShowExpectedChildrenCount,
+		configModel.KeyEnrollmentWaitlistEnabled,
+		configModel.KeyGroupMode,
+		configModel.KeyParentNotesEnabled,
+	}
+	if batch, ok := rs.SettingsService.(interface {
+		ResolveManyForTenant(context.Context, int64, []string) (*configSvc.SettingsSnapshot, error)
+	}); ok {
+		snapshot, err := batch.ResolveManyForTenant(ctx, tenantID, keys)
+		if err != nil {
+			logTenantResolveSettingFailure(ctx, tenantID, "tenant_shell", err, slog.LevelError)
+			return resolved
+		}
+		if snapshot != nil {
+			return resolveTenantShellSnapshot(ctx, tenantID, snapshot, resolved)
+		}
+	}
+
+	resolved.presenceMode = configSvc.ResolvePresenceModeForTenant(ctx, rs.SettingsService, tenantID, nil)
 	if value, err := rs.SettingsService.ResolveStringForTenant(ctx, tenantID, configModel.KeyStudentPhotosEnabled); err == nil {
 		resolved.studentPhotosEnabled = value == "true"
 	}
@@ -141,6 +169,50 @@ func (rs *Resource) resolveTenantShellSettings(ctx context.Context, tenantID int
 	// Messaging compose visibility intentionally fails open so it stays in
 	// lockstep with the unread badge, inbox row pills, and reply path.
 	resolved.parentMessagingEnabled = parentmessaging.MessagingEnabledForTenant(ctx, rs.SettingsService, tenantID, nil)
+	return resolved
+}
+
+func resolveTenantShellSnapshot(
+	ctx context.Context,
+	tenantID int64,
+	snapshot *configSvc.SettingsSnapshot,
+	resolved tenantShellSettings,
+) tenantShellSettings {
+	resolveBool := func(key string, fallback bool, level slog.Level) bool {
+		value, err := snapshot.Bool(key)
+		if err != nil {
+			logTenantResolveSettingFailure(ctx, tenantID, key, err, level)
+			return fallback
+		}
+		return value
+	}
+	resolveString := func(key, fallback string, level slog.Level) string {
+		value, err := snapshot.String(key)
+		if err != nil {
+			logTenantResolveSettingFailure(ctx, tenantID, key, err, level)
+			return fallback
+		}
+		return value
+	}
+
+	resolved.studentPhotosEnabled = resolveString(configModel.KeyStudentPhotosEnabled, "false", slog.LevelError) == "true"
+	resolved.nfcEnabled = resolveBool(configModel.KeyAttendanceNFCEnabled, false, slog.LevelError)
+	resolved.displayEnabled = resolveBool(configModel.KeyDisplayEnabled, false, slog.LevelError)
+	resolved.careOfferingsEnabled = resolveBool(configModel.KeyEnrollmentCareOfferingsEnabled, false, slog.LevelError)
+	resolved.attendanceWebEnabled = resolveBool(configModel.KeyAttendanceWebEnabled, false, slog.LevelError)
+	resolved.attendanceLogEnabled = resolveBool(configModel.KeyAttendanceLogEnabled, false, slog.LevelError)
+	resolved.showTimetableCounts = resolveBool(configModel.KeyTimetableShowExpectedChildrenCount, true, slog.LevelWarn)
+	resolved.waitlistEnabled = resolveBool(configModel.KeyEnrollmentWaitlistEnabled, true, slog.LevelError)
+	resolved.parentMessagingEnabled = resolveBool(configModel.KeyParentNotesEnabled, true, slog.LevelWarn)
+
+	mode := resolveString(configModel.KeyPresenceMode, configModel.PresenceModeDetailed, slog.LevelWarn)
+	if mode != "" {
+		resolved.presenceMode = mode
+	}
+	groupMode := resolveString(configModel.KeyGroupMode, configModel.GroupModeFixedGroups, slog.LevelError)
+	if groupMode == configModel.GroupModeOpenCare {
+		resolved.groupMode = groupMode
+	}
 	return resolved
 }
 

--- a/backend/api/iot/config.go
+++ b/backend/api/iot/config.go
@@ -65,6 +65,9 @@ func (rs *Resource) resolveDeviceConfig(ctx context.Context, tenantID int64) dev
 	}
 
 	settingsCtx, available := rs.deviceConfigSettingsContext(ctx, tenantID)
+	if rawTime := checkinSvc.ResolveRawDailyCheckoutTime(settingsCtx, rs.SettingsService); rawTime != "" {
+		response.Checkout.DailyCheckoutTime = &rawTime
+	}
 	if !available {
 		return response
 	}
@@ -78,9 +81,6 @@ func (rs *Resource) resolveDeviceConfig(ctx context.Context, tenantID int64) dev
 	response.Feedback.Enabled = resolveDeviceConfigBool(
 		settingsCtx, rs.SettingsService, configModel.KeyFeedbackEnabled, false)
 
-	if rawTime := checkinSvc.ResolveRawDailyCheckoutTime(settingsCtx, rs.SettingsService); rawTime != "" {
-		response.Checkout.DailyCheckoutTime = &rawTime
-	}
 	response.PresenceMode = configSvc.ResolvePresenceModeForTenant(
 		settingsCtx, rs.SettingsService, tenantID, rs.getLogger())
 	return response

--- a/backend/api/iot/config.go
+++ b/backend/api/iot/config.go
@@ -1,6 +1,7 @@
 package iot
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 
@@ -10,6 +11,7 @@ import (
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	checkinSvc "github.com/moto-nrw/project-phoenix/services/iot/checkin"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // deviceConfigCheckout holds checkout button visibility settings.
@@ -48,51 +50,87 @@ func (rs *Resource) getDeviceConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve checkout button settings (defaults to true if service unavailable)
-	raumwechsel := true
-	schulhof := true
-	wc := true
-	feedbackEnabled := false
+	response := rs.resolveDeviceConfig(r.Context(), deviceCtx.TenantID)
+	common.Respond(w, r, http.StatusOK, response, "Device configuration retrieved")
+}
 
-	if rs.SettingsService != nil {
-		if val, err := rs.SettingsService.ResolveBool(r.Context(), configModel.KeyCheckoutRaumwechselEnabled); err == nil {
-			raumwechsel = val
-		}
-		if val, err := rs.SettingsService.ResolveBool(r.Context(), configModel.KeyCheckoutSchulhofEnabled); err == nil {
-			schulhof = val
-		}
-		if val, err := rs.SettingsService.ResolveBool(r.Context(), configModel.KeyCheckoutWCEnabled); err == nil {
-			wc = val
-		}
-		if val, err := rs.SettingsService.ResolveBool(r.Context(), configModel.KeyFeedbackEnabled); err == nil {
-			feedbackEnabled = val
-		}
-	}
-
-	// Resolve daily checkout time via the shared helper so the fallback chain
-	// (tenant DB override → env var → nil) lives in a single place.
-	var dailyCheckoutTime *string
-	if rawTime := checkinSvc.ResolveRawDailyCheckoutTime(r.Context(), rs.SettingsService); rawTime != "" {
-		dailyCheckoutTime = &rawTime
-	}
-
-	// Resolve presence mode. Device auth runs before tenant middleware sets
-	// the PostgreSQL tenant role, so we use the ForTenant variant which opens
-	// its own tenant transaction.
-	presenceMode := configSvc.ResolvePresenceModeForTenant(r.Context(), rs.SettingsService, deviceCtx.TenantID, rs.getLogger())
-
+func (rs *Resource) resolveDeviceConfig(ctx context.Context, tenantID int64) deviceConfigResponse {
 	response := deviceConfigResponse{
 		Checkout: deviceConfigCheckout{
-			RaumwechselEnabled: raumwechsel,
-			SchulhofEnabled:    schulhof,
-			WCEnabled:          wc,
-			DailyCheckoutTime:  dailyCheckoutTime,
+			RaumwechselEnabled: true,
+			SchulhofEnabled:    true,
+			WCEnabled:          true,
 		},
-		Feedback: deviceConfigFeedback{
-			Enabled: feedbackEnabled,
-		},
-		PresenceMode: presenceMode,
+		PresenceMode: configModel.PresenceModeDetailed,
 	}
 
-	common.Respond(w, r, http.StatusOK, response, "Device configuration retrieved")
+	settingsCtx, available := rs.deviceConfigSettingsContext(ctx, tenantID)
+	if !available {
+		return response
+	}
+
+	response.Checkout.RaumwechselEnabled = resolveDeviceConfigBool(
+		settingsCtx, rs.SettingsService, configModel.KeyCheckoutRaumwechselEnabled, true)
+	response.Checkout.SchulhofEnabled = resolveDeviceConfigBool(
+		settingsCtx, rs.SettingsService, configModel.KeyCheckoutSchulhofEnabled, true)
+	response.Checkout.WCEnabled = resolveDeviceConfigBool(
+		settingsCtx, rs.SettingsService, configModel.KeyCheckoutWCEnabled, true)
+	response.Feedback.Enabled = resolveDeviceConfigBool(
+		settingsCtx, rs.SettingsService, configModel.KeyFeedbackEnabled, false)
+
+	if rawTime := checkinSvc.ResolveRawDailyCheckoutTime(settingsCtx, rs.SettingsService); rawTime != "" {
+		response.Checkout.DailyCheckoutTime = &rawTime
+	}
+	response.PresenceMode = configSvc.ResolvePresenceModeForTenant(
+		settingsCtx, rs.SettingsService, tenantID, rs.getLogger())
+	return response
+}
+
+func (rs *Resource) deviceConfigSettingsContext(ctx context.Context, tenantID int64) (context.Context, bool) {
+	if rs.SettingsService == nil {
+		return ctx, true
+	}
+	batch, ok := rs.SettingsService.(interface {
+		ResolveManyForTenant(context.Context, int64, []string) (*configSvc.SettingsSnapshot, error)
+	})
+	if !ok {
+		return ctx, true
+	}
+
+	snapshot, err := batch.ResolveManyForTenant(ctx, tenantID, []string{
+		configModel.KeyCheckoutRaumwechselEnabled,
+		configModel.KeyCheckoutSchulhofEnabled,
+		configModel.KeyCheckoutWCEnabled,
+		configModel.KeyFeedbackEnabled,
+		configModel.KeyStudentDailyCheckoutTime,
+		configModel.KeyPresenceMode,
+	})
+	if err != nil {
+		rs.getLogger().WarnContext(ctx, "device config settings batch failed",
+			slog.Int64("tenant_id", tenantID),
+			slog.String("error", err.Error()),
+		)
+		return ctx, false
+	}
+	if snapshot == nil {
+		return ctx, true
+	}
+	settingsCtx := tenant.WithTenantID(ctx, tenantID)
+	return configSvc.WithSettingsSnapshot(settingsCtx, snapshot), true
+}
+
+func resolveDeviceConfigBool(
+	ctx context.Context,
+	settings configSvc.SettingsService,
+	key string,
+	fallback bool,
+) bool {
+	if settings == nil {
+		return fallback
+	}
+	value, err := settings.ResolveBool(ctx, key)
+	if err != nil {
+		return fallback
+	}
+	return value
 }

--- a/backend/api/iot/config_test.go
+++ b/backend/api/iot/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/device"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/iot"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,6 +220,33 @@ func TestGetDeviceConfig_EnvVarFallback(t *testing.T) {
 		map[string]string{},
 	)},
 	}
+
+	req := httptest.NewRequest("GET", "/api/iot/config", nil)
+	ctx := context.WithValue(req.Context(), device.CtxDevice, &iot.Device{TenantModel: base.TenantModel{TenantID: 1}})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	rs.getDeviceConfig(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	data := response["data"].(map[string]any)
+	checkout := data["checkout"].(map[string]any)
+	assert.Equal(t, "14:00", checkout["daily_checkout_time"])
+}
+
+func TestGetDeviceConfig_EnvVarFallbackWhenBatchFails(t *testing.T) {
+	require.NoError(t, os.Setenv("STUDENT_DAILY_CHECKOUT_TIME", "14:00"))
+	defer func() { _ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME") }()
+
+	settings := newConfigMock(nil, nil)
+	settings.ResolveManyForTenantFn = func(context.Context, int64, []string) (*configSvc.SettingsSnapshot, error) {
+		return nil, fmt.Errorf("settings unavailable")
+	}
+	rs := &Resource{ServiceDependencies: ServiceDependencies{SettingsService: settings}}
 
 	req := httptest.NewRequest("GET", "/api/iot/config", nil)
 	ctx := context.WithValue(req.Context(), device.CtxDevice, &iot.Device{TenantModel: base.TenantModel{TenantID: 1}})

--- a/backend/database/repositories/config/setting_value.go
+++ b/backend/database/repositories/config/setting_value.go
@@ -73,6 +73,30 @@ func (r *SettingValueRepository) FindByTenantAndKeys(ctx context.Context, tenant
 	return values, nil
 }
 
+// FindByTenantsAndKeys retrieves stored overrides for several tenants and keys
+// in one query. The service layer wraps this privileged read in an admin
+// transaction; repository code deliberately does not change database roles.
+func (r *SettingValueRepository) FindByTenantsAndKeys(ctx context.Context, tenantIDs []int64, keys []string) ([]*config.SettingValue, error) {
+	if len(tenantIDs) == 0 || len(keys) == 0 {
+		return nil, nil
+	}
+
+	var values []*config.SettingValue
+	err := repoBase.GetDB(ctx, r.db).NewSelect().
+		Model(&values).
+		ModelTableExpr(tableSettingValuesAlias).
+		Where(`"setting_value".tenant_id IN (?)`, bun.List(tenantIDs)).
+		Where(`"setting_value".setting_key IN (?)`, bun.List(keys)).
+		Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find setting values by tenants and keys",
+			Err: err,
+		}
+	}
+	return values, nil
+}
+
 // Upsert inserts or updates a setting value.
 func (r *SettingValueRepository) Upsert(ctx context.Context, sv *config.SettingValue) error {
 	if sv == nil {

--- a/backend/models/config/setting_value_repository.go
+++ b/backend/models/config/setting_value_repository.go
@@ -14,6 +14,11 @@ type SettingValueRepository interface {
 	// one query. Keys without an override are absent from the result.
 	FindByTenantAndKeys(ctx context.Context, tenantID int64, keys []string) ([]*SettingValue, error)
 
+	// FindByTenantsAndKeys retrieves stored overrides for several tenants and
+	// keys in one query. Callers must provide an admin-scoped transaction
+	// because normal tenant RLS must never expose rows from another school.
+	FindByTenantsAndKeys(ctx context.Context, tenantIDs []int64, keys []string) ([]*SettingValue, error)
+
 	// Upsert inserts or updates a setting value (INSERT ... ON CONFLICT ... DO UPDATE).
 	Upsert(ctx context.Context, sv *SettingValue) error
 

--- a/backend/services/auth/mfa_service_settings_test.go
+++ b/backend/services/auth/mfa_service_settings_test.go
@@ -76,6 +76,29 @@ func (r *mfaTestValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int64
 	return out, nil
 }
 
+func (r *mfaTestValueRepo) FindByTenantsAndKeys(_ context.Context, tenantIDs []int64, settingKeys []string) ([]*configModel.SettingValue, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tenants := make(map[int64]struct{}, len(tenantIDs))
+	for _, tenantID := range tenantIDs {
+		tenants[tenantID] = struct{}{}
+	}
+	requested := make(map[string]struct{}, len(settingKeys))
+	for _, key := range settingKeys {
+		requested[key] = struct{}{}
+	}
+	var out []*configModel.SettingValue
+	for _, value := range r.values {
+		if _, ok := tenants[value.GetTenantID()]; !ok {
+			continue
+		}
+		if _, ok := requested[value.SettingKey]; ok {
+			out = append(out, value)
+		}
+	}
+	return out, nil
+}
+
 func (r *mfaTestValueRepo) Upsert(_ context.Context, sv *configModel.SettingValue) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/backend/services/config/configtest/mock.go
+++ b/backend/services/config/configtest/mock.go
@@ -21,6 +21,9 @@ type Mock struct {
 	GetSchemaFn                    func(ctx context.Context, userPermissions []string) (*config.SettingsSchema, error)
 	GetSchemaForOperatorFn         func(ctx context.Context, userPermissions []string) (*config.SettingsSchema, error)
 	ResolveFn                      func(ctx context.Context, key string) (any, error)
+	ResolveManyFn                  func(ctx context.Context, keys []string) (*config.SettingsSnapshot, error)
+	ResolveManyForTenantFn         func(ctx context.Context, tenantID int64, keys []string) (*config.SettingsSnapshot, error)
+	ResolveManyForTenantsFn        func(ctx context.Context, tenantIDs []int64, keys []string) (map[int64]*config.SettingsSnapshot, error)
 	ResolveStringFn                func(ctx context.Context, key string) (string, error)
 	ResolveStringForTenantFn       func(ctx context.Context, tenantID int64, key string) (string, error)
 	ResolveBoolFn                  func(ctx context.Context, key string) (bool, error)
@@ -41,6 +44,7 @@ type Mock struct {
 }
 
 var _ config.SettingsService = (*Mock)(nil)
+var _ config.BatchSettingsService = (*Mock)(nil)
 
 func (m *Mock) GetSchema(ctx context.Context, userPermissions []string) (*config.SettingsSchema, error) {
 	if m.GetSchemaFn != nil {
@@ -59,6 +63,27 @@ func (m *Mock) GetSchemaForOperator(ctx context.Context, userPermissions []strin
 func (m *Mock) Resolve(ctx context.Context, key string) (any, error) {
 	if m.ResolveFn != nil {
 		return m.ResolveFn(ctx, key)
+	}
+	return nil, nil
+}
+
+func (m *Mock) ResolveMany(ctx context.Context, keys []string) (*config.SettingsSnapshot, error) {
+	if m.ResolveManyFn != nil {
+		return m.ResolveManyFn(ctx, keys)
+	}
+	return nil, nil
+}
+
+func (m *Mock) ResolveManyForTenant(ctx context.Context, tenantID int64, keys []string) (*config.SettingsSnapshot, error) {
+	if m.ResolveManyForTenantFn != nil {
+		return m.ResolveManyForTenantFn(ctx, tenantID, keys)
+	}
+	return nil, nil
+}
+
+func (m *Mock) ResolveManyForTenants(ctx context.Context, tenantIDs []int64, keys []string) (map[int64]*config.SettingsSnapshot, error) {
+	if m.ResolveManyForTenantsFn != nil {
+		return m.ResolveManyForTenantsFn(ctx, tenantIDs, keys)
 	}
 	return nil, nil
 }

--- a/backend/services/config/configtest/mock_test.go
+++ b/backend/services/config/configtest/mock_test.go
@@ -1,0 +1,52 @@
+package configtest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockBatchResolversDelegateAndDefault(t *testing.T) {
+	ctx := context.Background()
+	keys := []string{"test.key"}
+	var tenantID int64
+	tenantIDs := []int64{tenantID}
+	delegateErr := errors.New("delegate called")
+
+	mock := &configtest.Mock{
+		ResolveManyForTenantFn: func(
+			gotCtx context.Context,
+			gotTenantID int64,
+			gotKeys []string,
+		) (*configService.SettingsSnapshot, error) {
+			assert.Equal(t, ctx, gotCtx)
+			assert.Equal(t, tenantID, gotTenantID)
+			assert.Equal(t, keys, gotKeys)
+			return nil, delegateErr
+		},
+		ResolveManyForTenantsFn: func(
+			gotCtx context.Context,
+			gotTenantIDs []int64,
+			gotKeys []string,
+		) (map[int64]*configService.SettingsSnapshot, error) {
+			assert.Equal(t, ctx, gotCtx)
+			assert.Equal(t, tenantIDs, gotTenantIDs)
+			assert.Equal(t, keys, gotKeys)
+			return nil, delegateErr
+		},
+	}
+
+	_, err := mock.ResolveManyForTenant(ctx, tenantID, keys)
+	require.ErrorIs(t, err, delegateErr)
+	_, err = mock.ResolveManyForTenants(ctx, tenantIDs, keys)
+	require.ErrorIs(t, err, delegateErr)
+
+	result, err := (&configtest.Mock{}).ResolveManyForTenants(ctx, tenantIDs, keys)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}

--- a/backend/services/config/helpers.go
+++ b/backend/services/config/helpers.go
@@ -26,6 +26,10 @@ type stringResolver interface {
 	ResolveString(ctx context.Context, key string) (string, error)
 }
 
+type snapshotResolver interface {
+	ResolveMany(ctx context.Context, keys []string) (*SettingsSnapshot, error)
+}
+
 // ResolveBoolOrDefault returns the tenant-override value for a boolean setting if
 // one exists, otherwise the provided fallback default.
 //
@@ -40,6 +44,29 @@ type stringResolver interface {
 func ResolveBoolOrDefault(ctx context.Context, svc boolResolver, key string, fallback bool, logger *slog.Logger) bool {
 	if svc == nil {
 		return fallback
+	}
+	if batch, ok := any(svc).(snapshotResolver); ok {
+		snapshot, err := batch.ResolveMany(ctx, []string{key})
+		if err != nil {
+			logSettingsFallback(logger, "settings snapshot failed, using fallback", key, err)
+			return fallback
+		}
+		if snapshot != nil {
+			has, err := snapshot.HasOverride(key)
+			if err != nil {
+				logSettingsFallback(logger, "settings override check failed, using fallback", key, err)
+				return fallback
+			}
+			if !has {
+				return fallback
+			}
+			value, err := snapshot.Bool(key)
+			if err != nil {
+				logSettingsFallback(logger, "settings resolve failed, using fallback", key, err)
+				return fallback
+			}
+			return value
+		}
 	}
 	has, err := svc.HasTenantOverride(ctx, key)
 	if err != nil {
@@ -71,6 +98,29 @@ func ResolveBoolOrDefault(ctx context.Context, svc boolResolver, key string, fal
 func ResolveIntOrDefault(ctx context.Context, svc intResolver, key string, fallback int, logger *slog.Logger) int {
 	if svc == nil {
 		return fallback
+	}
+	if batch, ok := any(svc).(snapshotResolver); ok {
+		snapshot, err := batch.ResolveMany(ctx, []string{key})
+		if err != nil {
+			logSettingsFallback(logger, "settings snapshot failed, using fallback", key, err)
+			return fallback
+		}
+		if snapshot != nil {
+			has, err := snapshot.HasOverride(key)
+			if err != nil {
+				logSettingsFallback(logger, "settings override check failed, using fallback", key, err)
+				return fallback
+			}
+			if !has {
+				return fallback
+			}
+			value, err := snapshot.Int(key)
+			if err != nil {
+				logSettingsFallback(logger, "settings resolve failed, using fallback", key, err)
+				return fallback
+			}
+			return value
+		}
 	}
 	has, err := svc.HasTenantOverride(ctx, key)
 	if err != nil {
@@ -105,6 +155,32 @@ func ResolveStringOrDefault(ctx context.Context, svc stringResolver, key, fallba
 	if svc == nil {
 		return fallback
 	}
+	if batch, ok := any(svc).(snapshotResolver); ok {
+		snapshot, err := batch.ResolveMany(ctx, []string{key})
+		if err != nil {
+			logSettingsFallback(logger, "settings snapshot failed, using fallback", key, err)
+			return fallback
+		}
+		if snapshot != nil {
+			has, err := snapshot.HasOverride(key)
+			if err != nil {
+				logSettingsFallback(logger, "settings override check failed, using fallback", key, err)
+				return fallback
+			}
+			if !has {
+				return fallback
+			}
+			value, err := snapshot.String(key)
+			if err != nil {
+				logSettingsFallback(logger, "settings resolve failed, using fallback", key, err)
+				return fallback
+			}
+			if value == "" {
+				return fallback
+			}
+			return value
+		}
+	}
 	has, err := svc.HasTenantOverride(ctx, key)
 	if err != nil {
 		if logger != nil {
@@ -132,4 +208,14 @@ func ResolveStringOrDefault(ctx context.Context, svc stringResolver, key, fallba
 		return fallback
 	}
 	return val
+}
+
+func logSettingsFallback(logger *slog.Logger, message, key string, err error) {
+	if logger == nil {
+		return
+	}
+	logger.Warn(message,
+		slog.String("key", key),
+		slog.String("error", err.Error()),
+	)
 }

--- a/backend/services/config/helpers_snapshot_test.go
+++ b/backend/services/config/helpers_snapshot_test.go
@@ -1,0 +1,195 @@
+package config_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func helperSnapshot(
+	t *testing.T,
+	key string,
+	fieldType config.FieldType,
+	defaultValue any,
+	override json.RawMessage,
+) *configService.SettingsSnapshot {
+	t.Helper()
+	setupTest(t)
+	registerTestSetting(key, fieldType, defaultValue)
+
+	repo := newMockValueRepo()
+	if override != nil {
+		value := &config.SettingValue{SettingKey: key, Value: override}
+		value.TenantID = 41
+		repo.values[repo.key(value.TenantID, key)] = value
+	}
+
+	service := createService(repo, &mockAuditRepo{})
+	batch, ok := service.(configService.BatchSettingsService)
+	require.True(t, ok)
+	snapshot, err := batch.ResolveMany(tenantCtx(41), []string{key})
+	require.NoError(t, err)
+	return snapshot
+}
+
+func snapshotMock(snapshot *configService.SettingsSnapshot, err error) *configtest.Mock {
+	return &configtest.Mock{
+		ResolveManyFn: func(context.Context, []string) (*configService.SettingsSnapshot, error) {
+			return snapshot, err
+		},
+	}
+}
+
+func TestResolveOrDefaultReturnsFallbackForSnapshotFailures(t *testing.T) {
+	fallbackErr := errors.New("settings unavailable")
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("boolean batch failure without logger", func(t *testing.T) {
+		got := configService.ResolveBoolOrDefault(
+			context.Background(),
+			snapshotMock(nil, fallbackErr),
+			"test.bool",
+			true,
+			nil,
+		)
+		assert.True(t, got)
+	})
+
+	t.Run("integer batch failure", func(t *testing.T) {
+		got := configService.ResolveIntOrDefault(
+			context.Background(),
+			snapshotMock(nil, fallbackErr),
+			"test.int",
+			17,
+			logger,
+		)
+		assert.Equal(t, 17, got)
+	})
+
+	t.Run("string batch failure", func(t *testing.T) {
+		got := configService.ResolveStringOrDefault(
+			context.Background(),
+			snapshotMock(nil, fallbackErr),
+			"test.string",
+			"fallback",
+			logger,
+		)
+		assert.Equal(t, "fallback", got)
+	})
+
+	t.Run("boolean missing from snapshot", func(t *testing.T) {
+		snapshot := helperSnapshot(t, "test.present_bool", config.FieldBoolean, false, nil)
+		got := configService.ResolveBoolOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.missing_bool",
+			true,
+			logger,
+		)
+		assert.True(t, got)
+	})
+
+	t.Run("integer missing from snapshot", func(t *testing.T) {
+		snapshot := helperSnapshot(t, "test.present_int", config.FieldNumber, 3, nil)
+		got := configService.ResolveIntOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.missing_int",
+			17,
+			logger,
+		)
+		assert.Equal(t, 17, got)
+	})
+
+	t.Run("string missing from snapshot", func(t *testing.T) {
+		snapshot := helperSnapshot(t, "test.present_string", config.FieldText, "value", nil)
+		got := configService.ResolveStringOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.missing_string",
+			"fallback",
+			logger,
+		)
+		assert.Equal(t, "fallback", got)
+	})
+
+	t.Run("boolean type mismatch", func(t *testing.T) {
+		snapshot := helperSnapshot(
+			t,
+			"test.bad_bool",
+			config.FieldBoolean,
+			false,
+			json.RawMessage(`"not-a-bool"`),
+		)
+		got := configService.ResolveBoolOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.bad_bool",
+			true,
+			logger,
+		)
+		assert.True(t, got)
+	})
+
+	t.Run("fractional integer", func(t *testing.T) {
+		snapshot := helperSnapshot(
+			t,
+			"test.bad_int",
+			config.FieldNumber,
+			3,
+			json.RawMessage(`1.5`),
+		)
+		got := configService.ResolveIntOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.bad_int",
+			17,
+			logger,
+		)
+		assert.Equal(t, 17, got)
+	})
+
+	t.Run("malformed string", func(t *testing.T) {
+		snapshot := helperSnapshot(
+			t,
+			"test.bad_string",
+			config.FieldText,
+			"default",
+			json.RawMessage(`{`),
+		)
+		got := configService.ResolveStringOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.bad_string",
+			"fallback",
+			logger,
+		)
+		assert.Equal(t, "fallback", got)
+	})
+
+	t.Run("empty string override", func(t *testing.T) {
+		snapshot := helperSnapshot(
+			t,
+			"test.empty_string",
+			config.FieldText,
+			"default",
+			json.RawMessage(`""`),
+		)
+		got := configService.ResolveStringOrDefault(
+			context.Background(),
+			snapshotMock(snapshot, nil),
+			"test.empty_string",
+			"fallback",
+			logger,
+		)
+		assert.Equal(t, "fallback", got)
+	})
+}

--- a/backend/services/config/payroll_status_service.go
+++ b/backend/services/config/payroll_status_service.go
@@ -85,12 +85,33 @@ var payrollCategories = []payrollCategory{
 }
 
 func (s *payrollStatusService) GetPayrollStatus(ctx context.Context) (*PayrollStatus, error) {
-	categories, configuredCategories, err := s.resolvePayrollCategories(ctx)
+	keys := []string{
+		configModel.KeyPayrollDatevBeraternummer,
+		configModel.KeyPayrollDatevMandantennummer,
+	}
+	for _, category := range payrollCategories {
+		keys = append(keys, category.key)
+		if category.unitKey != "" {
+			keys = append(keys, category.unitKey)
+		}
+	}
+	var snapshot *SettingsSnapshot
+	if batch, ok := s.settings.(interface {
+		ResolveMany(context.Context, []string) (*SettingsSnapshot, error)
+	}); ok {
+		var err error
+		snapshot, err = batch.ResolveMany(ctx, keys)
+		if err != nil {
+			return nil, fmt.Errorf("resolve payroll settings: %w", err)
+		}
+	}
+
+	categories, configuredCategories, err := s.resolvePayrollCategories(ctx, snapshot)
 	if err != nil {
 		return nil, err
 	}
 
-	berater, mandant, err := s.resolveLodasHeader(ctx)
+	berater, mandant, err := s.resolveLodasHeader(ctx, snapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -112,11 +133,11 @@ func (s *payrollStatusService) GetPayrollStatus(ctx context.Context) (*PayrollSt
 	}, nil
 }
 
-func (s *payrollStatusService) resolvePayrollCategories(ctx context.Context) ([]PayrollCategoryStatus, int, error) {
+func (s *payrollStatusService) resolvePayrollCategories(ctx context.Context, snapshot *SettingsSnapshot) ([]PayrollCategoryStatus, int, error) {
 	categories := make([]PayrollCategoryStatus, 0, len(payrollCategories))
 	configuredCategories := 0
 	for _, category := range payrollCategories {
-		entry, err := s.resolvePayrollCategory(ctx, category)
+		entry, err := s.resolvePayrollCategory(ctx, snapshot, category)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -128,8 +149,8 @@ func (s *payrollStatusService) resolvePayrollCategories(ctx context.Context) ([]
 	return categories, configuredCategories, nil
 }
 
-func (s *payrollStatusService) resolvePayrollCategory(ctx context.Context, category payrollCategory) (PayrollCategoryStatus, error) {
-	number, err := s.settings.ResolveString(ctx, category.key)
+func (s *payrollStatusService) resolvePayrollCategory(ctx context.Context, snapshot *SettingsSnapshot, category payrollCategory) (PayrollCategoryStatus, error) {
+	number, err := resolvedPayrollString(ctx, s.settings, snapshot, category.key)
 	if err != nil {
 		return PayrollCategoryStatus{}, fmt.Errorf("resolve %s: %w", category.key, err)
 	}
@@ -143,7 +164,7 @@ func (s *payrollStatusService) resolvePayrollCategory(ctx context.Context, categ
 		return entry, nil
 	}
 
-	unit, err := s.settings.ResolveString(ctx, category.unitKey)
+	unit, err := resolvedPayrollString(ctx, s.settings, snapshot, category.unitKey)
 	if err != nil {
 		return PayrollCategoryStatus{}, fmt.Errorf("resolve %s: %w", category.unitKey, err)
 	}
@@ -153,16 +174,23 @@ func (s *payrollStatusService) resolvePayrollCategory(ctx context.Context, categ
 	return entry, nil
 }
 
-func (s *payrollStatusService) resolveLodasHeader(ctx context.Context) (string, string, error) {
-	berater, err := s.settings.ResolveString(ctx, configModel.KeyPayrollDatevBeraternummer)
+func (s *payrollStatusService) resolveLodasHeader(ctx context.Context, snapshot *SettingsSnapshot) (string, string, error) {
+	berater, err := resolvedPayrollString(ctx, s.settings, snapshot, configModel.KeyPayrollDatevBeraternummer)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve beraternummer: %w", err)
 	}
-	mandant, err := s.settings.ResolveString(ctx, configModel.KeyPayrollDatevMandantennummer)
+	mandant, err := resolvedPayrollString(ctx, s.settings, snapshot, configModel.KeyPayrollDatevMandantennummer)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve mandantennummer: %w", err)
 	}
 	return berater, mandant, nil
+}
+
+func resolvedPayrollString(ctx context.Context, settings SettingsService, snapshot *SettingsSnapshot, key string) (string, error) {
+	if snapshot != nil {
+		return snapshot.String(key)
+	}
+	return settings.ResolveString(ctx, key)
 }
 
 func (s *payrollStatusService) countStaffPersonnelNumbers(ctx context.Context) (int, int, error) {

--- a/backend/services/config/schema_builder.go
+++ b/backend/services/config/schema_builder.go
@@ -48,10 +48,19 @@ func buildSchemaWithScope(
 	// separately. Tenant-visible settings can depend on operator-only
 	// provisioning flags such as attendance.nfc_enabled; hiding those parents
 	// before evaluating DependsOn would make the tenant-visible children vanish.
+	keys := make([]string, 0, len(defs))
+	for key := range defs {
+		keys = append(keys, key)
+	}
+	snapshot, err := svc.ResolveMany(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+
 	resolvedMap := make(map[string]*ResolvedSetting, len(defs))
 	outputMap := make(map[string]*ResolvedSetting, len(defs))
 	for key, def := range defs {
-		value, err := svc.Resolve(ctx, key)
+		value, err := snapshot.Value(key)
 		if err != nil {
 			svc.logger.Warn("failed to resolve setting",
 				"key", key,
@@ -71,7 +80,14 @@ func buildSchemaWithScope(
 		// stay tenant-pinned with no way to clear it from the UI).
 		// jsonValuesEqual handles the JSONB roundtrip (float64 vs int) and
 		// type-correct comparison.
-		hasOverride, _ := svc.HasTenantOverride(ctx, key)
+		hasOverride, overrideErr := snapshot.HasOverride(key)
+		if overrideErr != nil {
+			svc.logger.Warn("failed to inspect setting override",
+				"key", key,
+				"error", overrideErr.Error(),
+			)
+			continue
+		}
 		isDefault := !hasOverride
 		if def.Type == config.FieldBoolean {
 			isDefault = jsonValuesEqual(value, def.Default)

--- a/backend/services/config/settings_interface.go
+++ b/backend/services/config/settings_interface.go
@@ -115,6 +115,17 @@ type SettingsService interface {
 	LockClassCollectionPair(ctx context.Context) error
 }
 
+// BatchSettingsService extends SettingsService with query-coalescing reads.
+// Keeping it separate preserves the narrow test and domain interfaces that
+// intentionally expose only the single-value operations they consume.
+type BatchSettingsService interface {
+	SettingsService
+
+	ResolveMany(ctx context.Context, keys []string) (*SettingsSnapshot, error)
+	ResolveManyForTenant(ctx context.Context, tenantID int64, keys []string) (*SettingsSnapshot, error)
+	ResolveManyForTenants(ctx context.Context, tenantIDs []int64, keys []string) (map[int64]*SettingsSnapshot, error)
+}
+
 // --- Response types ---
 
 // SettingsSchema is the top-level response for the schema endpoint.

--- a/backend/services/config/settings_multi_tenant_test.go
+++ b/backend/services/config/settings_multi_tenant_test.go
@@ -1,0 +1,88 @@
+package config_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	configRepository "github.com/moto-nrw/project-phoenix/database/repositories/config"
+	"github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+type settingValuesSelectCounter struct {
+	count atomic.Int32
+}
+
+func (c *settingValuesSelectCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if strings.HasPrefix(strings.TrimSpace(query), "select") &&
+		strings.Contains(query, "config.setting_values") {
+		c.count.Add(1)
+	}
+	return ctx
+}
+
+func (*settingValuesSelectCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func TestResolveManyForTenantsUsesOneCrossTenantQuery(t *testing.T) {
+	config.ResetRegistry()
+	t.Cleanup(config.ResetRegistry)
+	registerTestSetting("test.multi_tenant", config.FieldText, "default")
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	tenantA := testpkg.UniqueTestTenantID(t)
+	tenantB := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantA)
+	testpkg.EnsureTestTenant(t, db, tenantB)
+	t.Cleanup(func() { testpkg.CleanupTenantTestData(t, db, tenantA, tenantB) })
+
+	repository := configRepository.NewSettingValueRepository(db)
+	valueA := &config.SettingValue{
+		SettingKey: "test.multi_tenant",
+		Value:      json.RawMessage(`"tenant-a"`),
+	}
+	valueA.SetTenantID(tenantA)
+	valueB := &config.SettingValue{
+		SettingKey: "test.multi_tenant",
+		Value:      json.RawMessage(`"tenant-b"`),
+	}
+	valueB.SetTenantID(tenantB)
+	require.NoError(t, repository.Upsert(tenant.WithTenantID(context.Background(), tenantA), valueA))
+	require.NoError(t, repository.Upsert(tenant.WithTenantID(context.Background(), tenantB), valueB))
+	t.Cleanup(func() {
+		_ = repository.Delete(tenant.WithTenantID(context.Background(), tenantA), tenantA, valueA.SettingKey)
+		_ = repository.Delete(tenant.WithTenantID(context.Background(), tenantB), tenantB, valueB.SettingKey)
+	})
+
+	counter := &settingValuesSelectCounter{}
+	db.AddQueryHook(counter)
+	service := configService.NewSettingsService(repository, nil, nil, db, slog.Default())
+	batch, ok := service.(configService.BatchSettingsService)
+	require.True(t, ok)
+
+	snapshots, err := batch.ResolveManyForTenants(
+		context.Background(),
+		[]int64{tenantA, tenantB, tenantA},
+		[]string{"test.multi_tenant"},
+	)
+	require.NoError(t, err)
+	require.Len(t, snapshots, 2)
+	resolvedA, err := snapshots[tenantA].String("test.multi_tenant")
+	require.NoError(t, err)
+	resolvedB, err := snapshots[tenantB].String("test.multi_tenant")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", resolvedA)
+	assert.Equal(t, "tenant-b", resolvedB)
+	assert.Equal(t, int32(1), counter.count.Load(),
+		"tenant count must not affect config.setting_values query count")
+}

--- a/backend/services/config/settings_service.go
+++ b/backend/services/config/settings_service.go
@@ -91,48 +91,114 @@ func NewSettingsService(
 // Resolve returns the value for a setting: tenant override if it exists,
 // otherwise the registry default.
 func (s *settingsService) Resolve(ctx context.Context, key string) (any, error) {
-	def := config.GetDefinition(key)
-	if def == nil {
-		return nil, &SettingsError{
-			Op:  "resolve",
-			Err: &DefinitionNotFoundError{Key: key},
-		}
+	snapshot, err := s.ResolveMany(ctx, []string{key})
+	if err != nil {
+		return nil, err
 	}
+	return snapshot.Value(key)
+}
 
+// ResolveMany resolves several settings in one repository query. A compatible
+// context snapshot wins, which lets scheduler-invoked downstream services
+// share the minute snapshot without knowing about scheduler internals.
+func (s *settingsService) ResolveMany(ctx context.Context, keys []string) (*SettingsSnapshot, error) {
 	tenantID := tenant.FromContext(ctx)
-	if tenantID > 0 {
-		sv, err := s.valueRepo.FindByTenantAndKey(ctx, tenantID, key)
-		if err != nil {
-			return nil, &SettingsError{Op: "resolve", Err: err}
+	if snapshot := snapshotFromContext(ctx, tenantID, keys); snapshot != nil {
+		return snapshot, nil
+	}
+
+	if tenantID <= 0 || len(keys) == 0 {
+		return newSettingsSnapshot(tenantID, keys, nil)
+	}
+
+	stored, err := s.valueRepo.FindByTenantAndKeys(ctx, tenantID, keys)
+	if err != nil {
+		return nil, &SettingsError{Op: "resolve_many", Err: err}
+	}
+	return newSettingsSnapshot(tenantID, keys, stored)
+}
+
+// ResolveManyForTenant resolves several settings inside one tenant
+// transaction. A matching context snapshot avoids both the transaction and
+// query when a scheduler already prefetched the values.
+func (s *settingsService) ResolveManyForTenant(ctx context.Context, tenantID int64, keys []string) (*SettingsSnapshot, error) {
+	if snapshot := snapshotFromContext(ctx, tenantID, keys); snapshot != nil {
+		return snapshot, nil
+	}
+
+	var result *SettingsSnapshot
+	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		var resolveErr error
+		result, resolveErr = s.ResolveMany(txCtx, keys)
+		return resolveErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ResolveManyForTenants resolves all tenant/key pairs in one privileged query.
+// Registry defaults are filled independently for every requested tenant.
+func (s *settingsService) ResolveManyForTenants(ctx context.Context, tenantIDs []int64, keys []string) (map[int64]*SettingsSnapshot, error) {
+	uniqueTenantIDs := make([]int64, 0, len(tenantIDs))
+	seenTenantIDs := make(map[int64]struct{}, len(tenantIDs))
+	for _, tenantID := range tenantIDs {
+		if tenantID <= 0 {
+			continue
 		}
-		if sv != nil {
-			var value any
-			if err := json.Unmarshal(sv.Value, &value); err != nil {
-				return nil, &SettingsError{Op: "resolve", Err: fmt.Errorf("unmarshal value: %w", err)}
-			}
-			return value, nil
+		if _, seen := seenTenantIDs[tenantID]; seen {
+			continue
+		}
+		seenTenantIDs[tenantID] = struct{}{}
+		uniqueTenantIDs = append(uniqueTenantIDs, tenantID)
+	}
+
+	result := make(map[int64]*SettingsSnapshot, len(uniqueTenantIDs))
+	if len(uniqueTenantIDs) == 0 {
+		return result, nil
+	}
+
+	var stored []*config.SettingValue
+	if len(keys) > 0 {
+		err := tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, _ bun.Tx) error {
+			var findErr error
+			stored, findErr = s.valueRepo.FindByTenantsAndKeys(txCtx, uniqueTenantIDs, keys)
+			return findErr
+		})
+		if err != nil {
+			return nil, &SettingsError{Op: "resolve_many_for_tenants", Err: err}
 		}
 	}
 
-	return def.Default, nil
+	storedByTenant := make(map[int64][]*config.SettingValue, len(uniqueTenantIDs))
+	for _, value := range stored {
+		if value == nil {
+			continue
+		}
+		tenantID := value.GetTenantID()
+		if _, requested := seenTenantIDs[tenantID]; requested {
+			storedByTenant[tenantID] = append(storedByTenant[tenantID], value)
+		}
+	}
+	for _, tenantID := range uniqueTenantIDs {
+		snapshot, err := newSettingsSnapshot(tenantID, keys, storedByTenant[tenantID])
+		if err != nil {
+			return nil, err
+		}
+		result[tenantID] = snapshot
+	}
+	return result, nil
 }
 
 // ResolveStringForTenant resolves a setting as a string for a specific tenant,
 // wrapping the query in a tenant transaction to satisfy RLS.
 func (s *settingsService) ResolveStringForTenant(ctx context.Context, tenantID int64, key string) (string, error) {
-	var result string
-	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		val, resolveErr := s.ResolveString(txCtx, key)
-		if resolveErr != nil {
-			return resolveErr
-		}
-		result = val
-		return nil
-	})
+	snapshot, err := s.ResolveManyForTenant(ctx, tenantID, []string{key})
 	if err != nil {
 		return "", err
 	}
-	return result, nil
+	return snapshot.String(key)
 }
 
 // ResolveBoolForTenant resolves a setting as a bool for a specific tenant,
@@ -140,181 +206,78 @@ func (s *settingsService) ResolveStringForTenant(ctx context.Context, tenantID i
 // call sites that run outside TenantTxMiddleware (e.g. /auth/mfa/verify)
 // but already know which tenant they're acting on.
 func (s *settingsService) ResolveBoolForTenant(ctx context.Context, tenantID int64, key string) (bool, error) {
-	var result bool
-	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		val, resolveErr := s.ResolveBool(txCtx, key)
-		if resolveErr != nil {
-			return resolveErr
-		}
-		result = val
-		return nil
-	})
+	snapshot, err := s.ResolveManyForTenant(ctx, tenantID, []string{key})
 	if err != nil {
 		return false, err
 	}
-	return result, nil
+	return snapshot.Bool(key)
 }
 
 // ResolveIntForTenant mirrors ResolveBoolForTenant but for integer settings.
 func (s *settingsService) ResolveIntForTenant(ctx context.Context, tenantID int64, key string) (int, error) {
-	var result int
-	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		val, resolveErr := s.ResolveInt(txCtx, key)
-		if resolveErr != nil {
-			return resolveErr
-		}
-		result = val
-		return nil
-	})
+	snapshot, err := s.ResolveManyForTenant(ctx, tenantID, []string{key})
 	if err != nil {
 		return 0, err
 	}
-	return result, nil
+	return snapshot.Int(key)
 }
 
 // ResolveString resolves a setting as a string.
 func (s *settingsService) ResolveString(ctx context.Context, key string) (string, error) {
-	val, err := s.Resolve(ctx, key)
+	snapshot, err := s.ResolveMany(ctx, []string{key})
 	if err != nil {
 		return "", err
 	}
-	if val == nil {
-		return "", nil
-	}
-	str, ok := val.(string)
-	if !ok {
-		return fmt.Sprintf("%v", val), nil
-	}
-	return str, nil
+	return snapshot.String(key)
 }
 
 // ResolveBool resolves a setting as a bool.
 func (s *settingsService) ResolveBool(ctx context.Context, key string) (bool, error) {
-	val, err := s.Resolve(ctx, key)
+	snapshot, err := s.ResolveMany(ctx, []string{key})
 	if err != nil {
 		return false, err
 	}
-	if val == nil {
-		return false, nil
-	}
-	b, ok := val.(bool)
-	if !ok {
-		return false, &SettingsError{Op: "resolve_bool", Err: fmt.Errorf("expected bool, got %T", val)}
-	}
-	return b, nil
+	return snapshot.Bool(key)
 }
 
 // ResolveBools resolves multiple boolean settings while loading all tenant
 // overrides in one query. Registry defaults are filled first, then explicit
 // tenant values replace them.
 func (s *settingsService) ResolveBools(ctx context.Context, keys []string) (map[string]bool, error) {
+	snapshot, err := s.ResolveMany(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
 	resolved := make(map[string]bool, len(keys))
-	uniqueKeys := make([]string, 0, len(keys))
 	for _, key := range keys {
 		if _, seen := resolved[key]; seen {
 			continue
 		}
-		def := config.GetDefinition(key)
-		if def == nil {
-			return nil, &SettingsError{
-				Op:  "resolve_bools",
-				Err: &DefinitionNotFoundError{Key: key},
-			}
-		}
-		value, ok := def.Default.(bool)
-		if !ok {
-			return nil, &SettingsError{
-				Op:  "resolve_bools",
-				Err: fmt.Errorf("expected bool default for %s, got %T", key, def.Default),
-			}
+		value, resolveErr := snapshot.Bool(key)
+		if resolveErr != nil {
+			return nil, resolveErr
 		}
 		resolved[key] = value
-		uniqueKeys = append(uniqueKeys, key)
-	}
-	if len(uniqueKeys) == 0 {
-		return resolved, nil
-	}
-
-	tenantID := tenant.FromContext(ctx)
-	if tenantID <= 0 {
-		return resolved, nil
-	}
-	stored, err := s.valueRepo.FindByTenantAndKeys(ctx, tenantID, uniqueKeys)
-	if err != nil {
-		return nil, &SettingsError{Op: "resolve_bools", Err: err}
-	}
-	for _, sv := range stored {
-		if _, requested := resolved[sv.SettingKey]; !requested {
-			continue
-		}
-		var value any
-		if err := json.Unmarshal(sv.Value, &value); err != nil {
-			return nil, &SettingsError{
-				Op:  "resolve_bools",
-				Err: fmt.Errorf("unmarshal value for %s: %w", sv.SettingKey, err),
-			}
-		}
-		if value == nil {
-			resolved[sv.SettingKey] = false
-			continue
-		}
-		boolean, ok := value.(bool)
-		if !ok {
-			return nil, &SettingsError{
-				Op:  "resolve_bools",
-				Err: fmt.Errorf("expected bool for %s, got %T", sv.SettingKey, value),
-			}
-		}
-		resolved[sv.SettingKey] = boolean
 	}
 	return resolved, nil
 }
 
 // ResolveInt resolves a setting as an int.
 func (s *settingsService) ResolveInt(ctx context.Context, key string) (int, error) {
-	val, err := s.Resolve(ctx, key)
+	snapshot, err := s.ResolveMany(ctx, []string{key})
 	if err != nil {
 		return 0, err
 	}
-	if val == nil {
-		return 0, nil
-	}
-	switch n := val.(type) {
-	case float64:
-		if n != math.Floor(n) {
-			return 0, &SettingsError{Op: "resolve_int", Err: fmt.Errorf("value %v has fractional part", n)}
-		}
-		if n > float64(math.MaxInt) || n < float64(math.MinInt) {
-			return 0, &SettingsError{Op: "resolve_int", Err: fmt.Errorf("value %v out of int range", n)}
-		}
-		return int(n), nil
-	case int:
-		return n, nil
-	case json.Number:
-		i, err := n.Int64()
-		if err != nil {
-			return 0, &SettingsError{Op: "resolve_int", Err: fmt.Errorf("invalid number: %w", err)}
-		}
-		if i > int64(math.MaxInt) || i < int64(math.MinInt) {
-			return 0, &SettingsError{Op: "resolve_int", Err: fmt.Errorf("value %v out of int range", i)}
-		}
-		return int(i), nil
-	default:
-		return 0, &SettingsError{Op: "resolve_int", Err: fmt.Errorf("expected number, got %T", val)}
-	}
+	return snapshot.Int(key)
 }
 
 // HasTenantOverride checks if a tenant has an explicit DB override for a setting.
 func (s *settingsService) HasTenantOverride(ctx context.Context, key string) (bool, error) {
-	tenantID := tenant.FromContext(ctx)
-	if tenantID <= 0 {
-		return false, nil
-	}
-	sv, err := s.valueRepo.FindByTenantAndKey(ctx, tenantID, key)
+	snapshot, err := s.ResolveMany(ctx, []string{key})
 	if err != nil {
-		return false, &SettingsError{Op: "has_override", Err: err}
+		return false, err
 	}
-	return sv != nil, nil
+	return snapshot.HasOverride(key)
 }
 
 // checkWritePermission verifies the caller has the required write permission.

--- a/backend/services/config/settings_service_tenant_test.go
+++ b/backend/services/config/settings_service_tenant_test.go
@@ -77,6 +77,27 @@ func (r *inMemoryValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int6
 	return out, nil
 }
 
+func (r *inMemoryValueRepo) FindByTenantsAndKeys(_ context.Context, tenantIDs []int64, settingKeys []string) ([]*config.SettingValue, error) {
+	tenants := make(map[int64]struct{}, len(tenantIDs))
+	for _, tenantID := range tenantIDs {
+		tenants[tenantID] = struct{}{}
+	}
+	requested := make(map[string]struct{}, len(settingKeys))
+	for _, key := range settingKeys {
+		requested[key] = struct{}{}
+	}
+	var out []*config.SettingValue
+	for _, value := range r.rows {
+		if _, ok := tenants[value.GetTenantID()]; !ok {
+			continue
+		}
+		if _, ok := requested[value.SettingKey]; ok {
+			out = append(out, value)
+		}
+	}
+	return out, nil
+}
+
 func (r *inMemoryValueRepo) Upsert(_ context.Context, sv *config.SettingValue) error {
 	r.rows[r.key(sv.GetTenantID(), sv.SettingKey)] = sv
 	return nil

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -68,6 +68,31 @@ func (m *mockValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int64, s
 	return result, nil
 }
 
+func (m *mockValueRepo) FindByTenantsAndKeys(_ context.Context, tenantIDs []int64, settingKeys []string) ([]*config.SettingValue, error) {
+	m.findManyCalls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	tenants := make(map[int64]struct{}, len(tenantIDs))
+	for _, tenantID := range tenantIDs {
+		tenants[tenantID] = struct{}{}
+	}
+	requested := make(map[string]struct{}, len(settingKeys))
+	for _, key := range settingKeys {
+		requested[key] = struct{}{}
+	}
+	var result []*config.SettingValue
+	for _, value := range m.values {
+		if _, ok := tenants[value.GetTenantID()]; !ok {
+			continue
+		}
+		if _, ok := requested[value.SettingKey]; ok {
+			result = append(result, value)
+		}
+	}
+	return result, nil
+}
+
 func (m *mockValueRepo) Upsert(_ context.Context, sv *config.SettingValue) error {
 	if m.err != nil {
 		return m.err

--- a/backend/services/config/settings_snapshot.go
+++ b/backend/services/config/settings_snapshot.go
@@ -1,0 +1,199 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+)
+
+type settingsSnapshotContextKey struct{}
+
+type snapshotValue struct {
+	value       any
+	hasOverride bool
+	err         error
+}
+
+// SettingsSnapshot is an immutable, tenant-bound set of resolved settings.
+// It keeps override presence separate from the effective value so callers with
+// legacy environment fallbacks do not need a second database query.
+type SettingsSnapshot struct {
+	tenantID int64
+	values   map[string]snapshotValue
+}
+
+// WithSettingsSnapshot attaches a tenant-bound snapshot to ctx. Settings
+// resolution reuses it only when its tenant matches the request context.
+func WithSettingsSnapshot(ctx context.Context, snapshot *SettingsSnapshot) context.Context {
+	if snapshot == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, settingsSnapshotContextKey{}, snapshot)
+}
+
+func snapshotFromContext(ctx context.Context, tenantID int64, keys []string) *SettingsSnapshot {
+	snapshot, _ := ctx.Value(settingsSnapshotContextKey{}).(*SettingsSnapshot)
+	if snapshot == nil || snapshot.tenantID != tenantID || !snapshot.containsAll(keys) {
+		return nil
+	}
+	return snapshot
+}
+
+func newSettingsSnapshot(tenantID int64, keys []string, stored []*configModel.SettingValue) (*SettingsSnapshot, error) {
+	values := make(map[string]snapshotValue, len(keys))
+	for _, key := range keys {
+		if _, exists := values[key]; exists {
+			continue
+		}
+		def := configModel.GetDefinition(key)
+		if def == nil {
+			return nil, &SettingsError{
+				Op:  "resolve_many",
+				Err: &DefinitionNotFoundError{Key: key},
+			}
+		}
+		values[key] = snapshotValue{value: def.Default}
+	}
+
+	for _, storedValue := range stored {
+		if storedValue == nil || storedValue.GetTenantID() != tenantID {
+			continue
+		}
+		if _, requested := values[storedValue.SettingKey]; !requested {
+			continue
+		}
+		var value any
+		err := json.Unmarshal(storedValue.Value, &value)
+		if err != nil {
+			err = fmt.Errorf("unmarshal value for %s: %w", storedValue.SettingKey, err)
+		}
+		values[storedValue.SettingKey] = snapshotValue{
+			value:       value,
+			hasOverride: true,
+			err:         err,
+		}
+	}
+
+	return &SettingsSnapshot{tenantID: tenantID, values: values}, nil
+}
+
+func (s *SettingsSnapshot) containsAll(keys []string) bool {
+	if s == nil {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := s.values[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *SettingsSnapshot) entry(key string) (snapshotValue, error) {
+	if s == nil {
+		return snapshotValue{}, &SettingsError{Op: "snapshot", Err: fmt.Errorf("settings snapshot is nil")}
+	}
+	entry, ok := s.values[key]
+	if !ok {
+		return snapshotValue{}, &SettingsError{
+			Op:  "snapshot",
+			Err: &DefinitionNotFoundError{Key: key},
+		}
+	}
+	if entry.err != nil {
+		return snapshotValue{}, &SettingsError{Op: "snapshot", Err: entry.err}
+	}
+	return entry, nil
+}
+
+// Value returns the effective override or registry default for key.
+func (s *SettingsSnapshot) Value(key string) (any, error) {
+	entry, err := s.entry(key)
+	if err != nil {
+		return nil, err
+	}
+	return entry.value, nil
+}
+
+// HasOverride reports whether key has an explicit tenant row.
+func (s *SettingsSnapshot) HasOverride(key string) (bool, error) {
+	if s == nil {
+		return false, &SettingsError{Op: "snapshot", Err: fmt.Errorf("settings snapshot is nil")}
+	}
+	entry, ok := s.values[key]
+	if !ok {
+		return false, &SettingsError{
+			Op:  "snapshot",
+			Err: &DefinitionNotFoundError{Key: key},
+		}
+	}
+	return entry.hasOverride, nil
+}
+
+// String resolves key with the same conversion semantics as ResolveString.
+func (s *SettingsSnapshot) String(key string) (string, error) {
+	value, err := s.Value(key)
+	if err != nil {
+		return "", err
+	}
+	if value == nil {
+		return "", nil
+	}
+	if stringValue, ok := value.(string); ok {
+		return stringValue, nil
+	}
+	return fmt.Sprintf("%v", value), nil
+}
+
+// Bool resolves key as a boolean.
+func (s *SettingsSnapshot) Bool(key string) (bool, error) {
+	value, err := s.Value(key)
+	if err != nil {
+		return false, err
+	}
+	if value == nil {
+		return false, nil
+	}
+	boolean, ok := value.(bool)
+	if !ok {
+		return false, &SettingsError{Op: "snapshot_bool", Err: fmt.Errorf("expected bool, got %T", value)}
+	}
+	return boolean, nil
+}
+
+// Int resolves key as a platform int without accepting fractional JSON values.
+func (s *SettingsSnapshot) Int(key string) (int, error) {
+	value, err := s.Value(key)
+	if err != nil {
+		return 0, err
+	}
+	if value == nil {
+		return 0, nil
+	}
+	switch number := value.(type) {
+	case float64:
+		if number != math.Floor(number) {
+			return 0, &SettingsError{Op: "snapshot_int", Err: fmt.Errorf("value %v has fractional part", number)}
+		}
+		if number > float64(math.MaxInt) || number < float64(math.MinInt) {
+			return 0, &SettingsError{Op: "snapshot_int", Err: fmt.Errorf("value %v out of int range", number)}
+		}
+		return int(number), nil
+	case int:
+		return number, nil
+	case json.Number:
+		integer, parseErr := number.Int64()
+		if parseErr != nil {
+			return 0, &SettingsError{Op: "snapshot_int", Err: fmt.Errorf("invalid number: %w", parseErr)}
+		}
+		if integer > int64(math.MaxInt) || integer < int64(math.MinInt) {
+			return 0, &SettingsError{Op: "snapshot_int", Err: fmt.Errorf("value %v out of int range", integer)}
+		}
+		return int(integer), nil
+	default:
+		return 0, &SettingsError{Op: "snapshot_int", Err: fmt.Errorf("expected number, got %T", value)}
+	}
+}

--- a/backend/services/config/settings_snapshot_edge_test.go
+++ b/backend/services/config/settings_snapshot_edge_test.go
@@ -1,0 +1,162 @@
+package config_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type noisyValueRepo struct {
+	*mockValueRepo
+	stored []*config.SettingValue
+}
+
+func (r *noisyValueRepo) FindByTenantAndKeys(
+	context.Context,
+	int64,
+	[]string,
+) ([]*config.SettingValue, error) {
+	r.findManyCalls++
+	return r.stored, nil
+}
+
+func TestSettingsSnapshotRejectsNilAndUnknownKeys(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.known", config.FieldText, "known")
+
+	service := createService(newMockValueRepo(), &mockAuditRepo{})
+	batch := service.(configService.BatchSettingsService)
+	snapshot, err := batch.ResolveMany(tenantCtx(9), []string{"test.known"})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	assert.Equal(t, ctx, configService.WithSettingsSnapshot(ctx, nil))
+
+	var nilSnapshot *configService.SettingsSnapshot
+	_, err = nilSnapshot.Value("test.known")
+	require.Error(t, err)
+	_, err = nilSnapshot.HasOverride("test.known")
+	require.Error(t, err)
+	_, err = nilSnapshot.String("test.known")
+	require.Error(t, err)
+	_, err = nilSnapshot.Int("test.known")
+	require.Error(t, err)
+
+	_, err = snapshot.Value("test.unknown")
+	require.Error(t, err)
+	_, err = snapshot.HasOverride("test.unknown")
+	require.Error(t, err)
+	_, err = snapshot.String("test.unknown")
+	require.Error(t, err)
+	_, err = snapshot.Int("test.unknown")
+	require.Error(t, err)
+}
+
+func TestSettingsSnapshotContextMustContainEveryRequestedKey(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.first", config.FieldText, "first")
+	registerTestSetting("test.second", config.FieldText, "second")
+
+	repo := newMockValueRepo()
+	service := createService(repo, &mockAuditRepo{})
+	batch := service.(configService.BatchSettingsService)
+	snapshot, err := batch.ResolveMany(tenantCtx(23), []string{"test.first"})
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.findManyCalls)
+
+	ctx := configService.WithSettingsSnapshot(tenantCtx(23), snapshot)
+	value, err := service.ResolveString(ctx, "test.second")
+	require.NoError(t, err)
+	assert.Equal(t, "second", value)
+	assert.Equal(t, 2, repo.findManyCalls, "an incomplete snapshot must not serve an unrequested key")
+}
+
+func TestSettingsSnapshotIgnoresRowsOutsideRequestedTenantAndKeys(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.requested", config.FieldText, "default")
+
+	wrongTenant := &config.SettingValue{
+		SettingKey: "test.requested",
+		Value:      json.RawMessage(`"wrong tenant"`),
+	}
+	wrongTenant.TenantID = 72
+	unrequested := &config.SettingValue{
+		SettingKey: "test.unrequested",
+		Value:      json.RawMessage(`"wrong key"`),
+	}
+	unrequested.TenantID = 71
+	requested := &config.SettingValue{
+		SettingKey: "test.requested",
+		Value:      json.RawMessage(`"tenant value"`),
+	}
+	requested.TenantID = 71
+
+	repo := &noisyValueRepo{
+		mockValueRepo: newMockValueRepo(),
+		stored:        []*config.SettingValue{nil, wrongTenant, unrequested, requested},
+	}
+	service := createService(repo, &mockAuditRepo{})
+	snapshot, err := service.(configService.BatchSettingsService).ResolveMany(
+		tenantCtx(71),
+		[]string{"test.requested"},
+	)
+	require.NoError(t, err)
+
+	value, err := snapshot.String("test.requested")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant value", value)
+}
+
+func TestSettingsSnapshotIntConversionsRejectInvalidNumbers(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.json_number", config.FieldNumber, json.Number("12"))
+	registerTestSetting("test.invalid_json_number", config.FieldNumber, json.Number("invalid"))
+	registerTestSetting("test.out_of_range", config.FieldNumber, 0)
+
+	repo := newMockValueRepo()
+	outOfRange := &config.SettingValue{
+		SettingKey: "test.out_of_range",
+		Value:      json.RawMessage(`1e100`),
+	}
+	outOfRange.TenantID = 31
+	repo.values[repo.key(outOfRange.TenantID, outOfRange.SettingKey)] = outOfRange
+
+	service := createService(repo, &mockAuditRepo{})
+	snapshot, err := service.(configService.BatchSettingsService).ResolveMany(
+		tenantCtx(31),
+		[]string{"test.json_number", "test.invalid_json_number", "test.out_of_range"},
+	)
+	require.NoError(t, err)
+
+	value, err := snapshot.Int("test.json_number")
+	require.NoError(t, err)
+	assert.Equal(t, 12, value)
+
+	_, err = snapshot.Int("test.invalid_json_number")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid number")
+
+	_, err = snapshot.Int("test.out_of_range")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of int range")
+}
+
+func TestGetSchemaPropagatesBatchResolutionError(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.schema_error", config.FieldText, "default")
+
+	repo := newMockValueRepo()
+	repo.err = errors.New("database unavailable")
+	service := createService(repo, &mockAuditRepo{})
+
+	schema, err := service.GetSchema(tenantCtx(11), nil)
+	require.Error(t, err)
+	assert.Nil(t, schema)
+	assert.Contains(t, err.Error(), "database unavailable")
+}

--- a/backend/services/config/settings_snapshot_test.go
+++ b/backend/services/config/settings_snapshot_test.go
@@ -1,0 +1,120 @@
+package config_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveManyUsesOneQueryAndContextSnapshot(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.batch_text", config.FieldText, "default")
+	registerTestSetting("test.batch_bool", config.FieldBoolean, false)
+	registerTestSetting("test.batch_int", config.FieldNumber, 7)
+
+	repo := newMockValueRepo()
+	textValue := &config.SettingValue{
+		SettingKey: "test.batch_text",
+		Value:      json.RawMessage(`"tenant"`),
+	}
+	textValue.TenantID = 41
+	repo.values[repo.key(41, textValue.SettingKey)] = textValue
+	boolValue := &config.SettingValue{
+		SettingKey: "test.batch_bool",
+		Value:      json.RawMessage(`true`),
+	}
+	boolValue.TenantID = 41
+	repo.values[repo.key(41, boolValue.SettingKey)] = boolValue
+
+	service := createService(repo, &mockAuditRepo{})
+	batch, ok := service.(configService.BatchSettingsService)
+	require.True(t, ok)
+
+	snapshot, err := batch.ResolveMany(tenantCtx(41), []string{
+		"test.batch_text",
+		"test.batch_bool",
+		"test.batch_int",
+		"test.batch_text",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.findManyCalls)
+
+	text, err := snapshot.String("test.batch_text")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant", text)
+	boolean, err := snapshot.Bool("test.batch_bool")
+	require.NoError(t, err)
+	assert.True(t, boolean)
+	integer, err := snapshot.Int("test.batch_int")
+	require.NoError(t, err)
+	assert.Equal(t, 7, integer)
+	hasOverride, err := snapshot.HasOverride("test.batch_text")
+	require.NoError(t, err)
+	assert.True(t, hasOverride)
+	hasOverride, err = snapshot.HasOverride("test.batch_int")
+	require.NoError(t, err)
+	assert.False(t, hasOverride)
+
+	snapshotCtx := configService.WithSettingsSnapshot(tenantCtx(41), snapshot)
+	_, err = service.ResolveString(snapshotCtx, "test.batch_text")
+	require.NoError(t, err)
+	_, err = service.ResolveBool(snapshotCtx, "test.batch_bool")
+	require.NoError(t, err)
+	_, err = service.ResolveInt(snapshotCtx, "test.batch_int")
+	require.NoError(t, err)
+	_, err = service.HasTenantOverride(snapshotCtx, "test.batch_text")
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.findManyCalls, "typed accessors must reuse the attached snapshot")
+
+	_, err = service.ResolveString(configService.WithSettingsSnapshot(tenantCtx(42), snapshot), "test.batch_text")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.findManyCalls, "a snapshot from another tenant must never be reused")
+}
+
+func TestResolveManyKeepsMalformedOverrideIsolated(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.valid", config.FieldBoolean, false)
+	registerTestSetting("test.malformed", config.FieldBoolean, false)
+
+	repo := newMockValueRepo()
+	valid := &config.SettingValue{SettingKey: "test.valid", Value: json.RawMessage(`true`)}
+	valid.TenantID = 8
+	repo.values[repo.key(8, valid.SettingKey)] = valid
+	malformed := &config.SettingValue{SettingKey: "test.malformed", Value: json.RawMessage(`{`)}
+	malformed.TenantID = 8
+	repo.values[repo.key(8, malformed.SettingKey)] = malformed
+
+	service := createService(repo, &mockAuditRepo{})
+	batch := service.(configService.BatchSettingsService)
+	snapshot, err := batch.ResolveMany(tenantCtx(8), []string{"test.valid", "test.malformed"})
+	require.NoError(t, err)
+
+	value, err := snapshot.Bool("test.valid")
+	require.NoError(t, err)
+	assert.True(t, value)
+	_, err = snapshot.Bool("test.malformed")
+	require.Error(t, err)
+	hasOverride, err := snapshot.HasOverride("test.malformed")
+	require.NoError(t, err)
+	assert.True(t, hasOverride, "malformed JSON must not erase knowledge that an override row exists")
+	assert.Equal(t, 1, repo.findManyCalls)
+}
+
+func TestGetSchemaLoadsAllSettingsWithOneQuery(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.schema_one", config.FieldText, "one")
+	registerTestSetting("test.schema_two", config.FieldBoolean, true)
+	registerTestSetting("test.schema_three", config.FieldNumber, 3)
+
+	repo := newMockValueRepo()
+	service := createService(repo, &mockAuditRepo{})
+
+	schema, err := service.GetSchema(tenantCtx(5), nil)
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	assert.Equal(t, 1, repo.findManyCalls, "schema size must not affect settings query count")
+}

--- a/backend/services/enrollment/request_service.go
+++ b/backend/services/enrollment/request_service.go
@@ -2885,6 +2885,29 @@ func (s *requestService) LegalTexts(ctx context.Context) (LegalTexts, error) {
 	if s.Settings == nil {
 		return LegalTexts{}, nil
 	}
+	keys := []string{
+		configModel.KeyEnrollmentLegalAGBText,
+		configModel.KeyEnrollmentLegalAGBDocumentURL,
+		configModel.KeyEnrollmentLegalAGBDisplayMode,
+		configModel.KeyEnrollmentLegalDSGVOText,
+		configModel.KeyEnrollmentLegalEmailContactText,
+		configModel.KeyEnrollmentLegalPhotoText,
+		configModel.KeyEnrollmentLegalTermsEnabled,
+		configModel.KeyEnrollmentLegalDSGVOEnabled,
+		configModel.KeyEnrollmentLegalEmailContactEnabled,
+		configModel.KeyEnrollmentLegalPhotoEnabled,
+	}
+	if batch, ok := s.Settings.(interface {
+		ResolveMany(context.Context, []string) (*config.SettingsSnapshot, error)
+	}); ok {
+		snapshot, err := batch.ResolveMany(ctx, keys)
+		if err != nil {
+			return LegalTexts{}, fmt.Errorf("resolve legal settings: %w", err)
+		}
+		if snapshot != nil {
+			ctx = config.WithSettingsSnapshot(ctx, snapshot)
+		}
+	}
 	agb, err := s.Settings.ResolveString(ctx, configModel.KeyEnrollmentLegalAGBText)
 	if err != nil {
 		return LegalTexts{}, fmt.Errorf("resolve AGB legal text: %w", err)

--- a/backend/services/parent/parent_write_service.go
+++ b/backend/services/parent/parent_write_service.go
@@ -24,6 +24,7 @@ import (
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
 	absenceSvc "github.com/moto-nrw/project-phoenix/services/absence"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
 	mealplanService "github.com/moto-nrw/project-phoenix/services/mealplan"
 	notificationsSvc "github.com/moto-nrw/project-phoenix/services/notifications"
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
@@ -476,49 +477,84 @@ func (s *service) ChildFeatures(ctx context.Context, accountID, studentID int64)
 	if err != nil {
 		return ChildFeatureFlags{}, err
 	}
-	sick, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentSickNoteEnabled)
+	keys := []string{
+		configModels.KeyParentSickNoteEnabled,
+		configModels.KeyParentExcusedRequiresApproval,
+		configModels.KeyParentNotesEnabled,
+		configModels.KeyParentPickupChangeEnabled,
+		configModels.KeyGuardianParentInviteMode,
+		configModels.KeyGuardianParentCanRemove,
+		configModels.KeyParentMasterDataEditEnabled,
+		configModels.KeyParentMasterDataRequestEnabled,
+		configModels.KeyMealPlanEnabled,
+		configModels.KeyParentNewsEnabled,
+		configModels.KeyParentGuardianManagementEnabled,
+	}
+	var snapshot *configService.SettingsSnapshot
+	if batch, ok := s.Settings.(interface {
+		ResolveManyForTenant(context.Context, int64, []string) (*configService.SettingsSnapshot, error)
+	}); ok {
+		snapshot, err = batch.ResolveManyForTenant(ctx, child.tenantID, keys)
+		if err != nil {
+			return ChildFeatureFlags{}, fmt.Errorf("parent: resolve child feature settings: %w", err)
+		}
+	}
+	resolveBool := func(key string) (bool, error) {
+		if snapshot != nil {
+			return snapshot.Bool(key)
+		}
+		return s.Settings.ResolveBoolForTenant(ctx, child.tenantID, key)
+	}
+	resolveString := func(key string) (string, error) {
+		if snapshot != nil {
+			return snapshot.String(key)
+		}
+		return s.Settings.ResolveStringForTenant(ctx, child.tenantID, key)
+	}
+
+	sick, err := resolveBool(configModels.KeyParentSickNoteEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve sick-note setting: %w", err)
 	}
-	excusedApproval, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentExcusedRequiresApproval)
+	excusedApproval, err := resolveBool(configModels.KeyParentExcusedRequiresApproval)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve excused-approval setting: %w", err)
 	}
-	notes, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentNotesEnabled)
+	notes, err := resolveBool(configModels.KeyParentNotesEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve notes setting: %w", err)
 	}
-	pickupChange, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentPickupChangeEnabled)
+	pickupChange, err := resolveBool(configModels.KeyParentPickupChangeEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve pickup-change setting: %w", err)
 	}
-	inviteMode, err := s.Settings.ResolveStringForTenant(ctx, child.tenantID, configModels.KeyGuardianParentInviteMode)
+	inviteMode, err := resolveString(configModels.KeyGuardianParentInviteMode)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve invite mode: %w", err)
 	}
-	canRemove, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyGuardianParentCanRemove)
+	canRemove, err := resolveBool(configModels.KeyGuardianParentCanRemove)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve remove setting: %w", err)
 	}
-	masterEdit, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentMasterDataEditEnabled)
+	masterEdit, err := resolveBool(configModels.KeyParentMasterDataEditEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve master-data edit setting: %w", err)
 	}
-	masterRequest, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentMasterDataRequestEnabled)
+	masterRequest, err := resolveBool(configModels.KeyParentMasterDataRequestEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve master-data request setting: %w", err)
 	}
-	mealPlan, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyMealPlanEnabled)
+	mealPlan, err := resolveBool(configModels.KeyMealPlanEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve meal-plan setting: %w", err)
 	}
-	news, err := s.Settings.ResolveBoolForTenant(ctx, child.tenantID, configModels.KeyParentNewsEnabled)
+	news, err := resolveBool(configModels.KeyParentNewsEnabled)
 	if err != nil {
 		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve parent-news setting: %w", err)
 	}
-	guardianManagement, err := s.guardianManagementEnabled(ctx, child.tenantID)
+	guardianManagement, err := resolveBool(configModels.KeyParentGuardianManagementEnabled)
 	if err != nil {
-		return ChildFeatureFlags{}, err
+		return ChildFeatureFlags{}, fmt.Errorf("parent: resolve guardian-management setting: %w", err)
 	}
 	canEditMasterData := masterEdit && child.hasPermission(authorize.GuardianPermissionMasterDataEdit)
 	return ChildFeatureFlags{

--- a/backend/services/reminders/batch.go
+++ b/backend/services/reminders/batch.go
@@ -81,6 +81,12 @@ func (s *service) ComputeBatch(ctx context.Context, scopes []BatchScope) (map[in
 		return disabledResults(recipients), nil
 	}
 
+	var err error
+	ctx, err = s.withSettingsSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg, err := s.loadBatchConfig(ctx, recipients)
 	if err != nil {
 		return nil, err

--- a/backend/services/reminders/service.go
+++ b/backend/services/reminders/service.go
@@ -24,6 +24,7 @@ import (
 	facilitiesModel "github.com/moto-nrw/project-phoenix/models/facilities"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
 )
 
@@ -136,6 +137,18 @@ type settingsResolver interface {
 	ResolveBool(ctx context.Context, key string) (bool, error)
 	ResolveInt(ctx context.Context, key string) (int, error)
 	ResolveString(ctx context.Context, key string) (string, error)
+}
+
+var reminderSettingKeys = []string{
+	configModel.KeyRemindersPickupUpcomingEnabled,
+	configModel.KeyRemindersPickupOverdueEnabled,
+	configModel.KeyRemindersActivityStartEnabled,
+	configModel.KeyRemindersActivityOverdueEnabled,
+	configModel.KeyRemindersPickupUpcomingLeadMinutes,
+	configModel.KeyRemindersActivityStartLeadMinutes,
+	configModel.KeyTimetableOverdueThresholdMinutes,
+	configModel.KeyPresenceMode,
+	configModel.KeyStudentDataScope,
 }
 
 type attendanceReader interface {
@@ -255,6 +268,11 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 	if s.Settings == nil {
 		return empty, nil
 	}
+	var err error
+	ctx, err = s.withSettingsSnapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// A resolution failure (DB/RLS/tenant-tx error) must surface, not be treated
 	// as "disabled" — otherwise a broken config read looks like a healthy empty
@@ -337,6 +355,20 @@ func (s *service) Compute(ctx context.Context, scope Scope) (*Result, error) {
 	}
 
 	return assembleResult(pickupPart, activityPart, nextChange), nil
+}
+
+func (s *service) withSettingsSnapshot(ctx context.Context) (context.Context, error) {
+	batch, ok := s.Settings.(interface {
+		ResolveMany(context.Context, []string) (*configService.SettingsSnapshot, error)
+	})
+	if !ok {
+		return ctx, nil
+	}
+	snapshot, err := batch.ResolveMany(ctx, reminderSettingKeys)
+	if err != nil {
+		return ctx, fmt.Errorf("resolve reminder settings: %w", err)
+	}
+	return configService.WithSettingsSnapshot(ctx, snapshot), nil
 }
 
 // errActivityRoomReaderMissing is returned when overdue activity reminders are

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -110,6 +111,10 @@ type Scheduler struct {
 	settings                   SettingsResolver
 	db                         *bun.DB
 	schoolRepo                 platform.SchoolRepository
+	minuteSnapshotMu           sync.Mutex
+	minuteSnapshotLoad         *schedulerMinuteSnapshotLoad
+	minuteSnapshotNow          func() time.Time
+	minuteSnapshotLoader       func(context.Context) (*schedulerMinuteSnapshot, error)
 	cleanupJobs                []CleanupJob
 	tasks                      map[string]*ScheduledTask
 	mu                         sync.RWMutex
@@ -346,8 +351,8 @@ func (s *Scheduler) SetStudentStatusDayRepo(repo activeModel.StudentStatusDayRep
 
 // forEachTenant executes fn for each active tenant inside a WithTenantTx.
 // If schoolRepo or db is not set, falls back to running fn with plain ctx (non-tenant-aware mode).
-// Thin wrapper over tenant.ForEachActive; the scheduler-owned fallback to non-tenant-aware mode
-// is preserved so existing tests that do not wire a school repo keep working.
+// Active tenant IDs share the same minute snapshot as settings-aware jobs so
+// concurrent polling goroutines do not repeat the platform.schools query.
 func (s *Scheduler) forEachTenant(ctx context.Context, opName string, fn func(ctx context.Context) error) error {
 	if s.db == nil || s.schoolRepo == nil {
 		s.getLogger().Warn("tenant iteration not configured, running without tenant context",
@@ -355,14 +360,19 @@ func (s *Scheduler) forEachTenant(ctx context.Context, opName string, fn func(ct
 		return fn(ctx)
 	}
 
-	return tenant.ForEachActive(ctx, s.db, s.schoolRepo, s.getLogger(), opName, func(txCtx context.Context, _ int64) error {
+	minuteSnapshot, err := s.getMinuteSnapshot(ctx)
+	if err != nil && (minuteSnapshot == nil || len(minuteSnapshot.tenantIDs) == 0) {
+		return fmt.Errorf("load active tenants for %s: %w", opName, err)
+	}
+	s.forEachKnownTenant(ctx, minuteSnapshot.tenantIDs, opName, func(txCtx context.Context, _ int64) error {
 		return fn(txCtx)
 	})
+	return nil
 }
 
 // forEachTenantSettings executes fn for each active tenant, passing tenant ID for settings resolution.
 // Falls back to non-tenant-aware mode if schoolRepo/db is not set (tests, local dev without
-// seeded schools). Shared with the CLI via tenant.ForEachActive.
+// seeded schools). Production jobs share one cross-tenant settings snapshot per minute.
 func (s *Scheduler) forEachTenantSettings(ctx context.Context, opName string, fn func(ctx context.Context, tenantID int64) error) {
 	if s.db == nil || s.schoolRepo == nil {
 		s.getLogger().Warn("tenant iteration not configured, running without tenant context",
@@ -371,12 +381,33 @@ func (s *Scheduler) forEachTenantSettings(ctx context.Context, opName string, fn
 		return
 	}
 
-	if err := tenant.ForEachActive(ctx, s.db, s.schoolRepo, s.getLogger(), opName, fn); err != nil {
-		s.getLogger().Error("failed to list active tenants",
+	minuteSnapshot, err := s.getMinuteSnapshot(ctx)
+	if err != nil {
+		// Older unit-test fakes implement only the narrow per-key resolver.
+		// Production SettingsService always implements the batch loader.
+		if errors.Is(err, errSchedulerSettingsBatchUnsupported) {
+			if iterationErr := tenant.ForEachActive(ctx, s.db, s.schoolRepo, s.getLogger(), opName, fn); iterationErr != nil {
+				s.getLogger().Error("failed to list active tenants",
+					slog.String("operation", opName),
+					slog.String("error", iterationErr.Error()),
+				)
+			}
+			return
+		}
+		s.getLogger().Error("scheduler settings snapshot unavailable",
 			slog.String("operation", opName),
 			slog.String("error", err.Error()),
 		)
+		return
 	}
+
+	s.forEachKnownTenant(ctx, minuteSnapshot.tenantIDs, opName, func(txCtx context.Context, tenantID int64) error {
+		snapshot := minuteSnapshot.settings[tenantID]
+		if snapshot == nil {
+			return fmt.Errorf("settings snapshot missing for tenant %d", tenantID)
+		}
+		return fn(config.WithSettingsSnapshot(txCtx, snapshot), tenantID)
+	})
 }
 
 // Start begins the scheduler

--- a/backend/services/scheduler/settings_snapshot.go
+++ b/backend/services/scheduler/settings_snapshot.go
@@ -1,0 +1,165 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+var errSchedulerSettingsBatchUnsupported = errors.New("scheduler settings resolver does not support batch snapshots")
+
+type schedulerSettingsBatchResolver interface {
+	ResolveManyForTenants(ctx context.Context, tenantIDs []int64, keys []string) (map[int64]*configService.SettingsSnapshot, error)
+}
+
+type schedulerMinuteSnapshot struct {
+	tenantIDs []int64
+	settings  map[int64]*configService.SettingsSnapshot
+}
+
+type schedulerMinuteSnapshotLoad struct {
+	bucket   time.Time
+	ready    chan struct{}
+	snapshot *schedulerMinuteSnapshot
+	err      error
+}
+
+// schedulerPollingSettingKeys lists settings read by idle polling paths and
+// the reminder/notification services they invoke every minute. Job-specific
+// values used only when a daily job actually fires stay demand-loaded.
+var schedulerPollingSettingKeys = []string{
+	configModel.KeyDataCleanupEnabled,
+	configModel.KeyDataCleanupTime,
+	configModel.KeyDataCleanupTimeoutMinutes,
+	configModel.KeyFeedbackDataRetentionDays,
+	configModel.KeySessionEndEnabled,
+	configModel.KeySessionEndTime,
+	configModel.KeySessionEndTimeoutMinutes,
+	configModel.KeySessionCleanupEnabled,
+	configModel.KeySessionCleanupIntervalMinutes,
+	configModel.KeySessionAbandonedThresholdMin,
+	configModel.KeyTrackingAutoCheckoutEnabled,
+	configModel.KeyTrackingAutoCheckoutGraceMinutes,
+	configModel.KeyStatusFlagClearTime,
+	configModel.KeySickClearMode,
+	configModel.KeyExcusedClearMode,
+	configModel.KeyTimetableMaterializationEnabled,
+	configModel.KeyTimetableMaterializationWeekday,
+	configModel.KeyTimetableMaterializationWeeksAhead,
+	configModel.KeyTimetableEnabled,
+	configModel.KeyTimetableAutoStartPlanned,
+	configModel.KeyTimetableOverdueThresholdMinutes,
+	configModel.KeyNotificationsDispatchEnabled,
+	configModel.KeyNotificationsOnDutyOnly,
+	configModel.KeyRemindersPickupUpcomingEnabled,
+	configModel.KeyRemindersPickupOverdueEnabled,
+	configModel.KeyRemindersActivityStartEnabled,
+	configModel.KeyRemindersActivityOverdueEnabled,
+	configModel.KeyRemindersPickupUpcomingLeadMinutes,
+	configModel.KeyRemindersActivityStartLeadMinutes,
+	configModel.KeyPresenceMode,
+	configModel.KeyStudentDataScope,
+	configModel.KeyEnrollmentWaitlistEnabled,
+	configModel.KeyEnrollmentAutoInviteGuardianOnApprove,
+	configModel.KeyEnrollmentCareOfferingsEnabled,
+	configModel.KeyEnrollmentDefaultActivationMode,
+	configModel.KeyEnrollmentNotifyPerDecision,
+}
+
+// getMinuteSnapshot coalesces concurrent scheduler goroutines into one active
+// tenant query and one config.setting_values batch query per wall-clock minute.
+func (s *Scheduler) getMinuteSnapshot(ctx context.Context) (*schedulerMinuteSnapshot, error) {
+	now := time.Now
+	if s.minuteSnapshotNow != nil {
+		now = s.minuteSnapshotNow
+	}
+	// This bucket only coalesces work within one minute; it does not model a
+	// Berlin calendar date or wall-clock business time.
+	bucket := now().Truncate(time.Minute) //nolint:forbidigo
+
+	s.minuteSnapshotMu.Lock()
+	if load := s.minuteSnapshotLoad; load != nil && load.bucket.Equal(bucket) {
+		s.minuteSnapshotMu.Unlock()
+		select {
+		case <-load.ready:
+			return load.snapshot, load.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.done:
+			return nil, context.Canceled
+		}
+	}
+
+	load := &schedulerMinuteSnapshotLoad{
+		bucket: bucket,
+		ready:  make(chan struct{}),
+	}
+	s.minuteSnapshotLoad = load
+	s.minuteSnapshotMu.Unlock()
+
+	loader := s.loadMinuteSnapshot
+	if s.minuteSnapshotLoader != nil {
+		loader = s.minuteSnapshotLoader
+	}
+	load.snapshot, load.err = loader(ctx)
+
+	s.minuteSnapshotMu.Lock()
+	close(load.ready)
+	s.minuteSnapshotMu.Unlock()
+	return load.snapshot, load.err
+}
+
+func (s *Scheduler) loadMinuteSnapshot(ctx context.Context) (*schedulerMinuteSnapshot, error) {
+	result := &schedulerMinuteSnapshot{}
+	err := tenant.WithAdminTx(ctx, s.db, func(txCtx context.Context, _ bun.Tx) error {
+		schools, listErr := s.schoolRepo.ListActive(txCtx)
+		if listErr != nil {
+			return listErr
+		}
+		result.tenantIDs = make([]int64, 0, len(schools))
+		for _, school := range schools {
+			result.tenantIDs = append(result.tenantIDs, school.ID)
+		}
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("list active tenants: %w", err)
+	}
+
+	batchResolver, ok := s.settings.(schedulerSettingsBatchResolver)
+	if !ok {
+		return result, errSchedulerSettingsBatchUnsupported
+	}
+	result.settings, err = batchResolver.ResolveManyForTenants(ctx, result.tenantIDs, schedulerPollingSettingKeys)
+	if err != nil {
+		return result, fmt.Errorf("load tenant settings: %w", err)
+	}
+	return result, nil
+}
+
+func (s *Scheduler) forEachKnownTenant(
+	ctx context.Context,
+	tenantIDs []int64,
+	opName string,
+	fn func(context.Context, int64) error,
+) {
+	for _, tenantID := range tenantIDs {
+		err := tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+			return fn(txCtx, tenantID)
+		})
+		if err != nil {
+			s.getLogger().Error("tenant operation failed, continuing to next tenant",
+				slog.String("operation", opName),
+				slog.Int64("tenant_id", tenantID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}

--- a/backend/services/scheduler/settings_snapshot_test.go
+++ b/backend/services/scheduler/settings_snapshot_test.go
@@ -1,0 +1,193 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	configRepository "github.com/moto-nrw/project-phoenix/database/repositories/config"
+	platformRepository "github.com/moto-nrw/project-phoenix/database/repositories/platform"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+type schedulerSettingQueryCounter struct {
+	count atomic.Int32
+}
+
+func (c *schedulerSettingQueryCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if strings.HasPrefix(strings.TrimSpace(query), "select") &&
+		strings.Contains(query, "config.setting_values") {
+		c.count.Add(1)
+	}
+	return ctx
+}
+
+func (*schedulerSettingQueryCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func TestSchedulerPollingSettingKeysAreRegisteredUniqueAndNonSecret(t *testing.T) {
+	seen := make(map[string]struct{}, len(schedulerPollingSettingKeys))
+	for _, key := range schedulerPollingSettingKeys {
+		require.NotEmpty(t, key)
+		_, duplicate := seen[key]
+		assert.False(t, duplicate, "duplicate scheduler snapshot key %q", key)
+		seen[key] = struct{}{}
+
+		definition := configModel.GetDefinition(key)
+		require.NotNil(t, definition, "scheduler snapshot key %q must be registered", key)
+		assert.NotEqual(t, configModel.FieldPassword, definition.Type,
+			"scheduler snapshots must not preload secret settings")
+	}
+}
+
+func TestLoadMinuteSnapshotUsesOneSettingsQuery(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	tenantA := testpkg.UniqueTestTenantID(t)
+	tenantB := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantA)
+	testpkg.EnsureTestTenant(t, db, tenantB)
+	t.Cleanup(func() { testpkg.CleanupTenantTestData(t, db, tenantA, tenantB) })
+
+	valueRepository := configRepository.NewSettingValueRepository(db)
+	settings := configService.NewSettingsService(valueRepository, nil, nil, db, slog.Default())
+	scheduler := &Scheduler{
+		db:         db,
+		schoolRepo: platformRepository.NewSchoolRepository(db),
+		settings:   settings,
+		done:       make(chan struct{}),
+		logger:     slog.Default(),
+	}
+	counter := &schedulerSettingQueryCounter{}
+	db.AddQueryHook(counter)
+
+	snapshot, err := scheduler.loadMinuteSnapshot(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	assert.Contains(t, snapshot.tenantIDs, tenantA)
+	assert.Contains(t, snapshot.tenantIDs, tenantB)
+	assert.Equal(t, int32(1), counter.count.Load(),
+		"one scheduler minute must issue one config.setting_values SELECT for all active tenants")
+}
+
+func TestGetMinuteSnapshotCoalescesConcurrentLoads(t *testing.T) {
+	fixedNow := time.Date(2026, time.July, 30, 12, 15, 10, 0, time.UTC)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	scheduler := &Scheduler{
+		done:              make(chan struct{}),
+		minuteSnapshotNow: func() time.Time { return fixedNow },
+		minuteSnapshotLoader: func(context.Context) (*schedulerMinuteSnapshot, error) {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			<-release
+			return &schedulerMinuteSnapshot{tenantIDs: []int64{1, 2}}, nil
+		},
+	}
+
+	const callers = 32
+	results := make(chan *schedulerMinuteSnapshot, callers)
+	errs := make(chan error, callers)
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	start := make(chan struct{})
+	for range callers {
+		go func() {
+			ready.Done()
+			<-start
+			result, err := scheduler.getMinuteSnapshot(context.Background())
+			results <- result
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	<-started
+	close(release)
+
+	for range callers {
+		require.NoError(t, <-errs)
+		require.Equal(t, []int64{1, 2}, (<-results).tenantIDs)
+	}
+	assert.Equal(t, int32(1), calls.Load(), "all jobs in one minute must share one loader call")
+}
+
+func TestGetMinuteSnapshotRetriesOnlyAfterMinuteChanges(t *testing.T) {
+	current := time.Date(2026, time.July, 30, 12, 15, 10, 0, time.UTC)
+	loadErr := errors.New("settings unavailable")
+	var calls atomic.Int32
+	scheduler := &Scheduler{
+		done:              make(chan struct{}),
+		minuteSnapshotNow: func() time.Time { return current },
+		minuteSnapshotLoader: func(context.Context) (*schedulerMinuteSnapshot, error) {
+			calls.Add(1)
+			return nil, loadErr
+		},
+	}
+
+	_, err := scheduler.getMinuteSnapshot(context.Background())
+	require.ErrorIs(t, err, loadErr)
+	_, err = scheduler.getMinuteSnapshot(context.Background())
+	require.ErrorIs(t, err, loadErr)
+	assert.Equal(t, int32(1), calls.Load(), "an outage must not trigger a retry storm within the same minute")
+
+	current = current.Add(time.Minute)
+	_, err = scheduler.getMinuteSnapshot(context.Background())
+	require.ErrorIs(t, err, loadErr)
+	assert.Equal(t, int32(2), calls.Load(), "the next minute must retry so settings recover within the freshness bound")
+}
+
+func TestGetMinuteSnapshotSlowPriorMinuteCannotOverwriteCurrent(t *testing.T) {
+	current := time.Date(2026, time.July, 30, 12, 15, 59, 0, time.UTC)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	scheduler := &Scheduler{
+		done:              make(chan struct{}),
+		minuteSnapshotNow: func() time.Time { return current },
+		minuteSnapshotLoader: func(context.Context) (*schedulerMinuteSnapshot, error) {
+			switch calls.Add(1) {
+			case 1:
+				close(firstStarted)
+				<-releaseFirst
+				return &schedulerMinuteSnapshot{tenantIDs: []int64{1}}, nil
+			case 2:
+				return &schedulerMinuteSnapshot{tenantIDs: []int64{2}}, nil
+			default:
+				return nil, errors.New("unexpected extra load")
+			}
+		},
+	}
+
+	firstResult := make(chan *schedulerMinuteSnapshot, 1)
+	go func() {
+		result, _ := scheduler.getMinuteSnapshot(context.Background())
+		firstResult <- result
+	}()
+	<-firstStarted
+
+	current = current.Add(time.Second)
+	second, err := scheduler.getMinuteSnapshot(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int64{2}, second.tenantIDs)
+
+	close(releaseFirst)
+	require.Equal(t, []int64{1}, (<-firstResult).tenantIDs)
+
+	cached, err := scheduler.getMinuteSnapshot(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []int64{2}, cached.tenantIDs)
+	assert.Equal(t, int32(2), calls.Load())
+}


### PR DESCRIPTION
## Summary

- Replace per-tenant, per-key scheduler setting reads with one immutable cross-tenant snapshot per wall-clock minute.
- Reuse that snapshot in scheduler-invoked services and batch other high-fanout settings consumers.
- Preserve the existing scheduler cadence and application behavior while making the polling query budget independent of tenant and key counts.

## Problem

Production telemetry showed settings traffic that could not be explained by HTTP requests:

- 1.39 million scans on `config.setting_values` in seven days
- 2.38 settings queries per second on average, with at least 1.94 per second overnight
- only 0.014 HTTP requests per second in the same period
- 10.63 million individual settings queries accumulated since June 4

The cause was polling amplification: several scheduler jobs wake every minute, iterate all active tenants, and resolve multiple settings individually. The resulting query count grew with `jobs × tenants × keys` even when there was no user traffic.

## Implementation

- Add `ResolveMany`, `ResolveManyForTenant`, and `ResolveManyForTenants` to resolve registered settings in batches.
- Add a repository query that loads overrides for multiple tenants and keys in one admin-scoped read.
- Introduce tenant-bound, immutable `SettingsSnapshot` values with typed accessors and explicit override tracking.
- Attach snapshots to tenant contexts so downstream scheduler services reuse prefetched values without depending on scheduler internals.
- Coalesce concurrent scheduler goroutines into one minute load per backend instance:
  - one active-tenant query
  - one `config.setting_values` query
- Retry snapshot failures in the next minute. Settings-dependent jobs skip the failed tick; unrelated scheduler jobs continue.
- Batch additional settings fan-outs in schema generation, payroll status, tenant shell, IoT config, parent features, enrollment legal text, and reminders.
- Keep malformed overrides isolated to the affected key and prevent snapshots from being reused across tenants.

No database migration is required.

## Query budget

| Path | Before | After |
|---|---:|---:|
| Idle scheduler settings polling | `O(jobs × tenants × keys)` | 1 settings query per minute per backend instance |
| Active tenant discovery | Repeated by scheduler jobs | 1 query per minute per backend instance |
| Covered downstream setting reads | Individual queries | Snapshot reads, no additional settings queries |

Demand-driven HTTP reads still resolve independently. This is intentionally not a process-wide settings cache.

## Behavior and risk

- No intended user-facing behavior change.
- Maximum scheduler settings delay remains 60 seconds, matching the existing once-per-minute scheduler cadence.
- Request-driven settings reads remain immediate for each request.
- The cross-tenant database read runs only in an admin transaction; snapshots remain tenant-bound when reused.
- Scheduler-prefetched keys are checked for registration, duplicates, and secret settings.

## Verification

- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd backend && go test ./test -count=1`
- Targeted race tests for config snapshots and scheduler minute coalescing
- Integration query hooks proving one `config.setting_values` query across multiple tenants and concurrent scheduler jobs
- Hermetic-test and complexity ratchets
- Pre-commit: Go imports and secret scan
- Pre-push: `go vet`, `golangci-lint`, dead-code scan, and secret scan
