### PR TITLE
fix(betreuungsplan): Wochenansicht auf Mo–Fr begrenzen

### DIFF
--- a/backend/api/timetable/api.go
+++ b/backend/api/timetable/api.go
@@ -110,12 +110,16 @@ type Dependencies struct {
 	Broadcaster            realtime.Broadcaster
 	Logger                 *slog.Logger
 	DB                     *bun.DB
+	Now                    func() time.Time
 }
 
 // NewResource creates a new timetable resource from the given Dependencies.
 // Nil deps are tolerated at construction time; the dependent handler returns
 // 500 at request time if one of its deps is unset.
 func NewResource(deps Dependencies) *Resource {
+	if deps.Now == nil {
+		deps.Now = timezone.Now
+	}
 	return &Resource{Dependencies: deps}
 }
 

--- a/backend/api/timetable/dates.go
+++ b/backend/api/timetable/dates.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
@@ -18,6 +19,19 @@ import (
 // cannot occur by construction.
 func berlinDate(input string) (timezone.Date, error) {
 	return timezone.ParseDate(input)
+}
+
+// validateTimetableWorkday keeps the planning contract consistent across the
+// three planning views: the OGS timetable accepts appointments only Monday to
+// Friday. It lives at the HTTP boundary so direct API clients cannot create
+// entries the workweek views intentionally do not display.
+func validateTimetableWorkday(date timezone.Date) error {
+	switch date.Weekday() {
+	case time.Saturday, time.Sunday:
+		return errors.New("timetable entries can only be scheduled from Monday to Friday")
+	default:
+		return nil
+	}
 }
 
 // inclusiveDayCount returns the number of calendar days in the inclusive

--- a/backend/api/timetable/dates.go
+++ b/backend/api/timetable/dates.go
@@ -14,6 +14,8 @@ import (
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 )
 
+var errTimetableWeekend = errors.New("timetable entries can only be scheduled from Monday to Friday")
+
 // berlinDate parses a YYYY-MM-DD input into a calendar date. timezone.Date
 // carries no instant, so the historical 00:00–02:00 CET/UTC anchoring pitfall
 // cannot occur by construction.
@@ -28,7 +30,7 @@ func berlinDate(input string) (timezone.Date, error) {
 func validateTimetableWorkday(date timezone.Date) error {
 	switch date.Weekday() {
 	case time.Saturday, time.Sunday:
-		return errors.New("timetable entries can only be scheduled from Monday to Friday")
+		return errTimetableWeekend
 	default:
 		return nil
 	}

--- a/backend/api/timetable/instances.go
+++ b/backend/api/timetable/instances.go
@@ -182,6 +182,8 @@ func renderInstanceLifecycleError(w http.ResponseWriter, r *http.Request, err er
 		common.RenderError(w, r, common.ErrorConflictWithCode(err, schulhofSupervisionRequiredCode))
 	case errors.Is(err, scheduleSvc.ErrInvalidInstanceReference):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	case errors.Is(err, scheduleSvc.ErrInstanceWeekend):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 	case errors.Is(err, scheduleSvc.ErrInstanceMoved):
 		common.RenderError(w, r, common.ErrorConflictWithCode(
 			errors.New("block was changed concurrently; reopen it and try again"),

--- a/backend/api/timetable/instances_create.go
+++ b/backend/api/timetable/instances_create.go
@@ -141,6 +141,10 @@ func bindCreateInstanceRequest(w http.ResponseWriter, r *http.Request) (*parsedC
 			errors.New("invalid date format, expected YYYY-MM-DD")))
 		return nil, false
 	}
+	if err := validateTimetableWorkday(date); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return nil, false
+	}
 	startTime, err := parseClockTime(req.StartTime)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(

--- a/backend/api/timetable/instances_create_test.go
+++ b/backend/api/timetable/instances_create_test.go
@@ -92,6 +92,14 @@ func doCreate(t *testing.T, router chi.Router, body any) *httptest.ResponseRecor
 	return w
 }
 
+func nextTimetableWorkday() timezone.Date {
+	date := timezone.TodayDate().AddDays(1)
+	for date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
+		date = date.AddDays(1)
+	}
+	return date
+}
+
 func decodeCreate(t *testing.T, w *httptest.ResponseRecorder) enrichedInstance {
 	t.Helper()
 	var env struct {
@@ -110,7 +118,7 @@ func TestCreateInstance_Spontaneous(t *testing.T) {
 	defer s.cleanupFn()
 	router := createRouter(s.ctx, s.res)
 
-	tomorrow := timezone.TodayDate().AddDays(1)
+	tomorrow := nextTimetableWorkday()
 
 	// The mock returns a real-looking instance row; the handler still calls
 	// enrichInstance against the real DB so room_name + counts are exercised.
@@ -159,7 +167,11 @@ func TestCreateInstance_Validation(t *testing.T) {
 	defer s.cleanupFn()
 	router := createRouter(s.ctx, s.res)
 
-	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	tomorrow := nextTimetableWorkday().String()
+	weekend := timezone.TodayDate()
+	for weekend.Weekday() != time.Saturday {
+		weekend = weekend.AddDays(1)
+	}
 	cases := []struct {
 		name string
 		body map[string]any
@@ -196,6 +208,10 @@ func TestCreateInstance_Validation(t *testing.T) {
 			name: "end before start",
 			body: map[string]any{"date": tomorrow, "start_time": "15:00", "end_time": "14:00", "title": "X", "room_id": s.roomID},
 		},
+		{
+			name: "weekend date",
+			body: map[string]any{"date": weekend.String(), "start_time": "14:00", "end_time": "15:00", "title": "X", "room_id": s.roomID},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -213,7 +229,7 @@ func TestCreateInstance_TemplateBoundAndErrorBranches(t *testing.T) {
 	template := testpkg.CreateTestActivityGroup(t, s.db, fmt.Sprintf("Create-Bound-%d", time.Now().UnixNano()))
 	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "activities.groups", template.ID) })
 	templateID := template.ID
-	tomorrow := timezone.TodayDate().AddDays(1)
+	tomorrow := nextTimetableWorkday()
 	persisted := testpkg.CreateTestActivityInstance(t, s.db, tomorrow, s.roomID, testpkg.ActivityInstanceOpts{
 		ActivityGroupID: &templateID,
 		StartHHMM:       "10:00",
@@ -277,7 +293,7 @@ func TestCreateInstance_DuplicateTemplateBoundReturnsConflict(t *testing.T) {
 	router := createRouter(ctx, res)
 
 	body := map[string]any{
-		"date":              time.Now().AddDate(0, 0, 1).Format("2006-01-02"),
+		"date":              nextTimetableWorkday().String(),
 		"start_time":        "10:00",
 		"end_time":          "11:00",
 		"title":             "Duplicate slot",
@@ -299,7 +315,7 @@ func TestCreateInstance_UnwiredResource(t *testing.T) {
 	router := createRouter(s.ctx, NewResource(Dependencies{InstanceService: s.mock}))
 
 	body := map[string]any{
-		"date":       time.Now().AddDate(0, 0, 1).Format("2006-01-02"),
+		"date":       nextTimetableWorkday().String(),
 		"start_time": "10:00",
 		"end_time":   "11:00",
 		"title":      "Unwired",

--- a/backend/api/timetable/instances_update.go
+++ b/backend/api/timetable/instances_update.go
@@ -71,14 +71,7 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
 		return
 	}
-	if err := rs.validateUpdateInstanceDate(r.Context(), id, date); err != nil {
-		if errors.Is(err, errTimetableWeekend) {
-			common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		} else if errors.Is(err, sql.ErrNoRows) {
-			common.RenderError(w, r, common.ErrorNotFound(errors.New("instance not found")))
-		} else {
-			common.RenderError(w, r, common.ErrorInternalServerWrap("load instance for workday validation failed", err))
-		}
+	if !rs.validateUpdateInstanceDateRequest(w, r, id, date) {
 		return
 	}
 	startTime, err := parseClockTime(req.StartTime)
@@ -154,4 +147,19 @@ func (rs *Resource) validateUpdateInstanceDate(ctx context.Context, id int64, da
 		return nil
 	}
 	return weekendErr
+}
+
+func (rs *Resource) validateUpdateInstanceDateRequest(w http.ResponseWriter, r *http.Request, id int64, date timezone.Date) bool {
+	err := rs.validateUpdateInstanceDate(r.Context(), id, date)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, errTimetableWeekend) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	} else if errors.Is(err, sql.ErrNoRows) {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("instance not found")))
+	} else {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load instance for workday validation failed", err))
+	}
+	return false
 }

--- a/backend/api/timetable/instances_update.go
+++ b/backend/api/timetable/instances_update.go
@@ -67,6 +67,10 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
 		return
 	}
+	if err := validateTimetableWorkday(date); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
 	startTime, err := parseClockTime(req.StartTime)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_time format, expected HH:MM")))

--- a/backend/api/timetable/instances_update.go
+++ b/backend/api/timetable/instances_update.go
@@ -1,13 +1,14 @@
 package timetable
 
 import (
+	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 )
 
@@ -68,15 +69,9 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
 		return
 	}
-	if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
-		// A legacy weekend instance may be maintained in place, but PUT must
-		// never move a weekday instance onto a weekend or create a new weekend
-		// date through an update.
-		existing, getErr := rs.TimetableData.GetActivityInstance(r.Context(), id)
-		if getErr != nil || existing.Date != date {
-			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("timetable entries can only be scheduled from Monday to Friday")))
-			return
-		}
+	if !rs.legacyInstanceDateIsAllowed(r.Context(), id, date) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("timetable entries can only be scheduled from Monday to Friday")))
+		return
 	}
 	startTime, err := parseClockTime(req.StartTime)
 	if err != nil {
@@ -132,4 +127,15 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	common.Respond(w, r, http.StatusOK, enriched, "Instance updated")
+}
+
+// legacyInstanceDateIsAllowed permits a legacy weekend instance to retain its
+// date while preventing PUT from introducing or moving an instance to a
+// weekend.
+func (rs *Resource) legacyInstanceDateIsAllowed(ctx context.Context, id int64, date timezone.Date) bool {
+	if validateTimetableWorkday(date) == nil {
+		return true
+	}
+	existing, err := rs.TimetableData.GetActivityInstance(ctx, id)
+	return err == nil && existing.Date == date
 }

--- a/backend/api/timetable/instances_update.go
+++ b/backend/api/timetable/instances_update.go
@@ -3,6 +3,7 @@ package timetable
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
@@ -67,9 +68,15 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
 		return
 	}
-	if err := validateTimetableWorkday(date); err != nil {
-		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-		return
+	if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
+		// A legacy weekend instance may be maintained in place, but PUT must
+		// never move a weekday instance onto a weekend or create a new weekend
+		// date through an update.
+		existing, getErr := rs.TimetableData.GetActivityInstance(r.Context(), id)
+		if getErr != nil || existing.Date != date {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("timetable entries can only be scheduled from Monday to Friday")))
+			return
+		}
 	}
 	startTime, err := parseClockTime(req.StartTime)
 	if err != nil {

--- a/backend/api/timetable/instances_update.go
+++ b/backend/api/timetable/instances_update.go
@@ -2,7 +2,9 @@ package timetable
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -69,8 +71,14 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
 		return
 	}
-	if !rs.legacyInstanceDateIsAllowed(r.Context(), id, date) {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("timetable entries can only be scheduled from Monday to Friday")))
+	if err := rs.validateUpdateInstanceDate(r.Context(), id, date); err != nil {
+		if errors.Is(err, errTimetableWeekend) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		} else if errors.Is(err, sql.ErrNoRows) {
+			common.RenderError(w, r, common.ErrorNotFound(errors.New("instance not found")))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServerWrap("load instance for workday validation failed", err))
+		}
 		return
 	}
 	startTime, err := parseClockTime(req.StartTime)
@@ -129,13 +137,21 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusOK, enriched, "Instance updated")
 }
 
-// legacyInstanceDateIsAllowed permits a legacy weekend instance to retain its
+// validateUpdateInstanceDate permits a legacy weekend instance to retain its
 // date while preventing PUT from introducing or moving an instance to a
-// weekend.
-func (rs *Resource) legacyInstanceDateIsAllowed(ctx context.Context, id int64, date timezone.Date) bool {
-	if validateTimetableWorkday(date) == nil {
-		return true
+// weekend. Lookup failures are retained so they are not misreported as a
+// client workday validation error.
+func (rs *Resource) validateUpdateInstanceDate(ctx context.Context, id int64, date timezone.Date) error {
+	weekendErr := validateTimetableWorkday(date)
+	if weekendErr == nil {
+		return nil
 	}
-	existing, err := rs.TimetableData.GetActivityInstance(ctx, id)
-	return err == nil && existing.Date == date
+	existing, lookupErr := rs.TimetableData.GetActivityInstance(ctx, id)
+	if lookupErr != nil {
+		return fmt.Errorf("get existing instance: %w", lookupErr)
+	}
+	if existing.Date == date {
+		return nil
+	}
+	return weekendErr
 }

--- a/backend/api/timetable/instances_update.go
+++ b/backend/api/timetable/instances_update.go
@@ -1,16 +1,12 @@
 package timetable
 
 import (
-	"context"
-	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
-	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 )
 
@@ -71,9 +67,6 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date format, expected YYYY-MM-DD")))
 		return
 	}
-	if !rs.validateUpdateInstanceDateRequest(w, r, id, date) {
-		return
-	}
 	startTime, err := parseClockTime(req.StartTime)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid start_time format, expected HH:MM")))
@@ -128,38 +121,4 @@ func (rs *Resource) updateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	common.Respond(w, r, http.StatusOK, enriched, "Instance updated")
-}
-
-// validateUpdateInstanceDate permits a legacy weekend instance to retain its
-// date while preventing PUT from introducing or moving an instance to a
-// weekend. Lookup failures are retained so they are not misreported as a
-// client workday validation error.
-func (rs *Resource) validateUpdateInstanceDate(ctx context.Context, id int64, date timezone.Date) error {
-	weekendErr := validateTimetableWorkday(date)
-	if weekendErr == nil {
-		return nil
-	}
-	existing, lookupErr := rs.TimetableData.GetActivityInstance(ctx, id)
-	if lookupErr != nil {
-		return fmt.Errorf("get existing instance: %w", lookupErr)
-	}
-	if existing.Date == date {
-		return nil
-	}
-	return weekendErr
-}
-
-func (rs *Resource) validateUpdateInstanceDateRequest(w http.ResponseWriter, r *http.Request, id int64, date timezone.Date) bool {
-	err := rs.validateUpdateInstanceDate(r.Context(), id, date)
-	if err == nil {
-		return true
-	}
-	if errors.Is(err, errTimetableWeekend) {
-		common.RenderError(w, r, common.ErrorInvalidRequest(err))
-	} else if errors.Is(err, sql.ErrNoRows) {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("instance not found")))
-	} else {
-		common.RenderError(w, r, common.ErrorInternalServerWrap("load instance for workday validation failed", err))
-	}
-	return false
 }

--- a/backend/api/timetable/instances_update_test.go
+++ b/backend/api/timetable/instances_update_test.go
@@ -87,10 +87,11 @@ func TestUpdateInstance_Validation(t *testing.T) {
 	}
 
 	cases := []struct {
-		name   string
-		path   string
-		mutate func(map[string]any)
-		want   int
+		name      string
+		path      string
+		mutate    func(map[string]any)
+		updateErr error
+		want      int
 	}{
 		{name: "invalid id", path: "/instances/not-number", mutate: func(_ map[string]any) {}, want: http.StatusBadRequest},
 		{name: "missing date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "" }, want: http.StatusBadRequest},
@@ -98,7 +99,7 @@ func TestUpdateInstance_Validation(t *testing.T) {
 		{name: "missing time", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "" }, want: http.StatusBadRequest},
 		{name: "missing room", path: "/instances/50", mutate: func(b map[string]any) { b["room_id"] = 0 }, want: http.StatusBadRequest},
 		{name: "invalid date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "tomorrow" }, want: http.StatusBadRequest},
-		{name: "weekend date on unknown instance", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "2026-05-09" }, want: http.StatusNotFound},
+		{name: "weekend date on unknown instance", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "2026-05-09" }, updateErr: scheduleSvc.ErrInstanceNotFound, want: http.StatusNotFound},
 		{name: "invalid start", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "soon" }, want: http.StatusBadRequest},
 		{name: "invalid end", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "later" }, want: http.StatusBadRequest},
 		{name: "end before start", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "10:30" }, want: http.StatusBadRequest},
@@ -106,6 +107,7 @@ func TestUpdateInstance_Validation(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			s.mock.updateErr = tc.updateErr
 			body := make(map[string]any, len(valid))
 			for key, value := range valid {
 				body[key] = value

--- a/backend/api/timetable/instances_update_test.go
+++ b/backend/api/timetable/instances_update_test.go
@@ -40,7 +40,7 @@ func TestUpdateInstance_Success(t *testing.T) {
 	defer s.cleanupFn()
 	router := updateRouter(s.ctx, s.res)
 
-	targetDate := timezone.TodayDate().AddDays(2)
+	targetDate := nextTimetableWorkday()
 	persisted := testpkg.CreateTestActivityInstance(t, s.db, targetDate, s.roomID, testpkg.ActivityInstanceOpts{
 		StartHHMM:     "09:00",
 		EndHHMM:       "10:00",
@@ -97,6 +97,7 @@ func TestUpdateInstance_Validation(t *testing.T) {
 		{name: "missing time", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "" }},
 		{name: "missing room", path: "/instances/50", mutate: func(b map[string]any) { b["room_id"] = 0 }},
 		{name: "invalid date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "tomorrow" }},
+		{name: "weekend date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "2026-05-09" }},
 		{name: "invalid start", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "soon" }},
 		{name: "invalid end", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "later" }},
 		{name: "end before start", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "10:30" }},

--- a/backend/api/timetable/instances_update_test.go
+++ b/backend/api/timetable/instances_update_test.go
@@ -90,17 +90,18 @@ func TestUpdateInstance_Validation(t *testing.T) {
 		name   string
 		path   string
 		mutate func(map[string]any)
+		want   int
 	}{
-		{name: "invalid id", path: "/instances/not-number", mutate: func(_ map[string]any) {}},
-		{name: "missing date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "" }},
-		{name: "missing title", path: "/instances/50", mutate: func(b map[string]any) { b["title"] = "" }},
-		{name: "missing time", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "" }},
-		{name: "missing room", path: "/instances/50", mutate: func(b map[string]any) { b["room_id"] = 0 }},
-		{name: "invalid date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "tomorrow" }},
-		{name: "weekend date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "2026-05-09" }},
-		{name: "invalid start", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "soon" }},
-		{name: "invalid end", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "later" }},
-		{name: "end before start", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "10:30" }},
+		{name: "invalid id", path: "/instances/not-number", mutate: func(_ map[string]any) {}, want: http.StatusBadRequest},
+		{name: "missing date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "" }, want: http.StatusBadRequest},
+		{name: "missing title", path: "/instances/50", mutate: func(b map[string]any) { b["title"] = "" }, want: http.StatusBadRequest},
+		{name: "missing time", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "" }, want: http.StatusBadRequest},
+		{name: "missing room", path: "/instances/50", mutate: func(b map[string]any) { b["room_id"] = 0 }, want: http.StatusBadRequest},
+		{name: "invalid date", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "tomorrow" }, want: http.StatusBadRequest},
+		{name: "weekend date on unknown instance", path: "/instances/50", mutate: func(b map[string]any) { b["date"] = "2026-05-09" }, want: http.StatusNotFound},
+		{name: "invalid start", path: "/instances/50", mutate: func(b map[string]any) { b["start_time"] = "soon" }, want: http.StatusBadRequest},
+		{name: "invalid end", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "later" }, want: http.StatusBadRequest},
+		{name: "end before start", path: "/instances/50", mutate: func(b map[string]any) { b["end_time"] = "10:30" }, want: http.StatusBadRequest},
 	}
 
 	for _, tc := range cases {
@@ -111,7 +112,7 @@ func TestUpdateInstance_Validation(t *testing.T) {
 			}
 			tc.mutate(body)
 			w := doTemplateJSON(t, router, http.MethodPut, tc.path, body)
-			assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			assert.Equal(t, tc.want, w.Code, "body=%s", w.Body.String())
 		})
 	}
 }

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -162,7 +162,7 @@ func (rs *Resource) operationsCreateAndStartSpontaneous(w http.ResponseWriter, r
 	if !ok {
 		return
 	}
-	window, err := spontaneousStartWorkdayWindow(timezone.Now())
+	window, err := spontaneousStartWorkdayWindow(rs.Now())
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -162,6 +162,11 @@ func (rs *Resource) operationsCreateAndStartSpontaneous(w http.ResponseWriter, r
 	if !ok {
 		return
 	}
+	window, err := spontaneousStartWorkdayWindow(timezone.Now())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
 	if len(req.StudentIDs) > 0 {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("student_ids are not accepted for spontaneous operational starts")))
 		return
@@ -185,7 +190,6 @@ func (rs *Resource) operationsCreateAndStartSpontaneous(w http.ResponseWriter, r
 	}
 
 	isSpontaneous := true
-	window := serverSpontaneousActivityWindow(timezone.Now())
 	claims := jwt.ClaimsFromCtx(r.Context())
 	result, err := rs.OperationsService.CreateAndStartSpontaneous(r.Context(), int64(claims.ID), claims.IsAdmin, scheduleSvc.CreateInstanceInput{
 		Date:             window.date,
@@ -348,6 +352,14 @@ func serverSpontaneousActivityWindow(now time.Time) spontaneousActivityWindow {
 		startTime: clockTimeFromMinutes(startMinutes),
 		endTime:   clockTimeFromMinutes(endMinutes),
 	}
+}
+
+func spontaneousStartWorkdayWindow(now time.Time) (spontaneousActivityWindow, error) {
+	window := serverSpontaneousActivityWindow(now)
+	if err := validateTimetableWorkday(window.date); err != nil {
+		return spontaneousActivityWindow{}, err
+	}
+	return window, nil
 }
 
 func clockTimeFromMinutes(minutes int) time.Time {

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -59,6 +59,10 @@ func TestOperationsPlannedNow(t *testing.T) {
 	assert.True(t, service.lastPlannedOptions.IncludeRoster)
 }
 
+func testWorkdayNow() time.Time {
+	return time.Date(2026, time.May, 11, 14, 0, 0, 0, timezone.Berlin)
+}
+
 func TestOperationsPlannedNowValidationAndWiring(t *testing.T) {
 	res := NewResource(Dependencies{})
 	router := operationRouter(http.MethodGet, "/planned-now", res.operationsPlannedNow)
@@ -161,6 +165,7 @@ func TestOperationsCreateAndStartSpontaneous(t *testing.T) {
 			boolValue:   true,
 		},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 	roomID := int64(70)
 
@@ -235,6 +240,7 @@ func TestOperationsCreateAndStartSpontaneousRollsBackNon5xxFailures(t *testing.T
 		PersonService:     personSvc,
 		SettingsService:   settings,
 	})
+	res.Now = testWorkdayNow
 
 	router := chi.NewRouter()
 	router.Use(render.SetContentType(render.ContentTypeJSON))
@@ -341,6 +347,7 @@ func TestOperationsCreateAndStartSpontaneousReusesActivityByName(t *testing.T) {
 		},
 		SettingsService: &fakeOperationSettingsService{hasOverride: true, boolValue: true},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
@@ -388,6 +395,7 @@ func TestOperationsCreateAndStartSpontaneousCreatesActivityForNewName(t *testing
 		},
 		SettingsService: &fakeOperationSettingsService{hasOverride: true, boolValue: true},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
@@ -433,6 +441,7 @@ func TestOperationsCreateAndStartSpontaneousRejectsStudents(t *testing.T) {
 			boolValue:   true,
 		},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
@@ -445,6 +454,28 @@ func TestOperationsCreateAndStartSpontaneousRejectsStudents(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestOperationsCreateAndStartSpontaneousRejectsWeekend(t *testing.T) {
+	service := &fakeOperationsService{}
+	res := NewResource(Dependencies{
+		TimetableData:     operationTimetableData(scheduleSvc.TimetableDataDependencies{ActiveGroupRepo: &fakeOperationActiveGroupRepo{}}),
+		InstanceService:   &mockInstanceService{},
+		OperationsService: service,
+		SettingsService:   &fakeOperationSettingsService{hasOverride: true, boolValue: true},
+		Now: func() time.Time {
+			return time.Date(2026, time.May, 9, 14, 0, 0, 0, timezone.Berlin)
+		},
+	})
+	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
+
+	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
+		"title":   "Freispiel",
+		"room_id": int64(7),
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, service.lastSpontaneousInput, "weekend starts must not reach the operations service")
 }
 
 func TestOperationsCreateAndStartSpontaneousRejectsSchulhofRoom(t *testing.T) {
@@ -465,6 +496,7 @@ func TestOperationsCreateAndStartSpontaneousRejectsSchulhofRoom(t *testing.T) {
 			boolValue:   true,
 		},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
@@ -488,6 +520,7 @@ func TestOperationsCreateAndStartSpontaneousRejectsOccupiedRoom(t *testing.T) {
 			boolValue:   true,
 		},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
@@ -513,6 +546,7 @@ func TestOperationsCreateAndStartSpontaneousRequiresSetting(t *testing.T) {
 			boolValue:   false,
 		},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
@@ -539,6 +573,7 @@ func TestOperationsCreateAndStartSpontaneousRejectsFixedScheduleCareConcept(t *t
 			stringValue: configModel.CareConceptFixedSchedule,
 		},
 	})
+	res.Now = testWorkdayNow
 	router := operationRouter(http.MethodPost, "/spontaneous/start", res.operationsCreateAndStartSpontaneous)
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -1072,6 +1072,11 @@ func executeOperationRequest(router chi.Router, method, path string, body any) *
 	return rr
 }
 
+func TestSpontaneousStartWorkdayWindow_RejectsWeekend(t *testing.T) {
+	_, err := spontaneousStartWorkdayWindow(time.Date(2026, time.May, 9, 14, 0, 0, 0, timezone.Berlin))
+	require.ErrorIs(t, err, errTimetableWeekend)
+}
+
 func lastPathSegment(path string) string {
 	for i := len(path) - 1; i >= 0; i-- {
 		if path[i] == '/' {

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -457,6 +457,7 @@ func TestOperationsCreateAndStartSpontaneousRejectsStudents(t *testing.T) {
 }
 
 func TestOperationsCreateAndStartSpontaneousRejectsWeekend(t *testing.T) {
+	const roomID int64 = 7
 	service := &fakeOperationsService{}
 	res := NewResource(Dependencies{
 		TimetableData:     operationTimetableData(scheduleSvc.TimetableDataDependencies{ActiveGroupRepo: &fakeOperationActiveGroupRepo{}}),
@@ -471,7 +472,7 @@ func TestOperationsCreateAndStartSpontaneousRejectsWeekend(t *testing.T) {
 
 	rr := executeOperationRequest(router, http.MethodPost, "/spontaneous/start", map[string]any{
 		"title":   "Freispiel",
-		"room_id": int64(7),
+		"room_id": roomID,
 	})
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)

--- a/backend/api/timetable/templates_create.go
+++ b/backend/api/timetable/templates_create.go
@@ -128,12 +128,21 @@ func (req *createTemplateRequest) Bind(_ *http.Request) error {
 }
 
 func validateTemplateWorkdays(weekdays []int) error {
+	if err := validateTemplateWeekdays(weekdays); err != nil {
+		return err
+	}
+	for _, weekday := range weekdays {
+		if weekday > activitiesModel.WeekdayFriday {
+			return errors.New("timetable templates can only be scheduled from Monday to Friday")
+		}
+	}
+	return nil
+}
+
+func validateTemplateWeekdays(weekdays []int) error {
 	for _, weekday := range weekdays {
 		if !activitiesModel.IsValidWeekday(weekday) {
 			return fmt.Errorf("invalid weekday %d (must be 1=Mon … 7=Sun)", weekday)
-		}
-		if weekday > activitiesModel.WeekdayFriday {
-			return errors.New("timetable templates can only be scheduled from Monday to Friday")
 		}
 	}
 	return nil

--- a/backend/api/timetable/templates_create.go
+++ b/backend/api/timetable/templates_create.go
@@ -105,10 +105,8 @@ func (req *createTemplateRequest) Bind(_ *http.Request) error {
 	if len(req.Weekdays) == 0 {
 		return errors.New("at least one weekday is required")
 	}
-	for _, w := range req.Weekdays {
-		if !activitiesModel.IsValidWeekday(w) {
-			return fmt.Errorf("invalid weekday %d (must be 1=Mon … 7=Sun)", w)
-		}
+	if err := validateTemplateWorkdays(req.Weekdays); err != nil {
+		return err
 	}
 	target := &activitiesModel.Group{
 		TargetGroupType:   req.TargetGroupType,
@@ -126,6 +124,18 @@ func (req *createTemplateRequest) Bind(_ *http.Request) error {
 		return err
 	}
 	req.ListKind = listKind
+	return nil
+}
+
+func validateTemplateWorkdays(weekdays []int) error {
+	for _, weekday := range weekdays {
+		if !activitiesModel.IsValidWeekday(weekday) {
+			return fmt.Errorf("invalid weekday %d (must be 1=Mon … 7=Sun)", weekday)
+		}
+		if weekday > activitiesModel.WeekdayFriday {
+			return errors.New("timetable templates can only be scheduled from Monday to Friday")
+		}
+	}
 	return nil
 }
 

--- a/backend/api/timetable/templates_list.go
+++ b/backend/api/timetable/templates_list.go
@@ -42,14 +42,6 @@ func (rs *Resource) loadTemplates(ctx context.Context, templateID *int64) ([]tem
 	return mapTemplateRows(rows, childrenPerStaffRatio), nil
 }
 
-func (rs *Resource) templateExists(ctx context.Context, templateID int64) (bool, error) {
-	templates, err := rs.loadTemplates(ctx, &templateID)
-	if err != nil {
-		return false, err
-	}
-	return len(templates) > 0, nil
-}
-
 func mapTemplateRows(rows []templateRow, childrenPerStaffRatio int) []templateResponse {
 	templates := make([]templateResponse, 0)
 	byID := make(map[int64]int)

--- a/backend/api/timetable/templates_split.go
+++ b/backend/api/timetable/templates_split.go
@@ -90,6 +90,9 @@ func (req *splitTemplateRequest) Bind(r *http.Request) error {
 	if err := req.updateTemplateRequest.Bind(r); err != nil {
 		return err
 	}
+	if err := validateTemplateWorkdays(req.Weekdays); err != nil {
+		return err
+	}
 	if req.EffectiveDate == "" {
 		return errors.New("effective_date is required (YYYY-MM-DD)")
 	}

--- a/backend/api/timetable/templates_split.go
+++ b/backend/api/timetable/templates_split.go
@@ -90,9 +90,6 @@ func (req *splitTemplateRequest) Bind(r *http.Request) error {
 	if err := req.updateTemplateRequest.Bind(r); err != nil {
 		return err
 	}
-	if err := validateTemplateWorkdays(req.Weekdays); err != nil {
-		return err
-	}
 	if req.EffectiveDate == "" {
 		return errors.New("effective_date is required (YYYY-MM-DD)")
 	}

--- a/backend/api/timetable/templates_split_unit_test.go
+++ b/backend/api/timetable/templates_split_unit_test.go
@@ -114,3 +114,19 @@ func TestBuildTemplateSplitInput_ListKindThreeState(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitTemplateRequestBind_RejectsWeekendWeekdays(t *testing.T) {
+	req := &splitTemplateRequest{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "AG Yoga",
+		"type": "activity",
+		"weekdays": [6],
+		"start_time": "14:00",
+		"end_time": "15:00",
+		"room_id": 3,
+		"category_id": 2,
+		"effective_date": "2026-05-04"
+	}`), req))
+
+	require.ErrorContains(t, req.Bind(nil), "Monday to Friday")
+}

--- a/backend/api/timetable/templates_split_unit_test.go
+++ b/backend/api/timetable/templates_split_unit_test.go
@@ -115,7 +115,7 @@ func TestBuildTemplateSplitInput_ListKindThreeState(t *testing.T) {
 	}
 }
 
-func TestSplitTemplateRequestBind_DefersWeekendWeekdaysToSourceValidation(t *testing.T) {
+func TestSplitTemplateRequestBind_RejectsWeekendWeekdays(t *testing.T) {
 	req := &splitTemplateRequest{}
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"name": "AG Yoga",
@@ -128,5 +128,5 @@ func TestSplitTemplateRequestBind_DefersWeekendWeekdaysToSourceValidation(t *tes
 		"effective_date": "2026-05-04"
 	}`), req))
 
-	require.NoError(t, req.Bind(nil))
+	require.ErrorContains(t, req.Bind(nil), "Monday to Friday")
 }

--- a/backend/api/timetable/templates_split_unit_test.go
+++ b/backend/api/timetable/templates_split_unit_test.go
@@ -115,7 +115,7 @@ func TestBuildTemplateSplitInput_ListKindThreeState(t *testing.T) {
 	}
 }
 
-func TestSplitTemplateRequestBind_RejectsWeekendWeekdays(t *testing.T) {
+func TestSplitTemplateRequestBind_DefersWeekendWeekdaysToSourceValidation(t *testing.T) {
 	req := &splitTemplateRequest{}
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"name": "AG Yoga",
@@ -128,5 +128,5 @@ func TestSplitTemplateRequestBind_RejectsWeekendWeekdays(t *testing.T) {
 		"effective_date": "2026-05-04"
 	}`), req))
 
-	require.ErrorContains(t, req.Bind(nil), "Monday to Friday")
+	require.NoError(t, req.Bind(nil))
 }

--- a/backend/api/timetable/templates_test.go
+++ b/backend/api/timetable/templates_test.go
@@ -592,6 +592,7 @@ func TestTemplateCreateValidationAndMaterializationFailure(t *testing.T) {
 	}{
 		{name: "invalid type", mutate: func(b map[string]any) { b["type"] = "party" }},
 		{name: "invalid weekday", mutate: func(b map[string]any) { b["weekdays"] = []int{8} }},
+		{name: "weekend weekday", mutate: func(b map[string]any) { b["weekdays"] = []int{activitiesModel.WeekdaySaturday} }},
 		{name: "invalid start time", mutate: func(b map[string]any) { b["start_time"] = "bad" }},
 		{name: "end before start", mutate: func(b map[string]any) { b["end_time"] = "11:00" }},
 		{name: "invalid week pattern", mutate: func(b map[string]any) { b["week_pattern"] = 9 }},
@@ -647,6 +648,7 @@ func TestTemplateUpdateValidationAndNotFound(t *testing.T) {
 		{name: "invalid end", path: "/templates/500", mutate: func(b map[string]any) { b["end_time"] = "nope" }, want: http.StatusBadRequest},
 		{name: "end before start", path: "/templates/500", mutate: func(b map[string]any) { b["end_time"] = "11:00" }, want: http.StatusBadRequest},
 		{name: "invalid week pattern", path: "/templates/500", mutate: func(b map[string]any) { b["week_pattern"] = -1 }, want: http.StatusBadRequest},
+		{name: "weekend weekday", path: "/templates/500", mutate: func(b map[string]any) { b["weekdays"] = []int{activitiesModel.WeekdaySunday} }, want: http.StatusBadRequest},
 		{name: "not found", path: "/templates/500", mutate: func(_ map[string]any) {}, want: http.StatusNotFound},
 	}
 

--- a/backend/api/timetable/templates_test.go
+++ b/backend/api/timetable/templates_test.go
@@ -57,6 +57,25 @@ type mockMaterializationService struct {
 	detectFn func(activityGroupID int64, from, to timezone.Date, includeDeletions bool) ([]scheduleSvc.EditedOccurrence, error)
 }
 
+func TestValidateLegacyTemplateWorkdays(t *testing.T) {
+	existing := []templateScheduleResponse{
+		{Weekday: activitiesModel.WeekdayFriday},
+		{Weekday: activitiesModel.WeekdaySaturday},
+	}
+
+	assert.NoError(t, validateLegacyTemplateWorkdays(existing, []int{
+		activitiesModel.WeekdayFriday,
+		activitiesModel.WeekdaySaturday,
+	}))
+	assert.NoError(t, validateLegacyTemplateWorkdays(existing, []int{
+		activitiesModel.WeekdayFriday,
+	}))
+	assert.Error(t, validateLegacyTemplateWorkdays(existing, []int{
+		activitiesModel.WeekdayFriday,
+		activitiesModel.WeekdaySunday,
+	}))
+}
+
 func (m *mockMaterializationService) MaterializeForTenant(_ context.Context, from, to timezone.Date, source scheduleSvc.MaterializationSource) (*scheduleSvc.MaterializationResult, error) {
 	m.from = from
 	m.to = to

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -65,7 +65,7 @@ func (req *updateTemplateRequest) Bind(_ *http.Request) error {
 	if len(req.Weekdays) == 0 {
 		return errors.New("at least one weekday is required")
 	}
-	if err := validateTemplateWorkdays(req.Weekdays); err != nil {
+	if err := validateTemplateWeekdays(req.Weekdays); err != nil {
 		return err
 	}
 	target := &activitiesModel.Group{
@@ -163,15 +163,25 @@ func (rs *Resource) updateTemplate(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInternalServer(errors.New("no tenant in context")))
 		return
 	}
+	templates, err := rs.loadTemplates(ctx, &id)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load template failed", err))
+		return
+	}
+	if len(templates) == 0 {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+		return
+	}
+	if err := validateLegacyTemplateWorkdays(templates[0].Schedules, parsed.req.Weekdays); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
 	gradeLevelMax, rosterValidFrom, ok := rs.templateWritePreflight(w, r, parsed.req.CalendarPeriodID)
 	if !ok {
 		return
 	}
 	if err := rs.TimetableData.ValidateTemplateEducationGroup(ctx, parsed.req.EducationGroupID); err != nil {
 		renderTemplateEducationGroupError(w, r, err)
-		return
-	}
-	if !rs.requireTemplateExists(w, r, id) {
 		return
 	}
 	timeframeID, err := rs.TimetableData.FindOrCreateTimeframe(ctx, parsed.startTime, parsed.endTime, parsed.req.Name)
@@ -188,12 +198,32 @@ func (rs *Resource) updateTemplate(w http.ResponseWriter, r *http.Request) {
 		renderUpdateTemplateError(w, r, updateErr)
 		return
 	}
-	templates, err := rs.loadTemplates(ctx, &id)
+	templates, err = rs.loadTemplates(ctx, &id)
 	if err != nil || len(templates) == 0 {
 		common.RenderError(w, r, common.ErrorInternalServerWrap("reload template failed", err))
 		return
 	}
 	common.Respond(w, r, http.StatusOK, templates[0], "Template updated")
+}
+
+// validateLegacyTemplateWorkdays permits an update to retain a weekend
+// schedule that already exists, so administrators can edit or normalize old
+// templates. A PUT can never introduce a new weekend weekday.
+func validateLegacyTemplateWorkdays(existing []templateScheduleResponse, requested []int) error {
+	legacy := make(map[int]struct{})
+	for _, schedule := range existing {
+		if schedule.Weekday > activitiesModel.WeekdayFriday {
+			legacy[schedule.Weekday] = struct{}{}
+		}
+	}
+	for _, weekday := range requested {
+		if weekday > activitiesModel.WeekdayFriday {
+			if _, ok := legacy[weekday]; !ok {
+				return errors.New("timetable templates can only be scheduled from Monday to Friday")
+			}
+		}
+	}
+	return nil
 }
 
 // requireTemplateExists renders a 404 (missing) or 500 (load failure) and

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -65,10 +65,8 @@ func (req *updateTemplateRequest) Bind(_ *http.Request) error {
 	if len(req.Weekdays) == 0 {
 		return errors.New("at least one weekday is required")
 	}
-	for _, w := range req.Weekdays {
-		if !activitiesModel.IsValidWeekday(w) {
-			return fmt.Errorf("invalid weekday %d (must be 1=Mon … 7=Sun)", w)
-		}
+	if err := validateTemplateWorkdays(req.Weekdays); err != nil {
+		return err
 	}
 	target := &activitiesModel.Group{
 		TargetGroupType:   req.TargetGroupType,

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -226,21 +226,6 @@ func validateLegacyTemplateWorkdays(existing []templateScheduleResponse, request
 	return nil
 }
 
-// requireTemplateExists renders a 404 (missing) or 500 (load failure) and
-// returns false when the caller should stop.
-func (rs *Resource) requireTemplateExists(w http.ResponseWriter, r *http.Request, id int64) bool {
-	exists, err := rs.templateExists(r.Context(), id)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServerWrap("load template failed", err))
-		return false
-	}
-	if !exists {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
-		return false
-	}
-	return true
-}
-
 // buildUpdateTemplateInput maps the parsed request and resolved preconditions
 // into the service input.
 func buildUpdateTemplateInput(

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -169,6 +169,10 @@ func (rs *Resource) updateTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(templates) == 0 {
+		if hasWeekendTemplateWeekday(parsed.req.Weekdays) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("timetable templates can only be scheduled from Monday to Friday")))
+			return
+		}
 		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
 		return
 	}
@@ -224,6 +228,15 @@ func validateLegacyTemplateWorkdays(existing []templateScheduleResponse, request
 		}
 	}
 	return nil
+}
+
+func hasWeekendTemplateWeekday(weekdays []int) bool {
+	for _, weekday := range weekdays {
+		if weekday > activitiesModel.WeekdayFriday {
+			return true
+		}
+	}
+	return false
 }
 
 // buildUpdateTemplateInput maps the parsed request and resolved preconditions

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -286,6 +286,8 @@ func renderUpdateTemplateError(w http.ResponseWriter, r *http.Request, err error
 	switch {
 	case errors.Is(err, scheduleSvc.ErrTemplateSegmentNotEditable):
 		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+	case errors.Is(err, scheduleSvc.ErrTemplateWeekendWeekday):
+		common.RenderError(w, r, common.ErrorInvalidRequest(scheduleSvc.ErrTemplateWeekendWeekday))
 	case renderTemplateCareOfferingConflict(w, r, err):
 	case renderTemplateRosterRebaseConflict(w, r, err):
 	case renderTemplateTargetGradeLimit(w, r, err):

--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -471,7 +471,7 @@ func (r *ActivityInstanceRepository) DeletePlannedMaterializedWeekendInstances(c
 		ModelTableExpr(modelTblActivityInstance).
 		Where(`"activity_instance".activity_group_id = ?`, activityGroupID).
 		Where(`"activity_instance".calendar_period_id IS NOT NULL`).
-		Where(`"activity_instance".date >= ?`, timezone.TodayDate()).
+		Where(`"activity_instance".date > ?`, timezone.TodayDate()).
 		Where(`"activity_instance".status = ?`, schedule.InstanceStatusPlanned).
 		Where(`"activity_instance".is_spontaneous = ?`, false).
 		Where(`EXTRACT(ISODOW FROM "activity_instance".date)::int IN (?)`, bun.List(weekdays))

--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -459,6 +459,31 @@ func (r *ActivityInstanceRepository) DeletePlannedNonSpontaneousInWindow(ctx con
 	return deleted, nil
 }
 
+// DeletePlannedMaterializedWeekendInstances removes future materialized rows
+// for weekdays removed from a legacy template. It deliberately leaves manual,
+// active, cancelled, and historical rows untouched.
+func (r *ActivityInstanceRepository) DeletePlannedMaterializedWeekendInstances(ctx context.Context, activityGroupID int64, weekdays []int) (int64, error) {
+	if len(weekdays) == 0 {
+		return 0, nil
+	}
+	q := base.GetDB(ctx, r.db).NewDelete().
+		Model((*schedule.ActivityInstance)(nil)).
+		ModelTableExpr(modelTblActivityInstance).
+		Where(`"activity_instance".activity_group_id = ?`, activityGroupID).
+		Where(`"activity_instance".calendar_period_id IS NOT NULL`).
+		Where(`"activity_instance".date >= ?`, timezone.TodayDate()).
+		Where(`"activity_instance".status = ?`, schedule.InstanceStatusPlanned).
+		Where(`"activity_instance".is_spontaneous = ?`, false).
+		Where(`EXTRACT(ISODOW FROM "activity_instance".date)::int IN (?)`, bun.In(weekdays))
+	q = base.WithTenantFilter(ctx, q, aliasActivityInstance)
+	res, err := q.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{Op: "delete removed legacy weekend instances", Err: err}
+	}
+	deleted, _ := res.RowsAffected()
+	return deleted, nil
+}
+
 // PropagateListKindToFutureInstances re-classifies the future template-backed
 // planned instances of one template whose list_kind still matches the series'
 // previous value, returning the number of rows changed. It closes the gap where

--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -474,7 +474,7 @@ func (r *ActivityInstanceRepository) DeletePlannedMaterializedWeekendInstances(c
 		Where(`"activity_instance".date >= ?`, timezone.TodayDate()).
 		Where(`"activity_instance".status = ?`, schedule.InstanceStatusPlanned).
 		Where(`"activity_instance".is_spontaneous = ?`, false).
-		Where(`EXTRACT(ISODOW FROM "activity_instance".date)::int IN (?)`, bun.In(weekdays))
+		Where(`EXTRACT(ISODOW FROM "activity_instance".date)::int IN (?)`, bun.List(weekdays))
 	q = base.WithTenantFilter(ctx, q, aliasActivityInstance)
 	res, err := q.Exec(ctx)
 	if err != nil {

--- a/backend/database/repositories/schedule/activity_instance_repo_test.go
+++ b/backend/database/repositories/schedule/activity_instance_repo_test.go
@@ -737,6 +737,57 @@ func TestActivityInstanceRepository_DeletePlannedNonSpontaneousInWindow_HardDele
 		"deviated instance must be deleted by the destructive series operation")
 }
 
+func TestActivityInstanceRepository_DeletePlannedMaterializedWeekendInstances(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repo := scheduleRepo.NewActivityInstanceRepository(db)
+	legacyWeekendRepo, ok := repo.(interface {
+		DeletePlannedMaterializedWeekendInstances(context.Context, int64, []int) (int64, error)
+	})
+	require.True(t, ok, "activity-instance repository must support legacy weekend cleanup")
+	fx := newActivityInstanceFixtures(t, db, "legacy-weekend-delete")
+	defer fx.cleanup()
+
+	saturday := timezone.TodayDate().AddDays(1)
+	for saturday.Weekday() != time.Saturday {
+		saturday = saturday.AddDays(1)
+	}
+	period := testpkg.CreateTestCalendarPeriod(t, db, fmt.Sprintf("Legacy weekend %d", time.Now().UnixNano()), saturday, saturday.AddDays(1))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "schedule.calendar_periods", period.ID) })
+
+	materialized := buildInstance(1, fx.roomID, &fx.activityID, saturday,
+		time.Date(2024, 1, 1, 14, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC), "legacy saturday")
+	materialized.CalendarPeriodID = &period.ID
+	require.NoError(t, repo.Create(ctx, materialized))
+
+	manual := buildInstance(1, fx.roomID, &fx.activityID, saturday,
+		time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 16, 0, 0, 0, time.UTC), "manual saturday")
+	require.NoError(t, repo.Create(ctx, manual))
+
+	sunday := buildInstance(1, fx.roomID, &fx.activityID, saturday.AddDays(1),
+		time.Date(2024, 1, 1, 16, 0, 0, 0, time.UTC), time.Date(2024, 1, 1, 17, 0, 0, 0, time.UTC), "legacy sunday")
+	sunday.CalendarPeriodID = &period.ID
+	require.NoError(t, repo.Create(ctx, sunday))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", materialized.ID, manual.ID, sunday.ID)
+
+	deleted, err := legacyWeekendRepo.DeletePlannedMaterializedWeekendInstances(ctx, fx.activityID, []int{6})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, deleted)
+
+	_, err = repo.FindByID(ctx, materialized.ID)
+	assert.True(t, modelBase.IsNoRows(err), "the removed Saturday slot must be deleted")
+	_, err = repo.FindByID(ctx, manual.ID)
+	require.NoError(t, err, "manual weekend instances must remain")
+	_, err = repo.FindByID(ctx, sunday.ID)
+	require.NoError(t, err, "weekend days retained by the template must remain")
+
+	deleted, err = legacyWeekendRepo.DeletePlannedMaterializedWeekendInstances(ctx, fx.activityID, nil)
+	require.NoError(t, err)
+	assert.Zero(t, deleted, "an empty weekday set must be a no-op")
+}
+
 // #1565 review: editing a series' Listenart must carry onto its already
 // materialized FUTURE occurrences that still hold the old value, while leaving
 // today/past rows, non-planned/spontaneous rows, and per-occurrence overrides

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1944,6 +1944,8 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 			EducationGroupRepo:         repos.Group,
 			ValidateCareOfferingSeries: careOfferingSeriesValidator.ValidateTemplateSeries,
 			DeviationEventRepo:         repos.DeviationEvent,
+			Broadcaster:                realtimeHub,
+			Logger:                     logger.With("service", "timetable-data"),
 			DB:                         db,
 		}),
 		OperatorSuggestions:  operatorSuggestionsService,

--- a/backend/services/schedule/edited_instance_detection.go
+++ b/backend/services/schedule/edited_instance_detection.go
@@ -235,6 +235,14 @@ func (s *materializationService) expectedSlotsOn(
 	exc *schedule.ActivityException,
 	date timezone.Date,
 ) []materialParams {
+	// Keep this projection aligned with materializeTemplate: legacy weekend
+	// schedules remain administrable, but are never materialized into new
+	// instances. Treating them as expected here would hide the warning that a
+	// re-plan will remove a retained weekend instance without recreating it.
+	if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
+		return nil
+	}
+
 	isoWd := isoWeekday(date)
 	out := make([]materialParams, 0, 1)
 	for _, sch := range schedules {

--- a/backend/services/schedule/edited_instance_detection_test.go
+++ b/backend/services/schedule/edited_instance_detection_test.go
@@ -182,6 +182,25 @@ func TestDiffOccurrence_NoExpectedSlotOnDate(t *testing.T) {
 	assert.Equal(t, []string{EditedChangeTime}, changes)
 }
 
+func TestExpectedSlotsOn_LegacyWeekendScheduleIsNotMaterializable(t *testing.T) {
+	// materializeTemplate skips legacy Saturday/Sunday schedules. The edited
+	// instance projection must do the same so it warns before a re-plan removes
+	// an existing weekend row without replacing it.
+	service := &materializationService{}
+	saturday := timezone.NewDate(2026, time.June, 13)
+
+	slots := service.expectedSlotsOn(
+		&activities.Group{},
+		[]*activities.Schedule{{Weekday: 6}},
+		nil,
+		nil,
+		nil,
+		saturday,
+	)
+
+	assert.Empty(t, slots)
+}
+
 func TestDiffOccurrence_ExceptionShiftedStartIsMatched(t *testing.T) {
 	// A modified exception shifts the template start to 16:00 for this date, so
 	// materialization creates the occurrence at 16:00–17:00. The (already

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -1549,22 +1549,11 @@ func (s *instanceService) ReplanWeek(ctx context.Context, from, to timezone.Date
 	// preserveDeviations=false: delete deviated occurrences too so they are
 	// regenerated with the current template values; the snapshot above lets us
 	// reapply the overrides afterward.
-	// Legacy Saturday/Sunday occurrences are not regenerated under the Mo–Fr
-	// planning contract, so a re-plan must leave them (and their rosters and
-	// deviations) intact. Delete each workday separately instead of widening
-	// the repository's shared delete contract used by split/end operations.
-	var deleted int64
-	for date := from; !date.After(to); date = date.AddDays(1) {
-		if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
-			continue
-		}
-		n, deleteErr := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, date, &date, activityGroupID, false)
-		if deleteErr != nil {
-			err = deleteErr
-			break
-		}
-		deleted += n
-	}
+	// A re-plan rebuilds every future derived row in its window. Legacy
+	// Saturday/Sunday occurrences must be deleted too: materialization no
+	// longer recreates weekends, and retaining them would leave stale title,
+	// room, time, roster, or notes after a series edit.
+	deleted, err := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, from, &to, activityGroupID, false)
 	if err != nil {
 		return nil, &ScheduleError{Op: "replan week: delete planned", Err: err}
 	}

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -1532,7 +1532,22 @@ func (s *instanceService) ReplanWeek(ctx context.Context, from, to timezone.Date
 	// preserveDeviations=false: delete deviated occurrences too so they are
 	// regenerated with the current template values; the snapshot above lets us
 	// reapply the overrides afterward.
-	deleted, err := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, from, &to, activityGroupID, false)
+	// Legacy Saturday/Sunday occurrences are not regenerated under the Mo–Fr
+	// planning contract, so a re-plan must leave them (and their rosters and
+	// deviations) intact. Delete each workday separately instead of widening
+	// the repository's shared delete contract used by split/end operations.
+	var deleted int64
+	for date := from; !date.After(to); date = date.AddDays(1) {
+		if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
+			continue
+		}
+		n, deleteErr := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, date, &date, activityGroupID, false)
+		if deleteErr != nil {
+			err = deleteErr
+			break
+		}
+		deleted += n
+	}
 	if err != nil {
 		return nil, &ScheduleError{Op: "replan week: delete planned", Err: err}
 	}
@@ -1659,6 +1674,9 @@ func (s *instanceService) snapshotDeviations(ctx context.Context, from, to timez
 	// including those with no override.
 	occurrences := make(map[groupDay]int)
 	for _, inst := range instances {
+		if inst.Date.Weekday() == time.Saturday || inst.Date.Weekday() == time.Sunday {
+			continue
+		}
 		if inst.Status != scheduleModel.InstanceStatusPlanned || inst.IsSpontaneous || inst.ActivityGroupID == nil {
 			continue
 		}

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -62,6 +62,11 @@ var (
 	// Handlers map this to 400.
 	ErrInvalidInstanceReference = errors.New("invalid instance reference")
 
+	// ErrInstanceWeekend is returned when an update introduces or restores a
+	// weekend date. Existing legacy weekend rows may retain their date, but the
+	// decision is made after the instance and day locks are held.
+	ErrInstanceWeekend = errors.New("timetable entries can only be scheduled from Monday to Friday")
+
 	// ErrAmbiguousTemplateInstanceDelete is returned when a single-instance
 	// delete would need to persist a date-wide cancellation exception but the
 	// template has multiple materialized slots on that date. Handlers map this
@@ -936,7 +941,6 @@ func (s *instanceService) UpdatePlanned(ctx context.Context, instanceID int64, r
 	if instance.Status != scheduleModel.InstanceStatusPlanned {
 		return nil, fmt.Errorf("%w: cannot update instance in status %q", ErrInvalidInstanceTransition, instance.Status)
 	}
-
 	// Serialize with the day-wide staffing endpoints (#1840). This edit rewrites
 	// the block's assignments and may MOVE it to another date, so it must hold the
 	// same (tenant, date) advisory lock the /deviations and /substitute saves take
@@ -967,6 +971,9 @@ func (s *instanceService) UpdatePlanned(ctx context.Context, instanceID int64, r
 	}
 	if instance.Status != scheduleModel.InstanceStatusPlanned {
 		return nil, fmt.Errorf("%w: cannot update instance in status %q", ErrInvalidInstanceTransition, instance.Status)
+	}
+	if err := validateLegacyWeekendInstanceDate(instance.Date, req.Date); err != nil {
+		return nil, err
 	}
 
 	if err := s.validateInstanceReferences(ctx, req.Date, req.RoomID, req.ActivityGroupID, req.StaffIDs, req.StudentIDs, nil); err != nil {
@@ -1033,6 +1040,16 @@ func (s *instanceService) UpdatePlanned(ctx context.Context, instanceID int64, r
 
 	s.broadcastPlannedInstanceChanged(ctx, "instance_update")
 	return instance, nil
+}
+
+func validateLegacyWeekendInstanceDate(existing, requested timezone.Date) error {
+	if requested.Weekday() != time.Saturday && requested.Weekday() != time.Sunday {
+		return nil
+	}
+	if existing == requested {
+		return nil
+	}
+	return ErrInstanceWeekend
 }
 
 // clearStaleAckIfStaffed clears a lingering "deliberately unstaffed"

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -1021,7 +1021,7 @@ func TestInstance_UpdatePlanned_RejectsCrossTenantReferencesBeforeMutation(t *te
 
 	ai := seedInstance(t, s, true, true)
 	valid := scheduleSvc.UpdateInstanceInput{
-		Date:            timezone.NewDate(2026, 5, 10),
+		Date:            timezone.NewDate(2026, 5, 11),
 		StartTime:       time.Date(1, 1, 1, 10, 0, 0, 0, time.UTC),
 		EndTime:         time.Date(1, 1, 1, 11, 0, 0, 0, time.UTC),
 		Title:           "Cross tenant update should fail",

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -760,6 +760,23 @@ func TestInstance_ReplanWeek_OnlyDeletesPlannedNonSpontaneous(t *testing.T) {
 	assert.True(t, instanceExists(t, s, cancelled), "cancelled must survive")
 }
 
+func TestInstance_ReplanWeek_RemovesFutureLegacyWeekendInstances(t *testing.T) {
+	s := buildLifecycle(t)
+
+	from := timezone.TodayDate()
+	for from.Weekday() != time.Monday {
+		from = from.AddDays(1)
+	}
+	to := from.AddDays(6)
+	legacyWeekend := insertInstance(t, s, from.AddDays(5), scheduleModels.InstanceStatusPlanned, false)
+
+	result, err := s.svc.ReplanWeek(s.ctx, from, to, &s.tmplID, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.DeletedInstances)
+	assert.False(t, instanceExists(t, s, legacyWeekend), "legacy weekend rows must not survive a series re-plan with stale template data")
+}
+
 // WP-B3: a re-plan scoped to one template deletes only that template's
 // planned non-spontaneous instances — other templates' rows survive.
 func TestInstance_ReplanWeek_ScopedToActivityGroup(t *testing.T) {

--- a/backend/services/schedule/instance_service_unit_test.go
+++ b/backend/services/schedule/instance_service_unit_test.go
@@ -33,6 +33,16 @@ func TestInstanceStart_SchulhofRequiresDedicatedSupervision(t *testing.T) {
 	assert.Equal(t, 1, roomRepo.findCalls)
 }
 
+func TestValidateLegacyWeekendInstanceDate(t *testing.T) {
+	saturday := timezone.NewDate(2026, time.May, 9)
+	monday := saturday.AddDays(2)
+
+	assert.NoError(t, validateLegacyWeekendInstanceDate(monday, monday), "weekday updates stay valid")
+	assert.NoError(t, validateLegacyWeekendInstanceDate(saturday, saturday), "legacy weekend rows may retain their original date")
+	assert.ErrorIs(t, validateLegacyWeekendInstanceDate(monday, saturday), ErrInstanceWeekend,
+		"new weekend dates must be rejected")
+}
+
 func TestInstanceStart_RoomLookupFailuresAreInternal(t *testing.T) {
 	inst := deleteUnitInstance(99, nil, timezone.NewDate(2026, 7, 4), scheduleModel.InstanceStatusPlanned, false)
 	tests := []struct {

--- a/backend/services/schedule/materialization_service.go
+++ b/backend/services/schedule/materialization_service.go
@@ -432,6 +432,12 @@ func (s *materializationService) materializeTemplate(
 	}
 
 	for date := from; !date.After(to); date = date.AddDays(1) {
+		// Templates created before the Mo–Fr planning rule may still contain
+		// weekend schedules. Keep those records intact for administration, but
+		// never create new invisible weekend instances from them.
+		if date.Weekday() == time.Saturday || date.Weekday() == time.Sunday {
+			continue
+		}
 		isoWd := isoWeekday(date)
 		for _, sch := range schedules {
 			if sch.Weekday != isoWd {

--- a/backend/services/schedule/materialization_service_test.go
+++ b/backend/services/schedule/materialization_service_test.go
@@ -661,6 +661,24 @@ func TestMaterializeForTenant_TemplateInsertErrorBubbles(t *testing.T) {
 	assert.Zero(t, result.CandidatesRaced)
 }
 
+func TestMaterializeForTenant_SkipsLegacyWeekendSchedules(t *testing.T) {
+	svc, saturday := newMaterializationBranchServiceForSchedule(
+		materializationFakeInstanceRepo{inserted: true},
+		timezone.NewDate(2026, time.April, 25),
+		activities.WeekdaySaturday,
+	)
+
+	result, err := svc.MaterializeForTenant(
+		tenant.WithTenantID(context.Background(), 300),
+		saturday,
+		saturday,
+		MaterializationSourceManual,
+	)
+
+	require.NoError(t, err)
+	assert.Zero(t, result.InstancesCreated)
+}
+
 func TestMaterializeForTenant_PreconditionWarnings(t *testing.T) {
 	date := timezone.NewDate(2026, 4, 20)
 
@@ -988,6 +1006,14 @@ func (r *materializationCountingStaffRepo) Create(_ context.Context, row *schedu
 
 func newMaterializationBranchService(instanceRepo materializationFakeInstanceRepo) (MaterializationService, timezone.Date) {
 	date := timezone.NewDate(2026, 4, 20)
+	return newMaterializationBranchServiceForSchedule(instanceRepo, date, activities.WeekdayMonday)
+}
+
+func newMaterializationBranchServiceForSchedule(
+	instanceRepo materializationFakeInstanceRepo,
+	date timezone.Date,
+	weekday int,
+) (MaterializationService, timezone.Date) {
 	start := time.Date(2024, time.January, 1, 14, 0, 0, 0, time.UTC)
 	end := time.Date(2024, time.January, 1, 15, 0, 0, 0, time.UTC)
 	roomID := int64(700)
@@ -1004,7 +1030,7 @@ func newMaterializationBranchService(instanceRepo materializationFakeInstanceRep
 		materializationFakeScheduleRepo{schedules: []*activities.Schedule{{
 			Model:           modelBase.Model{ID: 800},
 			ActivityGroupID: templateID,
-			Weekday:         activities.WeekdayMonday,
+			Weekday:         weekday,
 			TimeframeID:     &timeframeID,
 		}}},
 		materializationFakeEnrollmentRepo{},

--- a/backend/services/schedule/template_create_service.go
+++ b/backend/services/schedule/template_create_service.go
@@ -109,6 +109,9 @@ func validateTemplateCreateInput(in CreateTemplateInput) error {
 		if !activitiesModel.IsValidWeekday(weekday) {
 			return fmt.Errorf("invalid weekday %d", weekday)
 		}
+		if weekday > activitiesModel.WeekdayFriday {
+			return errors.New("timetable templates can only be scheduled from Monday to Friday")
+		}
 	}
 	if in.WeekPattern < 0 || in.WeekPattern > 2 {
 		return errors.New("week pattern must be 0, 1, or 2")

--- a/backend/services/schedule/template_split_service.go
+++ b/backend/services/schedule/template_split_service.go
@@ -407,6 +407,13 @@ func (s *TemplateSplitService) prepareSplitSource(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	schedules, err := s.deps.ScheduleRepo.FindByGroupID(ctx, old.ID)
+	if err != nil {
+		return nil, nil, nil, nil, &ScheduleError{Op: "split template: load source schedules", Err: err}
+	}
+	if err := validateLegacyTemplateWeekdays(schedules, in.Weekdays); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("%w: %w", ErrSplitInvalidInput, err)
+	}
 	if sourceValidUntil != nil {
 		return nil, nil, nil, nil, fmt.Errorf(
 			"%w: bounded template segments cannot be split again",

--- a/backend/services/schedule/template_split_service.go
+++ b/backend/services/schedule/template_split_service.go
@@ -407,13 +407,6 @@ func (s *TemplateSplitService) prepareSplitSource(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	schedules, err := s.deps.ScheduleRepo.FindByGroupID(ctx, old.ID)
-	if err != nil {
-		return nil, nil, nil, nil, &ScheduleError{Op: "split template: load source schedules", Err: err}
-	}
-	if err := validateLegacyTemplateWeekdays(schedules, in.Weekdays); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%w: %w", ErrSplitInvalidInput, err)
-	}
 	if sourceValidUntil != nil {
 		return nil, nil, nil, nil, fmt.Errorf(
 			"%w: bounded template segments cannot be split again",
@@ -659,6 +652,9 @@ func validateSplitRecurrence(in TemplateSplitInput) error {
 	for _, w := range in.Weekdays {
 		if !activitiesModel.IsValidWeekday(w) {
 			return fmt.Errorf("%w: invalid weekday %d (must be 1=Mon … 7=Sun)", ErrSplitInvalidInput, w)
+		}
+		if w > activitiesModel.WeekdayFriday {
+			return fmt.Errorf("%w: timetable templates can only be scheduled from Monday to Friday", ErrSplitInvalidInput)
 		}
 	}
 	if !in.EndTime.After(in.StartTime) {

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -20,6 +20,10 @@ import (
 // the recurrences.
 var ErrInconsistentTemplateScheduleValidity = errors.New("template schedules have inconsistent validity bounds")
 
+// ErrTemplateWeekendWeekday is returned when an update tries to introduce a
+// weekend weekday that was not already present on a legacy template.
+var ErrTemplateWeekendWeekday = errors.New("timetable templates can only be scheduled from Monday to Friday")
+
 // ErrTemplateSegmentNotEditable is returned when a full-series PUT reaches a
 // segment that has already been capped by Split/End. The active CRUD contract
 // exposes only open segments, so handlers map this race-safe service check to
@@ -133,6 +137,9 @@ func (s *TimetableDataService) updateTemplateLocked(ctx context.Context, in Temp
 	if err != nil {
 		return &ScheduleError{Op: "update template: load previous schedules", Err: err}
 	}
+	if err := validateLegacyTemplateWeekdays(previousSchedules, in.Weekdays); err != nil {
+		return &ScheduleError{Op: "update template: validate weekdays", Err: err}
+	}
 	// Capture the series' current Listenart before the field write so the
 	// instance propagation can tell an untouched occurrence (still carrying the
 	// series value) from a per-occurrence override.
@@ -162,6 +169,23 @@ func (s *TimetableDataService) updateTemplateLocked(ctx context.Context, in Temp
 			"updated recurrence is incompatible with an existing care offering",
 			err,
 		)
+	}
+	return nil
+}
+
+func validateLegacyTemplateWeekdays(existing []*activitiesModel.Schedule, requested []int) error {
+	legacy := make(map[int]struct{})
+	for _, schedule := range existing {
+		if schedule != nil && schedule.Weekday > activitiesModel.WeekdayFriday {
+			legacy[schedule.Weekday] = struct{}{}
+		}
+	}
+	for _, weekday := range requested {
+		if weekday > activitiesModel.WeekdayFriday {
+			if _, ok := legacy[weekday]; !ok {
+				return ErrTemplateWeekendWeekday
+			}
+		}
 	}
 	return nil
 }

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -129,6 +129,10 @@ func (s *TimetableDataService) updateTemplateLocked(ctx context.Context, in Temp
 	if err != nil {
 		return err
 	}
+	previousSchedules, err := s.deps.ActivityScheduleRepo.FindByGroupID(ctx, in.TemplateID)
+	if err != nil {
+		return &ScheduleError{Op: "update template: load previous schedules", Err: err}
+	}
 	// Capture the series' current Listenart before the field write so the
 	// instance propagation can tell an untouched occurrence (still carrying the
 	// series value) from a per-occurrence override.
@@ -140,6 +144,9 @@ func (s *TimetableDataService) updateTemplateLocked(ctx context.Context, in Temp
 		return err
 	}
 	if err := s.replaceTemplateSchedules(ctx, in, tenantID, validFrom, validUntil); err != nil {
+		return err
+	}
+	if err := s.deleteRemovedLegacyWeekendInstances(ctx, in.TemplateID, previousSchedules, in.Weekdays); err != nil {
 		return err
 	}
 	if err := s.replaceTemplateRoster(ctx, in, tenantID, validFrom, validUntil); err != nil {
@@ -155,6 +162,33 @@ func (s *TimetableDataService) updateTemplateLocked(ctx context.Context, in Temp
 			"updated recurrence is incompatible with an existing care offering",
 			err,
 		)
+	}
+	return nil
+}
+
+type legacyWeekendInstanceCleaner interface {
+	DeletePlannedMaterializedWeekendInstances(context.Context, int64, []int) (int64, error)
+}
+
+func (s *TimetableDataService) deleteRemovedLegacyWeekendInstances(ctx context.Context, templateID int64, previous []*activitiesModel.Schedule, requested []int) error {
+	requestedWeekdays := make(map[int]struct{}, len(requested))
+	for _, weekday := range requested {
+		requestedWeekdays[weekday] = struct{}{}
+	}
+	removed := make([]int, 0, 2)
+	for _, schedule := range previous {
+		if schedule.Weekday > activitiesModel.WeekdayFriday {
+			if _, retained := requestedWeekdays[schedule.Weekday]; !retained {
+				removed = append(removed, schedule.Weekday)
+			}
+		}
+	}
+	cleaner, ok := s.deps.ActivityInstanceRepo.(legacyWeekendInstanceCleaner)
+	if !ok || len(removed) == 0 {
+		return nil
+	}
+	if _, err := cleaner.DeletePlannedMaterializedWeekendInstances(ctx, templateID, removed); err != nil {
+		return &ScheduleError{Op: "update template: delete removed legacy weekend instances", Err: err}
 	}
 	return nil
 }

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -211,8 +211,14 @@ func (s *TimetableDataService) deleteRemovedLegacyWeekendInstances(ctx context.C
 	if !ok || len(removed) == 0 {
 		return nil
 	}
-	if _, err := cleaner.DeletePlannedMaterializedWeekendInstances(ctx, templateID, removed); err != nil {
+	deleted, err := cleaner.DeletePlannedMaterializedWeekendInstances(ctx, templateID, removed)
+	if err != nil {
 		return &ScheduleError{Op: "update template: delete removed legacy weekend instances", Err: err}
+	}
+	if deleted > 0 {
+		// This bulk deletion bypasses the planned-instance CRUD flow, so it must
+		// invalidate clients after the surrounding transaction commits.
+		broadcastStaffingChanged(ctx, s.deps.Broadcaster, s.getLogger(), "template_legacy_weekend_cleanup")
 	}
 	return nil
 }

--- a/backend/services/schedule/template_update_service_unit_test.go
+++ b/backend/services/schedule/template_update_service_unit_test.go
@@ -3,10 +3,14 @@ package schedule
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
 	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/realtime"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,6 +20,7 @@ type legacyWeekendCleanerTestRepo struct {
 	calls     int
 	template  int64
 	weekdays  []int
+	deleted   int64
 	deleteErr error
 }
 
@@ -23,7 +28,7 @@ func (r *legacyWeekendCleanerTestRepo) DeletePlannedMaterializedWeekendInstances
 	r.calls++
 	r.template = templateID
 	r.weekdays = append([]int(nil), weekdays...)
-	return 0, r.deleteErr
+	return r.deleted, r.deleteErr
 }
 
 func TestDeleteRemovedLegacyWeekendInstances(t *testing.T) {
@@ -44,6 +49,26 @@ func TestDeleteRemovedLegacyWeekendInstances(t *testing.T) {
 		assert.Equal(t, 1, repo.calls)
 		assert.Equal(t, templateID, repo.template)
 		assert.Equal(t, []int{activitiesModel.WeekdaySaturday}, repo.weekdays)
+	})
+
+	t.Run("broadcasts after deleting materialized instances", func(t *testing.T) {
+		broadcaster := testpkg.NewRecordingBroadcaster()
+		repo := &legacyWeekendCleanerTestRepo{deleted: 2}
+		svc := NewTimetableDataService(TimetableDataDependencies{
+			ActivityInstanceRepo: repo,
+			Broadcaster:          broadcaster,
+			Logger:               slog.Default(),
+		})
+		ctx := tenant.WithTenantID(context.Background(), 314)
+
+		require.NoError(t, svc.deleteRemovedLegacyWeekendInstances(ctx, templateID, previous, []int{activitiesModel.WeekdayFriday}))
+
+		calls := broadcaster.CallsByMethod("tenant")
+		require.Len(t, calls, 1)
+		assert.Equal(t, int64(314), calls[0].TenantID)
+		assert.Equal(t, realtime.EventStaffingDeviationChanged, calls[0].Event.Type)
+		require.NotNil(t, calls[0].Event.Data.Source)
+		assert.Equal(t, "template_legacy_weekend_cleanup", *calls[0].Event.Data.Source)
 	})
 
 	t.Run("skips cleanup when all legacy days remain", func(t *testing.T) {

--- a/backend/services/schedule/template_update_service_unit_test.go
+++ b/backend/services/schedule/template_update_service_unit_test.go
@@ -1,0 +1,66 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type legacyWeekendCleanerTestRepo struct {
+	scheduleModel.ActivityInstanceRepository
+	calls     int
+	template  int64
+	weekdays  []int
+	deleteErr error
+}
+
+func (r *legacyWeekendCleanerTestRepo) DeletePlannedMaterializedWeekendInstances(_ context.Context, templateID int64, weekdays []int) (int64, error) {
+	r.calls++
+	r.template = templateID
+	r.weekdays = append([]int(nil), weekdays...)
+	return 0, r.deleteErr
+}
+
+func TestDeleteRemovedLegacyWeekendInstances(t *testing.T) {
+	templateID := int64(921)
+	previous := []*activitiesModel.Schedule{
+		{Weekday: activitiesModel.WeekdayFriday},
+		{Weekday: activitiesModel.WeekdaySaturday},
+		{Weekday: activitiesModel.WeekdaySunday},
+	}
+
+	t.Run("deletes only removed legacy weekend days", func(t *testing.T) {
+		repo := &legacyWeekendCleanerTestRepo{}
+		svc := NewTimetableDataService(TimetableDataDependencies{ActivityInstanceRepo: repo})
+
+		err := svc.deleteRemovedLegacyWeekendInstances(context.Background(), templateID, previous, []int{activitiesModel.WeekdayFriday, activitiesModel.WeekdaySunday})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.calls)
+		assert.Equal(t, templateID, repo.template)
+		assert.Equal(t, []int{activitiesModel.WeekdaySaturday}, repo.weekdays)
+	})
+
+	t.Run("skips cleanup when all legacy days remain", func(t *testing.T) {
+		repo := &legacyWeekendCleanerTestRepo{}
+		svc := NewTimetableDataService(TimetableDataDependencies{ActivityInstanceRepo: repo})
+
+		require.NoError(t, svc.deleteRemovedLegacyWeekendInstances(context.Background(), templateID, previous, []int{activitiesModel.WeekdayFriday, activitiesModel.WeekdaySaturday, activitiesModel.WeekdaySunday}))
+		assert.Zero(t, repo.calls)
+	})
+
+	t.Run("wraps cleanup failures", func(t *testing.T) {
+		repo := &legacyWeekendCleanerTestRepo{deleteErr: errors.New("delete failed")}
+		svc := NewTimetableDataService(TimetableDataDependencies{ActivityInstanceRepo: repo})
+
+		err := svc.deleteRemovedLegacyWeekendInstances(context.Background(), templateID, previous, []int{activitiesModel.WeekdayFriday})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete removed legacy weekend instances")
+	})
+}

--- a/backend/services/schedule/template_update_service_unit_test.go
+++ b/backend/services/schedule/template_update_service_unit_test.go
@@ -64,3 +64,19 @@ func TestDeleteRemovedLegacyWeekendInstances(t *testing.T) {
 		assert.Contains(t, err.Error(), "delete removed legacy weekend instances")
 	})
 }
+
+func TestValidateLegacyTemplateWeekdays(t *testing.T) {
+	existing := []*activitiesModel.Schedule{
+		{Weekday: activitiesModel.WeekdayFriday},
+		{Weekday: activitiesModel.WeekdaySaturday},
+	}
+
+	assert.NoError(t, validateLegacyTemplateWeekdays(existing, []int{
+		activitiesModel.WeekdayFriday,
+		activitiesModel.WeekdaySaturday,
+	}))
+	assert.ErrorIs(t, validateLegacyTemplateWeekdays(existing, []int{
+		activitiesModel.WeekdayFriday,
+		activitiesModel.WeekdaySunday,
+	}), ErrTemplateWeekendWeekday)
+}

--- a/backend/services/schedule/template_weekday_validation_unit_test.go
+++ b/backend/services/schedule/template_weekday_validation_unit_test.go
@@ -1,0 +1,25 @@
+package schedule
+
+import (
+	"testing"
+
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTemplateCreateInputRejectsWeekendWeekday(t *testing.T) {
+	err := validateTemplateCreateInput(CreateTemplateInput{
+		Name:     "Wochenende",
+		Weekdays: []int{activitiesModel.WeekdaySaturday},
+	})
+
+	assert.ErrorContains(t, err, "Monday to Friday")
+}
+
+func TestValidateSplitRecurrenceRejectsWeekendWeekday(t *testing.T) {
+	err := validateSplitRecurrence(TemplateSplitInput{
+		Weekdays: []int{activitiesModel.WeekdaySunday},
+	})
+
+	assert.ErrorContains(t, err, "Monday to Friday")
+}

--- a/backend/services/schedule/timetable_data_service.go
+++ b/backend/services/schedule/timetable_data_service.go
@@ -1,6 +1,7 @@
 package schedule
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -75,10 +76,7 @@ func NewTimetableDataService(deps TimetableDataDependencies) *TimetableDataServi
 }
 
 func (s *TimetableDataService) getLogger() *slog.Logger {
-	if s.deps.Logger != nil {
-		return s.deps.Logger
-	}
-	return slog.Default()
+	return cmp.Or(s.deps.Logger, slog.Default())
 }
 
 // ListDeviationEvents returns the Änderungsprotokoll rows in [from, to],

--- a/backend/services/schedule/timetable_data_service.go
+++ b/backend/services/schedule/timetable_data_service.go
@@ -20,6 +20,7 @@ import (
 	facilitiesModel "github.com/moto-nrw/project-phoenix/models/facilities"
 	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	usersModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/realtime"
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
@@ -53,7 +54,11 @@ type TimetableDataDependencies struct {
 	ValidateCareOfferingSeries func(context.Context, int64) error
 	// DeviationEventRepo serves the Änderungsprotokoll read path (#1886).
 	DeviationEventRepo auditModel.DeviationEventRepository
-	DB                 *bun.DB
+	// Broadcaster invalidates planner and "Heute geplant" caches after
+	// template-side changes that bypass the instance CRUD flows.
+	Broadcaster realtime.Broadcaster
+	Logger      *slog.Logger
+	DB          *bun.DB
 }
 
 // TimetableDataService is the service boundary behind api/timetable (issue
@@ -67,6 +72,13 @@ type TimetableDataService struct {
 // NewTimetableDataService creates the data facade behind api/timetable.
 func NewTimetableDataService(deps TimetableDataDependencies) *TimetableDataService {
 	return &TimetableDataService{deps: deps}
+}
+
+func (s *TimetableDataService) getLogger() *slog.Logger {
+	if s.deps.Logger != nil {
+		return s.deps.Logger
+	}
+	return slog.Default()
 }
 
 // ListDeviationEvents returns the Änderungsprotokoll rows in [from, to],

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -924,7 +924,7 @@ export const appChapters: readonly GuideChapter[] = [
         summary:
           "Plant Termine, Regeltermine, Räume, Personal und erwartete Kinder im Voraus (nur für Admins).",
         steps: [
-          "In der Seitenleiste den Bereich `Planung` aufklappen und `Betreuungsplan` öffnen. Oben zwischen den Ansichten `Woche`, `Monat` und `Serien` wechseln; die Pfeile und `Heute` navigieren durch Woche oder Monat, die Serienansicht zeigt stattdessen die Liste aller Regeltermine des sichtbaren Planungszeitraums.",
+          "In der Seitenleiste den Bereich `Planung` aufklappen und `Betreuungsplan` öffnen. Oben zwischen den Ansichten `Woche`, `Monat` und `Serien` wechseln; die Wochenansicht zeigt Montag bis Freitag. Die Pfeile und `Heute` navigieren durch Woche oder Monat, die Serienansicht zeigt stattdessen die Liste aller Regeltermine des sichtbaren Planungszeitraums.",
           "Der `Zeitraum`-Chip in der Kontextzeile zeigt den Planungszeitraum des sichtbaren Datums; ein Klick öffnet eine Liste zum Umspringen, `Zeiträume verwalten` führt zur Verwaltungsseite. Der Chip `Bedarf: …` daneben zeigt, welche Anmeldephase den Bedarf des Zeitraums liefert.",
           "Der Lücken-Chip in der Kontextzeile zählt offene Personal-Lücken des sichtbaren Zeitraums; ein Klick öffnet eine Sprungliste mit Uhrzeit, Titel und Soll/Ist je Lücke, die direkt zum betroffenen Termin springt.",
           "In der Wochenansicht eine freie Zelle am gewünschten Tag und zur gewünschten Uhrzeit anklicken (beim Überfahren erscheint `+ Termin`). Das Formular öffnet sich als dreistufiger Assistent mit den Schritten `Termin`, `Wiederholung` und `Personal und Kinder`.",

--- a/frontend/src/components/timetable/betreuungsplan-view.test.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.test.tsx
@@ -245,12 +245,19 @@ vi.mock("~/components/timetable/conflict-warnings-banner", () => ({
 vi.mock("~/components/timetable/month-planner-grid", () => ({
   MonthPlannerGrid: ({
     onDayClick,
+    onInstanceClick,
   }: {
     onDayClick: (date: string) => void;
+    onInstanceClick?: (instance: { id: string }) => void;
   }) => (
-    <button type="button" onClick={() => onDayClick("2026-05-06")}>
-      month-grid
-    </button>
+    <div>
+      <button type="button" onClick={() => onDayClick("2026-05-06")}>
+        month-grid
+      </button>
+      <button type="button" onClick={() => onInstanceClick?.({ id: "42" })}>
+        month-instance
+      </button>
+    </div>
   ),
 }));
 
@@ -892,6 +899,15 @@ describe("BetreuungsplanView", () => {
     expect(urlParams().get("d")).toBe("2026-05-06");
     expect(urlParams().has("view")).toBe(false);
     expect(screen.getByText("week-grid")).toBeVisible();
+  });
+
+  it("keeps a weekend month anchor and opens retained month instances", () => {
+    setUrl("view=monat&d=2026-05-31");
+    render(<BetreuungsplanView />);
+
+    expect(screen.getByText("Mai 2026")).toBeVisible();
+    fireEvent.click(screen.getByText("month-instance"));
+    expect(screen.getByText("detail-close")).toBeVisible();
   });
 
   it("opens and closes the slide-over via the block param", async () => {

--- a/frontend/src/components/timetable/betreuungsplan-view.test.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.test.tsx
@@ -867,6 +867,23 @@ describe("BetreuungsplanView", () => {
     expect(urlParams().get("d")).toBe("2026-05-06");
   });
 
+  it("snaps weekend deep links and the Heute target to the following Monday", () => {
+    setUrl("d=2026-05-09");
+    const { unmount } = render(<BetreuungsplanView />);
+
+    fireEvent.click(screen.getByText("add-instance"));
+    expect(mockEventModalProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ defaultDate: "2026-05-11" }),
+    );
+
+    unmount();
+    vi.setSystemTime(new Date("2026-05-09T12:00:00Z"));
+    setUrl("d=2026-05-06");
+    render(<BetreuungsplanView />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Heute" })[0]!);
+    expect(urlParams().get("d")).toBe("2026-05-11");
+  });
+
   it("switches to the week and sets d when a month day is clicked", () => {
     setUrl("view=monat");
     render(<BetreuungsplanView />);

--- a/frontend/src/components/timetable/betreuungsplan-view.test.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.test.tsx
@@ -256,17 +256,20 @@ vi.mock("~/components/timetable/month-planner-grid", () => ({
 
 vi.mock("~/components/timetable/weekly-calendar-grid", () => ({
   WeeklyCalendarGrid: ({
+    weekDays,
     instances,
     onInstanceClick,
     onSlotClick,
     gapInstanceIds,
   }: {
+    weekDays: Date[];
     instances: Array<{ id: string }>;
     onInstanceClick: (instance: { id: string } | null) => void;
     onSlotClick?: (dateISO: string, hour: number) => void;
     gapInstanceIds?: ReadonlySet<string>;
   }) => (
     <div>
+      <span data-testid="grid-week-days">{weekDays.length}</span>
       <span data-testid="grid-gap-ids">
         {gapInstanceIds ? [...gapInstanceIds].join(",") : ""}
       </span>
@@ -783,6 +786,7 @@ describe("BetreuungsplanView", () => {
       screen.getByRole("heading", { name: "Betreuungsplan" }),
     ).toBeVisible();
     expect(screen.getByText("week-grid")).toBeVisible();
+    expect(screen.getByTestId("grid-week-days")).toHaveTextContent("5");
     expect(screen.getByTestId("conflicts")).toHaveTextContent("1");
     // Kein Alt-URL-Parameter überlebt.
     expect(urlParams().has("week")).toBe(false);

--- a/frontend/src/components/timetable/betreuungsplan-view.test.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.test.tsx
@@ -891,6 +891,19 @@ describe("BetreuungsplanView", () => {
     expect(urlParams().get("d")).toBe("2026-05-11");
   });
 
+  it("does not query gaps for a finished Friday workweek on Saturday", () => {
+    vi.setSystemTime(new Date("2026-05-09T12:00:00Z"));
+    setUrl("view=woche&d=2026-05-04");
+    render(<BetreuungsplanView />);
+
+    const gapKeys = mockUseSWRAuth.mock.calls
+      .map(([key]) => key)
+      .filter(
+        (key) => typeof key === "string" && key.startsWith("timetable-gaps"),
+      );
+    expect(gapKeys).toEqual([]);
+  });
+
   it("switches to the week and sets d when a month day is clicked", () => {
     setUrl("view=monat");
     render(<BetreuungsplanView />);

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -316,21 +316,28 @@ function TimetablesContent() {
   // Fetch-Fenster. Woche/Monat leiten ihr Fenster aus `d` ab; die Serienansicht
   // lädt keine Instanzen. Die Jahresansicht ist ersatzlos entfallen.
   const fromISO = toISODate(weekRange.from);
-  const toISO = toISODate(weekRange.to);
   const monthRange = useMemo(() => getMonthRange(visibleDate), [visibleDate]);
   const monthDays = useMemo(() => getMonthDays(visibleDate), [visibleDate]);
-  const fetchFromISO = view === "month" ? toISODate(monthRange.from) : fromISO;
-  const fetchToISO = view === "month" ? toISODate(monthRange.to) : toISO;
-  const weekDays = useMemo(() => getWeekdays(weekRange.from), [weekRange.from]);
+  // Der Betreuungsplan folgt derselben Betriebswoche wie Dienstplan und
+  // Vertretung: geplant und angezeigt wird nur Mo–Fr. Die Monatsansicht
+  // bleibt ein vollständiger Kalender, daher behält sie ihr eigenes Fenster.
+  const weekDays = useMemo(
+    () => getWeekdays(weekRange.from).slice(0, 5),
+    [weekRange.from],
+  );
   const weekDayISOs = useMemo(() => weekDays.map(toISODate), [weekDays]);
+  const workweekToISO = weekDayISOs[4]!;
+  const fetchFromISO = view === "month" ? toISODate(monthRange.from) : fromISO;
+  const fetchToISO =
+    view === "month" ? toISODate(monthRange.to) : workweekToISO;
   const periodContextDays = view === "month" ? monthDays : weekDays;
   const periodContextDayISOs = useMemo(
     () => periodContextDays.map(toISODate),
     [periodContextDays],
   );
   const weekLabel = useMemo(
-    () => formatWeekLabel(weekRange.from, weekRange.to),
-    [weekRange.from, weekRange.to],
+    () => formatWeekLabel(weekRange.from, weekDays[4]!),
+    [weekRange.from, weekDays],
   );
   const monthLabel = useMemo(
     () => formatMonthLabel(visibleDate),
@@ -945,7 +952,7 @@ function TimetablesContent() {
     view === "series"
       ? true
       : view === "week"
-        ? todayISO >= fromISO && todayISO <= toISO
+        ? todayISO >= fromISO && todayISO <= workweekToISO
         : visibleDate.getFullYear() === todayDate.getFullYear() &&
           visibleDate.getMonth() === todayDate.getMonth();
   const showTodayButton = view !== "series" && !isOnToday;
@@ -1224,7 +1231,7 @@ function TimetablesContent() {
         closingDayRanges={closingDayRanges}
         closingDaysLoading={closingDaysLoading}
         weekFrom={fromISO}
-        weekTo={toISO}
+        weekTo={workweekToISO}
         calendarPeriods={modalCalendarPeriods}
         defaultCalendarPeriodId={templatePeriodID ?? null}
         showPeriodField={showTemplatePeriodField}

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -92,6 +92,7 @@ import {
   getMonthRange,
   getWeekRange,
   getWeekdays,
+  nextWorkdayISO,
   resolveTemplateCalendarPeriodId,
   toISODate,
   type TimetableView,
@@ -194,13 +195,15 @@ function TimetablesContent() {
   // mehr). Ein ungültiges `d` fällt still auf heute zurück, ein unbekanntes
   // `view` auf die Woche.
   const rawDay = params.d;
-  const dayISO =
-    rawDay !== null && isValidISODate(rawDay) ? rawDay : berlinTodayISO();
+  const dayISO = nextWorkdayISO(
+    rawDay !== null && isValidISODate(rawDay) ? rawDay : berlinTodayISO(),
+  );
   const view: TimetableView = parseViewParam(params.view);
   const selectedInstanceId = params.block;
 
   const visibleDate = useMemo(() => parseISODate(dayISO), [dayISO]);
   const todayISO = useMemo(() => berlinTodayISO(), []);
+  const todayTargetISO = useMemo(() => nextWorkdayISO(todayISO), [todayISO]);
 
   const [eventModalOpen, setEventModalOpen] = useState(false);
   // Personalpool (#1884): Zielblock, für den der Pool-SlideOver offen ist.
@@ -276,8 +279,8 @@ function TimetablesContent() {
     [visibleDate, updateUrlParams],
   );
   const goToToday = useCallback(
-    () => updateUrlParams({ d: todayISO, block: null }),
-    [todayISO, updateUrlParams],
+    () => updateUrlParams({ d: todayTargetISO, block: null }),
+    [todayTargetISO, updateUrlParams],
   );
 
   const handlePrev = useCallback(() => {
@@ -301,7 +304,7 @@ function TimetablesContent() {
   // Monatsklick auf einen Tag: in die Woche wechseln und `d` auf den Tag setzen.
   const openWeekForDay = useCallback(
     (dateISO: string) => {
-      updateUrlParams({ view: null, d: dateISO, block: null });
+      updateUrlParams({ view: null, d: nextWorkdayISO(dateISO), block: null });
     },
     [updateUrlParams],
   );
@@ -947,12 +950,12 @@ function TimetablesContent() {
     );
   }
 
-  const todayDate = parseISODate(todayISO);
+  const todayDate = parseISODate(todayTargetISO);
   const isOnToday =
     view === "series"
       ? true
       : view === "week"
-        ? todayISO >= fromISO && todayISO <= workweekToISO
+        ? todayTargetISO >= fromISO && todayTargetISO <= workweekToISO
         : visibleDate.getFullYear() === todayDate.getFullYear() &&
           visibleDate.getMonth() === todayDate.getMonth();
   const showTodayButton = view !== "series" && !isOnToday;
@@ -1227,7 +1230,7 @@ function TimetablesContent() {
           setEventDefaultRepeat("none");
           setQuickPrefill(null);
         }}
-        defaultDate={quickPrefill?.date ?? dayISO}
+        defaultDate={nextWorkdayISO(quickPrefill?.date ?? dayISO)}
         closingDayRanges={closingDayRanges}
         closingDaysLoading={closingDaysLoading}
         weekFrom={fromISO}

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -198,10 +198,10 @@ function TimetablesContent() {
   const requestedDayISO =
     rawDay !== null && isValidISODate(rawDay) ? rawDay : berlinTodayISO();
   const view: TimetableView = parseViewParam(params.view);
-  // The monthly calendar remains a complete calendar, including weekend
-  // records. Only workweek/series navigation snaps its anchor to Monday.
+  // The monthly calendar and series period lookup retain their requested
+  // calendar date. Only the workweek view snaps weekend anchors to Monday.
   const dayISO =
-    view === "month" ? requestedDayISO : nextWorkdayISO(requestedDayISO);
+    view === "week" ? nextWorkdayISO(requestedDayISO) : requestedDayISO;
   const selectedInstanceId = params.block;
 
   const visibleDate = useMemo(() => parseISODate(dayISO), [dayISO]);
@@ -284,7 +284,7 @@ function TimetablesContent() {
   const goToToday = useCallback(
     () =>
       updateUrlParams({
-        d: view === "month" ? todayISO : todayTargetISO,
+        d: view === "week" ? todayTargetISO : todayISO,
         block: null,
       }),
     [todayISO, todayTargetISO, updateUrlParams, view],

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -371,8 +371,12 @@ function TimetablesContent() {
   // Spec 06 §5.2): GET /gaps begrenzt das Fenster hart auf 14 Tage und lehnt
   // das Monatsfenster mit 400 ab — ein leerer Zähler wäre in der
   // Monatsansicht eine falsche "Keine Lücken"-Aussage.
-  const gapsFromISO = fetchFromISO < todayISO ? todayISO : fetchFromISO;
-  const shouldLoadGaps = view === "week" && fetchToISO >= todayISO;
+  // The workweek has no Saturday/Sunday destination. On weekends, start at
+  // Monday so the gap list cannot offer a retained legacy weekend block that
+  // the week view deliberately does not expose.
+  const gapsFromISO =
+    fetchFromISO < todayTargetISO ? todayTargetISO : fetchFromISO;
+  const shouldLoadGaps = view === "week" && fetchToISO >= todayTargetISO;
   const gapsSWRKey = `timetable-gaps-${gapsFromISO}-${fetchToISO}`;
   const { data, error, isLoading } = useSWRAuth(
     status === "authenticated" && shouldLoadInstances ? swrKey : null,

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -195,10 +195,13 @@ function TimetablesContent() {
   // mehr). Ein ungültiges `d` fällt still auf heute zurück, ein unbekanntes
   // `view` auf die Woche.
   const rawDay = params.d;
-  const dayISO = nextWorkdayISO(
-    rawDay !== null && isValidISODate(rawDay) ? rawDay : berlinTodayISO(),
-  );
+  const requestedDayISO =
+    rawDay !== null && isValidISODate(rawDay) ? rawDay : berlinTodayISO();
   const view: TimetableView = parseViewParam(params.view);
+  // The monthly calendar remains a complete calendar, including weekend
+  // records. Only workweek/series navigation snaps its anchor to Monday.
+  const dayISO =
+    view === "month" ? requestedDayISO : nextWorkdayISO(requestedDayISO);
   const selectedInstanceId = params.block;
 
   const visibleDate = useMemo(() => parseISODate(dayISO), [dayISO]);
@@ -279,8 +282,12 @@ function TimetablesContent() {
     [visibleDate, updateUrlParams],
   );
   const goToToday = useCallback(
-    () => updateUrlParams({ d: todayTargetISO, block: null }),
-    [todayTargetISO, updateUrlParams],
+    () =>
+      updateUrlParams({
+        d: view === "month" ? todayISO : todayTargetISO,
+        block: null,
+      }),
+    [todayISO, todayTargetISO, updateUrlParams, view],
   );
 
   const handlePrev = useCallback(() => {
@@ -950,7 +957,7 @@ function TimetablesContent() {
     );
   }
 
-  const todayDate = parseISODate(todayTargetISO);
+  const todayDate = parseISODate(view === "month" ? todayISO : todayTargetISO);
   const isOnToday =
     view === "series"
       ? true
@@ -1110,6 +1117,7 @@ function TimetablesContent() {
                 todayISO={todayISO}
                 closingDays={closingDays}
                 onDayClick={openWeekForDay}
+                onInstanceClick={handleSelectInstance}
               />
             ))}
 

--- a/frontend/src/components/timetable/closing-days-in-plan.test.tsx
+++ b/frontend/src/components/timetable/closing-days-in-plan.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -134,5 +134,27 @@ describe("MonthPlannerGrid closing days (#2032)", () => {
 
     expect(screen.queryByText(/Schließtag/)).not.toBeInTheDocument();
     expect(screen.getAllByText("Leer")).toHaveLength(monthDays.length);
+  });
+
+  it("keeps the empty day action keyboard-accessible beside instance buttons", () => {
+    const onDayClick = vi.fn();
+
+    render(
+      <MonthPlannerGrid
+        days={monthDays}
+        monthDate={new Date("2026-05-01T00:00:00")}
+        instances={[instance]}
+        todayISO="2026-05-04"
+        onDayClick={onDayClick}
+        onInstanceClick={vi.fn()}
+      />,
+    );
+
+    const dayAction = screen.getByRole("button", { name: "Mo 4.5.2026" });
+    dayAction.focus();
+    expect(dayAction).toHaveFocus();
+    fireEvent.click(dayAction);
+
+    expect(onDayClick).toHaveBeenCalledWith("2026-05-04");
   });
 });

--- a/frontend/src/components/timetable/event-form/step-termin.tsx
+++ b/frontend/src/components/timetable/event-form/step-termin.tsx
@@ -239,6 +239,7 @@ export function StepTermin({
             value={form.date}
             error={fieldErrors.date}
             calendarLayout="popover"
+            disabledDay={(date) => date.getDay() === 0 || date.getDay() === 6}
             onChange={(nextDate) => {
               const nextWeekday = isoWeekday(nextDate);
               update("date", nextDate);

--- a/frontend/src/components/timetable/event-form/step-wiederholung.tsx
+++ b/frontend/src/components/timetable/event-form/step-wiederholung.tsx
@@ -71,6 +71,18 @@ export function StepWiederholung({
   dateWeekdayName,
   manualWeekPattern,
 }: Readonly<StepWiederholungProps>) {
+  const legacyWeekendWeekdays = form.weekdays.filter((iso) => iso > 5);
+  const normalizeLegacyWeekend = (legacyWeekday: number) => {
+    const weekdays = form.weekdays.filter((iso) => iso !== legacyWeekday);
+    if (!weekdays.some((iso) => iso >= 1 && iso <= 5)) {
+      weekdays.push(1);
+    }
+    update(
+      "weekdays",
+      weekdays.sort((a, b) => a - b),
+    );
+  };
+
   return (
     <>
       {expanded ? (
@@ -185,7 +197,26 @@ export function StepWiederholung({
                   </Button>
                 );
               })}
+              {legacyWeekendWeekdays.map((iso) => (
+                <Button
+                  key={iso}
+                  type="button"
+                  variant="outline_danger"
+                  size="compact"
+                  className="min-w-[44px]"
+                  onClick={() => normalizeLegacyWeekend(iso)}
+                  aria-label={`Alten Wochenendtag ${weekdayLabel(iso)} zu Montag ändern`}
+                >
+                  {weekdayLabel(iso)} zu Mo
+                </Button>
+              ))}
             </div>
+            {legacyWeekendWeekdays.length > 0 && (
+              <p className="text-xs text-gray-500">
+                Wochenendtermine aus bestehenden Serien werden zu Montag
+                verschoben oder entfernt, wenn ein Werktag verbleibt.
+              </p>
+            )}
             {fieldErrors.weekdays && (
               <p role="alert" className="mt-1 text-xs text-[#FF3130]">
                 {fieldErrors.weekdays}

--- a/frontend/src/components/timetable/event-form/step-wiederholung.tsx
+++ b/frontend/src/components/timetable/event-form/step-wiederholung.tsx
@@ -74,7 +74,10 @@ export function StepWiederholung({
   const legacyWeekendWeekdays = form.weekdays.filter((iso) => iso > 5);
   const normalizeLegacyWeekend = (legacyWeekday: number) => {
     const weekdays = form.weekdays.filter((iso) => iso !== legacyWeekday);
-    if (!weekdays.some((iso) => iso >= 1 && iso <= 5)) {
+    // This control explicitly migrates the selected legacy day to Monday. A
+    // different workday (for example Friday) must not turn that migration into
+    // a silent deletion of future weekend appointments.
+    if (!weekdays.includes(1)) {
       weekdays.push(1);
     }
     update(

--- a/frontend/src/components/timetable/month-planner-grid.tsx
+++ b/frontend/src/components/timetable/month-planner-grid.tsx
@@ -25,6 +25,7 @@ interface MonthPlannerGridProps {
    */
   closingDays?: ReadonlyMap<string, string>;
   onDayClick: (dateISO: string) => void;
+  onInstanceClick?: (instance: EnrichedInstance) => void;
 }
 
 export function MonthPlannerGrid({
@@ -34,6 +35,7 @@ export function MonthPlannerGrid({
   todayISO,
   closingDays,
   onDayClick,
+  onInstanceClick,
 }: MonthPlannerGridProps) {
   const grouped = groupInstancesByDate(instances);
   const currentMonth = monthDate.getMonth();
@@ -73,22 +75,27 @@ export function MonthPlannerGrid({
           }
 
           return (
-            <button
+            <div
               key={iso}
-              type="button"
-              onClick={() => onDayClick(iso)}
               className={`min-h-[112px] border-r border-b border-gray-100 p-2 text-left transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-inset ${backgroundClass} ${outsideMonth ? "text-gray-400" : ""}`}
             >
               <div className="flex items-center justify-between gap-2">
-                {isToday ? (
-                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-900 text-xs font-semibold text-white tabular-nums">
-                    {day.getDate()}
-                  </span>
-                ) : (
-                  <span className="text-sm font-semibold tabular-nums">
-                    {day.getDate()}
-                  </span>
-                )}
+                <button
+                  type="button"
+                  onClick={() => onDayClick(iso)}
+                  className="rounded focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+                  aria-label={`${getGermanWeekdayShort(day)} ${day.getDate()}.${day.getMonth() + 1}.${day.getFullYear()}`}
+                >
+                  {isToday ? (
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-900 text-xs font-semibold text-white tabular-nums">
+                      {day.getDate()}
+                    </span>
+                  ) : (
+                    <span className="text-sm font-semibold tabular-nums">
+                      {day.getDate()}
+                    </span>
+                  )}
+                </button>
                 {conflicts > 0 && (
                   <AlertTriangle className="h-3.5 w-3.5 text-[#EAB308]" />
                 )}
@@ -116,8 +123,11 @@ export function MonthPlannerGrid({
                     const hasConflict = inst.conflictWarnings.length > 0;
 
                     return (
-                      <div
+                      <button
                         key={inst.id}
+                        type="button"
+                        onClick={() => onInstanceClick?.(inst)}
+                        disabled={!onInstanceClick}
                         className={`flex min-w-0 items-center gap-1.5 rounded-lg border border-l-[3px] bg-white px-1.5 py-1 text-[11px] shadow-sm ${
                           isCancelled
                             ? "border-dashed border-[#FF3130] text-gray-400 line-through"
@@ -173,7 +183,7 @@ export function MonthPlannerGrid({
                             )}
                           />
                         )}
-                      </div>
+                      </button>
                     );
                   })}
                   {moreCount > 0 && (
@@ -183,7 +193,7 @@ export function MonthPlannerGrid({
                   )}
                 </div>
               )}
-            </button>
+            </div>
           );
         })}
       </div>

--- a/frontend/src/components/timetable/month-planner-grid.tsx
+++ b/frontend/src/components/timetable/month-planner-grid.tsx
@@ -75,30 +75,26 @@ export function MonthPlannerGrid({
           }
           const Cell = onInstanceClick ? "div" : "button";
           const InstanceCard = onInstanceClick ? "button" : "div";
-          const DayTrigger = onInstanceClick ? "button" : "span";
 
           return (
             <Cell
               key={iso}
               {...(!onInstanceClick
                 ? { type: "button" as const, onClick: () => onDayClick(iso) }
-                : { onClick: () => onDayClick(iso) })}
-              className={`min-h-[112px] border-r border-b border-gray-100 p-2 text-left transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-inset ${backgroundClass} ${outsideMonth ? "text-gray-400" : ""}`}
+                : {})}
+              className={`relative min-h-[112px] border-r border-b border-gray-100 p-2 text-left transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-inset ${backgroundClass} ${outsideMonth ? "text-gray-400" : ""}`}
             >
-              <div className="flex items-center justify-between gap-2">
-                <DayTrigger
-                  {...(onInstanceClick
-                    ? {
-                        type: "button" as const,
-                        onClick: (event: React.MouseEvent) => {
-                          event.stopPropagation();
-                          onDayClick(iso);
-                        },
-                        "aria-label": `${getGermanWeekdayShort(day)} ${day.getDate()}.${day.getMonth() + 1}.${day.getFullYear()}`,
-                      }
-                    : {})}
-                  className="rounded focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-                >
+              {onInstanceClick && (
+                <button
+                  type="button"
+                  onClick={() => onDayClick(iso)}
+                  aria-label={`${getGermanWeekdayShort(day)} ${day.getDate()}.${day.getMonth() + 1}.${day.getFullYear()}`}
+                  className="absolute inset-0 z-0 rounded focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-inset"
+                />
+              )}
+
+              <div className="pointer-events-none relative z-10">
+                <div className="flex items-center justify-between gap-2">
                   {isToday ? (
                     <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-900 text-xs font-semibold text-white tabular-nums">
                       {day.getDate()}
@@ -108,110 +104,107 @@ export function MonthPlannerGrid({
                       {day.getDate()}
                     </span>
                   )}
-                </DayTrigger>
-                {conflicts > 0 && (
-                  <AlertTriangle className="h-3.5 w-3.5 text-[#EAB308]" />
+                  {conflicts > 0 && (
+                    <AlertTriangle className="h-3.5 w-3.5 text-[#EAB308]" />
+                  )}
+                </div>
+
+                {closingReason !== undefined && (
+                  <ClosingDayChip
+                    reason={closingReason}
+                    className="mt-1 w-full"
+                  />
                 )}
-              </div>
 
-              {closingReason !== undefined && (
-                <ClosingDayChip
-                  reason={closingReason}
-                  className="mt-1 w-full"
-                />
-              )}
+                {dayInstances.length === 0 ? (
+                  closingReason === undefined && (
+                    <div className="mt-5 flex items-center gap-1 text-[11px] text-gray-400">
+                      <CalendarDays className="h-3 w-3" />
+                      Leer
+                    </div>
+                  )
+                ) : (
+                  <div className="mt-2 space-y-1">
+                    {visibleInstances.map((inst) => {
+                      const isCancelled = inst.status === "cancelled";
+                      const isActive = inst.status === "active";
+                      const hasConflict = inst.conflictWarnings.length > 0;
 
-              {dayInstances.length === 0 ? (
-                closingReason === undefined && (
-                  <div className="mt-5 flex items-center gap-1 text-[11px] text-gray-400">
-                    <CalendarDays className="h-3 w-3" />
-                    Leer
-                  </div>
-                )
-              ) : (
-                <div className="mt-2 space-y-1">
-                  {visibleInstances.map((inst) => {
-                    const isCancelled = inst.status === "cancelled";
-                    const isActive = inst.status === "active";
-                    const hasConflict = inst.conflictWarnings.length > 0;
-
-                    return (
-                      <InstanceCard
-                        key={inst.id}
-                        {...(onInstanceClick
-                          ? {
-                              type: "button" as const,
-                              onClick: (event: React.MouseEvent) => {
-                                event.stopPropagation();
-                                onInstanceClick(inst);
-                              },
-                            }
-                          : {})}
-                        className={`flex min-w-0 items-center gap-1.5 rounded-lg border border-l-[3px] bg-white px-1.5 py-1 text-[11px] shadow-sm ${
-                          isCancelled
-                            ? "border-dashed border-[#FF3130] text-gray-400 line-through"
-                            : "border-gray-200 text-gray-700"
-                        }`}
-                        style={{
-                          borderLeftColor: isCancelled
-                            ? "#FF3130"
-                            : getActivityColor(inst.activityType),
-                        }}
-                      >
-                        <span
-                          className="h-1.5 w-1.5 shrink-0 rounded-full"
+                      return (
+                        <InstanceCard
+                          key={inst.id}
+                          {...(onInstanceClick
+                            ? {
+                                type: "button" as const,
+                                onClick: () => onInstanceClick(inst),
+                              }
+                            : {})}
+                          className={`pointer-events-auto flex min-w-0 items-center gap-1.5 rounded-lg border border-l-[3px] bg-white px-1.5 py-1 text-[11px] shadow-sm ${
+                            isCancelled
+                              ? "border-dashed border-[#FF3130] text-gray-400 line-through"
+                              : "border-gray-200 text-gray-700"
+                          }`}
                           style={{
-                            backgroundColor: isCancelled
+                            borderLeftColor: isCancelled
                               ? "#FF3130"
                               : getActivityColor(inst.activityType),
                           }}
-                          aria-hidden
-                        />
-                        <span className="min-w-0 flex-1 truncate font-medium">
-                          {inst.title}
-                        </span>
-                        {inst.isSpontaneous && !isCancelled && (
+                        >
                           <span
-                            className="shrink-0 rounded-full bg-gray-100 px-1 text-[9px] font-bold tracking-wide text-gray-600 uppercase"
-                            title="Dieser Termin wurde spontan gestartet und war nicht geplant."
-                          >
-                            Spontan
+                            className="h-1.5 w-1.5 shrink-0 rounded-full"
+                            style={{
+                              backgroundColor: isCancelled
+                                ? "#FF3130"
+                                : getActivityColor(inst.activityType),
+                            }}
+                            aria-hidden
+                          />
+                          <span className="min-w-0 flex-1 truncate font-medium">
+                            {inst.title}
                           </span>
-                        )}
-                        {isActive && !isCancelled && (
-                          <span
-                            className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#83CD2D]"
-                            aria-label="läuft"
-                          />
-                        )}
-                        {hasConflict && (
-                          <AlertTriangle
-                            className="h-3 w-3 shrink-0 text-[#EAB308]"
-                            aria-label={`${inst.conflictWarnings.length} Konflikte`}
-                          />
-                        )}
-                        {!isCancelled && inst.requiredStaffCount > 0 && (
-                          <TimetableRatioPill
-                            variant="dot"
-                            icon={null}
-                            label="Besetzung"
-                            value={`${inst.assignedStaffCount}/${inst.requiredStaffCount}`}
-                            tone={capacityTone(
-                              inst.assignedStaffCount,
-                              inst.requiredStaffCount,
-                            )}
-                          />
-                        )}
-                      </InstanceCard>
-                    );
-                  })}
-                  {moreCount > 0 && (
-                    <div className="text-[10px] font-medium text-gray-500">
-                      + {moreCount} weitere
-                    </div>
-                  )}
-                </div>
-              )}
+                          {inst.isSpontaneous && !isCancelled && (
+                            <span
+                              className="shrink-0 rounded-full bg-gray-100 px-1 text-[9px] font-bold tracking-wide text-gray-600 uppercase"
+                              title="Dieser Termin wurde spontan gestartet und war nicht geplant."
+                            >
+                              Spontan
+                            </span>
+                          )}
+                          {isActive && !isCancelled && (
+                            <span
+                              className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#83CD2D]"
+                              aria-label="läuft"
+                            />
+                          )}
+                          {hasConflict && (
+                            <AlertTriangle
+                              className="h-3 w-3 shrink-0 text-[#EAB308]"
+                              aria-label={`${inst.conflictWarnings.length} Konflikte`}
+                            />
+                          )}
+                          {!isCancelled && inst.requiredStaffCount > 0 && (
+                            <TimetableRatioPill
+                              variant="dot"
+                              icon={null}
+                              label="Besetzung"
+                              value={`${inst.assignedStaffCount}/${inst.requiredStaffCount}`}
+                              tone={capacityTone(
+                                inst.assignedStaffCount,
+                                inst.requiredStaffCount,
+                              )}
+                            />
+                          )}
+                        </InstanceCard>
+                      );
+                    })}
+                    {moreCount > 0 && (
+                      <div className="text-[10px] font-medium text-gray-500">
+                        + {moreCount} weitere
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
             </Cell>
           );
         })}

--- a/frontend/src/components/timetable/month-planner-grid.tsx
+++ b/frontend/src/components/timetable/month-planner-grid.tsx
@@ -82,7 +82,7 @@ export function MonthPlannerGrid({
               key={iso}
               {...(!onInstanceClick
                 ? { type: "button" as const, onClick: () => onDayClick(iso) }
-                : {})}
+                : { onClick: () => onDayClick(iso) })}
               className={`min-h-[112px] border-r border-b border-gray-100 p-2 text-left transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-inset ${backgroundClass} ${outsideMonth ? "text-gray-400" : ""}`}
             >
               <div className="flex items-center justify-between gap-2">
@@ -90,7 +90,10 @@ export function MonthPlannerGrid({
                   {...(onInstanceClick
                     ? {
                         type: "button" as const,
-                        onClick: () => onDayClick(iso),
+                        onClick: (event: React.MouseEvent) => {
+                          event.stopPropagation();
+                          onDayClick(iso);
+                        },
                         "aria-label": `${getGermanWeekdayShort(day)} ${day.getDate()}.${day.getMonth() + 1}.${day.getFullYear()}`,
                       }
                     : {})}
@@ -138,7 +141,10 @@ export function MonthPlannerGrid({
                         {...(onInstanceClick
                           ? {
                               type: "button" as const,
-                              onClick: () => onInstanceClick(inst),
+                              onClick: (event: React.MouseEvent) => {
+                                event.stopPropagation();
+                                onInstanceClick(inst);
+                              },
                             }
                           : {})}
                         className={`flex min-w-0 items-center gap-1.5 rounded-lg border border-l-[3px] bg-white px-1.5 py-1 text-[11px] shadow-sm ${

--- a/frontend/src/components/timetable/month-planner-grid.tsx
+++ b/frontend/src/components/timetable/month-planner-grid.tsx
@@ -73,18 +73,28 @@ export function MonthPlannerGrid({
           } else if (outsideMonth) {
             backgroundClass = "bg-gray-50/40";
           }
+          const Cell = onInstanceClick ? "div" : "button";
+          const InstanceCard = onInstanceClick ? "button" : "div";
+          const DayTrigger = onInstanceClick ? "button" : "span";
 
           return (
-            <div
+            <Cell
               key={iso}
+              {...(!onInstanceClick
+                ? { type: "button" as const, onClick: () => onDayClick(iso) }
+                : {})}
               className={`min-h-[112px] border-r border-b border-gray-100 p-2 text-left transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:ring-inset ${backgroundClass} ${outsideMonth ? "text-gray-400" : ""}`}
             >
               <div className="flex items-center justify-between gap-2">
-                <button
-                  type="button"
-                  onClick={() => onDayClick(iso)}
+                <DayTrigger
+                  {...(onInstanceClick
+                    ? {
+                        type: "button" as const,
+                        onClick: () => onDayClick(iso),
+                        "aria-label": `${getGermanWeekdayShort(day)} ${day.getDate()}.${day.getMonth() + 1}.${day.getFullYear()}`,
+                      }
+                    : {})}
                   className="rounded focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-                  aria-label={`${getGermanWeekdayShort(day)} ${day.getDate()}.${day.getMonth() + 1}.${day.getFullYear()}`}
                 >
                   {isToday ? (
                     <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-900 text-xs font-semibold text-white tabular-nums">
@@ -95,7 +105,7 @@ export function MonthPlannerGrid({
                       {day.getDate()}
                     </span>
                   )}
-                </button>
+                </DayTrigger>
                 {conflicts > 0 && (
                   <AlertTriangle className="h-3.5 w-3.5 text-[#EAB308]" />
                 )}
@@ -123,11 +133,14 @@ export function MonthPlannerGrid({
                     const hasConflict = inst.conflictWarnings.length > 0;
 
                     return (
-                      <button
+                      <InstanceCard
                         key={inst.id}
-                        type="button"
-                        onClick={() => onInstanceClick?.(inst)}
-                        disabled={!onInstanceClick}
+                        {...(onInstanceClick
+                          ? {
+                              type: "button" as const,
+                              onClick: () => onInstanceClick(inst),
+                            }
+                          : {})}
                         className={`flex min-w-0 items-center gap-1.5 rounded-lg border border-l-[3px] bg-white px-1.5 py-1 text-[11px] shadow-sm ${
                           isCancelled
                             ? "border-dashed border-[#FF3130] text-gray-400 line-through"
@@ -183,7 +196,7 @@ export function MonthPlannerGrid({
                             )}
                           />
                         )}
-                      </button>
+                      </InstanceCard>
                     );
                   })}
                   {moreCount > 0 && (
@@ -193,7 +206,7 @@ export function MonthPlannerGrid({
                   )}
                 </div>
               )}
-            </div>
+            </Cell>
           );
         })}
       </div>

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -3223,6 +3223,33 @@ describe("TimetableEventModal", () => {
     );
   });
 
+  it("moves a legacy Saturday to Monday even when another workday remains", async () => {
+    const fridaySaturdayTemplate: TimetableTemplate = {
+      ...template,
+      schedules: [
+        { ...template.schedules[0]!, weekday: 5 },
+        { ...template.schedules[0]!, id: "10", weekday: 6 },
+      ],
+    };
+    renderModal({ initialSeries: fridaySaturdayTemplate });
+
+    await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+    await goToStep(2);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Alten Wochenendtag Sa zu Montag ändern",
+      }),
+    );
+    await clickSave();
+
+    await waitFor(() =>
+      expect(mockUpdateTemplate).toHaveBeenCalledWith(
+        "7",
+        expect.objectContaining({ weekdays: [1, 5] }),
+      ),
+    );
+  });
+
   it("defaults a new biweekly series to the parity of the selected week", async () => {
     const cyclePeriod: CalendarPeriod = {
       ...periods[0]!,

--- a/frontend/src/components/timetable/timetable-small-components.test.tsx
+++ b/frontend/src/components/timetable/timetable-small-components.test.tsx
@@ -341,6 +341,7 @@ describe("small timetable components", () => {
   it("renders week/month grids and forwards date selections", () => {
     const onInstanceClick = vi.fn();
     const onDayClick = vi.fn();
+    const onMonthInstanceClick = vi.fn();
     const weekDays = [
       new Date("2026-05-04T00:00:00"),
       new Date("2026-05-05T00:00:00"),
@@ -374,10 +375,13 @@ describe("small timetable components", () => {
         instances={[instance]}
         todayISO="2026-05-04"
         onDayClick={onDayClick}
+        onInstanceClick={onMonthInstanceClick}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /4/i }));
     expect(onDayClick).toHaveBeenCalledWith("2026-05-04");
+    fireEvent.click(screen.getByRole("button", { name: /mensa/i }));
+    expect(onMonthInstanceClick).toHaveBeenCalledWith(instance);
   });
 
   it("keeps week events outside configured hours reachable", () => {

--- a/frontend/src/components/timetable/weekly-calendar-grid.tsx
+++ b/frontend/src/components/timetable/weekly-calendar-grid.tsx
@@ -53,7 +53,10 @@ const smGridTemplate = (dayCount: number) =>
   `${SM_TIME_GUTTER_PX}px repeat(${dayCount}, minmax(0,1fr))`;
 
 interface WeeklyCalendarGridProps {
-  weekDays: Date[]; // Mo-So (7 dates)
+  // The caller chooses the visible dates (e.g. Mo-Fr in planning, a single
+  // day or Mo-Fr in substitutions). The grid deliberately has no fixed week
+  // length.
+  weekDays: Date[];
   instances: EnrichedInstance[];
   selectedId: string | null;
   onInstanceClick: (instance: EnrichedInstance) => void;

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { FocusScope } from "@radix-ui/react-focus-scope";
-import { DayPicker } from "react-day-picker";
+import { DayPicker, type Matcher } from "react-day-picker";
 import { format, addMonths, subMonths, type Locale } from "date-fns";
 import { de } from "date-fns/locale";
 import "react-day-picker/style.css";
@@ -99,6 +99,8 @@ type DatePickerProps =
       // Latest selectable day (inclusive). Days after it are disabled — used to
       // cap selection at a planning horizon while keeping that day choosable.
       readonly maxDate?: Date;
+      /** Additional days that cannot be selected. */
+      readonly disabledDay?: Matcher;
       /** Hide the inline clear ("X") control. Use when the value is required. */
       readonly hideClearButton?: boolean;
       /** Keeps a selected day from being deselected in the calendar. */
@@ -299,6 +301,7 @@ export function DatePicker({
       value={props.value}
       minDate={props.minDate}
       maxDate={props.maxDate}
+      disabledDay={props.disabledDay}
       monthYearNavigation={props.monthYearNavigation}
       locale={locale}
       labels={labels}
@@ -484,6 +487,7 @@ function DatePickerCalendar({
   value,
   minDate,
   maxDate,
+  disabledDay,
   monthYearNavigation,
   locale,
   labels,
@@ -495,6 +499,7 @@ function DatePickerCalendar({
   readonly value?: Date | null;
   readonly minDate?: Date;
   readonly maxDate?: Date;
+  readonly disabledDay?: Matcher;
   readonly monthYearNavigation?: boolean;
   readonly locale: Locale;
   readonly labels: Required<DatePickerLabels>;
@@ -524,7 +529,7 @@ function DatePickerCalendar({
         mode="single"
         selected={value ?? undefined}
         required={required}
-        disabled={buildSingleDisabledMatchers(minDate, maxDate)}
+        disabled={buildSingleDisabledMatchers(minDate, maxDate, disabledDay)}
         month={month}
         onMonthChange={setMonth}
         onSelect={(date: Date | undefined) => onChange(date ?? null)}
@@ -634,6 +639,7 @@ export function ISODatePicker({
   onChange,
   min,
   max,
+  disabledDay,
   label,
   error,
   ...rest
@@ -650,6 +656,8 @@ export function ISODatePicker({
   readonly min?: string;
   /** Latest selectable day as "YYYY-MM-DD". */
   readonly max?: string;
+  /** Additional days that cannot be selected. */
+  readonly disabledDay?: Matcher;
   readonly placeholder?: string;
   readonly className?: string;
   readonly dropdownPlacement?: "up" | "down";
@@ -676,6 +684,7 @@ export function ISODatePicker({
       value={toDateOrNull(value)}
       minDate={toDateOrNull(min) ?? undefined}
       maxDate={toDateOrNull(max) ?? undefined}
+      disabledDay={disabledDay}
       required={rest.required}
       onChange={(date) => onChange(date ? toISODate(date) : "")}
     />
@@ -895,10 +904,12 @@ function CalendarNavHeader({
 function buildSingleDisabledMatchers(
   minDate?: Date,
   maxDate?: Date,
-): ({ before: Date } | { after: Date })[] {
-  const matchers: ({ before: Date } | { after: Date })[] = [];
+  disabledDay?: Matcher,
+): Matcher[] {
+  const matchers: Matcher[] = [];
   if (minDate) matchers.push({ before: minDate });
   if (maxDate) matchers.push({ after: maxDate });
+  if (disabledDay) matchers.push(disabledDay);
   return matchers;
 }
 


### PR DESCRIPTION
## Zusammenfassung

- Vereinheitlicht die Wochenansicht von Betreuungsplan, Dienstplan und Vertretung auf Montag bis Freitag.
- Lädt im Betreuungsplan für die Wochenansicht nur noch die fünf Werktage; die Monatsansicht bleibt ein vollständiger Kalender.
- Lehnt neue Einzeltermine und Regeltermine an Samstag oder Sonntag über die Timetable-API ab.
- Ergänzt Regressionsprüfungen für die sichtbaren Wochentage und die API-Validierung.
- Ergänzt den Hilfe-Text zur Mo–Fr-Wochenansicht.

## Tests

- `cd frontend && pnpm exec vitest run src/components/timetable/betreuungsplan-view.test.tsx`
- `cd frontend && pnpm run check`
- `cd backend && go test ./api/timetable -count=1`
- Pre-Push: `golangci-lint`, Dependency Cruiser und Knip

## Offener Punkt

Der bestehende Hilfe-Screenshot zeigt noch die alte Sieben-Tage-Wochenansicht. Die lokale Umgebung hatte keine Demo-Anmeldung zum Neuaufnehmen; der Screenshot muss vor dem Merge mit echten Demo-Daten ersetzt werden.