### PR TITLE
Kontextsensitiver Zero State für Konto-Anfragen

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.test.tsx
@@ -16,8 +16,19 @@ vi.mock("~/lib/hooks/use-settings-schema", () => ({
 }));
 
 vi.mock("~/components/admin/guardian-approval-queue", () => ({
-  default: ({ inviteMode }: { inviteMode: string }) => (
-    <div data-testid="approval-queue">{inviteMode}</div>
+  default: ({
+    inviteModeState,
+  }: {
+    inviteModeState: { status: string; mode?: string; retry?: () => void };
+  }) => (
+    <div data-testid="approval-queue">
+      {inviteModeState.status}:{inviteModeState.mode}
+      {inviteModeState.retry ? (
+        <button type="button" onClick={inviteModeState.retry}>
+          Einstellungen erneut laden
+        </button>
+      ) : null}
+    </div>
   ),
 }));
 
@@ -80,15 +91,12 @@ describe("GuardianApprovalsPage", () => {
     setSettingsResult({ data: schemaWithInviteMode("staff_approval") });
   });
 
-  it("waits for the invite mode before rendering the queue", () => {
+  it("mounts the queue while the invite mode is loading", () => {
     setSettingsResult({ data: undefined, isLoading: true });
 
     render(<GuardianApprovalsPage />);
 
-    expect(
-      screen.getByLabelText("Einladungs-Einstellung wird geladen…"),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+    expect(screen.getByTestId("approval-queue")).toHaveTextContent("loading:");
   });
 
   it("passes a valid invite mode to the queue", () => {
@@ -96,20 +104,20 @@ describe("GuardianApprovalsPage", () => {
 
     render(<GuardianApprovalsPage />);
 
-    expect(screen.getByTestId("approval-queue")).toHaveTextContent("disabled");
+    expect(screen.getByTestId("approval-queue")).toHaveTextContent(
+      "ready:disabled",
+    );
   });
 
-  it("shows a retryable error when settings access returns no schema", () => {
+  it("passes an error state when settings access returns no schema", () => {
     setSettingsResult({ data: null });
 
     render(<GuardianApprovalsPage />);
 
-    expect(
-      screen.getByText(/Einladungs-Einstellung konnte nicht geladen werden/),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Erneut versuchen" }));
+    expect(screen.getByTestId("approval-queue")).toHaveTextContent("error:");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Einstellungen erneut laden" }),
+    );
     expect(mocks.mutate).toHaveBeenCalledOnce();
   });
 
@@ -121,10 +129,7 @@ describe("GuardianApprovalsPage", () => {
 
     render(<GuardianApprovalsPage />);
 
-    expect(
-      screen.getByText(/Einladungs-Einstellung konnte nicht geladen werden/),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+    expect(screen.getByTestId("approval-queue")).toHaveTextContent("error:");
   });
 
   it("shows an error when the required setting is missing", () => {
@@ -132,9 +137,6 @@ describe("GuardianApprovalsPage", () => {
 
     render(<GuardianApprovalsPage />);
 
-    expect(
-      screen.getByText(/Einladungs-Einstellung konnte nicht geladen werden/),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+    expect(screen.getByTestId("approval-queue")).toHaveTextContent("error:");
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  useRequireAdmin: vi.fn(),
+  useSettingsSchema: vi.fn(),
+}));
+
+vi.mock("~/lib/hooks/use-require-admin", () => ({
+  useRequireAdmin: () => mocks.useRequireAdmin(),
+}));
+
+vi.mock("~/lib/hooks/use-settings-schema", () => ({
+  useSettingsSchema: () => mocks.useSettingsSchema(),
+}));
+
+vi.mock("~/components/admin/guardian-approval-queue", () => ({
+  default: ({ inviteMode }: { inviteMode: string }) => (
+    <div data-testid="approval-queue">{inviteMode}</div>
+  ),
+}));
+
+vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
+  PageHeaderWithSearch: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+import GuardianApprovalsPage from "./page";
+
+function schemaWithInviteMode(value?: string) {
+  return {
+    tabs: [
+      {
+        key: "operations",
+        label: "Betrieb",
+        categories: [
+          {
+            key: "guardians",
+            label: "Bezugspersonen",
+            items:
+              value === undefined
+                ? []
+                : [
+                    {
+                      key: "guardians.parent_invite_mode",
+                      value,
+                    },
+                  ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function setSettingsResult({
+  data,
+  error,
+  isLoading = false,
+  isValidating = false,
+}: {
+  data?: ReturnType<typeof schemaWithInviteMode> | null;
+  error?: Error;
+  isLoading?: boolean;
+  isValidating?: boolean;
+}) {
+  mocks.useSettingsSchema.mockReturnValue({
+    data,
+    error,
+    isLoading,
+    isValidating,
+    mutate: mocks.mutate,
+  });
+}
+
+describe("GuardianApprovalsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useRequireAdmin.mockReturnValue({ isReady: true });
+    setSettingsResult({ data: schemaWithInviteMode("staff_approval") });
+  });
+
+  it("waits for the invite mode before rendering the queue", () => {
+    setSettingsResult({ data: undefined, isLoading: true });
+
+    render(<GuardianApprovalsPage />);
+
+    expect(
+      screen.getByLabelText("Einladungs-Einstellung wird geladen…"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+  });
+
+  it("passes a valid invite mode to the queue", () => {
+    setSettingsResult({ data: schemaWithInviteMode("disabled") });
+
+    render(<GuardianApprovalsPage />);
+
+    expect(screen.getByTestId("approval-queue")).toHaveTextContent("disabled");
+  });
+
+  it("shows a retryable error when settings access returns no schema", () => {
+    setSettingsResult({ data: null });
+
+    render(<GuardianApprovalsPage />);
+
+    expect(
+      screen.getByText(/Einladungs-Einstellung konnte nicht geladen werden/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Erneut versuchen" }));
+    expect(mocks.mutate).toHaveBeenCalledOnce();
+  });
+
+  it("shows an error when the schema request fails", () => {
+    setSettingsResult({
+      data: undefined,
+      error: new Error("request failed"),
+    });
+
+    render(<GuardianApprovalsPage />);
+
+    expect(
+      screen.getByText(/Einladungs-Einstellung konnte nicht geladen werden/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+  });
+
+  it("shows an error when the required setting is missing", () => {
+    setSettingsResult({ data: schemaWithInviteMode() });
+
+    render(<GuardianApprovalsPage />);
+
+    expect(
+      screen.getByText(/Einladungs-Einstellung konnte nicht geladen werden/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("approval-queue")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
@@ -3,6 +3,8 @@
 import GuardianApprovalQueue, {
   type GuardianInviteMode,
 } from "~/components/admin/guardian-approval-queue";
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { Loading } from "~/components/ui/loading";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
@@ -25,10 +27,16 @@ function parseInviteMode(value: unknown): GuardianInviteMode | undefined {
 export default function GuardianApprovalsPage() {
   const { isReady } = useRequireAdmin();
   // The queue is empty by design in the other two invite modes, so the empty
-  // state needs to know which one is active. Admins hold config:read; if the
-  // schema fetch fails the mode stays undefined and the empty state falls back
-  // to neutral wording.
-  const { data: settingsSchema } = useSettingsSchema(isReady, {
+  // state needs to know which one is active. Do not render the queue without
+  // that required setting: a failed or incomplete schema would otherwise make
+  // disabled/direct mode look like an empty staff-approval queue.
+  const {
+    data: settingsSchema,
+    error: settingsError,
+    isLoading: isSettingsLoading,
+    isValidating: isSettingsValidating,
+    mutate: retrySettings,
+  } = useSettingsSchema(isReady, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     shouldRetryOnError: false,
@@ -39,11 +47,38 @@ export default function GuardianApprovalsPage() {
 
   if (!isReady) return <Loading fullPage={false} />;
 
+  const settingsUnavailable =
+    settingsError != null || settingsSchema == null || inviteMode === undefined;
+
   return (
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch title="Konto-Anfragen" />
       <div className="mt-4">
-        <GuardianApprovalQueue inviteMode={inviteMode} />
+        {isSettingsLoading ? (
+          <Loading
+            message="Einladungs-Einstellung wird geladen…"
+            fullPage={false}
+          />
+        ) : settingsUnavailable ? (
+          <Alert
+            type="error"
+            message="Die Einladungs-Einstellung konnte nicht geladen werden. Konto-Anfragen können deshalb derzeit nicht zuverlässig angezeigt werden."
+            action={
+              <Button
+                type="button"
+                variant="outline_danger"
+                size="md"
+                isLoading={isSettingsValidating}
+                loadingText="Wird geladen…"
+                onClick={() => void retrySettings()}
+              >
+                Erneut versuchen
+              </Button>
+            }
+          />
+        ) : (
+          <GuardianApprovalQueue inviteMode={inviteMode} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
@@ -2,9 +2,8 @@
 
 import GuardianApprovalQueue, {
   type GuardianInviteMode,
+  type GuardianInviteModeState,
 } from "~/components/admin/guardian-approval-queue";
-import { Alert } from "~/components/ui/alert";
-import { Button } from "~/components/ui/button";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { Loading } from "~/components/ui/loading";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
@@ -27,9 +26,10 @@ function parseInviteMode(value: unknown): GuardianInviteMode | undefined {
 export default function GuardianApprovalsPage() {
   const { isReady } = useRequireAdmin();
   // The queue is empty by design in the other two invite modes, so the empty
-  // state needs to know which one is active. Do not render the queue without
-  // that required setting: a failed or incomplete schema would otherwise make
-  // disabled/direct mode look like an empty staff-approval queue.
+  // state needs to know which one is active. The queue still mounts while this
+  // independent request runs; only its empty-result copy waits for the mode.
+  // A failed or incomplete schema must not make disabled/direct mode look like
+  // an empty staff-approval queue.
   const {
     data: settingsSchema,
     error: settingsError,
@@ -47,38 +47,23 @@ export default function GuardianApprovalsPage() {
 
   if (!isReady) return <Loading fullPage={false} />;
 
-  const settingsUnavailable =
-    settingsError != null || settingsSchema == null || inviteMode === undefined;
+  const inviteModeState: GuardianInviteModeState = isSettingsLoading
+    ? { status: "loading" }
+    : settingsError != null ||
+        settingsSchema == null ||
+        inviteMode === undefined
+      ? {
+          status: "error",
+          isRetrying: isSettingsValidating,
+          retry: () => void retrySettings(),
+        }
+      : { status: "ready", mode: inviteMode };
 
   return (
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch title="Konto-Anfragen" />
       <div className="mt-4">
-        {isSettingsLoading ? (
-          <Loading
-            message="Einladungs-Einstellung wird geladen…"
-            fullPage={false}
-          />
-        ) : settingsUnavailable ? (
-          <Alert
-            type="error"
-            message="Die Einladungs-Einstellung konnte nicht geladen werden. Konto-Anfragen können deshalb derzeit nicht zuverlässig angezeigt werden."
-            action={
-              <Button
-                type="button"
-                variant="outline_danger"
-                size="md"
-                isLoading={isSettingsValidating}
-                loadingText="Wird geladen…"
-                onClick={() => void retrySettings()}
-              >
-                Erneut versuchen
-              </Button>
-            }
-          />
-        ) : (
-          <GuardianApprovalQueue inviteMode={inviteMode} />
-        )}
+        <GuardianApprovalQueue inviteModeState={inviteModeState} />
       </div>
     </div>
   );

--- a/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
@@ -1,22 +1,49 @@
 "use client";
 
-import GuardianApprovalQueue from "~/components/admin/guardian-approval-queue";
+import GuardianApprovalQueue, {
+  type GuardianInviteMode,
+} from "~/components/admin/guardian-approval-queue";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { Loading } from "~/components/ui/loading";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
+import { useSettingsSchema } from "~/lib/hooks/use-settings-schema";
+import { getSettingValue } from "~/lib/settings-api";
+
+const INVITE_MODES: readonly GuardianInviteMode[] = [
+  "disabled",
+  "direct",
+  "staff_approval",
+];
+
+function parseInviteMode(value: unknown): GuardianInviteMode | undefined {
+  return INVITE_MODES.find((mode) => mode === value);
+}
 
 // Staff approval queue for parent-initiated guardian invitations. Only
 // relevant when a school sets guardians.parent_invite_mode = staff_approval;
 // otherwise the queue is simply empty.
 export default function GuardianApprovalsPage() {
   const { isReady } = useRequireAdmin();
+  // The queue is empty by design in the other two invite modes, so the empty
+  // state needs to know which one is active. Admins hold config:read; if the
+  // schema fetch fails the mode stays undefined and the empty state falls back
+  // to neutral wording.
+  const { data: settingsSchema } = useSettingsSchema(isReady, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    shouldRetryOnError: false,
+  });
+  const inviteMode = parseInviteMode(
+    getSettingValue(settingsSchema, "guardians.parent_invite_mode"),
+  );
+
   if (!isReady) return <Loading fullPage={false} />;
 
   return (
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch title="Konto-Anfragen" />
       <div className="mt-4">
-        <GuardianApprovalQueue />
+        <GuardianApprovalQueue inviteMode={inviteMode} />
       </div>
     </div>
   );

--- a/frontend/src/components/admin/guardian-approval-queue.stories.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.stories.tsx
@@ -27,6 +27,7 @@ const sampleRequest = {
 const meta = {
   title: "admin/GuardianApprovalQueue",
   component: GuardianApprovalQueue,
+  args: { inviteModeState: { status: "ready", mode: "staff_approval" } },
   decorators: [
     (Story) => (
       <ToastProvider>
@@ -56,7 +57,7 @@ export const WithRequest: Story = {
       return {};
     },
   ],
-  args: { inviteMode: "staff_approval" },
+  args: { inviteModeState: { status: "ready", mode: "staff_approval" } },
 };
 
 // Approval mode active, queue drained: the calm resting state.
@@ -67,7 +68,7 @@ export const EmptyWaitingForRequests: Story = {
       return {};
     },
   ],
-  args: { inviteMode: "staff_approval" },
+  args: { inviteModeState: { status: "ready", mode: "staff_approval" } },
 };
 
 // Parents cannot invite at all, so this queue can never fill up. The empty
@@ -79,7 +80,7 @@ export const EmptyInvitesDisabled: Story = {
       return {};
     },
   ],
-  args: { inviteMode: "disabled" },
+  args: { inviteModeState: { status: "ready", mode: "disabled" } },
 };
 
 // Invitations go out without a review step, same consequence for this page.
@@ -90,5 +91,5 @@ export const EmptyInvitesDirect: Story = {
       return {};
     },
   ],
-  args: { inviteMode: "direct" },
+  args: { inviteModeState: { status: "ready", mode: "direct" } },
 };

--- a/frontend/src/components/admin/guardian-approval-queue.stories.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.stories.tsx
@@ -71,6 +71,18 @@ export const EmptyWaitingForRequests: Story = {
   args: { inviteModeState: { status: "ready", mode: "staff_approval" } },
 };
 
+// The approvals request has completed empty while the independent settings
+// request is still in flight.
+export const EmptyInviteModeLoading: Story = {
+  loaders: [
+    () => {
+      mockApprovals([]);
+      return {};
+    },
+  ],
+  args: { inviteModeState: { status: "loading" } },
+};
+
 // Parents cannot invite at all, so this queue can never fill up. The empty
 // state says so and links to the setting that changes it.
 export const EmptyInvitesDisabled: Story = {

--- a/frontend/src/components/admin/guardian-approval-queue.stories.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.stories.tsx
@@ -1,6 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { installStorybookFetch, jsonResponse } from "~storybook/mocks/fetch";
 import { ToastProvider } from "~/contexts/ToastContext";
 import GuardianApprovalQueue from "~/components/admin/guardian-approval-queue";
+
+function mockApprovals(rows: unknown[]) {
+  return installStorybookFetch(({ url }) => {
+    if (!url.includes("/api/guardians/invitations/pending-approval")) {
+      return undefined;
+    }
+    return jsonResponse({ status: "success", data: rows });
+  });
+}
+
+const sampleRequest = {
+  id: "42",
+  guardian_profile_id: "10",
+  guardian_name: "Julia Schröder",
+  guardian_email: "julia.schroeder@example.com",
+  student_id: "1",
+  student_name: "Felix Schneider",
+  requested_by_email: "karin.klein@example.com",
+  created_at: "2026-06-10T08:00:00Z",
+  expires_at: "2026-06-12T08:00:00Z",
+};
 
 const meta = {
   title: "admin/GuardianApprovalQueue",
@@ -8,7 +30,7 @@ const meta = {
   decorators: [
     (Story) => (
       <ToastProvider>
-        <div className="max-w-xl">
+        <div className="max-w-3xl">
           <Story />
         </div>
       </ToastProvider>
@@ -26,3 +48,47 @@ type Story = StoryObj<typeof meta>;
 // (loading -> failed fetch -> inline error banner with retry button),
 // which is a real, user-visible state of this component.
 export const Default: Story = {};
+
+export const WithRequest: Story = {
+  loaders: [
+    () => {
+      mockApprovals([sampleRequest]);
+      return {};
+    },
+  ],
+  args: { inviteMode: "staff_approval" },
+};
+
+// Approval mode active, queue drained: the calm resting state.
+export const EmptyWaitingForRequests: Story = {
+  loaders: [
+    () => {
+      mockApprovals([]);
+      return {};
+    },
+  ],
+  args: { inviteMode: "staff_approval" },
+};
+
+// Parents cannot invite at all, so this queue can never fill up. The empty
+// state says so and links to the setting that changes it.
+export const EmptyInvitesDisabled: Story = {
+  loaders: [
+    () => {
+      mockApprovals([]);
+      return {};
+    },
+  ],
+  args: { inviteMode: "disabled" },
+};
+
+// Invitations go out without a review step, same consequence for this page.
+export const EmptyInvitesDirect: Story = {
+  loaders: [
+    () => {
+      mockApprovals([]);
+      return {};
+    },
+  ],
+  args: { inviteMode: "direct" },
+};

--- a/frontend/src/components/admin/guardian-approval-queue.test.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.test.tsx
@@ -35,6 +35,12 @@ vi.mock("~/components/ui/modal", () => ({
     ) : null,
 }));
 
+const mockPush = vi.fn();
+
+vi.mock("~/lib/tenant-router", () => ({
+  useTenantRouter: () => ({ push: mockPush }),
+}));
+
 const mockList = vi.fn();
 const mockApprove = vi.fn();
 const mockReject = vi.fn();
@@ -81,6 +87,47 @@ describe("GuardianApprovalQueue", () => {
     await waitFor(() =>
       expect(screen.getByText(/Keine offenen Anfragen/)).toBeInTheDocument(),
     );
+    // Nothing is misconfigured, so no settings shortcut is offered.
+    expect(
+      screen.queryByRole("button", { name: /Einstellungen/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains an empty queue when parent invites are disabled", async () => {
+    mockList.mockResolvedValue([]);
+    render(<GuardianApprovalQueue inviteMode="disabled" />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Eltern können derzeit niemanden einladen/),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Einstellungen/ }));
+    expect(mockPush).toHaveBeenCalledWith("/settings?tab=operations");
+  });
+
+  it("explains an empty queue when invites are sent without approval", async () => {
+    mockList.mockResolvedValue([]);
+    render(<GuardianApprovalQueue inviteMode="direct" />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Einladungen gehen ohne Freigabe raus/),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("button", { name: /Einstellungen/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the neutral empty state when approval is the active mode", async () => {
+    mockList.mockResolvedValue([]);
+    render(<GuardianApprovalQueue inviteMode="staff_approval" />);
+    await waitFor(() =>
+      expect(screen.getByText(/Keine offenen Anfragen/)).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Einstellungen/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("approves a request and reloads the list", async () => {

--- a/frontend/src/components/admin/guardian-approval-queue.test.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.test.tsx
@@ -63,6 +63,11 @@ const sampleRequest: PendingApproval = {
   expiresAt: "2026-06-12T08:00:00Z",
 };
 
+const staffApprovalMode = {
+  status: "ready",
+  mode: "staff_approval",
+} as const;
+
 describe("GuardianApprovalQueue", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,7 +77,7 @@ describe("GuardianApprovalQueue", () => {
   });
 
   it("renders a pending request with guardian, child and requester", async () => {
-    render(<GuardianApprovalQueue />);
+    render(<GuardianApprovalQueue inviteModeState={{ status: "loading" }} />);
     await waitFor(() =>
       expect(screen.getByText("Julia Schröder")).toBeInTheDocument(),
     );
@@ -83,7 +88,7 @@ describe("GuardianApprovalQueue", () => {
 
   it("shows the empty state when there are no requests", async () => {
     mockList.mockResolvedValue([]);
-    render(<GuardianApprovalQueue />);
+    render(<GuardianApprovalQueue inviteModeState={staffApprovalMode} />);
     await waitFor(() =>
       expect(screen.getByText(/Keine offenen Anfragen/)).toBeInTheDocument(),
     );
@@ -95,7 +100,11 @@ describe("GuardianApprovalQueue", () => {
 
   it("explains an empty queue when parent invites are disabled", async () => {
     mockList.mockResolvedValue([]);
-    render(<GuardianApprovalQueue inviteMode="disabled" />);
+    render(
+      <GuardianApprovalQueue
+        inviteModeState={{ status: "ready", mode: "disabled" }}
+      />,
+    );
     await waitFor(() =>
       expect(
         screen.getByText(/Eltern können derzeit niemanden einladen/),
@@ -108,7 +117,11 @@ describe("GuardianApprovalQueue", () => {
 
   it("explains an empty queue when invites are sent without approval", async () => {
     mockList.mockResolvedValue([]);
-    render(<GuardianApprovalQueue inviteMode="direct" />);
+    render(
+      <GuardianApprovalQueue
+        inviteModeState={{ status: "ready", mode: "direct" }}
+      />,
+    );
     await waitFor(() =>
       expect(
         screen.getByText(/Einladungen gehen ohne Freigabe raus/),
@@ -121,7 +134,7 @@ describe("GuardianApprovalQueue", () => {
 
   it("keeps the neutral empty state when approval is the active mode", async () => {
     mockList.mockResolvedValue([]);
-    render(<GuardianApprovalQueue inviteMode="staff_approval" />);
+    render(<GuardianApprovalQueue inviteModeState={staffApprovalMode} />);
     await waitFor(() =>
       expect(screen.getByText(/Keine offenen Anfragen/)).toBeInTheDocument(),
     );
@@ -130,8 +143,36 @@ describe("GuardianApprovalQueue", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("defers only an empty result while the invite mode is loading", async () => {
+    mockList.mockResolvedValue([]);
+
+    render(<GuardianApprovalQueue inviteModeState={{ status: "loading" }} />);
+
+    expect(
+      await screen.findByText("Einladungs-Einstellung wird geladen…"),
+    ).toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledOnce();
+  });
+
+  it("shows a retryable settings error only for an empty result", async () => {
+    const retry = vi.fn();
+    mockList.mockResolvedValue([]);
+
+    render(
+      <GuardianApprovalQueue
+        inviteModeState={{ status: "error", isRetrying: false, retry }}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Einladungs-Einstellung konnte nicht geladen/),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Erneut versuchen" }));
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
   it("approves a request and reloads the list", async () => {
-    render(<GuardianApprovalQueue />);
+    render(<GuardianApprovalQueue inviteModeState={staffApprovalMode} />);
     await waitFor(() => screen.getByText("Julia Schröder"));
 
     fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
@@ -142,7 +183,7 @@ describe("GuardianApprovalQueue", () => {
   });
 
   it("rejects a request via the confirmation modal", async () => {
-    render(<GuardianApprovalQueue />);
+    render(<GuardianApprovalQueue inviteModeState={staffApprovalMode} />);
     await waitFor(() => screen.getByText("Julia Schröder"));
 
     fireEvent.click(screen.getByRole("button", { name: /Ablehnen/ }));

--- a/frontend/src/components/admin/guardian-approval-queue.test.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import GuardianApprovalQueue from "./guardian-approval-queue";
 import type { PendingApproval } from "@/lib/guardian-api";
+import { LOCATION_COLORS } from "~/lib/location-helper";
 
 vi.mock("~/contexts/ToastContext", () => ({
   useToast: vi.fn(() => ({ success: vi.fn(), error: vi.fn() })),
@@ -100,7 +101,7 @@ describe("GuardianApprovalQueue", () => {
 
   it("explains an empty queue when parent invites are disabled", async () => {
     mockList.mockResolvedValue([]);
-    render(
+    const { container } = render(
       <GuardianApprovalQueue
         inviteModeState={{ status: "ready", mode: "disabled" }}
       />,
@@ -113,6 +114,13 @@ describe("GuardianApprovalQueue", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Einstellungen/ }));
     expect(mockPush).toHaveBeenCalledWith("/settings?tab=operations");
+
+    const iconBadge =
+      container.querySelector(".lucide-settings")?.parentElement;
+    expect(iconBadge).toHaveStyle({
+      backgroundColor: `${LOCATION_COLORS.OTHER_ROOM}1F`,
+      color: LOCATION_COLORS.OTHER_ROOM,
+    });
   });
 
   it("explains an empty queue when invites are sent without approval", async () => {
@@ -134,13 +142,22 @@ describe("GuardianApprovalQueue", () => {
 
   it("keeps the neutral empty state when approval is the active mode", async () => {
     mockList.mockResolvedValue([]);
-    render(<GuardianApprovalQueue inviteModeState={staffApprovalMode} />);
+    const { container } = render(
+      <GuardianApprovalQueue inviteModeState={staffApprovalMode} />,
+    );
     await waitFor(() =>
       expect(screen.getByText(/Keine offenen Anfragen/)).toBeInTheDocument(),
     );
     expect(
       screen.queryByRole("button", { name: /Einstellungen/ }),
     ).not.toBeInTheDocument();
+
+    const iconBadge =
+      container.querySelector(".lucide-user-check")?.parentElement;
+    expect(iconBadge).toHaveStyle({
+      backgroundColor: `${LOCATION_COLORS.GROUP_ROOM}24`,
+      color: LOCATION_COLORS.GROUP_ROOM,
+    });
   });
 
   it("defers only an empty result while the invite mode is loading", async () => {
@@ -148,9 +165,10 @@ describe("GuardianApprovalQueue", () => {
 
     render(<GuardianApprovalQueue inviteModeState={{ status: "loading" }} />);
 
-    expect(
-      await screen.findByText("Einladungs-Einstellung wird geladen…"),
-    ).toBeInTheDocument();
+    const loading = await screen.findByLabelText(
+      "Einladungs-Einstellung wird geladen…",
+    );
+    expect(loading).toHaveAttribute("aria-live", "polite");
     expect(mockList).toHaveBeenCalledOnce();
   });
 

--- a/frontend/src/components/admin/guardian-approval-queue.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.tsx
@@ -8,6 +8,7 @@ import {
   rejectGuardianInvitation,
   type PendingApproval,
 } from "@/lib/guardian-api";
+import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { EmptyState } from "~/components/ui/empty-state";
 import { ConfirmationModal } from "~/components/ui/modal";
@@ -20,13 +21,22 @@ const logger = createLogger({ component: "GuardianApprovalQueue" });
 /** Values of the `guardians.parent_invite_mode` setting. */
 export type GuardianInviteMode = "disabled" | "direct" | "staff_approval";
 
+export type GuardianInviteModeState =
+  | { readonly status: "loading" }
+  | {
+      readonly status: "error";
+      readonly isRetrying: boolean;
+      readonly retry: () => void;
+    }
+  | { readonly status: "ready"; readonly mode: GuardianInviteMode };
+
 // Only staff_approval ever puts a request into this queue: "disabled" blocks
 // parent invites outright and "direct" sends them without a review step. An
 // empty list then means "configured away", not "nothing to do yet", so the
 // empty state says which of the two it is instead of leaving an admin to
-// wonder whether the page is broken. An unknown mode (settings schema not
-// readable) falls back to the neutral wording, which claims nothing.
-function emptyStateCopy(inviteMode: GuardianInviteMode | undefined): {
+// wonder whether the page is broken. Loading and error states are handled
+// separately, so this copy always receives a validated mode.
+function emptyStateCopy(inviteMode: GuardianInviteMode): {
   readonly configuredAway: boolean;
   readonly title: string;
   readonly description: string;
@@ -58,7 +68,7 @@ function emptyStateCopy(inviteMode: GuardianInviteMode | undefined): {
 function ApprovalsEmptyState({
   inviteMode,
 }: {
-  readonly inviteMode?: GuardianInviteMode;
+  readonly inviteMode: GuardianInviteMode;
 }) {
   const router = useTenantRouter();
   const { configuredAway, title, description } = emptyStateCopy(inviteMode);
@@ -100,10 +110,50 @@ function ApprovalsEmptyState({
   );
 }
 
-export default function GuardianApprovalQueue({
-  inviteMode,
+function InviteModeDependentEmptyState({
+  state,
 }: {
-  readonly inviteMode?: GuardianInviteMode;
+  readonly state: GuardianInviteModeState;
+}) {
+  if (state.status === "loading") {
+    return (
+      <div className="flex items-center justify-center rounded-2xl border border-gray-200 bg-white p-12 shadow-sm">
+        <div className="flex items-center gap-3 text-sm text-gray-600">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-gray-900" />
+          Einladungs-Einstellung wird geladen…
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <Alert
+        type="error"
+        message="Die Einladungs-Einstellung konnte nicht geladen werden. Der leere Zustand der Konto-Anfragen kann deshalb derzeit nicht zuverlässig eingeordnet werden."
+        action={
+          <Button
+            type="button"
+            variant="outline_danger"
+            size="md"
+            isLoading={state.isRetrying}
+            loadingText="Wird geladen…"
+            onClick={state.retry}
+          >
+            Erneut versuchen
+          </Button>
+        }
+      />
+    );
+  }
+
+  return <ApprovalsEmptyState inviteMode={state.mode} />;
+}
+
+export default function GuardianApprovalQueue({
+  inviteModeState,
+}: {
+  readonly inviteModeState: GuardianInviteModeState;
 }) {
   const [requests, setRequests] = useState<PendingApproval[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -197,7 +247,7 @@ export default function GuardianApprovalQueue({
       )}
 
       {requests.length === 0 && !error ? (
-        <ApprovalsEmptyState inviteMode={inviteMode} />
+        <InviteModeDependentEmptyState state={inviteModeState} />
       ) : (
         requests.map((req) => (
           <div

--- a/frontend/src/components/admin/guardian-approval-queue.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Check, X, UserPlus } from "lucide-react";
+import { Check, X, Settings, UserCheck } from "lucide-react";
 import {
   listPendingApprovals,
   approveGuardianInvitation,
@@ -9,13 +9,102 @@ import {
   type PendingApproval,
 } from "@/lib/guardian-api";
 import { Button } from "~/components/ui/button";
+import { EmptyState } from "~/components/ui/empty-state";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
+import { useTenantRouter } from "~/lib/tenant-router";
 
 const logger = createLogger({ component: "GuardianApprovalQueue" });
 
-export default function GuardianApprovalQueue() {
+/** Values of the `guardians.parent_invite_mode` setting. */
+export type GuardianInviteMode = "disabled" | "direct" | "staff_approval";
+
+// Only staff_approval ever puts a request into this queue: "disabled" blocks
+// parent invites outright and "direct" sends them without a review step. An
+// empty list then means "configured away", not "nothing to do yet", so the
+// empty state says which of the two it is instead of leaving an admin to
+// wonder whether the page is broken. An unknown mode (settings schema not
+// readable) falls back to the neutral wording, which claims nothing.
+function emptyStateCopy(inviteMode: GuardianInviteMode | undefined): {
+  readonly configuredAway: boolean;
+  readonly title: string;
+  readonly description: string;
+} {
+  if (inviteMode === "disabled") {
+    return {
+      configuredAway: true,
+      title: "Eltern können derzeit niemanden einladen",
+      description:
+        "Das Einladen weiterer Bezugspersonen durch Eltern ist ausgeschaltet. Anfragen erscheinen hier erst, wenn die Einstellung auf „Mit Freigabe durch das Team“ steht.",
+    };
+  }
+  if (inviteMode === "direct") {
+    return {
+      configuredAway: true,
+      title: "Einladungen gehen ohne Freigabe raus",
+      description:
+        "Eltern laden weitere Bezugspersonen aktuell direkt ein, ohne Bestätigung durch das Team. Diese Liste bleibt deshalb leer.",
+    };
+  }
+  return {
+    configuredAway: false,
+    title: "Keine offenen Anfragen",
+    description:
+      "Lädt eine Familie im Elternportal eine weitere Bezugsperson zu ihrem Kind ein, erscheint die Anfrage hier zur Freigabe. Bis dahin bekommt niemand zusätzlichen Zugang.",
+  };
+}
+
+function ApprovalsEmptyState({
+  inviteMode,
+}: {
+  readonly inviteMode?: GuardianInviteMode;
+}) {
+  const router = useTenantRouter();
+  const { configuredAway, title, description } = emptyStateCopy(inviteMode);
+
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+      <EmptyState
+        icon={
+          <span
+            className={`flex h-12 w-12 items-center justify-center rounded-2xl ${
+              configuredAway
+                ? "bg-[#5080D8]/12 text-[#3D63B0]"
+                : "bg-[#83CD2D]/14 text-[#3F6F12]"
+            }`}
+          >
+            {configuredAway ? (
+              <Settings className="h-6 w-6" />
+            ) : (
+              <UserCheck className="h-6 w-6" />
+            )}
+          </span>
+        }
+        title={title}
+        description={description}
+        action={
+          configuredAway ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={() => router.push("/settings?tab=operations")}
+            >
+              Zu den Einstellungen
+            </Button>
+          ) : undefined
+        }
+      />
+    </div>
+  );
+}
+
+export default function GuardianApprovalQueue({
+  inviteMode,
+}: {
+  readonly inviteMode?: GuardianInviteMode;
+}) {
   const [requests, setRequests] = useState<PendingApproval[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -108,12 +197,7 @@ export default function GuardianApprovalQueue() {
       )}
 
       {requests.length === 0 && !error ? (
-        <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-10 text-center">
-          <UserPlus className="mx-auto mb-2 h-8 w-8 text-gray-400" />
-          <p className="text-sm text-gray-500">
-            Keine offenen Anfragen zur Freigabe
-          </p>
-        </div>
+        <ApprovalsEmptyState inviteMode={inviteMode} />
       ) : (
         requests.map((req) => (
           <div

--- a/frontend/src/components/admin/guardian-approval-queue.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.tsx
@@ -11,9 +11,11 @@ import {
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { EmptyState } from "~/components/ui/empty-state";
+import { Loading } from "~/components/ui/loading";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
+import { LOCATION_COLORS } from "~/lib/location-helper";
 import { useTenantRouter } from "~/lib/tenant-router";
 
 const logger = createLogger({ component: "GuardianApprovalQueue" });
@@ -72,17 +74,18 @@ function ApprovalsEmptyState({
 }) {
   const router = useTenantRouter();
   const { configuredAway, title, description } = emptyStateCopy(inviteMode);
+  const iconColor = configuredAway
+    ? LOCATION_COLORS.OTHER_ROOM
+    : LOCATION_COLORS.GROUP_ROOM;
+  const iconBackground = `${iconColor}${configuredAway ? "1F" : "24"}`;
 
   return (
     <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
       <EmptyState
         icon={
           <span
-            className={`flex h-12 w-12 items-center justify-center rounded-2xl ${
-              configuredAway
-                ? "bg-[#5080D8]/12 text-[#3D63B0]"
-                : "bg-[#83CD2D]/14 text-[#3F6F12]"
-            }`}
+            className="flex h-12 w-12 items-center justify-center rounded-2xl"
+            style={{ backgroundColor: iconBackground, color: iconColor }}
           >
             {configuredAway ? (
               <Settings className="h-6 w-6" />
@@ -117,12 +120,10 @@ function InviteModeDependentEmptyState({
 }) {
   if (state.status === "loading") {
     return (
-      <div className="flex items-center justify-center rounded-2xl border border-gray-200 bg-white p-12 shadow-sm">
-        <div className="flex items-center gap-3 text-sm text-gray-600">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-gray-900" />
-          Einladungs-Einstellung wird geladen…
-        </div>
-      </div>
+      <Loading
+        message="Einladungs-Einstellung wird geladen…"
+        fullPage={false}
+      />
     );
   }
 


### PR DESCRIPTION
## Problem

Der leere Zustand unter **Eltern → Konto-Anfragen** war ein gestrichelter grauer Kasten mit einer grauen Zeile („Keine offenen Anfragen zur Freigabe"), mitten in einer ansonsten leeren Seite. Er erklärte weder, was hier auftauchen soll, noch warum gerade nichts da ist.

Wichtiger als die Optik: Anfragen landen **nur** im Modus `guardians.parent_invite_mode = staff_approval` in dieser Warteschlange. Bei `disabled` (dem Standard) blockiert das Backend Eltern-Einladungen komplett, bei `direct` gehen sie ohne Review-Schritt raus (`services/parent/parent_related_accounts_service.go`). In beiden Fällen bleibt die Seite dauerhaft leer und niemand erfährt, warum.

## Änderung

Die Seite liest den Invite-Modus aus dem Settings-Schema (Admins haben `config:read`) und gibt ihn an die Queue weiter. Der Zero State benennt den Grund:

| Modus | Aussage | Aktion |
|---|---|---|
| `staff_approval` / unbekannt | „Keine offenen Anfragen" plus Erklärung, wann hier etwas auftaucht | keine |
| `disabled` | „Eltern können derzeit niemanden einladen" | Button „Zu den Einstellungen" → `/settings?tab=operations` |
| `direct` | „Einladungen gehen ohne Freigabe raus" | gleicher Button |

Schlägt der Schema-Abruf fehl, bleibt der Modus `undefined` und es greift die neutrale Variante, die nichts behauptet.

Optisch: kanonische Kartenfläche (`moto-content-surface rounded-2xl border shadow-sm`) statt gestricheltem Kasten, Kit-`EmptyState` statt handgebautem Block, Icon-Badge im gleichen Stil wie die Karten auf der Eltern-Übersicht (`UserCheck`, grün getönt; `Settings`, blau getönt für die beiden Konfigurations-Hinweise). Keine neuen Komponenten, keine generischen Tailwind-Farben.

## Screenshots

Aus Storybook, echte Komponente mit echten Styles. Die Bilder liegen lokal unter `/private/tmp/claude-501/-Users-yonnock-Developer-moto-project-phoenix/e336795d-d2f0-42a5-939c-bb7043fbc8b0/scratchpad/` (`empty-waiting.png`, `empty-disabled.png`, `with-request.png`) und müssen noch manuell angehängt werden.

## Tests

- `pnpm run check` sauber
- 42 Tests in `src/components/admin/` grün, davon 4 neue Fälle für die drei Varianten und den Settings-Shortcut
- Im bestehenden Testfile kam nur ein Mock für die neu genutzte `useTenantRouter`-Abhängigkeit dazu, keine Assertion wurde abgeschwächt
- Neue Storybook-Stories für alle drei leeren Zustände plus die befüllte Liste (bisher deckte die einzige Story nur den Fehlerpfad ab)

## Offen

Der Sichtcheck lief über Storybook, nicht gegen den vollen lokalen Stack.
