### PR TITLE
Seitentitel nicht doppelt neben der Breadcrumb zeigen

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
@@ -4,6 +4,7 @@ import { CareRequestReviewList } from "~/components/students/care-request-review
 import { ExcusedRequestReviewList } from "~/components/students/excused-request-review-list";
 import { MasterDataReviewList } from "~/components/students/master-data-review-list";
 import { Loading } from "~/components/ui/loading";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { useRequirePermission } from "~/lib/hooks/use-require-permission";
 
 export default function AdminChangeRequestsPage() {
@@ -20,14 +21,14 @@ export default function AdminChangeRequestsPage() {
   // request renders as a calm card (flex-wrap, mobile-safe), not a bare table.
   return (
     <div className="-mt-1.5 w-full">
-      <header className="mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">
-          Änderungsanfragen
-        </h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Von Eltern eingereichte Änderungen, die eine Freigabe benötigen.
-        </p>
-      </header>
+      {/* Der Seitentitel steht auf dem Desktop in der Breadcrumb der Kopfzeile.
+          PageHeaderWithSearch blendet seine Überschrift deshalb ab md ein
+          (md:hidden), genau wie auf der Schwesterseite Konto-Anfragen. Ein
+          eigenes h1 hätte den Titel zweimal untereinander gezeigt. */}
+      <PageHeaderWithSearch title="Änderungsanfragen" />
+      <p className="mb-6 max-w-3xl text-sm text-gray-600">
+        Von Eltern eingereichte Änderungen, die eine Freigabe benötigen.
+      </p>
 
       <section className="mb-8">
         <h2 className="text-base font-semibold text-gray-900">Stammdaten</h2>

--- a/frontend/src/app/[tenant]/(protected)/meal-plan/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/meal-plan/page.tsx
@@ -16,6 +16,7 @@ import { Button } from "~/components/ui/button";
 import { Loading } from "~/components/ui/loading";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { hasPermission, isAdmin } from "~/lib/auth-utils";
 import { useToast } from "~/contexts/ToastContext";
 import { parseISODate, toISODate } from "~/lib/date-helpers";
@@ -450,320 +451,323 @@ export default function MealPlanPage() {
   const isCurrentWeek = weekOffset === 0;
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6 pb-24">
-      <section className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-        <div>
-          <h1 className="text-xl font-semibold text-gray-900">Essensplan</h1>
-          <p className="mt-1 text-sm text-gray-500">
+    <div className="-mt-1.5 w-full pb-24">
+      {/* Der Seitentitel steht auf dem Desktop in der Breadcrumb der Kopfzeile;
+          PageHeaderWithSearch zeigt ihn nur mobil (md:hidden). Das frühere h1
+          in der Kopf-Karte stand direkt unter derselben Breadcrumb. */}
+      <PageHeaderWithSearch title="Essensplan" />
+      <div className="space-y-6">
+        <section className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+          <p className="text-sm text-gray-500">
             Pro Tag ein oder mehrere Gerichte mit optionalem Hinweis. Eltern
             sehen den Plan im Elternportal.
           </p>
-        </div>
 
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-          {/* Week navigation */}
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Vorherige Woche"
-              onClick={() => attemptWeekChange(weekOffset - 1)}
-              disabled={loading || saving || copyingPrev}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <div className="min-w-32 text-center">
-              <div className="text-sm font-semibold text-gray-900">
-                KW {weekNumber}
-                {isCurrentWeek ? (
-                  <span className="ml-1.5 text-[#83CD2D]">· Diese Woche</span>
-                ) : null}
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+            {/* Week navigation */}
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Vorherige Woche"
+                onClick={() => attemptWeekChange(weekOffset - 1)}
+                disabled={loading || saving || copyingPrev}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <div className="min-w-32 text-center">
+                <div className="text-sm font-semibold text-gray-900">
+                  KW {weekNumber}
+                  {isCurrentWeek ? (
+                    <span className="ml-1.5 text-[#83CD2D]">· Diese Woche</span>
+                  ) : null}
+                </div>
+                <div className="text-xs text-gray-500">{rangeLabel}</div>
               </div>
-              <div className="text-xs text-gray-500">{rangeLabel}</div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Nächste Woche"
+                onClick={() => attemptWeekChange(weekOffset + 1)}
+                disabled={loading || saving || copyingPrev}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+              {!isCurrentWeek && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="md"
+                  onClick={() => attemptWeekChange(0)}
+                  disabled={loading || saving || copyingPrev}
+                >
+                  Heute
+                </Button>
+              )}
             </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Nächste Woche"
-              onClick={() => attemptWeekChange(weekOffset + 1)}
-              disabled={loading || saving || copyingPrev}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-            {!isCurrentWeek && (
+
+            {canEdit && (
               <Button
                 type="button"
                 variant="outline"
                 size="md"
-                onClick={() => attemptWeekChange(0)}
-                disabled={loading || saving || copyingPrev}
+                onClick={requestCopyPreviousWeek}
+                disabled={loading || saving || copyingPrev || loadError}
+                isLoading={copyingPrev}
+                loadingText="Übernehmen…"
               >
-                Heute
+                <Copy className="mr-2 h-4 w-4" />
+                Vorwoche übernehmen
               </Button>
             )}
           </div>
+        </section>
 
-          {canEdit && (
+        {loading && !hasLoaded ? (
+          <Loading fullPage={false} />
+        ) : loadError ? (
+          <section className="moto-content-surface flex flex-col items-center gap-4 rounded-2xl border p-8 text-center shadow-sm">
+            <p className="text-sm text-gray-500">
+              Essensplan konnte nicht geladen werden.
+            </p>
             <Button
               type="button"
               variant="outline"
               size="md"
-              onClick={requestCopyPreviousWeek}
-              disabled={loading || saving || copyingPrev || loadError}
-              isLoading={copyingPrev}
-              loadingText="Übernehmen…"
+              onClick={() => void load()}
+              disabled={loading}
             >
-              <Copy className="mr-2 h-4 w-4" />
-              Vorwoche übernehmen
+              Erneut versuchen
             </Button>
-          )}
-        </div>
-      </section>
-
-      {loading && !hasLoaded ? (
-        <Loading fullPage={false} />
-      ) : loadError ? (
-        <section className="moto-content-surface flex flex-col items-center gap-4 rounded-2xl border p-8 text-center shadow-sm">
-          <p className="text-sm text-gray-500">
-            Essensplan konnte nicht geladen werden.
-          </p>
-          <Button
-            type="button"
-            variant="outline"
-            size="md"
-            onClick={() => void load()}
-            disabled={loading}
+          </section>
+        ) : (
+          <div
+            className={`overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-opacity duration-200 ${
+              loading ? "opacity-50" : "opacity-100"
+            }`}
           >
-            Erneut versuchen
-          </Button>
-        </section>
-      ) : (
-        <div
-          className={`overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-opacity duration-200 ${
-            loading ? "opacity-50" : "opacity-100"
-          }`}
-        >
-          <div className="grid grid-cols-1 divide-y divide-gray-200 md:grid-cols-5 md:divide-x md:divide-y-0">
-            {weekDates.map((date) => {
-              const rows = drafts[date] ?? [];
-              const isToday = date === today;
-              const hasContent = dayHasContent(rows);
-              return (
-                <div
-                  key={date}
-                  data-meal-day-column
-                  className={`flex flex-col ${isToday ? "bg-[#83CD2D]/[0.04]" : ""}`}
-                >
+            <div className="grid grid-cols-1 divide-y divide-gray-200 md:grid-cols-5 md:divide-x md:divide-y-0">
+              {weekDates.map((date) => {
+                const rows = drafts[date] ?? [];
+                const isToday = date === today;
+                const hasContent = dayHasContent(rows);
+                return (
                   <div
-                    className={`flex items-center justify-between gap-2 border-b px-4 py-3 ${
-                      isToday ? "border-[#83CD2D]/30" : "border-gray-200"
-                    }`}
+                    key={date}
+                    data-meal-day-column
+                    className={`flex flex-col ${isToday ? "bg-[#83CD2D]/[0.04]" : ""}`}
                   >
-                    <div>
-                      <div className="text-sm font-semibold text-gray-900">
-                        {weekdayLabel(date)}
+                    <div
+                      className={`flex items-center justify-between gap-2 border-b px-4 py-3 ${
+                        isToday ? "border-[#83CD2D]/30" : "border-gray-200"
+                      }`}
+                    >
+                      <div>
+                        <div className="text-sm font-semibold text-gray-900">
+                          {weekdayLabel(date)}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {shortDate(date)}
+                        </div>
                       </div>
-                      <div className="text-xs text-gray-500">
-                        {shortDate(date)}
+                      <div className="flex items-center gap-1">
+                        {isToday && (
+                          <span className="rounded-full bg-[#83CD2D] px-2 py-0.5 text-[11px] font-semibold text-white">
+                            Heute
+                          </span>
+                        )}
+                        {canEdit && (
+                          <OverflowMenu
+                            ariaLabel={`Aktionen für ${weekdayLabel(date)}`}
+                            triggerClassName="!size-7"
+                            matchContainerSelector="[data-meal-day-column]"
+                            items={[
+                              {
+                                label: "Tag kopieren",
+                                icon: <Copy className="h-4 w-4" />,
+                                onClick: () => copyDay(date),
+                                disabled: !hasContent || editingLocked,
+                              },
+                              {
+                                label: "Einfügen",
+                                icon: <ClipboardPaste className="h-4 w-4" />,
+                                onClick: () => pasteDay(date),
+                                disabled: clipboard === null || editingLocked,
+                              },
+                              {
+                                label: "Tag leeren",
+                                icon: <Trash2 className="h-4 w-4" />,
+                                onClick: () => clearDay(date),
+                                destructive: true,
+                                disabled: !hasContent || editingLocked,
+                              },
+                            ]}
+                          />
+                        )}
                       </div>
                     </div>
-                    <div className="flex items-center gap-1">
-                      {isToday && (
-                        <span className="rounded-full bg-[#83CD2D] px-2 py-0.5 text-[11px] font-semibold text-white">
-                          Heute
-                        </span>
-                      )}
+
+                    <div className="flex flex-1 flex-col gap-3 p-3">
+                      {rows.map((row, idx) => (
+                        <div
+                          key={row.clientId}
+                          className="group relative min-h-20 rounded-lg border border-gray-200 bg-white p-3.5 pr-8 transition focus-within:border-gray-300 focus-within:ring-1 focus-within:ring-gray-200"
+                        >
+                          <textarea
+                            rows={1}
+                            className={dishFieldClass}
+                            value={row.dish}
+                            placeholder="Gericht eintragen…"
+                            readOnly={!canEditNow}
+                            onChange={(e) =>
+                              updateDish(date, idx, "dish", e.target.value)
+                            }
+                          />
+                          <textarea
+                            rows={1}
+                            className={noteFieldClass}
+                            value={row.note}
+                            placeholder="Hinweis (optional)"
+                            readOnly={!canEditNow}
+                            onChange={(e) =>
+                              updateDish(date, idx, "note", e.target.value)
+                            }
+                          />
+                          {canEdit &&
+                            (rows.length > 1 ||
+                              row.dish.trim() !== "" ||
+                              row.note.trim() !== "") && (
+                              <button
+                                type="button"
+                                aria-label="Gericht entfernen"
+                                onClick={() => requestRemove(date, idx)}
+                                disabled={editingLocked}
+                                className="absolute top-2 right-2 rounded p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                              >
+                                <X className="h-4 w-4" />
+                              </button>
+                            )}
+                        </div>
+                      ))}
+
                       {canEdit && (
-                        <OverflowMenu
-                          ariaLabel={`Aktionen für ${weekdayLabel(date)}`}
-                          triggerClassName="!size-7"
-                          matchContainerSelector="[data-meal-day-column]"
-                          items={[
-                            {
-                              label: "Tag kopieren",
-                              icon: <Copy className="h-4 w-4" />,
-                              onClick: () => copyDay(date),
-                              disabled: !hasContent || editingLocked,
-                            },
-                            {
-                              label: "Einfügen",
-                              icon: <ClipboardPaste className="h-4 w-4" />,
-                              onClick: () => pasteDay(date),
-                              disabled: clipboard === null || editingLocked,
-                            },
-                            {
-                              label: "Tag leeren",
-                              icon: <Trash2 className="h-4 w-4" />,
-                              onClick: () => clearDay(date),
-                              destructive: true,
-                              disabled: !hasContent || editingLocked,
-                            },
-                          ]}
-                        />
+                        <button
+                          type="button"
+                          onClick={() => addRow(date)}
+                          disabled={editingLocked}
+                          className="flex items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 py-2 text-sm font-medium text-gray-500 transition hover:border-gray-400 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-gray-300 disabled:hover:bg-transparent disabled:hover:text-gray-500"
+                        >
+                          <Plus className="h-4 w-4" />
+                          Gericht
+                        </button>
                       )}
                     </div>
                   </div>
-
-                  <div className="flex flex-1 flex-col gap-3 p-3">
-                    {rows.map((row, idx) => (
-                      <div
-                        key={row.clientId}
-                        className="group relative min-h-20 rounded-lg border border-gray-200 bg-white p-3.5 pr-8 transition focus-within:border-gray-300 focus-within:ring-1 focus-within:ring-gray-200"
-                      >
-                        <textarea
-                          rows={1}
-                          className={dishFieldClass}
-                          value={row.dish}
-                          placeholder="Gericht eintragen…"
-                          readOnly={!canEditNow}
-                          onChange={(e) =>
-                            updateDish(date, idx, "dish", e.target.value)
-                          }
-                        />
-                        <textarea
-                          rows={1}
-                          className={noteFieldClass}
-                          value={row.note}
-                          placeholder="Hinweis (optional)"
-                          readOnly={!canEditNow}
-                          onChange={(e) =>
-                            updateDish(date, idx, "note", e.target.value)
-                          }
-                        />
-                        {canEdit &&
-                          (rows.length > 1 ||
-                            row.dish.trim() !== "" ||
-                            row.note.trim() !== "") && (
-                            <button
-                              type="button"
-                              aria-label="Gericht entfernen"
-                              onClick={() => requestRemove(date, idx)}
-                              disabled={editingLocked}
-                              className="absolute top-2 right-2 rounded p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-gray-400"
-                            >
-                              <X className="h-4 w-4" />
-                            </button>
-                          )}
-                      </div>
-                    ))}
-
-                    {canEdit && (
-                      <button
-                        type="button"
-                        onClick={() => addRow(date)}
-                        disabled={editingLocked}
-                        className="flex items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 py-2 text-sm font-medium text-gray-500 transition hover:border-gray-400 hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-gray-300 disabled:hover:bg-transparent disabled:hover:text-gray-500"
-                      >
-                        <Plus className="h-4 w-4" />
-                        Gericht
-                      </button>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* Sticky save bar — only while there are unsaved changes. */}
-      {canEdit && isDirty && !loading && !loadError && (
-        <div className="sticky bottom-4 z-20">
-          <div className="moto-content-surface flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 shadow-lg">
-            <span className="text-sm font-medium text-gray-700">
-              {changedDays.length}{" "}
-              {changedDays.length === 1 ? "Tag geändert" : "Tage geändert"}
-            </span>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="md"
-                onClick={discard}
-                disabled={saving}
-              >
-                Verwerfen
-              </Button>
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                onClick={handleSave}
-                disabled={saving}
-                isLoading={saving}
-                loadingText="Speichern…"
-              >
-                Speichern
-              </Button>
+                );
+              })}
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      <ConfirmationModal
-        isOpen={deleteTarget !== null}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={confirmRemove}
-        title="Gericht entfernen?"
-        confirmText="Entfernen"
-        cancelText="Abbrechen"
-        confirmButtonClass="bg-[#FF3130] hover:bg-[#e02020]"
-      >
-        <p className="text-sm text-gray-600">
-          {deleteTarget
-            ? `„${drafts[deleteTarget.date]?.[deleteTarget.idx]?.dish.trim() || "Dieses Gericht"}" wird aus dem Plan entfernt. Die Änderung wird mit „Speichern" übernommen.`
-            : ""}
-        </p>
-      </ConfirmationModal>
+        {/* Sticky save bar — only while there are unsaved changes. */}
+        {canEdit && isDirty && !loading && !loadError && (
+          <div className="sticky bottom-4 z-20">
+            <div className="moto-content-surface flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 shadow-lg">
+              <span className="text-sm font-medium text-gray-700">
+                {changedDays.length}{" "}
+                {changedDays.length === 1 ? "Tag geändert" : "Tage geändert"}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="md"
+                  onClick={discard}
+                  disabled={saving}
+                >
+                  Verwerfen
+                </Button>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="md"
+                  onClick={handleSave}
+                  disabled={saving}
+                  isLoading={saving}
+                  loadingText="Speichern…"
+                >
+                  Speichern
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
 
-      <ConfirmationModal
-        isOpen={pendingOffset !== null}
-        onClose={() => setPendingOffset(null)}
-        onConfirm={confirmWeekChange}
-        title="Ungespeicherte Änderungen"
-        confirmText="Verwerfen & wechseln"
-        cancelText="Hierbleiben"
-        confirmButtonClass="bg-[#FF3130] hover:bg-[#e02020]"
-      >
-        <p className="text-sm text-gray-600">
-          Du hast Änderungen in dieser Woche, die noch nicht gespeichert sind.
-          Beim Wochenwechsel gehen sie verloren.
-        </p>
-      </ConfirmationModal>
+        <ConfirmationModal
+          isOpen={deleteTarget !== null}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={confirmRemove}
+          title="Gericht entfernen?"
+          confirmText="Entfernen"
+          cancelText="Abbrechen"
+          confirmButtonClass="bg-[#FF3130] hover:bg-[#e02020]"
+        >
+          <p className="text-sm text-gray-600">
+            {deleteTarget
+              ? `„${drafts[deleteTarget.date]?.[deleteTarget.idx]?.dish.trim() || "Dieses Gericht"}" wird aus dem Plan entfernt. Die Änderung wird mit „Speichern" übernommen.`
+              : ""}
+          </p>
+        </ConfirmationModal>
 
-      <ConfirmationModal
-        isOpen={pendingHref !== null}
-        onClose={cancelNavigation}
-        onConfirm={confirmNavigation}
-        title="Ungespeicherte Änderungen"
-        confirmText="Verwerfen & verlassen"
-        cancelText="Hierbleiben"
-        confirmButtonClass="bg-[#FF3130] hover:bg-[#e02020]"
-      >
-        <p className="text-sm text-gray-600">
-          Du hast Änderungen, die noch nicht gespeichert sind. Beim Verlassen
-          der Seite gehen sie verloren.
-        </p>
-      </ConfirmationModal>
+        <ConfirmationModal
+          isOpen={pendingOffset !== null}
+          onClose={() => setPendingOffset(null)}
+          onConfirm={confirmWeekChange}
+          title="Ungespeicherte Änderungen"
+          confirmText="Verwerfen & wechseln"
+          cancelText="Hierbleiben"
+          confirmButtonClass="bg-[#FF3130] hover:bg-[#e02020]"
+        >
+          <p className="text-sm text-gray-600">
+            Du hast Änderungen in dieser Woche, die noch nicht gespeichert sind.
+            Beim Wochenwechsel gehen sie verloren.
+          </p>
+        </ConfirmationModal>
 
-      <ConfirmationModal
-        isOpen={confirmCopyPrev}
-        onClose={() => setConfirmCopyPrev(false)}
-        onConfirm={() => {
-          setConfirmCopyPrev(false);
-          void doCopyPreviousWeek();
-        }}
-        title="Vorwoche übernehmen?"
-        confirmText="Übernehmen"
-        cancelText="Abbrechen"
-      >
-        <p className="text-sm text-gray-600">
-          Die aktuelle Woche wird mit dem Plan der Vorwoche überschrieben. Die
-          Änderung wird erst mit „Speichern" übernommen.
-        </p>
-      </ConfirmationModal>
+        <ConfirmationModal
+          isOpen={pendingHref !== null}
+          onClose={cancelNavigation}
+          onConfirm={confirmNavigation}
+          title="Ungespeicherte Änderungen"
+          confirmText="Verwerfen & verlassen"
+          cancelText="Hierbleiben"
+          confirmButtonClass="bg-[#FF3130] hover:bg-[#e02020]"
+        >
+          <p className="text-sm text-gray-600">
+            Du hast Änderungen, die noch nicht gespeichert sind. Beim Verlassen
+            der Seite gehen sie verloren.
+          </p>
+        </ConfirmationModal>
+
+        <ConfirmationModal
+          isOpen={confirmCopyPrev}
+          onClose={() => setConfirmCopyPrev(false)}
+          onConfirm={() => {
+            setConfirmCopyPrev(false);
+            void doCopyPreviousWeek();
+          }}
+          title="Vorwoche übernehmen?"
+          confirmText="Übernehmen"
+          cancelText="Abbrechen"
+        >
+          <p className="text-sm text-gray-600">
+            Die aktuelle Woche wird mit dem Plan der Vorwoche überschrieben. Die
+            Änderung wird erst mit „Speichern" übernommen.
+          </p>
+        </ConfirmationModal>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
@@ -6,6 +6,7 @@ import { Alert } from "~/components/ui/alert";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Input } from "~/components/ui/input";
 import { Loading } from "~/components/ui/loading";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { useRequirePermission } from "~/lib/hooks/use-require-permission";
 import {
   duplicateLohnartNumbers,
@@ -77,7 +78,8 @@ export default function PayrollPage() {
   }
   if (error) {
     return (
-      <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="-mt-1.5 w-full">
+        <PageHeaderWithSearch title="Abrechnung" />
         <Alert
           type="error"
           message="Die Abrechnungs-Konfiguration konnte nicht geladen werden."
@@ -92,28 +94,32 @@ export default function PayrollPage() {
   const duplicates = duplicateLohnartNumbers(status);
 
   return (
-    <div className="mx-auto max-w-4xl space-y-5 px-4 py-6">
-      <div>
-        <h1 className="text-xl font-bold text-gray-900">Abrechnung</h1>
-        <p className="mt-1 text-sm text-gray-500">
+    // Volle Inhaltsbreite und Abstände wie auf den übrigen Seiten: die eigene
+    // zentrierte max-w-4xl-Spalte mit extra px/py ließ die Abrechnung schmaler
+    // und tiefer beginnen als jede andere Seite. Der Titel steht auf dem
+    // Desktop in der Breadcrumb, PageHeaderWithSearch zeigt ihn nur mobil.
+    <div className="-mt-1.5 w-full">
+      <PageHeaderWithSearch title="Abrechnung" />
+      <div className="space-y-5">
+        <p className="max-w-3xl text-sm text-gray-600">
           Zuordnung der Zeiterfassungs-Kategorien zu den Lohnarten des
           Lohnsystems und DATEV-Mandantendaten. Grundlage für den späteren
           DATEV-Export (LODAS und Lohn und Gehalt).
         </p>
+
+        <ReadinessCard status={status} />
+
+        {saveError && <Alert type="error" message={saveError} />}
+        {duplicates.length > 0 && (
+          <Alert
+            type="warning"
+            message={`Lohnartnummer ${duplicates.join(", ")} ist mehreren Kategorien zugeordnet. Das ist zulässig, führt aber meist zu doppelt gebuchten Stunden — bitte prüfen.`}
+          />
+        )}
+
+        <LohnartenCard status={status} onSave={save} />
+        <DatevCard status={status} onSave={save} />
       </div>
-
-      <ReadinessCard status={status} />
-
-      {saveError && <Alert type="error" message={saveError} />}
-      {duplicates.length > 0 && (
-        <Alert
-          type="warning"
-          message={`Lohnartnummer ${duplicates.join(", ")} ist mehreren Kategorien zugeordnet. Das ist zulässig, führt aber meist zu doppelt gebuchten Stunden — bitte prüfen.`}
-        />
-      )}
-
-      <LohnartenCard status={status} onSave={save} />
-      <DatevCard status={status} onSave={save} />
     </div>
   );
 }
@@ -144,9 +150,7 @@ function ReadinessCard({ status }: { readonly status: PayrollStatus }) {
 
   return (
     <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-      <h2 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
-        Vollständigkeit
-      </h2>
+      <h2 className="text-base font-semibold text-gray-900">Vollständigkeit</h2>
       <ul className="mt-3 space-y-2">
         {items.map((item) => (
           <li key={item.label} className="flex items-start gap-2 text-sm">
@@ -180,10 +184,8 @@ function LohnartenCard({
 }) {
   return (
     <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-      <h2 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
-        Lohnarten
-      </h2>
-      <p className="mt-1 text-xs text-gray-500">
+      <h2 className="text-base font-semibold text-gray-900">Lohnarten</h2>
+      <p className="mt-1 max-w-3xl text-sm text-gray-500">
         Mandantenspezifische Lohnartnummern aus dem Lohnsystem des Trägers (1
         bis 4 Ziffern). Für Krank, Urlaub und Fortbildung zusätzlich die
         Einheit, die die Lohnart erwartet.
@@ -191,7 +193,7 @@ function LohnartenCard({
       <div className="mt-4 overflow-x-auto">
         <table className="w-full min-w-[28rem] text-sm">
           <thead>
-            <tr className="border-b border-gray-200 text-left text-xs font-semibold tracking-wide text-gray-400 uppercase">
+            <tr className="border-b border-gray-100 text-left text-xs font-medium text-gray-500">
               <th className="py-2 pr-4">Kategorie</th>
               <th className="py-2 pr-4">Lohnartnummer</th>
               <th className="py-2">Einheit</th>
@@ -272,10 +274,8 @@ function DatevCard({
 }) {
   return (
     <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-      <h2 className="text-sm font-semibold tracking-wide text-gray-400 uppercase">
-        DATEV-Mandant
-      </h2>
-      <p className="mt-1 text-xs text-gray-500">
+      <h2 className="text-base font-semibold text-gray-900">DATEV-Mandant</h2>
+      <p className="mt-1 max-w-3xl text-sm text-gray-500">
         Kennzahlen für den Kopf der LODAS-Datei. Lohn und Gehalt benötigt sie
         nicht.
       </p>


### PR DESCRIPTION
## Problem

Auf dem Desktop **ist** die Breadcrumb in der Kopfzeile der Seitentitel. Die Kit-Komponente `PageHeaderWithSearch` trägt dem Rechnung: ihr `PageHeader` ist `mb-6 md:hidden` und zeigt die Überschrift nur mobil, wo es keine Breadcrumb gibt.

Drei Seiten haben stattdessen ein eigenes `<h1>` gerendert, das direkt unter derselben Wortmarke stand:

- Änderungsanfragen (`/admin/change-requests`)
- Essensplan (`/meal-plan`)
- Abrechnung (`/payroll`)

Die Abrechnung wich zusätzlich im Format ab: eine eigene zentrierte `max-w-4xl`-Spalte mit extra `px-4 py-6` ließ sie schmaler und tiefer beginnen als jede andere Seite, obwohl `app-shell.tsx` (`main`, `p-4 md:p-8`) Breite und Polster bereits liefert.

## Änderung

Alle drei folgen jetzt der Schwesterseite Konto-Anfragen (`admin/guardian-approvals`): `-mt-1.5 w-full` + `PageHeaderWithSearch` + Inhalt. Dasselbe Muster nutzen Kalenderzeiträume und Dienstplan.

| Seite | Fix |
|---|---|
| `admin/change-requests` | eigener `<header>`-Block raus, `PageHeaderWithSearch title="Änderungsanfragen"`; Einleitungssatz bleibt |
| `meal-plan` | `<h1>` aus der Kopf-Karte raus, Kit-Header davor; `mx-auto max-w-7xl` raus, Inhalt in eigenes `space-y-6` |
| `payroll` | zentrierte `max-w-4xl`-Spalte und `<h1>` raus; Karten-Überschriften von `text-xs uppercase text-gray-400` auf `text-base font-semibold text-gray-900` (wie `SettingsCategory`/`InfoCard`), Tabellenkopf auf den `DataTable`-Stil |

Elternmitteilungen wurde geprüft und nicht angefasst: die Seite nutzt bereits `PageHeaderWithSearch`.

Mobil bleibt der Titel auf allen drei Seiten sichtbar (dort fehlt die Breadcrumb), mit 390px nachgeprüft.

Zwei Fallen, die beim Umbau auffielen und in den Kommentaren festgehalten sind:

1. Ein Container mit `space-y-*` bekommt durch den auf dem Desktop leeren Header-Wrapper 24px Extra-Abstand oben. Inhalt gehört deshalb in ein eigenes `<div className="space-y-6">`.
2. Der große Diff in `meal-plan/page.tsx` ist reine Prettier-Einrückung durch diesen Wrapper. `git diff -w` zeigt 34 geänderte Zeilen über alle drei Dateien.

## Test

- `pnpm run check` (verify-locales + oxlint + tsc): grün
- Vitest für `admin/change-requests` und `payroll`: 3/3 grün, keine Testdatei angefasst
- Visuell gegen den lokalen Stack geprüft, Vorher/Nachher-Screenshots je Seite (Desktop 1440x900 und Mobil 390x844)

## Screenshots

Vorher/Nachher-Paare (links vorher, rechts nachher) werden manuell angehängt.

