### PR TITLE
feat(students): Kind inklusive verknüpfter Daten kontrolliert löschen

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -408,6 +408,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		PersonService:           api.Services.Users,
 		GuardianService:         api.Services.Guardian,
 		StudentService:          api.Services.Students,
+		StudentDeletionService:  api.Services.StudentDeletion,
 		StudentAuditService:     api.Services.StudentAudit,
 		EducationService:        api.Services.Education,
 		GradeTransitionService:  api.Services.GradeTransition,

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -62,6 +62,7 @@ type ResourceConfig struct {
 	SchoolService           platformSvc.SchoolService
 	SettingsService         configService.SettingsService
 	StudentService          userService.StudentService
+	StudentDeletionService  userService.StudentDeletionService
 	StudentAuditService     userService.StudentAuditService
 	MasterDataReviewService userService.MasterDataReviewService
 	CareRequestService      scheduleService.CareScheduleRequestService
@@ -161,6 +162,7 @@ func (rs *Resource) Router() chi.Router {
 
 		// Routes requiring users:delete permission
 		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Delete("/{id}", rs.deleteStudent)
+		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Get("/{id}/delete-impact", rs.getStudentDeleteImpact)
 		// Hard-deletes a child that a grade transition graduated. Separate from
 		// the route above because the alumnus gate that route relies on is
 		// exactly what this one has to bypass — see purgeGraduatedStudent.

--- a/backend/api/students/delete_person_failure_test.go
+++ b/backend/api/students/delete_person_failure_test.go
@@ -38,6 +38,7 @@ func TestPurgeGraduatedStudent_PersonDeleteFailureRollsBack(t *testing.T) {
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.GradeTransition,
 		repos.DataDeletion,
 		repos.StudentDeletionAudit,
 		tc.db,

--- a/backend/api/students/delete_person_failure_test.go
+++ b/backend/api/students/delete_person_failure_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/services/users/userstest"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
@@ -30,6 +32,16 @@ func TestPurgeGraduatedStudent_PersonDeleteFailureRollsBack(t *testing.T) {
 	require.NoError(t, err)
 
 	tc.resource.GradeTransitionService = tc.services.GradeTransition
+	repos := repositories.NewFactory(tc.db)
+	tc.resource.StudentDeletionService = usersService.NewStudentDeletionService(
+		tc.resource.StudentService,
+		repos.Student,
+		repos.Person,
+		repos.StudentDeletion,
+		repos.DataDeletion,
+		repos.StudentDeletionAudit,
+		tc.db,
+	)
 
 	realPersons := tc.resource.PersonService
 	tc.resource.PersonService = &userstest.PersonServiceMock{

--- a/backend/api/students/graduate_purge_audit_test.go
+++ b/backend/api/students/graduate_purge_audit_test.go
@@ -24,6 +24,7 @@ func TestPurgeGraduatedStudent_CreatesDeletionAudits(t *testing.T) {
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.GradeTransition,
 		repos.DataDeletion,
 		repos.StudentDeletionAudit,
 		tc.db,

--- a/backend/api/students/graduate_purge_audit_test.go
+++ b/backend/api/students/graduate_purge_audit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	usersService "github.com/moto-nrw/project-phoenix/services/users"
@@ -33,10 +34,19 @@ func TestPurgeGraduatedStudent_CreatesDeletionAudits(t *testing.T) {
 
 	student := testpkg.CreateTestStudent(t, tc.db, "Purge", "Audited", "4a")
 	actor := testpkg.CreateTestAccount(t, tc.db, "graduate-purge-audit@example.com")
+	room := testpkg.CreateTestRoom(t, tc.db, "graduate-purge-audit-room")
+	instance := testpkg.CreateTestActivityInstance(t, tc.db, timezone.TodayDate().AddDays(-1), room.ID, testpkg.ActivityInstanceOpts{
+		Title:         "Retained graduate roster assignment",
+		IsSpontaneous: true,
+	})
+	assignment := testpkg.CreateTestInstanceStudent(t, tc.db, instance.ID, student.ID, "")
 	graduateStudent(t, tc, student.ID)
 	t.Cleanup(func() {
 		_, _ = tc.db.NewDelete().TableExpr(`audit.student_deletions`).Where(`student_id = ?`, student.ID).Exec(context.Background())
 		_, _ = tc.db.NewDelete().TableExpr(`audit.data_deletions`).Where(`student_id = ?`, student.ID).Exec(context.Background())
+		testpkg.CleanupTableRecords(t, tc.db, "schedule.instance_students", assignment.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "schedule.activity_instances", instance.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "facilities.rooms", room.ID)
 		testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
 		testpkg.CleanupAuthFixtures(t, tc.db, actor.ID)
 	})
@@ -51,14 +61,19 @@ func TestPurgeGraduatedStudent_CreatesDeletionAudits(t *testing.T) {
 		Scan(testpkg.TenantContext(1)))
 	assert.Equal(t, actor.ID, deletionAudit.ActorAccountID)
 	assert.Equal(t, usersService.StudentDeletionReasonGraduatePurge, deletionAudit.Reason)
-	assert.Zero(t, deletionAudit.Counts.Total())
+	assert.Equal(t, 1, deletionAudit.Counts.TimetableAssignments)
 
 	var dataAudit auditModels.DataDeletion
 	require.NoError(t, tc.db.NewSelect().Model(&dataAudit).
 		Where(`tenant_id = ? AND student_id = ? AND deletion_type = ?`, student.TenantID, student.ID, auditModels.DeletionTypeManual).
 		Scan(testpkg.TenantContext(1)))
-	assert.Equal(t, 2, dataAudit.RecordsDeleted, "graduate purge deletes the student and person rows")
+	assert.Equal(t, 3, dataAudit.RecordsDeleted, "graduate purge deletes the student, person, and retained timetable assignment")
 	assert.Equal(t, usersService.StudentDeletionReasonGraduatePurge, dataAudit.DeletionReason)
 	assert.Equal(t, true, dataAudit.Metadata["student_deletion"])
-	assert.Equal(t, usersModels.StudentDeletionCounts{}, deletionAudit.Counts)
+	assert.Equal(t, usersModels.StudentDeletionCounts{TimetableAssignments: 1}, deletionAudit.Counts)
+
+	var assignmentCount int
+	require.NoError(t, tc.db.NewSelect().TableExpr(`schedule.instance_students`).ColumnExpr("COUNT(*)").
+		Where("id = ?", assignment.ID).Scan(testpkg.TenantContext(1), &assignmentCount))
+	assert.Zero(t, assignmentCount, "the retained historical assignment must not block the student delete")
 }

--- a/backend/api/students/graduate_purge_audit_test.go
+++ b/backend/api/students/graduate_purge_audit_test.go
@@ -1,0 +1,63 @@
+package students_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurgeGraduatedStudent_CreatesDeletionAudits(t *testing.T) {
+	tc := setupTestContext(t)
+	repos := repositories.NewFactory(tc.db)
+	tc.resource.StudentDeletionService = usersService.NewStudentDeletionService(
+		tc.resource.StudentService,
+		repos.Student,
+		repos.Person,
+		repos.StudentDeletion,
+		repos.DataDeletion,
+		repos.StudentDeletionAudit,
+		tc.db,
+	)
+	tc.resource.GradeTransitionService = tc.services.GradeTransition
+
+	student := testpkg.CreateTestStudent(t, tc.db, "Purge", "Audited", "4a")
+	actor := testpkg.CreateTestAccount(t, tc.db, "graduate-purge-audit@example.com")
+	graduateStudent(t, tc, student.ID)
+	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr(`audit.student_deletions`).Where(`student_id = ?`, student.ID).Exec(context.Background())
+		_, _ = tc.db.NewDelete().TableExpr(`audit.data_deletions`).Where(`student_id = ?`, student.ID).Exec(context.Background())
+		testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+		testpkg.CleanupAuthFixtures(t, tc.db, actor.ID)
+	})
+
+	req := testutil.NewRequest(http.MethodDelete, fmt.Sprintf("/%d/purge", student.ID), nil)
+	response := authExec(t, tc, req, testutil.AdminTestClaims(int(actor.ID)), []string{"admin:*"})
+	require.Equal(t, http.StatusOK, response.Code, "Body: %s", response.Body.String())
+
+	var deletionAudit auditModels.StudentDeletion
+	require.NoError(t, tc.db.NewSelect().Model(&deletionAudit).
+		Where(`tenant_id = ? AND student_id = ?`, student.TenantID, student.ID).
+		Scan(testpkg.TenantContext(1)))
+	assert.Equal(t, actor.ID, deletionAudit.ActorAccountID)
+	assert.Equal(t, usersService.StudentDeletionReasonGraduatePurge, deletionAudit.Reason)
+	assert.Zero(t, deletionAudit.Counts.Total())
+
+	var dataAudit auditModels.DataDeletion
+	require.NoError(t, tc.db.NewSelect().Model(&dataAudit).
+		Where(`tenant_id = ? AND student_id = ? AND deletion_type = ?`, student.TenantID, student.ID, auditModels.DeletionTypeManual).
+		Scan(testpkg.TenantContext(1)))
+	assert.Equal(t, 2, dataAudit.RecordsDeleted, "graduate purge deletes the student and person rows")
+	assert.Equal(t, usersService.StudentDeletionReasonGraduatePurge, dataAudit.DeletionReason)
+	assert.Equal(t, true, dataAudit.Metadata["student_deletion"])
+	assert.Equal(t, usersModels.StudentDeletionCounts{}, deletionAudit.Counts)
+}

--- a/backend/api/students/student_deletion_handlers_test.go
+++ b/backend/api/students/student_deletion_handlers_test.go
@@ -39,6 +39,7 @@ func TestStudentDeletionHandlers_RequirePreviewAndExplicitConfirmation(t *testin
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.GradeTransition,
 		repos.DataDeletion,
 		repos.StudentDeletionAudit,
 		tc.db,

--- a/backend/api/students/student_deletion_handlers_test.go
+++ b/backend/api/students/student_deletion_handlers_test.go
@@ -1,0 +1,129 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	userService "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func studentDeletionRowCount(t *testing.T, tc *testContext, table string, id int64) int {
+	t.Helper()
+	var count int
+	require.NoError(t, tc.db.NewSelect().TableExpr(table).ColumnExpr("COUNT(*)").
+		Where("id = ?", id).Scan(context.Background(), &count))
+	return count
+}
+
+func TestStudentDeletionHandlers_RequirePreviewAndExplicitConfirmation(t *testing.T) {
+	tc := setupTestContext(t)
+	repos := repositories.NewFactory(tc.db)
+	studentService := userService.NewStudentService(
+		repos.Student,
+		repos.PrivacyConsent,
+		repos.StudentCompanion,
+		nil,
+	)
+	tc.resource.StudentDeletionService = userService.NewStudentDeletionService(
+		studentService,
+		repos.Student,
+		repos.Person,
+		repos.StudentDeletion,
+		repos.StudentDeletionAudit,
+		tc.db,
+	)
+
+	target := testpkg.CreateTestStudent(t, tc.db, "DeleteApi", "Target", "1a")
+	spared := testpkg.CreateTestStudent(t, tc.db, "DeleteApi", "Spared", "1a")
+	room := testpkg.CreateTestRoom(t, tc.db, "delete-api-room")
+	instance := testpkg.CreateTestActivityInstance(t, tc.db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{
+		Title:         "Shared API deletion instance",
+		IsSpontaneous: true,
+	})
+	targetAssignment := testpkg.CreateTestInstanceStudent(t, tc.db, instance.ID, target.ID, "")
+	sparedAssignment := testpkg.CreateTestInstanceStudent(t, tc.db, instance.ID, spared.ID, "")
+	actor := testpkg.CreateTestAccount(t, tc.db, "student-delete-api@example.com")
+	var auditID int64
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, tc.db, "audit.student_deletions", auditID)
+		testpkg.CleanupTableRecords(t, tc.db, "schedule.instance_students", targetAssignment.ID, sparedAssignment.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "schedule.activity_instances", instance.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "users.students", target.ID, spared.ID)
+		testpkg.CleanupTableRecords(t, tc.db, "users.persons", target.PersonID, spared.PersonID)
+		testpkg.CleanupTableRecords(t, tc.db, "facilities.rooms", room.ID)
+		testpkg.CleanupAuthFixtures(t, tc.db, actor.ID)
+	})
+	claims := testutil.AdminTestClaims(int(actor.ID))
+
+	previewRequest := testutil.NewAuthenticatedRequest(t, http.MethodGet, fmt.Sprintf("/%d/delete-impact", target.ID), nil)
+	previewResponse := authExec(t, tc, previewRequest, claims, []string{"admin:*"})
+	require.Equal(t, http.StatusOK, previewResponse.Code, "Body: %s", previewResponse.Body.String())
+	var previewBody struct {
+		Data struct {
+			ConfirmationName string                           `json:"confirmation_name"`
+			Fingerprint      string                           `json:"fingerprint"`
+			Total            int                              `json:"total"`
+			Counts           userModels.StudentDeletionCounts `json:"counts"`
+			Preserved        struct {
+				OtherStudents   bool `json:"other_students"`
+				SharedInstances bool `json:"shared_instances"`
+			} `json:"preserved"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(previewResponse.Body.Bytes(), &previewBody))
+	assert.Equal(t, "DeleteApi Target", previewBody.Data.ConfirmationName)
+	assert.NotEmpty(t, previewBody.Data.Fingerprint)
+	assert.Equal(t, 1, previewBody.Data.Counts.TimetableAssignments)
+	assert.Equal(t, previewBody.Data.Counts.Total(), previewBody.Data.Total)
+	assert.True(t, previewBody.Data.Preserved.OtherStudents)
+	assert.True(t, previewBody.Data.Preserved.SharedInstances)
+
+	legacyRequest := testutil.NewAuthenticatedRequest(t, http.MethodDelete, fmt.Sprintf("/%d", target.ID), nil)
+	legacyResponse := authExec(t, tc, legacyRequest, claims, []string{"admin:*"})
+	require.Equal(t, http.StatusConflict, legacyResponse.Code, "Body: %s", legacyResponse.Body.String())
+	assert.Equal(t, 1, studentDeletionRowCount(t, tc, "users.students", target.ID))
+
+	wrongNameRequest := testutil.NewAuthenticatedRequest(t, http.MethodDelete, fmt.Sprintf("/%d", target.ID), map[string]any{
+		"expected_fingerprint": previewBody.Data.Fingerprint,
+		"confirmation_name":    "Wrong Name",
+		"reason":               userService.StudentDeletionReasonTestData,
+		"acknowledged":         true,
+	})
+	wrongNameResponse := authExec(t, tc, wrongNameRequest, claims, []string{"admin:*"})
+	require.Equal(t, http.StatusBadRequest, wrongNameResponse.Code, "Body: %s", wrongNameResponse.Body.String())
+	assert.Equal(t, 1, studentDeletionRowCount(t, tc, "users.students", target.ID))
+
+	deleteRequest := testutil.NewAuthenticatedRequest(t, http.MethodDelete, fmt.Sprintf("/%d", target.ID), map[string]any{
+		"expected_fingerprint": previewBody.Data.Fingerprint,
+		"confirmation_name":    previewBody.Data.ConfirmationName,
+		"reason":               userService.StudentDeletionReasonTestData,
+		"acknowledged":         true,
+	})
+	deleteResponse := authExec(t, tc, deleteRequest, claims, []string{"admin:*"})
+	require.Equal(t, http.StatusOK, deleteResponse.Code, "Body: %s", deleteResponse.Body.String())
+
+	assert.Zero(t, studentDeletionRowCount(t, tc, "users.students", target.ID))
+	assert.Zero(t, studentDeletionRowCount(t, tc, "schedule.instance_students", targetAssignment.ID))
+	assert.Equal(t, 1, studentDeletionRowCount(t, tc, "users.students", spared.ID))
+	assert.Equal(t, 1, studentDeletionRowCount(t, tc, "schedule.instance_students", sparedAssignment.ID))
+	assert.Equal(t, 1, studentDeletionRowCount(t, tc, "schedule.activity_instances", instance.ID))
+
+	require.NoError(t, tc.db.NewRaw(`
+		SELECT id
+		FROM audit.student_deletions
+		WHERE tenant_id = ? AND actor_account_id = ?
+		ORDER BY id DESC
+		LIMIT 1
+	`, int64(1), actor.ID).Scan(testpkg.TenantContext(1), &auditID))
+	assert.Positive(t, auditID)
+}

--- a/backend/api/students/student_deletion_handlers_test.go
+++ b/backend/api/students/student_deletion_handlers_test.go
@@ -39,6 +39,7 @@ func TestStudentDeletionHandlers_RequirePreviewAndExplicitConfirmation(t *testin
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.DataDeletion,
 		repos.StudentDeletionAudit,
 		tc.db,
 	)
@@ -55,6 +56,7 @@ func TestStudentDeletionHandlers_RequirePreviewAndExplicitConfirmation(t *testin
 	actor := testpkg.CreateTestAccount(t, tc.db, "student-delete-api@example.com")
 	var auditID int64
 	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr(`audit.data_deletions`).Where(`student_id = ?`, target.ID).Exec(context.Background())
 		testpkg.CleanupTableRecords(t, tc.db, "audit.student_deletions", auditID)
 		testpkg.CleanupTableRecords(t, tc.db, "schedule.instance_students", targetAssignment.ID, sparedAssignment.ID)
 		testpkg.CleanupTableRecords(t, tc.db, "schedule.activity_instances", instance.ID)

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -1645,10 +1645,18 @@ func (rs *Resource) purgeGraduatedStudent(w http.ResponseWriter, r *http.Request
 			errors.New("grade transition service not configured, refusing to purge")))
 		return
 	}
+	if rs.StudentDeletionService == nil {
+		renderError(w, r, common.ErrorInternalServer(
+			errors.New("student deletion service not configured, refusing to purge")))
+		return
+	}
 
 	tenantID := tenant.FromContext(r.Context())
+	actorAccountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
 	if err := tenant.WithTenantTx(r.Context(), rs.DB, tenantID, func(ctx context.Context, _ bun.Tx) error {
-		if err := rs.deleteStudentTxMode(ctx, tenantID, student, true); err != nil {
+		if err := rs.deleteStudentTxMode(ctx, tenantID, student, true, func(ctx context.Context) error {
+			return rs.StudentDeletionService.AuditGraduatePurge(ctx, student.ID, actorAccountID)
+		}); err != nil {
 			return err
 		}
 		// Same transaction: the ledger name and the student row must vanish
@@ -1706,7 +1714,7 @@ var errStudentNoLongerGraduated = errors.New("Kind ist kein Abgänger mehr und w
 // a concurrent upload can't orphan a new file on disk; the unlink itself runs
 // after the OUTER tenant tx commits.
 func (rs *Resource) deleteStudentTx(ctx context.Context, tenantID int64, student *users.Student) error {
-	return rs.deleteStudentTxMode(ctx, tenantID, student, false)
+	return rs.deleteStudentTxMode(ctx, tenantID, student, false, nil)
 }
 
 // deleteStudentTxMode is deleteStudentTx with the alumnus rule inverted for the
@@ -1718,7 +1726,13 @@ func (rs *Resource) deleteStudentTx(ctx context.Context, tenantID int64, student
 // and a child restored by a concurrent revert must not be deleted by a click
 // aimed at a graduate). Sharing one body keeps the companion lock protocol,
 // the photo capture and the person delete identical for both.
-func (rs *Resource) deleteStudentTxMode(ctx context.Context, tenantID int64, student *users.Student, purgeGraduate bool) error {
+func (rs *Resource) deleteStudentTxMode(
+	ctx context.Context,
+	tenantID int64,
+	student *users.Student,
+	purgeGraduate bool,
+	afterLock func(context.Context) error,
+) error {
 	if err := rs.lockStudentCompanionGraph(ctx, student.ID, nil); err != nil {
 		return err
 	}
@@ -1763,6 +1777,11 @@ func (rs *Resource) deleteStudentTxMode(ctx context.Context, tenantID int64, stu
 	// the refreshed list simply no longer offers the action.
 	if purgeGraduate && !fresh.IsAlumnus() {
 		return errStudentNoLongerGraduated
+	}
+	if afterLock != nil {
+		if err := afterLock(ctx); err != nil {
+			return err
+		}
 	}
 
 	var photoToRemove string

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -1453,6 +1453,19 @@ func (rs *Resource) deleteStudent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A configured permanent-delete service makes the preview and explicit
+	// confirmation mandatory even when the child currently has no dependent
+	// rows. Otherwise an old or hand-written client could bypass the typed name,
+	// acknowledgement and audit trail simply by sending an empty DELETE.
+	if r.ContentLength != 0 {
+		rs.deleteStudentWithData(w, r, student)
+		return
+	}
+	if rs.StudentDeletionService != nil {
+		renderError(w, r, common.ErrorConflictMessage("Bitte die Löschvorschau prüfen und die endgültige Löschung bestätigen."))
+		return
+	}
+
 	tenantID := tenant.FromContext(r.Context())
 	if err := tenant.WithTenantTx(r.Context(), rs.DB, tenantID, func(ctx context.Context, _ bun.Tx) error {
 		return rs.deleteStudentTx(ctx, tenantID, student)
@@ -1466,6 +1479,126 @@ func (rs *Resource) deleteStudent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	common.Respond(w, r, http.StatusOK, nil, "Student deleted successfully")
+}
+
+type studentDeleteImpactResponse struct {
+	ConfirmationName string                             `json:"confirmation_name"`
+	Fingerprint      string                             `json:"fingerprint"`
+	Total            int                                `json:"total"`
+	Counts           users.StudentDeletionCounts        `json:"counts"`
+	Preserved        studentDeletePreservedDataResponse `json:"preserved"`
+}
+
+type studentDeletePreservedDataResponse struct {
+	GuardianProfiles bool `json:"guardian_profiles"`
+	ParentAccounts   bool `json:"parent_accounts"`
+	OtherStudents    bool `json:"other_students"`
+	SharedInstances  bool `json:"shared_instances"`
+}
+
+func (rs *Resource) getStudentDeleteImpact(w http.ResponseWriter, r *http.Request) {
+	student, ok := rs.parseAndGetStudent(w, r)
+	if !ok {
+		return
+	}
+	authorized, authErr := canDeleteStudent(
+		r.Context(),
+		jwt.PermissionsFromCtx(r.Context()),
+		student,
+		rs.UserContextService,
+	)
+	if !authorized {
+		renderError(w, r, common.ErrorForbidden(authErr))
+		return
+	}
+	if rs.StudentDeletionService == nil {
+		renderError(w, r, common.ErrorInternalServer(errors.New("student deletion service not configured")))
+		return
+	}
+	impact, err := rs.StudentDeletionService.Preview(r.Context(), student.ID)
+	if err != nil {
+		renderError(w, r, studentDeletionErrorRenderer(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, studentDeleteImpactResponse{
+		ConfirmationName: impact.ConfirmationName,
+		Fingerprint:      impact.Fingerprint,
+		Total:            impact.Counts.Total(),
+		Counts:           impact.Counts,
+		Preserved: studentDeletePreservedDataResponse{
+			GuardianProfiles: true,
+			ParentAccounts:   true,
+			OtherStudents:    true,
+			SharedInstances:  true,
+		},
+	}, "Student deletion impact retrieved")
+}
+
+type studentDeleteRequest struct {
+	ExpectedFingerprint string `json:"expected_fingerprint"`
+	ConfirmationName    string `json:"confirmation_name"`
+	Reason              string `json:"reason"`
+	Acknowledged        bool   `json:"acknowledged"`
+}
+
+func (req *studentDeleteRequest) Bind(_ *http.Request) error {
+	if strings.TrimSpace(req.ExpectedFingerprint) == "" {
+		return errors.New("expected_fingerprint is required")
+	}
+	if strings.TrimSpace(req.ConfirmationName) == "" {
+		return errors.New("confirmation_name is required")
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return errors.New("reason is required")
+	}
+	if !req.Acknowledged {
+		return userService.ErrStudentDeletionNotAcknowledged
+	}
+	return nil
+}
+
+func (rs *Resource) deleteStudentWithData(w http.ResponseWriter, r *http.Request, student *users.Student) {
+	if rs.StudentDeletionService == nil {
+		renderError(w, r, common.ErrorInternalServer(errors.New("student deletion service not configured")))
+		return
+	}
+	body := new(studentDeleteRequest)
+	if err := render.Bind(r, body); err != nil {
+		renderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	actorAccountID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	err := tenant.WithTenantTx(r.Context(), rs.DB, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		result, deleteErr := rs.StudentDeletionService.Delete(ctx, userService.StudentDeletionInput{
+			StudentID:           student.ID,
+			ActorAccountID:      actorAccountID,
+			ExpectedFingerprint: body.ExpectedFingerprint,
+			ConfirmationName:    body.ConfirmationName,
+			Reason:              body.Reason,
+			Acknowledged:        body.Acknowledged,
+		})
+		if deleteErr != nil {
+			return deleteErr
+		}
+		if rs.StudentPhotos != nil {
+			rs.StudentPhotos.ScheduleUnlinkAfterCommit(ctx, result.PhotoPath)
+		}
+		if len(result.CompanionIDs) > 0 {
+			studentID := student.ID
+			tenant.RegisterAfterCommit(ctx, func() {
+				rs.broadcastStudentCompanionsChanged(tenantID, studentID)
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		tenant.MarkRollback(r.Context())
+		renderError(w, r, studentDeletionErrorRenderer(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, nil, "Student and linked data deleted successfully")
 }
 
 // purgeGraduatedStudent hard-deletes a child that a grade transition graduated.
@@ -1683,3 +1816,16 @@ func deleteStudentTxErrorRenderer(err error) render.Renderer {
 		return common.ErrorInternalServer(err)
 	}
 }
+
+var studentDeletionErrorRenderer = common.RulesRenderer([]common.ErrorRule{
+	{Target: userService.ErrStudentDeletionPreviewChanged, Render: common.ErrorConflict},
+	{Target: userService.ErrStudentDeletionConfirmationMismatch, Render: common.ErrorInvalidRequest},
+	{Target: userService.ErrStudentDeletionNotAcknowledged, Render: common.ErrorInvalidRequest},
+	{Target: userService.ErrStudentDeletionInvalidReason, Render: common.ErrorInvalidRequest},
+	{Target: userService.ErrStudentDeletionAlumnus, Render: common.ErrorConflict},
+	{Target: userService.ErrCompanionWouldLoseDeparture, Render: common.ErrorConflict},
+	{Target: userService.ErrCompanionLockBusy, Render: common.ErrorConflict},
+	{Match: common.IsConstraintViolation, Render: func(error) render.Renderer {
+		return common.ErrorConflictMessage("Kind konnte wegen gleichzeitig geänderter Verknüpfungen nicht gelöscht werden. Bitte erneut prüfen.")
+	}},
+}, common.ErrorInternalServer)

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -326,6 +326,7 @@ GET /api/students/{id}/change-history
 GET /api/students/{id}/companions
 GET /api/students/{id}/current-location
 GET /api/students/{id}/current-visit
+GET /api/students/{id}/delete-impact
 GET /api/students/{id}/enrollment-extra-fields
 GET /api/students/{id}/in-group-room
 GET /api/students/{id}/photo/{filename}

--- a/backend/database/migrations/001015242_student_deletions_audit.go
+++ b/backend/database/migrations/001015242_student_deletions_audit.go
@@ -1,0 +1,76 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	studentDeletionsAuditVersion     = "1.15.242"
+	studentDeletionsAuditDescription = "Create data-minimal audit trail for permanent student deletion (#2068)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     studentDeletionsAuditVersion,
+		Description: studentDeletionsAuditDescription,
+		DependsOn:   []string{parentSuggestionsVersion},
+	})
+
+	Migrations.MustRegister(studentDeletionsAuditUp, studentDeletionsAuditDown)
+}
+
+func studentDeletionsAuditUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.242: Creating audit.student_deletions...")
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS audit.student_deletions (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			student_id BIGINT NOT NULL,
+			actor_account_id BIGINT NOT NULL,
+			reason TEXT NOT NULL CHECK (reason IN ('test_data', 'incorrect_entry', 'duplicate', 'privacy_request')),
+			counts JSONB NOT NULL,
+			deleted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_student_deletions_student
+			ON audit.student_deletions (tenant_id, student_id, deleted_at DESC);
+		CREATE INDEX IF NOT EXISTS idx_student_deletions_actor
+			ON audit.student_deletions (tenant_id, actor_account_id, deleted_at DESC);
+
+		ALTER TABLE audit.student_deletions ENABLE ROW LEVEL SECURITY;
+		DO $$
+		BEGIN
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_policies
+				WHERE schemaname = 'audit'
+				  AND tablename = 'student_deletions'
+				  AND policyname = 'tenant_isolation_audit_student_deletions'
+			) THEN
+				CREATE POLICY tenant_isolation_audit_student_deletions ON audit.student_deletions
+					FOR ALL
+					USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+					WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+			END IF;
+		END $$;
+		ALTER TABLE audit.student_deletions FORCE ROW LEVEL SECURITY;
+
+		GRANT SELECT, INSERT ON audit.student_deletions TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE audit.student_deletions_id_seq TO phoenix_tenant;
+		REVOKE UPDATE, DELETE, TRUNCATE ON audit.student_deletions FROM phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("create audit.student_deletions: %w", err)
+	}
+	return nil
+}
+
+func studentDeletionsAuditDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.242: Dropping audit.student_deletions...")
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS audit.student_deletions CASCADE`); err != nil {
+		return fmt.Errorf("drop audit.student_deletions: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015242_student_deletions_audit_test.go
+++ b/backend/database/migrations/001015242_student_deletions_audit_test.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func studentDeletionAuditColumnExists(t *testing.T, db *bun.DB, column string) bool {
+	t.Helper()
+	var exists bool
+	require.NoError(t, db.NewRaw(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'audit'
+			  AND table_name = 'student_deletions'
+			  AND column_name = ?
+		)
+	`, column).Scan(context.Background(), &exists))
+	return exists
+}
+
+func TestStudentDeletionsAuditMigration(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	// Exercise the migration from a clean relation and leave the fully migrated
+	// schema behind for packages sharing the test database.
+	require.NoError(t, studentDeletionsAuditDown(ctx, db))
+	t.Cleanup(func() {
+		require.NoError(t, studentDeletionsAuditUp(context.Background(), db))
+	})
+	require.NoError(t, studentDeletionsAuditUp(ctx, db))
+	require.NoError(t, studentDeletionsAuditUp(ctx, db), "up must be idempotent")
+
+	for _, column := range []string{
+		"tenant_id",
+		"student_id",
+		"actor_account_id",
+		"reason",
+		"counts",
+		"deleted_at",
+	} {
+		assert.True(t, studentDeletionAuditColumnExists(t, db, column), column)
+	}
+
+	var policyCount int
+	require.NoError(t, db.NewRaw(`
+		SELECT COUNT(*) FROM pg_policies
+		WHERE schemaname = 'audit'
+		  AND tablename = 'student_deletions'
+		  AND policyname = 'tenant_isolation_audit_student_deletions'
+	`).Scan(ctx, &policyCount))
+	assert.Equal(t, 1, policyCount)
+
+	for privilege, want := range map[string]bool{
+		"SELECT":   true,
+		"INSERT":   true,
+		"UPDATE":   false,
+		"DELETE":   false,
+		"TRUNCATE": false,
+	} {
+		var got bool
+		require.NoError(t, db.NewRaw(
+			`SELECT has_table_privilege('phoenix_tenant', 'audit.student_deletions', ?)`,
+			privilege,
+		).Scan(ctx, &got))
+		assert.Equal(t, want, got, privilege)
+	}
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	t.Cleanup(func() {
+		_, _ = db.NewDelete().TableExpr("platform.schools").Where("id = ?", tenantID).Exec(context.Background())
+		_, _ = db.NewDelete().TableExpr("platform.organizations").Where("id = ?", tenantID).Exec(context.Background())
+	})
+	_, err := db.NewRaw(`
+		INSERT INTO audit.student_deletions
+			(tenant_id, student_id, actor_account_id, reason, counts)
+		VALUES (?, ?, ?, 'test_data', '{}'::jsonb)
+	`, tenantID, tenantID+1, tenantID+2).Exec(ctx)
+	require.NoError(t, err)
+}

--- a/backend/database/migrations/001015243_student_deletions_audit.go
+++ b/backend/database/migrations/001015243_student_deletions_audit.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	studentDeletionsAuditVersion     = "1.15.242"
+	studentDeletionsAuditVersion     = "1.15.243"
 	studentDeletionsAuditDescription = "Create data-minimal audit trail for permanent student deletion (#2068)"
 )
 
@@ -23,7 +23,7 @@ func init() {
 }
 
 func studentDeletionsAuditUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.242: Creating audit.student_deletions...")
+	fmt.Println("Migration 1.15.243: Creating audit.student_deletions...")
 	_, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS audit.student_deletions (
 			id BIGSERIAL PRIMARY KEY,
@@ -68,7 +68,7 @@ func studentDeletionsAuditUp(ctx context.Context, db *bun.DB) error {
 }
 
 func studentDeletionsAuditDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.242: Dropping audit.student_deletions...")
+	fmt.Println("Rolling back migration 1.15.243: Dropping audit.student_deletions...")
 	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS audit.student_deletions CASCADE`); err != nil {
 		return fmt.Errorf("drop audit.student_deletions: %w", err)
 	}

--- a/backend/database/migrations/001015243_student_deletions_audit_test.go
+++ b/backend/database/migrations/001015243_student_deletions_audit_test.go
@@ -36,6 +36,7 @@ func TestStudentDeletionsAuditMigration(t *testing.T) {
 	require.NoError(t, studentDeletionsAuditDown(ctx, db))
 	t.Cleanup(func() {
 		require.NoError(t, studentDeletionsAuditUp(context.Background(), db))
+		require.NoError(t, studentDeletionGraduatePurgeReasonUp(context.Background(), db))
 	})
 	require.NoError(t, studentDeletionsAuditUp(ctx, db))
 	require.NoError(t, studentDeletionsAuditUp(ctx, db), "up must be idempotent")

--- a/backend/database/migrations/001015243_student_deletions_audit_test.go
+++ b/backend/database/migrations/001015243_student_deletions_audit_test.go
@@ -1,5 +1,7 @@
 package migrations
 
+// The filename follows the migration version to make collision checks auditable.
+
 import (
 	"context"
 	"testing"

--- a/backend/database/migrations/001015244_preserve_student_deletion_audit.go
+++ b/backend/database/migrations/001015244_preserve_student_deletion_audit.go
@@ -1,0 +1,87 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	preserveStudentDeletionAuditVersion     = "1.15.244"
+	preserveStudentDeletionAuditDescription = "Preserve data-deletion audit records after permanent student deletion (#2068)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     preserveStudentDeletionAuditVersion,
+		Description: preserveStudentDeletionAuditDescription,
+		DependsOn:   []string{studentDeletionsAuditVersion},
+	})
+
+	Migrations.MustRegister(preserveStudentDeletionAuditUp, preserveStudentDeletionAuditDown)
+}
+
+func preserveStudentDeletionAuditUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.244: Preserving data-deletion audit records for deleted students...")
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE audit.data_deletions
+			DROP CONSTRAINT IF EXISTS fk_data_deletions_student;
+
+		-- Ferienbetreuung visits belong to the hosting tenant and are therefore
+		-- hidden by active.visits RLS from the child's home tenant. The function
+		-- only returns a count and verifies that the requested child belongs to
+		-- that home tenant before bypassing RLS.
+		CREATE OR REPLACE FUNCTION active.count_student_visits_for_deletion(
+			p_tenant_id BIGINT,
+			p_student_id BIGINT
+		)
+		RETURNS INTEGER
+		LANGUAGE sql
+		STABLE
+		SECURITY DEFINER
+		SET search_path = pg_catalog, active, users
+		AS $$
+			SELECT COUNT(*)::INTEGER
+			FROM active.visits AS visit
+			JOIN users.students AS student ON student.id = visit.student_id
+			WHERE visit.student_id = p_student_id
+			  AND student.tenant_id = p_tenant_id
+			  AND (
+				NULLIF(current_setting('app.current_tenant_id', true), '') IS NULL
+				OR student.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::BIGINT
+			  );
+		$$;
+		REVOKE ALL ON FUNCTION active.count_student_visits_for_deletion(BIGINT, BIGINT) FROM PUBLIC;
+		GRANT EXECUTE ON FUNCTION active.count_student_visits_for_deletion(BIGINT, BIGINT) TO phoenix_tenant;
+	`); err != nil {
+		return fmt.Errorf("preserve student deletion audit records: %w", err)
+	}
+	return nil
+}
+
+func preserveStudentDeletionAuditDown(ctx context.Context, db *bun.DB) error {
+	var orphanedRows int
+	if err := db.NewRaw(`
+		SELECT COUNT(*)
+		FROM audit.data_deletions AS deletion
+		LEFT JOIN users.students AS student ON student.id = deletion.student_id
+		WHERE deletion.student_id IS NOT NULL AND student.id IS NULL
+	`).Scan(ctx, &orphanedRows); err != nil {
+		return fmt.Errorf("check preserved student deletion audit records: %w", err)
+	}
+	if orphanedRows > 0 {
+		return fmt.Errorf("cannot restore data_deletions student foreign key while %d preserved deletion audit records exist", orphanedRows)
+	}
+	if _, err := db.ExecContext(ctx, `DROP FUNCTION IF EXISTS active.count_student_visits_for_deletion(BIGINT, BIGINT);`); err != nil {
+		return fmt.Errorf("drop cross-tenant visit count function: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE audit.data_deletions
+			ADD CONSTRAINT fk_data_deletions_student
+			FOREIGN KEY (student_id) REFERENCES users.students(id) ON DELETE CASCADE;
+	`); err != nil {
+		return fmt.Errorf("restore data_deletions student foreign key: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015244_preserve_student_deletion_audit_test.go
+++ b/backend/database/migrations/001015244_preserve_student_deletion_audit_test.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreserveStudentDeletionAuditMigration(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var foreignKeyExists bool
+	require.NoError(t, db.NewRaw(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_constraint
+			WHERE conrelid = 'audit.data_deletions'::regclass
+			  AND conname = 'fk_data_deletions_student'
+		)
+	`).Scan(context.Background(), &foreignKeyExists))
+	assert.False(t, foreignKeyExists, "permanent deletion audit rows must outlive their student")
+
+	var functionExists bool
+	require.NoError(t, db.NewRaw(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_proc
+			WHERE oid = 'active.count_student_visits_for_deletion(bigint,bigint)'::regprocedure
+		)
+	`).Scan(context.Background(), &functionExists))
+	assert.True(t, functionExists)
+}

--- a/backend/database/migrations/001015245_student_deletion_graduate_purge_reason.go
+++ b/backend/database/migrations/001015245_student_deletion_graduate_purge_reason.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	studentDeletionGraduatePurgeReasonVersion     = "1.15.245"
+	studentDeletionGraduatePurgeReasonDescription = "Audit permanent graduate purges with a dedicated deletion reason (#2068)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     studentDeletionGraduatePurgeReasonVersion,
+		Description: studentDeletionGraduatePurgeReasonDescription,
+		DependsOn:   []string{preserveStudentDeletionAuditVersion},
+	})
+
+	Migrations.MustRegister(studentDeletionGraduatePurgeReasonUp, studentDeletionGraduatePurgeReasonDown)
+}
+
+func studentDeletionGraduatePurgeReasonUp(ctx context.Context, db *bun.DB) error {
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE audit.student_deletions
+			DROP CONSTRAINT IF EXISTS student_deletions_reason_check,
+			ADD CONSTRAINT student_deletions_reason_check
+			CHECK (reason IN ('test_data', 'incorrect_entry', 'duplicate', 'privacy_request', 'graduate_purge'));
+	`); err != nil {
+		return fmt.Errorf("add graduate purge deletion reason: %w", err)
+	}
+	return nil
+}
+
+func studentDeletionGraduatePurgeReasonDown(ctx context.Context, db *bun.DB) error {
+	var graduatePurgeRows int
+	if err := db.NewRaw(`
+		SELECT COUNT(*) FROM audit.student_deletions WHERE reason = 'graduate_purge'
+	`).Scan(ctx, &graduatePurgeRows); err != nil {
+		return fmt.Errorf("check graduate purge deletion audits: %w", err)
+	}
+	if graduatePurgeRows > 0 {
+		return fmt.Errorf("cannot remove graduate_purge deletion reason while %d audit records exist", graduatePurgeRows)
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE audit.student_deletions
+			DROP CONSTRAINT IF EXISTS student_deletions_reason_check,
+			ADD CONSTRAINT student_deletions_reason_check
+			CHECK (reason IN ('test_data', 'incorrect_entry', 'duplicate', 'privacy_request'));
+	`); err != nil {
+		return fmt.Errorf("remove graduate purge deletion reason: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/audit/student_deletion.go
+++ b/backend/database/repositories/audit/student_deletion.go
@@ -1,0 +1,33 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/uptrace/bun"
+)
+
+type StudentDeletionRepository struct {
+	db *bun.DB
+}
+
+func NewStudentDeletionRepository(db *bun.DB) auditModels.StudentDeletionRepository {
+	return &StudentDeletionRepository{db: db}
+}
+
+func (r *StudentDeletionRepository) Create(ctx context.Context, event *auditModels.StudentDeletion) error {
+	if event == nil {
+		return fmt.Errorf("student deletion audit event is required")
+	}
+	base.EnsureTenantID(ctx, event)
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(event).
+		ModelTableExpr(`audit.student_deletions AS "student_deletion"`).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("create student deletion audit event: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/audit/student_deletion_repository_test.go
+++ b/backend/database/repositories/audit/student_deletion_repository_test.go
@@ -1,0 +1,28 @@
+package audit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStudentDeletionRepository_Create(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	repo := repositories.NewFactory(db).StudentDeletionAudit
+
+	assert.ErrorContains(t, repo.Create(context.Background(), nil), "audit event is required")
+
+	event := &auditModels.StudentDeletion{StudentID: 99, ActorAccountID: 42, Reason: "test_data"}
+	require.NoError(t, repo.Create(testpkg.TenantContext(1), event))
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "audit.student_deletions", event.ID)
+	})
+	assert.Equal(t, int64(1), event.TenantID)
+	assert.Positive(t, event.ID)
+}

--- a/backend/database/repositories/audit/student_deletion_repository_test.go
+++ b/backend/database/repositories/audit/student_deletion_repository_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,10 +20,12 @@ func TestStudentDeletionRepository_Create(t *testing.T) {
 	assert.ErrorContains(t, repo.Create(context.Background(), nil), "audit event is required")
 
 	event := &auditModels.StudentDeletion{StudentID: 99, ActorAccountID: 42, Reason: "test_data"}
-	require.NoError(t, repo.Create(testpkg.TenantContext(1), event))
+	ctx := testpkg.TenantContext(1)
+	expectedTenantID := tenant.FromContext(ctx)
+	require.NoError(t, repo.Create(ctx, event))
 	t.Cleanup(func() {
 		testpkg.CleanupTableRecords(t, db, "audit.student_deletions", event.ID)
 	})
-	assert.Equal(t, int64(1), event.TenantID)
+	assert.Equal(t, expectedTenantID, event.TenantID)
 	assert.Positive(t, event.ID)
 }

--- a/backend/database/repositories/education/grade_transition.go
+++ b/backend/database/repositories/education/grade_transition.go
@@ -1092,21 +1092,23 @@ func (r *GradeTransitionRepository) FindStudentStatesByIDs(ctx context.Context, 
 	return states, nil
 }
 
-// AnonymizeHistoryForStudent replaces the stored name on every ledger row of a
-// student that has just been hard-deleted.
+// AnonymizeHistoryForStudent replaces the stored name and clears the stored
+// RFID identifier on every ledger row of a student that has just been
+// hard-deleted.
 //
 // Without it the "endgültig löschen" the UI promises would be a half-truth:
 // grade_transition_history.person_name is a denormalized copy of the child's
 // name that carries no foreign key, so it survives the delete of both the
-// student and the person row and would keep naming the child indefinitely.
+// student and the person row and would keep identifying the child indefinitely.
 func (r *GradeTransitionRepository) AnonymizeHistoryForStudent(ctx context.Context, studentID int64) error {
 	updQuery := base.GetDB(ctx, r.db).NewUpdate().
 		Model((*struct{})(nil)).
 		ModelTableExpr(`education.grade_transition_history AS "history"`).
 		Set("person_name = ?", PurgedStudentPlaceholder).
+		Set("rfid_tag = NULL").
 		Set("updated_at = NOW()").
 		Where(`"history".student_id = ?`, studentID).
-		Where(`"history".person_name <> ?`, PurgedStudentPlaceholder)
+		Where(`("history".person_name <> ? OR "history".rfid_tag IS NOT NULL)`, PurgedStudentPlaceholder)
 
 	updQuery = base.WithTenantFilter(ctx, updQuery, "history")
 

--- a/backend/database/repositories/education/grade_transition_students_test.go
+++ b/backend/database/repositories/education/grade_transition_students_test.go
@@ -283,6 +283,7 @@ func TestGradeTransitionRepository_AnonymizeHistoryForStudent(t *testing.T) {
 	defer testpkg.CleanupActivityFixtures(t, db, purged.ID)
 	kept := testpkg.CreateTestStudent(t, db, "Bleibendes", "Kind", fmt.Sprintf("4anon-%s", suffix))
 	defer testpkg.CleanupActivityFixtures(t, db, kept.ID)
+	rfidTag := "rfid-deleted-student"
 
 	require.NoError(t, repo.CreateHistoryBatch(ctx, []*educationModels.GradeTransitionHistory{
 		{
@@ -291,6 +292,7 @@ func TestGradeTransitionRepository_AnonymizeHistoryForStudent(t *testing.T) {
 			PersonName:   "Mika Muster",
 			FromClass:    "4a",
 			Action:       educationModels.ActionGraduated,
+			RFIDTag:      &rfidTag,
 		},
 		{
 			TransitionID: transition.ID,
@@ -301,16 +303,16 @@ func TestGradeTransitionRepository_AnonymizeHistoryForStudent(t *testing.T) {
 		},
 	}))
 
-	nameOf := func(studentID int64) string {
+	historyOf := func(studentID int64) *educationModels.GradeTransitionHistory {
 		records, err := repo.GetHistory(ctx, transition.ID)
 		require.NoError(t, err)
 		for _, record := range records {
 			if record.StudentID == studentID {
-				return record.PersonName
+				return record
 			}
 		}
 		t.Fatalf("no ledger row for student %d", studentID)
-		return ""
+		return nil
 	}
 
 	require.NoError(t, repo.AnonymizeHistoryForStudent(ctx, purged.ID))
@@ -318,12 +320,15 @@ func TestGradeTransitionRepository_AnonymizeHistoryForStudent(t *testing.T) {
 	// person_name is a denormalized copy with no foreign key: it survives the
 	// hard delete of both the student and the person row, so "endgültig löschen"
 	// is only true once this replaced it.
-	assert.Equal(t, education.PurgedStudentPlaceholder, nameOf(purged.ID))
-	assert.Equal(t, "Nina Beispiel", nameOf(kept.ID), "only the purged child's rows may change")
+	assert.Equal(t, education.PurgedStudentPlaceholder, historyOf(purged.ID).PersonName)
+	assert.Nil(t, historyOf(purged.ID).RFIDTag)
+	assert.Equal(t, "Nina Beispiel", historyOf(kept.ID).PersonName, "only the purged child's rows may change")
 
-	// Idempotent: the second call matches no row thanks to the <> guard.
+	// Idempotent: the second call matches no row after both identifying fields
+	// have been cleared.
 	require.NoError(t, repo.AnonymizeHistoryForStudent(ctx, purged.ID))
-	assert.Equal(t, education.PurgedStudentPlaceholder, nameOf(purged.ID))
+	assert.Equal(t, education.PurgedStudentPlaceholder, historyOf(purged.ID).PersonName)
+	assert.Nil(t, historyOf(purged.ID).RFIDTag)
 }
 
 func TestGradeTransitionRepository_GetMappingsByTransitionIDs(t *testing.T) {

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -70,6 +70,7 @@ type Factory struct {
 	RFIDCard            userModels.RFIDCardRepository
 	Staff               userModels.StaffRepository
 	Student             userModels.StudentRepository
+	StudentDeletion     userModels.StudentDeletionRepository
 	Teacher             userModels.TeacherRepository
 	Guest               userModels.GuestRepository
 	Profile             userModels.ProfileRepository
@@ -161,6 +162,7 @@ type Factory struct {
 
 	// Audit domain
 	DataDeletion                 auditModels.DataDeletionRepository
+	StudentDeletionAudit         auditModels.StudentDeletionRepository
 	EnrollmentDeletionAudit      auditModels.EnrollmentDeletionRepository
 	DataAccessLog                auditModels.DataAccessLogRepository
 	EnrollmentOfferingAdjustment auditModels.EnrollmentOfferingAdjustmentRepository
@@ -266,6 +268,7 @@ func NewFactory(db *bun.DB) *Factory {
 		RFIDCard:            users.NewRFIDCardRepository(db),
 		Staff:               users.NewStaffRepository(db),
 		Student:             users.NewStudentRepository(db),
+		StudentDeletion:     users.NewStudentDeletionRepository(db),
 		Teacher:             users.NewTeacherRepository(db),
 		Guest:               users.NewGuestRepository(db),
 		Profile:             users.NewProfileRepository(db),
@@ -357,6 +360,7 @@ func NewFactory(db *bun.DB) *Factory {
 
 		// Audit repositories
 		DataDeletion:                 audit.NewDataDeletionRepository(db),
+		StudentDeletionAudit:         audit.NewStudentDeletionRepository(db),
 		EnrollmentDeletionAudit:      audit.NewEnrollmentDeletionRepository(db),
 		DataAccessLog:                audit.NewDataAccessLogRepository(db),
 		EnrollmentOfferingAdjustment: audit.NewEnrollmentOfferingAdjustmentRepository(db),

--- a/backend/database/repositories/users/student_deletion.go
+++ b/backend/database/repositories/users/student_deletion.go
@@ -34,7 +34,7 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 			(SELECT COUNT(*) FROM schedule.instance_students WHERE tenant_id = ? AND student_id = ?)::int AS timetable_assignments,
 			(SELECT COUNT(*) FROM activities.student_enrollments WHERE tenant_id = ? AND student_id = ?)::int AS activity_enrollments,
 			(
-				(SELECT COUNT(*) FROM active.visits WHERE tenant_id = ? AND student_id = ?) +
+				active.count_student_visits_for_deletion(?, ?) +
 				(SELECT COUNT(*) FROM active.attendance WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM active.student_status_days WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM active.scheduled_checkouts WHERE tenant_id = ? AND student_id = ?) +

--- a/backend/database/repositories/users/student_deletion.go
+++ b/backend/database/repositories/users/student_deletion.go
@@ -56,6 +56,14 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 			(
 				(SELECT COUNT(*) FROM users.parent_message_threads WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM users.parent_messages WHERE tenant_id = ? AND student_id = ?) +
+				(
+					SELECT COUNT(*)
+					FROM users.parent_message_reads AS "parent_message_read"
+					JOIN users.parent_message_threads AS "parent_message_thread"
+						ON "parent_message_thread".id = "parent_message_read".thread_id
+						AND "parent_message_thread".tenant_id = "parent_message_read".tenant_id
+					WHERE "parent_message_read".tenant_id = ? AND "parent_message_thread".student_id = ?
+				) +
 				(SELECT COUNT(*) FROM users.student_data_change_requests WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM schedule.care_schedule_change_requests WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM auth.guardian_invitations WHERE tenant_id = ? AND student_id = ?)
@@ -68,7 +76,8 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 				(SELECT COUNT(*) FROM audit.enrollment_offering_adjustments WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.guardian_changes WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.student_field_edits WHERE tenant_id = ? AND student_id = ?) +
-				(SELECT COUNT(*) FROM schedule.grade_transition_roster_removals WHERE tenant_id = ? AND student_id = ?)
+				(SELECT COUNT(*) FROM schedule.grade_transition_roster_removals WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM education.grade_transition_history WHERE tenant_id = ? AND student_id = ? AND person_name <> 'Gelöschtes Kind')
 			)::int AS other_records
 	`,
 		tenantID, studentID,
@@ -77,10 +86,10 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 		tenantID, studentID, tenantID, tenantID, studentID,
 		tenantID, studentID, studentID,
-		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 		tenantID, studentID,
 		tenantID, studentID, studentID,
-		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 	).Scan(ctx, counts)
 	if err != nil {
 		return nil, fmt.Errorf("preview student deletion: %w", err)

--- a/backend/database/repositories/users/student_deletion.go
+++ b/backend/database/repositories/users/student_deletion.go
@@ -66,7 +66,6 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 				(SELECT COUNT(*) FROM feedback.entries WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM calendar.appointment_recipient_students WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.data_access_log WHERE tenant_id = ? AND student_id = ?) +
-				(SELECT COUNT(*) FROM audit.data_deletions WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.enrollment_offering_adjustments WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.guardian_changes WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.student_field_edits WHERE tenant_id = ? AND student_id = ?) +
@@ -82,7 +81,7 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 		tenantID, studentID,
 		tenantID, studentID, studentID,
-		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 	).Scan(ctx, counts)
 	if err != nil {
 		return nil, fmt.Errorf("preview student deletion: %w", err)

--- a/backend/database/repositories/users/student_deletion.go
+++ b/backend/database/repositories/users/student_deletion.go
@@ -1,0 +1,169 @@
+package users
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// StudentDeletionRepository owns the deliberately cross-schema preview for a
+// permanent child deletion. Keeping the counts together prevents the UI
+// preview and the transactional stale-preview check from drifting apart.
+type StudentDeletionRepository struct {
+	db *bun.DB
+}
+
+func NewStudentDeletionRepository(db *bun.DB) userModels.StudentDeletionRepository {
+	return &StudentDeletionRepository{db: db}
+}
+
+func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64) (*userModels.StudentDeletionCounts, error) {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return nil, fmt.Errorf("preview student deletion: tenant context is required")
+	}
+
+	counts := new(userModels.StudentDeletionCounts)
+	err := base.GetDB(ctx, r.db).NewRaw(`
+		SELECT
+			(SELECT COUNT(*) FROM schedule.instance_students WHERE tenant_id = ? AND student_id = ?)::int AS timetable_assignments,
+			(SELECT COUNT(*) FROM activities.student_enrollments WHERE tenant_id = ? AND student_id = ?)::int AS activity_enrollments,
+			(
+				(SELECT COUNT(*) FROM active.visits WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM active.attendance WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM active.student_status_days WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM active.scheduled_checkouts WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM active.excused_absence_requests WHERE tenant_id = ? AND student_id = ?)
+			)::int AS attendance_records,
+			(
+				(SELECT COUNT(*) FROM schedule.student_pickup_schedules WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.student_pickup_exceptions WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.student_pickup_notes WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.student_arrival_schedules WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.student_arrival_exceptions WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.student_arrival_notes WHERE tenant_id = ? AND student_id = ?)
+			)::int AS care_schedules,
+			(
+				(SELECT COUNT(*) FROM users.students_guardians WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM users.persons_guardians WHERE tenant_id = ? AND person_id = (SELECT person_id FROM users.students WHERE tenant_id = ? AND id = ?))
+			)::int AS guardian_links,
+			(SELECT COUNT(*) FROM users.student_companions WHERE tenant_id = ? AND (student_low_id = ? OR student_high_id = ?))::int AS companion_links,
+			(
+				(SELECT COUNT(*) FROM users.parent_message_threads WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM users.parent_messages WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM users.student_data_change_requests WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.care_schedule_change_requests WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM auth.guardian_invitations WHERE tenant_id = ? AND student_id = ?)
+			)::int AS communications,
+			(SELECT COUNT(*) FROM users.privacy_consents WHERE tenant_id = ? AND student_id = ?)::int AS consents,
+			(SELECT COUNT(*) FROM enrollment.request_children WHERE tenant_id = ? AND (created_student_id = ? OR matched_student_id = ?))::int AS enrollment_references,
+			(
+				(SELECT COUNT(*) FROM feedback.entries WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM calendar.appointment_recipient_students WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM audit.data_access_log WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM audit.data_deletions WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM audit.enrollment_offering_adjustments WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM audit.guardian_changes WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM audit.student_field_edits WHERE tenant_id = ? AND student_id = ?) +
+				(SELECT COUNT(*) FROM schedule.grade_transition_roster_removals WHERE tenant_id = ? AND student_id = ?)
+			)::int AS other_records
+	`,
+		tenantID, studentID,
+		tenantID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID, tenantID, tenantID, studentID,
+		tenantID, studentID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID,
+		tenantID, studentID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+	).Scan(ctx, counts)
+	if err != nil {
+		return nil, fmt.Errorf("preview student deletion: %w", err)
+	}
+	return counts, nil
+}
+
+// DeleteLegacyGuardianLinks removes relationships from the superseded
+// person-based guardian junction. Current guardian links cascade from the
+// student row; these do not because the anonymized person tombstone remains.
+func (r *StudentDeletionRepository) DeleteLegacyGuardianLinks(ctx context.Context, personID int64) error {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return fmt.Errorf("delete legacy student guardian links: tenant context is required")
+	}
+	_, err := base.GetDB(ctx, r.db).NewDelete().
+		TableExpr(`users.persons_guardians AS "person_guardian"`).
+		Where(`"person_guardian".tenant_id = ?`, tenantID).
+		Where(`"person_guardian".person_id = ?`, personID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("delete legacy student guardian links: %w", err)
+	}
+	return nil
+}
+
+// AnonymizePersonIfUnchanged removes the child's remaining direct identifiers
+// and creates the soft-deleted person tombstone only if the previewed person
+// row is still current. The updated_at predicate closes the race between name
+// confirmation and a concurrent person edit.
+func (r *StudentDeletionRepository) AnonymizePersonIfUnchanged(
+	ctx context.Context,
+	personID int64,
+	updatedAt time.Time,
+) (bool, error) {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return false, fmt.Errorf("anonymize deleted student person: tenant context is required")
+	}
+	result, err := base.GetDB(ctx, r.db).NewUpdate().
+		TableExpr(`users.persons AS "person"`).
+		Set(`first_name = ?`, "Gelöscht").
+		Set(`last_name = ?`, "Benutzer").
+		Set(`birthday = NULL`).
+		Set(`tag_id = NULL`).
+		Set(`account_id = NULL`).
+		Set(`deleted_at = NOW()`).
+		Where(`"person".tenant_id = ?`, tenantID).
+		Where(`"person".id = ?`, personID).
+		Where(`"person".updated_at = ?`, updatedAt).
+		Where(`"person".deleted_at IS NULL`).
+		Exec(ctx)
+	if err != nil {
+		return false, fmt.Errorf("anonymize deleted student person: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("count anonymized deleted student persons: %w", err)
+	}
+	return rows == 1, nil
+}
+
+// DeleteTimetableAssignments removes only the child rows from shared
+// activity instances. The instance itself and every other child's assignment
+// remain untouched.
+func (r *StudentDeletionRepository) DeleteTimetableAssignments(ctx context.Context, studentID int64) (int64, error) {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return 0, fmt.Errorf("delete student timetable assignments: tenant context is required")
+	}
+	result, err := base.GetDB(ctx, r.db).NewDelete().
+		TableExpr(`schedule.instance_students AS "instance_student"`).
+		Where(`"instance_student".tenant_id = ?`, tenantID).
+		Where(`"instance_student".student_id = ?`, studentID).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("delete student timetable assignments: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count deleted student timetable assignments: %w", err)
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/users/student_deletion.go
+++ b/backend/database/repositories/users/student_deletion.go
@@ -65,7 +65,6 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 			(
 				(SELECT COUNT(*) FROM feedback.entries WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM calendar.appointment_recipient_students WHERE tenant_id = ? AND student_id = ?) +
-				(SELECT COUNT(*) FROM audit.data_access_log WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.enrollment_offering_adjustments WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.guardian_changes WHERE tenant_id = ? AND student_id = ?) +
 				(SELECT COUNT(*) FROM audit.student_field_edits WHERE tenant_id = ? AND student_id = ?) +
@@ -81,7 +80,7 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 		tenantID, studentID,
 		tenantID, studentID, studentID,
-		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
+		tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID, tenantID, studentID,
 	).Scan(ctx, counts)
 	if err != nil {
 		return nil, fmt.Errorf("preview student deletion: %w", err)

--- a/backend/database/repositories/users/student_deletion.go
+++ b/backend/database/repositories/users/student_deletion.go
@@ -97,6 +97,31 @@ func (r *StudentDeletionRepository) Preview(ctx context.Context, studentID int64
 	return counts, nil
 }
 
+// LockMessageThreads prevents a read cursor or message from being added after
+// the deletion preview is rechecked. Both rows reference their thread, so the
+// FOR UPDATE lock serializes their FK checks until the deletion commits or
+// rolls back.
+func (r *StudentDeletionRepository) LockMessageThreads(ctx context.Context, studentID int64) error {
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return fmt.Errorf("lock student message threads: tenant context is required")
+	}
+
+	var threadIDs []int64
+	err := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`users.parent_message_threads AS "parent_message_thread"`).
+		ColumnExpr(`"parent_message_thread".id`).
+		Where(`"parent_message_thread".tenant_id = ?`, tenantID).
+		Where(`"parent_message_thread".student_id = ?`, studentID).
+		OrderExpr(`"parent_message_thread".id ASC`).
+		For("UPDATE").
+		Scan(ctx, &threadIDs)
+	if err != nil {
+		return fmt.Errorf("lock student message threads: %w", err)
+	}
+	return nil
+}
+
 // DeleteLegacyGuardianLinks removes relationships from the superseded
 // person-based guardian junction. Current guardian links cascade from the
 // student row; these do not because the anonymized person tombstone remains.

--- a/backend/database/repositories/users/student_deletion_test.go
+++ b/backend/database/repositories/users/student_deletion_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,47 @@ func TestStudentDeletionRepository_RequiresTenantContext(t *testing.T) {
 
 	_, err = repo.DeleteTimetableAssignments(context.Background(), 1)
 	assert.ErrorContains(t, err, "tenant context is required")
+
+	err = repo.LockMessageThreads(context.Background(), 1)
+	assert.ErrorContains(t, err, "tenant context is required")
+}
+
+func TestStudentDeletionRepository_LockMessageThreadsBlocksNewRead(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	target := testpkg.CreateTestStudent(t, db, "DeletePreview", "Locked", "1a")
+	guardian := testpkg.CreateTestAccount(t, db, "delete-preview-message-guardian@example.com")
+	var threadID int64
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
+		VALUES (?, ?, ?)
+		RETURNING id
+	`, target.TenantID, target.ID, guardian.ID).Scan(ctx, &threadID))
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "users.students", target.ID)
+		testpkg.CleanupTableRecords(t, db, "users.persons", target.PersonID)
+		testpkg.CleanupAuthFixtures(t, db, guardian.ID)
+	})
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	txCtx := modelBase.ContextWithTx(ctx, &tx)
+	repo := repositories.NewFactory(db).StudentDeletion
+	require.NoError(t, repo.LockMessageThreads(txCtx, target.ID))
+
+	concurrentTx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = concurrentTx.Rollback() })
+	_, err = concurrentTx.ExecContext(ctx, `SET LOCAL lock_timeout = '100ms'`)
+	require.NoError(t, err)
+	_, err = concurrentTx.ExecContext(ctx, `
+		INSERT INTO users.parent_message_reads (tenant_id, thread_id, account_id)
+		VALUES (?, ?, ?)
+	`, target.TenantID, threadID, guardian.ID)
+	require.Error(t, err, "a read cursor must wait for the locked message thread")
 }
 
 func TestStudentDeletionRepository_DeletesOnlyTargetAssignments(t *testing.T) {

--- a/backend/database/repositories/users/student_deletion_test.go
+++ b/backend/database/repositories/users/student_deletion_test.go
@@ -1,0 +1,73 @@
+package users_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStudentDeletionRepository_DeletesOnlyTargetAssignments(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	target := testpkg.CreateTestStudent(t, db, "DeletePreview", "Target", "1a")
+	spared := testpkg.CreateTestStudent(t, db, "DeletePreview", "Spared", "1a")
+	room := testpkg.CreateTestRoom(t, db, "delete-preview-room")
+	instance := testpkg.CreateTestActivityInstance(t, db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{
+		Title:         "Shared deletion preview instance",
+		IsSpontaneous: true,
+	})
+	targetAssignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, target.ID, "")
+	sparedAssignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, spared.ID, "")
+
+	t.Cleanup(func() {
+		testpkg.CleanupScheduleFixturesB11(t, db, nil, nil, nil, nil,
+			[]int64{targetAssignment.ID, sparedAssignment.ID}, []int64{instance.ID})
+		testpkg.CleanupTableRecords(t, db, "users.students", target.ID, spared.ID)
+		testpkg.CleanupTableRecords(t, db, "users.persons", target.PersonID, spared.PersonID)
+		testpkg.CleanupTableRecords(t, db, "facilities.rooms", room.ID)
+	})
+
+	repo := repositories.NewFactory(db).StudentDeletion
+	preview, err := repo.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, preview.TimetableAssignments)
+
+	deleted, err := repo.DeleteTimetableAssignments(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(preview.TimetableAssignments), deleted)
+
+	var targetCount, sparedCount, instanceCount int
+	require.NoError(t, db.NewSelect().TableExpr(`schedule.instance_students`).ColumnExpr("COUNT(*)").
+		Where("id = ?", targetAssignment.ID).Scan(ctx, &targetCount))
+	require.NoError(t, db.NewSelect().TableExpr(`schedule.instance_students`).ColumnExpr("COUNT(*)").
+		Where("id = ?", sparedAssignment.ID).Scan(ctx, &sparedCount))
+	require.NoError(t, db.NewSelect().TableExpr(`schedule.activity_instances`).ColumnExpr("COUNT(*)").
+		Where("id = ?", instance.ID).Scan(ctx, &instanceCount))
+
+	assert.Zero(t, targetCount)
+	assert.Equal(t, 1, sparedCount)
+	assert.Equal(t, 1, instanceCount)
+
+	person, err := repositories.NewFactory(db).Person.FindByID(ctx, target.PersonID)
+	require.NoError(t, err)
+	_, err = db.NewUpdate().
+		TableExpr(`users.persons AS "person"`).
+		Set(`updated_at = updated_at + INTERVAL '1 second'`).
+		Where(`"person".id = ?`, target.PersonID).
+		Exec(ctx)
+	require.NoError(t, err)
+	anonymized, err := repo.AnonymizePersonIfUnchanged(ctx, target.PersonID, person.UpdatedAt)
+	require.NoError(t, err)
+	assert.False(t, anonymized, "a concurrent person edit must invalidate the confirmed preview")
+
+	var firstName string
+	require.NoError(t, db.NewSelect().TableExpr(`users.persons`).Column("first_name").
+		Where("id = ?", target.PersonID).Scan(ctx, &firstName))
+	assert.Equal(t, "DeletePreview", firstName)
+}

--- a/backend/database/repositories/users/student_deletion_test.go
+++ b/backend/database/repositories/users/student_deletion_test.go
@@ -1,7 +1,9 @@
 package users_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
@@ -10,9 +12,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStudentDeletionRepository_RequiresTenantContext(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	repo := repositories.NewFactory(db).StudentDeletion
+
+	_, err := repo.Preview(context.Background(), 1)
+	assert.ErrorContains(t, err, "tenant context is required")
+
+	err = repo.DeleteLegacyGuardianLinks(context.Background(), 1)
+	assert.ErrorContains(t, err, "tenant context is required")
+
+	_, err = repo.AnonymizePersonIfUnchanged(context.Background(), 1, time.Now())
+	assert.ErrorContains(t, err, "tenant context is required")
+
+	_, err = repo.DeleteTimetableAssignments(context.Background(), 1)
+	assert.ErrorContains(t, err, "tenant context is required")
+}
+
 func TestStudentDeletionRepository_DeletesOnlyTargetAssignments(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
-	defer func() { _ = db.Close() }()
+	t.Cleanup(func() { _ = db.Close() })
 
 	ctx := testpkg.TenantContext(1)
 	target := testpkg.CreateTestStudent(t, db, "DeletePreview", "Target", "1a")

--- a/backend/models/audit/student_deletion.go
+++ b/backend/models/audit/student_deletion.go
@@ -1,0 +1,26 @@
+package audit
+
+import (
+	"context"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// StudentDeletion is an append-only, data-minimal tombstone for a permanently
+// deleted child. It keeps the internal student ID for accountability, but no
+// name, birthday, contact information or snapshot of the erased data.
+type StudentDeletion struct {
+	ID int64 `bun:"id,pk,autoincrement" json:"id"`
+	base.TenantModel
+	StudentID      int64                       `bun:"student_id,notnull" json:"student_id"`
+	ActorAccountID int64                       `bun:"actor_account_id,notnull" json:"actor_account_id"`
+	Reason         string                      `bun:"reason,notnull" json:"reason"`
+	Counts         users.StudentDeletionCounts `bun:"counts,type:jsonb,notnull" json:"counts"`
+	DeletedAt      time.Time                   `bun:"deleted_at,notnull,default:now()" json:"deleted_at"`
+}
+
+type StudentDeletionRepository interface {
+	Create(ctx context.Context, event *StudentDeletion) error
+}

--- a/backend/models/education/grade_transition.go
+++ b/backend/models/education/grade_transition.go
@@ -228,10 +228,10 @@ type GradeTransitionRepository interface {
 	// after graduation. It is the ONE student read without the alumnus filter,
 	// because listing graduates is exactly its purpose.
 	FindStudentStatesByIDs(ctx context.Context, studentIDs []int64) (map[int64]string, error)
-	// AnonymizeHistoryForStudent replaces the denormalized name on the student's
-	// ledger rows. Those rows carry no foreign key and outlive both the student
-	// and the person row, so without this the "endgültig löschen" would leave
-	// the child's name in the database.
+	// AnonymizeHistoryForStudent replaces the denormalized name and clears the
+	// RFID snapshot on the student's ledger rows. Those values carry no foreign
+	// key and outlive both the student and the person row, so without this the
+	// "endgültig löschen" would leave identifying data in the database.
 	AnonymizeHistoryForStudent(ctx context.Context, studentID int64) error
 	// ReleaseStudentTagsByIDs clears the RFID tag on the given students' person
 	// rows and returns what each of them was holding, keyed by student id.

--- a/backend/models/users/student_deletion.go
+++ b/backend/models/users/student_deletion.go
@@ -1,0 +1,42 @@
+package users
+
+import (
+	"context"
+	"time"
+)
+
+// StudentDeletionCounts groups every child-owned or child-linked row affected
+// by a permanent student deletion. The groups are deliberately user-facing:
+// the API and confirmation dialog expose these names instead of leaking the
+// physical table layout.
+type StudentDeletionCounts struct {
+	TimetableAssignments int `bun:"timetable_assignments" json:"timetable_assignments"`
+	ActivityEnrollments  int `bun:"activity_enrollments" json:"activity_enrollments"`
+	AttendanceRecords    int `bun:"attendance_records" json:"attendance_records"`
+	CareSchedules        int `bun:"care_schedules" json:"care_schedules"`
+	GuardianLinks        int `bun:"guardian_links" json:"guardian_links"`
+	CompanionLinks       int `bun:"companion_links" json:"companion_links"`
+	Communications       int `bun:"communications" json:"communications"`
+	Consents             int `bun:"consents" json:"consents"`
+	EnrollmentReferences int `bun:"enrollment_references" json:"enrollment_references"`
+	OtherRecords         int `bun:"other_records" json:"other_records"`
+}
+
+// Total is the number of dependent rows the deletion removes or unlinks. The
+// student and person rows themselves are intentionally not included.
+func (c StudentDeletionCounts) Total() int {
+	return c.TimetableAssignments + c.ActivityEnrollments +
+		c.AttendanceRecords + c.CareSchedules + c.GuardianLinks +
+		c.CompanionLinks + c.Communications + c.Consents +
+		c.EnrollmentReferences + c.OtherRecords
+}
+
+// StudentDeletionRepository owns the cross-schema read model and the one
+// explicit cleanup required before users.students can be deleted. Every other
+// child relation either cascades safely or is unlinked via ON DELETE SET NULL.
+type StudentDeletionRepository interface {
+	Preview(ctx context.Context, studentID int64) (*StudentDeletionCounts, error)
+	DeleteTimetableAssignments(ctx context.Context, studentID int64) (int64, error)
+	DeleteLegacyGuardianLinks(ctx context.Context, personID int64) error
+	AnonymizePersonIfUnchanged(ctx context.Context, personID int64, updatedAt time.Time) (bool, error)
+}

--- a/backend/models/users/student_deletion.go
+++ b/backend/models/users/student_deletion.go
@@ -36,6 +36,7 @@ func (c StudentDeletionCounts) Total() int {
 // child relation either cascades safely or is unlinked via ON DELETE SET NULL.
 type StudentDeletionRepository interface {
 	Preview(ctx context.Context, studentID int64) (*StudentDeletionCounts, error)
+	LockMessageThreads(ctx context.Context, studentID int64) error
 	DeleteTimetableAssignments(ctx context.Context, studentID int64) (int64, error)
 	DeleteLegacyGuardianLinks(ctx context.Context, personID int64) error
 	AnonymizePersonIfUnchanged(ctx context.Context, personID int64, updatedAt time.Time) (bool, error)

--- a/backend/models/users/student_deletion_test.go
+++ b/backend/models/users/student_deletion_test.go
@@ -1,0 +1,24 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStudentDeletionCountsTotal(t *testing.T) {
+	counts := StudentDeletionCounts{
+		TimetableAssignments: 1,
+		ActivityEnrollments:  2,
+		AttendanceRecords:    3,
+		CareSchedules:        4,
+		GuardianLinks:        5,
+		CompanionLinks:       6,
+		Communications:       7,
+		Consents:             8,
+		EnrollmentReferences: 9,
+		OtherRecords:         10,
+	}
+
+	assert.Equal(t, 55, counts.Total())
+}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -143,6 +143,7 @@ type Factory struct {
 	Schools              platform.SchoolService
 	WorkTimeModels       *config.WorkTimeModelService
 	Students             users.StudentService
+	StudentDeletion      users.StudentDeletionService
 	StudentAudit         users.StudentAuditService
 	MasterDataReview     users.MasterDataReviewService
 	CareRequests         schedule.CareScheduleRequestService
@@ -1522,6 +1523,14 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.StudentCompanion,
 		studentAuditService,
 	)
+	studentDeletionService := users.NewStudentDeletionService(
+		studentService,
+		repos.Student,
+		repos.Person,
+		repos.StudentDeletion,
+		repos.StudentDeletionAudit,
+		db,
+	)
 
 	enrollmentChangeRequestService := enrollment.NewChangeRequestService(enrollment.ChangeRequestServiceConfig{
 		ChangeRequestRepo:        repos.ChangeRequest,
@@ -1914,6 +1923,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Schools:              platform.NewSchoolService(repos.School),
 		WorkTimeModels:       workTimeModelService,
 		Students:             studentService,
+		StudentDeletion:      studentDeletionService,
 		StudentAudit:         studentAuditService,
 		MasterDataReview:     users.NewMasterDataReviewServiceWithAudit(repos.StudentDataChangeRequest, repos.Student, repos.Person, userContextService, pillEmitter, studentAuditService, logger.With("service", "master-data-review"), realtimeHub),
 		CareRequests:         careRequestService,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1528,6 +1528,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.DataDeletion,
 		repos.StudentDeletionAudit,
 		db,
 	)

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1528,6 +1528,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.GradeTransition,
 		repos.DataDeletion,
 		repos.StudentDeletionAudit,
 		db,

--- a/backend/services/users/errors.go
+++ b/backend/services/users/errors.go
@@ -117,6 +117,19 @@ var (
 	// reaches across siblings the caller may not supervise, so it is restricted
 	// to admins.
 	ErrGuardianForceDeleteRequiresAdmin = errors.New("only administrators can fully delete a guardian linked to students")
+
+	// ErrStudentDeletionPreviewChanged refuses a permanent deletion when the
+	// dependent row counts or the student/person record changed after the admin
+	// reviewed the impact.
+	ErrStudentDeletionPreviewChanged = errors.New("Die Daten haben sich seit der Vorschau geändert. Bitte Auswirkungen erneut prüfen.") //nolint:staticcheck // ST1005: user-facing German message
+
+	// ErrStudentDeletionConfirmationMismatch means the typed name does not
+	// exactly match the currently stored child name.
+	ErrStudentDeletionConfirmationMismatch = errors.New("Der eingegebene Name stimmt nicht mit dem Kind überein.") //nolint:staticcheck // ST1005: user-facing German message
+
+	ErrStudentDeletionNotAcknowledged = errors.New("Die Unwiderruflichkeit der Löschung muss bestätigt werden.")    //nolint:staticcheck // ST1005: user-facing German message
+	ErrStudentDeletionInvalidReason   = errors.New("Ungültiger Löschgrund.")                                        //nolint:staticcheck // ST1005: user-facing German message
+	ErrStudentDeletionAlumnus         = errors.New("Abgänger werden über den Jahrgangswechsel endgültig gelöscht.") //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // GuardianStillLinkedError signals that a guardian delete was refused because the

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -13,6 +13,7 @@ import (
 
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/uptrace/bun"
 )
@@ -57,6 +58,7 @@ type studentDeletionService struct {
 	studentRepo    userModels.StudentRepository
 	personRepo     userModels.PersonRepository
 	deletionRepo   userModels.StudentDeletionRepository
+	transitionRepo educationModels.GradeTransitionRepository
 	dataAuditRepo  auditModels.DataDeletionRepository
 	auditRepo      auditModels.StudentDeletionRepository
 	txHandler      *modelBase.TxHandler
@@ -67,6 +69,7 @@ func NewStudentDeletionService(
 	studentRepo userModels.StudentRepository,
 	personRepo userModels.PersonRepository,
 	deletionRepo userModels.StudentDeletionRepository,
+	transitionRepo educationModels.GradeTransitionRepository,
 	dataAuditRepo auditModels.DataDeletionRepository,
 	auditRepo auditModels.StudentDeletionRepository,
 	db *bun.DB,
@@ -76,6 +79,7 @@ func NewStudentDeletionService(
 		studentRepo:    studentRepo,
 		personRepo:     personRepo,
 		deletionRepo:   deletionRepo,
+		transitionRepo: transitionRepo,
 		dataAuditRepo:  dataAuditRepo,
 		auditRepo:      auditRepo,
 		txHandler:      modelBase.NewTxHandler(db),
@@ -148,6 +152,9 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 		}
 
 		if err := s.studentRepo.Delete(txCtx, input.StudentID); err != nil {
+			return err
+		}
+		if err := s.transitionRepo.AnonymizeHistoryForStudent(txCtx, input.StudentID); err != nil {
 			return err
 		}
 		anonymized, err := s.deletionRepo.AnonymizePersonIfUnchanged(txCtx, student.PersonID, person.UpdatedAt)
@@ -225,6 +232,7 @@ func (s *studentDeletionService) loadPreview(
 ) (*userModels.Student, *userModels.Person, *userModels.StudentDeletionCounts, error) {
 	var (
 		student *userModels.Student
+		person  *userModels.Person
 		err     error
 	)
 	if lock {
@@ -235,7 +243,11 @@ func (s *studentDeletionService) loadPreview(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	person, err := s.personRepo.FindByID(ctx, student.PersonID)
+	if lock {
+		person, err = s.personRepo.FindByIDForUpdate(ctx, student.PersonID)
+	} else {
+		person, err = s.personRepo.FindByID(ctx, student.PersonID)
+	}
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -188,6 +188,12 @@ func (s *studentDeletionService) AuditGraduatePurge(ctx context.Context, student
 	if studentID <= 0 || actorAccountID <= 0 {
 		return errors.New("graduate purge audit requires student and actor IDs")
 	}
+	// The purge path calculates its audit counts before the cascaded delete.
+	// Locking the threads first serializes new messages and read cursors with
+	// that snapshot, just as the regular deletion path does.
+	if err := s.deletionRepo.LockMessageThreads(ctx, studentID); err != nil {
+		return err
+	}
 	counts, err := s.deletionRepo.Preview(ctx, studentID)
 	if err != nil {
 		return err

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -244,6 +244,11 @@ func (s *studentDeletionService) loadPreview(
 		return nil, nil, nil, err
 	}
 	if lock {
+		if err := s.deletionRepo.LockMessageThreads(ctx, studentID); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	if lock {
 		person, err = s.personRepo.FindByIDForUpdate(ctx, student.PersonID)
 	} else {
 		person, err = s.personRepo.FindByID(ctx, student.PersonID)

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -1,0 +1,255 @@
+package users
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/uptrace/bun"
+)
+
+const (
+	StudentDeletionReasonTestData       = "test_data"
+	StudentDeletionReasonIncorrectEntry = "incorrect_entry"
+	StudentDeletionReasonDuplicate      = "duplicate"
+	StudentDeletionReasonPrivacyRequest = "privacy_request"
+)
+
+type StudentDeletionPreview struct {
+	ConfirmationName string
+	Fingerprint      string
+	Counts           userModels.StudentDeletionCounts
+}
+
+type StudentDeletionInput struct {
+	StudentID           int64
+	ActorAccountID      int64
+	ExpectedFingerprint string
+	ConfirmationName    string
+	Reason              string
+	Acknowledged        bool
+}
+
+type StudentDeletionResult struct {
+	PhotoPath    string
+	CompanionIDs []int64
+	Counts       userModels.StudentDeletionCounts
+}
+
+type StudentDeletionService interface {
+	Preview(ctx context.Context, studentID int64) (*StudentDeletionPreview, error)
+	Delete(ctx context.Context, input StudentDeletionInput) (*StudentDeletionResult, error)
+}
+
+type studentDeletionService struct {
+	studentService StudentService
+	studentRepo    userModels.StudentRepository
+	personRepo     userModels.PersonRepository
+	deletionRepo   userModels.StudentDeletionRepository
+	auditRepo      auditModels.StudentDeletionRepository
+	txHandler      *modelBase.TxHandler
+}
+
+func NewStudentDeletionService(
+	studentService StudentService,
+	studentRepo userModels.StudentRepository,
+	personRepo userModels.PersonRepository,
+	deletionRepo userModels.StudentDeletionRepository,
+	auditRepo auditModels.StudentDeletionRepository,
+	db *bun.DB,
+) StudentDeletionService {
+	return &studentDeletionService{
+		studentService: studentService,
+		studentRepo:    studentRepo,
+		personRepo:     personRepo,
+		deletionRepo:   deletionRepo,
+		auditRepo:      auditRepo,
+		txHandler:      modelBase.NewTxHandler(db),
+	}
+}
+
+func (s *studentDeletionService) Preview(ctx context.Context, studentID int64) (*StudentDeletionPreview, error) {
+	student, person, counts, err := s.loadPreview(ctx, studentID, false)
+	if err != nil {
+		return nil, err
+	}
+	if student.IsAlumnus() {
+		return nil, ErrStudentDeletionAlumnus
+	}
+	return buildStudentDeletionPreview(student, person, counts)
+}
+
+func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeletionInput) (*StudentDeletionResult, error) {
+	if input.StudentID <= 0 || input.ActorAccountID <= 0 || strings.TrimSpace(input.ExpectedFingerprint) == "" {
+		return nil, ErrStudentDeletionPreviewChanged
+	}
+	if !input.Acknowledged {
+		return nil, ErrStudentDeletionNotAcknowledged
+	}
+	if !isValidStudentDeletionReason(input.Reason) {
+		return nil, ErrStudentDeletionInvalidReason
+	}
+
+	result := new(StudentDeletionResult)
+	err := s.txHandler.RunInTx(ctx, func(txCtx context.Context, _ bun.Tx) error {
+		if err := s.studentService.LockCompanionGraph(txCtx, []int64{input.StudentID}, nil); err != nil {
+			return err
+		}
+		if err := s.studentService.CheckCompanionTrim(txCtx, input.StudentID, nil); err != nil {
+			return err
+		}
+
+		companionIDs, err := s.studentService.ListCompanionIDs(txCtx, input.StudentID)
+		if err != nil {
+			return err
+		}
+		student, person, counts, err := s.loadPreview(txCtx, input.StudentID, true)
+		if err != nil {
+			return err
+		}
+		if student.IsAlumnus() {
+			return ErrStudentDeletionAlumnus
+		}
+
+		preview, err := buildStudentDeletionPreview(student, person, counts)
+		if err != nil {
+			return err
+		}
+		if !equalFingerprint(preview.Fingerprint, input.ExpectedFingerprint) {
+			return ErrStudentDeletionPreviewChanged
+		}
+		if input.ConfirmationName != preview.ConfirmationName {
+			return ErrStudentDeletionConfirmationMismatch
+		}
+
+		deletedAssignments, err := s.deletionRepo.DeleteTimetableAssignments(txCtx, input.StudentID)
+		if err != nil {
+			return err
+		}
+		if deletedAssignments != int64(counts.TimetableAssignments) {
+			return ErrStudentDeletionPreviewChanged
+		}
+		if err := s.deletionRepo.DeleteLegacyGuardianLinks(txCtx, student.PersonID); err != nil {
+			return err
+		}
+
+		if err := s.studentRepo.Delete(txCtx, input.StudentID); err != nil {
+			return err
+		}
+		anonymized, err := s.deletionRepo.AnonymizePersonIfUnchanged(txCtx, student.PersonID, person.UpdatedAt)
+		if err != nil {
+			return err
+		}
+		if !anonymized {
+			return ErrStudentDeletionPreviewChanged
+		}
+		if s.auditRepo == nil {
+			return errors.New("student deletion audit repository is not configured")
+		}
+		if err := s.auditRepo.Create(txCtx, &auditModels.StudentDeletion{
+			StudentID:      input.StudentID,
+			ActorAccountID: input.ActorAccountID,
+			Reason:         input.Reason,
+			Counts:         *counts,
+		}); err != nil {
+			return err
+		}
+
+		if student.PhotoPath != nil {
+			result.PhotoPath = *student.PhotoPath
+		}
+		result.CompanionIDs = companionIDs
+		result.Counts = *counts
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *studentDeletionService) loadPreview(
+	ctx context.Context,
+	studentID int64,
+	lock bool,
+) (*userModels.Student, *userModels.Person, *userModels.StudentDeletionCounts, error) {
+	var (
+		student *userModels.Student
+		err     error
+	)
+	if lock {
+		student, err = s.studentService.GetByIDForUpdate(ctx, studentID)
+	} else {
+		student, err = s.studentRepo.FindByID(ctx, studentID)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	person, err := s.personRepo.FindByID(ctx, student.PersonID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	counts, err := s.deletionRepo.Preview(ctx, studentID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return student, person, counts, nil
+}
+
+func buildStudentDeletionPreview(
+	student *userModels.Student,
+	person *userModels.Person,
+	counts *userModels.StudentDeletionCounts,
+) (*StudentDeletionPreview, error) {
+	if student == nil || person == nil || counts == nil {
+		return nil, errors.New("student deletion preview is incomplete")
+	}
+	payload := struct {
+		StudentUpdatedAt int64                            `json:"student_updated_at"`
+		PersonUpdatedAt  int64                            `json:"person_updated_at"`
+		Counts           userModels.StudentDeletionCounts `json:"counts"`
+	}{
+		StudentUpdatedAt: student.UpdatedAt.UnixNano(),
+		PersonUpdatedAt:  person.UpdatedAt.UnixNano(),
+		Counts:           *counts,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal student deletion preview: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return &StudentDeletionPreview{
+		ConfirmationName: person.GetFullName(),
+		Fingerprint:      hex.EncodeToString(sum[:]),
+		Counts:           *counts,
+	}, nil
+}
+
+func equalFingerprint(actual, expected string) bool {
+	actualBytes, actualErr := hex.DecodeString(actual)
+	expectedBytes, expectedErr := hex.DecodeString(strings.TrimSpace(expected))
+	if actualErr != nil || expectedErr != nil || len(actualBytes) != len(expectedBytes) {
+		return false
+	}
+	return subtle.ConstantTimeCompare(actualBytes, expectedBytes) == 1
+}
+
+func isValidStudentDeletionReason(reason string) bool {
+	switch reason {
+	case StudentDeletionReasonTestData,
+		StudentDeletionReasonIncorrectEntry,
+		StudentDeletionReasonDuplicate,
+		StudentDeletionReasonPrivacyRequest:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -181,9 +181,10 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 	return result, nil
 }
 
-// AuditGraduatePurge records the dedicated Abgänge hard-delete path. The
-// caller invokes it after taking the graph locks and before deleting any row;
-// its transaction therefore rolls the audit back when the purge cannot finish.
+// AuditGraduatePurge removes retained timetable assignments and records the
+// dedicated Abgänge hard-delete path. The caller invokes it after taking the
+// graph locks and before deleting the student row; its transaction therefore
+// rolls both cleanup and audit back when the purge cannot finish.
 func (s *studentDeletionService) AuditGraduatePurge(ctx context.Context, studentID, actorAccountID int64) error {
 	if studentID <= 0 || actorAccountID <= 0 {
 		return errors.New("graduate purge audit requires student and actor IDs")
@@ -197,6 +198,13 @@ func (s *studentDeletionService) AuditGraduatePurge(ctx context.Context, student
 	counts, err := s.deletionRepo.Preview(ctx, studentID)
 	if err != nil {
 		return err
+	}
+	deletedAssignments, err := s.deletionRepo.DeleteTimetableAssignments(ctx, studentID)
+	if err != nil {
+		return err
+	}
+	if deletedAssignments != int64(counts.TimetableAssignments) {
+		return ErrStudentDeletionPreviewChanged
 	}
 	return s.createAudit(ctx, studentID, actorAccountID, StudentDeletionReasonGraduatePurge, *counts, 2)
 }

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -22,6 +22,7 @@ const (
 	StudentDeletionReasonIncorrectEntry = "incorrect_entry"
 	StudentDeletionReasonDuplicate      = "duplicate"
 	StudentDeletionReasonPrivacyRequest = "privacy_request"
+	StudentDeletionReasonGraduatePurge  = "graduate_purge"
 )
 
 type StudentDeletionPreview struct {
@@ -48,6 +49,7 @@ type StudentDeletionResult struct {
 type StudentDeletionService interface {
 	Preview(ctx context.Context, studentID int64) (*StudentDeletionPreview, error)
 	Delete(ctx context.Context, input StudentDeletionInput) (*StudentDeletionResult, error)
+	AuditGraduatePurge(ctx context.Context, studentID, actorAccountID int64) error
 }
 
 type studentDeletionService struct {
@@ -155,27 +157,7 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 		if !anonymized {
 			return ErrStudentDeletionPreviewChanged
 		}
-		if s.dataAuditRepo == nil || s.auditRepo == nil {
-			return errors.New("student deletion audit repositories are not configured")
-		}
-		dataDeletion := auditModels.NewDataDeletion(
-			input.StudentID,
-			auditModels.DeletionTypeManual,
-			counts.Total()+1,
-			"account:"+strconv.FormatInt(input.ActorAccountID, 10),
-		)
-		dataDeletion.DeletionReason = input.Reason
-		dataDeletion.SetMetadata("student_deletion", true)
-		dataDeletion.SetMetadata("counts", *counts)
-		if err := s.dataAuditRepo.Create(txCtx, dataDeletion); err != nil {
-			return err
-		}
-		if err := s.auditRepo.Create(txCtx, &auditModels.StudentDeletion{
-			StudentID:      input.StudentID,
-			ActorAccountID: input.ActorAccountID,
-			Reason:         input.Reason,
-			Counts:         *counts,
-		}); err != nil {
+		if err := s.createAudit(txCtx, input.StudentID, input.ActorAccountID, input.Reason, *counts, 1); err != nil {
 			return err
 		}
 
@@ -190,6 +172,50 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 		return nil, err
 	}
 	return result, nil
+}
+
+// AuditGraduatePurge records the dedicated Abgänge hard-delete path. The
+// caller invokes it after taking the graph locks and before deleting any row;
+// its transaction therefore rolls the audit back when the purge cannot finish.
+func (s *studentDeletionService) AuditGraduatePurge(ctx context.Context, studentID, actorAccountID int64) error {
+	if studentID <= 0 || actorAccountID <= 0 {
+		return errors.New("graduate purge audit requires student and actor IDs")
+	}
+	counts, err := s.deletionRepo.Preview(ctx, studentID)
+	if err != nil {
+		return err
+	}
+	return s.createAudit(ctx, studentID, actorAccountID, StudentDeletionReasonGraduatePurge, *counts, 2)
+}
+
+func (s *studentDeletionService) createAudit(
+	ctx context.Context,
+	studentID, actorAccountID int64,
+	reason string,
+	counts userModels.StudentDeletionCounts,
+	primaryRowsDeleted int,
+) error {
+	if s.dataAuditRepo == nil || s.auditRepo == nil {
+		return errors.New("student deletion audit repositories are not configured")
+	}
+	dataDeletion := auditModels.NewDataDeletion(
+		studentID,
+		auditModels.DeletionTypeManual,
+		counts.Total()+primaryRowsDeleted,
+		"account:"+strconv.FormatInt(actorAccountID, 10),
+	)
+	dataDeletion.DeletionReason = reason
+	dataDeletion.SetMetadata("student_deletion", true)
+	dataDeletion.SetMetadata("counts", counts)
+	if err := s.dataAuditRepo.Create(ctx, dataDeletion); err != nil {
+		return err
+	}
+	return s.auditRepo.Create(ctx, &auditModels.StudentDeletion{
+		StudentID:      studentID,
+		ActorAccountID: actorAccountID,
+		Reason:         reason,
+		Counts:         counts,
+	})
 }
 
 func (s *studentDeletionService) loadPreview(

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -139,6 +139,13 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 		if input.ConfirmationName != preview.ConfirmationName {
 			return ErrStudentDeletionConfirmationMismatch
 		}
+		// Child rows can be removed by another transaction without touching the
+		// locked student or person rows. Re-read every counted category directly
+		// before the cascade so the confirmation and both audit records describe
+		// this transaction's deletion, not an earlier snapshot.
+		if err := s.ensureCountsUnchanged(txCtx, input.StudentID, *counts); err != nil {
+			return err
+		}
 
 		deletedAssignments, err := s.deletionRepo.DeleteTimetableAssignments(txCtx, input.StudentID)
 		if err != nil {
@@ -199,6 +206,9 @@ func (s *studentDeletionService) AuditGraduatePurge(ctx context.Context, student
 	if err != nil {
 		return err
 	}
+	if err := s.ensureCountsUnchanged(ctx, studentID, *counts); err != nil {
+		return err
+	}
 	deletedAssignments, err := s.deletionRepo.DeleteTimetableAssignments(ctx, studentID)
 	if err != nil {
 		return err
@@ -207,6 +217,24 @@ func (s *studentDeletionService) AuditGraduatePurge(ctx context.Context, student
 		return ErrStudentDeletionPreviewChanged
 	}
 	return s.createAudit(ctx, studentID, actorAccountID, StudentDeletionReasonGraduatePurge, *counts, 2)
+}
+
+// ensureCountsUnchanged closes the gap between the locked preview and the
+// delete. Not every child relation updates users.students when it is removed,
+// so a student-row lock alone cannot make its earlier count authoritative.
+func (s *studentDeletionService) ensureCountsUnchanged(
+	ctx context.Context,
+	studentID int64,
+	expected userModels.StudentDeletionCounts,
+) error {
+	current, err := s.deletionRepo.Preview(ctx, studentID)
+	if err != nil {
+		return err
+	}
+	if *current != expected {
+		return ErrStudentDeletionPreviewChanged
+	}
+	return nil
 }
 
 func (s *studentDeletionService) createAudit(

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
@@ -54,6 +55,7 @@ type studentDeletionService struct {
 	studentRepo    userModels.StudentRepository
 	personRepo     userModels.PersonRepository
 	deletionRepo   userModels.StudentDeletionRepository
+	dataAuditRepo  auditModels.DataDeletionRepository
 	auditRepo      auditModels.StudentDeletionRepository
 	txHandler      *modelBase.TxHandler
 }
@@ -63,6 +65,7 @@ func NewStudentDeletionService(
 	studentRepo userModels.StudentRepository,
 	personRepo userModels.PersonRepository,
 	deletionRepo userModels.StudentDeletionRepository,
+	dataAuditRepo auditModels.DataDeletionRepository,
 	auditRepo auditModels.StudentDeletionRepository,
 	db *bun.DB,
 ) StudentDeletionService {
@@ -71,6 +74,7 @@ func NewStudentDeletionService(
 		studentRepo:    studentRepo,
 		personRepo:     personRepo,
 		deletionRepo:   deletionRepo,
+		dataAuditRepo:  dataAuditRepo,
 		auditRepo:      auditRepo,
 		txHandler:      modelBase.NewTxHandler(db),
 	}
@@ -151,8 +155,20 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 		if !anonymized {
 			return ErrStudentDeletionPreviewChanged
 		}
-		if s.auditRepo == nil {
-			return errors.New("student deletion audit repository is not configured")
+		if s.dataAuditRepo == nil || s.auditRepo == nil {
+			return errors.New("student deletion audit repositories are not configured")
+		}
+		dataDeletion := auditModels.NewDataDeletion(
+			input.StudentID,
+			auditModels.DeletionTypeManual,
+			counts.Total()+1,
+			"account:"+strconv.FormatInt(input.ActorAccountID, 10),
+		)
+		dataDeletion.DeletionReason = input.Reason
+		dataDeletion.SetMetadata("student_deletion", true)
+		dataDeletion.SetMetadata("counts", *counts)
+		if err := s.dataAuditRepo.Create(txCtx, dataDeletion); err != nil {
+			return err
 		}
 		if err := s.auditRepo.Create(txCtx, &auditModels.StudentDeletion{
 			StudentID:      input.StudentID,

--- a/backend/services/users/student_deletion_service_internal_test.go
+++ b/backend/services/users/student_deletion_service_internal_test.go
@@ -1,0 +1,30 @@
+package users
+
+import (
+	"testing"
+
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStudentDeletionValidationHelpers(t *testing.T) {
+	for _, reason := range []string{
+		StudentDeletionReasonTestData,
+		StudentDeletionReasonIncorrectEntry,
+		StudentDeletionReasonDuplicate,
+		StudentDeletionReasonPrivacyRequest,
+	} {
+		assert.True(t, isValidStudentDeletionReason(reason))
+	}
+	assert.False(t, isValidStudentDeletionReason("other"))
+
+	assert.True(t, equalFingerprint("aabb", " aabb "))
+	assert.False(t, equalFingerprint("aabb", "ccdd"))
+	assert.False(t, equalFingerprint("invalid", "aabb"))
+	assert.False(t, equalFingerprint("aabb", "abc"))
+}
+
+func TestBuildStudentDeletionPreviewRejectsIncompleteData(t *testing.T) {
+	_, err := buildStudentDeletionPreview(nil, nil, &userModels.StudentDeletionCounts{})
+	assert.ErrorContains(t, err, "preview is incomplete")
+}

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -102,7 +102,9 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 		Action:       educationModels.ActionPromoted,
 	}
 	history.SetTenantID(target.TenantID)
-	_, err := db.NewInsert().Model(history).Exec(ctx)
+	_, err := db.NewInsert().Model(history).
+		ModelTableExpr(`education.grade_transition_history`).
+		Exec(ctx)
 	require.NoError(t, err)
 	childAccount := testpkg.CreateTestAccount(t, db, "student-delete-child@example.com")
 	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-parent@example.com")

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -71,7 +71,7 @@ func tableRowCount(t *testing.T, db *bun.DB, table string, id int64) int {
 
 func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
-	defer func() { _ = db.Close() }()
+	t.Cleanup(func() { _ = db.Close() })
 
 	ctx := testpkg.TenantContext(1)
 	repos := repositories.NewFactory(db)
@@ -94,6 +94,13 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 		SET account_id = ?, tag_id = ?
 		WHERE id = ?
 	`, childAccount.ID, card.ID, target.PersonID).Exec(ctx)
+	require.NoError(t, err)
+	photoPath := "students/delete-service-target.webp"
+	_, err = db.NewUpdate().
+		TableExpr(`users.students AS "student"`).
+		Set(`photo_path = ?`, photoPath).
+		Where(`"student".id = ?`, target.ID).
+		Exec(ctx)
 	require.NoError(t, err)
 	var legacyGuardianLinkID int64
 	require.NoError(t, db.NewRaw(`
@@ -128,6 +135,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	})
 	require.NoError(t, err)
 	assert.Equal(t, preview.Counts, result.Counts)
+	assert.Equal(t, photoPath, result.PhotoPath)
 
 	assert.Zero(t, tableRowCount(t, db, "users.students", target.ID))
 	assert.Zero(t, tableRowCount(t, db, "schedule.instance_students", targetAssignment.ID))
@@ -181,7 +189,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 
 func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
-	defer func() { _ = db.Close() }()
+	t.Cleanup(func() { _ = db.Close() })
 
 	ctx := testpkg.TenantContext(1)
 	repos := repositories.NewFactory(db)
@@ -216,9 +224,79 @@ func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
 	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", assignment.ID))
 }
 
+func TestStudentDeletionService_DeleteRejectsIncompleteConfirmation(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	service := newStudentDeletionTestService(db, nil)
+
+	_, err := service.Delete(testpkg.TenantContext(1), usersService.StudentDeletionInput{})
+	require.ErrorIs(t, err, usersService.ErrStudentDeletionPreviewChanged)
+
+	_, err = service.Delete(testpkg.TenantContext(1), usersService.StudentDeletionInput{
+		StudentID:           1,
+		ActorAccountID:      1,
+		ExpectedFingerprint: "aabb",
+	})
+	require.ErrorIs(t, err, usersService.ErrStudentDeletionNotAcknowledged)
+
+	_, err = service.Delete(testpkg.TenantContext(1), usersService.StudentDeletionInput{
+		StudentID:           1,
+		ActorAccountID:      1,
+		ExpectedFingerprint: "aabb",
+		Acknowledged:        true,
+		Reason:              "other",
+	})
+	require.ErrorIs(t, err, usersService.ErrStudentDeletionInvalidReason)
+}
+
+func TestStudentDeletionService_PreviewRejectsAlumnus(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := testpkg.TenantContext(1)
+	student := testpkg.CreateTestStudent(t, db, "DeleteAlumnus", "Target", "1a")
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "users.students", student.ID)
+		testpkg.CleanupTableRecords(t, db, "users.persons", student.PersonID)
+	})
+	_, err := db.NewUpdate().
+		TableExpr(`users.students AS "student"`).
+		Set(`status = ?`, userModels.StudentStatusAlumnus).
+		Where(`"student".id = ?`, student.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = newStudentDeletionTestService(db, nil).Preview(ctx, student.ID)
+	require.ErrorIs(t, err, usersService.ErrStudentDeletionAlumnus)
+}
+
+func TestStudentDeletionService_DeleteRollsBackWhenAuditRepositoryIsMissing(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := testpkg.TenantContext(1)
+	student := testpkg.CreateTestStudent(t, db, "DeleteMissingAudit", "Target", "1a")
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "users.students", student.ID)
+		testpkg.CleanupTableRecords(t, db, "users.persons", student.PersonID)
+	})
+	service := newStudentDeletionTestService(db, nil)
+	preview, err := service.Preview(ctx, student.ID)
+	require.NoError(t, err)
+
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           student.ID,
+		ActorAccountID:      1,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.ErrorContains(t, err, "audit repository is not configured")
+	assert.Equal(t, 1, tableRowCount(t, db, "users.students", student.ID))
+}
+
 func TestStudentDeletionService_DeleteRollsBackWhenAuditFails(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
-	defer func() { _ = db.Close() }()
+	t.Cleanup(func() { _ = db.Close() })
 
 	ctx := testpkg.TenantContext(1)
 	auditErr := errors.New("audit unavailable")

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	usersService "github.com/moto-nrw/project-phoenix/services/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -43,6 +44,7 @@ func newStudentDeletionTestService(
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		repos.GradeTransition,
 		dataAuditRepo,
 		auditRepo,
 		db,
@@ -91,10 +93,21 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	targetAssignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, target.ID, "")
 	sparedAssignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, spared.ID, "")
 	actor := testpkg.CreateTestAccount(t, db, "student-delete-actor@example.com")
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", actor.ID)
+	history := &educationModels.GradeTransitionHistory{
+		TransitionID: transition.ID,
+		StudentID:    target.ID,
+		PersonName:   "DeleteService Target",
+		FromClass:    "1a",
+		Action:       educationModels.ActionPromoted,
+	}
+	history.SetTenantID(target.TenantID)
+	_, err := db.NewInsert().Model(history).Exec(ctx)
+	require.NoError(t, err)
 	childAccount := testpkg.CreateTestAccount(t, db, "student-delete-child@example.com")
 	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-parent@example.com")
 	card := testpkg.CreateTestRFIDCard(t, db, "STUDENTDELETE")
-	_, err := db.NewRaw(`
+	_, err = db.NewRaw(`
 		UPDATE users.persons
 		SET account_id = ?, tag_id = ?
 		WHERE id = ?
@@ -117,6 +130,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	var auditID int64
 	t.Cleanup(func() {
 		testpkg.CleanupTableRecords(t, db, "users.persons_guardians", legacyGuardianLinkID)
+		testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
 		cleanupStudentDeletionTest(t, db,
 			[]int64{target.ID, spared.ID}, []int64{target.PersonID, spared.PersonID},
 			[]int64{targetAssignment.ID, sparedAssignment.ID}, []int64{instance.ID},
@@ -148,6 +162,11 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	assert.Equal(t, 1, tableRowCount(t, db, "users.students", spared.ID))
 	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", sparedAssignment.ID))
 	assert.Equal(t, 1, tableRowCount(t, db, "schedule.activity_instances", instance.ID))
+	var historyName string
+	require.NoError(t, db.NewRaw(`
+		SELECT person_name FROM education.grade_transition_history WHERE id = ?
+	`, history.ID).Scan(ctx, &historyName))
+	assert.Equal(t, "Gelöschtes Kind", historyName)
 
 	var anonymized struct {
 		FirstName string
@@ -251,7 +270,15 @@ func TestStudentDeletionService_PreviewExcludesPreservedDeletionAudits(t *testin
 	actor := testpkg.CreateTestAccount(t, db, "preserved-deletion-audit@example.com")
 	priorAudit := auditModels.NewDataDeletion(target.ID, auditModels.DeletionTypeVisitRetention, 1, "system")
 	require.NoError(t, repos.DataDeletion.Create(ctx, priorAudit))
+	var accessLogID int64
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO audit.data_access_log
+			(tenant_id, actor_account_id, actor_role, resource_type, student_id, range_start, range_end)
+		VALUES (?, ?, 'admin', 'attendance_history', ?, NOW(), NOW())
+		RETURNING id
+	`, target.TenantID, actor.ID, target.ID).Scan(ctx, &accessLogID))
 	t.Cleanup(func() {
+		_, _ = db.NewDelete().TableExpr(`audit.data_access_log`).Where(`id = ?`, accessLogID).Exec(context.Background())
 		_, _ = db.NewDelete().TableExpr(`audit.data_deletions`).Where(`student_id = ?`, target.ID).Exec(context.Background())
 		_, _ = db.NewDelete().TableExpr(`audit.student_deletions`).Where(`student_id = ?`, target.ID).Exec(context.Background())
 		testpkg.CleanupActivityFixtures(t, db, target.ID)
@@ -283,6 +310,11 @@ func TestStudentDeletionService_PreviewExcludesPreservedDeletionAudits(t *testin
 		Where(`tenant_id = ? AND student_id = ? AND deletion_type = ?`, target.TenantID, target.ID, auditModels.DeletionTypeManual).
 		Scan(ctx))
 	assert.Equal(t, 1, deletionAudit.RecordsDeleted)
+	var detachedStudentID *int64
+	require.NoError(t, db.NewRaw(`
+		SELECT student_id FROM audit.data_access_log WHERE id = ?
+	`, accessLogID).Scan(ctx, &detachedStudentID))
+	assert.Nil(t, detachedStudentID)
 }
 
 func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -3,6 +3,7 @@ package users_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ func (r failingStudentDeletionAudit) Create(context.Context, *auditModels.Studen
 
 func newStudentDeletionTestService(
 	db *bun.DB,
+	dataAuditRepo auditModels.DataDeletionRepository,
 	auditRepo auditModels.StudentDeletionRepository,
 ) usersService.StudentDeletionService {
 	repos := repositories.NewFactory(db)
@@ -41,6 +43,7 @@ func newStudentDeletionTestService(
 		repos.Student,
 		repos.Person,
 		repos.StudentDeletion,
+		dataAuditRepo,
 		auditRepo,
 		db,
 	)
@@ -52,6 +55,8 @@ func cleanupStudentDeletionTest(
 	studentIDs, personIDs, assignmentIDs, instanceIDs, roomIDs, accountIDs, auditIDs []int64,
 ) {
 	t.Helper()
+	_, err := db.NewDelete().TableExpr(`audit.data_deletions`).Where(`student_id IN (?)`, bun.List(studentIDs)).Exec(context.Background())
+	require.NoError(t, err)
 	testpkg.CleanupTableRecords(t, db, "audit.student_deletions", auditIDs...)
 	testpkg.CleanupTableRecords(t, db, "schedule.instance_students", assignmentIDs...)
 	testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", instanceIDs...)
@@ -75,7 +80,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 
 	ctx := testpkg.TenantContext(1)
 	repos := repositories.NewFactory(db)
-	service := newStudentDeletionTestService(db, repos.StudentDeletionAudit)
+	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
 	target := testpkg.CreateTestStudent(t, db, "DeleteService", "Target", "1a")
 	spared := testpkg.CreateTestStudent(t, db, "DeleteService", "Spared", "1a")
 	room := testpkg.CreateTestRoom(t, db, "delete-service-room")
@@ -185,6 +190,54 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	assert.Equal(t, actor.ID, audit.ActorAccountID)
 	assert.Equal(t, usersService.StudentDeletionReasonTestData, audit.Reason)
 	assert.Equal(t, preview.Counts, audit.Counts)
+
+	var dataAudit auditModels.DataDeletion
+	require.NoError(t, db.NewSelect().Model(&dataAudit).
+		Where(`tenant_id = ? AND student_id = ? AND deletion_type = ?`, target.TenantID, target.ID, auditModels.DeletionTypeManual).
+		Scan(ctx))
+	assert.Equal(t, preview.Counts.Total()+1, dataAudit.RecordsDeleted)
+	assert.Equal(t, usersService.StudentDeletionReasonTestData, dataAudit.DeletionReason)
+	assert.Equal(t, "account:"+fmt.Sprint(actor.ID), dataAudit.DeletedBy)
+	assert.Equal(t, true, dataAudit.Metadata["student_deletion"])
+	assert.NotNil(t, dataAudit.Metadata["counts"])
+}
+
+func TestStudentDeletionService_DeleteCountsCrossTenantVisits(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	const hostingTenantID int64 = 91
+	testpkg.CleanupTenantTestData(t, db, hostingTenantID)
+	t.Cleanup(func() { testpkg.CleanupTenantTestData(t, db, hostingTenantID) })
+	testpkg.EnsureTestTenant(t, db, hostingTenantID)
+
+	ctx := testpkg.TenantContext(1)
+	repos := repositories.NewFactory(db)
+	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
+	target := testpkg.CreateTestStudent(t, db, "CrossTenant", "Visitor", "1a")
+	actor := testpkg.CreateTestAccount(t, db, "student-delete-cross-tenant@example.com")
+	hostingGroup := testpkg.CreateTestActiveGroupForTenant(t, db, hostingTenantID)
+	hostedVisit := testpkg.CreateTestVisitForTenant(t, db, hostingTenantID, target.ID, hostingGroup.ID, time.Now(), nil)
+	t.Cleanup(func() {
+		cleanupStudentDeletionTest(t, db,
+			[]int64{target.ID}, []int64{target.PersonID}, nil, nil, nil, []int64{actor.ID}, nil)
+		testpkg.CleanupTableRecords(t, db, "active.visits", hostedVisit.ID)
+	})
+
+	preview, err := service.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, preview.Counts.AttendanceRecords)
+
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           target.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.NoError(t, err)
+	assert.Zero(t, tableRowCount(t, db, "active.visits", hostedVisit.ID))
 }
 
 func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
@@ -193,7 +246,7 @@ func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
 
 	ctx := testpkg.TenantContext(1)
 	repos := repositories.NewFactory(db)
-	service := newStudentDeletionTestService(db, repos.StudentDeletionAudit)
+	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
 	target := testpkg.CreateTestStudent(t, db, "DeleteStale", "Target", "1a")
 	room := testpkg.CreateTestRoom(t, db, "delete-stale-room")
 	instance := testpkg.CreateTestActivityInstance(t, db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{
@@ -227,7 +280,7 @@ func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
 func TestStudentDeletionService_DeleteRejectsIncompleteConfirmation(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
-	service := newStudentDeletionTestService(db, nil)
+	service := newStudentDeletionTestService(db, nil, nil)
 
 	_, err := service.Delete(testpkg.TenantContext(1), usersService.StudentDeletionInput{})
 	require.ErrorIs(t, err, usersService.ErrStudentDeletionPreviewChanged)
@@ -265,7 +318,7 @@ func TestStudentDeletionService_PreviewRejectsAlumnus(t *testing.T) {
 		Exec(ctx)
 	require.NoError(t, err)
 
-	_, err = newStudentDeletionTestService(db, nil).Preview(ctx, student.ID)
+	_, err = newStudentDeletionTestService(db, nil, nil).Preview(ctx, student.ID)
 	require.ErrorIs(t, err, usersService.ErrStudentDeletionAlumnus)
 }
 
@@ -278,7 +331,7 @@ func TestStudentDeletionService_DeleteRollsBackWhenAuditRepositoryIsMissing(t *t
 		testpkg.CleanupTableRecords(t, db, "users.students", student.ID)
 		testpkg.CleanupTableRecords(t, db, "users.persons", student.PersonID)
 	})
-	service := newStudentDeletionTestService(db, nil)
+	service := newStudentDeletionTestService(db, repositories.NewFactory(db).DataDeletion, nil)
 	preview, err := service.Preview(ctx, student.ID)
 	require.NoError(t, err)
 
@@ -290,7 +343,7 @@ func TestStudentDeletionService_DeleteRollsBackWhenAuditRepositoryIsMissing(t *t
 		Reason:              usersService.StudentDeletionReasonTestData,
 		Acknowledged:        true,
 	})
-	require.ErrorContains(t, err, "audit repository is not configured")
+	require.ErrorContains(t, err, "audit repositories are not configured")
 	assert.Equal(t, 1, tableRowCount(t, db, "users.students", student.ID))
 }
 
@@ -300,7 +353,7 @@ func TestStudentDeletionService_DeleteRollsBackWhenAuditFails(t *testing.T) {
 
 	ctx := testpkg.TenantContext(1)
 	auditErr := errors.New("audit unavailable")
-	service := newStudentDeletionTestService(db, failingStudentDeletionAudit{err: auditErr})
+	service := newStudentDeletionTestService(db, repositories.NewFactory(db).DataDeletion, failingStudentDeletionAudit{err: auditErr})
 	target := testpkg.CreateTestStudent(t, db, "DeleteRollback", "Target", "1a")
 	room := testpkg.CreateTestRoom(t, db, "delete-rollback-room")
 	instance := testpkg.CreateTestActivityInstance(t, db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -108,6 +108,23 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	require.NoError(t, err)
 	childAccount := testpkg.CreateTestAccount(t, db, "student-delete-child@example.com")
 	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-parent@example.com")
+	var messageThreadID, messageID int64
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
+		VALUES (?, ?, ?)
+		RETURNING id
+	`, target.TenantID, target.ID, parentAccount.ID).Scan(ctx, &messageThreadID))
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO users.parent_messages
+			(tenant_id, thread_id, student_id, sender_account_id, sender_kind, sender_name, body)
+		VALUES (?, ?, ?, ?, 'guardian', 'Elternteil', 'Bitte um Rückruf')
+		RETURNING id
+	`, target.TenantID, messageThreadID, target.ID, parentAccount.ID).Scan(ctx, &messageID))
+	_, err = db.NewRaw(`
+		INSERT INTO users.parent_message_reads (tenant_id, thread_id, account_id)
+		VALUES (?, ?, ?)
+	`, target.TenantID, messageThreadID, actor.ID).Exec(ctx)
+	require.NoError(t, err)
 	card := testpkg.CreateTestRFIDCard(t, db, "STUDENTDELETE")
 	_, err = db.NewRaw(`
 		UPDATE users.persons
@@ -145,6 +162,8 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	require.NoError(t, err)
 	require.Equal(t, 1, preview.Counts.TimetableAssignments)
 	require.Equal(t, 1, preview.Counts.GuardianLinks)
+	require.Equal(t, 3, preview.Counts.Communications)
+	require.Equal(t, 1, preview.Counts.OtherRecords)
 
 	result, err := service.Delete(ctx, usersService.StudentDeletionInput{
 		StudentID:           target.ID,
@@ -161,6 +180,13 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	assert.Zero(t, tableRowCount(t, db, "users.students", target.ID))
 	assert.Zero(t, tableRowCount(t, db, "schedule.instance_students", targetAssignment.ID))
 	assert.Zero(t, tableRowCount(t, db, "users.persons_guardians", legacyGuardianLinkID))
+	assert.Zero(t, tableRowCount(t, db, "users.parent_message_threads", messageThreadID))
+	assert.Zero(t, tableRowCount(t, db, "users.parent_messages", messageID))
+	var readCursorCount int
+	require.NoError(t, db.NewRaw(`
+		SELECT COUNT(*) FROM users.parent_message_reads WHERE thread_id = ?
+	`, messageThreadID).Scan(ctx, &readCursorCount))
+	assert.Zero(t, readCursorCount)
 	assert.Equal(t, 1, tableRowCount(t, db, "users.students", spared.ID))
 	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", sparedAssignment.ID))
 	assert.Equal(t, 1, tableRowCount(t, db, "schedule.activity_instances", instance.ID))
@@ -354,6 +380,49 @@ func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
 	require.ErrorIs(t, err, usersService.ErrStudentDeletionPreviewChanged)
 	assert.Equal(t, 1, tableRowCount(t, db, "users.students", target.ID))
 	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", assignment.ID))
+}
+
+func TestStudentDeletionService_DeleteRejectsStalePreviewAfterMessageRead(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	repos := repositories.NewFactory(db)
+	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
+	target := testpkg.CreateTestStudent(t, db, "DeleteStale", "Read", "1a")
+	actor := testpkg.CreateTestAccount(t, db, "student-delete-stale-read@example.com")
+	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-stale-read-parent@example.com")
+	var messageThreadID int64
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
+		VALUES (?, ?, ?)
+		RETURNING id
+	`, target.TenantID, target.ID, parentAccount.ID).Scan(ctx, &messageThreadID))
+	t.Cleanup(func() {
+		cleanupStudentDeletionTest(t, db,
+			[]int64{target.ID}, []int64{target.PersonID}, nil, nil, nil, []int64{actor.ID}, nil)
+		testpkg.CleanupParentAccountFixtures(t, db, parentAccount.ID)
+	})
+
+	preview, err := service.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, preview.Counts.Communications)
+	_, err = db.NewRaw(`
+		INSERT INTO users.parent_message_reads (tenant_id, thread_id, account_id)
+		VALUES (?, ?, ?)
+	`, target.TenantID, messageThreadID, actor.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           target.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.ErrorIs(t, err, usersService.ErrStudentDeletionPreviewChanged)
+	assert.Equal(t, 1, tableRowCount(t, db, "users.students", target.ID))
 }
 
 func TestStudentDeletionService_DeleteRejectsIncompleteConfirmation(t *testing.T) {

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -240,6 +240,51 @@ func TestStudentDeletionService_DeleteCountsCrossTenantVisits(t *testing.T) {
 	assert.Zero(t, tableRowCount(t, db, "active.visits", hostedVisit.ID))
 }
 
+func TestStudentDeletionService_PreviewExcludesPreservedDeletionAudits(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	repos := repositories.NewFactory(db)
+	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
+	target := testpkg.CreateTestStudent(t, db, "Preserved", "Audit", "1a")
+	actor := testpkg.CreateTestAccount(t, db, "preserved-deletion-audit@example.com")
+	priorAudit := auditModels.NewDataDeletion(target.ID, auditModels.DeletionTypeVisitRetention, 1, "system")
+	require.NoError(t, repos.DataDeletion.Create(ctx, priorAudit))
+	t.Cleanup(func() {
+		_, _ = db.NewDelete().TableExpr(`audit.data_deletions`).Where(`student_id = ?`, target.ID).Exec(context.Background())
+		_, _ = db.NewDelete().TableExpr(`audit.student_deletions`).Where(`student_id = ?`, target.ID).Exec(context.Background())
+		testpkg.CleanupActivityFixtures(t, db, target.ID)
+		testpkg.CleanupAuthFixtures(t, db, actor.ID)
+	})
+
+	preview, err := service.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Zero(t, preview.Counts.OtherRecords)
+	assert.Zero(t, preview.Counts.Total())
+
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           target.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.NoError(t, err)
+
+	var retainedAuditCount int
+	retainedAuditCount, err = db.NewSelect().TableExpr(`audit.data_deletions`).
+		Where(`id = ?`, priorAudit.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, retainedAuditCount)
+	var deletionAudit auditModels.DataDeletion
+	require.NoError(t, db.NewSelect().Model(&deletionAudit).
+		Where(`tenant_id = ? AND student_id = ? AND deletion_type = ?`, target.TenantID, target.ID, auditModels.DeletionTypeManual).
+		Scan(ctx))
+	assert.Equal(t, 1, deletionAudit.RecordsDeleted)
+}
+
 func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -255,7 +255,7 @@ func TestStudentDeletionService_DeleteCountsCrossTenantVisits(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
 
-	const hostingTenantID int64 = 91
+	hostingTenantID := testpkg.UniqueTestTenantID(t)
 	testpkg.CleanupTenantTestData(t, db, hostingTenantID)
 	t.Cleanup(func() { testpkg.CleanupTenantTestData(t, db, hostingTenantID) })
 	testpkg.EnsureTestTenant(t, db, hostingTenantID)

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -107,19 +107,20 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 		Exec(ctx)
 	require.NoError(t, err)
 	childAccount := testpkg.CreateTestAccount(t, db, "student-delete-child@example.com")
-	parentAccount := testpkg.CreateTestAccount(t, db, "student-delete-parent@example.com")
+	messageGuardianAccount := testpkg.CreateTestAccount(t, db, "student-delete-message-guardian@example.com")
+	legacyGuardianAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-legacy-guardian@example.com")
 	var messageThreadID, messageID int64
 	require.NoError(t, db.NewRaw(`
 		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
 		VALUES (?, ?, ?)
 		RETURNING id
-	`, target.TenantID, target.ID, parentAccount.ID).Scan(ctx, &messageThreadID))
+	`, target.TenantID, target.ID, messageGuardianAccount.ID).Scan(ctx, &messageThreadID))
 	require.NoError(t, db.NewRaw(`
 		INSERT INTO users.parent_messages
 			(tenant_id, thread_id, student_id, sender_account_id, sender_kind, sender_name, body)
 		VALUES (?, ?, ?, ?, 'guardian', 'Elternteil', 'Bitte um Rückruf')
 		RETURNING id
-	`, target.TenantID, messageThreadID, target.ID, parentAccount.ID).Scan(ctx, &messageID))
+	`, target.TenantID, messageThreadID, target.ID, messageGuardianAccount.ID).Scan(ctx, &messageID))
 	_, err = db.NewRaw(`
 		INSERT INTO users.parent_message_reads (tenant_id, thread_id, account_id)
 		VALUES (?, ?, ?)
@@ -145,7 +146,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 			(tenant_id, person_id, guardian_account_id, relationship_type)
 		VALUES (?, ?, ?, 'parent')
 		RETURNING id
-	`, target.TenantID, target.PersonID, parentAccount.ID).Scan(ctx, &legacyGuardianLinkID))
+	`, target.TenantID, target.PersonID, legacyGuardianAccount.ID).Scan(ctx, &legacyGuardianLinkID))
 	var auditID int64
 	t.Cleanup(func() {
 		testpkg.CleanupTableRecords(t, db, "users.persons_guardians", legacyGuardianLinkID)
@@ -153,7 +154,8 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 		cleanupStudentDeletionTest(t, db,
 			[]int64{target.ID, spared.ID}, []int64{target.PersonID, spared.PersonID},
 			[]int64{targetAssignment.ID, sparedAssignment.ID}, []int64{instance.ID},
-			[]int64{room.ID}, []int64{actor.ID, childAccount.ID, parentAccount.ID}, []int64{auditID})
+			[]int64{room.ID}, []int64{actor.ID, childAccount.ID, messageGuardianAccount.ID}, []int64{auditID})
+		testpkg.CleanupParentAccountFixtures(t, db, legacyGuardianAccount.ID)
 		testpkg.CleanupRFIDCards(t, db, card.ID)
 	})
 
@@ -215,7 +217,8 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	assert.Nil(t, anonymized.AccountID)
 	assert.NotNil(t, anonymized.DeletedAt)
 	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts", childAccount.ID))
-	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts", parentAccount.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts", messageGuardianAccount.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts_parents", legacyGuardianAccount.ID))
 
 	var audit struct {
 		ID             int64

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -1,0 +1,267 @@
+package users_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+type failingStudentDeletionAudit struct {
+	err error
+}
+
+func (r failingStudentDeletionAudit) Create(context.Context, *auditModels.StudentDeletion) error {
+	return r.err
+}
+
+func newStudentDeletionTestService(
+	db *bun.DB,
+	auditRepo auditModels.StudentDeletionRepository,
+) usersService.StudentDeletionService {
+	repos := repositories.NewFactory(db)
+	studentService := usersService.NewStudentService(
+		repos.Student,
+		repos.PrivacyConsent,
+		repos.StudentCompanion,
+		nil,
+	)
+	return usersService.NewStudentDeletionService(
+		studentService,
+		repos.Student,
+		repos.Person,
+		repos.StudentDeletion,
+		auditRepo,
+		db,
+	)
+}
+
+func cleanupStudentDeletionTest(
+	t *testing.T,
+	db *bun.DB,
+	studentIDs, personIDs, assignmentIDs, instanceIDs, roomIDs, accountIDs, auditIDs []int64,
+) {
+	t.Helper()
+	testpkg.CleanupTableRecords(t, db, "audit.student_deletions", auditIDs...)
+	testpkg.CleanupTableRecords(t, db, "schedule.instance_students", assignmentIDs...)
+	testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", instanceIDs...)
+	testpkg.CleanupTableRecords(t, db, "users.students", studentIDs...)
+	testpkg.CleanupTableRecords(t, db, "users.persons", personIDs...)
+	testpkg.CleanupTableRecords(t, db, "facilities.rooms", roomIDs...)
+	testpkg.CleanupAuthFixtures(t, db, accountIDs...)
+}
+
+func tableRowCount(t *testing.T, db *bun.DB, table string, id int64) int {
+	t.Helper()
+	var count int
+	require.NoError(t, db.NewSelect().TableExpr(table).ColumnExpr("COUNT(*)").
+		Where("id = ?", id).Scan(context.Background(), &count))
+	return count
+}
+
+func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repos := repositories.NewFactory(db)
+	service := newStudentDeletionTestService(db, repos.StudentDeletionAudit)
+	target := testpkg.CreateTestStudent(t, db, "DeleteService", "Target", "1a")
+	spared := testpkg.CreateTestStudent(t, db, "DeleteService", "Spared", "1a")
+	room := testpkg.CreateTestRoom(t, db, "delete-service-room")
+	instance := testpkg.CreateTestActivityInstance(t, db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{
+		Title:         "Shared deletion service instance",
+		IsSpontaneous: true,
+	})
+	targetAssignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, target.ID, "")
+	sparedAssignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, spared.ID, "")
+	actor := testpkg.CreateTestAccount(t, db, "student-delete-actor@example.com")
+	childAccount := testpkg.CreateTestAccount(t, db, "student-delete-child@example.com")
+	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-parent@example.com")
+	card := testpkg.CreateTestRFIDCard(t, db, "STUDENTDELETE")
+	_, err := db.NewRaw(`
+		UPDATE users.persons
+		SET account_id = ?, tag_id = ?
+		WHERE id = ?
+	`, childAccount.ID, card.ID, target.PersonID).Exec(ctx)
+	require.NoError(t, err)
+	var legacyGuardianLinkID int64
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO users.persons_guardians
+			(tenant_id, person_id, guardian_account_id, relationship_type)
+		VALUES (?, ?, ?, 'parent')
+		RETURNING id
+	`, target.TenantID, target.PersonID, parentAccount.ID).Scan(ctx, &legacyGuardianLinkID))
+	var auditID int64
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "users.persons_guardians", legacyGuardianLinkID)
+		cleanupStudentDeletionTest(t, db,
+			[]int64{target.ID, spared.ID}, []int64{target.PersonID, spared.PersonID},
+			[]int64{targetAssignment.ID, sparedAssignment.ID}, []int64{instance.ID},
+			[]int64{room.ID}, []int64{actor.ID, childAccount.ID}, []int64{auditID})
+		testpkg.CleanupParentAccountFixtures(t, db, parentAccount.ID)
+		testpkg.CleanupRFIDCards(t, db, card.ID)
+	})
+
+	preview, err := service.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, preview.Counts.TimetableAssignments)
+	require.Equal(t, 1, preview.Counts.GuardianLinks)
+
+	result, err := service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           target.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, preview.Counts, result.Counts)
+
+	assert.Zero(t, tableRowCount(t, db, "users.students", target.ID))
+	assert.Zero(t, tableRowCount(t, db, "schedule.instance_students", targetAssignment.ID))
+	assert.Zero(t, tableRowCount(t, db, "users.persons_guardians", legacyGuardianLinkID))
+	assert.Equal(t, 1, tableRowCount(t, db, "users.students", spared.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", sparedAssignment.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "schedule.activity_instances", instance.ID))
+
+	var anonymized struct {
+		FirstName string
+		LastName  string
+		Birthday  *timezone.Date
+		TagID     *string
+		AccountID *int64
+		DeletedAt *time.Time
+	}
+	require.NoError(t, db.NewRaw(`
+		SELECT first_name, last_name, birthday, tag_id, account_id, deleted_at
+		FROM users.persons
+		WHERE id = ?
+	`, target.PersonID).Scan(ctx, &anonymized))
+	assert.Equal(t, "Gelöscht", anonymized.FirstName)
+	assert.Equal(t, "Benutzer", anonymized.LastName)
+	assert.Nil(t, anonymized.Birthday)
+	assert.Nil(t, anonymized.TagID)
+	assert.Nil(t, anonymized.AccountID)
+	assert.NotNil(t, anonymized.DeletedAt)
+	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts", childAccount.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts_parents", parentAccount.ID))
+
+	var audit struct {
+		ID             int64
+		StudentID      int64
+		ActorAccountID int64
+		Reason         string
+		Counts         userModels.StudentDeletionCounts
+	}
+	require.NoError(t, db.NewRaw(`
+		SELECT id, student_id, actor_account_id, reason, counts
+		FROM audit.student_deletions
+		WHERE tenant_id = ? AND actor_account_id = ?
+		ORDER BY id DESC
+		LIMIT 1
+	`, target.TenantID, actor.ID).Scan(ctx, &audit))
+	auditID = audit.ID
+	assert.Equal(t, target.ID, audit.StudentID)
+	assert.Equal(t, actor.ID, audit.ActorAccountID)
+	assert.Equal(t, usersService.StudentDeletionReasonTestData, audit.Reason)
+	assert.Equal(t, preview.Counts, audit.Counts)
+}
+
+func TestStudentDeletionService_DeleteRejectsStalePreview(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	repos := repositories.NewFactory(db)
+	service := newStudentDeletionTestService(db, repos.StudentDeletionAudit)
+	target := testpkg.CreateTestStudent(t, db, "DeleteStale", "Target", "1a")
+	room := testpkg.CreateTestRoom(t, db, "delete-stale-room")
+	instance := testpkg.CreateTestActivityInstance(t, db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{
+		Title:         "Stale deletion preview instance",
+		IsSpontaneous: true,
+	})
+	actor := testpkg.CreateTestAccount(t, db, "student-delete-stale@example.com")
+
+	preview, err := service.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	assignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, target.ID, "")
+	t.Cleanup(func() {
+		cleanupStudentDeletionTest(t, db,
+			[]int64{target.ID}, []int64{target.PersonID}, []int64{assignment.ID}, []int64{instance.ID},
+			[]int64{room.ID}, []int64{actor.ID}, nil)
+	})
+
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           target.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.ErrorIs(t, err, usersService.ErrStudentDeletionPreviewChanged)
+	assert.Equal(t, 1, tableRowCount(t, db, "users.students", target.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", assignment.ID))
+}
+
+func TestStudentDeletionService_DeleteRollsBackWhenAuditFails(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := testpkg.TenantContext(1)
+	auditErr := errors.New("audit unavailable")
+	service := newStudentDeletionTestService(db, failingStudentDeletionAudit{err: auditErr})
+	target := testpkg.CreateTestStudent(t, db, "DeleteRollback", "Target", "1a")
+	room := testpkg.CreateTestRoom(t, db, "delete-rollback-room")
+	instance := testpkg.CreateTestActivityInstance(t, db, timezone.TodayDate(), room.ID, testpkg.ActivityInstanceOpts{
+		Title:         "Rollback deletion instance",
+		IsSpontaneous: true,
+	})
+	assignment := testpkg.CreateTestInstanceStudent(t, db, instance.ID, target.ID, "")
+	actor := testpkg.CreateTestAccount(t, db, "student-delete-rollback@example.com")
+	t.Cleanup(func() {
+		cleanupStudentDeletionTest(t, db,
+			[]int64{target.ID}, []int64{target.PersonID}, []int64{assignment.ID}, []int64{instance.ID},
+			[]int64{room.ID}, []int64{actor.ID}, nil)
+	})
+
+	preview, err := service.Preview(ctx, target.ID)
+	require.NoError(t, err)
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           target.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonIncorrectEntry,
+		Acknowledged:        true,
+	})
+	require.ErrorIs(t, err, auditErr)
+	assert.Equal(t, 1, tableRowCount(t, db, "users.students", target.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "schedule.instance_students", assignment.ID))
+
+	var person struct {
+		FirstName string
+		LastName  string
+		DeletedAt *time.Time
+	}
+	require.NoError(t, db.NewRaw(`
+		SELECT first_name, last_name, deleted_at
+		FROM users.persons
+		WHERE id = ?
+	`, target.PersonID).Scan(ctx, &person))
+	assert.Equal(t, "DeleteRollback", person.FirstName)
+	assert.Equal(t, "Target", person.LastName)
+	assert.Nil(t, person.DeletedAt)
+}

--- a/backend/services/users/student_deletion_service_test.go
+++ b/backend/services/users/student_deletion_service_test.go
@@ -107,7 +107,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 		Exec(ctx)
 	require.NoError(t, err)
 	childAccount := testpkg.CreateTestAccount(t, db, "student-delete-child@example.com")
-	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-parent@example.com")
+	parentAccount := testpkg.CreateTestAccount(t, db, "student-delete-parent@example.com")
 	var messageThreadID, messageID int64
 	require.NoError(t, db.NewRaw(`
 		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
@@ -153,8 +153,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 		cleanupStudentDeletionTest(t, db,
 			[]int64{target.ID, spared.ID}, []int64{target.PersonID, spared.PersonID},
 			[]int64{targetAssignment.ID, sparedAssignment.ID}, []int64{instance.ID},
-			[]int64{room.ID}, []int64{actor.ID, childAccount.ID}, []int64{auditID})
-		testpkg.CleanupParentAccountFixtures(t, db, parentAccount.ID)
+			[]int64{room.ID}, []int64{actor.ID, childAccount.ID, parentAccount.ID}, []int64{auditID})
 		testpkg.CleanupRFIDCards(t, db, card.ID)
 	})
 
@@ -216,7 +215,7 @@ func TestStudentDeletionService_DeletePreservesSharedInstanceAndAnonymizesPerson
 	assert.Nil(t, anonymized.AccountID)
 	assert.NotNil(t, anonymized.DeletedAt)
 	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts", childAccount.ID))
-	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts_parents", parentAccount.ID))
+	assert.Equal(t, 1, tableRowCount(t, db, "auth.accounts", parentAccount.ID))
 
 	var audit struct {
 		ID             int64
@@ -391,7 +390,7 @@ func TestStudentDeletionService_DeleteRejectsStalePreviewAfterMessageRead(t *tes
 	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
 	target := testpkg.CreateTestStudent(t, db, "DeleteStale", "Read", "1a")
 	actor := testpkg.CreateTestAccount(t, db, "student-delete-stale-read@example.com")
-	parentAccount := testpkg.CreateTestParentAccount(t, db, "student-delete-stale-read-parent@example.com")
+	parentAccount := testpkg.CreateTestAccount(t, db, "student-delete-stale-read-parent@example.com")
 	var messageThreadID int64
 	require.NoError(t, db.NewRaw(`
 		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
@@ -400,8 +399,7 @@ func TestStudentDeletionService_DeleteRejectsStalePreviewAfterMessageRead(t *tes
 	`, target.TenantID, target.ID, parentAccount.ID).Scan(ctx, &messageThreadID))
 	t.Cleanup(func() {
 		cleanupStudentDeletionTest(t, db,
-			[]int64{target.ID}, []int64{target.PersonID}, nil, nil, nil, []int64{actor.ID}, nil)
-		testpkg.CleanupParentAccountFixtures(t, db, parentAccount.ID)
+			[]int64{target.ID}, []int64{target.PersonID}, nil, nil, nil, []int64{actor.ID, parentAccount.ID}, nil)
 	})
 
 	preview, err := service.Preview(ctx, target.ID)

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -60,11 +60,6 @@ vi.mock("~/components/ui/hooks/useIsMobile", () => ({
   useIsMobile: vi.fn(() => false),
 }));
 
-// Use the real `useDeleteConfirmation` hook so the delete path is actually
-// exercised end-to-end (click "Löschen" → ConfirmationModal opens → click
-// "confirm-delete" button → handleDeleteStudent runs). The ConfirmationModal
-// mock below surfaces a `confirm-delete` button wired to `onConfirm`.
-
 const mockToastError = vi.fn();
 vi.mock("~/contexts/ToastContext", () => ({
   useToast: vi.fn(() => ({
@@ -271,19 +266,27 @@ vi.mock("@/components/students/student-create-modal", () => ({
     ) : null,
 }));
 
-vi.mock("~/components/ui/modal", () => ({
-  ConfirmationModal: ({
+vi.mock("~/components/students/student-deletion-modal", () => ({
+  StudentDeletionModal: ({
     isOpen,
-    onConfirm,
+    studentId,
+    displayName,
+    onDeleted,
     onClose,
   }: {
     isOpen: boolean;
-    onConfirm?: () => void;
+    studentId: string;
+    displayName: string;
+    onDeleted?: () => void;
     onClose?: () => void;
   }) =>
     isOpen ? (
-      <div data-testid="confirmation-modal">
-        <button type="button" data-testid="confirm-delete" onClick={onConfirm}>
+      <div
+        data-testid="student-deletion-modal"
+        data-student-id={studentId}
+        data-display-name={displayName}
+      >
+        <button type="button" data-testid="finish-delete" onClick={onDeleted}>
           Confirm
         </button>
         <button type="button" data-testid="cancel-delete" onClick={onClose}>
@@ -749,33 +752,7 @@ describe("StudentsPage", () => {
     expect(mockUpdate.mock.calls[0]?.[0]).toBe("1");
   });
 
-  it("calls delete service when deleting the selected student", async () => {
-    mockDelete.mockResolvedValueOnce(null);
-
-    setSelectedStudent("1");
-    render(<StudentsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("student-detail-panel")).toBeInTheDocument();
-    });
-
-    // The Löschen button lives inside the page-supplied `detailActions`.
-    // Clicking it opens the ConfirmationModal; then the user confirms.
-    fireEvent.click(screen.getByRole("button", { name: /Löschen/i }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId("confirm-delete"));
-
-    await waitFor(() => {
-      expect(mockDelete).toHaveBeenCalledWith("1");
-    });
-  });
-
-  it("shows error toast when delete returns error", async () => {
-    mockDelete.mockResolvedValueOnce("Kind kann nicht gelöscht werden");
-
+  it("opens the guarded deletion workflow for the selected student", async () => {
     setSelectedStudent("1");
     render(<StudentsPage />);
 
@@ -786,15 +763,33 @@ describe("StudentsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Löschen/i }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId("confirm-delete"));
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith(
-        "Kind kann nicht gelöscht werden",
+      expect(screen.getByTestId("student-deletion-modal")).toHaveAttribute(
+        "data-student-id",
+        "1",
       );
     });
+    expect(screen.getByTestId("student-deletion-modal")).toHaveAttribute(
+      "data-display-name",
+      "Max Mustermann",
+    );
+  });
+
+  it("clears the selected child after the guarded workflow succeeds", async () => {
+    setSelectedStudent("1");
+    render(<StudentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("student-detail-panel")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Löschen/i }));
+    fireEvent.click(await screen.findByTestId("finish-delete"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByTestId("student-deletion-modal"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows not found message when search has no matches", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -347,7 +347,7 @@ describe("StudentsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setSelectedStudent(null);
-    mockSessionWithPermissions(["config:manage"]);
+    mockSessionWithPermissions(["config:manage", "users:delete"]);
 
     // Default SWR mock - returns students data
     vi.mocked(useSWRAuth).mockImplementation((key: string | null) => {
@@ -412,6 +412,20 @@ describe("StudentsPage", () => {
         "true",
       );
     });
+  });
+
+  it("does not expose the deletion workflow without users delete permission", async () => {
+    mockSessionWithPermissions(["config:manage"]);
+    setSelectedStudent("1");
+
+    render(<StudentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("student-detail-panel")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: /Löschen/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows loading state when data is loading", () => {

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -25,11 +25,10 @@ import {
   StudentsMasterDetail,
   type GroupingMode,
 } from "@/components/students/students-master-detail";
-import { ConfirmationModal } from "~/components/ui/modal";
+import { StudentDeletionModal } from "~/components/students/student-deletion-modal";
 import { getDbOperationMessage } from "@/lib/use-notification";
 import { createCrudService } from "@/lib/database/service-factory";
 import { studentsConfig } from "@/components/database/configs/students.config";
-import { useDeleteConfirmation } from "~/hooks/useDeleteConfirmation";
 import type { Student } from "@/lib/api";
 import type { StudentGuardianPayload } from "@/lib/guardian-helpers";
 import { useSWRAuth, useTenantMutate } from "~/lib/swr";
@@ -85,10 +84,11 @@ function StudentsPageContent() {
   const [searchTerm, setSearchTerm] = useState("");
   const [groupFilter, setGroupFilter] = useState("all");
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Student | null>(null);
   const [arrivalRevision, setArrivalRevision] = useState(0);
   const isMobile = useIsMobile();
 
-  const { success: toastSuccess, error: toastError } = useToast();
+  const { success: toastSuccess } = useToast();
 
   const { data: session, status } = useSession({
     required: true,
@@ -313,14 +313,9 @@ function StudentsPageContent() {
     [service, tenantMutate, toastSuccess],
   );
 
-  const handleDeleteStudent = useCallback(async () => {
-    if (!selectedStudent) return;
-    const deleteError = await service.delete(selectedStudent.id);
-    if (deleteError) {
-      toastError(deleteError);
-      return;
-    }
-    const displayName = studentsConfig.list.item.title(selectedStudent);
+  const handleStudentDeleted = useCallback(async () => {
+    if (!deleteTarget) return;
+    const displayName = studentsConfig.list.item.title(deleteTarget);
     toastSuccess(
       getDbOperationMessage(
         "delete",
@@ -328,23 +323,10 @@ function StudentsPageContent() {
         displayName,
       ),
     );
+    setDeleteTarget(null);
     handleSelect(null);
     await tenantMutate("database-students-list");
-  }, [
-    selectedStudent,
-    service,
-    tenantMutate,
-    toastSuccess,
-    toastError,
-    handleSelect,
-  ]);
-
-  const {
-    showConfirmModal: showDeleteConfirmModal,
-    handleDeleteClick,
-    handleDeleteCancel,
-    confirmDelete,
-  } = useDeleteConfirmation();
+  }, [deleteTarget, tenantMutate, toastSuccess, handleSelect]);
 
   const handleArrivalChanged = useCallback(() => {
     setArrivalRevision((prev) => prev + 1);
@@ -378,7 +360,7 @@ function StudentsPageContent() {
   const detailActions = selectedStudent ? (
     <button
       type="button"
-      onClick={handleDeleteClick}
+      onClick={() => setDeleteTarget(selectedStudent)}
       className="flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100"
     >
       <Trash2 className="h-3.5 w-3.5" aria-hidden />
@@ -490,24 +472,14 @@ function StudentsPageContent() {
         groups={allGroups}
       />
 
-      {selectedStudent ? (
-        <ConfirmationModal
-          isOpen={showDeleteConfirmModal}
-          onClose={handleDeleteCancel}
-          onConfirm={() => confirmDelete(() => void handleDeleteStudent())}
-          title="Kind löschen?"
-          confirmText="Löschen"
-          cancelText="Abbrechen"
-          confirmButtonClass="bg-red-600 hover:bg-red-700"
-        >
-          <p className="text-sm text-gray-700">
-            Möchten Sie das Kind{" "}
-            <span className="font-medium">
-              {selectedStudent.first_name} {selectedStudent.second_name}
-            </span>{" "}
-            wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
-          </p>
-        </ConfirmationModal>
+      {deleteTarget ? (
+        <StudentDeletionModal
+          isOpen
+          studentId={String(deleteTarget.id)}
+          displayName={studentsConfig.list.item.title(deleteTarget)}
+          onClose={() => setDeleteTarget(null)}
+          onDeleted={handleStudentDeleted}
+        />
       ) : null}
     </DatabasePageLayout>
   );

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -356,17 +356,19 @@ function StudentsPageContent() {
 
   const canShowDetail = !loading && filteredStudents.length > 0;
   const canViewEnrollments = hasPermission(session, "config:manage");
+  const canDeleteStudents = hasPermission(session, "users:delete");
 
-  const detailActions = selectedStudent ? (
-    <button
-      type="button"
-      onClick={() => setDeleteTarget(selectedStudent)}
-      className="flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100"
-    >
-      <Trash2 className="h-3.5 w-3.5" aria-hidden />
-      Löschen
-    </button>
-  ) : null;
+  const detailActions =
+    selectedStudent && canDeleteStudents ? (
+      <button
+        type="button"
+        onClick={() => setDeleteTarget(selectedStudent)}
+        className="flex items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100"
+      >
+        <Trash2 className="h-3.5 w-3.5" aria-hidden />
+        Löschen
+      </button>
+    ) : null;
 
   return (
     <DatabasePageLayout

--- a/frontend/src/app/api/students/[id]/delete-impact/route.test.ts
+++ b/frontend/src/app/api/students/[id]/delete-impact/route.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session } from "next-auth";
+import { NextRequest } from "next/server";
+
+import { GET } from "./route";
+
+interface ExtendedSession extends Session {
+  user: Session["user"] & { token?: string };
+}
+
+const { mockAuth, mockApiGet } = vi.hoisted(() => ({
+  mockAuth: vi.fn<() => Promise<ExtendedSession | null>>(),
+  mockApiGet: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+  auth: mockAuth,
+  uncachedAuth: mockAuth,
+}));
+
+vi.mock("~/lib/api-helpers.server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/lib/api-helpers.server")>();
+  return {
+    ...actual,
+    apiGet: mockApiGet,
+  };
+});
+
+const session: ExtendedSession = {
+  user: { id: "1", token: "test-token", name: "Test User" },
+  expires: "2099-01-01",
+};
+
+describe("GET /api/students/[id]/delete-impact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(session);
+  });
+
+  it("forwards the request and returns the impact without a double envelope", async () => {
+    const impact = {
+      confirmation_name: "Mia Muster",
+      fingerprint: "abc",
+      total: 2,
+      counts: { timetable_assignments: 2 },
+      preserved: { shared_instances: true },
+    };
+    mockApiGet.mockResolvedValueOnce({ data: impact });
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/students/42/delete-impact"),
+      { params: Promise.resolve({ id: "42" }) },
+    );
+
+    expect(mockApiGet).toHaveBeenCalledWith(
+      "/api/students/42/delete-impact",
+      "test-token",
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: impact });
+  });
+
+  it("requires authentication", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/students/42/delete-impact"),
+      { params: Promise.resolve({ id: "42" }) },
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/api/students/[id]/delete-impact/route.ts
+++ b/frontend/src/app/api/students/[id]/delete-impact/route.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+
+import { apiGet } from "~/lib/api-helpers.server";
+import { createGetHandler } from "~/lib/route-wrapper.server";
+
+interface StudentDeletionImpact {
+  confirmation_name: string;
+  fingerprint: string;
+  total: number;
+  counts: Record<string, number>;
+  preserved: Record<string, boolean>;
+}
+
+interface BackendResponse {
+  data: StudentDeletionImpact;
+}
+
+export const GET = createGetHandler(
+  async (
+    _request: NextRequest,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const id = params.id as string;
+    if (!id) {
+      throw new Error("Student ID is required");
+    }
+    const response = await apiGet<BackendResponse>(
+      `/api/students/${encodeURIComponent(id)}/delete-impact`,
+      token,
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/students/[id]/route.test.ts
+++ b/frontend/src/app/api/students/[id]/route.test.ts
@@ -436,4 +436,29 @@ describe("DELETE /api/students/[id]", () => {
     }>(response);
     expect(json.success).toBe(true);
   });
+
+  it("forwards the guarded deletion confirmation body", async () => {
+    mockApiDelete.mockResolvedValueOnce({
+      message: "Student and linked data deleted successfully",
+    });
+    const body = {
+      expected_fingerprint: "abc123",
+      confirmation_name: "Mia Muster",
+      reason: "test_data",
+      acknowledged: true,
+    };
+
+    const request = createMockRequest("/api/students/123", {
+      method: "DELETE",
+      body,
+    });
+    const response = await DELETE(request, createMockContext({ id: "123" }));
+
+    expect(mockApiDelete).toHaveBeenCalledWith(
+      "/api/students/123",
+      "test-token",
+      body,
+    );
+    expect(response.status).toBe(200);
+  });
 });

--- a/frontend/src/app/api/students/[id]/route.ts
+++ b/frontend/src/app/api/students/[id]/route.ts
@@ -4,7 +4,7 @@ import { apiGet, apiPut, apiDelete } from "~/lib/api-helpers.server";
 import {
   createGetHandler,
   createPutHandler,
-  createDeleteHandler,
+  createDeleteWithBodyHandler,
 } from "~/lib/route-wrapper.server";
 import { createLogger } from "~/lib/logger";
 
@@ -396,9 +396,20 @@ export const PATCH = PUT;
  * Handler for DELETE /api/students/[id]
  * Deletes a student
  */
-export const DELETE = createDeleteHandler(
+interface StudentDeletionRequest {
+  expected_fingerprint?: string;
+  confirmation_name?: string;
+  reason?: string;
+  acknowledged?: boolean;
+}
+
+export const DELETE = createDeleteWithBodyHandler<
+  { success: true; message: string },
+  StudentDeletionRequest
+>(
   async (
     _request: NextRequest,
+    body: StudentDeletionRequest,
     token: string,
     params: Record<string, unknown>,
   ) => {
@@ -410,10 +421,14 @@ export const DELETE = createDeleteHandler(
 
     try {
       // Call backend API to delete student
-      const response = await apiDelete<{ message: string }>(
-        `/api/students/${id}`,
-        token,
-      );
+      const hasConfirmationBody = Object.keys(body).length > 0;
+      const response = hasConfirmationBody
+        ? await apiDelete<{ message: string }, StudentDeletionRequest>(
+            `/api/students/${id}`,
+            token,
+            body,
+          )
+        : await apiDelete<{ message: string }>(`/api/students/${id}`, token);
 
       return {
         success: true,

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1172,6 +1172,26 @@ export const appChapters: readonly GuideChapter[] = [
         image: "/help/screens/datenverwaltung.webp",
       },
       {
+        id: "kind-dauerhaft-loeschen",
+        title: "Kind dauerhaft löschen",
+        summary:
+          "Entfernt einen Kind-Datensatz zusammen mit seinen kindbezogenen Verknüpfungen. Die App zeigt vorher genau, welche Daten betroffen sind, und verlangt mehrere Bestätigungen.",
+        steps: [
+          "`Datenverwaltung` -> `Kinder` öffnen und das betreffende Kind auswählen.",
+          "Oben in der Detailansicht `Löschen` wählen und warten, bis die Auswirkungs-Vorschau vollständig geladen ist.",
+          "Die aufgeführten Datensätze prüfen. Stundenplan-Zuordnungen, Anwesenheitsdaten, Betreuungszeiten, Einwilligungen und weitere kindbezogene Verknüpfungen werden gelöscht oder vom Kind getrennt.",
+          "Einen Löschgrund auswählen und bestätigen, dass die Daten geprüft wurden. Danach `Weiter` wählen.",
+          "Den Namen des Kindes exakt wie angezeigt erneut eingeben und erst dann `Kind endgültig löschen` wählen.",
+        ],
+        callout: {
+          title: "Gemeinsam genutzte Daten bleiben erhalten",
+          body: "Elternkonten und Profile der Erziehungsberechtigten, andere Kinder sowie gemeinsam genutzte Stundenplan-Termine werden nicht gelöscht. Nur die Zuordnungen des gelöschten Kindes verschwinden. Ändern sich Daten zwischen Vorschau und Bestätigung, lädt moto die Vorschau neu und verlangt die Bestätigung erneut.",
+          tone: "red",
+        },
+        screenshot:
+          "Mehrstufiger Löschdialog mit Auswirkungs-Vorschau, Löschgrund, Bestätigung und Eingabe des vollständigen Kindernamens.",
+      },
+      {
         id: "jahrgangswechsel",
         title: "Jahrgangswechsel zum neuen Schuljahr",
         icon: GraduationCap,

--- a/frontend/src/components/students/student-deletion-modal.stories.tsx
+++ b/frontend/src/components/students/student-deletion-modal.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { installStorybookFetch, jsonResponse } from "~storybook/mocks/fetch";
+import type { StudentDeletionImpact } from "~/lib/student-api";
+
+import { StudentDeletionModal } from "./student-deletion-modal";
+
+const impact: StudentDeletionImpact = {
+  confirmation_name: "Mia Musterkind",
+  fingerprint: "storybook-student-deletion-fingerprint",
+  total: 28,
+  counts: {
+    timetable_assignments: 4,
+    activity_enrollments: 2,
+    attendance_records: 8,
+    care_schedules: 5,
+    guardian_links: 2,
+    companion_links: 1,
+    communications: 3,
+    consents: 1,
+    enrollment_references: 1,
+    other_records: 1,
+  },
+  preserved: {
+    guardian_profiles: true,
+    parent_accounts: true,
+    other_students: true,
+    shared_instances: true,
+  },
+};
+
+function withStudentDeletionApi() {
+  return installStorybookFetch(({ url, method }) => {
+    if (url.includes("/delete-impact") && method === "GET") {
+      return jsonResponse({ data: impact });
+    }
+    if (url.endsWith("/api/students/42") && method === "DELETE") {
+      return jsonResponse({ data: null });
+    }
+    return undefined;
+  });
+}
+
+const meta = {
+  title: "students/StudentDeletionModal",
+  component: StudentDeletionModal,
+  args: {
+    isOpen: true,
+    studentId: "42",
+    displayName: "Mia Musterkind",
+    onClose: () => undefined,
+    onDeleted: () => undefined,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  beforeEach: withStudentDeletionApi,
+} satisfies Meta<typeof StudentDeletionModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ImpactPreview: Story = {};

--- a/frontend/src/components/students/student-deletion-modal.test.tsx
+++ b/frontend/src/components/students/student-deletion-modal.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ModalProvider } from "~/components/dashboard/modal-context";
+import type { StudentDeletionImpact } from "~/lib/student-api";
+import { StudentDeletionModal } from "./student-deletion-modal";
+
+const { mockFetchImpact, mockDeleteStudent } = vi.hoisted(() => ({
+  mockFetchImpact: vi.fn(),
+  mockDeleteStudent: vi.fn(),
+}));
+
+vi.mock("~/lib/student-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/student-api")>();
+  return {
+    ...actual,
+    fetchStudentDeletionImpact: mockFetchImpact,
+    deleteStudentWithData: mockDeleteStudent,
+  };
+});
+
+const impact: StudentDeletionImpact = {
+  confirmation_name: "Mia Muster",
+  fingerprint: "abc123",
+  total: 5,
+  counts: {
+    timetable_assignments: 2,
+    activity_enrollments: 0,
+    attendance_records: 1,
+    care_schedules: 1,
+    guardian_links: 1,
+    companion_links: 0,
+    communications: 0,
+    consents: 0,
+    enrollment_references: 0,
+    other_records: 0,
+  },
+  preserved: {
+    guardian_profiles: true,
+    parent_accounts: true,
+    other_students: true,
+    shared_instances: true,
+  },
+};
+
+function renderModal(onDeleted = vi.fn(), onClose = vi.fn()) {
+  render(
+    <ModalProvider>
+      <StudentDeletionModal
+        isOpen
+        studentId="42"
+        displayName="Mia Muster"
+        onClose={onClose}
+        onDeleted={onDeleted}
+      />
+    </ModalProvider>,
+  );
+  return { onDeleted, onClose };
+}
+
+async function completeFirstStep() {
+  const nextButton = await screen.findByRole("button", {
+    name: "Weiter",
+  });
+  expect(nextButton).toBeDisabled();
+
+  fireEvent.click(screen.getByRole("combobox", { name: "Löschgrund" }));
+  fireEvent.click(await screen.findByRole("option", { name: "Testdaten" }));
+  fireEvent.click(screen.getByRole("checkbox"));
+
+  expect(nextButton).toBeEnabled();
+  fireEvent.click(nextButton);
+}
+
+describe("StudentDeletionModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchImpact.mockResolvedValue(impact);
+    mockDeleteStudent.mockResolvedValue(undefined);
+  });
+
+  it("shows the impact and requires reason, acknowledgement and exact name", async () => {
+    const { onDeleted } = renderModal();
+
+    expect(await screen.findByText("Stundenplan-Zuordnungen")).toBeVisible();
+    expect(
+      screen.getByRole("heading", { name: "Mia Muster löschen" }),
+    ).toBeVisible();
+    expect(screen.getByText("Anwesenheits- und Statusdaten")).toBeVisible();
+    expect(
+      screen.getByText(/Elternkonten und Profile der Erziehungsberechtigten/),
+    ).toBeVisible();
+
+    await completeFirstStep();
+    expect(
+      screen.getByRole("heading", {
+        name: "Löschung von Mia Muster bestätigen",
+      }),
+    ).toBeVisible();
+
+    const finalButton = screen.getByRole("button", {
+      name: "Kind endgültig löschen",
+    });
+    expect(finalButton).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Name erneut eingeben"), {
+      target: { value: "Mia Muste" },
+    });
+    expect(finalButton).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Name erneut eingeben"), {
+      target: { value: "Mia Muster" },
+    });
+    expect(finalButton).toBeEnabled();
+    fireEvent.click(finalButton);
+
+    await waitFor(() => {
+      expect(mockDeleteStudent).toHaveBeenCalledWith("42", {
+        expected_fingerprint: "abc123",
+        confirmation_name: "Mia Muster",
+        reason: "test_data",
+        acknowledged: true,
+      });
+    });
+    expect(onDeleted).toHaveBeenCalledOnce();
+  });
+
+  it("returns to a refreshed impact when the backend reports a conflict", async () => {
+    const { StudentDeletionApiError } = await import("~/lib/student-api");
+    mockDeleteStudent.mockRejectedValueOnce(
+      new StudentDeletionApiError(409, "Die Daten haben sich geändert."),
+    );
+    renderModal();
+
+    await completeFirstStep();
+    fireEvent.change(screen.getByLabelText("Name erneut eingeben"), {
+      target: { value: "Mia Muster" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Kind endgültig löschen" }),
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Weiter",
+      }),
+    ).toBeDisabled();
+    expect(screen.getByText("Die Daten haben sich geändert.")).toBeVisible();
+    expect(mockFetchImpact).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+  });
+
+  it("does not expose the destructive controls when the preview fails", async () => {
+    mockFetchImpact.mockRejectedValueOnce(
+      new Error("Vorschau nicht verfügbar"),
+    );
+    renderModal();
+
+    expect(await screen.findByText("Vorschau nicht verfügbar")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Weiter" })).toBeDisabled();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("does not offer a second deletion when refreshing after success fails", async () => {
+    const onDeleted = vi.fn().mockRejectedValue(new Error("refresh failed"));
+    const onClose = vi.fn();
+    renderModal(onDeleted, onClose);
+
+    await completeFirstStep();
+    fireEvent.change(screen.getByLabelText("Name erneut eingeben"), {
+      target: { value: "Mia Muster" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Kind endgültig löschen" }),
+    );
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+    expect(mockDeleteStudent).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByText("Das Kind konnte nicht gelöscht werden."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/students/student-deletion-modal.tsx
+++ b/frontend/src/components/students/student-deletion-modal.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { Database, ShieldCheck, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { Input } from "~/components/ui/input";
+import { Modal } from "~/components/ui/modal";
+import {
+  DataField,
+  DataGrid,
+  InfoSection,
+  InfoText,
+} from "~/components/ui/detail-modal-components";
+import { WizardStepper } from "~/components/ui/wizard-stepper";
+import {
+  deleteStudentWithData,
+  fetchStudentDeletionImpact,
+  StudentDeletionApiError,
+  type StudentDeletionCounts,
+  type StudentDeletionImpact,
+  type StudentDeletionReason,
+} from "~/lib/student-api";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "StudentDeletionModal" });
+
+const COUNT_LABELS: Record<keyof StudentDeletionCounts, string> = {
+  timetable_assignments: "Stundenplan-Zuordnungen",
+  activity_enrollments: "Angebotsanmeldungen",
+  attendance_records: "Anwesenheits- und Statusdaten",
+  care_schedules: "Ankunfts- und Abholpläne",
+  guardian_links: "Verknüpfungen zu Erziehungsberechtigten",
+  companion_links: "Laufgemeinschaften",
+  communications: "Nachrichten und Änderungsanfragen",
+  consents: "Einwilligungen",
+  enrollment_references: "Verknüpfungen zu Anmeldungen",
+  other_records: "Weitere kindbezogene Datensätze",
+};
+
+const REASON_OPTIONS: ReadonlyArray<{
+  value: StudentDeletionReason | "";
+  label: string;
+}> = [
+  { value: "", label: "Bitte auswählen" },
+  { value: "test_data", label: "Testdaten" },
+  { value: "incorrect_entry", label: "Fehlerhafte Erfassung" },
+  { value: "duplicate", label: "Doppelter Datensatz" },
+  { value: "privacy_request", label: "Datenschutz-/Löschanfrage" },
+];
+
+const DELETION_STEPS = ["Daten prüfen", "Name bestätigen"] as const;
+
+interface StudentDeletionModalProps {
+  readonly isOpen: boolean;
+  readonly studentId: string;
+  readonly displayName: string;
+  readonly onClose: () => void;
+  readonly onDeleted: () => Promise<void> | void;
+}
+
+export function StudentDeletionModal({
+  isOpen,
+  studentId,
+  displayName,
+  onClose,
+  onDeleted,
+}: StudentDeletionModalProps) {
+  const [impact, setImpact] = useState<StudentDeletionImpact | null>(null);
+  const [step, setStep] = useState<1 | 2>(1);
+  const [reason, setReason] = useState<StudentDeletionReason | "">("");
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [confirmationName, setConfirmationName] = useState("");
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setImpact(null);
+      setStep(1);
+      setReason("");
+      setAcknowledged(false);
+      setConfirmationName("");
+      setError("");
+      return;
+    }
+
+    let active = true;
+    setLoadingPreview(true);
+    setError("");
+    void fetchStudentDeletionImpact(studentId)
+      .then((result) => {
+        if (active) setImpact(result);
+      })
+      .catch((previewError: unknown) => {
+        const message =
+          previewError instanceof Error
+            ? previewError.message
+            : "Auswirkungen der Löschung konnten nicht geladen werden.";
+        logger.error("student_delete_preview_failed", {
+          student_id: studentId,
+          error: message,
+        });
+        if (active) setError(message);
+      })
+      .finally(() => {
+        if (active) setLoadingPreview(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [isOpen, studentId]);
+
+  const countRows = useMemo(() => {
+    if (!impact) return [];
+    return (Object.keys(COUNT_LABELS) as Array<keyof StudentDeletionCounts>)
+      .map((key) => ({
+        key,
+        label: COUNT_LABELS[key],
+        value: impact.counts[key],
+      }))
+      .filter((row) => row.value > 0);
+  }, [impact]);
+
+  const firstStepComplete = Boolean(impact && reason && acknowledged);
+  const nameMatches = confirmationName === impact?.confirmation_name;
+
+  const handleDelete = async () => {
+    if (!impact || !reason || !acknowledged || !nameMatches) return;
+    setDeleting(true);
+    setError("");
+    try {
+      await deleteStudentWithData(studentId, {
+        expected_fingerprint: impact.fingerprint,
+        confirmation_name: confirmationName,
+        reason,
+        acknowledged: true,
+      });
+      try {
+        await onDeleted();
+      } catch (refreshError) {
+        // The destructive request already succeeded. A failed list refresh
+        // must not be presented as a failed deletion or leave a retry button
+        // that can only answer 404 on the second attempt.
+        logger.error("student_delete_success_callback_failed", {
+          student_id: studentId,
+          error:
+            refreshError instanceof Error
+              ? refreshError.message
+              : String(refreshError),
+        });
+        onClose();
+      }
+    } catch (deleteError) {
+      const message =
+        deleteError instanceof Error
+          ? deleteError.message
+          : "Das Kind konnte nicht gelöscht werden.";
+      logger.error("student_delete_failed", {
+        student_id: studentId,
+        status:
+          deleteError instanceof StudentDeletionApiError
+            ? deleteError.status
+            : undefined,
+        error: message,
+      });
+
+      if (
+        deleteError instanceof StudentDeletionApiError &&
+        deleteError.status === 409
+      ) {
+        // The backend re-checks the preview under a row lock. A 409 means the
+        // user must see a fresh impact before confirming again.
+        setStep(1);
+        setAcknowledged(false);
+        setConfirmationName("");
+        setLoadingPreview(true);
+        try {
+          setImpact(await fetchStudentDeletionImpact(studentId));
+        } catch (refreshError) {
+          logger.error("student_delete_preview_refresh_failed", {
+            student_id: studentId,
+            error:
+              refreshError instanceof Error
+                ? refreshError.message
+                : String(refreshError),
+          });
+          setImpact(null);
+        } finally {
+          setLoadingPreview(false);
+        }
+      }
+      setError(message);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const footer =
+    step === 1 ? (
+      <>
+        <Button
+          type="button"
+          variant="outline"
+          size="md"
+          onClick={onClose}
+          disabled={deleting}
+        >
+          Abbrechen
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          size="md"
+          className="text-white"
+          disabled={!firstStepComplete || loadingPreview || deleting}
+          onClick={() => {
+            setError("");
+            setStep(2);
+          }}
+        >
+          Weiter
+        </Button>
+      </>
+    ) : (
+      <>
+        <Button
+          type="button"
+          variant="outline"
+          size="md"
+          onClick={() => setStep(1)}
+          disabled={deleting}
+        >
+          Zurück
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          size="md"
+          className="text-white"
+          isLoading={deleting}
+          loadingText="Wird gelöscht…"
+          disabled={!nameMatches || deleting}
+          onClick={() => void handleDelete()}
+        >
+          <Trash2 className="mr-2 h-4 w-4" aria-hidden="true" />
+          Kind endgültig löschen
+        </Button>
+      </>
+    );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        step === 1
+          ? `${displayName} löschen`
+          : `Löschung von ${displayName} bestätigen`
+      }
+      widthClass="mx-4 w-[calc(100%-2rem)] max-w-2xl"
+      footer={footer}
+      isDismissDisabled={deleting}
+    >
+      <div className="space-y-4">
+        <WizardStepper steps={DELETION_STEPS} current={step - 1} />
+
+        <Alert
+          type="warning"
+          message={`${displayName} und die unten aufgeführten Daten werden dauerhaft entfernt. Dieser Schritt kann nicht rückgängig gemacht werden.`}
+        />
+
+        {loadingPreview ? (
+          <p className="text-sm text-gray-500">Auswirkungen werden geladen…</p>
+        ) : null}
+        {error ? <Alert type="error" message={error} /> : null}
+
+        {impact && step === 1 ? (
+          <>
+            <InfoSection
+              title={`Was wird entfernt? (${impact.total})`}
+              icon={<Database className="h-full w-full" strokeWidth={2} />}
+              accentColor="red"
+            >
+              {countRows.length > 0 ? (
+                <DataGrid>
+                  {countRows.map((row) => (
+                    <DataField key={row.key} label={row.label}>
+                      {row.value}
+                    </DataField>
+                  ))}
+                </DataGrid>
+              ) : (
+                <InfoText>Keine weiteren verknüpften Daten gefunden.</InfoText>
+              )}
+            </InfoSection>
+
+            <InfoSection
+              title="Was bleibt erhalten?"
+              icon={<ShieldCheck className="h-full w-full" strokeWidth={2} />}
+              accentColor="gray"
+            >
+              <InfoText>
+                Elternkonten und Profile der Erziehungsberechtigten, andere
+                Kinder sowie gemeinsam genutzte Stundenplan-Termine bleiben
+                bestehen.
+              </InfoText>
+            </InfoSection>
+
+            <div>
+              <label
+                id="student-deletion-reason-label"
+                htmlFor="student-deletion-reason"
+                className="mb-2 block text-sm font-medium text-gray-700"
+              >
+                Löschgrund
+              </label>
+              <CustomSelect
+                id="student-deletion-reason"
+                value={reason}
+                options={REASON_OPTIONS}
+                onChange={(value) =>
+                  setReason(value as StudentDeletionReason | "")
+                }
+                ariaLabelledBy="student-deletion-reason-label"
+                disabled={deleting}
+                required
+              />
+            </div>
+
+            <label
+              htmlFor="student-deletion-acknowledgement"
+              className="flex cursor-pointer items-start gap-3 rounded-xl border border-[#FF3130]/20 bg-white p-4 text-sm text-gray-700"
+            >
+              <Checkbox
+                id="student-deletion-acknowledgement"
+                checked={acknowledged}
+                onChange={(event) => setAcknowledged(event.target.checked)}
+                disabled={deleting}
+              />
+              <span>
+                Ich habe geprüft, welche Daten entfernt werden, und möchte das
+                Kind dauerhaft löschen.
+              </span>
+            </label>
+          </>
+        ) : null}
+
+        {impact && step === 2 ? (
+          <section className="space-y-3">
+            <p className="text-sm text-gray-700">
+              Zur Sicherheit: Tippe den Namen genau so ein, wie er hier steht.
+            </p>
+            <InfoSection
+              title="Name des Kindes"
+              icon={<ShieldCheck className="h-full w-full" strokeWidth={2} />}
+              accentColor="gray"
+            >
+              <InfoText>{impact.confirmation_name}</InfoText>
+            </InfoSection>
+            <Input
+              name="student-deletion-confirmation-name"
+              label="Name erneut eingeben"
+              value={confirmationName}
+              onChange={(event) => setConfirmationName(event.target.value)}
+              placeholder={impact.confirmation_name}
+              autoComplete="off"
+              disabled={deleting}
+              error={
+                confirmationName.length > 0 && !nameMatches
+                  ? "Der Name stimmt noch nicht exakt überein."
+                  : undefined
+              }
+            />
+          </section>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/students/student-deletion-modal.tsx
+++ b/frontend/src/components/students/student-deletion-modal.tsx
@@ -37,7 +37,7 @@ const COUNT_LABELS: Record<keyof StudentDeletionCounts, string> = {
   companion_links: "Laufgemeinschaften",
   communications: "Nachrichten und Änderungsanfragen",
   consents: "Einwilligungen",
-  enrollment_references: "Verknüpfungen zu Anmeldungen",
+  enrollment_references: "Von Anmeldungen gelöste Verknüpfungen",
   other_records: "Weitere kindbezogene Datensätze",
 };
 
@@ -272,7 +272,7 @@ export function StudentDeletionModal({
 
         <Alert
           type="warning"
-          message={`${displayName} und die unten aufgeführten Daten werden dauerhaft entfernt. Dieser Schritt kann nicht rückgängig gemacht werden.`}
+          message={`${displayName} wird dauerhaft entfernt. Die unten aufgeführten Daten werden je nach Art gelöscht oder vom Kind gelöst. Dieser Schritt kann nicht rückgängig gemacht werden.`}
         />
 
         {loadingPreview ? (
@@ -283,7 +283,7 @@ export function StudentDeletionModal({
         {impact && step === 1 ? (
           <>
             <InfoSection
-              title={`Was wird entfernt? (${impact.total})`}
+              title={`Was wird gelöscht oder gelöst? (${impact.total})`}
               icon={<Database className="h-full w-full" strokeWidth={2} />}
               accentColor="red"
             >
@@ -308,7 +308,8 @@ export function StudentDeletionModal({
               <InfoText>
                 Elternkonten und Profile der Erziehungsberechtigten, andere
                 Kinder sowie gemeinsam genutzte Stundenplan-Termine bleiben
-                bestehen.
+                bestehen. Anmeldungen und Zugriffsprotokolle bleiben erhalten
+                und verlieren nur die Kindzuordnung.
               </InfoText>
             </InfoSection>
 

--- a/frontend/src/lib/api-helpers.server.ts
+++ b/frontend/src/lib/api-helpers.server.ts
@@ -348,12 +348,14 @@ export async function apiPatch<T, B = unknown>(
  * @param token Authentication token
  * @returns Promise with the response data, or void for 204 No Content responses
  */
-export async function apiDelete<T>(
+export async function apiDelete<T, B = unknown>(
   endpoint: string,
   token: string,
+  body?: B,
 ): Promise<T | void> {
   return serverFetchWithRetry<T>(endpoint, token, {
     method: "DELETE",
+    body,
     returnVoidOn204: true,
   });
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1905,54 +1905,6 @@ describe("api.ts helper functions", () => {
     });
   });
 
-  describe("studentService.deleteStudent", () => {
-    it("calls fetch with correct URL and method", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
-
-      const { getSession } = await import("next-auth/react");
-      vi.mocked(getSession).mockResolvedValue({
-        user: { token: "test-token" },
-      } as never);
-
-      const { studentService } = await import("./api");
-
-      const restore = setupBrowserEnv();
-      try {
-        await studentService.deleteStudent("123");
-        expect(global.fetch).toHaveBeenCalledWith(
-          expect.stringContaining("/api/students/123"),
-          expect.objectContaining({ method: "DELETE" }),
-        );
-      } finally {
-        restore();
-      }
-    });
-
-    it("throws error on delete failure", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        text: () => Promise.resolve("Delete failed"),
-      });
-
-      const { getSession } = await import("next-auth/react");
-      vi.mocked(getSession).mockResolvedValue({
-        user: { token: "test-token" },
-      } as never);
-
-      const { studentService } = await import("./api");
-
-      const restore = setupBrowserEnv();
-      try {
-        await expect(studentService.deleteStudent("123")).rejects.toThrow();
-      } finally {
-        restore();
-      }
-    });
-  });
-
   describe("roomService.deleteRoom", () => {
     it("calls fetch with correct URL and method", async () => {
       global.fetch = vi.fn().mockResolvedValue({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1275,48 +1275,6 @@ export const studentService = {
       throw handleApiError(error, `Error updating student ${id}`);
     }
   },
-
-  // Delete a student
-  deleteStudent: async (id: string): Promise<void> => {
-    const useProxyApi = globalThis.window !== undefined;
-    const url = useProxyApi
-      ? `/api/students/${id}`
-      : `${env.API_URL}/api/students/${id}`;
-
-    try {
-      if (useProxyApi) {
-        // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
-        const response = await fetch(url, {
-          method: "DELETE",
-          credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          logger.error("api error during fetch", {
-            status: response.status,
-            error_text: errorText.substring(0, 200), // Truncate long errors
-          });
-          throw new Error(`API error: ${response.status}`);
-        }
-
-        return;
-      } else {
-        // Server-side: use axios with the API URL directly
-        await api.delete(url);
-        return;
-      }
-    } catch (error) {
-      throw handleApiError(error, `Error deleting student ${id}`);
-    }
-  },
 };
 
 // Group service for API operations

--- a/frontend/src/lib/route-wrapper.server.ts
+++ b/frontend/src/lib/route-wrapper.server.ts
@@ -260,3 +260,14 @@ export function createPatchHandler<T, B = unknown>(
 export function createDeleteHandler<T>(handler: NoBodyHandler<T>) {
   return createNoBodyHandler(handler, (data) => formatDeleteResponse(data));
 }
+
+/**
+ * DELETE variant for destructive workflows that require an explicit JSON
+ * confirmation payload. Empty legacy requests still parse as an empty object,
+ * letting the backend reject them with the domain-specific conflict response.
+ */
+export function createDeleteWithBodyHandler<T, B = unknown>(
+  handler: WithBodyHandler<T, B>,
+) {
+  return createWithBodyHandler(handler, (data) => formatDeleteResponse(data));
+}

--- a/frontend/src/lib/student-api.test.ts
+++ b/frontend/src/lib/student-api.test.ts
@@ -47,6 +47,9 @@ import {
   updateStudentPrivacyConsent,
   uploadStudentPhoto,
   deleteStudentPhoto,
+  fetchStudentDeletionImpact,
+  deleteStudentWithData,
+  StudentDeletionApiError,
   type StudentFilters,
 } from "./student-api";
 
@@ -336,6 +339,95 @@ describe("student-api", () => {
         expect(mockDelete).toHaveBeenCalledWith(
           "http://server:8080/students/123",
         );
+      });
+    });
+  });
+
+  describe("guarded student deletion", () => {
+    const originalFetch = global.fetch;
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+      global.fetch = fetchMock as unknown as typeof fetch;
+      fetchMock.mockReset();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("loads and unwraps the deletion impact", async () => {
+      const impact = {
+        confirmation_name: "Mia Muster",
+        fingerprint: "abc",
+        total: 0,
+        counts: {},
+        preserved: {},
+      };
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: impact }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(fetchStudentDeletionImpact("42/unsafe")).resolves.toEqual(
+        impact,
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/students/42%2Funsafe/delete-impact",
+        { cache: "no-store" },
+      );
+    });
+
+    it("sends every confirmation field in the DELETE body", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const input = {
+        expected_fingerprint: "abc",
+        confirmation_name: "Mia Muster",
+        reason: "test_data" as const,
+        acknowledged: true as const,
+      };
+
+      await deleteStudentWithData("42", input);
+
+      expect(fetchMock).toHaveBeenCalledWith("/api/students/42", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+    });
+
+    it("preserves the status and original backend message on conflicts", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error:
+              'API error (409): {"status":"error","error":"Vorschau veraltet"}',
+          }),
+          {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+      const error = await deleteStudentWithData("42", {
+        expected_fingerprint: "abc",
+        confirmation_name: "Mia Muster",
+        reason: "test_data",
+        acknowledged: true,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(StudentDeletionApiError);
+      expect(error).toMatchObject({
+        status: 409,
+        message: "Vorschau veraltet",
       });
     });
   });

--- a/frontend/src/lib/student-api.test.ts
+++ b/frontend/src/lib/student-api.test.ts
@@ -40,7 +40,6 @@ import {
   fetchStudent,
   createStudent,
   updateStudent,
-  deleteStudent,
   fetchGroups,
   fetchStudentPrivacyConsent,
   fetchStudentEnrollmentExtraFields,
@@ -303,42 +302,6 @@ describe("student-api", () => {
           token: "test-token",
         });
         expect(result.id).toBe("1");
-      });
-    });
-  });
-
-  describe("deleteStudent", () => {
-    describe("client-side (browser)", () => {
-      beforeEach(() => {
-        mockedIsBrowserContext.mockReturnValue(true);
-      });
-
-      it("deletes a student", async () => {
-        mockedAuthFetch.mockResolvedValueOnce(undefined);
-
-        await deleteStudent("123");
-
-        expect(mockedAuthFetch).toHaveBeenCalledWith("/api/students/123", {
-          method: "DELETE",
-          token: "test-token",
-        });
-      });
-    });
-
-    describe("server-side (SSR)", () => {
-      beforeEach(() => {
-        mockedIsBrowserContext.mockReturnValue(false);
-      });
-
-      it("deletes a student using axios", async () => {
-        const mockDelete = vi.mocked(api.delete);
-        mockDelete.mockResolvedValueOnce(createAxiosResponse({}));
-
-        await deleteStudent("123");
-
-        expect(mockDelete).toHaveBeenCalledWith(
-          "http://server:8080/students/123",
-        );
       });
     });
   });

--- a/frontend/src/lib/student-api.ts
+++ b/frontend/src/lib/student-api.ts
@@ -449,6 +449,126 @@ export async function deleteStudent(id: string): Promise<void> {
   }
 }
 
+export interface StudentDeletionCounts {
+  timetable_assignments: number;
+  activity_enrollments: number;
+  attendance_records: number;
+  care_schedules: number;
+  guardian_links: number;
+  companion_links: number;
+  communications: number;
+  consents: number;
+  enrollment_references: number;
+  other_records: number;
+}
+
+export interface StudentDeletionImpact {
+  confirmation_name: string;
+  fingerprint: string;
+  total: number;
+  counts: StudentDeletionCounts;
+  preserved: {
+    guardian_profiles: boolean;
+    parent_accounts: boolean;
+    other_students: boolean;
+    shared_instances: boolean;
+  };
+}
+
+export type StudentDeletionReason =
+  "test_data" | "incorrect_entry" | "duplicate" | "privacy_request";
+
+export interface DeleteStudentWithDataInput {
+  expected_fingerprint: string;
+  confirmation_name: string;
+  reason: StudentDeletionReason;
+  acknowledged: true;
+}
+
+export class StudentDeletionApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "StudentDeletionApiError";
+    this.status = status;
+  }
+}
+
+function studentDeletionErrorMessage(payload: unknown, fallback: string) {
+  if (!payload || typeof payload !== "object") return fallback;
+  const candidate = payload as { error?: unknown; message?: unknown };
+  const raw =
+    typeof candidate.error === "string"
+      ? candidate.error
+      : typeof candidate.message === "string"
+        ? candidate.message
+        : "";
+  if (!raw) return fallback;
+
+  // The Next.js proxy may wrap the backend JSON inside
+  // "API error (409): {...}". Prefer the original German domain message.
+  const jsonStart = raw.indexOf("{");
+  if (jsonStart >= 0) {
+    try {
+      const nested = JSON.parse(raw.slice(jsonStart)) as {
+        error?: unknown;
+        message?: unknown;
+      };
+      if (typeof nested.error === "string") return nested.error;
+      if (typeof nested.message === "string") return nested.message;
+    } catch {
+      // Fall through to the unwrapped proxy message.
+    }
+  }
+  return raw;
+}
+
+async function studentDeletionResponse<T>(
+  response: Response,
+  fallbackError: string,
+): Promise<T> {
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    throw new StudentDeletionApiError(
+      response.status,
+      studentDeletionErrorMessage(payload, fallbackError),
+    );
+  }
+  if (payload && typeof payload === "object" && "data" in payload) {
+    return (payload as { data: T }).data;
+  }
+  return payload as T;
+}
+
+export async function fetchStudentDeletionImpact(
+  id: string,
+): Promise<StudentDeletionImpact> {
+  const response = await fetch(
+    `/api/students/${encodeURIComponent(id)}/delete-impact`,
+    { cache: "no-store" },
+  );
+  return studentDeletionResponse<StudentDeletionImpact>(
+    response,
+    "Auswirkungen der Löschung konnten nicht geladen werden.",
+  );
+}
+
+export async function deleteStudentWithData(
+  id: string,
+  input: DeleteStudentWithDataInput,
+): Promise<void> {
+  const response = await fetch(`/api/students/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  await studentDeletionResponse<unknown>(
+    response,
+    "Das Kind konnte nicht gelöscht werden.",
+  );
+}
+
 // ─── Student photo (Datenverwaltung) ────────────────────────────────────────
 
 /**

--- a/frontend/src/lib/student-api.ts
+++ b/frontend/src/lib/student-api.ts
@@ -427,28 +427,6 @@ export async function schoolCheckinStudent(
   }
 }
 
-// Delete a student
-export async function deleteStudent(id: string): Promise<void> {
-  const useProxy = isBrowserContext();
-  const url = useProxy
-    ? `/api/students/${id}`
-    : `${env.API_URL}/students/${id}`;
-
-  try {
-    if (useProxy) {
-      const session = await getCachedSession();
-      await authFetch<void>(url, {
-        method: "DELETE",
-        token: session?.user?.token,
-      });
-    } else {
-      await api.delete(url);
-    }
-  } catch (error) {
-    handleStudentApiError(error, "delete student");
-  }
-}
-
 export interface StudentDeletionCounts {
   timetable_assignments: number;
   activity_enrollments: number;


### PR DESCRIPTION
Closes #2068

## Kontext

In der Kindverwaltung gab es zwar bereits eine Löschaktion, sie scheiterte aber bei Kindern mit Betreuungszeiten, Terminzuordnungen oder Anwesenheitsdaten mit `409 Conflict`. Schulen mussten dann selbst herausfinden, welche Verknüpfung das Löschen blockiert, und die Daten einzeln entfernen. Das ist für Testdaten, Dubletten, Fehleingaben und DSGVO-Löschanfragen weder zuverlässig noch nachvollziehbar.

Diese Änderung führt deshalb einen kontrollierten, serverseitig abgesicherten Löschweg ein. Er entfernt nur Daten, die ausschließlich zu dem Kind gehören, und erhält Daten, die mit anderen Kindern oder Eltern geteilt werden.

## Was sich ändert

- Unter **Datenverwaltung → Kinder** lädt die Löschaktion zuerst eine aktuelle Auswirkungs-Vorschau. Sie fasst die betroffenen Zuordnungen und Datensätze in verständlichen Kategorien zusammen, statt Datenbanktabellen offenzulegen.
- Die endgültige Löschung verlangt einen Grund, eine Bestätigung der Unwiderruflichkeit und die exakte erneute Eingabe des vollständigen Kindernamens.
- Der Server prüft den Fingerprint der Vorschau erneut. Haben sich die Daten zwischen Vorschau und Bestätigung geändert, bricht er ab und verlangt eine neue Vorschau.
- Die Löschung läuft in einer Tenant-Transaktion. Wenn ein Schritt fehlschlägt, bleiben Kind und alle abhängigen Daten unverändert.
- Ein minimaler, beständiger Audit-Eintrag hält Akteur, Zeitpunkt, Grund und aggregierte Löschzahlen fest. Er speichert keinen Namen, kein Geburtsdatum und keine Kontaktinformationen des gelöschten Kindes.

## Schutz gemeinsamer Daten

Der Ablauf löscht oder anonymisiert ausschließlich das Zielkind und seine exklusiven Verknüpfungen. Er erhält ausdrücklich:

- Elternkonten und Erziehungsberechtigtenprofile, auch wenn sie noch mit Geschwistern verknüpft sind
- gemeinsame Termine und Aktivitäten; entfernt wird nur die Zuordnung des gelöschten Kindes
- Daten anderer Kinder, einschließlich Geschwistern und deren Beziehungen
- Mehrkind-Anmeldungen; sie verlieren nur das gelöschte Kind
- den besonderen Abgänger-Löschweg

Nach erfolgreichem Commit kann der Aufrufer ein hinterlegtes Kinderfoto entfernen; dadurch kann kein Dateilöschfehler eine bereits bestätigte Datenbanklöschung rückgängig machen oder einen halbfertigen Zustand erzeugen.

## Umsetzung

- Neuer Endpunkt für die serverseitig berechnete Löschvorschau sowie bestätigter `DELETE`-Ablauf
- Gemeinsame fachliche Zählung für Vorschau und Löschung, damit beide nicht auseinanderlaufen
- Sperren für den Kind- und Laufgemeinschaftsgraphen gegen parallele Änderungen
- gezieltes Entfernen der Kind-Zuordnung bei gemeinsam genutzten Termininstanzen
- Anonymisierung des verbleibenden Personen-Tombstones statt Löschen von Eltern- oder Konto-Daten
- append-only Audit-Tabelle mit RLS und eingeschränkten Datenbankrechten
- In-App-Hilfe ergänzt, damit der bewusste endgültige Löschablauf für Schulen dokumentiert ist

## Validierung

- `go run main.go migrate validate` — Migrationen einschließlich der neuen Audit-Migration sind eindeutig und valide
- Backend-Tests für erfolgreichen Löschvorgang, Rollback bei Audit-Fehlern, veraltete Vorschau, falschen Namen, unvollständige Bestätigung, Alumnus-Schutz, Tenant-Pflicht und Audit-Eintrag
- Frontend-Tests für Vorschau, Lade- und Fehlerzustände, Namensprüfung, Checkbox und erfolgreichen Löschablauf
- `pnpm run check`
- manueller Browser-Test des vollständigen Ablaufs im Docker-Stack

<details>
<summary>Screenshots</summary>

<img width="1440" height="1000" alt="Löschvorschau mit konkreten Auswirkungen" src="https://github.com/user-attachments/assets/79d6ff92-60f6-451e-becd-28ccc970b7ec" />
<img width="1440" height="1000" alt="Namensbestätigung vor endgültiger Löschung" src="https://github.com/user-attachments/assets/469d5dca-da73-4fe8-8096-3812817a1e82" />

</details>