### PR TITLE
Add privacy-safe product analytics

### DIFF
--- a/backend/analytics/analytics.go
+++ b/backend/analytics/analytics.go
@@ -105,6 +105,10 @@ func (t *httpTracker) Capture(distinctID, event string, props map[string]any) {
 		properties[k] = v
 	}
 	properties["$lib"] = "phoenix-backend"
+	// Product analytics is aggregated by school. Disable IP enrichment and
+	// person-profile processing for every backend event, regardless of caller.
+	properties["$geoip_disable"] = true
+	properties["$process_person_profile"] = false
 
 	body, err := json.Marshal(batchPayload{
 		APIKey: t.apiKey,

--- a/backend/analytics/analytics_test.go
+++ b/backend/analytics/analytics_test.go
@@ -107,6 +107,8 @@ func TestCapturePostsBatchPayload(t *testing.T) {
 	assert.NotEmpty(t, payload.Batch[0].Timestamp)
 	assert.Equal(t, "rfid", payload.Batch[0].Properties["method"])
 	assert.Equal(t, "phoenix-backend", payload.Batch[0].Properties["$lib"])
+	assert.Equal(t, true, payload.Batch[0].Properties["$geoip_disable"])
+	assert.Equal(t, false, payload.Batch[0].Properties["$process_person_profile"])
 	assert.Empty(t, logs.String())
 }
 

--- a/frontend/src/app/[tenant]/(protected)/suggestions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/suggestions/page.tsx
@@ -231,6 +231,7 @@ function SuggestionsPageContent() {
                     onEdit={handleEdit}
                     onDelete={setDeleteTarget}
                     onVoteChange={handleVoteChange}
+                    analyticsEnabled
                   />
                 </motion.div>
               ))}
@@ -244,6 +245,7 @@ function SuggestionsPageContent() {
         onClose={handleFormClose}
         onSuccess={handleFormSuccess}
         editSuggestion={editSuggestion}
+        analyticsEnabled
       />
 
       <ConfirmationModal

--- a/frontend/src/app/[tenant]/layout.tsx
+++ b/frontend/src/app/[tenant]/layout.tsx
@@ -1,6 +1,5 @@
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
-import { TenantProvider } from "~/lib/tenant-context";
 import { TenantGuard } from "~/components/tenant/tenant-guard";
 import { TenantProviders } from "./providers";
 import type { TenantInfo, TenantSettings } from "~/lib/tenant-api";
@@ -152,14 +151,12 @@ export default async function TenantLayout({
     : "path";
 
   return (
-    <TenantProviders>
-      <TenantProvider
-        tenantSlug={tenantSlug}
-        tenant={tenant}
-        routingMode={routingMode}
-      >
-        <TenantGuard>{children}</TenantGuard>
-      </TenantProvider>
+    <TenantProviders
+      tenantSlug={tenantSlug}
+      tenant={tenant}
+      routingMode={routingMode}
+    >
+      <TenantGuard>{children}</TenantGuard>
     </TenantProviders>
   );
 }

--- a/frontend/src/app/[tenant]/page.test.tsx
+++ b/frontend/src/app/[tenant]/page.test.tsx
@@ -11,6 +11,11 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+const mockTrackTenantEvent = vi.fn();
+vi.mock("~/lib/analytics", () => ({
+  trackTenantEvent: (...args: unknown[]) => mockTrackTenantEvent(...args),
+}));
+
 // Mock next-auth/react
 const mockSignIn = vi.fn();
 vi.mock("next-auth/react", () => ({
@@ -107,6 +112,12 @@ const mockAnimate = vi.fn(() => ({
 
 const originalFetch = global.fetch;
 
+const resolvedTenant = {
+  tenantId: 42,
+  name: "",
+  settings: {},
+} as ReturnType<typeof useTenant>["tenant"];
+
 function mockFetchResponse(status: number, body: unknown): typeof global.fetch {
   return vi.fn().mockResolvedValue(
     new Response(JSON.stringify(body), {
@@ -136,7 +147,7 @@ describe("HomePage (Login)", () => {
     vi.mocked(useTenant).mockReturnValue({
       tenantSlug: "test-tenant",
       routingMode: "path",
-      tenant: null,
+      tenant: resolvedTenant,
     });
 
     // Mock Element.animate globally
@@ -323,6 +334,11 @@ describe("HomePage (Login)", () => {
         refreshToken: "refresh-token",
       });
     });
+    expect(mockTrackTenantEvent).toHaveBeenCalledWith(
+      "login_success",
+      "42",
+      undefined,
+    );
   });
 
   it("removes stale session-expired query params before seeding the new session", async () => {
@@ -394,6 +410,9 @@ describe("HomePage (Login)", () => {
       expect(
         screen.getByText("Ungültige E-Mail oder Passwort"),
       ).toBeInTheDocument();
+    });
+    expect(mockTrackTenantEvent).toHaveBeenCalledWith("login_failed", "42", {
+      reason: "invalid_credentials",
     });
   });
 

--- a/frontend/src/app/[tenant]/page.tsx
+++ b/frontend/src/app/[tenant]/page.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import { KeyRound } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { refreshToken } from "~/lib/auth-api";
-import { trackEvent } from "~/lib/analytics";
+import { trackTenantEvent } from "~/lib/analytics";
 import { SmartRedirect } from "~/components/auth/smart-redirect";
 import {
   AuthShell,
@@ -92,6 +92,15 @@ function LoginForm() {
   const loginTitle = tenant?.name?.trim() ? tenant.name : "Willkommen bei moto";
   const tenantLoginImageUrl = tenant?.settings?.loginImageUrl;
   const hasTenantLoginLogo = Boolean(tenantLoginImageUrl);
+  const analyticsSchoolId = tenant?.tenantId?.toString() ?? null;
+
+  const trackLoginEvent = (
+    event: "login_success" | "login_failed",
+    props?: Record<string, string | number | boolean>,
+  ) => {
+    if (!analyticsSchoolId) return;
+    trackTenantEvent(event, analyticsSchoolId, props);
+  };
 
   // Guard against calling signOut multiple times during stale session cleanup
   const isCleaningSessionRef = useRef(false);
@@ -225,10 +234,10 @@ function LoginForm() {
     if (result?.error) {
       setError("Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.");
       logger.error("session_seed_failed", { error: result.error });
-      trackEvent("login_failed", { reason: "error" });
+      trackLoginEvent("login_failed", { reason: "error" });
       return;
     }
-    trackEvent("login_success");
+    trackLoginEvent("login_success");
     setAwaitingRedirect(true);
     router.refresh();
   };
@@ -278,10 +287,10 @@ function LoginForm() {
     } catch (err) {
       if (err instanceof MFAApiError && err.status === 401) {
         setError("Ungültige E-Mail oder Passwort");
-        trackEvent("login_failed", { reason: "invalid_credentials" });
+        trackLoginEvent("login_failed", { reason: "invalid_credentials" });
       } else {
         setError(germanMFAErrorMessage(err));
-        trackEvent("login_failed", { reason: "error" });
+        trackLoginEvent("login_failed", { reason: "error" });
       }
       logger.error("login failed", {
         error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/app/[tenant]/providers.test.tsx
+++ b/frontend/src/app/[tenant]/providers.test.tsx
@@ -1,0 +1,67 @@
+import type React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TenantInfo } from "~/lib/tenant-api";
+import { TenantProviders } from "./providers";
+
+const { mockTenantProvider } = vi.hoisted(() => ({
+  mockTenantProvider: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("~/components/notifications/service-worker-registrar", () => ({
+  PushSubscriptionSync: () => null,
+}));
+
+vi.mock("~/components/auth/tenant-auth-wrapper", () => ({
+  TenantAuthWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tenant-auth-wrapper">{children}</div>
+  ),
+}));
+
+vi.mock("~/lib/profile-context", () => ({
+  ProfileProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("~/lib/supervision-context", () => ({
+  SupervisionProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+vi.mock("~/lib/tenant-context", () => ({
+  TenantProvider: (props: {
+    children: React.ReactNode;
+    tenantSlug: string;
+    tenant: TenantInfo;
+    routingMode: "path" | "subdomain";
+  }) => {
+    mockTenantProvider(props);
+    return <div data-testid="tenant-provider">{props.children}</div>;
+  },
+}));
+
+describe("TenantProviders", () => {
+  it("renders analytics hooks inside the tenant routing context", () => {
+    const tenant = { subdomain: "school-a" } as TenantInfo;
+
+    render(
+      <TenantProviders tenantSlug="school-a" tenant={tenant} routingMode="path">
+        <div>Tenant content</div>
+      </TenantProviders>,
+    );
+
+    expect(screen.getByTestId("tenant-auth-wrapper").parentElement).toBe(
+      screen.getByTestId("tenant-provider"),
+    );
+    expect(mockTenantProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantSlug: "school-a",
+        tenant,
+        routingMode: "path",
+      }),
+    );
+  });
+});

--- a/frontend/src/app/[tenant]/providers.tsx
+++ b/frontend/src/app/[tenant]/providers.tsx
@@ -5,6 +5,8 @@ import { ProfileProvider } from "~/lib/profile-context";
 import { SupervisionProvider } from "~/lib/supervision-context";
 import { TenantAuthWrapper } from "~/components/auth/tenant-auth-wrapper";
 import { PushSubscriptionSync } from "~/components/notifications/service-worker-registrar";
+import { TenantProvider, type TenantRoutingMode } from "~/lib/tenant-context";
+import type { TenantInfo } from "~/lib/tenant-api";
 
 /**
  * Tenant-scoped providers.
@@ -15,15 +17,29 @@ import { PushSubscriptionSync } from "~/components/notifications/service-worker-
  */
 export function TenantProviders({
   children,
-}: Readonly<{ children: React.ReactNode }>) {
+  tenantSlug,
+  tenant,
+  routingMode,
+}: Readonly<{
+  children: React.ReactNode;
+  tenantSlug: string;
+  tenant: TenantInfo;
+  routingMode: TenantRoutingMode;
+}>) {
   return (
     <SessionProvider refetchInterval={4 * 60} refetchOnWindowFocus={false}>
       <PushSubscriptionSync portal="tenant" />
-      <TenantAuthWrapper>
-        <ProfileProvider>
-          <SupervisionProvider>{children}</SupervisionProvider>
-        </ProfileProvider>
-      </TenantAuthWrapper>
+      <TenantProvider
+        tenantSlug={tenantSlug}
+        tenant={tenant}
+        routingMode={routingMode}
+      >
+        <TenantAuthWrapper>
+          <ProfileProvider>
+            <SupervisionProvider>{children}</SupervisionProvider>
+          </ProfileProvider>
+        </TenantAuthWrapper>
+      </TenantProvider>
     </SessionProvider>
   );
 }

--- a/frontend/src/components/auth/tenant-auth-wrapper.test.tsx
+++ b/frontend/src/components/auth/tenant-auth-wrapper.test.tsx
@@ -83,7 +83,7 @@ describe("TenantAuthWrapper analytics", () => {
     expect(mocks.unregister).toHaveBeenCalledWith("school_id");
     expect(mocks.unregister).toHaveBeenCalledWith("$groups");
     expect(mocks.unregister).toHaveBeenCalledWith("deployment");
-    expect(mocks.reset).not.toHaveBeenCalled();
+    expect(mocks.reset).toHaveBeenCalledOnce();
 
     mocks.useSession.mockReturnValue({
       status: "authenticated",
@@ -101,5 +101,51 @@ describe("TenantAuthWrapper analytics", () => {
       deployment: "moto-app.de",
     });
     expect(mocks.trackPageView).toHaveBeenCalledWith("/dashboard", "2");
+  });
+
+  it("resets identity before a direct authenticated tenant change", () => {
+    mocks.useTenant.mockReturnValue({
+      tenantSlug: "school-a",
+      routingMode: "path",
+      tenant: { tenantId: 1 },
+    });
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { tenantId: 1 } },
+    });
+
+    const view = renderWrapper();
+
+    expect(mocks.reset).not.toHaveBeenCalled();
+    expect(mocks.register).toHaveBeenCalledWith({
+      school_id: "1",
+      $groups: { school: "1" },
+      deployment: "moto-app.de",
+    });
+
+    mocks.useTenant.mockReturnValue({
+      tenantSlug: "school-b",
+      routingMode: "path",
+      tenant: { tenantId: 2 },
+    });
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { tenantId: 2 } },
+    });
+    view.rerender(
+      <TenantAuthWrapper>
+        <div>Tenant content</div>
+      </TenantAuthWrapper>,
+    );
+
+    expect(mocks.reset).toHaveBeenCalledOnce();
+    expect(mocks.register).toHaveBeenNthCalledWith(2, {
+      school_id: "2",
+      $groups: { school: "2" },
+      deployment: "moto-app.de",
+    });
+    expect(mocks.reset.mock.invocationCallOrder[0]!).toBeLessThan(
+      mocks.register.mock.invocationCallOrder[1]!,
+    );
   });
 });

--- a/frontend/src/components/auth/tenant-auth-wrapper.test.tsx
+++ b/frontend/src/components/auth/tenant-auth-wrapper.test.tsx
@@ -1,0 +1,105 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TenantAuthWrapper } from "./tenant-auth-wrapper";
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  useTenant: vi.fn(),
+  register: vi.fn(),
+  unregister: vi.fn(),
+  reset: vi.fn(),
+  trackPageView: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({ useSession: mocks.useSession }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/school-b/dashboard",
+}));
+vi.mock("posthog-js", () => ({
+  default: {
+    register: mocks.register,
+    unregister: mocks.unregister,
+    reset: mocks.reset,
+  },
+}));
+vi.mock("~/env", () => ({
+  env: { NEXT_PUBLIC_TENANT_DOMAIN: "moto-app.de" },
+}));
+vi.mock("~/lib/hooks/use-user-context", () => ({
+  useUserContext: () => ({ isReady: true }),
+}));
+vi.mock("~/lib/hooks/use-global-sse", () => ({
+  useGlobalSSE: () => ({ status: "connected" }),
+}));
+vi.mock("~/lib/analytics", () => ({
+  trackPageView: mocks.trackPageView,
+}));
+vi.mock("~/lib/tenant-context", () => ({ useTenant: mocks.useTenant }));
+
+function renderWrapper() {
+  return render(
+    <TenantAuthWrapper>
+      <div>Tenant content</div>
+    </TenantAuthWrapper>,
+  );
+}
+
+describe("TenantAuthWrapper analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useTenant.mockReturnValue({
+      tenantSlug: "school-b",
+      routingMode: "path",
+      tenant: { tenantId: 2 },
+    });
+  });
+
+  it("captures after the URL tenant matches the session tenant", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { tenantId: 2 } },
+    });
+
+    renderWrapper();
+
+    expect(mocks.register).toHaveBeenCalledWith({
+      school_id: "2",
+      $groups: { school: "2" },
+      deployment: "moto-app.de",
+    });
+    expect(mocks.trackPageView).toHaveBeenCalledWith("/dashboard", "2");
+  });
+
+  it("clears context and skips capture while TenantGuard switches tenants", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { tenantId: 1 } },
+    });
+
+    const view = renderWrapper();
+
+    expect(mocks.register).not.toHaveBeenCalled();
+    expect(mocks.trackPageView).not.toHaveBeenCalled();
+    expect(mocks.unregister).toHaveBeenCalledWith("school_id");
+    expect(mocks.unregister).toHaveBeenCalledWith("$groups");
+    expect(mocks.unregister).toHaveBeenCalledWith("deployment");
+    expect(mocks.reset).not.toHaveBeenCalled();
+
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { tenantId: 2 } },
+    });
+    view.rerender(
+      <TenantAuthWrapper>
+        <div>Tenant content</div>
+      </TenantAuthWrapper>,
+    );
+
+    expect(mocks.register).toHaveBeenCalledWith({
+      school_id: "2",
+      $groups: { school: "2" },
+      deployment: "moto-app.de",
+    });
+    expect(mocks.trackPageView).toHaveBeenCalledWith("/dashboard", "2");
+  });
+});

--- a/frontend/src/components/auth/tenant-auth-wrapper.tsx
+++ b/frontend/src/components/auth/tenant-auth-wrapper.tsx
@@ -18,32 +18,62 @@
 
 import { useEffect } from "react";
 import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
+import { env } from "~/env";
 import { useUserContext } from "~/lib/hooks/use-user-context";
 import { useGlobalSSE } from "~/lib/hooks/use-global-sse";
 import { createLogger } from "~/lib/logger";
+import { trackPageView } from "~/lib/analytics";
+import { resolveAnalyticsViewId } from "~/lib/analytics-routes";
+import {
+  useTenantRoutingModeSafe,
+  useTenantSlugSafe,
+} from "~/lib/tenant-context";
+import { normalizeTenantPathname } from "~/lib/tenant-path";
 
 const logger = createLogger({ component: "TenantAuthWrapper" });
 
 function TeacherSpecificHooks() {
   const { data: session, status } = useSession();
+  const rawPathname = usePathname();
+  const tenantSlug = useTenantSlugSafe();
+  const routingMode = useTenantRoutingModeSafe();
+  const pathname = normalizeTenantPathname(
+    rawPathname,
+    tenantSlug,
+    routingMode,
+  );
+  const viewId = resolveAnalyticsViewId(pathname);
+  const schoolId = session?.user?.tenantId?.toString() ?? null;
 
   const { isReady: contextReady } = useUserContext();
   const { status: sseStatus } = useGlobalSSE();
 
   useEffect(() => {
-    if (status === "authenticated" && session?.user?.id) {
-      // GDPR: identify with the pseudonymous account ID only — never attach
-      // person properties like email.
-      posthog.identify(session.user.id);
-      if (session.user.tenantId != null) {
-        posthog.group("school", String(session.user.tenantId));
-        posthog.register({ school_id: session.user.tenantId });
-      }
+    if (status === "authenticated" && schoolId) {
+      // School-level context only. Never send an account/person identifier.
+      posthog.register({
+        school_id: schoolId,
+        $groups: { school: schoolId },
+        deployment: env.NEXT_PUBLIC_TENANT_DOMAIN,
+      });
     } else if (status === "unauthenticated") {
+      posthog.unregister("school_id");
+      posthog.unregister("$groups");
+      posthog.unregister("deployment");
       posthog.reset();
     }
-  }, [status, session]);
+  }, [status, schoolId]);
+
+  useEffect(() => {
+    if (status === "authenticated" && schoolId && viewId) {
+      trackPageView(viewId, schoolId);
+    }
+    // `pathname` is intentionally a dependency: navigating between two
+    // resources with the same template (for example /students/1 ->
+    // /students/2) is a new page view, while only `viewId` leaves the browser.
+  }, [status, schoolId, viewId, pathname]);
 
   useEffect(() => {
     if (process.env.NODE_ENV === "development" && status === "authenticated") {

--- a/frontend/src/components/auth/tenant-auth-wrapper.tsx
+++ b/frontend/src/components/auth/tenant-auth-wrapper.tsx
@@ -9,7 +9,7 @@
 
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
@@ -38,18 +38,26 @@ function TeacherSpecificHooks() {
   const urlSchoolId = tenant?.tenantId?.toString() ?? null;
   const tenantMatchesSession =
     schoolId !== null && urlSchoolId !== null && schoolId === urlSchoolId;
+  const registeredSchoolIdRef = useRef<string | null>(null);
 
   const { isReady: contextReady } = useUserContext();
   const { status: sseStatus } = useGlobalSSE();
 
   useEffect(() => {
     if (status === "authenticated" && tenantMatchesSession && schoolId) {
+      if (
+        registeredSchoolIdRef.current !== null &&
+        registeredSchoolIdRef.current !== schoolId
+      ) {
+        posthog.reset();
+      }
       // School-level context only. Never send an account/person identifier.
       posthog.register({
         school_id: schoolId,
         $groups: { school: schoolId },
         deployment: env.NEXT_PUBLIC_TENANT_DOMAIN,
       });
+      registeredSchoolIdRef.current = schoolId;
     } else if (
       status === "unauthenticated" ||
       (status === "authenticated" && !tenantMatchesSession)
@@ -57,7 +65,8 @@ function TeacherSpecificHooks() {
       posthog.unregister("school_id");
       posthog.unregister("$groups");
       posthog.unregister("deployment");
-      if (status === "unauthenticated") posthog.reset();
+      posthog.reset();
+      registeredSchoolIdRef.current = null;
     }
   }, [status, schoolId, tenantMatchesSession]);
 

--- a/frontend/src/components/auth/tenant-auth-wrapper.tsx
+++ b/frontend/src/components/auth/tenant-auth-wrapper.tsx
@@ -3,6 +3,7 @@
  *
  * Runs teacher-specific hooks: user context pre-warming, global SSE, PostHog.
  * Only active for tenant sessions — never runs for operator sessions.
+ * Must run inside both SessionProvider and TenantProvider.
  *
  * @example
  * ```tsx

--- a/frontend/src/components/auth/tenant-auth-wrapper.tsx
+++ b/frontend/src/components/auth/tenant-auth-wrapper.tsx
@@ -4,15 +4,7 @@
  * Runs teacher-specific hooks: user context pre-warming, global SSE, PostHog.
  * Only active for tenant sessions — never runs for operator sessions.
  * Must run inside both SessionProvider and TenantProvider.
- *
- * @example
- * ```tsx
- * <SessionProvider>
- *   <TenantAuthWrapper>
- *     {children}
- *   </TenantAuthWrapper>
- * </SessionProvider>
- * ```
+ * TenantProviders owns this composition so routing context is always present.
  */
 
 "use client";
@@ -27,10 +19,7 @@ import { useGlobalSSE } from "~/lib/hooks/use-global-sse";
 import { createLogger } from "~/lib/logger";
 import { trackPageView } from "~/lib/analytics";
 import { resolveAnalyticsViewId } from "~/lib/analytics-routes";
-import {
-  useTenantRoutingModeSafe,
-  useTenantSlugSafe,
-} from "~/lib/tenant-context";
+import { useTenant } from "~/lib/tenant-context";
 import { normalizeTenantPathname } from "~/lib/tenant-path";
 
 const logger = createLogger({ component: "TenantAuthWrapper" });
@@ -38,8 +27,7 @@ const logger = createLogger({ component: "TenantAuthWrapper" });
 function TeacherSpecificHooks() {
   const { data: session, status } = useSession();
   const rawPathname = usePathname();
-  const tenantSlug = useTenantSlugSafe();
-  const routingMode = useTenantRoutingModeSafe();
+  const { tenantSlug, tenant, routingMode } = useTenant();
   const pathname = normalizeTenantPathname(
     rawPathname,
     tenantSlug,
@@ -47,34 +35,45 @@ function TeacherSpecificHooks() {
   );
   const viewId = resolveAnalyticsViewId(pathname);
   const schoolId = session?.user?.tenantId?.toString() ?? null;
+  const urlSchoolId = tenant?.tenantId?.toString() ?? null;
+  const tenantMatchesSession =
+    schoolId !== null && urlSchoolId !== null && schoolId === urlSchoolId;
 
   const { isReady: contextReady } = useUserContext();
   const { status: sseStatus } = useGlobalSSE();
 
   useEffect(() => {
-    if (status === "authenticated" && schoolId) {
+    if (status === "authenticated" && tenantMatchesSession && schoolId) {
       // School-level context only. Never send an account/person identifier.
       posthog.register({
         school_id: schoolId,
         $groups: { school: schoolId },
         deployment: env.NEXT_PUBLIC_TENANT_DOMAIN,
       });
-    } else if (status === "unauthenticated") {
+    } else if (
+      status === "unauthenticated" ||
+      (status === "authenticated" && !tenantMatchesSession)
+    ) {
       posthog.unregister("school_id");
       posthog.unregister("$groups");
       posthog.unregister("deployment");
-      posthog.reset();
+      if (status === "unauthenticated") posthog.reset();
     }
-  }, [status, schoolId]);
+  }, [status, schoolId, tenantMatchesSession]);
 
   useEffect(() => {
-    if (status === "authenticated" && schoolId && viewId) {
+    if (
+      status === "authenticated" &&
+      tenantMatchesSession &&
+      schoolId &&
+      viewId
+    ) {
       trackPageView(viewId, schoolId);
     }
     // `pathname` is intentionally a dependency: navigating between two
     // resources with the same template (for example /students/1 ->
     // /students/2) is a new page view, while only `viewId` leaves the browser.
-  }, [status, schoolId, viewId, pathname]);
+  }, [status, schoolId, tenantMatchesSession, viewId, pathname]);
 
   useEffect(() => {
     if (process.env.NODE_ENV === "development" && status === "authenticated") {

--- a/frontend/src/components/suggestions/suggestion-card.tsx
+++ b/frontend/src/components/suggestions/suggestion-card.tsx
@@ -25,6 +25,8 @@ interface SuggestionCardProps {
   readonly onVoteChange: (updated: Suggestion) => void;
   /** Which board this card belongs to. Defaults to the staff board. */
   readonly api?: SuggestionsBoardApi;
+  /** Enable analytics only from the authenticated tenant board. */
+  readonly analyticsEnabled?: boolean;
   /** Unread-refresh event name forwarded to the comment accordion. */
   readonly unreadRefreshEvent?: string;
   /**
@@ -43,6 +45,7 @@ export function SuggestionCard({
   onDelete,
   onVoteChange,
   api = staffBoardApi,
+  analyticsEnabled = false,
   unreadRefreshEvent,
   statusLabels = STATUS_LABELS,
   menuLabels = DEFAULT_MENU_LABELS,
@@ -70,6 +73,7 @@ export function SuggestionCard({
             suggestion={suggestion}
             onVoteChange={onVoteChange}
             api={api}
+            analyticsEnabled={analyticsEnabled}
           />
         </div>
 
@@ -135,6 +139,7 @@ export function SuggestionCard({
                 suggestion={suggestion}
                 onVoteChange={onVoteChange}
                 api={api}
+                analyticsEnabled={analyticsEnabled}
               />
             </div>
           </div>

--- a/frontend/src/components/suggestions/suggestion-form.test.tsx
+++ b/frontend/src/components/suggestions/suggestion-form.test.tsx
@@ -9,10 +9,15 @@ import type { Suggestion } from "~/lib/suggestions-helpers";
 
 const mockCreateSuggestion = vi.hoisted(() => vi.fn());
 const mockUpdateSuggestion = vi.hoisted(() => vi.fn());
+const mockTrackEvent = vi.hoisted(() => vi.fn());
 
 vi.mock("~/lib/suggestions-api", () => ({
   createSuggestion: mockCreateSuggestion,
   updateSuggestion: mockUpdateSuggestion,
+}));
+
+vi.mock("~/lib/analytics", () => ({
+  trackEvent: mockTrackEvent,
 }));
 
 const mockToastSuccess = vi.fn();
@@ -199,6 +204,32 @@ describe("SuggestionForm", () => {
       );
       expect(onSuccess).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("tracks new submissions only when tenant analytics are enabled", async () => {
+    mockCreateSuggestion.mockResolvedValue(editSuggestion);
+
+    render(
+      <SuggestionForm
+        isOpen={true}
+        onClose={onClose}
+        onSuccess={onSuccess}
+        analyticsEnabled
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Titel/), {
+      target: { value: "New Title" },
+    });
+    fireEvent.change(screen.getByLabelText(/Beschreibung/), {
+      target: { value: "New Description" },
+    });
+    fireEvent.submit(document.getElementById("suggestion-form")!);
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith("suggestion_created");
     });
   });
 

--- a/frontend/src/components/suggestions/suggestion-form.tsx
+++ b/frontend/src/components/suggestions/suggestion-form.tsx
@@ -29,6 +29,8 @@ interface SuggestionFormProps {
   readonly editSuggestion?: Suggestion | null;
   /** Which board to write to. Defaults to the school's staff board. */
   readonly api?: SuggestionFormApi;
+  /** Enable analytics only from the authenticated tenant board. */
+  readonly analyticsEnabled?: boolean;
   /** Optional note above the fields, e.g. who will read this. */
   readonly hint?: ReactNode;
   /** Example wording. The staff default names a staff feature. */
@@ -42,6 +44,7 @@ export function SuggestionForm({
   onSuccess,
   editSuggestion,
   api = staffFormApi,
+  analyticsEnabled = false,
   hint,
   titlePlaceholder = "z.B. 'PDF-Export für Vertretungsplan'",
   descriptionPlaceholder = "Beschreibe dein Feedback...",
@@ -96,7 +99,9 @@ export function SuggestionForm({
         toastSuccess("Beitrag wurde aktualisiert.");
       } else {
         await api.create(trimmedTitle, trimmedDescription);
-        trackEvent("suggestion_created");
+        if (analyticsEnabled) {
+          trackEvent("suggestion_created");
+        }
         toastSuccess("Beitrag wurde eingereicht.");
       }
       onSuccess();

--- a/frontend/src/components/suggestions/vote-buttons.test.tsx
+++ b/frontend/src/components/suggestions/vote-buttons.test.tsx
@@ -9,10 +9,15 @@ import type { Suggestion } from "~/lib/suggestions-helpers";
 
 const mockVoteSuggestion = vi.hoisted(() => vi.fn());
 const mockRemoveVote = vi.hoisted(() => vi.fn());
+const mockTrackEvent = vi.hoisted(() => vi.fn());
 
 vi.mock("~/lib/suggestions-api", () => ({
   voteSuggestion: mockVoteSuggestion,
   removeVote: mockRemoveVote,
+}));
+
+vi.mock("~/lib/analytics", () => ({
+  trackEvent: mockTrackEvent,
 }));
 
 // ============================================================================
@@ -126,6 +131,28 @@ describe("VoteButtons", () => {
     // Wait for async call
     await vi.waitFor(() => {
       expect(mockVoteSuggestion).toHaveBeenCalledWith("1", "up");
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("tracks votes only when tenant analytics are enabled", async () => {
+    const updated = createSuggestion({ userVote: "up", upvotes: 5, score: 4 });
+    mockVoteSuggestion.mockResolvedValue(updated);
+
+    render(
+      <VoteButtons
+        suggestion={createSuggestion()}
+        onVoteChange={onVoteChange}
+        analyticsEnabled
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Positiv bewerten"));
+
+    await vi.waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith("suggestion_voted", {
+        direction: "up",
+      });
     });
   });
 

--- a/frontend/src/components/suggestions/vote-buttons.tsx
+++ b/frontend/src/components/suggestions/vote-buttons.tsx
@@ -15,12 +15,15 @@ interface VoteButtonsProps {
   readonly onVoteChange: (updated: Suggestion) => void;
   /** Which board to vote on. Defaults to the school's staff board. */
   readonly api?: SuggestionsBoardApi;
+  /** Enable analytics only from the authenticated tenant board. */
+  readonly analyticsEnabled?: boolean;
 }
 
 export function VoteButtons({
   suggestion,
   onVoteChange,
   api = staffBoardApi,
+  analyticsEnabled = false,
 }: VoteButtonsProps) {
   const [optimistic, setOptimistic] = useState<{
     upvotes: number;
@@ -87,7 +90,9 @@ export function VoteButtons({
 
       try {
         const updated = await api.vote(suggestion.id, direction);
-        trackEvent("suggestion_voted", { direction });
+        if (analyticsEnabled) {
+          trackEvent("suggestion_voted", { direction });
+        }
         setOptimistic(null);
         onVoteChange(updated);
       } catch (err) {
@@ -103,7 +108,15 @@ export function VoteButtons({
         });
       }
     },
-    [suggestion, upvotes, downvotes, userVote, onVoteChange, api],
+    [
+      suggestion,
+      upvotes,
+      downvotes,
+      userVote,
+      onVoteChange,
+      api,
+      analyticsEnabled,
+    ],
   );
 
   const upClasses =

--- a/frontend/src/components/tenant/tenant-switcher.test.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.test.tsx
@@ -26,6 +26,10 @@ const { mockUseTenantSlugSafe } = vi.hoisted(() => ({
   mockUseTenantSlugSafe: vi.fn(),
 }));
 
+const { mockTrackTenantEvent } = vi.hoisted(() => ({
+  mockTrackTenantEvent: vi.fn(),
+}));
+
 vi.mock("~/lib/tenant-api", () => ({
   listAvailableTenants: mockListAvailableTenants,
   performTenantSwitch: mockPerformTenantSwitch,
@@ -43,6 +47,10 @@ vi.mock("~/lib/swr", () => ({
 vi.mock("~/lib/tenant-context", () => ({
   useTenantSlugSafe: mockUseTenantSlugSafe,
   useNFCEnabled: vi.fn(() => true),
+}));
+
+vi.mock("~/lib/analytics", () => ({
+  trackTenantEvent: mockTrackTenantEvent,
 }));
 
 vi.mock("~/env", () => ({
@@ -281,6 +289,9 @@ describe("BrandTenantSwitcher", () => {
         mockSignIn,
         mockMutate,
       );
+    });
+    await waitFor(() => {
+      expect(mockTrackTenantEvent).toHaveBeenCalledWith("tenant_switched", "2");
     });
 
     // Should redirect to the new tenant subdomain

--- a/frontend/src/components/tenant/tenant-switcher.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.tsx
@@ -11,7 +11,7 @@ import {
 } from "~/lib/tenant-api";
 import { useTenantSlugSafe } from "~/lib/tenant-context";
 import { createLogger } from "~/lib/logger";
-import { trackEvent } from "~/lib/analytics";
+import { trackTenantEvent } from "~/lib/analytics";
 import { env } from "~/env";
 import { Alert } from "~/components/ui/alert";
 import {
@@ -103,7 +103,7 @@ export function BrandTenantSwitcher({
         };
         logger.info("tenant_switched", switchPayload);
         // Slugs identify organizations and must stay out of product analytics.
-        trackEvent("tenant_switched");
+        trackTenantEvent("tenant_switched", targetTenant.tenantId.toString());
 
         // 5. Hard-navigate to the new tenant subdomain.
         // Always use subdomain routing — the proxy rewrites subdomains

--- a/frontend/src/components/tenant/tenant-switcher.tsx
+++ b/frontend/src/components/tenant/tenant-switcher.tsx
@@ -102,7 +102,8 @@ export function BrandTenantSwitcher({
           to_slug: targetTenant.subdomain,
         };
         logger.info("tenant_switched", switchPayload);
-        trackEvent("tenant_switched", switchPayload);
+        // Slugs identify organizations and must stay out of product analytics.
+        trackEvent("tenant_switched");
 
         // 5. Hard-navigate to the new tenant subdomain.
         // Always use subdomain routing — the proxy rewrites subdomains

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -24,10 +24,31 @@ describe("instrumentation-client", () => {
 
     await import("./instrumentation-client");
 
-    expect(mockInit).toHaveBeenCalledWith("phc_test_key_123", {
-      api_host: "https://eu.i.posthog.com",
-      defaults: "2026-01-30",
-    });
+    expect(mockInit).toHaveBeenCalledOnce();
+    expect(mockInit).toHaveBeenCalledWith(
+      "phc_test_key_123",
+      expect.objectContaining({
+        api_host: "https://eu.i.posthog.com",
+        defaults: "2026-01-30",
+        autocapture: false,
+        rageclick: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        capture_performance: false,
+        capture_heatmaps: false,
+        capture_dead_clicks: false,
+        capture_exceptions: false,
+        disable_session_recording: true,
+        disable_persistence: true,
+        person_profiles: "never",
+        save_referrer: false,
+        save_campaign_params: false,
+        disable_surveys: true,
+        advanced_disable_feature_flags: true,
+        advanced_disable_feature_flags_on_first_load: true,
+        before_send: expect.any(Function),
+      }),
+    );
   });
 
   it("does not initialize PostHog when NEXT_PUBLIC_POSTHOG_KEY is not set", async () => {

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -18,7 +18,7 @@ describe("instrumentation-client", () => {
     vi.unstubAllEnvs();
   });
 
-  it("initializes PostHog when NEXT_PUBLIC_POSTHOG_KEY is set", async () => {
+  it("initializes PostHog with remote configuration disabled", async () => {
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test_key_123");
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.i.posthog.com");
 
@@ -45,11 +45,20 @@ describe("instrumentation-client", () => {
         save_referrer: false,
         save_campaign_params: false,
         disable_surveys: true,
-        advanced_disable_feature_flags: true,
-        advanced_disable_feature_flags_on_first_load: true,
+        advanced_disable_flags: true,
         before_send: expect.any(Function),
       }),
     );
+  });
+
+  it("rejects an analytics key without an explicit ingestion host", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test_key_123");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "");
+
+    await expect(import("./instrumentation-client")).rejects.toThrow(
+      "NEXT_PUBLIC_POSTHOG_HOST is required when NEXT_PUBLIC_POSTHOG_KEY is set",
+    );
+    expect(mockInit).not.toHaveBeenCalled();
   });
 
   it("does not initialize PostHog when NEXT_PUBLIC_POSTHOG_KEY is not set", async () => {

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -39,6 +39,7 @@ describe("instrumentation-client", () => {
         capture_dead_clicks: false,
         capture_exceptions: false,
         disable_session_recording: true,
+        persistence: "memory",
         disable_persistence: true,
         person_profiles: "never",
         save_referrer: false,

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -2,9 +2,18 @@ import "./sentry.client.config";
 import posthog from "posthog-js";
 import { sanitizePostHogEvent } from "~/lib/posthog-privacy";
 
-if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+const postHogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+if (postHogKey) {
+  const postHogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  if (!postHogHost) {
+    throw new Error(
+      "NEXT_PUBLIC_POSTHOG_HOST is required when NEXT_PUBLIC_POSTHOG_KEY is set.",
+    );
+  }
+
+  posthog.init(postHogKey, {
+    api_host: postHogHost,
     defaults: "2026-01-30",
     autocapture: false,
     rageclick: false,
@@ -24,8 +33,7 @@ if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
     save_referrer: false,
     save_campaign_params: false,
     disable_surveys: true,
-    advanced_disable_feature_flags: true,
-    advanced_disable_feature_flags_on_first_load: true,
+    advanced_disable_flags: true,
     before_send: sanitizePostHogEvent,
   });
 }

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -16,6 +16,9 @@ if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
     capture_exceptions: false,
     disable_scroll_properties: true,
     disable_session_recording: true,
+    // Select memory storage during construction so the SDK never reads a
+    // distinct ID persisted by an older deployment.
+    persistence: "memory",
     disable_persistence: true,
     person_profiles: "never",
     save_referrer: false,

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -1,9 +1,28 @@
 import "./sentry.client.config";
 import posthog from "posthog-js";
+import { sanitizePostHogEvent } from "~/lib/posthog-privacy";
 
 if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     defaults: "2026-01-30",
+    autocapture: false,
+    rageclick: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    capture_performance: false,
+    capture_heatmaps: false,
+    capture_dead_clicks: false,
+    capture_exceptions: false,
+    disable_scroll_properties: true,
+    disable_session_recording: true,
+    disable_persistence: true,
+    person_profiles: "never",
+    save_referrer: false,
+    save_campaign_params: false,
+    disable_surveys: true,
+    advanced_disable_feature_flags: true,
+    advanced_disable_feature_flags_on_first_load: true,
+    before_send: sanitizePostHogEvent,
   });
 }

--- a/frontend/src/lib/analytics-routes.test.ts
+++ b/frontend/src/lib/analytics-routes.test.ts
@@ -1,0 +1,55 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  resolveAnalyticsViewId,
+  TRACKED_TENANT_ROUTE_TEMPLATES,
+} from "./analytics-routes";
+
+function collectPageRoutes(directory: string, prefix = ""): string[] {
+  const routes: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      routes.push(
+        ...collectPageRoutes(path.join(directory, entry.name), relative),
+      );
+    } else if (entry.name === "page.tsx") {
+      const route = relative
+        .replace(/\/page\.tsx$/, "")
+        .split("/")
+        .map((segment) => segment.replace(/^\[(.+)]$/, ":$1"))
+        .join("/");
+      routes.push(`/${route}`);
+    }
+  }
+  return routes;
+}
+
+describe("tenant analytics route allowlist", () => {
+  it("covers every authenticated tenant page", () => {
+    const protectedRoot = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../app/[tenant]/(protected)",
+    );
+    const pageRoutes = collectPageRoutes(protectedRoot).sort();
+
+    expect([...TRACKED_TENANT_ROUTE_TEMPLATES].sort()).toEqual(pageRoutes);
+  });
+
+  it.each(TRACKED_TENANT_ROUTE_TEMPLATES)(
+    "resolves %s without exposing dynamic values",
+    (template) => {
+      const pathname = template.replace(/:[^/]+/g, "sensitive-value-123");
+      expect(resolveAnalyticsViewId(pathname)).toBe(template);
+    },
+  );
+
+  it("rejects unknown, public, operator, and query-bearing paths", () => {
+    expect(resolveAnalyticsViewId("/new-unreviewed-page")).toBeNull();
+    expect(resolveAnalyticsViewId("/enroll/status/secret-token")).toBeNull();
+    expect(resolveAnalyticsViewId("/operator/accounts")).toBeNull();
+    expect(resolveAnalyticsViewId("/dashboard?student=42")).toBeNull();
+  });
+});

--- a/frontend/src/lib/analytics-routes.ts
+++ b/frontend/src/lib/analytics-routes.ts
@@ -1,0 +1,115 @@
+/**
+ * Explicit allowlist of authenticated tenant pages that may be sent to
+ * product analytics. Dynamic URL segments are represented by their route
+ * parameter name, never by the value from the browser URL.
+ */
+export const TRACKED_TENANT_ROUTE_TEMPLATES = [
+  "/active-supervisions",
+  "/activities",
+  "/admin/change-requests",
+  "/admin/enrollments",
+  "/admin/enrollments/:id",
+  "/admin/enrollments/change-requests",
+  "/admin/enrollments/change-requests/:id",
+  "/admin/enrollments/phases/:phaseId",
+  "/admin/guardian-approvals",
+  "/betreuungsplan",
+  "/calendar",
+  "/calendar-periods",
+  "/care-offerings",
+  "/dashboard",
+  "/database",
+  "/database/activities",
+  "/database/devices",
+  "/database/exports",
+  "/database/grade-transitions",
+  "/database/groups",
+  "/database/permissions",
+  "/database/personal",
+  "/database/personal/import",
+  "/database/roles",
+  "/database/rooms",
+  "/database/students",
+  "/database/students/import",
+  "/day-log",
+  "/dienstplan",
+  "/eltern",
+  "/emergency",
+  "/enrollment-form",
+  "/enrollment-phases",
+  "/enrollment-phases/:id/review",
+  "/info-displays",
+  "/invitations",
+  "/lists",
+  "/meal-plan",
+  "/messages",
+  "/messages/:threadId",
+  "/ogs-groups",
+  "/parent-announcements",
+  "/payroll",
+  "/planung",
+  "/profile",
+  "/reminders",
+  "/rooms",
+  "/rooms/:id",
+  "/settings",
+  "/staff",
+  "/staff/:id",
+  "/staff/dienstplan",
+  "/students/:id",
+  "/students/:id/change-history",
+  "/students/:id/feedback-history",
+  "/students/:id/room-history",
+  "/students/search",
+  "/substitutions",
+  "/suggestions",
+  "/time-tracking",
+  "/timetables",
+  "/vertretung",
+  "/vertretungsplan",
+] as const;
+
+export type AnalyticsViewId = (typeof TRACKED_TENANT_ROUTE_TEMPLATES)[number];
+
+const routeMatchers = [...TRACKED_TENANT_ROUTE_TEMPLATES]
+  .sort((left, right) => {
+    const leftDynamicSegments = left.split(":").length - 1;
+    const rightDynamicSegments = right.split(":").length - 1;
+    return leftDynamicSegments - rightDynamicSegments;
+  })
+  .map((template) => ({
+    template,
+    pattern: new RegExp(
+      `^${template
+        .split("/")
+        .map((segment) =>
+          segment.startsWith(":")
+            ? "[^/]+"
+            : segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+        )
+        .join("/")}$`,
+    ),
+  }));
+
+const trackedTemplateSet = new Set<string>(TRACKED_TENANT_ROUTE_TEMPLATES);
+
+export function isAnalyticsViewId(value: unknown): value is AnalyticsViewId {
+  return typeof value === "string" && trackedTemplateSet.has(value);
+}
+
+/**
+ * Converts a browser pathname into an allowlisted route template. Unknown,
+ * public, operator, and parent-portal paths deliberately return null.
+ */
+export function resolveAnalyticsViewId(
+  pathname: string,
+): AnalyticsViewId | null {
+  if (pathname.includes("?") || pathname.includes("#")) return null;
+
+  const normalized =
+    pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  return (
+    routeMatchers.find(({ pattern }) => pattern.test(normalized))?.template ??
+    null
+  );
+}

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockCapture = vi.fn();
 const mockEnv = vi.hoisted(() => ({
   NEXT_PUBLIC_POSTHOG_KEY: undefined as string | undefined,
+  NEXT_PUBLIC_TENANT_DOMAIN: "localhost",
 }));
 
 vi.mock("posthog-js", () => ({
@@ -13,7 +14,7 @@ vi.mock("posthog-js", () => ({
 
 vi.mock("~/env", () => ({ env: mockEnv }));
 
-import { trackEvent } from "./analytics";
+import { trackEvent, trackPageView } from "./analytics";
 
 describe("trackEvent", () => {
   beforeEach(() => {
@@ -62,5 +63,21 @@ describe("trackEvent", () => {
       error: "boom",
     });
     warnSpy.mockRestore();
+  });
+
+  it("captures allowlisted page views without an account identifier", () => {
+    mockEnv.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+
+    trackPageView("/students/:id", "42");
+
+    expect(mockCapture).toHaveBeenCalledWith("page_viewed", {
+      view_id: "/students/:id",
+      portal: "tenant",
+      deployment: "localhost",
+      school_id: "42",
+      $groups: { school: "42" },
+      $geoip_disable: true,
+      $process_person_profile: false,
+    });
   });
 });

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockCapture = vi.fn();
+const mockReset = vi.fn();
 const mockEnv = vi.hoisted(() => ({
   NEXT_PUBLIC_POSTHOG_KEY: undefined as string | undefined,
   NEXT_PUBLIC_TENANT_DOMAIN: "localhost",
@@ -9,6 +10,7 @@ const mockEnv = vi.hoisted(() => ({
 vi.mock("posthog-js", () => ({
   default: {
     capture: (...args: unknown[]) => mockCapture(...args) as void,
+    reset: (...args: unknown[]) => mockReset(...args) as void,
   },
 }));
 
@@ -102,5 +104,40 @@ describe("trackEvent", () => {
     trackTenantEvent("login_success", "school-a");
 
     expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  it("resets identity before capturing a completed tenant switch", () => {
+    mockEnv.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+
+    trackTenantEvent("tenant_switched", "42");
+
+    expect(mockReset).toHaveBeenCalledOnce();
+    expect(mockCapture).toHaveBeenCalledWith("tenant_switched", {
+      deployment: "localhost",
+      school_id: "42",
+      $groups: { school: "42" },
+    });
+    expect(mockReset.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockCapture.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("drops a tenant switch event when identity reset fails", () => {
+    mockEnv.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+    mockReset.mockImplementationOnce(() => {
+      throw new Error("reset failed");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // suppress test output
+    });
+
+    expect(() => trackTenantEvent("tenant_switched", "42")).not.toThrow();
+
+    expect(mockCapture).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith("analytics_capture_failed", {
+      event: "tenant_switched",
+      error: "reset failed",
+    });
+    warnSpy.mockRestore();
   });
 });

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -14,7 +14,7 @@ vi.mock("posthog-js", () => ({
 
 vi.mock("~/env", () => ({ env: mockEnv }));
 
-import { trackEvent, trackPageView } from "./analytics";
+import { trackEvent, trackPageView, trackTenantEvent } from "./analytics";
 
 describe("trackEvent", () => {
   beforeEach(() => {
@@ -79,5 +79,28 @@ describe("trackEvent", () => {
       $geoip_disable: true,
       $process_person_profile: false,
     });
+  });
+
+  it("attaches trusted school context directly to pre-session events", () => {
+    mockEnv.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+
+    trackTenantEvent("login_failed", "42", {
+      reason: "invalid_credentials",
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith("login_failed", {
+      reason: "invalid_credentials",
+      deployment: "localhost",
+      school_id: "42",
+      $groups: { school: "42" },
+    });
+  });
+
+  it("rejects tenant events without a numeric school ID", () => {
+    mockEnv.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+
+    trackTenantEvent("login_success", "school-a");
+
+    expect(mockCapture).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -9,6 +9,10 @@
 import posthog from "posthog-js";
 import { env } from "~/env";
 import { createLogger } from "~/lib/logger";
+import {
+  isAnalyticsViewId,
+  type AnalyticsViewId,
+} from "~/lib/analytics-routes";
 
 const logger = createLogger({ component: "Analytics" });
 
@@ -37,6 +41,28 @@ export function trackEvent(
     // should not go dark silently either.
     logger.warn("analytics_capture_failed", {
       event,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export function trackPageView(viewId: AnalyticsViewId, schoolId: string): void {
+  if (!env.NEXT_PUBLIC_POSTHOG_KEY) return;
+  if (!isAnalyticsViewId(viewId) || !/^\d+$/.test(schoolId)) return;
+
+  try {
+    posthog.capture("page_viewed", {
+      view_id: viewId,
+      portal: "tenant",
+      deployment: env.NEXT_PUBLIC_TENANT_DOMAIN,
+      school_id: schoolId,
+      $groups: { school: schoolId },
+      $geoip_disable: true,
+      $process_person_profile: false,
+    });
+  } catch (err) {
+    logger.warn("analytics_capture_failed", {
+      event: "page_viewed",
       error: err instanceof Error ? err.message : String(err),
     });
   }

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -55,7 +55,21 @@ export function trackTenantEvent(
   schoolId: string,
   props?: Record<string, string | number | boolean>,
 ): void {
-  if (!/^\d+$/.test(schoolId)) return;
+  if (!env.NEXT_PUBLIC_POSTHOG_KEY || !/^\d+$/.test(schoolId)) return;
+
+  // A completed tenant switch belongs to the target school and must not share
+  // the previous school's anonymous runtime identity.
+  if (event === "tenant_switched") {
+    try {
+      posthog.reset();
+    } catch (err) {
+      logger.warn("analytics_capture_failed", {
+        event,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+  }
 
   captureEvent(event, {
     ...props,

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -6,7 +6,7 @@
  * PII; student IDs are forbidden entirely (GDPR).
  */
 
-import posthog from "posthog-js";
+import posthog, { type Properties } from "posthog-js";
 import { env } from "~/env";
 import { createLogger } from "~/lib/logger";
 import {
@@ -27,10 +27,7 @@ export type AnalyticsEvent =
   | "user_invited"
   | "data_exported";
 
-export function trackEvent(
-  event: AnalyticsEvent,
-  props?: Record<string, string | number | boolean>,
-): void {
+function captureEvent(event: AnalyticsEvent, props?: Properties): void {
   if (!env.NEXT_PUBLIC_POSTHOG_KEY) {
     return;
   }
@@ -44,6 +41,28 @@ export function trackEvent(
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+export function trackEvent(
+  event: AnalyticsEvent,
+  props?: Record<string, string | number | boolean>,
+): void {
+  captureEvent(event, props);
+}
+
+export function trackTenantEvent(
+  event: AnalyticsEvent,
+  schoolId: string,
+  props?: Record<string, string | number | boolean>,
+): void {
+  if (!/^\d+$/.test(schoolId)) return;
+
+  captureEvent(event, {
+    ...props,
+    deployment: env.NEXT_PUBLIC_TENANT_DOMAIN,
+    school_id: schoolId,
+    $groups: { school: schoolId },
+  });
 }
 
 export function trackPageView(viewId: AnalyticsViewId, schoolId: string): void {

--- a/frontend/src/lib/env-validation.js
+++ b/frontend/src/lib/env-validation.js
@@ -39,23 +39,57 @@ export const clientEnvSchema = {
   NEXT_PUBLIC_SENTRY_ENVIRONMENT: optionalString,
 };
 
-const buildEnvSchema = z.object({
-  API_URL: serverEnvSchema.API_URL,
-  TENANT_DOMAIN: serverEnvSchema.TENANT_DOMAIN,
-  NEXT_PUBLIC_API_URL: clientEnvSchema.NEXT_PUBLIC_API_URL,
-  NEXT_PUBLIC_TENANT_DOMAIN: clientEnvSchema.NEXT_PUBLIC_TENANT_DOMAIN,
-  NEXT_PUBLIC_OPERATOR_HOSTNAME: clientEnvSchema.NEXT_PUBLIC_OPERATOR_HOSTNAME,
-  NEXT_PUBLIC_PARENTS_HOSTNAME: clientEnvSchema.NEXT_PUBLIC_PARENTS_HOSTNAME,
-  NEXT_PUBLIC_SENTRY_DSN: clientEnvSchema.NEXT_PUBLIC_SENTRY_DSN,
-  NEXT_PUBLIC_SENTRY_ENVIRONMENT:
-    clientEnvSchema.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-});
+/**
+ * @param {{ NEXT_PUBLIC_POSTHOG_KEY?: string, NEXT_PUBLIC_POSTHOG_HOST?: string }} values
+ * @param {z.RefinementCtx} ctx
+ */
+function requirePostHogHost(values, ctx) {
+  if (values.NEXT_PUBLIC_POSTHOG_KEY && !values.NEXT_PUBLIC_POSTHOG_HOST) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["NEXT_PUBLIC_POSTHOG_HOST"],
+      message: "Required when NEXT_PUBLIC_POSTHOG_KEY is set",
+    });
+  }
+  if (
+    values.NEXT_PUBLIC_POSTHOG_HOST &&
+    URL.canParse(values.NEXT_PUBLIC_POSTHOG_HOST) &&
+    !["http:", "https:"].includes(
+      new URL(values.NEXT_PUBLIC_POSTHOG_HOST).protocol,
+    )
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["NEXT_PUBLIC_POSTHOG_HOST"],
+      message: "Must use the http or https protocol",
+    });
+  }
+}
 
-const runtimeEnvSchema = z.object({
-  ...serverEnvSchema,
-  ...clientEnvSchema,
-  METRICS_BEARER_TOKEN: z.string().trim().min(1),
-});
+const buildEnvSchema = z
+  .object({
+    API_URL: serverEnvSchema.API_URL,
+    TENANT_DOMAIN: serverEnvSchema.TENANT_DOMAIN,
+    NEXT_PUBLIC_API_URL: clientEnvSchema.NEXT_PUBLIC_API_URL,
+    NEXT_PUBLIC_TENANT_DOMAIN: clientEnvSchema.NEXT_PUBLIC_TENANT_DOMAIN,
+    NEXT_PUBLIC_POSTHOG_KEY: clientEnvSchema.NEXT_PUBLIC_POSTHOG_KEY,
+    NEXT_PUBLIC_POSTHOG_HOST: clientEnvSchema.NEXT_PUBLIC_POSTHOG_HOST,
+    NEXT_PUBLIC_OPERATOR_HOSTNAME:
+      clientEnvSchema.NEXT_PUBLIC_OPERATOR_HOSTNAME,
+    NEXT_PUBLIC_PARENTS_HOSTNAME: clientEnvSchema.NEXT_PUBLIC_PARENTS_HOSTNAME,
+    NEXT_PUBLIC_SENTRY_DSN: clientEnvSchema.NEXT_PUBLIC_SENTRY_DSN,
+    NEXT_PUBLIC_SENTRY_ENVIRONMENT:
+      clientEnvSchema.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+  })
+  .superRefine(requirePostHogHost);
+
+const runtimeEnvSchema = z
+  .object({
+    ...serverEnvSchema,
+    ...clientEnvSchema,
+    METRICS_BEARER_TOKEN: z.string().trim().min(1),
+  })
+  .superRefine(requirePostHogHost);
 
 export function isSkipEnvValidationEnabled() {
   return process.env.SKIP_ENV_VALIDATION === "true";

--- a/frontend/src/lib/env-validation.test.ts
+++ b/frontend/src/lib/env-validation.test.ts
@@ -10,6 +10,8 @@ const validBuildEnv = {
   TENANT_DOMAIN: "moto-app.de",
   NEXT_PUBLIC_API_URL: "https://api.moto-app.de",
   NEXT_PUBLIC_TENANT_DOMAIN: "moto-app.de",
+  NEXT_PUBLIC_POSTHOG_KEY: "",
+  NEXT_PUBLIC_POSTHOG_HOST: "",
   NEXT_PUBLIC_OPERATOR_HOSTNAME: "operator.moto-app.de",
   NEXT_PUBLIC_PARENTS_HOSTNAME: "eltern.moto-app.de",
   NEXT_PUBLIC_SENTRY_DSN: "",
@@ -24,8 +26,6 @@ const validRuntimeEnv = {
   NEXTAUTH_URL: "https://moto-app.de",
   NEXTAUTH_SECRET: "test-nextauth-secret",
   NEXT_PUBLIC_LOG_LEVEL: "info",
-  NEXT_PUBLIC_POSTHOG_KEY: "",
-  NEXT_PUBLIC_POSTHOG_HOST: "",
   METRICS_BEARER_TOKEN: "test-token-with-enough-length",
 };
 
@@ -47,6 +47,42 @@ describe("env validation", () => {
 
   it("does not require runtime secrets during build validation", () => {
     expect(() => validateBuildEnv(validBuildEnv)).not.toThrow();
+  });
+
+  it("fails build validation when a PostHog key has no ingestion host", () => {
+    expect(() =>
+      validateBuildEnv({
+        ...validBuildEnv,
+        NEXT_PUBLIC_POSTHOG_KEY: "phc_test_key_123",
+        NEXT_PUBLIC_POSTHOG_HOST: "",
+      }),
+    ).toThrow(
+      "Frontend build env validation failed: NEXT_PUBLIC_POSTHOG_HOST: Required when NEXT_PUBLIC_POSTHOG_KEY is set",
+    );
+  });
+
+  it("fails build validation when the PostHog host is invalid", () => {
+    expect(() =>
+      validateBuildEnv({
+        ...validBuildEnv,
+        NEXT_PUBLIC_POSTHOG_KEY: "phc_test_key_123",
+        NEXT_PUBLIC_POSTHOG_HOST: "not-a-url",
+      }),
+    ).toThrow(
+      "Frontend build env validation failed: NEXT_PUBLIC_POSTHOG_HOST: Invalid URL",
+    );
+  });
+
+  it("fails build validation when the PostHog host is not HTTP(S)", () => {
+    expect(() =>
+      validateBuildEnv({
+        ...validBuildEnv,
+        NEXT_PUBLIC_POSTHOG_KEY: "phc_test_key_123",
+        NEXT_PUBLIC_POSTHOG_HOST: "data:text/plain,analytics",
+      }),
+    ).toThrow(
+      "Frontend build env validation failed: NEXT_PUBLIC_POSTHOG_HOST: Must use the http or https protocol",
+    );
   });
 
   it("fails runtime validation when a server secret is missing", () => {

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -395,10 +395,10 @@ describe("useGlobalSSE — SWR invalidation debounce", () => {
 // Reminders revalidation (issue #1457)
 // ---------------------------------------------------------------------------
 
-// useGlobalSSE runs ABOVE TenantProvider, so it cannot build the tenant-prefixed
-// "{slug}:reminders" SWR key. Instead of mutating the wrong key it dispatches a
-// window event; useReminders() (which runs under TenantProvider and owns the
-// correctly-scoped key + the enabled gate) performs the actual revalidation.
+// useGlobalSSE does not own the tenant-prefixed "{slug}:reminders" SWR key.
+// Instead of mutating the wrong key it dispatches a window event; useReminders()
+// owns the correctly scoped key and enabled gate, so it performs the actual
+// revalidation.
 describe("useGlobalSSE — reminders revalidation", () => {
   function listenForRemindersStale() {
     const listener = vi.fn();

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -510,15 +510,13 @@ export function useGlobalSSE(): SSEHookState {
     // receive check-ins only as the dashboard_counts_changed broadcast, so
     // include hasPendingDashboardEvent or their bell/list stays stale until poll.
     //
-    // This hook runs in TenantAuthWrapper, ABOVE TenantProvider, so
-    // useTenantSlugSafe() is null here and it cannot build the real
-    // "{slug}:reminders" SWR key that useReminders() writes under. Rather than
-    // mutate the wrong (unprefixed) key, dispatch a window event and let
-    // useReminders() — which runs under TenantProvider, owns the correctly
-    // tenant-prefixed key, and knows whether the feature is enabled — perform
-    // the revalidation. This mirrors the tenant_settings_changed / parent_message
-    // decoupling above and keeps the idle-poll throttle intact for disabled
-    // tenants (the consumer skips the mutate when the feature is off).
+    // This hook deliberately does not own the tenant-prefixed
+    // "{slug}:reminders" SWR key. Dispatch a window event and let
+    // useReminders() — which owns that key and knows whether the feature is
+    // enabled — perform the revalidation. This mirrors the
+    // tenant_settings_changed / parent_message decoupling above and keeps the
+    // idle-poll throttle intact for disabled tenants (the consumer skips the
+    // mutate when the feature is off).
     if (
       pendingGroupIds.current.size > 0 ||
       pendingStudentIds.current.size > 0 ||

--- a/frontend/src/lib/hooks/use-reminders.ts
+++ b/frontend/src/lib/hooks/use-reminders.ts
@@ -206,8 +206,8 @@ export function useReminders() {
   const enabled = data?.enabled ?? false;
   const nextChangeAt = data?.next_change_at;
 
-  // Event-driven refresh. useGlobalSSE() runs above TenantProvider and cannot
-  // build the tenant-prefixed reminders SWR key, so it dispatches
+  // Event-driven refresh. useGlobalSSE() does not own the tenant-prefixed
+  // reminders SWR key, so it dispatches
   // "phoenix:reminders-stale" whenever an attendance / activity / student-data
   // change may alter what's due (or who may see it). Revalidate here, where the
   // SWR key is correctly tenant-scoped via useSWRAuth. Gate on `enabled`: a

--- a/frontend/src/lib/posthog-privacy.test.ts
+++ b/frontend/src/lib/posthog-privacy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePostHogEvent } from "./posthog-privacy";
+
+describe("sanitizePostHogEvent", () => {
+  it("removes browser, URL, and person properties from allowed events", () => {
+    const result = sanitizePostHogEvent({
+      uuid: "018f47ac-10b5-7c3d-9d3c-0123456789ab",
+      event: "page_viewed",
+      properties: {
+        token: "phc_test",
+        distinct_id: "anonymous-runtime-id",
+        view_id: "/students/:id",
+        portal: "tenant",
+        deployment: "moto-app.de",
+        school_id: "42",
+        $groups: { school: "42" },
+        $current_url: "https://school.example/students/123?token=secret",
+        $pathname: "/students/123",
+        $referrer: "https://school.example/dashboard",
+        $raw_user_agent: "browser fingerprint",
+        email: "person@example.com",
+      },
+      $set: { email: "person@example.com" },
+    });
+
+    expect(result).toEqual({
+      uuid: "018f47ac-10b5-7c3d-9d3c-0123456789ab",
+      event: "page_viewed",
+      timestamp: undefined,
+      properties: {
+        token: "phc_test",
+        distinct_id: "anonymous-runtime-id",
+        view_id: "/students/:id",
+        portal: "tenant",
+        deployment: "moto-app.de",
+        school_id: "42",
+        $groups: { school: "42" },
+        $geoip_disable: true,
+        $process_person_profile: false,
+      },
+    });
+  });
+
+  it("drops SDK-generated and unknown events", () => {
+    expect(
+      sanitizePostHogEvent({
+        uuid: "018f47ac-10b5-7c3d-9d3c-0123456789ab",
+        event: "$pageview",
+        properties: { token: "phc_test", distinct_id: "id" },
+      }),
+    ).toBeNull();
+  });
+
+  it("drops unrecognized values even for allowlisted property names", () => {
+    const result = sanitizePostHogEvent({
+      uuid: "018f47ac-10b5-7c3d-9d3c-0123456789ab",
+      event: "login_failed",
+      properties: {
+        token: "phc_test",
+        distinct_id: "id",
+        reason: "person@example.com",
+      },
+    });
+
+    expect(result?.properties).not.toHaveProperty("reason");
+  });
+});

--- a/frontend/src/lib/posthog-privacy.ts
+++ b/frontend/src/lib/posthog-privacy.ts
@@ -1,0 +1,105 @@
+import type { BeforeSendFn, Properties } from "posthog-js";
+import { isAnalyticsViewId } from "~/lib/analytics-routes";
+
+const allowedEvents = new Set([
+  "page_viewed",
+  "login_success",
+  "login_failed",
+  "tenant_switched",
+  "suggestion_created",
+  "suggestion_voted",
+  "group_created",
+  "group_updated",
+  "user_invited",
+  "data_exported",
+]);
+
+const safePropertyValues: Readonly<Record<string, ReadonlySet<string>>> = {
+  direction: new Set(["up", "down"]),
+  export_type: new Set(["rooms", "emergency", "students"]),
+  format: new Set(["pdf", "docx", "xlsx"]),
+  reason: new Set(["error", "invalid_credentials"]),
+};
+
+const safeSdkProperties = new Set([
+  "token",
+  "distinct_id",
+  "$lib",
+  "$lib_version",
+]);
+
+function isSafeSchoolID(value: unknown): value is string {
+  return typeof value === "string" && /^\d+$/.test(value);
+}
+
+function isSafeDeployment(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= 253 &&
+    /^[a-z0-9.-]+(?::\d+)?$/i.test(value)
+  );
+}
+
+function sanitizeGroups(value: unknown): Properties["$groups"] | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const school = (value as Record<string, unknown>).school;
+  if (!isSafeSchoolID(school) || Object.keys(value).length !== 1) {
+    return undefined;
+  }
+  return { school };
+}
+
+function sanitizeProperties(properties: Properties): Properties {
+  const safe: Properties = {};
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (safeSdkProperties.has(key) && typeof value === "string") {
+      safe[key] = value;
+      continue;
+    }
+    if (typeof value === "string" && safePropertyValues[key]?.has(value)) {
+      safe[key] = value;
+      continue;
+    }
+    if (key === "view_id" && isAnalyticsViewId(value)) {
+      safe.view_id = value;
+      continue;
+    }
+    if (key === "portal" && value === "tenant") {
+      safe.portal = value;
+      continue;
+    }
+    if (key === "deployment" && isSafeDeployment(value)) {
+      safe.deployment = value;
+      continue;
+    }
+    if (key === "school_id" && isSafeSchoolID(value)) {
+      safe.school_id = value;
+      continue;
+    }
+    if (key === "$groups") {
+      const groups = sanitizeGroups(value);
+      if (groups) safe.$groups = groups;
+    }
+  }
+
+  // These flags are forced after filtering so callers cannot override them.
+  safe.$geoip_disable = true;
+  safe.$process_person_profile = false;
+  return safe;
+}
+
+/** Final defense before any browser event leaves the application. */
+export const sanitizePostHogEvent: BeforeSendFn = (captureResult) => {
+  if (!captureResult || !allowedEvents.has(captureResult.event)) return null;
+
+  return {
+    uuid: captureResult.uuid,
+    event: captureResult.event,
+    timestamp: captureResult.timestamp,
+    properties: sanitizeProperties(captureResult.properties),
+  };
+};

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -4,11 +4,13 @@ import { LOCALE_SCOPE_HEADER } from "~/i18n/locales";
 
 const OPERATOR_HOSTNAME = "operator.localhost:3000";
 const PARENTS_HOSTNAME = "parents.localhost:3000";
+const POSTHOG_KEY = "phc_test_key_123";
 const POSTHOG_HOST = "https://eu.i.posthog.com";
 
 vi.stubEnv("NEXT_PUBLIC_OPERATOR_HOSTNAME", OPERATOR_HOSTNAME);
 vi.stubEnv("NEXT_PUBLIC_PARENTS_HOSTNAME", PARENTS_HOSTNAME);
 vi.stubEnv("TENANT_DOMAIN", "localhost");
+vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", POSTHOG_KEY);
 vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", POSTHOG_HOST);
 
 // Import after env is stubbed , proxy reads the env var at module load
@@ -66,6 +68,19 @@ describe("proxy env validation", () => {
       import("./proxy?invalid-posthog-protocol"),
     ).rejects.toThrow(
       "NEXT_PUBLIC_POSTHOG_HOST must use the http or https protocol",
+    );
+
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", POSTHOG_HOST);
+  });
+
+  it("rejects an analytics key without an explicit ingestion host", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "");
+
+    await expect(
+      // @ts-expect-error query string forces fresh module evaluation
+      import("./proxy?missing-posthog-host"),
+    ).rejects.toThrow(
+      "NEXT_PUBLIC_POSTHOG_HOST is required when NEXT_PUBLIC_POSTHOG_KEY is set",
     );
 
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", POSTHOG_HOST);

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -4,10 +4,12 @@ import { LOCALE_SCOPE_HEADER } from "~/i18n/locales";
 
 const OPERATOR_HOSTNAME = "operator.localhost:3000";
 const PARENTS_HOSTNAME = "parents.localhost:3000";
+const POSTHOG_HOST = "https://eu.i.posthog.com";
 
 vi.stubEnv("NEXT_PUBLIC_OPERATOR_HOSTNAME", OPERATOR_HOSTNAME);
 vi.stubEnv("NEXT_PUBLIC_PARENTS_HOSTNAME", PARENTS_HOSTNAME);
 vi.stubEnv("TENANT_DOMAIN", "localhost");
+vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", POSTHOG_HOST);
 
 // Import after env is stubbed , proxy reads the env var at module load
 const { proxy } = await import("./proxy");
@@ -55,9 +57,32 @@ describe("proxy env validation", () => {
     // Restore
     vi.stubEnv("TENANT_DOMAIN", "localhost");
   });
+
+  it("rejects a non-HTTP PostHog ingestion URL", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "data:text/plain,analytics");
+
+    await expect(
+      // @ts-expect-error query string forces fresh module evaluation
+      import("./proxy?invalid-posthog-protocol"),
+    ).rejects.toThrow(
+      "NEXT_PUBLIC_POSTHOG_HOST must use the http or https protocol",
+    );
+
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", POSTHOG_HOST);
+  });
 });
 
 describe("proxy", () => {
+  it("allows the configured PostHog ingestion origin in connect-src", () => {
+    const res = proxy(
+      makeRequest("http://school.localhost:3000/dashboard", "school.localhost"),
+    );
+
+    expect(res.headers.get("Content-Security-Policy")).toContain(
+      `connect-src 'self' ${POSTHOG_HOST}`,
+    );
+  });
+
   it("preserves x-forwarded-host as the original request host", () => {
     const req = new NextRequest(
       "http://next-internal:3000/api/auth/passkeys/login/options",

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -41,6 +41,19 @@ const TENANT_DOMAIN: string = (() => {
   return val;
 })();
 
+const POSTHOG_INGESTION_ORIGIN: string | null = (() => {
+  const configuredHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  if (!configuredHost) return null;
+
+  const url = new URL(configuredHost);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      "NEXT_PUBLIC_POSTHOG_HOST must use the http or https protocol.",
+    );
+  }
+  return url.origin;
+})();
+
 // --- CSP Headers ---
 
 const CSP_HEADER = [
@@ -48,7 +61,7 @@ const CSP_HEADER = [
   `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
-  "connect-src 'self'",
+  `connect-src 'self'${POSTHOG_INGESTION_ORIGIN ? ` ${POSTHOG_INGESTION_ORIGIN}` : ""}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -42,8 +42,14 @@ const TENANT_DOMAIN: string = (() => {
 })();
 
 const POSTHOG_INGESTION_ORIGIN: string | null = (() => {
+  const configuredKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   const configuredHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
-  if (!configuredHost) return null;
+  if (!configuredKey) return null;
+  if (!configuredHost) {
+    throw new Error(
+      "NEXT_PUBLIC_POSTHOG_HOST is required when NEXT_PUBLIC_POSTHOG_KEY is set.",
+    );
+  }
 
   const url = new URL(configuredHost);
   if (url.protocol !== "http:" && url.protocol !== "https:") {


### PR DESCRIPTION
## Summary
- track authenticated tenant page views through an explicit route allowlist
- normalize dynamic routes such as /students/:id before capture
- remove account identification and tenant slugs from browser analytics
- disable PostHog autocapture, persistence, replay, heatmaps, performance, surveys, and feature flags
- force IP and person-profile processing off for browser and backend events

## Privacy safeguards
- sends no account IDs, student IDs, names, email addresses, raw URLs, query strings, referrers, or user agents
- uses only the school ID as an aggregate group key
- drops unknown events and properties in a final before-send filter
- captures only authenticated tenant routes; public, operator, parent, and unknown routes are rejected

## PostHog setup
- project timezone: Europe/Berlin
- privacy-sensitive project features disabled server-side
- product dashboard: https://eu.posthog.com/project/140838/dashboard/865260
- dashboard queries only page_viewed events with deployment = moto-app.de

## Verification
- pnpm run check
- 75 focused frontend analytics tests
- full frontend suite: 12,751 tests
- go test ./analytics
- pre-push checks: git-secrets, Knip, dependency-cruise, go vet, and deadcode
