### PR TITLE
fix(calendar-periods): keep header actions inside container

### DIFF
--- a/frontend/src/components/planning/calendar-periods-editor.test.tsx
+++ b/frontend/src/components/planning/calendar-periods-editor.test.tsx
@@ -187,6 +187,24 @@ describe("CalendarPeriodsEditor", () => {
     expect(actionCell).toHaveClass("w-px");
   });
 
+  it("allows header actions to wrap within a constrained content column", async () => {
+    mockListPeriods.mockResolvedValue([makePeriod()]);
+
+    render(<CalendarPeriodsEditor />);
+
+    const createPeriodButton = await screen.findByRole("button", {
+      name: "Zeitraum anlegen",
+    });
+    const actions = createPeriodButton.parentElement;
+    const description = screen.getByText(
+      /Halbjahre, Ferien und Sonderzeiträume als gemeinsame Basis/,
+    );
+
+    expect(actions).toHaveClass("sm:flex-wrap");
+    expect(actions).toHaveClass("sm:justify-end");
+    expect(description).toHaveClass("min-w-0");
+  });
+
   it("keeps the modal mounted while the post-save refresh is in flight", async () => {
     const refresh = deferred<CalendarPeriod[]>();
     mockListPeriods

--- a/frontend/src/components/planning/calendar-periods-editor.tsx
+++ b/frontend/src/components/planning/calendar-periods-editor.tsx
@@ -353,11 +353,14 @@ export function CalendarPeriodsEditor() {
 
       <section className="moto-content-surface rounded-2xl border p-4 shadow-sm backdrop-blur-md">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-sm text-gray-600">
+          <p className="min-w-0 text-sm text-gray-600">
             Halbjahre, Ferien und Sonderzeiträume als gemeinsame Basis für
             Anmeldung und Betreuungsplan.
           </p>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          {/* The page content can be narrower than the viewport beside the
+              persistent sidebar. Let actions wrap in that constrained space
+              instead of forcing the header surface wider than its container. */}
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">
             <Button
               type="button"
               variant="primary"


### PR DESCRIPTION
## Zusammenfassung

- verhindert, dass die Aktionen in der Kalenderzeiträume-Header-Box bei schmalen Inhaltsbreiten herauslaufen
- lässt Beschreibung und Aktionsbereich innerhalb des Containers umbrechen
- ergänzt einen Regressionstest für das responsive Layout

## Verifiziert

- `pnpm test:run src/components/planning/calendar-periods-editor.test.tsx`
- `pnpm run check`
- Pre-Commit- und Pre-Push-Prüfungen erfolgreich