### PR TITLE
fix(pwa): Install-Hinweis korrekt positionieren und sichtbar machen

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import ActivitiesPage from "./page";
 
 const { mockToastSuccess, mockPush, mockRedirect } = vi.hoisted(() => ({
@@ -231,6 +231,16 @@ describe("ActivitiesPage", () => {
   const mockMutate = vi.fn();
 
   beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: true,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    document.documentElement.style.removeProperty("--moto-floating-fab-offset");
     vi.clearAllMocks();
     mockMutate.mockClear();
     mockToastSuccess.mockClear();
@@ -245,6 +255,11 @@ describe("ActivitiesPage", () => {
       error: null,
       mutate: mockMutate,
     } as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty("--moto-floating-fab-offset");
   });
 
   it("renders activities and opens management modal", async () => {
@@ -304,6 +319,24 @@ describe("ActivitiesPage", () => {
     }
 
     expect(screen.getByTestId("quick-create-modal")).toBeInTheDocument();
+  });
+
+  it("publishes stack clearance while the mobile create FAB is visible", () => {
+    const { unmount } = render(<ActivitiesPage />);
+
+    expect(window.matchMedia).toHaveBeenCalledWith("(max-width: 767px)");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--moto-floating-fab-offset",
+      ),
+    ).toBe("4.5rem");
+
+    unmount();
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--moto-floating-fab-offset",
+      ),
+    ).toBe("");
   });
 
   it("shows loading state when data is loading", () => {

--- a/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.test.tsx
@@ -350,6 +350,29 @@ describe("ActivitiesPage", () => {
     render(<ActivitiesPage />);
 
     expect(screen.getByTestId("activities-skeleton")).toBeInTheDocument();
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--moto-floating-fab-offset",
+      ),
+    ).toBe("");
+  });
+
+  it("does not publish FAB clearance during the authenticated-to-SWR transition", () => {
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      mutate: mockMutate,
+    } as never);
+
+    render(<ActivitiesPage />);
+
+    expect(screen.getByTestId("activities-skeleton")).toBeInTheDocument();
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--moto-floating-fab-offset",
+      ),
+    ).toBe("");
   });
 
   it("shows error state when fetch fails", () => {

--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -25,6 +25,10 @@ import { BinaryModeGuard } from "~/components/tenant/binary-mode-guard";
 import { useTenantRouter } from "~/lib/tenant-router";
 import { useTenantAwarePath } from "~/lib/tenant-path";
 import { NfcModeGuard } from "~/components/tenant/nfc-mode-guard";
+import {
+  MOBILE_CREATE_FAB_MEDIA_QUERY,
+  useFloatingFabOffset,
+} from "~/lib/hooks/use-floating-fab-offset";
 import { ActivitiesSkeleton } from "./page-skeleton";
 import { redirect } from "next/navigation";
 
@@ -122,6 +126,10 @@ function ActivitiesPageContent() {
       revalidateOnFocus: false,
     },
   );
+  useFloatingFabOffset({
+    active: !isLoading,
+    mediaQuery: MOBILE_CREATE_FAB_MEDIA_QUERY,
+  });
 
   // Extract data with defaults (memoized to prevent dependency issues)
   const activities = useMemo(

--- a/frontend/src/app/[tenant]/(protected)/activities/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/activities/page.tsx
@@ -126,8 +126,12 @@ function ActivitiesPageContent() {
       revalidateOnFocus: false,
     },
   );
+  const showSkeleton =
+    status === "loading" ||
+    isLoading ||
+    (pageData === undefined && !fetchError);
   useFloatingFabOffset({
-    active: !isLoading,
+    active: !showSkeleton,
     mediaQuery: MOBILE_CREATE_FAB_MEDIA_QUERY,
   });
 
@@ -301,11 +305,7 @@ function ActivitiesPageContent() {
   // visits redirect via the required-session guard, and expired/tokenless
   // sessions redirect via the effect above, so this cannot show the skeleton
   // indefinitely.
-  if (
-    status === "loading" ||
-    isLoading ||
-    (pageData === undefined && !fetchError)
-  ) {
+  if (showSkeleton) {
     return <ActivitiesSkeleton />;
   }
 

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "~/lib/dashboard-helpers";
 import { useSWRAuth } from "~/lib/swr/hooks";
 import { RoleGuard } from "~/components/auth/role-guard";
+import { PwaInstallHint } from "~/components/tenant/pwa-install-hint";
 import {
   useNFCEnabled,
   useOpenCareGroupMode,
@@ -422,6 +423,13 @@ function DashboardContent() {
             loading={isLoading}
           />
         ) : null}
+      </div>
+
+      {/* Install promotion — in-flow so it never overlaps the bottom nav or
+          the check-in FAB. Lives on the dashboard only, not in the layout.
+          `empty:hidden` drops the spacing on the (usual) render-nothing case. */}
+      <div className="mb-6 empty:hidden md:mb-8">
+        <PwaInstallHint />
       </div>
 
       {/* Activity Lists Grid */}

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -16,7 +16,6 @@ import {
 } from "~/lib/dashboard-helpers";
 import { useSWRAuth } from "~/lib/swr/hooks";
 import { RoleGuard } from "~/components/auth/role-guard";
-import { PwaInstallHint } from "~/components/tenant/pwa-install-hint";
 import {
   useNFCEnabled,
   useOpenCareGroupMode,
@@ -423,13 +422,6 @@ function DashboardContent() {
             loading={isLoading}
           />
         ) : null}
-      </div>
-
-      {/* Install promotion — in-flow so it never overlaps the bottom nav or
-          the check-in FAB. Lives on the dashboard only, not in the layout.
-          `empty:hidden` drops the spacing on the (usual) render-nothing case. */}
-      <div className="mb-6 empty:hidden md:mb-8">
-        <PwaInstallHint />
       </div>
 
       {/* Activity Lists Grid */}

--- a/frontend/src/app/[tenant]/(protected)/layout.tsx
+++ b/frontend/src/app/[tenant]/(protected)/layout.tsx
@@ -6,6 +6,7 @@ import { TeacherShellProvider } from "~/lib/shell-auth-context";
 import { AppShell } from "~/components/dashboard/app-shell";
 import { ShellNavIntlProvider } from "~/components/dashboard/shell-nav-intl-provider";
 import { AnnouncementModal } from "~/components/platform/announcement-modal";
+import { PwaInstallHint } from "~/components/tenant/pwa-install-hint";
 import { useSettingsCacheBridge } from "~/lib/hooks/use-settings-cache-bridge";
 
 export default function ProtectedLayout({
@@ -23,6 +24,10 @@ export default function ProtectedLayout({
           </ShellNavIntlProvider>
         </GroupAttendanceCountProvider>
         <AnnouncementModal />
+        {/* Layout-level on purpose: the install promotion targets staff on
+            phones and tablets, and most of them never reach the admin-only
+            dashboard. */}
+        <PwaInstallHint />
       </BreadcrumbProvider>
     </TeacherShellProvider>
   );

--- a/frontend/src/app/[tenant]/(protected)/layout.tsx
+++ b/frontend/src/app/[tenant]/(protected)/layout.tsx
@@ -6,7 +6,6 @@ import { TeacherShellProvider } from "~/lib/shell-auth-context";
 import { AppShell } from "~/components/dashboard/app-shell";
 import { ShellNavIntlProvider } from "~/components/dashboard/shell-nav-intl-provider";
 import { AnnouncementModal } from "~/components/platform/announcement-modal";
-import { PwaInstallHint } from "~/components/tenant/pwa-install-hint";
 import { useSettingsCacheBridge } from "~/lib/hooks/use-settings-cache-bridge";
 
 export default function ProtectedLayout({
@@ -24,7 +23,6 @@ export default function ProtectedLayout({
           </ShellNavIntlProvider>
         </GroupAttendanceCountProvider>
         <AnnouncementModal />
-        <PwaInstallHint />
       </BreadcrumbProvider>
     </TeacherShellProvider>
   );

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -1581,6 +1581,7 @@ function OGSGroupPageContent() {
         <div className="hidden md:block lg:hidden">
           <SchoolCheckinFab
             variant="floating"
+            floatingUntil="lg"
             isActive={schoolCheckin.isActive}
             onToggle={schoolCheckin.toggleActive}
             successCount={schoolCheckin.successCount}

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -2803,6 +2803,7 @@ function SearchPageContent() {
         <div className="hidden md:block xl:hidden">
           <SchoolCheckinFab
             variant="floating"
+            floatingUntil="xl"
             isActive={schoolCheckin.isActive}
             onToggle={schoolCheckin.toggleActive}
             successCount={schoolCheckin.successCount}

--- a/frontend/src/components/database/database-create-action.test.tsx
+++ b/frontend/src/components/database/database-create-action.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseCreateAction } from "./database-create-action";
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
+describe("DatabaseCreateAction", () => {
+  beforeEach(() => {
+    stubMatchMedia(true);
+    document.documentElement.style.removeProperty("--moto-floating-fab-offset");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty("--moto-floating-fab-offset");
+  });
+
+  it("publishes stack clearance while its mobile FAB is visible", () => {
+    const { unmount } = render(
+      <DatabaseCreateAction
+        label="Raum"
+        ariaLabel="Raum erstellen"
+        onClick={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("button", { name: "Raum erstellen" }),
+    ).toHaveLength(2);
+    expect(window.matchMedia).toHaveBeenCalledWith("(max-width: 767px)");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--moto-floating-fab-offset",
+      ),
+    ).toBe("4.5rem");
+
+    unmount();
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--moto-floating-fab-offset",
+      ),
+    ).toBe("");
+  });
+});

--- a/frontend/src/components/database/database-create-action.tsx
+++ b/frontend/src/components/database/database-create-action.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  MOBILE_CREATE_FAB_MEDIA_QUERY,
+  useFloatingFabOffset,
+} from "~/lib/hooks/use-floating-fab-offset";
+
 interface DatabaseCreateActionProps {
   label: string;
   ariaLabel: string;
@@ -15,6 +20,11 @@ export function DatabaseCreateAction({
   ariaLabel,
   onClick,
 }: DatabaseCreateActionProps) {
+  useFloatingFabOffset({
+    active: true,
+    mediaQuery: MOBILE_CREATE_FAB_MEDIA_QUERY,
+  });
+
   return (
     <>
       <button

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -281,16 +281,17 @@ export const setupChapters: readonly GuideChapter[] = [
           "Auch auf Android-Geräten lässt sich moto als App installieren und startet dann im Vollbild ohne Browserleisten.",
         steps: [
           "moto in Chrome öffnen und in der eigenen Einrichtung anmelden.",
-          "Auf der Seite der Einrichtung das Browser-Menü mit den drei Punkten öffnen.",
-          "`App installieren` oder `Zum Startbildschirm hinzufügen` wählen und bestätigen.",
+          "Ab dem zweiten Besuch im Hinweis `moto als App nutzen` auf `App installieren` tippen.",
+          "Die Installation in Chrome bestätigen.",
           "moto künftig über das neue Symbol auf dem Startbildschirm starten.",
         ],
         callout: {
           title: "Erst anmelden, dann installieren",
-          body: "Wie auf dem iPhone gilt: moto erst nach der Anmeldung in der eigenen Einrichtung installieren. Wer für mehrere Einrichtungen arbeitet, legt für jede Einrichtung ein eigenes Symbol an.",
+          body: "Wie auf dem iPhone gilt: moto erst nach der Anmeldung in der eigenen Einrichtung installieren. Fehlt der Installationsbutton, im Chrome-Menü `App installieren` oder `Zum Startbildschirm hinzufügen` wählen. Wer für mehrere Einrichtungen arbeitet, legt für jede Einrichtung ein eigenes Symbol an.",
           tone: "blue",
         },
-        screenshot: "Chrome-Menü auf Android mit der Option App installieren.",
+        screenshot:
+          "Installationshinweis in moto mit dem Button App installieren.",
         printCompact: true,
       },
       {
@@ -1578,16 +1579,16 @@ export const appChapters: readonly GuideChapter[] = [
           "In Chrome auf Android lässt sich moto in wenigen Schritten installieren. Danach öffnet sich die App vom Startbildschirm aus im Vollbild, ohne Browserleiste.",
         steps: [
           "moto in Chrome öffnen und anmelden.",
-          "Oben rechts das Menü (drei Punkte) antippen.",
-          "`App installieren` bzw. `Zum Startbildschirm hinzufügen` wählen und bestätigen.",
+          "Ab dem zweiten Besuch im Hinweis `moto als App nutzen` auf `App installieren` tippen.",
+          "Die Installation in Chrome bestätigen.",
           "Die App künftig über das neue moto-Symbol auf dem Startbildschirm öffnen.",
         ],
         callout: {
           title: "Kein App Store nötig",
-          body: "moto steht nicht im Play Store. Die Installation läuft direkt über den Browser; Updates kommen automatisch, es muss nichts aktualisiert werden.",
+          body: "moto steht nicht im Play Store. Fehlt der Installationsbutton, im Chrome-Menü `App installieren` oder `Zum Startbildschirm hinzufügen` wählen. Updates kommen automatisch, es muss nichts aktualisiert werden.",
         },
         screenshot:
-          "Chrome-Menü auf Android mit dem Eintrag zum Installieren der App.",
+          "Installationshinweis in moto mit dem Button App installieren.",
       },
       {
         id: "iphone-ipad-installieren",

--- a/frontend/src/components/students/school-checkin-fab.stories.tsx
+++ b/frontend/src/components/students/school-checkin-fab.stories.tsx
@@ -24,6 +24,7 @@ export const FloatingOff: Story = {
     successCount: 0,
     pendingCount: 0,
     variant: "floating",
+    floatingUntil: "lg",
   },
 };
 
@@ -36,6 +37,7 @@ export const FloatingActive: Story = {
     successCount: 3,
     pendingCount: 0,
     variant: "floating",
+    floatingUntil: "lg",
   },
 };
 
@@ -48,6 +50,7 @@ export const FloatingPending: Story = {
     successCount: 2,
     pendingCount: 1,
     variant: "floating",
+    floatingUntil: "lg",
   },
 };
 

--- a/frontend/src/components/students/school-checkin-fab.test.tsx
+++ b/frontend/src/components/students/school-checkin-fab.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
@@ -40,7 +40,29 @@ vi.mock("framer-motion", () => ({
 
 import { SchoolCheckinFab } from "./school-checkin-fab";
 
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
 describe("SchoolCheckinFab", () => {
+  beforeEach(() => {
+    stubMatchMedia(true);
+    document.documentElement.style.removeProperty("--moto-floating-fab-offset");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty("--moto-floating-fab-offset");
+  });
+
   describe("inline variant", () => {
     it("renders the idle label when inactive", () => {
       render(
@@ -115,6 +137,7 @@ describe("SchoolCheckinFab", () => {
       const { container } = render(
         <SchoolCheckinFab
           variant="floating"
+          floatingUntil="lg"
           isActive={false}
           onToggle={() => undefined}
           successCount={0}
@@ -136,6 +159,7 @@ describe("SchoolCheckinFab", () => {
       render(
         <SchoolCheckinFab
           variant="floating"
+          floatingUntil="lg"
           isActive={false}
           onToggle={() => undefined}
           successCount={0}
@@ -145,6 +169,55 @@ describe("SchoolCheckinFab", () => {
 
       const button = screen.getByRole("button");
       expect(button).toHaveAttribute("data-checkin-fab-variant", "floating");
+    });
+
+    it("publishes stack clearance only within its visible breakpoint range", () => {
+      const { unmount } = render(
+        <SchoolCheckinFab
+          variant="floating"
+          floatingUntil="xl"
+          isActive={false}
+          onToggle={() => undefined}
+          successCount={0}
+          pendingCount={0}
+        />,
+      );
+
+      expect(window.matchMedia).toHaveBeenCalledWith(
+        "(min-width: 768px) and (max-width: 1279px)",
+      );
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--moto-floating-fab-offset",
+        ),
+      ).toBe("4.5rem");
+
+      unmount();
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--moto-floating-fab-offset",
+        ),
+      ).toBe("");
+    });
+
+    it("does not publish stack clearance while CSS hides the FAB", () => {
+      stubMatchMedia(false);
+      render(
+        <SchoolCheckinFab
+          variant="floating"
+          floatingUntil="lg"
+          isActive={false}
+          onToggle={() => undefined}
+          successCount={0}
+          pendingCount={0}
+        />,
+      );
+
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--moto-floating-fab-offset",
+        ),
+      ).toBe("");
     });
   });
 

--- a/frontend/src/components/students/school-checkin-fab.tsx
+++ b/frontend/src/components/students/school-checkin-fab.tsx
@@ -1,19 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, CheckSquare, Loader2 } from "lucide-react";
 import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { useAttendanceWebEnabled } from "~/lib/tenant-context";
-
-/**
- * Published while a floating FAB is on screen so other bottom-anchored
- * elements (currently the PWA install hint) can stack above it instead of
- * hardcoding a gap for a button that exists on two pages only.
- * Value = FAB height (3.5rem) + gap (1rem).
- */
-const FAB_STACK_OFFSET_VAR = "--moto-floating-fab-offset";
-const FAB_STACK_OFFSET = "4.5rem";
+import { useFloatingFabOffset } from "~/lib/hooks/use-floating-fab-offset";
 
 interface SchoolCheckinFabBaseProps {
   /** Whether the page is currently in check-in/out mode. */
@@ -72,27 +63,11 @@ export function SchoolCheckinFab({
   // its parent wrapper displays it. The two pages intentionally stop at
   // different breakpoints (`lg` for OGS groups, `xl` for student search).
   const occupiesBottomSpace = attendanceWebEnabled && variant === "floating";
-  useEffect(() => {
-    if (!occupiesBottomSpace) return;
-    const root = document.documentElement;
-    const maxWidth = floatingUntil === "lg" ? 1023 : 1279;
-    const mediaQuery = window.matchMedia(
-      `(min-width: 768px) and (max-width: ${maxWidth}px)`,
-    );
-    const publishOffset = () => {
-      if (mediaQuery.matches) {
-        root.style.setProperty(FAB_STACK_OFFSET_VAR, FAB_STACK_OFFSET);
-      } else {
-        root.style.removeProperty(FAB_STACK_OFFSET_VAR);
-      }
-    };
-    publishOffset();
-    mediaQuery.addEventListener("change", publishOffset);
-    return () => {
-      mediaQuery.removeEventListener("change", publishOffset);
-      root.style.removeProperty(FAB_STACK_OFFSET_VAR);
-    };
-  }, [floatingUntil, occupiesBottomSpace]);
+  const maxFloatingWidth = floatingUntil === "lg" ? 1023 : 1279;
+  useFloatingFabOffset({
+    active: occupiesBottomSpace,
+    mediaQuery: `(min-width: 768px) and (max-width: ${maxFloatingWidth}px)`,
+  });
 
   if (!attendanceWebEnabled) return null;
 

--- a/frontend/src/components/students/school-checkin-fab.tsx
+++ b/frontend/src/components/students/school-checkin-fab.tsx
@@ -15,7 +15,7 @@ import { useAttendanceWebEnabled } from "~/lib/tenant-context";
 const FAB_STACK_OFFSET_VAR = "--moto-floating-fab-offset";
 const FAB_STACK_OFFSET = "4.5rem";
 
-interface SchoolCheckinFabProps {
+interface SchoolCheckinFabBaseProps {
   /** Whether the page is currently in check-in/out mode. */
   readonly isActive: boolean;
   /** Toggle the mode on/off. */
@@ -24,21 +24,29 @@ interface SchoolCheckinFabProps {
   readonly successCount: number;
   /** Open API calls in flight — surfaces as a small spinner badge top-right. */
   readonly pendingCount: number;
-  /**
-   * Form-factor variant. Pages typically render the component twice —
-   * once with `"floating"` inside an `lg:hidden` wrapper for mobile/tablet,
-   * once with `"inline"` passed as the header's `primaryAction` for desktop.
-   * Each render is gated by CSS so only one is visible per viewport.
-   */
-  readonly variant: "floating" | "inline";
 }
+
+type SchoolCheckinFabProps = SchoolCheckinFabBaseProps &
+  (
+    | {
+        /** Floating trigger shown from `md` until this exclusive breakpoint. */
+        readonly variant: "floating";
+        readonly floatingUntil: "lg" | "xl";
+      }
+    | {
+        /** Header action used after the page's floating breakpoint. */
+        readonly variant: "inline";
+        readonly floatingUntil?: never;
+      }
+  );
 
 /**
  * Shared check-in/out mode trigger used on both the OGS-Groups and
  * Students/Search pages.
  *
  * - `floating` variant: anchored bottom-right with `safe-area-inset` padding
- *   so it clears the iPhone home indicator. Default below 1024px.
+ *   so it clears the iPhone home indicator. Used from `md` to the page's
+ *   explicit `floatingUntil` breakpoint.
  * - `inline` variant: relative-flow pill that lives inside the page header's
  *   primaryAction slot. Default at ≥1024px so desktop reads as a native
  *   page-level action instead of a mobile-style floating button.
@@ -54,22 +62,37 @@ export function SchoolCheckinFab({
   successCount,
   pendingCount,
   variant,
+  floatingUntil,
 }: SchoolCheckinFabProps) {
   const attendanceWebEnabled = useAttendanceWebEnabled();
   const reduceMotion = useReducedMotion();
   const resolved = variant;
 
-  // Announce the space this FAB occupies for as long as it is mounted. Runs
-  // before the early return below so the hook order stays stable.
+  // Announce the space this FAB occupies only across the viewport range where
+  // its parent wrapper displays it. The two pages intentionally stop at
+  // different breakpoints (`lg` for OGS groups, `xl` for student search).
   const occupiesBottomSpace = attendanceWebEnabled && variant === "floating";
   useEffect(() => {
     if (!occupiesBottomSpace) return;
     const root = document.documentElement;
-    root.style.setProperty(FAB_STACK_OFFSET_VAR, FAB_STACK_OFFSET);
+    const maxWidth = floatingUntil === "lg" ? 1023 : 1279;
+    const mediaQuery = window.matchMedia(
+      `(min-width: 768px) and (max-width: ${maxWidth}px)`,
+    );
+    const publishOffset = () => {
+      if (mediaQuery.matches) {
+        root.style.setProperty(FAB_STACK_OFFSET_VAR, FAB_STACK_OFFSET);
+      } else {
+        root.style.removeProperty(FAB_STACK_OFFSET_VAR);
+      }
+    };
+    publishOffset();
+    mediaQuery.addEventListener("change", publishOffset);
     return () => {
+      mediaQuery.removeEventListener("change", publishOffset);
       root.style.removeProperty(FAB_STACK_OFFSET_VAR);
     };
-  }, [occupiesBottomSpace]);
+  }, [floatingUntil, occupiesBottomSpace]);
 
   if (!attendanceWebEnabled) return null;
 

--- a/frontend/src/components/students/school-checkin-fab.tsx
+++ b/frontend/src/components/students/school-checkin-fab.tsx
@@ -1,9 +1,19 @@
 "use client";
 
+import { useEffect } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, CheckSquare, Loader2 } from "lucide-react";
 import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { useAttendanceWebEnabled } from "~/lib/tenant-context";
+
+/**
+ * Published while a floating FAB is on screen so other bottom-anchored
+ * elements (currently the PWA install hint) can stack above it instead of
+ * hardcoding a gap for a button that exists on two pages only.
+ * Value = FAB height (3.5rem) + gap (1rem).
+ */
+const FAB_STACK_OFFSET_VAR = "--moto-floating-fab-offset";
+const FAB_STACK_OFFSET = "4.5rem";
 
 interface SchoolCheckinFabProps {
   /** Whether the page is currently in check-in/out mode. */
@@ -48,6 +58,18 @@ export function SchoolCheckinFab({
   const attendanceWebEnabled = useAttendanceWebEnabled();
   const reduceMotion = useReducedMotion();
   const resolved = variant;
+
+  // Announce the space this FAB occupies for as long as it is mounted. Runs
+  // before the early return below so the hook order stays stable.
+  const occupiesBottomSpace = attendanceWebEnabled && variant === "floating";
+  useEffect(() => {
+    if (!occupiesBottomSpace) return;
+    const root = document.documentElement;
+    root.style.setProperty(FAB_STACK_OFFSET_VAR, FAB_STACK_OFFSET);
+    return () => {
+      root.style.removeProperty(FAB_STACK_OFFSET_VAR);
+    };
+  }, [occupiesBottomSpace]);
 
   if (!attendanceWebEnabled) return null;
 

--- a/frontend/src/components/students/school-checkin-mode-mobile.test.tsx
+++ b/frontend/src/components/students/school-checkin-mode-mobile.test.tsx
@@ -1,10 +1,32 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 import { SchoolCheckinModeMobile } from "./school-checkin-mode-mobile";
 
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
 describe("SchoolCheckinModeMobile", () => {
+  beforeEach(() => {
+    stubMatchMedia(true);
+    document.documentElement.style.removeProperty("--moto-checkin-bar-offset");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty("--moto-checkin-bar-offset");
+  });
+
   describe("inactive (OFF) state", () => {
     it("renders an inline pill with the idle label", () => {
       render(
@@ -120,6 +142,49 @@ describe("SchoolCheckinModeMobile", () => {
         }),
       );
       expect(onToggle).toHaveBeenCalledOnce();
+    });
+
+    it("publishes install-hint clearance only below md", () => {
+      const { unmount } = render(
+        <SchoolCheckinModeMobile
+          isActive
+          onToggle={() => undefined}
+          successCount={0}
+          pendingCount={0}
+        />,
+      );
+
+      expect(window.matchMedia).toHaveBeenCalledWith("(max-width: 767px)");
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--moto-checkin-bar-offset",
+        ),
+      ).toBe("4.5rem");
+
+      unmount();
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--moto-checkin-bar-offset",
+        ),
+      ).toBe("");
+    });
+
+    it("does not publish install-hint clearance at md and above", () => {
+      stubMatchMedia(false);
+      render(
+        <SchoolCheckinModeMobile
+          isActive
+          onToggle={() => undefined}
+          successCount={0}
+          pendingCount={0}
+        />,
+      );
+
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--moto-checkin-bar-offset",
+        ),
+      ).toBe("");
     });
   });
 });

--- a/frontend/src/components/students/school-checkin-mode-mobile.tsx
+++ b/frontend/src/components/students/school-checkin-mode-mobile.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useEffect } from "react";
 import { CheckSquare, Loader2 } from "lucide-react";
 import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { useAttendanceWebEnabled } from "~/lib/tenant-context";
+
+const CHECKIN_BAR_OFFSET_VAR = "--moto-checkin-bar-offset";
+const CHECKIN_BAR_OFFSET = "4.5rem";
 
 interface SchoolCheckinModeMobileProps {
   /** Whether the page is currently in check-in/out mode. */
@@ -36,6 +40,26 @@ export function SchoolCheckinModeMobile({
   pendingCount,
 }: SchoolCheckinModeMobileProps) {
   const attendanceWebEnabled = useAttendanceWebEnabled();
+
+  useEffect(() => {
+    if (!attendanceWebEnabled || !isActive) return;
+    const root = document.documentElement;
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const publishOffset = () => {
+      if (mediaQuery.matches) {
+        root.style.setProperty(CHECKIN_BAR_OFFSET_VAR, CHECKIN_BAR_OFFSET);
+      } else {
+        root.style.removeProperty(CHECKIN_BAR_OFFSET_VAR);
+      }
+    };
+    publishOffset();
+    mediaQuery.addEventListener("change", publishOffset);
+    return () => {
+      mediaQuery.removeEventListener("change", publishOffset);
+      root.style.removeProperty(CHECKIN_BAR_OFFSET_VAR);
+    };
+  }, [attendanceWebEnabled, isActive]);
+
   if (!attendanceWebEnabled) return null;
   if (!isActive) {
     return (

--- a/frontend/src/components/tenant/pwa-install-hint.test.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.test.tsx
@@ -198,7 +198,12 @@ describe("PwaInstallHint", () => {
     expect(screen.getByText("Zum Home-Bildschirm")).toBeInTheDocument();
 
     const card = container.firstElementChild;
-    expect(card).toHaveClass("moto-content-surface", "fixed", "rounded-2xl");
+    expect(card).toHaveClass("fixed", "rounded-2xl");
+    // Brand-tinted surface with a 2px brand border so the promotion is
+    // distinguishable from the neutral gray content cards. `moto-content-surface`
+    // is deliberately absent: it is unlayered and would force white + gray-200.
+    expect(card).toHaveClass("border-2", "border-[#83CD2D]", "bg-[#f0f9e4]");
+    expect(card?.className).not.toMatch(/moto-content-surface/);
     // Centered at every width, not an edge-to-edge banner that snaps to the
     // right at sm.
     expect(card).toHaveClass("left-1/2", "-translate-x-1/2", "max-w-md");
@@ -337,6 +342,32 @@ describe("PwaInstallHint", () => {
 
   it("does not render on desktop devices", () => {
     stubNavigator({ userAgent: DESKTOP_UA });
+    stubMatchMedia(false);
+    render(<PwaInstallHint />);
+    expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
+  });
+
+  it("does not render in desktop Safari on macOS", () => {
+    // Closest thing to a false positive: iPadOS Safari sends this exact UA.
+    // Only maxTouchPoints tells the two apart, so a Mac must stay excluded
+    // even though the wide iPad layout looks the same.
+    stubNavigator({
+      userAgent: IPAD_SAFARI_DESKTOP_UA,
+      platform: "MacIntel",
+      maxTouchPoints: 0,
+    });
+    stubMatchMedia(false);
+    render(<PwaInstallHint />);
+    expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
+  });
+
+  it("does not render on a touchscreen Windows laptop", () => {
+    stubNavigator({
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+      platform: "Win32",
+      maxTouchPoints: 10,
+    });
     stubMatchMedia(false);
     render(<PwaInstallHint />);
     expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();

--- a/frontend/src/components/tenant/pwa-install-hint.test.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.test.tsx
@@ -180,6 +180,8 @@ describe("recordVisit", () => {
 
 describe("PwaInstallHint", () => {
   beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_TENANT_DOMAIN", "moto-app.de");
+    window.location.href = "https://school-a.moto-app.de/dashboard";
     localStorage.clear();
     sessionStorage.clear();
     resetInstallPromptForTests();
@@ -187,6 +189,7 @@ describe("PwaInstallHint", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     resetInstallPromptForTests();
   });

--- a/frontend/src/components/tenant/pwa-install-hint.test.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.test.tsx
@@ -190,7 +190,7 @@ describe("PwaInstallHint", () => {
     resetInstallPromptForTests();
   });
 
-  it("renders Safari instructions as an in-flow card, not a floating overlay", () => {
+  it("renders Safari instructions in a centered floating card", () => {
     stubNavigator({ userAgent: IPHONE_UA });
     stubMatchMedia(false);
     const { container } = render(<PwaInstallHint />);
@@ -198,12 +198,30 @@ describe("PwaInstallHint", () => {
     expect(screen.getByText("Zum Home-Bildschirm")).toBeInTheDocument();
 
     const card = container.firstElementChild;
-    expect(card).toHaveClass("moto-content-surface", "rounded-2xl");
-    // The whole point of the redesign: no fixed positioning, so no offset
-    // arithmetic against the bottom nav or the check-in FAB.
-    expect(card?.className).not.toMatch(/\bfixed\b/);
-    expect(card?.className).not.toMatch(/\bbottom-/);
-    expect(card?.className).not.toMatch(/\bz-\d/);
+    expect(card).toHaveClass("moto-content-surface", "fixed", "rounded-2xl");
+    // Centered at every width, not an edge-to-edge banner that snaps to the
+    // right at sm.
+    expect(card).toHaveClass("left-1/2", "-translate-x-1/2", "max-w-md");
+    expect(card?.className).not.toMatch(/\binset-x-/);
+    expect(card?.className).not.toMatch(/\bsm:right-/);
+  });
+
+  it("clears the bottom nav and only reserves FAB space when a FAB is mounted", () => {
+    stubNavigator({ userAgent: IPHONE_UA });
+    stubMatchMedia(false);
+    const { container } = render(<PwaInstallHint />);
+    const card = container.firstElementChild;
+
+    // The FAB contribution is a CSS variable defaulting to 0, so pages
+    // without a FAB do not reserve room for one.
+    expect(card).toHaveClass(
+      "bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+env(safe-area-inset-bottom))]",
+    );
+    // Switches with the shell (AppShell drops its mobile padding at lg and
+    // the bottom nav is lg:hidden), not one breakpoint later at xl.
+    expect(card).toHaveClass("lg:bottom-8");
+    expect(card?.className).not.toMatch(/\bxl:bottom-/);
+    expect(card?.className).not.toMatch(/10\.5rem/);
   });
 
   it("stays hidden on the very first visit", () => {

--- a/frontend/src/components/tenant/pwa-install-hint.test.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.test.tsx
@@ -8,6 +8,7 @@ import {
   isStandaloneDisplay,
   recordVisit,
 } from "./pwa-install-hint";
+import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { resetInstallPromptForTests } from "~/lib/pwa-install-prompt";
 
 const IPHONE_UA =
@@ -202,7 +203,11 @@ describe("PwaInstallHint", () => {
     // Brand-tinted surface with a 2px brand border so the promotion is
     // distinguishable from the neutral gray content cards. `moto-content-surface`
     // is deliberately absent: it is unlayered and would force white + gray-200.
-    expect(card).toHaveClass("border-2", "border-[#83CD2D]", "bg-[#f0f9e4]");
+    expect(card).toHaveClass("border-2");
+    expect(card).toHaveStyle({
+      borderColor: GROUP_ROOM_SHADES.base,
+      backgroundColor: GROUP_ROOM_SHADES.bgHover,
+    });
     expect(card?.className).not.toMatch(/moto-content-surface/);
     // Centered at every width, not an edge-to-edge banner that snaps to the
     // right at sm.
@@ -211,7 +216,7 @@ describe("PwaInstallHint", () => {
     expect(card?.className).not.toMatch(/\bsm:right-/);
   });
 
-  it("clears the bottom nav and only reserves FAB space when a FAB is mounted", () => {
+  it("clears responsive bottom controls only while they are visible", () => {
     stubNavigator({ userAgent: IPHONE_UA });
     stubMatchMedia(false);
     const { container } = render(<PwaInstallHint />);
@@ -220,10 +225,10 @@ describe("PwaInstallHint", () => {
     // The FAB contribution is a CSS variable defaulting to 0, so pages
     // without a FAB do not reserve room for one.
     expect(card).toHaveClass(
-      "bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+env(safe-area-inset-bottom))]",
+      "bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+var(--moto-checkin-bar-offset,0rem)+env(safe-area-inset-bottom))]",
     );
-    // Switches with the shell (AppShell drops its mobile padding at lg and
-    // the bottom nav is lg:hidden), not one breakpoint later at xl.
+    // At lg the centered card and right-aligned FAB no longer intersect, so
+    // the hint can use the shell's normal desktop bottom spacing.
     expect(card).toHaveClass("lg:bottom-8");
     expect(card?.className).not.toMatch(/\bxl:bottom-/);
     expect(card?.className).not.toMatch(/10\.5rem/);
@@ -328,6 +333,19 @@ describe("PwaInstallHint", () => {
     // Falls back to the manual instructions because the one-shot event is
     // spent, but the promotion itself must not disappear silently.
     expect(screen.getByText("moto als App nutzen")).toBeInTheDocument();
+  });
+
+  it("hides and persistently dismisses the card after browser-menu installation", async () => {
+    stubNavigator({ userAgent: ANDROID_UA, platform: "Linux armv81" });
+    stubMatchMedia(false);
+    render(<PwaInstallHint />);
+
+    fireEvent(window, new Event("appinstalled"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
+    });
+    expect(localStorage.getItem("moto-pwa-install-hint-dismissed")).toBe("1");
   });
 
   it("does not render inside Android WebViews", () => {

--- a/frontend/src/components/tenant/pwa-install-hint.test.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   PwaInstallHint,
@@ -6,7 +6,9 @@ import {
   isIosDevice,
   isIosSafari,
   isStandaloneDisplay,
+  recordVisit,
 } from "./pwa-install-hint";
+import { resetInstallPromptForTests } from "~/lib/pwa-install-prompt";
 
 const IPHONE_UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
@@ -141,25 +143,91 @@ describe("isStandaloneDisplay", () => {
   });
 });
 
+/**
+ * Puts storage in the state of someone opening the app for a second browser
+ * session, which is the earliest point the hint is allowed to appear.
+ */
+function seedReturningVisitor() {
+  localStorage.setItem("moto-pwa-install-hint-visits", "1");
+  sessionStorage.clear();
+}
+
+/** Fires the Chrome event the install-prompt module captures at import time. */
+function dispatchInstallPrompt(outcome: "accepted" | "dismissed" = "accepted") {
+  const prompt = vi.fn().mockResolvedValue(undefined);
+  const event = Object.assign(new Event("beforeinstallprompt"), {
+    prompt,
+    userChoice: Promise.resolve({ outcome }),
+  });
+  window.dispatchEvent(event);
+  return prompt;
+}
+
+describe("recordVisit", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("counts one visit per browser session, not per call", () => {
+    expect(recordVisit(window)).toBe(1);
+    expect(recordVisit(window)).toBe(1);
+    sessionStorage.clear();
+    expect(recordVisit(window)).toBe(2);
+  });
+});
+
 describe("PwaInstallHint", () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
+    resetInstallPromptForTests();
+    seedReturningVisitor();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    resetInstallPromptForTests();
   });
 
-  it("renders Safari instructions above mobile check-in controls", () => {
+  it("renders Safari instructions as an in-flow card, not a floating overlay", () => {
     stubNavigator({ userAgent: IPHONE_UA });
     stubMatchMedia(false);
     const { container } = render(<PwaInstallHint />);
     expect(screen.getByText("moto als App nutzen")).toBeInTheDocument();
     expect(screen.getByText("Zum Home-Bildschirm")).toBeInTheDocument();
-    expect(container.firstElementChild).toHaveClass(
-      "bottom-[calc(10.5rem+env(safe-area-inset-bottom))]",
-      "xl:bottom-6",
-    );
+
+    const card = container.firstElementChild;
+    expect(card).toHaveClass("moto-content-surface", "rounded-2xl");
+    // The whole point of the redesign: no fixed positioning, so no offset
+    // arithmetic against the bottom nav or the check-in FAB.
+    expect(card?.className).not.toMatch(/\bfixed\b/);
+    expect(card?.className).not.toMatch(/\bbottom-/);
+    expect(card?.className).not.toMatch(/\bz-\d/);
+  });
+
+  it("stays hidden on the very first visit", () => {
+    localStorage.clear();
+    sessionStorage.clear();
+    stubNavigator({ userAgent: IPHONE_UA });
+    stubMatchMedia(false);
+    render(<PwaInstallHint />);
+    expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
+  });
+
+  it("appears on the second visit", () => {
+    localStorage.clear();
+    sessionStorage.clear();
+    stubNavigator({ userAgent: IPHONE_UA });
+    stubMatchMedia(false);
+
+    const first = render(<PwaInstallHint />);
+    expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
+    first.unmount();
+
+    sessionStorage.clear(); // a new browser session
+    render(<PwaInstallHint />);
+    expect(screen.getByText("moto als App nutzen")).toBeInTheDocument();
   });
 
   it("does not render Safari instructions in other iOS browsers", () => {
@@ -176,12 +244,67 @@ describe("PwaInstallHint", () => {
     expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
   });
 
-  it("renders browser-menu instructions on Android in browser mode", () => {
+  it("renders browser-menu instructions on Android when no install event was captured", () => {
     stubNavigator({ userAgent: ANDROID_UA, platform: "Linux armv81" });
     stubMatchMedia(false);
     render(<PwaInstallHint />);
     expect(screen.getByText("moto als App nutzen")).toBeInTheDocument();
     expect(screen.getByText("App installieren")).toBeInTheDocument();
+    // Fallback path: instructions only, no actionable button.
+    expect(
+      screen.queryByRole("button", { name: "App installieren" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers a one-tap install on Android once Chrome fires beforeinstallprompt", () => {
+    stubNavigator({ userAgent: ANDROID_UA, platform: "Linux armv81" });
+    stubMatchMedia(false);
+    dispatchInstallPrompt();
+    render(<PwaInstallHint />);
+    expect(
+      screen.getByText("Installieren Sie moto direkt aus dieser Ansicht.", {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "App installieren" }),
+    ).toBeInTheDocument();
+    // The manual browser-menu instructions are replaced, not stacked on top.
+    expect(
+      screen.queryByText("Zum Startbildschirm hinzufügen"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("replays the captured prompt and hides the card once install is accepted", async () => {
+    stubNavigator({ userAgent: ANDROID_UA, platform: "Linux armv81" });
+    stubMatchMedia(false);
+    const prompt = dispatchInstallPrompt("accepted");
+    render(<PwaInstallHint />);
+
+    fireEvent.click(screen.getByRole("button", { name: "App installieren" }));
+
+    await waitFor(() => {
+      expect(prompt).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("moto als App nutzen")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the card in place when the install prompt is declined", async () => {
+    stubNavigator({ userAgent: ANDROID_UA, platform: "Linux armv81" });
+    stubMatchMedia(false);
+    const prompt = dispatchInstallPrompt("dismissed");
+    render(<PwaInstallHint />);
+
+    fireEvent.click(screen.getByRole("button", { name: "App installieren" }));
+
+    await waitFor(() => {
+      expect(prompt).toHaveBeenCalledTimes(1);
+    });
+    // Falls back to the manual instructions because the one-shot event is
+    // spent, but the promotion itself must not disappear silently.
+    expect(screen.getByText("moto als App nutzen")).toBeInTheDocument();
   });
 
   it("does not render inside Android WebViews", () => {

--- a/frontend/src/components/tenant/pwa-install-hint.test.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.test.tsx
@@ -6,10 +6,12 @@ import {
   isIosDevice,
   isIosSafari,
   isStandaloneDisplay,
-  recordVisit,
 } from "./pwa-install-hint";
 import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
-import { resetInstallPromptForTests } from "~/lib/pwa-install-prompt";
+import {
+  recordVisit,
+  resetInstallPromptForTests,
+} from "~/lib/pwa-install-prompt";
 
 const IPHONE_UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";

--- a/frontend/src/components/tenant/pwa-install-hint.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.tsx
@@ -1,10 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { EllipsisVertical, Share, X } from "lucide-react";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { Download, EllipsisVertical, Share, X } from "lucide-react";
 import { Button } from "~/components/ui/button";
+import { createLogger } from "~/lib/logger";
+import {
+  canPromptInstall,
+  subscribeInstallPrompt,
+  triggerInstallPrompt,
+} from "~/lib/pwa-install-prompt";
+
+const logger = createLogger({ component: "PwaInstallHint" });
 
 const DISMISS_KEY = "moto-pwa-install-hint-dismissed";
+const VISIT_COUNT_KEY = "moto-pwa-install-hint-visits";
+const SESSION_COUNTED_KEY = "moto-pwa-install-hint-session-counted";
+
+/**
+ * web.dev "Patterns for promoting PWA installation": promote after a few
+ * interactions, never on the first page load, or the promotion is missed and
+ * reads as noise. One visit = one browser session.
+ */
+const MIN_VISITS = 2;
 
 export type InstallPlatform = "ios" | "android";
 
@@ -39,15 +56,54 @@ export function isStandaloneDisplay(win: Window): boolean {
 }
 
 /**
- * Subtle, dismissible hint for iOS Safari and Android users browsing the
- * tenant app in a normal browser tab: add moto to the home screen from THIS
- * subdomain so the installed app keeps its standalone scope (issue #2010 —
- * both platforms show browser chrome after a cross-origin redirect, so
- * installing on the root host breaks fullscreen). Never rendered inside an
- * already-installed PWA or on desktop devices.
+ * Counts this browser session as one visit, exactly once, and returns the
+ * running total. The sessionStorage flag makes the call idempotent, so a
+ * StrictMode double-effect or a remount does not inflate the count.
+ */
+export function recordVisit(win: Window): number {
+  try {
+    const stored = Number(win.localStorage.getItem(VISIT_COUNT_KEY) ?? "0");
+    const previous = Number.isFinite(stored) && stored > 0 ? stored : 0;
+    if (win.sessionStorage.getItem(SESSION_COUNTED_KEY) === "1") {
+      return previous;
+    }
+    const next = previous + 1;
+    win.localStorage.setItem(VISIT_COUNT_KEY, String(next));
+    win.sessionStorage.setItem(SESSION_COUNTED_KEY, "1");
+    return next;
+  } catch {
+    // Private mode can block storage. Treat the visit as sufficient rather
+    // than hiding the hint forever on browsers that deny storage.
+    return MIN_VISITS;
+  }
+}
+
+/**
+ * Install promotion for iOS Safari and Android users browsing the tenant app
+ * in a normal browser tab: add moto to the home screen from THIS subdomain so
+ * the installed app keeps its standalone scope (issue #2010 — both platforms
+ * show browser chrome after a cross-origin redirect, so installing on the
+ * root host breaks fullscreen).
+ *
+ * Renders as a normal in-flow card, not a floating overlay, so it never
+ * overlaps the mobile bottom nav, the check-in FAB, or page content, and
+ * needs no offset arithmetic against them. Mount it inside page content, not
+ * in a layout: web.dev advises keeping install promotions out of the flow of
+ * user journeys.
+ *
+ * Never rendered on desktop, inside an already-installed PWA, before the
+ * second visit, or after the user dismissed it.
  */
 export function PwaInstallHint() {
   const [platform, setPlatform] = useState<InstallPlatform | null>(null);
+
+  // Chrome may fire beforeinstallprompt before or after this mounts, so read
+  // it from the module-level store rather than a local listener.
+  const oneTapInstallReady = useSyncExternalStore(
+    subscribeInstallPrompt,
+    canPromptInstall,
+    () => false,
+  );
 
   useEffect(() => {
     let detected: InstallPlatform | null = null;
@@ -60,6 +116,7 @@ export function PwaInstallHint() {
     } catch {
       // Private mode can block storage access; show the hint anyway.
     }
+    if (recordVisit(window) < MIN_VISITS) return;
     setPlatform(detected);
   }, []);
 
@@ -74,19 +131,52 @@ export function PwaInstallHint() {
     }
   };
 
-  const PlatformIcon = platform === "ios" ? Share : EllipsisVertical;
+  const install = () => {
+    void triggerInstallPrompt()
+      .then((outcome) => {
+        logger.info("pwa_install_prompt_answered", { outcome });
+        // A declined prompt leaves the card in place so the user can retry.
+        if (outcome === "accepted") dismiss();
+      })
+      .catch((err: unknown) => {
+        logger.error("pwa_install_prompt_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  };
 
-  // Below xl, reserve the bottom nav (5.5rem), the tallest fixed check-in
-  // control (3.5rem), and a 1.5rem gap. Those controls are hidden at xl.
+  // Android with a captured event gets a real one-tap install. Without one
+  // (event missed, or the browser exposes no install action) it falls back to
+  // the same manual instructions iOS needs, which is all Safari ever allows.
+  const showOneTapInstall = platform === "android" && oneTapInstallReady;
+  const PlatformIcon = showOneTapInstall
+    ? Download
+    : platform === "ios"
+      ? Share
+      : EllipsisVertical;
+
   return (
-    <div className="moto-content-surface fixed inset-x-4 bottom-[calc(10.5rem+env(safe-area-inset-bottom))] z-40 rounded-2xl border p-4 shadow-lg sm:right-6 sm:left-auto sm:max-w-sm xl:bottom-6">
+    <section
+      aria-labelledby="pwa-install-hint-title"
+      className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6"
+    >
       <div className="flex items-start gap-3">
         <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[#83CD2D]/10">
           <PlatformIcon className="h-4 w-4 text-[#669f21]" aria-hidden="true" />
         </div>
-        <div className="min-w-0 text-sm text-gray-700">
-          <p className="font-semibold text-gray-900">moto als App nutzen</p>
-          {platform === "ios" ? (
+        <div className="min-w-0 flex-1 text-sm text-gray-700">
+          <h2
+            id="pwa-install-hint-title"
+            className="font-semibold text-gray-900"
+          >
+            moto als App nutzen
+          </h2>
+          {showOneTapInstall ? (
+            <p className="mt-1">
+              Installieren Sie moto direkt aus dieser Ansicht. So öffnet sich
+              moto immer im Vollbild, ohne Browserleiste.
+            </p>
+          ) : platform === "ios" ? (
             <p className="mt-1">
               Tippen Sie in Safari auf{" "}
               <span className="font-medium">Teilen</span> und dann auf{" "}
@@ -103,6 +193,17 @@ export function PwaInstallHint() {
               . So öffnet sich moto immer im Vollbild.
             </p>
           )}
+          {showOneTapInstall && (
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              className="mt-3"
+              onClick={install}
+            >
+              App installieren
+            </Button>
+          )}
         </div>
         <Button
           type="button"
@@ -114,6 +215,6 @@ export function PwaInstallHint() {
           <X className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
-    </div>
+    </section>
   );
 }

--- a/frontend/src/components/tenant/pwa-install-hint.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.tsx
@@ -79,17 +79,27 @@ export function recordVisit(win: Window): number {
 }
 
 /**
- * Install promotion for iOS Safari and Android users browsing the tenant app
- * in a normal browser tab: add moto to the home screen from THIS subdomain so
- * the installed app keeps its standalone scope (issue #2010 — both platforms
- * show browser chrome after a cross-origin redirect, so installing on the
- * root host breaks fullscreen).
+ * Floating, dismissible install promotion for iOS Safari and Android users
+ * browsing the tenant app in a normal browser tab: add moto to the home
+ * screen from THIS subdomain so the installed app keeps its standalone scope
+ * (issue #2010 — both platforms show browser chrome after a cross-origin
+ * redirect, so installing on the root host breaks fullscreen).
  *
- * Renders as a normal in-flow card, not a floating overlay, so it never
- * overlaps the mobile bottom nav, the check-in FAB, or page content, and
- * needs no offset arithmetic against them. Mount it inside page content, not
- * in a layout: web.dev advises keeping install promotions out of the flow of
- * user journeys.
+ * Mounted in the protected layout on purpose. The audience is staff on phones
+ * and tablets, and most of them never reach the admin-only dashboard, so a
+ * single in-page slot would not reach them.
+ *
+ * Geometry, all of it previously wrong:
+ * - Switches at `lg`, the same breakpoint at which AppShell drops its mobile
+ *   bottom padding and the bottom nav and FAB become `lg:hidden`. The old
+ *   `xl` switch left the card floating over nothing between 1024 and 1280px,
+ *   which is exactly where iPad landscape sits.
+ * - Below lg the offset clears the bottom nav (~4.75rem visible) plus a 1rem
+ *   gap, and adds `--moto-floating-fab-offset` only on the two pages that
+ *   actually render the check-in FAB. The old fixed 10.5rem reserved FAB
+ *   space everywhere.
+ * - Horizontally centered at every width instead of jumping from an
+ *   edge-to-edge mobile banner to a right-anchored card at `sm`.
  *
  * Never rendered on desktop, inside an already-installed PWA, before the
  * second visit, or after the user dismissed it.
@@ -158,7 +168,7 @@ export function PwaInstallHint() {
   return (
     <section
       aria-labelledby="pwa-install-hint-title"
-      className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6"
+      className="moto-content-surface fixed bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+env(safe-area-inset-bottom))] left-1/2 z-40 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-2xl border p-4 shadow-lg lg:bottom-8"
     >
       <div className="flex items-start gap-3">
         <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[#83CD2D]/10">

--- a/frontend/src/components/tenant/pwa-install-hint.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.tsx
@@ -7,10 +7,13 @@ import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { createLogger } from "~/lib/logger";
 import {
   canPromptInstall,
+  isAndroidDevice,
   isInstallationCompleted,
   subscribeInstallPrompt,
   triggerInstallPrompt,
 } from "~/lib/pwa-install-prompt";
+
+export { isAndroidDevice } from "~/lib/pwa-install-prompt";
 
 const logger = createLogger({ component: "PwaInstallHint" });
 
@@ -39,14 +42,6 @@ export function isIosSafari(nav: Navigator): boolean {
   return (
     /version\/[\d.]+.*safari\//i.test(nav.userAgent) &&
     !/(crios|fxios|edgios|opios)/i.test(nav.userAgent)
-  );
-}
-
-/** True in Android browsers that can expose an install action. */
-export function isAndroidDevice(nav: Navigator): boolean {
-  return (
-    /android/i.test(nav.userAgent) &&
-    !/(?:;\s*wv\b|version\/4\.0)/i.test(nav.userAgent)
   );
 }
 
@@ -96,10 +91,10 @@ export function recordVisit(win: Window): number {
  *   bottom nav disappears. The centered card and right-aligned search-page
  *   FAB do not intersect at `lg` widths, so no FAB clearance is needed there.
  * - Below lg the offset clears the bottom nav (~4.75rem visible) plus a 1rem
- *   gap, and adds `--moto-floating-fab-offset` only on the two pages that
- *   actually show the check-in FAB. An active mobile check-in bar publishes
- *   `--moto-checkin-bar-offset` in the same way. The old fixed 10.5rem
- *   reserved FAB space everywhere.
+ *   gap, and adds `--moto-floating-fab-offset` only on pages that actually
+ *   show a check-in or create FAB. An active mobile check-in bar publishes
+ *   `--moto-checkin-bar-offset` in the same way. The old fixed 10.5rem reserved
+ *   FAB space everywhere.
  * - Horizontally centered at every width instead of jumping from an
  *   edge-to-edge mobile banner to a right-anchored card at `sm`.
  *

--- a/frontend/src/components/tenant/pwa-install-hint.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.tsx
@@ -3,9 +3,11 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { Download, EllipsisVertical, Share, X } from "lucide-react";
 import { Button } from "~/components/ui/button";
+import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { createLogger } from "~/lib/logger";
 import {
   canPromptInstall,
+  isInstallationCompleted,
   subscribeInstallPrompt,
   triggerInstallPrompt,
 } from "~/lib/pwa-install-prompt";
@@ -90,14 +92,14 @@ export function recordVisit(win: Window): number {
  * single in-page slot would not reach them.
  *
  * Geometry, all of it previously wrong:
- * - Switches at `lg`, the same breakpoint at which AppShell drops its mobile
- *   bottom padding and the bottom nav and FAB become `lg:hidden`. The old
- *   `xl` switch left the card floating over nothing between 1024 and 1280px,
- *   which is exactly where iPad landscape sits.
+ * - Switches at `lg`, where AppShell drops its mobile bottom padding and the
+ *   bottom nav disappears. The centered card and right-aligned search-page
+ *   FAB do not intersect at `lg` widths, so no FAB clearance is needed there.
  * - Below lg the offset clears the bottom nav (~4.75rem visible) plus a 1rem
  *   gap, and adds `--moto-floating-fab-offset` only on the two pages that
- *   actually render the check-in FAB. The old fixed 10.5rem reserved FAB
- *   space everywhere.
+ *   actually show the check-in FAB. An active mobile check-in bar publishes
+ *   `--moto-checkin-bar-offset` in the same way. The old fixed 10.5rem
+ *   reserved FAB space everywhere.
  * - Horizontally centered at every width instead of jumping from an
  *   edge-to-edge mobile banner to a right-anchored card at `sm`.
  *
@@ -112,6 +114,11 @@ export function PwaInstallHint() {
   const oneTapInstallReady = useSyncExternalStore(
     subscribeInstallPrompt,
     canPromptInstall,
+    () => false,
+  );
+  const installationCompleted = useSyncExternalStore(
+    subscribeInstallPrompt,
+    isInstallationCompleted,
     () => false,
   );
 
@@ -130,7 +137,17 @@ export function PwaInstallHint() {
     setPlatform(detected);
   }, []);
 
-  if (!platform) return null;
+  useEffect(() => {
+    if (!installationCompleted) return;
+    setPlatform(null);
+    try {
+      window.localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      // The published state still hides the hint for the current page.
+    }
+  }, [installationCompleted]);
+
+  if (!platform || installationCompleted) return null;
 
   const dismiss = () => {
     setPlatform(null);
@@ -173,13 +190,21 @@ export function PwaInstallHint() {
     // separate the promotion from the neutral content cards around it.
     <section
       aria-labelledby="pwa-install-hint-title"
-      className="fixed bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+env(safe-area-inset-bottom))] left-1/2 z-40 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-2xl border-2 border-[#83CD2D] bg-[#f0f9e4] p-4 shadow-lg lg:bottom-8"
+      className="fixed bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+var(--moto-checkin-bar-offset,0rem)+env(safe-area-inset-bottom))] left-1/2 z-40 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-2xl border-2 p-4 shadow-lg lg:bottom-8"
+      style={{
+        borderColor: GROUP_ROOM_SHADES.base,
+        backgroundColor: GROUP_ROOM_SHADES.bgHover,
+      }}
     >
       <div className="flex items-start gap-3">
         {/* White bubble, because the previous #83CD2D/10 tint is invisible on
             the green card background. */}
         <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-white">
-          <PlatformIcon className="h-4 w-4 text-[#4a7a15]" aria-hidden="true" />
+          <PlatformIcon
+            className="h-4 w-4"
+            style={{ color: GROUP_ROOM_SHADES.text }}
+            aria-hidden="true"
+          />
         </div>
         <div className="min-w-0 flex-1 text-sm text-gray-700">
           <h2

--- a/frontend/src/components/tenant/pwa-install-hint.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.tsx
@@ -7,7 +7,9 @@ import { GROUP_ROOM_SHADES } from "~/lib/location-helper";
 import { createLogger } from "~/lib/logger";
 import {
   canPromptInstall,
+  dismissInstallHint,
   isAndroidDevice,
+  isInstallHintEligible,
   isInstallationCompleted,
   subscribeInstallPrompt,
   triggerInstallPrompt,
@@ -16,17 +18,6 @@ import {
 export { isAndroidDevice } from "~/lib/pwa-install-prompt";
 
 const logger = createLogger({ component: "PwaInstallHint" });
-
-const DISMISS_KEY = "moto-pwa-install-hint-dismissed";
-const VISIT_COUNT_KEY = "moto-pwa-install-hint-visits";
-const SESSION_COUNTED_KEY = "moto-pwa-install-hint-session-counted";
-
-/**
- * web.dev "Patterns for promoting PWA installation": promote after a few
- * interactions, never on the first page load, or the promotion is missed and
- * reads as noise. One visit = one browser session.
- */
-const MIN_VISITS = 2;
 
 export type InstallPlatform = "ios" | "android";
 
@@ -50,29 +41,6 @@ export function isStandaloneDisplay(win: Window): boolean {
   if (win.matchMedia("(display-mode: standalone)").matches) return true;
   const nav = win.navigator as Navigator & { standalone?: boolean };
   return nav.standalone === true;
-}
-
-/**
- * Counts this browser session as one visit, exactly once, and returns the
- * running total. The sessionStorage flag makes the call idempotent, so a
- * StrictMode double-effect or a remount does not inflate the count.
- */
-export function recordVisit(win: Window): number {
-  try {
-    const stored = Number(win.localStorage.getItem(VISIT_COUNT_KEY) ?? "0");
-    const previous = Number.isFinite(stored) && stored > 0 ? stored : 0;
-    if (win.sessionStorage.getItem(SESSION_COUNTED_KEY) === "1") {
-      return previous;
-    }
-    const next = previous + 1;
-    win.localStorage.setItem(VISIT_COUNT_KEY, String(next));
-    win.sessionStorage.setItem(SESSION_COUNTED_KEY, "1");
-    return next;
-  } catch {
-    // Private mode can block storage. Treat the visit as sufficient rather
-    // than hiding the hint forever on browsers that deny storage.
-    return MIN_VISITS;
-  }
 }
 
 /**
@@ -123,34 +91,20 @@ export function PwaInstallHint() {
     else if (isAndroidDevice(window.navigator)) detected = "android";
     if (!detected) return;
     if (isStandaloneDisplay(window)) return;
-    try {
-      if (window.localStorage.getItem(DISMISS_KEY) === "1") return;
-    } catch {
-      // Private mode can block storage access; show the hint anyway.
-    }
-    if (recordVisit(window) < MIN_VISITS) return;
+    if (!isInstallHintEligible(window)) return;
     setPlatform(detected);
   }, []);
 
   useEffect(() => {
     if (!installationCompleted) return;
     setPlatform(null);
-    try {
-      window.localStorage.setItem(DISMISS_KEY, "1");
-    } catch {
-      // The published state still hides the hint for the current page.
-    }
   }, [installationCompleted]);
 
   if (!platform || installationCompleted) return null;
 
   const dismiss = () => {
     setPlatform(null);
-    try {
-      window.localStorage.setItem(DISMISS_KEY, "1");
-    } catch {
-      // Without storage the hint reappears next visit; acceptable.
-    }
+    dismissInstallHint(window);
   };
 
   const install = () => {

--- a/frontend/src/components/tenant/pwa-install-hint.tsx
+++ b/frontend/src/components/tenant/pwa-install-hint.tsx
@@ -166,13 +166,20 @@ export function PwaInstallHint() {
       : EllipsisVertical;
 
   return (
+    // Deliberately NOT `moto-content-surface`: that utility is unlayered and
+    // hardcodes a white background plus a gray-200 border, which Tailwind
+    // utilities cannot override and which made this card blend into the page.
+    // A brand-green tint (GROUP_ROOM_SHADES.bgHover) and a 2px brand border
+    // separate the promotion from the neutral content cards around it.
     <section
       aria-labelledby="pwa-install-hint-title"
-      className="moto-content-surface fixed bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+env(safe-area-inset-bottom))] left-1/2 z-40 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-2xl border p-4 shadow-lg lg:bottom-8"
+      className="fixed bottom-[calc(5.75rem+var(--moto-floating-fab-offset,0rem)+env(safe-area-inset-bottom))] left-1/2 z-40 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-2xl border-2 border-[#83CD2D] bg-[#f0f9e4] p-4 shadow-lg lg:bottom-8"
     >
       <div className="flex items-start gap-3">
-        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[#83CD2D]/10">
-          <PlatformIcon className="h-4 w-4 text-[#669f21]" aria-hidden="true" />
+        {/* White bubble, because the previous #83CD2D/10 tint is invisible on
+            the green card background. */}
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-white">
+          <PlatformIcon className="h-4 w-4 text-[#4a7a15]" aria-hidden="true" />
         </div>
         <div className="min-w-0 flex-1 text-sm text-gray-700">
           <h2

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -68,4 +68,21 @@ describe("instrumentation-client", () => {
 
     expect(mockInit).not.toHaveBeenCalled();
   });
+
+  it("captures the install prompt before React hydration", async () => {
+    await import("./instrumentation-client");
+    const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+    const event = Object.assign(
+      new Event("beforeinstallprompt", { cancelable: true }),
+      {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "accepted" as const }),
+      },
+    );
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(canPromptInstall()).toBe(true);
+  });
 });

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockInit = vi.fn();
+const ANDROID_UA =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.71 Mobile Safari/537.36";
+const DESKTOP_CHROME_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
 
 vi.mock("posthog-js", () => ({
   default: {
@@ -13,11 +17,13 @@ describe("instrumentation-client", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.stubEnv("NEXT_PUBLIC_TENANT_DOMAIN", "moto-app.de");
+    vi.stubGlobal("navigator", { userAgent: ANDROID_UA });
     window.location.href = "https://school-a.moto-app.de/dashboard";
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("initializes PostHog with remote configuration disabled", async () => {
@@ -86,6 +92,24 @@ describe("instrumentation-client", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(canPromptInstall()).toBe(true);
+  });
+
+  it("leaves Chrome's native install prompt enabled on desktop tenant hosts", async () => {
+    vi.stubGlobal("navigator", { userAgent: DESKTOP_CHROME_UA });
+    await import("./instrumentation-client");
+    const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+    const event = Object.assign(
+      new Event("beforeinstallprompt", { cancelable: true }),
+      {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "accepted" as const }),
+      },
+    );
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(canPromptInstall()).toBe(false);
   });
 
   it.each([

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -113,6 +113,55 @@ describe("instrumentation-client", () => {
   });
 
   it.each([
+    "/",
+    "/display",
+    "/enroll",
+    "/enroll/phase-1",
+    "/invite",
+    "/reset-password",
+  ])(
+    "keeps Chrome's native prompt on public tenant path %s while caching the event",
+    async (path) => {
+      window.location.href = `https://school-a.moto-app.de${path}`;
+      await import("./instrumentation-client");
+      const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+      const event = Object.assign(
+        new Event("beforeinstallprompt", { cancelable: true }),
+        {
+          prompt: vi.fn().mockResolvedValue(undefined),
+          userChoice: Promise.resolve({ outcome: "accepted" as const }),
+        },
+      );
+
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(canPromptInstall()).toBe(true);
+    },
+  );
+
+  it.each(["/invitations", "/enrollment-form"])(
+    "suppresses Chrome's native prompt on protected tenant path %s",
+    async (path) => {
+      window.location.href = `https://school-a.moto-app.de${path}`;
+      await import("./instrumentation-client");
+      const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+      const event = Object.assign(
+        new Event("beforeinstallprompt", { cancelable: true }),
+        {
+          prompt: vi.fn().mockResolvedValue(undefined),
+          userChoice: Promise.resolve({ outcome: "accepted" as const }),
+        },
+      );
+
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(canPromptInstall()).toBe(true);
+    },
+  );
+
+  it.each([
     "https://operator.moto-app.de/",
     "https://eltern.moto-app.de/",
     "https://moto-app.de/",

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -12,6 +12,8 @@ describe("instrumentation-client", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_TENANT_DOMAIN", "moto-app.de");
+    window.location.href = "https://school-a.moto-app.de/dashboard";
   });
 
   afterEach(() => {
@@ -84,5 +86,28 @@ describe("instrumentation-client", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(canPromptInstall()).toBe(true);
+  });
+
+  it.each([
+    "https://operator.moto-app.de/",
+    "https://eltern.moto-app.de/",
+    "https://moto-app.de/",
+    "https://help.moto-app.de/",
+  ])("leaves Chrome's native install prompt enabled on %s", async (url) => {
+    window.location.href = url;
+    await import("./instrumentation-client");
+    const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+    const event = Object.assign(
+      new Event("beforeinstallprompt", { cancelable: true }),
+      {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "accepted" as const }),
+      },
+    );
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(canPromptInstall()).toBe(false);
   });
 });

--- a/frontend/src/instrumentation-client.test.ts
+++ b/frontend/src/instrumentation-client.test.ts
@@ -19,6 +19,9 @@ describe("instrumentation-client", () => {
     vi.stubEnv("NEXT_PUBLIC_TENANT_DOMAIN", "moto-app.de");
     vi.stubGlobal("navigator", { userAgent: ANDROID_UA });
     window.location.href = "https://school-a.moto-app.de/dashboard";
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem("moto-pwa-install-hint-visits", "1");
   });
 
   afterEach(() => {
@@ -120,7 +123,7 @@ describe("instrumentation-client", () => {
     "/invite",
     "/reset-password",
   ])(
-    "keeps Chrome's native prompt on public tenant path %s while caching the event",
+    "leaves the native prompt uncaptured on public tenant path %s",
     async (path) => {
       window.location.href = `https://school-a.moto-app.de${path}`;
       await import("./instrumentation-client");
@@ -136,9 +139,47 @@ describe("instrumentation-client", () => {
       window.dispatchEvent(event);
 
       expect(event.defaultPrevented).toBe(false);
-      expect(canPromptInstall()).toBe(true);
+      expect(canPromptInstall()).toBe(false);
     },
   );
+
+  it("leaves the native prompt enabled when the custom hint is not eligible yet", async () => {
+    localStorage.clear();
+    sessionStorage.clear();
+    await import("./instrumentation-client");
+    const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+    const event = Object.assign(
+      new Event("beforeinstallprompt", { cancelable: true }),
+      {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "accepted" as const }),
+      },
+    );
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(canPromptInstall()).toBe(false);
+    expect(localStorage.getItem("moto-pwa-install-hint-visits")).toBe("1");
+  });
+
+  it("leaves the native prompt enabled after the custom hint was dismissed", async () => {
+    localStorage.setItem("moto-pwa-install-hint-dismissed", "1");
+    await import("./instrumentation-client");
+    const { canPromptInstall } = await import("./lib/pwa-install-prompt");
+    const event = Object.assign(
+      new Event("beforeinstallprompt", { cancelable: true }),
+      {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "accepted" as const }),
+      },
+    );
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(canPromptInstall()).toBe(false);
+  });
 
   it.each(["/invitations", "/enrollment-form"])(
     "suppresses Chrome's native prompt on protected tenant path %s",

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -1,3 +1,4 @@
+import "./lib/pwa-install-prompt";
 import "./sentry.client.config";
 import posthog from "posthog-js";
 import { sanitizePostHogEvent } from "~/lib/posthog-privacy";

--- a/frontend/src/lib/hooks/use-floating-fab-offset.ts
+++ b/frontend/src/lib/hooks/use-floating-fab-offset.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+
+const FLOATING_FAB_OFFSET_VAR = "--moto-floating-fab-offset";
+const FLOATING_FAB_OFFSET = "4.5rem";
+
+export const MOBILE_CREATE_FAB_MEDIA_QUERY = "(max-width: 767px)";
+
+interface FloatingFabOffsetOptions {
+  readonly active: boolean;
+  readonly mediaQuery: string;
+}
+
+/** Publishes a FAB's height plus gap while its responsive variant is visible. */
+export function useFloatingFabOffset({
+  active,
+  mediaQuery,
+}: FloatingFabOffsetOptions): void {
+  useEffect(() => {
+    if (!active) return;
+
+    const root = document.documentElement;
+    const visibilityQuery = window.matchMedia(mediaQuery);
+    const publishOffset = () => {
+      if (visibilityQuery.matches) {
+        root.style.setProperty(FLOATING_FAB_OFFSET_VAR, FLOATING_FAB_OFFSET);
+      } else {
+        root.style.removeProperty(FLOATING_FAB_OFFSET_VAR);
+      }
+    };
+
+    publishOffset();
+    visibilityQuery.addEventListener("change", publishOffset);
+    return () => {
+      visibilityQuery.removeEventListener("change", publishOffset);
+      root.style.removeProperty(FLOATING_FAB_OFFSET_VAR);
+    };
+  }, [active, mediaQuery]);
+}

--- a/frontend/src/lib/pwa-install-prompt.ts
+++ b/frontend/src/lib/pwa-install-prompt.ts
@@ -21,6 +21,14 @@ interface BeforeInstallPromptEvent extends Event {
 
 export type InstallOutcome = "accepted" | "dismissed" | "unavailable";
 
+/** True in Android browsers where the custom install card can render. */
+export function isAndroidDevice(nav: Navigator): boolean {
+  return (
+    /android/i.test(nav.userAgent) &&
+    !/(?:;\s*wv\b|version\/4\.0)/i.test(nav.userAgent)
+  );
+}
+
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 let installationCompleted = false;
 const subscribers = new Set<() => void>();
@@ -52,9 +60,11 @@ function isCurrentTenantInstallHost(): boolean {
 
 if (typeof window !== "undefined") {
   window.addEventListener("beforeinstallprompt", (event) => {
-    // Operator, parents, root, and infrastructure hosts do not render our
-    // install UI, so Chrome must retain its native install promotion there.
-    if (!isCurrentTenantInstallHost()) return;
+    // Only Android tenant surfaces render our one-tap UI. Chrome must retain
+    // its native install promotion on desktop and every other portal.
+    if (!isCurrentTenantInstallHost() || !isAndroidDevice(window.navigator)) {
+      return;
+    }
     // Suppress Chrome's own mini-infobar so our in-flow card is the single
     // install surface instead of two competing prompts.
     event.preventDefault();
@@ -62,7 +72,9 @@ if (typeof window !== "undefined") {
     notify();
   });
   window.addEventListener("appinstalled", () => {
-    if (!isCurrentTenantInstallHost()) return;
+    if (!isCurrentTenantInstallHost() || !isAndroidDevice(window.navigator)) {
+      return;
+    }
     deferredPrompt = null;
     installationCompleted = true;
     notify();

--- a/frontend/src/lib/pwa-install-prompt.ts
+++ b/frontend/src/lib/pwa-install-prompt.ts
@@ -21,6 +21,17 @@ interface BeforeInstallPromptEvent extends Event {
 
 export type InstallOutcome = "accepted" | "dismissed" | "unavailable";
 
+const DISMISS_KEY = "moto-pwa-install-hint-dismissed";
+const VISIT_COUNT_KEY = "moto-pwa-install-hint-visits";
+const SESSION_COUNTED_KEY = "moto-pwa-install-hint-session-counted";
+
+/**
+ * web.dev "Patterns for promoting PWA installation": promote after a few
+ * interactions, never on the first page load, or the promotion is missed and
+ * reads as noise. One visit = one browser session.
+ */
+const MIN_VISITS = 2;
+
 /** True in Android browsers where the custom install card can render. */
 export function isAndroidDevice(nav: Navigator): boolean {
   return (
@@ -74,6 +85,48 @@ function isCurrentProtectedTenantPath(): boolean {
   });
 }
 
+/**
+ * Counts this browser session as one visit, exactly once, and returns the
+ * running total. The sessionStorage flag makes the call idempotent, so a
+ * StrictMode double-effect or a remount does not inflate the count.
+ */
+export function recordVisit(win: Window): number {
+  try {
+    const stored = Number(win.localStorage.getItem(VISIT_COUNT_KEY) ?? "0");
+    const previous = Number.isFinite(stored) && stored > 0 ? stored : 0;
+    if (win.sessionStorage.getItem(SESSION_COUNTED_KEY) === "1") {
+      return previous;
+    }
+    const next = previous + 1;
+    win.localStorage.setItem(VISIT_COUNT_KEY, String(next));
+    win.sessionStorage.setItem(SESSION_COUNTED_KEY, "1");
+    return next;
+  } catch {
+    // Private mode can block storage. Treat the visit as sufficient rather
+    // than hiding the hint forever on browsers that deny storage.
+    return MIN_VISITS;
+  }
+}
+
+/** True when the custom card may replace Chrome's native install promotion. */
+export function isInstallHintEligible(win: Window): boolean {
+  try {
+    if (win.localStorage.getItem(DISMISS_KEY) === "1") return false;
+  } catch {
+    // Private mode can block storage access; show the hint anyway.
+  }
+  return recordVisit(win) >= MIN_VISITS;
+}
+
+/** Persists that the custom install card should no longer render. */
+export function dismissInstallHint(win: Window): void {
+  try {
+    win.localStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // The published component state still hides the hint for this page.
+  }
+}
+
 if (typeof window !== "undefined") {
   window.addEventListener("beforeinstallprompt", (event) => {
     // Only Android tenant surfaces render our one-tap UI. Chrome must retain
@@ -81,12 +134,16 @@ if (typeof window !== "undefined") {
     if (!isCurrentTenantInstallHost() || !isAndroidDevice(window.navigator)) {
       return;
     }
-    // Cache the one-shot event even on public routes so it survives a later
-    // login navigation. Suppress Chrome's native UI only where the protected
-    // layout renders our replacement card.
+    // Public routes have no custom install card, so Chrome owns the event
+    // there. Retaining an uncancelled one-shot event would leave a later
+    // protected page with a prompt Chrome may already have consumed.
+    if (!isCurrentProtectedTenantPath()) return;
+    // Do not suppress Chrome unless the replacement card can actually render.
+    if (!isInstallHintEligible(window)) return;
+
+    event.preventDefault();
     deferredPrompt = event as BeforeInstallPromptEvent;
     notify();
-    if (isCurrentProtectedTenantPath()) event.preventDefault();
   });
   window.addEventListener("appinstalled", () => {
     if (!isCurrentTenantInstallHost() || !isAndroidDevice(window.navigator)) {
@@ -94,6 +151,7 @@ if (typeof window !== "undefined") {
     }
     deferredPrompt = null;
     installationCompleted = true;
+    dismissInstallHint(window);
     notify();
   });
 }

--- a/frontend/src/lib/pwa-install-prompt.ts
+++ b/frontend/src/lib/pwa-install-prompt.ts
@@ -20,6 +20,7 @@ interface BeforeInstallPromptEvent extends Event {
 export type InstallOutcome = "accepted" | "dismissed" | "unavailable";
 
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
+let installationCompleted = false;
 const subscribers = new Set<() => void>();
 
 function notify(): void {
@@ -36,6 +37,7 @@ if (typeof window !== "undefined") {
   });
   window.addEventListener("appinstalled", () => {
     deferredPrompt = null;
+    installationCompleted = true;
     notify();
   });
 }
@@ -51,6 +53,11 @@ export function subscribeInstallPrompt(onChange: () => void): () => void {
 /** True once Chrome has offered an installable event we can replay. */
 export function canPromptInstall(): boolean {
   return deferredPrompt !== null;
+}
+
+/** True after this browser tab reports a completed app installation. */
+export function isInstallationCompleted(): boolean {
+  return installationCompleted;
 }
 
 /**
@@ -73,5 +80,6 @@ export async function triggerInstallPrompt(): Promise<InstallOutcome> {
 /** Test seam: drops any captured event so cases start from a clean slate. */
 export function resetInstallPromptForTests(): void {
   deferredPrompt = null;
+  installationCompleted = false;
   notify();
 }

--- a/frontend/src/lib/pwa-install-prompt.ts
+++ b/frontend/src/lib/pwa-install-prompt.ts
@@ -1,0 +1,77 @@
+/**
+ * Capture point for Chrome's `beforeinstallprompt` event.
+ *
+ * Chrome fires the event as soon as the PWA becomes installable, which is
+ * usually before any single component has mounted. Registering the listener
+ * inside a component therefore loses the event. This module registers at
+ * import time and caches the event so a later-mounting component can still
+ * offer a one-tap install.
+ *
+ * Safari never fires the event (Apple has not implemented it), so the iOS
+ * path stays a manual "Zum Home-Bildschirm" instruction.
+ */
+
+/** The non-standard Chrome event; not in lib.dom.d.ts. Module-internal. */
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export type InstallOutcome = "accepted" | "dismissed" | "unavailable";
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const subscriber of subscribers) subscriber();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("beforeinstallprompt", (event) => {
+    // Suppress Chrome's own mini-infobar so our in-flow card is the single
+    // install surface instead of two competing prompts.
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    notify();
+  });
+  window.addEventListener("appinstalled", () => {
+    deferredPrompt = null;
+    notify();
+  });
+}
+
+/** React `useSyncExternalStore` subscribe. Returns the unsubscribe callback. */
+export function subscribeInstallPrompt(onChange: () => void): () => void {
+  subscribers.add(onChange);
+  return () => {
+    subscribers.delete(onChange);
+  };
+}
+
+/** True once Chrome has offered an installable event we can replay. */
+export function canPromptInstall(): boolean {
+  return deferredPrompt !== null;
+}
+
+/**
+ * Replays the captured event. `prompt()` may only be called once per event,
+ * so the reference is dropped immediately; Chrome fires a fresh
+ * `beforeinstallprompt` if the user declines and stays eligible.
+ */
+export async function triggerInstallPrompt(): Promise<InstallOutcome> {
+  const event = deferredPrompt;
+  if (!event) return "unavailable";
+
+  deferredPrompt = null;
+  notify();
+
+  await event.prompt();
+  const { outcome } = await event.userChoice;
+  return outcome;
+}
+
+/** Test seam: drops any captured event so cases start from a clean slate. */
+export function resetInstallPromptForTests(): void {
+  deferredPrompt = null;
+  notify();
+}

--- a/frontend/src/lib/pwa-install-prompt.ts
+++ b/frontend/src/lib/pwa-install-prompt.ts
@@ -33,6 +33,14 @@ let deferredPrompt: BeforeInstallPromptEvent | null = null;
 let installationCompleted = false;
 const subscribers = new Set<() => void>();
 
+const PUBLIC_TENANT_PATHS = [
+  "/",
+  "/display",
+  "/enroll",
+  "/invite",
+  "/reset-password",
+] as const;
+
 function notify(): void {
   for (const subscriber of subscribers) subscriber();
 }
@@ -58,6 +66,14 @@ function isCurrentTenantInstallHost(): boolean {
   return isTenantInstallHost(window.location.hostname, tenantDomain);
 }
 
+function isCurrentProtectedTenantPath(): boolean {
+  const pathname = window.location.pathname;
+  return !PUBLIC_TENANT_PATHS.some((publicPath) => {
+    if (publicPath === "/") return pathname === publicPath;
+    return pathname === publicPath || pathname.startsWith(`${publicPath}/`);
+  });
+}
+
 if (typeof window !== "undefined") {
   window.addEventListener("beforeinstallprompt", (event) => {
     // Only Android tenant surfaces render our one-tap UI. Chrome must retain
@@ -65,11 +81,12 @@ if (typeof window !== "undefined") {
     if (!isCurrentTenantInstallHost() || !isAndroidDevice(window.navigator)) {
       return;
     }
-    // Suppress Chrome's own mini-infobar so our in-flow card is the single
-    // install surface instead of two competing prompts.
-    event.preventDefault();
+    // Cache the one-shot event even on public routes so it survives a later
+    // login navigation. Suppress Chrome's native UI only where the protected
+    // layout renders our replacement card.
     deferredPrompt = event as BeforeInstallPromptEvent;
     notify();
+    if (isCurrentProtectedTenantPath()) event.preventDefault();
   });
   window.addEventListener("appinstalled", () => {
     if (!isCurrentTenantInstallHost() || !isAndroidDevice(window.navigator)) {

--- a/frontend/src/lib/pwa-install-prompt.ts
+++ b/frontend/src/lib/pwa-install-prompt.ts
@@ -11,6 +11,8 @@
  * path stays a manual "Zum Home-Bildschirm" instruction.
  */
 
+import { RESERVED_SLUGS } from "~/lib/reserved-slugs";
+
 /** The non-standard Chrome event; not in lib.dom.d.ts. Module-internal. */
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -27,8 +29,32 @@ function notify(): void {
   for (const subscriber of subscribers) subscriber();
 }
 
+/** True only for a direct, non-reserved tenant subdomain. */
+function isTenantInstallHost(hostname: string, tenantDomain: string): boolean {
+  const normalizedHostname = hostname.toLowerCase().replace(/\.$/, "");
+  const normalizedTenantDomain = tenantDomain.toLowerCase().replace(/\.$/, "");
+  if (!normalizedHostname.endsWith(`.${normalizedTenantDomain}`)) return false;
+
+  const slug = normalizedHostname.slice(
+    0,
+    -(normalizedTenantDomain.length + 1),
+  );
+  return Boolean(slug && !slug.includes(".") && !RESERVED_SLUGS.has(slug));
+}
+
+function isCurrentTenantInstallHost(): boolean {
+  const tenantDomain = process.env.NEXT_PUBLIC_TENANT_DOMAIN;
+  if (!tenantDomain) {
+    throw new Error("NEXT_PUBLIC_TENANT_DOMAIN is not set.");
+  }
+  return isTenantInstallHost(window.location.hostname, tenantDomain);
+}
+
 if (typeof window !== "undefined") {
   window.addEventListener("beforeinstallprompt", (event) => {
+    // Operator, parents, root, and infrastructure hosts do not render our
+    // install UI, so Chrome must retain its native install promotion there.
+    if (!isCurrentTenantInstallHost()) return;
     // Suppress Chrome's own mini-infobar so our in-flow card is the single
     // install surface instead of two competing prompts.
     event.preventDefault();
@@ -36,6 +62,7 @@ if (typeof window !== "undefined") {
     notify();
   });
   window.addEventListener("appinstalled", () => {
+    if (!isCurrentTenantInstallHost()) return;
     deferredPrompt = null;
     installationCompleted = true;
     notify();


### PR DESCRIPTION
## Problem

Der Install-Hinweis („moto als App nutzen") schwebt als fixiertes Banner über dem Inhalt und liegt dabei fast nie richtig.

**Breakpoint-Versatz, der eigentliche Fehler.** Bottom-Nav und Check-in-FAB verschwinden bei `lg` (1024px), der Hinweis behielt seinen 10.5rem-Versatz aber bis `xl` (1280px). Zwischen 1024 und 1280 hängt die Karte 168px über dem unteren Rand und landet mitten im Kachelraster. iPad im Querformat (1194px) liegt exakt in dieser Lücke, und iPadOS-Safari ist über den `MacIntel` + `maxTouchPoints`-Zweig genau das Gerät, das den Hinweis am ehesten sieht.

**Platz für einen FAB, der meistens fehlt.** Die 10.5rem waren 5.5 (Nav) + 3.5 (FAB-Höhe) + 1.5 (Abstand). Der FAB rendert auf zwei Seiten (`ogs-groups`, `students/search`) und nur bei aktivem `attendance.web_enabled`. Überall sonst stand die Karte 5rem zu hoch.

**Nie zentriert.** Mobil `inset-x-4`, also randbündiges Vollbreiten-Banner, ab `sm` Sprung auf rechtsbündig mit `max-w-sm`. Entweder Balken oder Ecke, dazwischen nichts.

Dazu ein Punkt jenseits der Geometrie: Es gab im Repo keinen `beforeinstallprompt`-Handler. Android-Nutzer wurden ins Browser-Menü geschickt, obwohl Chrome ein echtes Ein-Tipp-Install anbietet.

## Lösung

Das Banner bleibt schwebend und wegklickbar im geschützten Layout, damit es alle Rollen auf Handys und Tablets erreicht. Korrigiert wird die Geometrie.

- **Umschaltpunkt `lg` statt `xl`**, derselbe Punkt, an dem `AppShell` sein mobiles Bottom-Padding fallen lässt und Nav und FAB `lg:hidden` werden.
- **Bei jeder Breite horizontal zentriert** (`left-1/2 -translate-x-1/2`, `w-[calc(100%-2rem)] max-w-md`), kein Sprung mehr bei `sm`.
- **Versatz = Nav (~4.75rem sichtbar) + 1rem Abstand**, plus `--moto-floating-fab-offset`. Diese Variable setzt `SchoolCheckinFab` selbst, solange eine schwebende Instanz gemountet ist, und räumt sie beim Unmount wieder ab. Damit wird FAB-Platz nur dort reserviert, wo wirklich einer steht, statt pauschal überall.
- **Echtes Ein-Tipp-Install auf Android.** Neues Modul `src/lib/pwa-install-prompt.ts` fängt `beforeinstallprompt` beim Import ab, nicht erst beim Mount, sonst geht das Event verloren. Chromes eigene Mini-Infobar wird unterdrückt, damit nicht zwei Prompts konkurrieren. Ohne Event bleibt es bei der bisherigen Menü-Anleitung, das Verhalten wird also nirgends schlechter. Safari implementiert das Event nicht, dort bleibt die manuelle Anleitung.
- **Erst ab dem zweiten Besuch.** `recordVisit` zählt einmal pro Browser-Session, über ein sessionStorage-Flag idempotent, damit StrictMode-Doppeleffekte nicht hochzählen. Der bestehende Dismiss-Key bleibt unverändert, wer schon weggeklickt hat, wird nicht erneut behelligt. Das ist ein Vorschlag nach [web.dev](https://web.dev/articles/promote-install) („never on the first page load") und lässt sich über die Konstante `MIN_VISITS` in einer Zeile abschalten, falls die Reichweite wichtiger ist.

## Verlauf der PR

Der erste Commit hatte den Hinweis in den Seitenfluss des Dashboards verlegt. Das war falsch: `dashboard/page.tsx` steckt in `<RoleGuard variant="adminOnly">`, Nicht-Admins bekommen dort eine `ForbiddenPage`. Die Zielgruppe sind aber Betreuer auf mobilen Geräten, die diese Seite nie sehen. Der zweite Commit nimmt das zurück und behält das schwebende Banner.

## Geänderte Tests

`pwa-install-hint.test.tsx` hatte die alten Positionsklassen festgeschrieben (`bottom-[calc(10.5rem+...)]`, `xl:bottom-6`). Genau die ändern sich. Die Assertions prüfen jetzt den neuen Versatz, `lg:bottom-8` und die Zentrierung, und schließen `inset-x-`, `sm:right-` sowie `xl:bottom-` aus. Alle übrigen Fälle bleiben inhaltlich unverändert. Neu dazu: Besuchsschwelle, Ein-Tipp-Pfad, abgelehnter Prompt.

## Sichtbarkeit und Kontrast

Die Karte nutzte `moto-content-surface`. Diese Utility ist ungelayert und setzt hart `background:#ffffff` plus `border-color:#e5e7eb`; Tailwind-Utilities können das nicht überschreiben. Die Aufforderung sah dadurch exakt aus wie jede neutrale Inhaltskarte dahinter und war schwer auszumachen.

Die Utility ist jetzt raus, die Fläche wird explizit gesetzt: markengrüne Tönung (`GROUP_ROOM_SHADES.bgHover`, `#f0f9e4`) mit 2px Rahmen in `#83CD2D`. Die Icon-Blase wechselt auf Weiß, weil eine `#83CD2D/10`-Tönung auf grünem Grund unsichtbar ist. Alle Werte stammen aus `LOCATION_COLORS` beziehungsweise den davon abgeleiteten `GROUP_ROOM_SHADES`, keine generischen Tailwind-Farbtöne.

## Kein Desktop

Der Hinweis erscheint ausschließlich auf iOS-Safari und Android-Browsern. Desktop fällt schon an der UA-Erkennung durch. Zwei zusätzliche Tests halten das fest:

- **macOS-Safari**: sendet exakt dieselbe UA wie iPadOS-Safari im Desktop-Modus. Unterschieden werden beide nur über `navigator.maxTouchPoints`. Der Test fixiert, dass ein Mac außen vor bleibt.
- **Touchscreen-Windows-Laptop**: `maxTouchPoints: 10`, aber weder iOS noch Android, bleibt ebenfalls außen vor.

Der iPad-Screenshot zeigt das breite Layout mit Seitenleiste, weil iPad im Querformat 1194px breit ist. Das ist ein iPad, kein Desktop.

## Screenshots

Links vorher, rechts nachher, aufgenommen mit echten iOS-Safari-User-Agents (mit Desktop-UA rendert die Komponente per Definition nichts).

Auf dem iPad (1194px) hängt die alte Karte mitten im Kachelraster und verdeckt „Auslastung"; danach sitzt sie unten und die Kachel ist wieder lesbar. Auf dem iPhone (390px) rückt sie vom randbündigen Balken auf eine zentrierte Karte direkt über der Navigation.

## Test

- `pnpm run check`: exit 0
- `pnpm run knip`: exit 0
- Volle Vitest-Suite: 930 Dateien, 12792 Tests grün
- Visuell verifiziert gegen den lokalen Stack, iPhone 390x844 und iPad 1194x834

## Nicht visuell belegt

Das Stapeln über dem Check-in-FAB ist durch eine Unit-Assertion auf die CSS-Variable abgedeckt, aber nicht per Screenshot. Der FAB hängt an `attendance.web_enabled`, das im lokalen Seed aus ist; nach dem Einschalten hielt der 300s-Cache der Tenant-Auflösung den alten Wert, auch über einen Dev-Server-Neustart hinweg. Die testweise gesetzte Setting-Zeile wurde wieder entfernt. Wer das visuell sehen will, braucht eine Umgebung mit aktivem `attendance.web_enabled`.
