### PR TITLE
fix(calendar): Raum bei Timetable-Events im Mitarbeitendenkalender

### DIFF
--- a/backend/api/staff/balance_adjustment_api_test.go
+++ b/backend/api/staff/balance_adjustment_api_test.go
@@ -59,8 +59,11 @@ func TestBalanceAdjustmentAPI(t *testing.T) {
 	resetDate := today.AddDays(-1)
 	adjustmentsPath := fmt.Sprintf("/staff/%d/time-tracking/adjustments", subject.ID)
 	resetPath := fmt.Sprintf("/staff/%d/time-tracking/reset", subject.ID)
-	summaryPath := fmt.Sprintf("/staff/%d/time-tracking/month-summary?year=%d&month=%d", subject.ID, today.Year, int(today.Month))
-	listPath := fmt.Sprintf("%s?from=%d-01-01&to=%d-12-31", adjustmentsPath, today.Year, today.Year)
+	// Anchor summary and list windows to resetDate, not today: on the 1st of a
+	// month (or Jan 1) the adjustments land in the previous month/year and a
+	// today-based window would miss them.
+	summaryPath := fmt.Sprintf("/staff/%d/time-tracking/month-summary?year=%d&month=%d", subject.ID, resetDate.Year, int(resetDate.Month))
+	listPath := fmt.Sprintf("%s?from=%d-01-01&to=%d-12-31", adjustmentsPath, resetDate.Year, today.Year)
 	var payoutID int64
 
 	t.Run("requires manage permission", func(t *testing.T) {

--- a/backend/services/calendar/service.go
+++ b/backend/services/calendar/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	calModels "github.com/moto-nrw/project-phoenix/models/calendar"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
+	facilitiesModels "github.com/moto-nrw/project-phoenix/models/facilities"
 	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -84,8 +85,12 @@ type Config struct {
 	InstanceStaffRepo    scheduleModels.InstanceStaffRepository
 	InstanceStudentRepo  scheduleModels.InstanceStudentRepository
 	ActivityInstanceRepo scheduleModels.ActivityInstanceRepository
-	StaffShiftRepo       scheduleModels.StaffShiftRepository
-	ShiftTypeRepo        scheduleModels.ShiftTypeRepository
+	// RoomRepo resolves room names for timetable events in one batch per
+	// window (#2078). Optional: nil leaves Location empty instead of failing
+	// the whole calendar, mirroring StaffShiftRepo/ShiftTypeRepo below.
+	RoomRepo       facilitiesModels.RoomRepository
+	StaffShiftRepo scheduleModels.StaffShiftRepository
+	ShiftTypeRepo  scheduleModels.ShiftTypeRepository
 	// CareDays judges unfinished timetable blocks against the care plan; a
 	// completed block is read from its persisted marker instead (#1747).
 	CareDays    scheduleSvc.CareDayService
@@ -1207,8 +1212,70 @@ func (s *service) expandGuardianAppointmentEvents(ctx context.Context, appointme
 	return events, nil
 }
 
-func (s *service) staffTimetableEvents(ctx context.Context, staffID int64, from, to timezone.Date) ([]Event, error) {
-	events := []Event{}
+// staffTimetableAssignment pairs a timetable instance with the staff row that
+// put this staff member on it — the row carries the per-person room override.
+type staffTimetableAssignment struct {
+	instance   *scheduleModels.ActivityInstance
+	assignment *scheduleModels.InstanceStaff
+}
+
+// timetableRoomID resolves the room the staff member is actually in: the
+// per-person override on instance_staff wins over the instance's own room
+// (the Lernzeit split pattern), matching the Dienstplan overview in
+// services/schedule/staff_schedule_overview.go.
+func timetableRoomID(instance *scheduleModels.ActivityInstance, assignment *scheduleModels.InstanceStaff) int64 {
+	if assignment != nil && assignment.RoomID != nil {
+		return *assignment.RoomID
+	}
+	if instance == nil {
+		return 0
+	}
+	return instance.RoomID
+}
+
+func distinctTimetableRoomIDs(assigned []staffTimetableAssignment) []int64 {
+	seen := make(map[int64]struct{}, len(assigned))
+	roomIDs := make([]int64, 0, len(assigned))
+	for _, entry := range assigned {
+		roomID := timetableRoomID(entry.instance, entry.assignment)
+		if roomID <= 0 {
+			continue
+		}
+		if _, ok := seen[roomID]; ok {
+			continue
+		}
+		seen[roomID] = struct{}{}
+		roomIDs = append(roomIDs, roomID)
+	}
+	return roomIDs
+}
+
+// timetableRoomNames resolves every room in the window with one query so the
+// room name does not cost one read per event (#2078). An unwired room
+// repository yields an empty map: events keep an empty Location instead of
+// failing the calendar, mirroring the ShiftTypeRepo guard in staffShiftEvents.
+func (s *service) timetableRoomNames(ctx context.Context, roomIDs []int64) (map[int64]string, error) {
+	names := make(map[int64]string, len(roomIDs))
+	if s.cfg.RoomRepo == nil || len(roomIDs) == 0 {
+		return names, nil
+	}
+	rooms, err := s.cfg.RoomRepo.FindByIDs(ctx, roomIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, room := range rooms {
+		if room != nil {
+			names[room.ID] = room.Name
+		}
+	}
+	return names, nil
+}
+
+// collectStaffTimetableAssignments walks the window day by day and keeps the
+// first assignment per instance; cancelled instances drop out here, so their
+// rooms never reach the batch lookup.
+func (s *service) collectStaffTimetableAssignments(ctx context.Context, staffID int64, from, to timezone.Date) ([]staffTimetableAssignment, error) {
+	collected := []staffTimetableAssignment{}
 	seen := make(map[int64]struct{})
 	for d := from; !d.After(to); d = d.AddDays(1) {
 		assignments, err := s.cfg.InstanceStaffRepo.FindByStaffAndDate(ctx, staffID, d)
@@ -1227,20 +1294,43 @@ func (s *service) staffTimetableEvents(ctx context.Context, staffID int64, from,
 			if instance.Status == scheduleModels.InstanceStatusCancelled {
 				continue
 			}
-			id := formatID(instance.ID)
-			events = append(events, Event{
-				ID:          fmt.Sprintf("timetable:%d", instance.ID),
-				Source:      EventSourceTimetable,
-				TimetableID: &id,
-				Title:       instance.Title,
-				Description: instance.Description,
-				StartDate:   instance.Date.String(),
-				EndDate:     instance.Date.String(),
-				StartTime:   formatClock(instance.StartTime),
-				EndTime:     formatClock(instance.EndTime),
-				AllDay:      false,
-			})
+			collected = append(collected, staffTimetableAssignment{instance: instance, assignment: assignment})
 		}
+	}
+	return collected, nil
+}
+
+func (s *service) staffTimetableEvents(ctx context.Context, staffID int64, from, to timezone.Date) ([]Event, error) {
+	assigned, err := s.collectStaffTimetableAssignments(ctx, staffID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	roomNames, err := s.timetableRoomNames(ctx, distinctTimetableRoomIDs(assigned))
+	if err != nil {
+		return nil, err
+	}
+	events := make([]Event, 0, len(assigned))
+	for _, entry := range assigned {
+		instance := entry.instance
+		id := formatID(instance.ID)
+		event := Event{
+			ID:          fmt.Sprintf("timetable:%d", instance.ID),
+			Source:      EventSourceTimetable,
+			TimetableID: &id,
+			Title:       instance.Title,
+			Description: instance.Description,
+			StartDate:   instance.Date.String(),
+			EndDate:     instance.Date.String(),
+			StartTime:   formatClock(instance.StartTime),
+			EndTime:     formatClock(instance.EndTime),
+			AllDay:      false,
+		}
+		// A room deleted between assignment and this read misses the map;
+		// Location then stays nil rather than becoming an empty string.
+		if name := roomNames[timetableRoomID(instance, entry.assignment)]; name != "" {
+			event.Location = &name
+		}
+		events = append(events, event)
 	}
 	return events, nil
 }
@@ -1262,6 +1352,8 @@ func shiftsReferenceTypes(shifts []*scheduleModels.StaffShift) bool {
 // range finder does not load the ShiftType relation, so names come from one
 // batch ListAll (the tenant's shift-type table is small); a type missing from
 // the map (concurrently deleted) falls back to the generic title.
+// Location stays deliberately empty: schedule.staff_shifts carries no room
+// column, so there is nothing to resolve (#2078).
 func (s *service) staffShiftEvents(ctx context.Context, staffID int64, from, to timezone.Date) ([]Event, error) {
 	if s.cfg.StaffShiftRepo == nil {
 		return []Event{}, nil

--- a/backend/services/calendar/service_helpers_test.go
+++ b/backend/services/calendar/service_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/base"
 	calModels "github.com/moto-nrw/project-phoenix/models/calendar"
 	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -646,4 +647,14 @@ func TestCalendarServiceValidatesInputsBeforeDependencies(t *testing.T) {
 
 	_, err = svc.GetParentAppointmentOverview(ctx, 1, 0)
 	assert.True(t, errors.Is(err, ErrInvalidRequest))
+}
+
+func TestTimetableRoomIDPrefersAssignmentOverride(t *testing.T) {
+	instance := &scheduleModels.ActivityInstance{RoomID: 70}
+	override := int64(90)
+
+	assert.Equal(t, int64(70), timetableRoomID(instance, &scheduleModels.InstanceStaff{}))
+	assert.Equal(t, int64(90), timetableRoomID(instance, &scheduleModels.InstanceStaff{RoomID: &override}))
+	assert.Equal(t, int64(70), timetableRoomID(instance, nil))
+	assert.Equal(t, int64(0), timetableRoomID(nil, nil))
 }

--- a/backend/services/calendar/service_integration_test.go
+++ b/backend/services/calendar/service_integration_test.go
@@ -68,6 +68,7 @@ func calendarTestConfig(db *bun.DB) calendarSvc.Config {
 		InstanceStaffRepo:    repos.InstanceStaff,
 		InstanceStudentRepo:  repos.InstanceStudent,
 		ActivityInstanceRepo: repos.ActivityInstance,
+		RoomRepo:             repos.Room,
 		StaffShiftRepo:       repos.StaffShift,
 		ShiftTypeRepo:        repos.ShiftType,
 		CareDays: scheduleSvc.NewCareDayService(scheduleSvc.CareDayDependencies{
@@ -2710,4 +2711,62 @@ func TestCalendarServiceIntegration_CancelOccurrenceClearsPendingNotifications(t
 	// Removing a single occurrence clears the still-pending notice.
 	require.NoError(t, service.CancelStaffAppointmentOccurrence(calendarContext(organizerAccount.ID), detail.Appointment.ID, timezone.NewDate(2026, 1, 12)))
 	assert.Equal(t, 1, outbox.cancelled, "single-occurrence cancel must clear pending notifications")
+}
+
+func TestCalendarServiceIntegration_StaffTimetableEventsCarryRoom(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	service := setupCalendarService(t, db)
+	staff, account := testpkg.CreateTestCalendarStaff(t, db, "Room", "Staff")
+	mainRoom := testpkg.CreateTestRoom(t, db, "Calendar Main Room")
+	overrideRoom := testpkg.CreateTestRoom(t, db, "Calendar Override Room")
+
+	day := timezone.NewDate(2026, 3, 10)
+	plainInstance := testpkg.CreateTestActivityInstance(t, db, day, mainRoom.ID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "09:00",
+		EndHHMM:   "10:00",
+		Title:     "Betreuung Hauptraum",
+	})
+	splitInstance := testpkg.CreateTestActivityInstance(t, db, day, mainRoom.ID, testpkg.ActivityInstanceOpts{
+		StartHHMM: "11:00",
+		EndHHMM:   "12:00",
+		Title:     "Betreuung Split",
+	})
+	plainAssignment := testpkg.CreateTestInstanceStaff(t, db, plainInstance.ID, staff.ID, testpkg.InstanceStaffOpts{IsPrimary: true})
+	splitAssignment := testpkg.CreateTestInstanceStaff(t, db, splitInstance.ID, staff.ID, testpkg.InstanceStaffOpts{
+		IsPrimary: true,
+		RoomID:    &overrideRoom.ID,
+	})
+	shift := testpkg.CreateTestStaffShift(t, db, staff.ID, day, testpkg.StaffShiftOpts{
+		StartHHMM: "14:00",
+		EndHHMM:   "15:00",
+	})
+
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.staff_shifts", shift.ID)
+		testpkg.CleanupTableRecords(t, db, "schedule.instance_staff", plainAssignment.ID, splitAssignment.ID)
+		testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", plainInstance.ID, splitInstance.ID)
+		testpkg.CleanupActivityFixtures(t, db, mainRoom.ID, overrideRoom.ID)
+		testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+	})
+
+	events, err := service.ListMyStaffEvents(calendarContext(account.ID), day, day)
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+
+	// Instance room, no override.
+	assert.Equal(t, calModels.EventSourceTimetable, events[0].Source)
+	require.NotNil(t, events[0].Location)
+	assert.Equal(t, mainRoom.Name, *events[0].Location)
+
+	// Per-person override wins over the instance room (Lernzeit split, #2078).
+	assert.Equal(t, calModels.EventSourceTimetable, events[1].Source)
+	require.NotNil(t, events[1].Location)
+	assert.Equal(t, overrideRoom.Name, *events[1].Location)
+
+	// Shifts carry no room column, so Location stays deliberately empty.
+	assert.Equal(t, calModels.EventSourceShift, events[2].Source)
+	assert.Nil(t, events[2].Location)
 }

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1647,6 +1647,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		InstanceStaffRepo:    repos.InstanceStaff,
 		InstanceStudentRepo:  repos.InstanceStudent,
 		ActivityInstanceRepo: repos.ActivityInstance,
+		RoomRepo:             repos.Room,
 		StaffShiftRepo:       repos.StaffShift,
 		ShiftTypeRepo:        repos.ShiftType,
 		CareDays:             careDayService,

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -1238,16 +1238,18 @@ function CalendarEventDetail({
           />
           <span>{dateLabel}</span>
         </div>
-        <div className="flex items-center gap-2">
-          <Clock className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
-          <span>{eventTime(event)}</span>
-        </div>
-        {event.location ? (
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
           <div className="flex items-center gap-2">
-            <MapPin className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
-            <span>{event.location}</span>
+            <Clock className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
+            <span>{eventTime(event)}</span>
           </div>
-        ) : null}
+          {event.location ? (
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
+              <span>{event.location}</span>
+            </div>
+          ) : null}
+        </div>
         {subtitle ? (
           <div className="flex items-center gap-2">
             <Users className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />


### PR DESCRIPTION
Closes #2078

## Was

Timetable-Events in `GET /api/calendar/my` tragen jetzt den Raumnamen im vorhandenen Feld `location`. Auflösungsreihenfolge wie im Dienstplan der Leitung (`services/schedule/staff_schedule_overview.go`):

1. `instance_staff.room_id` (persönlicher Mehrraum-Override, Lernzeit-Split) gewinnt,
2. sonst `activity_instances.room_id`.

Die Raumnamen werden pro Kalenderfenster mit **einer** `RoomRepository.FindByIDs`-Abfrage gebündelt aufgelöst, es entsteht keine zusätzliche Abfrage pro Raum oder Event. Ein zwischenzeitlich gelöschter Raum lässt `location` weg (nie leerer String).

Im Termin-Detail-Sheet stehen Uhrzeit und Ort jetzt auf einer Zeile (Zeit links, Ort rechtsbündig), damit die Breite des Sheets genutzt wird; bei langen Ortsnamen bricht die Zeile kontrolliert um.

## Bewusste Entscheidungen (wie im Issue gefordert)

- **Schicht-Events**: `schedule.staff_shifts` hat keine Raumspalte, es gibt nichts aufzulösen. `location` bleibt bewusst leer; als Kommentar an `staffShiftEvents` dokumentiert und im Integrationstest festgepinnt.
- **Elternkalender**: eigener Codepfad (`parentTimetableEvents`), unverändert. Ob Eltern den Raum sehen sollen, ist eine fachliche/datenschutzrechtliche Entscheidung, die dieses Issue nicht trifft.
- **Frontend**: für die Anzeige selbst war keine Änderung nötig — `location?: string` existiert im Typ, der Proxy reicht die Antwort ungefiltert durch, und `personal-calendar.tsx` rendert `event.location` quellen-agnostisch im Wochen-/Tagesraster, im mobilen Agenda-Untertitel und im Detail-Sheet. Einzige UI-Anpassung: das Zeilen-Layout im Detail-Sheet (siehe oben).
- **Vorbestehende Tages-/Instanz-N+1** in der Sammelphase bleibt unangetastet (Issue verlangt nur die gebündelte Raumabfrage). Follow-up möglich: `InstanceStaffRepo.FindByStaffAndDateRange` + `ActivityInstanceRepo.FindByIDs` existieren bereits und würden das Fenster auf zwei Abfragen reduzieren.
- Doppelte `instance_staff`-Zeilen pro Staff+Instanz dedupliziert weiterhin die bestehende `seen`-Map (erste Zeile gewinnt) — Verhalten unverändert.

## Tests

- `TestCalendarServiceIntegration_StaffTimetableEventsCarryRoom`: Instanzraum, Override-Raum und Schicht ohne Raum in einem Fenster.
- `TestTimetableRoomIDPrefersAssignmentOverride`: reine Unit-Abdeckung der Vorrangregel.
- Bestehende Tests unverändert; `go test ./services/calendar/...`, Ratchet-Gates, `golangci-lint`, `pnpm run check` und die komplette Frontend-Testsuite grün.

## Screenshots

Vorher/Nachher folgen als Kommentar-Attachments (Wochenansicht + Detail-Sheet, Detail-Sheet zusätzlich mobil geprüft).