### PR TITLE
perf(settings): Request-Memo-Cache dedupliziert Tenant-Lookups pro Request

### DIFF
--- a/.claude/rules/settings-system.md
+++ b/.claude/rules/settings-system.md
@@ -57,6 +57,36 @@ The settings service resolves values in **two tiers**:
 2. Registry default    (Definition.Default)
 ```
 
+### Request-Scoped Resolution Cache (#2065)
+
+Every `Resolve*`/`HasTenantOverride` call funnels through `ResolveMany`, which
+consults (in order): an explicit context snapshot (`WithSettingsSnapshot`,
+used by scheduler/prefetch paths), then a **request-scoped memo cache**
+(`WithSettingsRequestCache`, attached by `RequestSettingsCacheMiddleware`
+router-wide in `api/base.go` and group-wide in `ProtectedTenantGroup`), then
+the repository. Within one HTTP request each (tenant_id, key) pair is loaded
+from PostgreSQL at most once; a full cache hit in `Resolve*ForTenant` skips
+the tenant transaction entirely.
+
+Consistency model:
+- Cache lifetime is one request; other transactions' committed writes become
+  visible at the latest with the next request.
+- `SetValue`/`ResetValue` evict the written key, so same-request reads
+  (including side-effect hooks in the same transaction) see the new value.
+- The advisory-lock helpers (`LockSlotListCutoffPair[Shared]`,
+  `LockClassCollectionPair`) flush the whole tenant bucket. **Any new
+  cross-field guard MUST take one of the `Lock*` helpers** — the lock is the
+  freshness barrier that makes post-lock re-reads observe a concurrent
+  writer's committed state (#1565/#1663).
+- Explicit snapshots are never copied into the request cache (a scheduler
+  minute-snapshot value must not be promoted into request scope).
+
+Handlers that resolve several known keys should still batch explicitly:
+`api/common.PrefetchSettings(ctx, settingsService, keys...)` attaches a
+snapshot so downstream single-key reads (including in services) are free.
+Read paths only — prefetched snapshots are immutable and not evicted by
+writes. There is deliberately NO process-wide cache.
+
 The service does **not** check environment variables. `Resolve*()` returns the registry default when no tenant override exists. Consumers that need env var backward compatibility must implement a three-step pattern manually: `HasTenantOverride()` → `Resolve*()` → `os.Getenv()`. See [Step 3](#step-3-add-consuming-code).
 
 ### SettingsService Interface

--- a/backend/api/active/groups_handlers.go
+++ b/backend/api/active/groups_handlers.go
@@ -242,6 +242,15 @@ func (rs *Resource) getActiveGroupVisitsWithDisplay(w http.ResponseWriter, r *ht
 		return
 	}
 
+	// One batch query for every setting this handler and its downstream
+	// helpers (DetermineStudentAccess included) resolve (issue #2065).
+	r = r.WithContext(common.PrefetchSettings(r.Context(), rs.SettingsService,
+		configModel.KeyAdminSupervisionOverview,
+		configModel.KeyGroupMode,
+		configModel.KeyStudentDataScope,
+		configModel.KeyStudentPhotosEnabled,
+	))
+
 	// Admin overview and open-care both broaden the operational room scope.
 	// Per-student GDPR fields below still use DetermineStudentAccess and are
 	// never broadened by group mode.

--- a/backend/api/active/tracking_handlers.go
+++ b/backend/api/active/tracking_handlers.go
@@ -34,7 +34,14 @@ func (rs *Resource) getTrackingIndicators(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	ctx := r.Context()
+	// One batch query for the toggle plus the three label keys; the per-key
+	// reads below then resolve from the snapshot (issue #2065).
+	ctx := common.PrefetchSettings(r.Context(), rs.SettingsService,
+		configModel.KeyTrackingIndicatorsEnabled,
+		configModel.KeyTrackingIndicator1,
+		configModel.KeyTrackingIndicator2,
+		configModel.KeyTrackingIndicator3,
+	)
 
 	// Check if tracking indicators are enabled for this tenant.
 	enabled, err := rs.SettingsService.ResolveBool(ctx, configModel.KeyTrackingIndicatorsEnabled)

--- a/backend/api/active/tracking_query_budget_test.go
+++ b/backend/api/active/tracking_query_budget_test.go
@@ -1,0 +1,112 @@
+package active
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	configRepository "github.com/moto-nrw/project-phoenix/database/repositories/config"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+type trackingSettingValuesCounter struct {
+	count atomic.Int32
+}
+
+func (c *trackingSettingValuesCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if strings.HasPrefix(strings.TrimSpace(query), "select") &&
+		strings.Contains(query, "config.setting_values") {
+		c.count.Add(1)
+	}
+	return ctx
+}
+
+func (*trackingSettingValuesCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+// JWT-safe tenant IDs: UniqueTestTenantID values exceed 2^53 and corrupt when
+// the tenant_id claim round-trips through JSON, so JWT-driving tests use a
+// small offset counter (same pattern as api/rooms/system_filter_test.go).
+var trackingBudgetTenantCounter int64 = 890_000 + time.Now().UnixNano()%100_000
+
+// TestTrackingIndicatorsIssuesOneSettingValuesQuery drives the REAL router
+// (ProtectedTenantGroup chain, so the request cache middleware is attached the
+// way production attaches it) and asserts the four settings the handler reads
+// (toggle + three labels) cost exactly one config.setting_values query
+// (issue #2065).
+func TestTrackingIndicatorsIssuesOneSettingValuesQuery(t *testing.T) {
+	testutil.SeedTestJWTConfig()
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tenantID := atomic.AddInt64(&trackingBudgetTenantCounter, 1)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		_, _ = db.ExecContext(ctx, `DELETE FROM config.setting_audit WHERE tenant_id = ?`, tenantID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM config.setting_values WHERE tenant_id = ?`, tenantID)
+		testpkg.CleanupTenantTestData(t, db, tenantID)
+	})
+
+	valueRepo := configRepository.NewSettingValueRepository(db)
+	auditRepo := configRepository.NewSettingAuditRepository(db)
+	settings := configSvc.NewSettingsService(valueRepo, auditRepo, nil, db, slog.Default())
+
+	seedCtx := tenant.WithTenantID(context.Background(), tenantID)
+	require.NoError(t, settings.SetValue(seedCtx, configModel.KeyTrackingIndicatorsEnabled, true, nil, nil))
+	require.NoError(t, settings.SetValue(seedCtx, configModel.KeyTrackingIndicator1, "Bibliothek", nil, nil))
+
+	student := testpkg.CreateTestStudentForTenant(t, db, tenantID, "Budget", "Test", "1a")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, db, student.ID) })
+
+	active := &trackingMockActiveService{
+		getTrackingIndicatorsFunc: func(_ context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+			result := make(map[int64][]bool, len(studentIDs))
+			for _, id := range studentIDs {
+				result[id] = make([]bool, len(labels))
+			}
+			return result, nil
+		},
+	}
+	rs := NewResource(active, nil, nil, nil, nil, settings, db, slog.Default())
+	router := rs.Router()
+
+	body, err := json.Marshal(map[string]any{"student_ids": []int64{student.ID}})
+	require.NoError(t, err)
+
+	counter := &trackingSettingValuesCounter{}
+	db.AddQueryHook(counter)
+
+	req := httptest.NewRequest("POST", "/tracking-indicators", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := testutil.ExecuteWithAuth(t, router, req, testutil.AdminTestClaimsForTenant(1, tenantID))
+	queries := counter.count.Load()
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp struct {
+		Data struct {
+			Labels []string `json:"labels"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"Bibliothek"}, resp.Data.Labels,
+		"empty label keys must still be skipped by the per-key reads")
+	assert.Equal(t, int32(1), queries,
+		"toggle + three label keys must share one config.setting_values query")
+}

--- a/backend/api/auth/tenant_handlers.go
+++ b/backend/api/auth/tenant_handlers.go
@@ -70,6 +70,11 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 		orgName = school.Organization.Name
 	}
 
+	// Shell settings resolve first: their batch includes grade_level_max, so
+	// the request cache satisfies the hard-fail resolve below without a second
+	// tenant transaction (issue #2065).
+	resolved := rs.resolveTenantShellSettings(r.Context(), school.ID)
+
 	// GradeLevelMax is a validation constraint, not an optional display hint.
 	// The registry returns the legitimate default for tenants without an
 	// override; a missing settings service, read error, or corrupt value must
@@ -82,7 +87,6 @@ func (rs *Resource) resolveTenant(w http.ResponseWriter, r *http.Request) {
 		))
 		return
 	}
-	resolved := rs.resolveTenantShellSettings(r.Context(), school.ID)
 
 	resp := &TenantResolveResponse{
 		TenantID:               school.ID,
@@ -135,6 +139,10 @@ func (rs *Resource) resolveTenantShellSettings(ctx context.Context, tenantID int
 		configModel.KeyEnrollmentWaitlistEnabled,
 		configModel.KeyGroupMode,
 		configModel.KeyParentNotesEnabled,
+		// Not read from this snapshot — prefetched so the hard-fail
+		// resolveTenantGradeLevelMax call hits the request cache instead of
+		// opening a second tenant transaction (issue #2065).
+		configModel.KeyEnrollmentGradeLevelMax,
 	}
 	if batch, ok := rs.SettingsService.(interface {
 		ResolveManyForTenant(context.Context, int64, []string) (*configSvc.SettingsSnapshot, error)

--- a/backend/api/auth/tenant_resolve_query_budget_test.go
+++ b/backend/api/auth/tenant_resolve_query_budget_test.go
@@ -1,0 +1,75 @@
+// Query-budget guard for the public GET /auth/tenant/resolve endpoint
+// (issue #2065): the shell-settings batch prefetches every key the handler
+// needs — including enrollment.grade_level_max for the separate hard-fail
+// resolve — so one request issues exactly ONE config.setting_values query and
+// zero additional tenant transactions for settings.
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	authAPI "github.com/moto-nrw/project-phoenix/api/auth"
+	apiCommon "github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	platformRepo "github.com/moto-nrw/project-phoenix/database/repositories/platform"
+	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
+)
+
+type settingValuesQueryCounter struct {
+	count atomic.Int32
+}
+
+func (c *settingValuesQueryCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if strings.HasPrefix(strings.TrimSpace(query), "select") &&
+		strings.Contains(query, "config.setting_values") {
+		c.count.Add(1)
+	}
+	return ctx
+}
+
+func (*settingValuesQueryCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func TestResolveTenant_IssuesOneSettingValuesQuery(t *testing.T) {
+	db, svc := testutil.SetupAPITest(t)
+	t.Cleanup(func() { _ = db.Close() })
+	_, slug := newTenantResolveScope(t, db)
+
+	schoolRepo := platformRepo.NewSchoolRepository(db)
+	resource := authAPI.NewResource(svc.Auth, svc.Invitation, platformSvc.NewSchoolService(schoolRepo), db)
+	resource.SettingsService = svc.Settings
+
+	// The blanket attachment in api/base.go is what production requests run
+	// through; mirror it here so the request cache is present.
+	router := chi.NewRouter()
+	router.Use(apiCommon.RequestSettingsCacheMiddleware)
+	router.Mount("/auth", resource.Router())
+
+	counter := &settingValuesQueryCounter{}
+	db.AddQueryHook(counter)
+
+	req := httptest.NewRequest("GET", "/auth/tenant/resolve?slug="+slug, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	queries := counter.count.Load()
+
+	require.Equal(t, http.StatusOK, rr.Code, "Body: %s", rr.Body.String())
+
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, 4, resp.Data.GradeLevelMax,
+		"grade cap must still resolve correctly through the batch + cache path")
+	assert.Equal(t, int32(1), queries,
+		"tenant resolve must load config.setting_values exactly once per request")
+}

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -213,6 +213,11 @@ func setupBasicMiddleware(router chi.Router, logger *slog.Logger, httpMetrics *o
 	sentryMiddleware := sentryhttp.New(sentryhttp.Options{Repanic: true})
 	router.Use(sentryMiddleware.Handle)
 	router.Use(customMiddleware.SecurityHeaders)
+	// Request-scoped settings memo cache (issue #2065). Router-wide so routes
+	// outside ProtectedTenantGroup (/auth incl. /auth/tenant/resolve,
+	// /operator, /parent, public enrollment) dedupe their settings lookups
+	// too. Idempotent with the group-wide attachment in api/common.
+	router.Use(apiCommon.RequestSettingsCacheMiddleware)
 }
 
 func syncClientIPToRemoteAddr(next http.Handler) http.Handler {

--- a/backend/api/common/router.go
+++ b/backend/api/common/router.go
@@ -28,6 +28,10 @@ func ProtectedTenantGroup(r chi.Router, db *bun.DB, fn func(r chi.Router, withTx
 		gr.Use(tokenAuth.Verifier())
 		gr.Use(jwt.Authenticator)
 		gr.Use(jwt.TenantMiddleware)
+		// Request-scoped settings memo cache (issue #2065). Unlike withTx this
+		// IS applied group-wide: it opens no transaction and does no DB work,
+		// so running it on requests that later 403 costs one map allocation.
+		gr.Use(RequestSettingsCacheMiddleware)
 		fn(gr, tenant.TenantTxMiddleware(db))
 	})
 }

--- a/backend/api/common/settings_prefetch.go
+++ b/backend/api/common/settings_prefetch.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"context"
+
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+)
+
+// PrefetchSettings batch-resolves keys and attaches the resulting snapshot to
+// the returned context, so every subsequent single-key Resolve*/HasTenantOverride
+// call for those keys is served in-memory (issue #2065). Best-effort: when the
+// service is not batch-capable (test mocks) or the batch read fails, the
+// original context is returned and the per-key calls behave exactly as before,
+// preserving each call site's error semantics.
+//
+// Read paths only: an attached snapshot is immutable and not evicted by
+// SetValue/ResetValue or the advisory-lock helpers, so handlers that write
+// settings must not prefetch the keys they write.
+func PrefetchSettings(ctx context.Context, settings configSvc.SettingsService, keys ...string) context.Context {
+	batch, ok := settings.(configSvc.BatchSettingsService)
+	if !ok {
+		return ctx
+	}
+	snapshot, err := batch.ResolveMany(ctx, keys)
+	if err != nil {
+		return ctx
+	}
+	return configSvc.WithSettingsSnapshot(ctx, snapshot)
+}

--- a/backend/api/common/settings_request_cache_middleware.go
+++ b/backend/api/common/settings_request_cache_middleware.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"net/http"
+
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+)
+
+// RequestSettingsCacheMiddleware attaches the request-scoped settings memo
+// cache (issue #2065) to every request context. It does no database work —
+// it only seeds an empty per-request map — so it is safe to run before
+// authorization and to stack: WithSettingsRequestCache is idempotent, letting
+// the router-wide attachment in api/base.go and the group-wide attachment in
+// ProtectedTenantGroup share one cache.
+func RequestSettingsCacheMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(configSvc.WithSettingsRequestCache(r.Context())))
+	})
+}

--- a/backend/api/common/settings_request_cache_middleware_test.go
+++ b/backend/api/common/settings_request_cache_middleware_test.go
@@ -1,0 +1,30 @@
+package common_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+)
+
+// WithSettingsRequestCache returns its input unchanged when a cache is already
+// attached, so comparing the handler-observed context with a re-wrapped copy
+// proves the middleware attached the cache.
+func TestRequestSettingsCacheMiddlewareAttachesCache(t *testing.T) {
+	var observed context.Context
+	handler := common.RequestSettingsCacheMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = r.Context()
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+	require.NotNil(t, observed)
+	assert.Equal(t, observed, configSvc.WithSettingsRequestCache(observed),
+		"middleware must have attached the request cache (idempotent re-wrap returns the same context)")
+}

--- a/backend/api/rooms/api.go
+++ b/backend/api/rooms/api.go
@@ -459,7 +459,15 @@ func (rs *Resource) getAvailableRooms(w http.ResponseWriter, r *http.Request) {
 // per-student IDs or names leave the backend — per-child movement detail
 // lives behind /students/{id}/attendance-history under its own gates.
 func (rs *Resource) GetRoomHistory(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	// One batch query for the three gates below; the scope check in
+	// resolveRoomHistorySupervisorFilter reads from the snapshot too
+	// (issue #2065).
+	ctx := common.PrefetchSettings(r.Context(), rs.SettingsService,
+		configModel.KeyAttendanceLogEnabled,
+		configModel.KeyRoomDetailVisibleDays,
+		configModel.KeyAttendanceLogScope,
+	)
+	r = r.WithContext(ctx)
 	logger := rs.roomHistoryLogger()
 
 	id, err := common.ParseID(r)

--- a/backend/api/students/school_checkin_handlers.go
+++ b/backend/api/students/school_checkin_handlers.go
@@ -81,6 +81,12 @@ func (rs *Resource) schoolCheckinHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// One batch query for both access-gate settings read below (issue #2065).
+	r = r.WithContext(common.PrefetchSettings(r.Context(), rs.SettingsService,
+		configModel.KeyWebCheckinAccess,
+		configModel.KeyGroupMode,
+	))
+
 	if err := rs.enforceWebCheckinAccess(r.Context(), staffID, student.ID); err != nil {
 		common.RenderError(w, r, common.ErrorForbidden(err))
 		return

--- a/backend/services/config/settings_request_cache.go
+++ b/backend/services/config/settings_request_cache.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"context"
+	"sync"
+)
+
+type settingsRequestCacheContextKey struct{}
+
+type requestCacheEntryKey struct {
+	tenantID   int64
+	settingKey string
+}
+
+// settingsRequestCache memoizes resolved setting values for the lifetime of a
+// single request context. Entries are keyed by (tenant_id, setting_key), so a
+// cache attached to a context that touches several tenants (operator flows,
+// *ForTenant resolves) can never serve one tenant's value to another.
+//
+// Consistency contract (see also the Lock* helpers in settings_service.go):
+//   - lifetime is one request; the cache dies with the request context
+//   - SetValue/ResetValue evict the written key, so same-request reads after a
+//     write (including side-effect hooks running in the same transaction) see
+//     the new value
+//   - the advisory-lock helpers (LockSlotListCutoffPair, LockClassCollectionPair)
+//     flush the whole tenant bucket, so post-lock reads observe a concurrent
+//     writer's committed state instead of a pre-lock memoized value
+//   - writes committed by other transactions become visible at the latest with
+//     the next request
+type settingsRequestCache struct {
+	mu      sync.Mutex
+	entries map[requestCacheEntryKey]snapshotValue
+}
+
+// WithSettingsRequestCache attaches a request-scoped settings memo cache to
+// ctx. Idempotent: a context that already carries a cache is returned
+// unchanged, so stacked attachment points (router-wide and group-wide
+// middleware) share one cache instead of shadowing each other.
+func WithSettingsRequestCache(ctx context.Context) context.Context {
+	if requestCacheFromContext(ctx) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, settingsRequestCacheContextKey{}, &settingsRequestCache{
+		entries: make(map[requestCacheEntryKey]snapshotValue),
+	})
+}
+
+func requestCacheFromContext(ctx context.Context) *settingsRequestCache {
+	cache, _ := ctx.Value(settingsRequestCacheContextKey{}).(*settingsRequestCache)
+	return cache
+}
+
+// lookup returns the cached entries for keys plus the deduplicated list of
+// keys that have no cache entry yet.
+func (c *settingsRequestCache) lookup(tenantID int64, keys []string) (map[string]snapshotValue, []string) {
+	hits := make(map[string]snapshotValue, len(keys))
+	missing := make([]string, 0, len(keys))
+	seenMissing := make(map[string]struct{}, len(keys))
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, key := range keys {
+		if _, hit := hits[key]; hit {
+			continue
+		}
+		if _, miss := seenMissing[key]; miss {
+			continue
+		}
+		if entry, ok := c.entries[requestCacheEntryKey{tenantID: tenantID, settingKey: key}]; ok {
+			hits[key] = entry
+			continue
+		}
+		seenMissing[key] = struct{}{}
+		missing = append(missing, key)
+	}
+	return hits, missing
+}
+
+// store memoizes freshly resolved entries for tenantID.
+func (c *settingsRequestCache) store(tenantID int64, values map[string]snapshotValue) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key, entry := range values {
+		c.entries[requestCacheEntryKey{tenantID: tenantID, settingKey: key}] = entry
+	}
+}
+
+// evictKey drops a single (tenant, key) entry after a write to that key.
+func (c *settingsRequestCache) evictKey(tenantID int64, key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, requestCacheEntryKey{tenantID: tenantID, settingKey: key})
+}
+
+// evictTenant drops every entry for tenantID. Called by the advisory-lock
+// helpers: taking a lock is the freshness barrier of the cross-field guards,
+// and which keys a guard re-reads under the lock is not this cache's business
+// to enumerate (#1565/#1663).
+func (c *settingsRequestCache) evictTenant(tenantID int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.entries {
+		if key.tenantID == tenantID {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/backend/services/config/settings_request_cache_db_test.go
+++ b/backend/services/config/settings_request_cache_db_test.go
@@ -1,0 +1,121 @@
+package config_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	configRepository "github.com/moto-nrw/project-phoenix/database/repositories/config"
+	"github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func setupRequestCacheDBTest(t *testing.T) (*bun.DB, int64, configService.SettingsService) {
+	t.Helper()
+	config.ResetRegistry()
+	t.Cleanup(config.ResetRegistry)
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	t.Cleanup(func() {
+		ctx := context.Background()
+		_, _ = db.ExecContext(ctx, `DELETE FROM config.setting_audit WHERE tenant_id = ?`, tenantID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM config.setting_values WHERE tenant_id = ?`, tenantID)
+		testpkg.CleanupTenantTestData(t, db, tenantID)
+	})
+
+	repository := configRepository.NewSettingValueRepository(db)
+	auditRepository := configRepository.NewSettingAuditRepository(db)
+	service := configService.NewSettingsService(repository, auditRepository, nil, db, slog.Default())
+	return db, tenantID, service
+}
+
+// TestSlotListCutoffWriteSeesConcurrentCommitDespiteRequestCache is the #1565
+// regression under the request cache: the cross-field validator re-reads the
+// sibling cutoff AFTER taking the advisory lock, and the lock helpers flush
+// the tenant's cache bucket. A request that memoized the old sibling value
+// before the concurrent writer committed must still reject the now-inverted
+// pair — a stale cache serving the pre-lock value would accept it.
+func TestSlotListCutoffWriteSeesConcurrentCommitDespiteRequestCache(t *testing.T) {
+	db, tenantID, service := setupRequestCacheDBTest(t)
+	registerTestSetting(config.KeySlotListShortDayCutoff, config.FieldTime, "15:00")
+	registerTestSetting(config.KeySlotListLongDayCutoff, config.FieldTime, "16:00")
+
+	requestCtx := configService.WithSettingsRequestCache(
+		tenant.WithTenantID(context.Background(), tenantID),
+	)
+
+	// The request memoizes the short cutoff default (15:00) before any writer.
+	short, err := service.ResolveString(requestCtx, config.KeySlotListShortDayCutoff)
+	require.NoError(t, err)
+	require.Equal(t, "15:00", short)
+
+	// A concurrent request commits short=15:30.
+	repository := configRepository.NewSettingValueRepository(db)
+	override := &config.SettingValue{
+		SettingKey: config.KeySlotListShortDayCutoff,
+		Value:      json.RawMessage(`"15:30"`),
+	}
+	override.SetTenantID(tenantID)
+	require.NoError(t, repository.Upsert(
+		tenant.WithTenantID(context.Background(), tenantID), override,
+	))
+
+	// The first request now writes long=15:15. Against its stale cache entry
+	// (short=15:00) the pair looks valid; against the committed 15:30 it is
+	// inverted and must be rejected.
+	err = tenant.WithTenantTx(requestCtx, db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		return service.SetValue(txCtx, config.KeySlotListLongDayCutoff, "15:15", nil, nil)
+	})
+	require.Error(t, err, "the inverted pair must be rejected despite the request cache")
+	var invalid *configService.InvalidValueError
+	require.True(t, errors.As(err, &invalid), "expected InvalidValueError, got %v", err)
+}
+
+// TestLockClassCollectionPairFlushesGradeLevelMax pins the whole-bucket flush:
+// the enrollment phase guard reads enrollment.grade_level_max under
+// LockClassCollectionPair, a key outside the class-collection toggle pair. A
+// per-key eviction list would miss it; the tenant-wide flush must force the
+// post-lock read back to the database.
+func TestLockClassCollectionPairFlushesGradeLevelMax(t *testing.T) {
+	db, tenantID, service := setupRequestCacheDBTest(t)
+	registerTestSetting(config.KeyEnrollmentGradeLevelMax, config.FieldNumber, 4)
+
+	counter := &settingValuesSelectCounter{}
+	db.AddQueryHook(counter)
+
+	requestCtx := configService.WithSettingsRequestCache(
+		tenant.WithTenantID(context.Background(), tenantID),
+	)
+
+	err := tenant.WithTenantTx(requestCtx, db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
+		value, resolveErr := service.ResolveInt(txCtx, config.KeyEnrollmentGradeLevelMax)
+		require.NoError(t, resolveErr)
+		require.Equal(t, 4, value)
+		require.Equal(t, int32(1), counter.count.Load())
+
+		// Cached: no additional query.
+		_, resolveErr = service.ResolveInt(txCtx, config.KeyEnrollmentGradeLevelMax)
+		require.NoError(t, resolveErr)
+		require.Equal(t, int32(1), counter.count.Load())
+
+		require.NoError(t, service.LockClassCollectionPair(txCtx))
+
+		// Post-lock read must hit the database again.
+		_, resolveErr = service.ResolveInt(txCtx, config.KeyEnrollmentGradeLevelMax)
+		require.NoError(t, resolveErr)
+		assert.Equal(t, int32(2), counter.count.Load(),
+			"LockClassCollectionPair must flush grade_level_max from the request cache")
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/backend/services/config/settings_request_cache_test.go
+++ b/backend/services/config/settings_request_cache_test.go
@@ -1,0 +1,310 @@
+package config_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/config"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The request cache guarantees that within one request context every
+// (tenant_id, key) pair is loaded from the repository at most once (#2065).
+
+func TestRequestCacheSecondResolveIssuesNoRepoCall(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.cached_flag", config.FieldBoolean, true)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	first, err := svc.ResolveBool(ctx, "test.cached_flag")
+	require.NoError(t, err)
+	second, err := svc.ResolveBool(ctx, "test.cached_flag")
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, repo.findManyCalls, "second resolve must be served from the request cache")
+
+	// HasTenantOverride shares the cached entry too.
+	hasOverride, err := svc.HasTenantOverride(ctx, "test.cached_flag")
+	require.NoError(t, err)
+	assert.False(t, hasOverride)
+	assert.Equal(t, 1, repo.findManyCalls)
+}
+
+func TestRequestCachePartialHitQueriesOnlyMissingKeys(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.first", config.FieldBoolean, false)
+	registerTestSetting("test.second", config.FieldNumber, 5)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	batch, ok := svc.(configService.BatchSettingsService)
+	require.True(t, ok)
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	_, err := svc.ResolveBool(ctx, "test.first")
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.findManyCalls)
+
+	snapshot, err := batch.ResolveMany(ctx, []string{"test.first", "test.second"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.findManyCalls, "only the missing key may trigger a repository query")
+	require.Len(t, repo.findManyKeys, 2)
+	assert.Equal(t, []string{"test.second"}, repo.findManyKeys[1], "cached keys must not be re-requested")
+
+	integer, err := snapshot.Int("test.second")
+	require.NoError(t, err)
+	assert.Equal(t, 5, integer)
+}
+
+func TestRequestCacheIsolatesTenants(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.isolated", config.FieldText, "default")
+
+	repo := newMockValueRepo()
+	overrideA := &config.SettingValue{SettingKey: "test.isolated", Value: json.RawMessage(`"tenant-a"`)}
+	overrideA.TenantID = 41
+	repo.values[repo.key(41, overrideA.SettingKey)] = overrideA
+
+	svc := createService(repo, &mockAuditRepo{})
+
+	// One shared cache observed under two tenant contexts: the second tenant
+	// must get its own repository read and its own value.
+	base := configService.WithSettingsRequestCache(tenantCtx(41))
+	valueA, err := svc.ResolveString(base, "test.isolated")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", valueA)
+	require.Equal(t, 1, repo.findManyCalls)
+
+	ctxB := tenant.WithTenantID(base, 42)
+	valueB, err := svc.ResolveString(ctxB, "test.isolated")
+	require.NoError(t, err)
+	assert.Equal(t, "default", valueB)
+	assert.Equal(t, 2, repo.findManyCalls, "tenant B must not be served tenant A's cache entry")
+}
+
+func TestRequestCacheCachesAbsentOverride(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.absent", config.FieldNumber, 30)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	value, err := svc.ResolveInt(ctx, "test.absent")
+	require.NoError(t, err)
+	assert.Equal(t, 30, value)
+
+	hasOverride, err := svc.HasTenantOverride(ctx, "test.absent")
+	require.NoError(t, err)
+	assert.False(t, hasOverride)
+	assert.Equal(t, 1, repo.findManyCalls, "the absent-override result must be cached, not re-queried")
+}
+
+func TestRequestCacheCachesUnmarshalError(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.corrupt", config.FieldBoolean, false)
+
+	repo := newMockValueRepo()
+	corrupt := &config.SettingValue{SettingKey: "test.corrupt", Value: json.RawMessage(`{invalid`)}
+	corrupt.TenantID = 41
+	repo.values[repo.key(41, corrupt.SettingKey)] = corrupt
+
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	_, firstErr := svc.ResolveBool(ctx, "test.corrupt")
+	require.Error(t, firstErr)
+	_, secondErr := svc.ResolveBool(ctx, "test.corrupt")
+	require.Error(t, secondErr)
+	assert.Equal(t, firstErr.Error(), secondErr.Error(), "the cached error must be identical")
+	assert.Equal(t, 1, repo.findManyCalls)
+}
+
+func TestWithSettingsRequestCacheIsIdempotent(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.idempotent", config.FieldBoolean, true)
+
+	base := tenantCtx(41)
+	once := configService.WithSettingsRequestCache(base)
+	twice := configService.WithSettingsRequestCache(once)
+	assert.Equal(t, once, twice, "re-attaching must return the same context (shared cache)")
+
+	// Behavioral proof: a resolve through the doubly-wrapped context is served
+	// by the same cache the singly-wrapped context populated.
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	_, err := svc.ResolveBool(once, "test.idempotent")
+	require.NoError(t, err)
+	_, err = svc.ResolveBool(twice, "test.idempotent")
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.findManyCalls)
+}
+
+func TestResolveManyDoesNotCacheContextSnapshotValues(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.snapshot_key", config.FieldBoolean, false)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	batch, ok := svc.(configService.BatchSettingsService)
+	require.True(t, ok)
+
+	cached := configService.WithSettingsRequestCache(tenantCtx(41))
+	snapshot, err := batch.ResolveMany(tenantCtx(41), []string{"test.snapshot_key"})
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.findManyCalls)
+
+	// Resolving through an explicit snapshot must not promote its (possibly
+	// stale) values into the request cache.
+	snapCtx := configService.WithSettingsSnapshot(cached, snapshot)
+	_, err = svc.ResolveBool(snapCtx, "test.snapshot_key")
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.findManyCalls, "snapshot serves the read")
+
+	_, err = svc.ResolveBool(cached, "test.snapshot_key")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.findManyCalls, "without the snapshot the cache must still be empty")
+}
+
+func TestResolveManyWithoutCacheInContextStillWorks(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.plain", config.FieldBoolean, true)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+
+	// Scheduler / CLI contexts carry no request cache: every resolve queries.
+	_, err := svc.ResolveBool(tenantCtx(41), "test.plain")
+	require.NoError(t, err)
+	_, err = svc.ResolveBool(tenantCtx(41), "test.plain")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.findManyCalls)
+}
+
+func TestRequestCacheUnknownKeyFailsWithoutQuery(t *testing.T) {
+	setupTest(t)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	_, err := svc.Resolve(ctx, "nonexistent.key")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Equal(t, 0, repo.findManyCalls, "unknown keys fail before any repository access")
+}
+
+func TestSetValueEvictsRequestCacheEntry(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.rewritten", config.FieldNumber, 10)
+
+	repo := newMockValueRepo()
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	before, err := svc.ResolveInt(ctx, "test.rewritten")
+	require.NoError(t, err)
+	assert.Equal(t, 10, before)
+
+	require.NoError(t, svc.SetValue(ctx, "test.rewritten", 20, nil, nil))
+
+	after, err := svc.ResolveInt(ctx, "test.rewritten")
+	require.NoError(t, err)
+	assert.Equal(t, 20, after, "a same-request read after SetValue must see the new value")
+}
+
+func TestResetValueEvictsRequestCacheEntry(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.reset", config.FieldNumber, 10)
+
+	repo := newMockValueRepo()
+	override := &config.SettingValue{SettingKey: "test.reset", Value: json.RawMessage(`99`)}
+	override.TenantID = 41
+	repo.values[repo.key(41, override.SettingKey)] = override
+
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	before, err := svc.ResolveInt(ctx, "test.reset")
+	require.NoError(t, err)
+	assert.Equal(t, 99, before)
+
+	require.NoError(t, svc.ResetValue(ctx, "test.reset", nil, nil))
+
+	after, err := svc.ResolveInt(ctx, "test.reset")
+	require.NoError(t, err)
+	assert.Equal(t, 10, after, "a same-request read after ResetValue must see the registry default")
+}
+
+func TestLockHelpersFlushTenantCache(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.locked_a", config.FieldBoolean, false)
+	registerTestSetting("test.locked_b", config.FieldNumber, 1)
+
+	cases := []struct {
+		name string
+		lock func(svc configService.SettingsService, ctx context.Context) error
+	}{
+		{"slot_list_cutoff", func(svc configService.SettingsService, ctx context.Context) error {
+			return svc.LockSlotListCutoffPair(ctx)
+		}},
+		{"slot_list_cutoff_shared", func(svc configService.SettingsService, ctx context.Context) error {
+			return svc.LockSlotListCutoffPairShared(ctx)
+		}},
+		{"class_collection", func(svc configService.SettingsService, ctx context.Context) error {
+			return svc.LockClassCollectionPair(ctx)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newMockValueRepo()
+			svc := createService(repo, &mockAuditRepo{})
+			ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+			// Prime the tenant bucket with two unrelated keys.
+			_, err := svc.ResolveBool(ctx, "test.locked_a")
+			require.NoError(t, err)
+			_, err = svc.ResolveInt(ctx, "test.locked_b")
+			require.NoError(t, err)
+			require.Equal(t, 2, repo.findManyCalls)
+
+			// Taking the lock — even without an ambient transaction — must
+			// flush the whole tenant bucket (#1565/#1663 freshness barrier).
+			require.NoError(t, tc.lock(svc, ctx))
+
+			_, err = svc.ResolveBool(ctx, "test.locked_a")
+			require.NoError(t, err)
+			_, err = svc.ResolveInt(ctx, "test.locked_b")
+			require.NoError(t, err)
+			assert.Equal(t, 4, repo.findManyCalls, "post-lock reads must hit the repository again")
+		})
+	}
+}
+
+func TestResolveBoolForTenantSkipsTxOnFullCacheHit(t *testing.T) {
+	setupTest(t)
+	registerTestSetting("test.for_tenant", config.FieldBoolean, true)
+
+	repo := newMockValueRepo()
+	// createService wires a nil *bun.DB: if ResolveBoolForTenant reached
+	// WithTenantTx, the nil DB would blow up. Returning successfully from the
+	// second call therefore proves the transaction was skipped.
+	svc := createService(repo, &mockAuditRepo{})
+	ctx := configService.WithSettingsRequestCache(tenantCtx(41))
+
+	_, err := svc.ResolveBool(ctx, "test.for_tenant")
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.findManyCalls)
+
+	value, err := svc.ResolveBoolForTenant(ctx, 41, "test.for_tenant")
+	require.NoError(t, err)
+	assert.True(t, value)
+	assert.Equal(t, 1, repo.findManyCalls, "a full cache hit must skip the tenant transaction and the query")
+}

--- a/backend/services/config/settings_service.go
+++ b/backend/services/config/settings_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math"
 	"strings"
 	"time"
@@ -100,10 +101,17 @@ func (s *settingsService) Resolve(ctx context.Context, key string) (any, error) 
 
 // ResolveMany resolves several settings in one repository query. A compatible
 // context snapshot wins, which lets scheduler-invoked downstream services
-// share the minute snapshot without knowing about scheduler internals.
+// share the minute snapshot without knowing about scheduler internals. Below
+// the explicit snapshot sits the request-scoped memo cache (issue #2065):
+// within one request every (tenant_id, key) pair is loaded from PostgreSQL at
+// most once; only cache-missing keys reach the repository.
 func (s *settingsService) ResolveMany(ctx context.Context, keys []string) (*SettingsSnapshot, error) {
 	tenantID := tenant.FromContext(ctx)
 	if snapshot := snapshotFromContext(ctx, tenantID, keys); snapshot != nil {
+		// Explicit snapshots are returned as-is and deliberately NEVER copied
+		// into the request cache: the scheduler's minute snapshot may be up to
+		// a minute old, and promoting its values into request scope would
+		// leak that staleness into paths that expect request freshness.
 		return snapshot, nil
 	}
 
@@ -111,19 +119,70 @@ func (s *settingsService) ResolveMany(ctx context.Context, keys []string) (*Sett
 		return newSettingsSnapshot(tenantID, keys, nil)
 	}
 
-	stored, err := s.valueRepo.FindByTenantAndKeys(ctx, tenantID, keys)
-	if err != nil {
-		return nil, &SettingsError{Op: "resolve_many", Err: err}
+	// Validate every key up front so an unknown key fails deterministically
+	// regardless of which keys happen to be cached already.
+	for _, key := range keys {
+		if config.GetDefinition(key) == nil {
+			return nil, &SettingsError{
+				Op:  "resolve_many",
+				Err: &DefinitionNotFoundError{Key: key},
+			}
+		}
 	}
-	return newSettingsSnapshot(tenantID, keys, stored)
+
+	cache := requestCacheFromContext(ctx)
+	if cache == nil {
+		stored, err := s.valueRepo.FindByTenantAndKeys(ctx, tenantID, keys)
+		if err != nil {
+			return nil, &SettingsError{Op: "resolve_many", Err: err}
+		}
+		return newSettingsSnapshot(tenantID, keys, stored)
+	}
+
+	resolved, missing := cache.lookup(tenantID, keys)
+	if len(missing) > 0 {
+		stored, err := s.valueRepo.FindByTenantAndKeys(ctx, tenantID, missing)
+		if err != nil {
+			return nil, &SettingsError{Op: "resolve_many", Err: err}
+		}
+		loaded, err := newSettingsSnapshot(tenantID, missing, stored)
+		if err != nil {
+			return nil, err
+		}
+		cache.store(tenantID, loaded.values)
+		maps.Copy(resolved, loaded.values)
+	}
+	return newSettingsSnapshotFromValues(tenantID, resolved), nil
 }
 
 // ResolveManyForTenant resolves several settings inside one tenant
 // transaction. A matching context snapshot avoids both the transaction and
-// query when a scheduler already prefetched the values.
+// query when a scheduler already prefetched the values, and a full
+// request-cache hit skips the tenant transaction entirely (issue #2065).
 func (s *settingsService) ResolveManyForTenant(ctx context.Context, tenantID int64, keys []string) (*SettingsSnapshot, error) {
 	if snapshot := snapshotFromContext(ctx, tenantID, keys); snapshot != nil {
 		return snapshot, nil
+	}
+
+	// Consult the request cache only when the ambient tenant context is absent
+	// or matches tenantID: a mismatched ambient tenant must still reach
+	// WithTenantTx below so its nested-transaction guard surfaces the wiring
+	// bug instead of the cache silently succeeding.
+	if ctxTenant := tenant.FromContext(ctx); tenantID > 0 && len(keys) > 0 &&
+		(ctxTenant == 0 || ctxTenant == tenantID) {
+		if cache := requestCacheFromContext(ctx); cache != nil {
+			for _, key := range keys {
+				if config.GetDefinition(key) == nil {
+					return nil, &SettingsError{
+						Op:  "resolve_many",
+						Err: &DefinitionNotFoundError{Key: key},
+					}
+				}
+			}
+			if resolved, missing := cache.lookup(tenantID, keys); len(missing) == 0 {
+				return newSettingsSnapshotFromValues(tenantID, resolved), nil
+			}
+		}
 	}
 
 	var result *SettingsSnapshot
@@ -140,6 +199,9 @@ func (s *settingsService) ResolveManyForTenant(ctx context.Context, tenantID int
 
 // ResolveManyForTenants resolves all tenant/key pairs in one privileged query.
 // Registry defaults are filled independently for every requested tenant.
+// Deliberately NOT request-cached: its only callers are the scheduler (which
+// owns the minute snapshot) and other admin-tx batch paths that already
+// coalesce their reads.
 func (s *settingsService) ResolveManyForTenants(ctx context.Context, tenantIDs []int64, keys []string) (map[int64]*SettingsSnapshot, error) {
 	uniqueTenantIDs := make([]int64, 0, len(tenantIDs))
 	seenTenantIDs := make(map[int64]struct{}, len(tenantIDs))
@@ -370,6 +432,13 @@ func (s *settingsService) SetValue(ctx context.Context, key string, value any, c
 		return &SettingsError{Op: "set_value", Err: err}
 	}
 
+	// Evict the written key from the request cache so same-request reads —
+	// including side-effect hooks running inside this transaction — see the
+	// new value instead of a memoized pre-write entry.
+	if cache := requestCacheFromContext(ctx); cache != nil {
+		cache.evictKey(tenantID, key)
+	}
+
 	// Audit — redact password values to avoid storing cleartext PINs
 	auditOld := oldValue
 	auditNew := valueJSON
@@ -435,6 +504,11 @@ func (s *settingsService) ResetValue(ctx context.Context, key string, changedBy 
 
 	if err := s.valueRepo.Delete(ctx, tenantID, key); err != nil {
 		return &SettingsError{Op: "reset_value", Err: err}
+	}
+
+	// See SetValue: same-request reads must observe the reset immediately.
+	if cache := requestCacheFromContext(ctx); cache != nil {
+		cache.evictKey(tenantID, key)
 	}
 
 	// Audit — redact password values
@@ -751,7 +825,12 @@ func (s *settingsService) validateSlotListCutoffPair(ctx context.Context, key st
 // transaction the xact lock is meaningless — the settings read/write paths always
 // run inside a tenant tx (the RLS-scoped repos require one) — so it is skipped
 // rather than failing.
+// Taking the lock is also the freshness barrier of the request cache: the
+// tenant bucket is flushed (before the no-tx early return, so tests without an
+// ambient transaction behave like production) so post-lock reads hit the
+// database and observe the concurrent writer's committed state.
 func (s *settingsService) LockSlotListCutoffPair(ctx context.Context) error {
+	s.flushRequestCacheForLock(ctx)
 	if _, hasTx := modelBase.TxFromContext(ctx); !hasTx {
 		return nil
 	}
@@ -761,6 +840,16 @@ func (s *settingsService) LockSlotListCutoffPair(ctx context.Context) error {
 	return nil
 }
 
+// flushRequestCacheForLock drops every request-cache entry for the ambient
+// tenant. All Lock* helpers call it first: which keys a cross-field guard
+// re-reads under its lock is deliberately not enumerated here — a whole-tenant
+// flush stays correct when the next guard adds another key (#1565/#1663).
+func (s *settingsService) flushRequestCacheForLock(ctx context.Context) {
+	if cache := requestCacheFromContext(ctx); cache != nil {
+		cache.evictTenant(tenant.FromContext(ctx))
+	}
+}
+
 // LockSlotListCutoffPairShared takes the SHARED variant of the Ganztag cutoff
 // lock for read paths (services/slotlists pickupBuckets). Shared holders never
 // block one another, so concurrent /options, pickup-preview and export requests
@@ -768,7 +857,11 @@ func (s *settingsService) LockSlotListCutoffPair(ctx context.Context) error {
 // rosters or rendering a PDF/XLSX cannot stall every other reader in the tenant.
 // It still conflicts with the exclusive writer lock, so a cutoff update can never
 // commit a partial pair while a reader observes the two cutoffs (#1565 review).
+// Flushes the tenant's request-cache bucket like the exclusive variant — the
+// slotlists reader resolves both cutoffs after taking this lock and must see
+// the writer's committed pair, not memoized pre-lock values.
 func (s *settingsService) LockSlotListCutoffPairShared(ctx context.Context) error {
+	s.flushRequestCacheForLock(ctx)
 	if _, hasTx := modelBase.TxFromContext(ctx); !hasTx {
 		return nil
 	}
@@ -796,7 +889,12 @@ func slotListCutoffLockKey(ctx context.Context) string {
 // Best-effort: without an ambient transaction the xact lock is meaningless (the
 // settings and phase write paths always run inside a tenant tx), so it is
 // skipped rather than failing.
+// Flushes the tenant's request-cache bucket first: both the settings-side
+// guard and the enrollment-side phase guard re-read settings (including
+// enrollment.grade_level_max) under this lock and must observe committed
+// state, not memoized pre-lock values.
 func (s *settingsService) LockClassCollectionPair(ctx context.Context) error {
+	s.flushRequestCacheForLock(ctx)
 	if _, hasTx := modelBase.TxFromContext(ctx); !hasTx {
 		return nil
 	}

--- a/backend/services/config/settings_service_test.go
+++ b/backend/services/config/settings_service_test.go
@@ -25,6 +25,7 @@ type mockValueRepo struct {
 	values        map[string]*config.SettingValue // key: "tenantID:settingKey"
 	err           error
 	findManyCalls int
+	findManyKeys  [][]string // per FindByTenantAndKeys call, the requested keys
 }
 
 func newMockValueRepo() *mockValueRepo {
@@ -48,6 +49,7 @@ func (m *mockValueRepo) FindByTenantAndKey(_ context.Context, tenantID int64, se
 
 func (m *mockValueRepo) FindByTenantAndKeys(_ context.Context, tenantID int64, settingKeys []string) ([]*config.SettingValue, error) {
 	m.findManyCalls++
+	m.findManyKeys = append(m.findManyKeys, append([]string(nil), settingKeys...))
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/backend/services/config/settings_snapshot.go
+++ b/backend/services/config/settings_snapshot.go
@@ -80,6 +80,13 @@ func newSettingsSnapshot(tenantID int64, keys []string, stored []*configModel.Se
 	return &SettingsSnapshot{tenantID: tenantID, values: values}, nil
 }
 
+// newSettingsSnapshotFromValues builds a snapshot from already-resolved
+// entries (the request-cache merge path). Callers must have validated every
+// key against the registry beforehand.
+func newSettingsSnapshotFromValues(tenantID int64, values map[string]snapshotValue) *SettingsSnapshot {
+	return &SettingsSnapshot{tenantID: tenantID, values: values}
+}
+
 func (s *SettingsSnapshot) containsAll(keys []string) bool {
 	if s == nil {
 		return false


### PR DESCRIPTION
Closes #2065

## Was

Ein request-gebundener Memo-Cache für die Settings-Auflösung plus Batch-Prefetches auf den heißen Routen. Alle `Resolve*`/`HasTenantOverride`-Aufrufe laufen durch den Trichter `ResolveMany`; dort sitzt der Cache unterhalb des bestehenden expliziten Context-Snapshots (PR #2066). Innerhalb eines Requests wird jedes `(tenant_id, setting_key)`-Paar höchstens einmal aus PostgreSQL geladen; ein voller Cache-Hit in `Resolve*ForTenant` spart zusätzlich die komplette Tenant-Transaktion.

## Design

- **`services/config/settings_request_cache.go`**: Mutex-geschützte `(tenant_id, key)`-Map am Request-Context. `WithSettingsRequestCache` ist idempotent (zwei Einhängepunkte teilen einen Cache). Tenant-Isolation per Konstruktion: der Tenant ist Teil des Cache-Keys, Kollisionen über Tenants sind ausgeschlossen.
- **Einhängepunkte**: router-weit in `api/base.go` (deckt `/auth` inkl. `/auth/tenant/resolve`, `/operator`, `/parent`, öffentliche Enrollment-Routen) und gruppen-weit in `ProtectedTenantGroup` (test-sichtbar, da `api/testutil` `resource.Router()` direkt treibt). Die Middleware macht keine DB-Arbeit.
- **Konsistenzmodell** (dokumentiert in `.claude/rules/settings-system.md`):
  - Cache lebt genau einen Request; fremde Commits sind spätestens im Folge-Request sichtbar.
  - `SetValue`/`ResetValue` evicten den geschriebenen Key → Side-Effect-Hooks in derselben Transaktion und spätere Same-Request-Reads sehen den neuen Wert.
  - Die Advisory-Lock-Helfer (`LockSlotListCutoffPair[Shared]`, `LockClassCollectionPair`) flushen den **gesamten** Tenant-Bucket, bevor sie locken. Der Lock bleibt damit die Frische-Barriere der Cross-Field-Guards (#1565/#1663). Ganzer Bucket statt Key-Liste, weil die Enrollment-Seite unter demselben Lock auch `enrollment.grade_level_max` liest — eine Key-Liste hätte das verpasst.
  - Explizite Snapshots (Scheduler-Minuten-Snapshot) werden nie in den Request-Cache befördert.
- **Batch-Prefetches** (`api/common.PrefetchSettings`): Gruppen-Display-Route (4 Keys inkl. `gdpr.student_data_scope` für `DetermineStudentAccess` downstream), Tracking-Indicators (Toggle + 3 Labels, per-Key-Fehlertoleranz bleibt), Raum-Historie (3 Gates), School-Checkin (2 Zugriffs-Gates). `/auth/tenant/resolve` nimmt `grade_level_max` in den bestehenden 11-Key-Batch auf und tauscht die Aufruf-Reihenfolge; die Hard-Fail-Politik des Grade-Caps bleibt unverändert (eigene Funktion, bedient sich aus dem Cache).
- **Kein prozessweiter Cache** — bewusst außerhalb des Scopes, wie im Issue abgegrenzt.

## Messung (lokal, pg_stat_statements, 5 Requests pro Lauf)

| Route | Vorher | Nachher |
|---|---|---|
| `GET /auth/tenant/resolve` (live gemessen) | 2 Queries + 2 Tenant-Tx pro Request | **1 Query + 1 Tx** |
| `POST /active/tracking-indicators` (Query-Budget-Test) | bis zu 4 Queries | **1** |
| `GET /active/groups/{id}/visits/display` (Code-Analyse) | bis zu 4 Queries | 1 |
| `GET /rooms/{id}/history` (Code-Analyse) | 3 Queries | 1 |
| `POST /students/{id}/school-checkin` (Code-Analyse) | 3 Queries | 2 (Gate-Middleware + Batch) |

p95/p99 unter Produktionslast kann erst nach dem Staging-/Prod-Deploy mit `pg_stat_statements` gemessen werden — Follow-up im Issue.

## Tests

- Unit: Dedup, partielle Hits (nur fehlende Keys in der Query), Tenant-Isolation, Absent-Override- und Unmarshal-Fehler-Caching, Idempotenz, Snapshot-Nicht-Beförderung, Write-Evict, Lock-Flush aller drei Helfer, Tx-Skip bei vollem Hit.
- DB-Regression: der #1565-Cutoff-Race-Test schlägt nachweislich fehl, wenn der Lock-Flush entfernt wird (verifiziert), und besteht mit ihm. `LockClassCollectionPair` flusht `grade_level_max` (der Key, den eine Key-Listen-Eviction verpasst hätte).
- Query-Budgets durch die echte Router-Kette: `/auth/tenant/resolve` = genau 1 `config.setting_values`-Query, Tracking-Indicators = genau 1.
- Alle Ratchet-Gates grün (HandlerLayer, ServiceRepository, HandlerComplexity, ModelCeremony, Hermetic, DateColumnTypes), `golangci-lint` 0 Issues, volle Backend-Suite grün.

## E2E

Lokal gegen den Docker-Stack verifiziert (agent-browser): Login, Dashboard, Kindersuche, Gruppenzugriff, Einstellungen. Settings-Roundtrip: Toggle schreiben → 200, UI aktualisiert, Wert übersteht Reload; direkter Backend-Write wird von der UI korrekt gelesen. Screenshots hänge ich als Kommentar an.

## Hinweise für Review

- `configtest.Mock` und das `SettingsService`-Interface sind unverändert (der Cache ist service-intern).
- Vorbestehend, nicht Teil dieses PRs: die lokale Test-DB brauchte `migrate` (Fehlschläge in `services/users`/`api/students` wegen fehlender `active.count_student_visits_for_deletion` existierten auch auf `development`).