### PR TITLE
OGS-Dashboard: Synchronisierten SSE-Refetch-Herd beseitigen

### DIFF
--- a/backend/database/repositories/active/group.go
+++ b/backend/database/repositories/active/group.go
@@ -507,6 +507,7 @@ func (r *GroupRepository) FindActiveSessionsOlderThan(ctx context.Context, cutof
 				CreatedAt: r.CreatedAt,
 				UpdatedAt: r.UpdatedAt,
 			},
+			TenantModel:    modelBase.TenantModel{TenantID: r.TenantID},
 			StartTime:      r.StartTime,
 			EndTime:        r.EndTime,
 			LastActivity:   r.LastActivity,

--- a/backend/database/repositories/active/group_repository_test.go
+++ b/backend/database/repositories/active/group_repository_test.go
@@ -111,6 +111,51 @@ func TestActiveGroupRepository_Create(t *testing.T) {
 	})
 }
 
+func TestActiveGroupRepository_FindActiveSessionsOlderThanPreservesTenant(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	ctx := testpkg.TenantContext(tenantID)
+	repo := repositories.NewFactory(db).ActiveGroup
+
+	group := testpkg.CreateTestActiveGroupForTenant(t, db, tenantID)
+	device := testpkg.CreateTestDeviceForTenant(t, db, tenantID, "abandoned-session-tenant")
+	group.DeviceID = &device.ID
+	group.LastActivity = time.Now().Add(-10 * time.Minute)
+	_, err := db.NewUpdate().
+		TableExpr("active.groups").
+		Set("device_id = ?", group.DeviceID).
+		Set("last_activity = ?", group.LastActivity).
+		Where("id = ?", group.ID).
+		Where("tenant_id = ?", tenantID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	defer func() {
+		_, _ = db.NewDelete().
+			TableExpr("active.groups").
+			Where("id = ?", group.ID).
+			Where("tenant_id = ?", tenantID).
+			Exec(context.Background())
+		testpkg.CleanupTenantTestData(t, db, tenantID)
+	}()
+
+	sessions, err := repo.FindActiveSessionsOlderThan(context.Background(), time.Now().Add(-5*time.Minute))
+	require.NoError(t, err)
+
+	var found *active.Group
+	for _, session := range sessions {
+		if session.ID == group.ID {
+			found = session
+			break
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, tenantID, found.TenantID)
+}
+
 func TestActiveGroupRepository_FindByID(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -69,7 +69,13 @@ const (
 	// "instance_delete").
 	EventStaffingDeviationChanged EventType = "staffing_deviation_changed"
 
-	// Global refresh event — tells all clients to re-fetch dashboard counts
+	// Tenant-wide refresh event — tells every client of the tenant to re-fetch
+	// dashboard counts. Broadcast via BroadcastToTenant (issue #2057; it was
+	// BroadcastToAll before, which fanned every school's check-in traffic out to
+	// every OTHER school's clients). Carries GroupIDs (educational group ids,
+	// never student identity) when the emitting site knows them, so clients can
+	// scope their ogs-students-{gid} revalidation; without GroupIDs clients fall
+	// back to a broad refresh.
 	EventDashboardCountsChanged EventType = "dashboard_counts_changed"
 
 	// EventStaffTimeTrackingChanged is a tenant-wide invalidation trigger for
@@ -181,6 +187,18 @@ type EventData struct {
 	// (whole-session end). The client adds each to its per-student
 	// detail-cache invalidation set; the refetch itself is topic-driven.
 	StudentIDs *[]string `json:"student_ids,omitempty"`
+
+	// GroupIDs carries the affected educational (OGS) group ids on
+	// dashboard_counts_changed / student_checkin / student_checkout /
+	// bulk_student_checkout (#2057). Group ids only — NEVER student identity —
+	// so the tenant-wide dashboard_counts_changed stays GDPR-safe under
+	// gdpr.student_data_scope: it reveals "counts in group X changed", nothing
+	// about who. Clients scope their ogs-students-{gid} revalidation to these
+	// ids. Contract: absence of the field means "scope unknown → refresh
+	// broadly"; emitters MUST omit the field entirely (nil) instead of sending
+	// an empty array, which clients would read as "scope to nothing" and
+	// silently drop the invalidation.
+	GroupIDs *[]string `json:"group_ids,omitempty"`
 
 	// Activity session fields (for activity_start/end/update events)
 	ActivityName  *string   `json:"activity_name,omitempty"`

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -874,10 +874,14 @@ func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active
 	activeGroupID := fmt.Sprintf("%d", endedVisit.ActiveGroupID)
 	studentID := fmt.Sprintf("%d", endedVisit.StudentID)
 	studentName, studentRec := s.getStudentDisplayData(ctx, endedVisit.StudentID)
+	eduGroupIDs := eduGroupIDsOf(studentRec)
 
 	data := realtime.EventData{
 		StudentID:   &studentID,
 		StudentName: &studentName,
+	}
+	if len(eduGroupIDs) > 0 {
+		data.GroupIDs = &eduGroupIDs
 	}
 	applyAttendanceSnapshot(&data, snapshot)
 
@@ -890,8 +894,9 @@ func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active
 	s.broadcastWithLogging(ctx, activeGroupID, studentID, event, "student_checkout")
 	s.broadcastToEducationalGroup(ctx, studentRec, event)
 
-	// Notify all clients so dashboard counts refresh
-	_ = s.Broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	// Notify every client of the tenant so dashboard counts refresh, scoped to
+	// the affected educational group when known (#2057).
+	s.broadcastDashboardCountsChanged(ctx, eduGroupIDs)
 	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
 }
 
@@ -965,11 +970,24 @@ func (s *service) broadcastStudentCheckoutEvents(ctx context.Context, sessionIDS
 		}
 	}
 
-	// One event to the active-group topic carrying every checked-out student.
+	// Every affected educational group id, for scoped client-side invalidation
+	// (#2057). Students without an OGS group contribute no id; they appear in
+	// no ogs-students-{gid} list, so the scope stays correct.
+	allEduGroupIDs := make([]string, 0, len(eduGroups))
+	for gid := range eduGroups {
+		allEduGroupIDs = append(allEduGroupIDs, strconv.FormatInt(gid, 10))
+	}
+
+	// One event to the active-group topic carrying every checked-out student
+	// and every affected educational group.
+	activeData := realtime.EventData{StudentIDs: &allStudentIDs}
+	if len(allEduGroupIDs) > 0 {
+		activeData.GroupIDs = &allEduGroupIDs
+	}
 	activeEvent := realtime.NewEvent(
 		realtime.EventBulkStudentCheckOut,
 		sessionIDStr,
-		realtime.EventData{StudentIDs: &allStudentIDs},
+		activeData,
 	)
 	s.broadcastWithLogging(ctx, sessionIDStr, "", activeEvent, "bulk_student_checkout")
 
@@ -977,17 +995,19 @@ func (s *service) broadcastStudentCheckoutEvents(ctx context.Context, sessionIDS
 	// students so each subscribed client invalidates the right detail caches.
 	for gid, ids := range eduGroups {
 		groupIDs := ids
+		eduGroupID := []string{strconv.FormatInt(gid, 10)}
 		eduEvent := realtime.NewEvent(
 			realtime.EventBulkStudentCheckOut,
 			sessionIDStr,
-			realtime.EventData{StudentIDs: &groupIDs},
+			realtime.EventData{StudentIDs: &groupIDs, GroupIDs: &eduGroupID},
 		)
 		s.broadcastToEducationalGroup(ctx, eduReps[gid], eduEvent)
 	}
 
-	// Single global broadcast for the entire batch.
+	// Single tenant-wide broadcast for the entire batch, scoped to the
+	// affected educational groups (#2057).
 	if s.Broadcaster != nil {
-		_ = s.Broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+		s.broadcastDashboardCountsChanged(ctx, allEduGroupIDs)
 		s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonStudentMoved)
 	}
 }
@@ -1016,8 +1036,10 @@ func (s *service) broadcastActivityEndEvent(ctx context.Context, sessionID int64
 
 	s.broadcastWithLogging(ctx, sessionIDStr, "", event, "activity_end")
 
-	// Notify all clients (including zero-topic) so dashboard refreshes
-	_ = s.Broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	// Notify every client of the tenant (including zero-topic) so dashboards
+	// refresh. No group scope: a session end affects room occupancy across
+	// groups, so clients fall back to a broad refresh (#2057).
+	s.broadcastDashboardCountsChanged(ctx, nil)
 	s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonActivityEnded)
 }
 

--- a/backend/services/active/attendance_service.go
+++ b/backend/services/active/attendance_service.go
@@ -597,25 +597,31 @@ func (s *service) BroadcastDailyCheckout(ctx context.Context, studentID int64) {
 
 	studentIDStr := fmt.Sprintf("%d", studentID)
 	studentName, studentRec := s.getStudentDisplayData(ctx, studentID)
+	eduGroupIDs := eduGroupIDsOf(studentRec)
 
 	source := "daily_checkout"
+	data := realtime.EventData{
+		StudentID:   &studentIDStr,
+		StudentName: &studentName,
+		Source:      &source,
+	}
+	if len(eduGroupIDs) > 0 {
+		data.GroupIDs = &eduGroupIDs
+	}
 	event := realtime.NewEvent(
 		realtime.EventStudentCheckOut,
 		"", // no active group — student already left their room
-		realtime.EventData{
-			StudentID:   &studentIDStr,
-			StudentName: &studentName,
-			Source:      &source,
-		},
+		data,
 	)
 
 	// Broadcast to educational (OGS) group topic so the "Meine Gruppe" page updates
 	s.broadcastToEducationalGroup(ctx, studentRec, event)
 
-	// Notify all clients so dashboard counts and search page refresh —
-	// the educational group broadcast only reaches staff in that group,
-	// but the search page is used by all staff.
-	_ = s.Broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	// Notify every client of the tenant so dashboard counts and the search
+	// page refresh — the educational group broadcast only reaches staff in
+	// that group, but the search page is used by all staff. Scoped to the
+	// student's educational group when known (#2057).
+	s.broadcastDashboardCountsChanged(ctx, eduGroupIDs)
 }
 
 // ConfirmDailyCheckout processes the deferred daily-checkout confirmation for an

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -59,10 +59,14 @@ func TestBroadcast_CreateVisitSendsDashboardCounts(t *testing.T) {
 	activity := testpkg.CreateTestActivityGroup(t, db, "broadcast-checkin")
 	room := testpkg.CreateTestRoom(t, db, "Broadcast Room")
 	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	eduGroup := testpkg.CreateTestEducationGroup(t, db, "OGS-Broadcast-Checkin")
 	student := testpkg.CreateTestStudent(t, db, "Broadcast", "Student", "1a")
+	assignStudentToEducationGroup(t, db, context.Background(), student.ID, eduGroup.ID)
 	staff := testpkg.CreateTestStaff(t, db, "Broadcast", "Staff")
 	iotDevice := testpkg.CreateTestDevice(t, db, "broadcast-device")
-	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, activeGroup.ID, student.ID, staff.ID, iotDevice.ID)
+	// Students before their education group (FK ON DELETE SET NULL nulls
+	// students.tenant_id otherwise — see the edu-batch test below).
+	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, activeGroup.ID, student.ID, eduGroup.ID, staff.ID, iotDevice.ID)
 
 	staffCtx := context.WithValue(testpkg.TenantContext(1), device.CtxStaff, staff)
 	deviceCtx := context.WithValue(staffCtx, device.CtxDevice, iotDevice)
@@ -77,10 +81,39 @@ func TestBroadcast_CreateVisitSendsDashboardCounts(t *testing.T) {
 	require.NoError(t, err)
 	defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
 
-	assert.True(t, broadcaster.HasEventType(realtime.EventDashboardCountsChanged),
-		"expected dashboard_counts_changed after CreateVisit")
 	assert.True(t, broadcaster.HasEventType(realtime.EventActiveSupervisionChanged),
 		"expected active_supervision_changed after CreateVisit")
+
+	// #2057: the dashboard refresh is tenant-scoped (not broadcast to every
+	// school on the deployment) and carries the student's educational group id
+	// so clients can scope their ogs-students-{gid} revalidation.
+	eduGroupIDStr := strconv.FormatInt(eduGroup.ID, 10)
+	counts := dashboardCountsTenantCalls(broadcaster)
+	require.Len(t, counts, 1, "expected exactly one tenant-scoped dashboard_counts_changed after CreateVisit")
+	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
+	assert.NotZero(t, counts[0].TenantID, "tenant id from the request context must reach the broadcast")
+	require.NotNil(t, counts[0].Event.Data.GroupIDs, "dashboard_counts_changed must carry the educational group id")
+	assert.Equal(t, []string{eduGroupIDStr}, *counts[0].Event.Data.GroupIDs)
+
+	// The scoped student_checkin carries the edu group id too, so the client's
+	// backpressure fallback path (checkin delivered, counts event dropped)
+	// stays scoped.
+	checkins := broadcaster.EventsOfType(realtime.EventStudentCheckIn)
+	require.NotEmpty(t, checkins)
+	require.NotNil(t, checkins[0].Data.GroupIDs, "student_checkin must carry the educational group id")
+	assert.Equal(t, []string{eduGroupIDStr}, *checkins[0].Data.GroupIDs)
+}
+
+// dashboardCountsTenantCalls returns every tenant-scoped
+// dashboard_counts_changed broadcast recorded so far.
+func dashboardCountsTenantCalls(broadcaster *testpkg.RecordingBroadcaster) []testpkg.BroadcastCall {
+	out := make([]testpkg.BroadcastCall, 0)
+	for _, c := range broadcaster.CallsByMethod("tenant") {
+		if c.Event.Type == realtime.EventDashboardCountsChanged {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func TestBroadcast_EndVisitSendsDashboardCounts(t *testing.T) {
@@ -91,9 +124,11 @@ func TestBroadcast_EndVisitSendsDashboardCounts(t *testing.T) {
 	activity := testpkg.CreateTestActivityGroup(t, db, "broadcast-checkout")
 	room := testpkg.CreateTestRoom(t, db, "Broadcast Checkout Room")
 	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	eduGroup := testpkg.CreateTestEducationGroup(t, db, "OGS-Broadcast-Checkout")
 	student := testpkg.CreateTestStudent(t, db, "Broadcast", "Checkout", "1b")
+	assignStudentToEducationGroup(t, db, context.Background(), student.ID, eduGroup.ID)
 	visit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, time.Now(), nil)
-	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, activeGroup.ID, student.ID, visit.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, activeGroup.ID, student.ID, visit.ID, eduGroup.ID)
 
 	// Clear calls from visit creation
 	broadcaster.Reset()
@@ -101,10 +136,21 @@ func TestBroadcast_EndVisitSendsDashboardCounts(t *testing.T) {
 	err := svc.EndVisit(testpkg.TenantContext(1), visit.ID)
 	require.NoError(t, err)
 
-	assert.True(t, broadcaster.HasEventType(realtime.EventDashboardCountsChanged),
-		"expected dashboard_counts_changed after EndVisit")
 	assert.True(t, broadcaster.HasEventType(realtime.EventActiveSupervisionChanged),
 		"expected active_supervision_changed after EndVisit")
+
+	// #2057: tenant-scoped, carrying the student's educational group id.
+	eduGroupIDStr := strconv.FormatInt(eduGroup.ID, 10)
+	counts := dashboardCountsTenantCalls(broadcaster)
+	require.Len(t, counts, 1, "expected exactly one tenant-scoped dashboard_counts_changed after EndVisit")
+	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
+	require.NotNil(t, counts[0].Event.Data.GroupIDs, "dashboard_counts_changed must carry the educational group id")
+	assert.Equal(t, []string{eduGroupIDStr}, *counts[0].Event.Data.GroupIDs)
+
+	checkouts := broadcaster.EventsOfType(realtime.EventStudentCheckOut)
+	require.NotEmpty(t, checkouts)
+	require.NotNil(t, checkouts[0].Data.GroupIDs, "student_checkout must carry the educational group id")
+	assert.Equal(t, []string{eduGroupIDStr}, *checkouts[0].Data.GroupIDs)
 }
 
 func TestBroadcast_UpdateVisitMoveSendsMovementEvents(t *testing.T) {
@@ -188,16 +234,17 @@ func TestBroadcast_EndActivitySessionSendsDashboardCounts(t *testing.T) {
 	err := svc.EndActivitySession(testpkg.TenantContext(1), session.ID)
 	require.NoError(t, err)
 
-	// Should have dashboard_counts_changed from the batch student checkout
-	calls := broadcaster.Events()
-	found := false
-	for _, call := range calls {
-		if call.Type == realtime.EventDashboardCountsChanged {
-			assert.Empty(t, call.ActiveGroupID, "global events should not leak group IDs")
-			found = true
-		}
+	// Should have dashboard_counts_changed from the batch student checkout,
+	// tenant-scoped (#2057). The student here has no educational group, so
+	// group_ids must be ABSENT (nil, never an empty slice) — clients read the
+	// absence as "scope unknown → refresh broadly".
+	counts := dashboardCountsTenantCalls(broadcaster)
+	require.NotEmpty(t, counts, "expected dashboard_counts_changed after EndActivitySession with active visits")
+	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
+	for _, c := range counts {
+		assert.Empty(t, c.Event.ActiveGroupID, "tenant-wide events should not leak group IDs in the topic")
+		assert.Nil(t, c.Event.Data.GroupIDs, "no educational group -> group_ids must be omitted entirely")
 	}
-	assert.True(t, found, "expected dashboard_counts_changed after EndActivitySession with active visits")
 	assert.True(t, broadcaster.HasEventType(realtime.EventActiveSupervisionChanged),
 		"expected active_supervision_changed after EndActivitySession")
 }
@@ -330,7 +377,8 @@ func TestBroadcast_EndActivitySessionBatchesPerEducationGroup(t *testing.T) {
 	assert.ElementsMatch(t, []string{idC}, *groupYCalls[0].Event.Data.StudentIDs,
 		"groupY event must carry only groupY's student")
 
-	// The active-group topic still carries every student.
+	// The active-group topic still carries every student — and every affected
+	// educational group id (#2057).
 	sessionIDStr := strconv.FormatInt(session.ID, 10)
 	var activeTopicBulk *realtime.Event
 	for _, e := range broadcaster.EventsOfType(realtime.EventBulkStudentCheckOut) {
@@ -341,6 +389,27 @@ func TestBroadcast_EndActivitySessionBatchesPerEducationGroup(t *testing.T) {
 	}
 	require.NotNil(t, activeTopicBulk, "active-group topic must carry a bulk event with all students")
 	assert.ElementsMatch(t, []string{idA, idB, idC}, *activeTopicBulk.Data.StudentIDs)
+
+	gidX := strconv.FormatInt(groupX.ID, 10)
+	gidY := strconv.FormatInt(groupY.ID, 10)
+	require.NotNil(t, activeTopicBulk.Data.GroupIDs, "active-topic bulk event must carry the affected edu group ids")
+	assert.ElementsMatch(t, []string{gidX, gidY}, *activeTopicBulk.Data.GroupIDs)
+
+	// Each edu-topic bulk event carries only its own group id.
+	require.NotNil(t, groupXCalls[0].Event.Data.GroupIDs)
+	assert.Equal(t, []string{gidX}, *groupXCalls[0].Event.Data.GroupIDs)
+	require.NotNil(t, groupYCalls[0].Event.Data.GroupIDs)
+	assert.Equal(t, []string{gidY}, *groupYCalls[0].Event.Data.GroupIDs)
+
+	// The batch's single dashboard refresh is tenant-scoped and lists every
+	// affected edu group; the activity-end refresh right after carries none
+	// (session end affects room occupancy across groups -> broad refresh).
+	counts := dashboardCountsTenantCalls(broadcaster)
+	require.Len(t, counts, 2, "batch + activity end fire one dashboard refresh each")
+	require.NotNil(t, counts[0].Event.Data.GroupIDs, "batch dashboard refresh must carry the affected edu group ids")
+	assert.ElementsMatch(t, []string{gidX, gidY}, *counts[0].Event.Data.GroupIDs)
+	assert.Nil(t, counts[1].Event.Data.GroupIDs, "activity-end dashboard refresh is deliberately unscoped")
+	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
 }
 
 // assignStudentToEducationGroup sets a student's OGS group_id in the DB so the
@@ -366,6 +435,35 @@ func TestBroadcast_DailyCheckoutSendsDashboardCounts(t *testing.T) {
 
 	svc.BroadcastDailyCheckout(testpkg.TenantContext(1), student.ID)
 
-	assert.True(t, broadcaster.HasEventType(realtime.EventDashboardCountsChanged),
-		"expected dashboard_counts_changed after BroadcastDailyCheckout")
+	// #2057: tenant-scoped; the student has no educational group, so group_ids
+	// must be absent (broad-refresh fallback on the client).
+	counts := dashboardCountsTenantCalls(broadcaster)
+	require.Len(t, counts, 1, "expected dashboard_counts_changed after BroadcastDailyCheckout")
+	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
+	assert.Nil(t, counts[0].Event.Data.GroupIDs, "no educational group -> group_ids must be omitted entirely")
+}
+
+func TestBroadcast_DailyCheckoutCarriesEducationGroupID(t *testing.T) {
+	svc, broadcaster := setupServiceWithBroadcaster(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	eduGroup := testpkg.CreateTestEducationGroup(t, db, "OGS-DailyCheckout")
+	student := testpkg.CreateTestStudent(t, db, "Broadcast", "DailyCheckoutGrp", "3b")
+	assignStudentToEducationGroup(t, db, context.Background(), student.ID, eduGroup.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID, eduGroup.ID)
+
+	svc.BroadcastDailyCheckout(testpkg.TenantContext(1), student.ID)
+
+	eduGroupIDStr := strconv.FormatInt(eduGroup.ID, 10)
+	counts := dashboardCountsTenantCalls(broadcaster)
+	require.Len(t, counts, 1)
+	require.NotNil(t, counts[0].Event.Data.GroupIDs, "dashboard_counts_changed must carry the educational group id")
+	assert.Equal(t, []string{eduGroupIDStr}, *counts[0].Event.Data.GroupIDs)
+
+	// The educational-group student_checkout carries the group id too.
+	checkouts := broadcaster.EventsOfType(realtime.EventStudentCheckOut)
+	require.NotEmpty(t, checkouts)
+	require.NotNil(t, checkouts[0].Data.GroupIDs)
+	assert.Equal(t, []string{eduGroupIDStr}, *checkouts[0].Data.GroupIDs)
 }

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -62,8 +62,10 @@ func (s *service) broadcastActivityStartEvent(ctx context.Context, group *active
 
 	s.broadcastWithLogging(ctx, activeGroupID, "", event, "activity_start")
 
-	// Notify all clients (including zero-topic) so dashboard refreshes
-	_ = s.Broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	// Notify every client of the tenant (including zero-topic) so dashboards
+	// refresh. No group scope: a session start affects room occupancy across
+	// groups, so clients fall back to a broad refresh (#2057).
+	s.broadcastDashboardCountsChanged(ctx, nil)
 	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, "", activeSupervisionReasonActivityStarted)
 }
 
@@ -1222,7 +1224,15 @@ func (s *service) CleanupAbandonedSessions(ctx context.Context, threshold time.D
 		// Use ProcessSessionTimeoutByID with the session ID directly to prevent TOCTOU race condition
 		// This ensures we end the exact session we identified as abandoned, not whatever
 		// session happens to be current for the device at cleanup time
-		_, err := s.ProcessSessionTimeoutByID(ctx, session.ID)
+		//
+		// Stamp the session's tenant into the context: the CLI cleanup path
+		// (cmd/cleanup.go) calls with context.Background(), and the SSE
+		// broadcasts inside the timeout flow are tenant-scoped
+		// (BroadcastToTenant) — without a tenant id they would be silently
+		// dropped. The scheduler path already carries the same tenant id, so
+		// re-stamping is a no-op there.
+		sessionCtx := tenant.WithTenantID(ctx, session.TenantID)
+		_, err := s.ProcessSessionTimeoutByID(sessionCtx, session.ID)
 		if err != nil {
 			// Log error but continue with other sessions
 			// Note: ErrActiveGroupAlreadyEnded is expected if session was ended between

--- a/backend/services/active/sse_adapter.go
+++ b/backend/services/active/sse_adapter.go
@@ -3,7 +3,9 @@ package active
 import (
 	"context"
 	"log/slog"
+	"strconv"
 
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/realtime"
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
@@ -34,4 +36,46 @@ func (s *service) broadcastActiveSupervisionChanged(ctx context.Context, activeG
 			slog.Int64("tenant_id", tenantID),
 		)
 	}
+}
+
+// broadcastDashboardCountsChanged sends the tenant-wide dashboard refresh
+// signal (#2057). eduGroupIDs are the affected educational (OGS) group ids —
+// group ids only, never student identity — so clients can scope their
+// ogs-students-{gid} revalidation instead of refetching every group list.
+// Empty/nil ids omit the field entirely (clients then refresh broadly);
+// callers must never pass a deliberately-empty-but-known scope.
+//
+// Tenant-scoped on purpose: the old BroadcastToAll fanned every school's
+// check-in traffic out to every other school's clients, multiplying the
+// refetch herd across tenants.
+func (s *service) broadcastDashboardCountsChanged(ctx context.Context, eduGroupIDs []string) {
+	if s.Broadcaster == nil {
+		return
+	}
+
+	data := realtime.EventData{}
+	if len(eduGroupIDs) > 0 {
+		data.GroupIDs = &eduGroupIDs
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	event := realtime.NewEvent(realtime.EventDashboardCountsChanged, "", data)
+	if err := s.Broadcaster.BroadcastToTenant(tenantID, event); err != nil {
+		s.getLogger().Warn("SSE dashboard counts broadcast failed",
+			slog.String("error", err.Error()),
+			slog.Int64("tenant_id", tenantID),
+		)
+	}
+}
+
+// eduGroupIDsOf returns the educational group id of a student as a slice for
+// broadcastDashboardCountsChanged / EventData.GroupIDs, or nil when unknown
+// (nil student — e.g. a repo error during display-data lookup — or a student
+// without an OGS group). nil keeps the field absent so clients fall back to a
+// broad refresh instead of scoping to nothing.
+func eduGroupIDsOf(student *userModels.Student) []string {
+	if student == nil || student.GroupID == nil {
+		return nil
+	}
+	return []string{strconv.FormatInt(*student.GroupID, 10)}
 }

--- a/backend/services/active/visit_helpers.go
+++ b/backend/services/active/visit_helpers.go
@@ -346,10 +346,14 @@ func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit
 	studentID := fmt.Sprintf("%d", visit.StudentID)
 
 	studentName, studentRec := s.getStudentDisplayData(ctx, visit.StudentID)
+	eduGroupIDs := eduGroupIDsOf(studentRec)
 
 	data := realtime.EventData{
 		StudentID:   &studentID,
 		StudentName: &studentName,
+	}
+	if len(eduGroupIDs) > 0 {
+		data.GroupIDs = &eduGroupIDs
 	}
 	applyAttendanceSnapshot(&data, snapshot)
 
@@ -370,8 +374,9 @@ func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit
 
 	s.broadcastToEducationalGroup(ctx, studentRec, event)
 
-	// Notify all clients so dashboard counts refresh
-	_ = s.Broadcaster.BroadcastToAll(realtime.NewEvent(realtime.EventDashboardCountsChanged, "", realtime.EventData{}))
+	// Notify every client of the tenant so dashboard counts refresh, scoped to
+	// the affected educational group when known (#2057).
+	s.broadcastDashboardCountsChanged(ctx, eduGroupIDs)
 	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
 }
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -4153,6 +4153,71 @@ describe("OGSGroupPage ID-based selection: First load initialization", () => {
     // Should show Group A students since it's the first group
     expect(screen.getByText(/Max Mustermann/)).toBeInTheDocument();
   });
+
+  it("applies a newer BFF snapshot while the first group stays selected", async () => {
+    let dashboardData = {
+      groups: [
+        {
+          id: 1,
+          name: "Group A",
+          room_id: 10,
+          room: { id: 10, name: "Raum 101" },
+        },
+      ],
+      students: [
+        {
+          id: "1",
+          name: "Max Mustermann",
+          first_name: "Max",
+          last_name: "Mustermann",
+          current_location: "Raum 101",
+        },
+      ],
+      roomStatus: {
+        student_room_status: {
+          "1": { in_group_room: true },
+        } as Record<string, { in_group_room: boolean }>,
+      },
+      substitutions: [],
+      pickupTimes: [],
+      firstGroupId: "1",
+    };
+    vi.mocked(useSWRAuth).mockImplementation(((key: string | null) => ({
+      data: key === "ogs-dashboard" ? dashboardData : null,
+      isLoading: false,
+      error: null,
+      mutate: mockMutate,
+      isValidating: false,
+    })) as unknown as typeof useSWRAuth);
+
+    const { rerender } = render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max Mustermann/)).toBeInTheDocument();
+    });
+
+    dashboardData = {
+      ...dashboardData,
+      students: [
+        {
+          id: "2",
+          name: "Erika Schmidt",
+          first_name: "Erika",
+          last_name: "Schmidt",
+          current_location: "Raum 101",
+        },
+      ],
+      roomStatus: {
+        student_room_status: { "2": { in_group_room: true } },
+      },
+    };
+    rerender(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Erika Schmidt/)).toBeInTheDocument();
+      expect(screen.queryByText(/Max Mustermann/)).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe("OGSGroupPage ID-based selection: URL param matching", () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -4218,6 +4218,86 @@ describe("OGSGroupPage ID-based selection: First load initialization", () => {
       expect(screen.queryByText(/Max Mustermann/)).not.toBeInTheDocument();
     });
   });
+
+  it("does not apply a BFF snapshot older than the current group snapshot", async () => {
+    let dashboardData = {
+      groups: [
+        {
+          id: 1,
+          name: "Group A",
+          room_id: 10,
+          room: { id: 10, name: "Raum 101" },
+        },
+      ],
+      students: [
+        {
+          id: "1",
+          name: "Initial Student",
+          first_name: "Initial",
+          last_name: "Student",
+          current_location: "Raum 101",
+        },
+      ],
+      roomStatus: null,
+      substitutions: [],
+      pickupTimes: [],
+      firstGroupId: "1",
+      clientRequestVersion: 1,
+    };
+    const currentGroupData = {
+      groupId: "1",
+      students: [
+        {
+          id: "2",
+          name: "Fresh Student",
+          first_name: "Fresh",
+          second_name: "Student",
+          current_location: "Raum 101",
+        },
+      ],
+      roomStatus: { "2": { in_group_room: true } },
+      pickupTimes: new Map(),
+      clientRequestVersion: 4,
+    };
+    vi.mocked(useSWRAuth).mockImplementation(((key: string | null) => ({
+      data:
+        key === "ogs-dashboard"
+          ? dashboardData
+          : key === "ogs-students-1"
+            ? currentGroupData
+            : null,
+      isLoading: false,
+      error: null,
+      mutate: mockMutate,
+      isValidating: false,
+    })) as unknown as typeof useSWRAuth);
+
+    const { rerender } = render(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fresh Student/)).toBeInTheDocument();
+    });
+
+    dashboardData = {
+      ...dashboardData,
+      students: [
+        {
+          id: "3",
+          name: "Stale Student",
+          first_name: "Stale",
+          last_name: "Student",
+          current_location: "Raum 101",
+        },
+      ],
+      clientRequestVersion: 3,
+    };
+    rerender(<OGSGroupPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fresh Student/)).toBeInTheDocument();
+      expect(screen.queryByText(/Stale Student/)).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe("OGSGroupPage ID-based selection: URL param matching", () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -361,8 +361,22 @@ function OGSGroupPageContent() {
     {
       keepPreviousData: true, // Show cached data while revalidating
       revalidateOnFocus: false, // Handled by global SSE
+      // Safety net (#2057): group transfers/substitutions emit NO SSE event
+      // today, and this BFF no longer rides the check-in-driven invalidation
+      // (its live per-group data is covered by ogs-students-{gid}). Without a
+      // periodic refresh, a group transferred to this user would stay
+      // invisible until a hard reload.
+      refreshInterval: 5 * 60_000,
     },
   );
+
+  // One-shot guard (#2057): the BFF seeds students/pickup/roomStatus exactly
+  // once for the fast first paint; afterwards ogs-students-{currentGroupId}
+  // is the sole writer of those states. Without the guard, this effect re-ran
+  // on every selectedGroupId change and re-applied the (now only
+  // periodically refreshed, so possibly minutes-old) BFF snapshot over
+  // fresher SSE-driven data when switching back to the first group.
+  const hasSeededFirstGroupRef = useRef(false);
 
   // Sync SWR dashboard data with local state
   useEffect(() => {
@@ -417,8 +431,13 @@ function OGSGroupPageContent() {
 
     // If the previously selected group no longer exists in the refreshed list
     // (e.g., access revoked, group removed), reset to the first group so
-    // the student data stays in sync with what the UI displays.
+    // the student data stays in sync with what the UI displays. Allow a
+    // re-seed for this case: the reset can only fire when a NEW BFF response
+    // arrived (this effect's dashboardData dep changed), so its data is fresh
+    // and bridges the gap until the ogs-students fetch for the new group
+    // resolves.
     if (selectedGroupId && !ogsGroups.some((g) => g.id === selectedGroupId)) {
+      hasSeededFirstGroupRef.current = false;
       setSelectedGroupId(firstGroupId ?? null);
     }
 
@@ -429,31 +448,38 @@ function OGSGroupPageContent() {
         setSelectedGroupId(firstGroupId);
       }
 
-      // Map backend students to frontend format (last_name → second_name)
-      const mappedStudents = studentsData.map(mapStudentForOgsPage);
-      setStudents(mappedStudents);
+      // Seed students/pickup/roomStatus from the BFF exactly once (see
+      // hasSeededFirstGroupRef above) — after that, the SSE-driven
+      // ogs-students-{gid} SWR owns these states.
+      if (!hasSeededFirstGroupRef.current) {
+        hasSeededFirstGroupRef.current = true;
 
-      // Set pickup times from BFF response (prevents loading flash)
-      // Convert backend format to Map for O(1) lookup
-      const pickupMap = new Map<string, BulkPickupTime>();
-      for (const pt of pickupTimesData ?? []) {
-        pickupMap.set(pt.student_id.toString(), {
-          studentId: pt.student_id.toString(),
-          date: pt.date,
-          weekdayName: pt.weekday_name,
-          pickupTime: pt.pickup_time,
-          isException: pt.is_exception,
-          dayNotes: (pt.day_notes ?? []).map((n) => ({
-            id: n.id.toString(),
-            content: n.content,
-          })),
-          notes: pt.notes,
-        });
-      }
-      setPickupTimes(pickupMap);
+        // Map backend students to frontend format (last_name → second_name)
+        const mappedStudents = studentsData.map(mapStudentForOgsPage);
+        setStudents(mappedStudents);
 
-      if (rs?.student_room_status) {
-        setRoomStatus(rs.student_room_status);
+        // Set pickup times from BFF response (prevents loading flash)
+        // Convert backend format to Map for O(1) lookup
+        const pickupMap = new Map<string, BulkPickupTime>();
+        for (const pt of pickupTimesData ?? []) {
+          pickupMap.set(pt.student_id.toString(), {
+            studentId: pt.student_id.toString(),
+            date: pt.date,
+            weekdayName: pt.weekday_name,
+            pickupTime: pt.pickup_time,
+            isException: pt.is_exception,
+            dayNotes: (pt.day_notes ?? []).map((n) => ({
+              id: n.id.toString(),
+              content: n.content,
+            })),
+            notes: pt.notes,
+          });
+        }
+        setPickupTimes(pickupMap);
+
+        if (rs?.student_room_status) {
+          setRoomStatus(rs.student_room_status);
+        }
       }
     }
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -86,6 +86,12 @@ import { createLogger } from "~/lib/logger";
 import { OgsGroupsPageSkeleton } from "./page-skeleton";
 
 const logger = createLogger({ component: "OgsGroupsPage" });
+let nextDataRequestVersion = 0;
+
+function createDataRequestVersion() {
+  nextDataRequestVersion += 1;
+  return nextDataRequestVersion;
+}
 
 // Backend pickup time response (from BFF)
 interface BackendPickupTime {
@@ -170,6 +176,19 @@ interface OGSDashboardBFFResponse {
   }>;
   pickupTimes: BackendPickupTime[];
   firstGroupId: string | null;
+  // Client-only ordering metadata; never part of the BFF wire response.
+  clientRequestVersion?: number;
+}
+
+function recordLatestStudentSnapshotVersion(
+  versions: Map<string, number>,
+  groupId: string,
+  version: number,
+) {
+  const latestVersion = versions.get(groupId);
+  if (latestVersion === undefined || version > latestVersion) {
+    versions.set(groupId, version);
+  }
 }
 
 function mapStudentForOgsPage(
@@ -324,6 +343,13 @@ function OGSGroupPageContent() {
   const [availableUsers, setAvailableUsers] = useState<StaffWithRole[]>([]);
   const [activeTransfers, setActiveTransfers] = useState<GroupTransfer[]>([]);
 
+  // Orders BFF and per-group requests across their separate SWR keys. The
+  // successful per-group version map prevents a slower, older BFF response
+  // from overwriting newer SSE-driven state for the same group.
+  const latestStudentSnapshotVersionByGroupRef = useRef<Map<string, number>>(
+    new Map(),
+  );
+
   // SWR-based dashboard data fetching with caching
   // Cache key "ogs-dashboard" will be invalidated by global SSE on relevant events
   const {
@@ -333,6 +359,7 @@ function OGSGroupPageContent() {
   } = useSWRAuth<OGSDashboardBFFResponse>(
     session?.user?.token ? "ogs-dashboard" : null,
     async () => {
+      const clientRequestVersion = createDataRequestVersion();
       logger.debug("SWR fetching dashboard via BFF");
       const start = performance.now();
 
@@ -356,7 +383,7 @@ function OGSGroupPageContent() {
       logger.debug("SWR fetch complete", {
         duration_ms: (performance.now() - start).toFixed(0),
       });
-      return json.data;
+      return { ...json.data, clientRequestVersion };
     },
     {
       keepPreviousData: true, // Show cached data while revalidating
@@ -410,8 +437,18 @@ function OGSGroupPageContent() {
       }))
       .sort((a, b) => a.name.localeCompare(b.name, "de"));
 
+    // The BFF pre-loads data for the first alphabetically sorted group.
+    const firstGroupId = ogsGroups[0]?.id;
+    const latestStudentSnapshotVersion = firstGroupId
+      ? latestStudentSnapshotVersionByGroupRef.current.get(firstGroupId)
+      : undefined;
+    const isOlderThanStudentSnapshot =
+      dashboardData.clientRequestVersion !== undefined &&
+      latestStudentSnapshotVersion !== undefined &&
+      dashboardData.clientRequestVersion < latestStudentSnapshotVersion;
+
     // Update student count on the first sorted group (BFF pre-loads data for it)
-    if (ogsGroups[0]) {
+    if (ogsGroups[0] && !isOlderThanStudentSnapshot) {
       ogsGroups[0].student_count = studentsData.length;
       ogsGroups[0].present_count = countCheckedInStudents(studentsData);
       setGroupAttendanceCount(ogsGroups[0].id, {
@@ -420,14 +457,33 @@ function OGSGroupPageContent() {
       });
     }
 
-    setAllGroups(ogsGroups);
+    setAllGroups((previousGroups) => {
+      if (!isOlderThanStudentSnapshot || !firstGroupId) {
+        return ogsGroups;
+      }
+
+      const previousFirstGroup = previousGroups.find(
+        (group) => group.id === firstGroupId,
+      );
+      if (!previousFirstGroup) {
+        return ogsGroups;
+      }
+
+      return ogsGroups.map((group) =>
+        group.id === firstGroupId
+          ? {
+              ...group,
+              student_count: previousFirstGroup.student_count,
+              present_count: previousFirstGroup.present_count,
+            }
+          : group,
+      );
+    });
 
     // IMPORTANT: Only apply first group's students/roomStatus when first group is selected.
     // The BFF sorts groups alphabetically, so groups[0] matches ogsGroups[0].
     // When SSE triggers revalidation while user views another group, we must NOT
     // overwrite their current view with the first group's data.
-    const firstGroupId = ogsGroups[0]?.id;
-
     const isNewDashboardSnapshot =
       lastHandledDashboardSnapshotRef.current !== dashboardData;
     lastHandledDashboardSnapshotRef.current = dashboardData;
@@ -456,7 +512,7 @@ function OGSGroupPageContent() {
 
       // Apply only a newly fetched BFF snapshot. Re-renders caused by group
       // selection keep the SSE-driven ogs-students-{gid} SWR as sole writer.
-      if (isNewDashboardSnapshot) {
+      if (isNewDashboardSnapshot && !isOlderThanStudentSnapshot) {
         // Map backend students to frontend format (last_name → second_name)
         const mappedStudents = studentsData.map(mapStudentForOgsPage);
         setStudents(mappedStudents);
@@ -597,18 +653,21 @@ function OGSGroupPageContent() {
     >;
     pickupTimes?: Map<string, BulkPickupTime>;
     trackingIndicators?: TrackingIndicatorsResponse;
+    clientRequestVersion?: number;
   }>(
     hasAccess && currentGroupId ? `ogs-students-${currentGroupId}` : null,
     async () => {
+      const groupId = currentGroupId!;
+      const clientRequestVersion = createDataRequestVersion();
       // Fetch students and room status in parallel for accurate filtering
       const [studentsResponse, roomStatusResponse] = await Promise.all([
         studentService.getStudents({
-          groupId: currentGroupId!,
+          groupId,
           includeArrivalTimes: true,
           token: session?.user?.token,
         }),
         // Fetch room status inline (don't use callback that sets state)
-        fetch(`/api/groups/${currentGroupId}/students/room-status`, {
+        fetch(`/api/groups/${groupId}/students/room-status`, {
           headers: {
             Authorization: `Bearer ${session?.user?.token}`,
             "Content-Type": "application/json",
@@ -659,12 +718,19 @@ function OGSGroupPageContent() {
         trackingIndicators = trackingResult;
       }
 
+      recordLatestStudentSnapshotVersion(
+        latestStudentSnapshotVersionByGroupRef.current,
+        groupId,
+        clientRequestVersion,
+      );
+
       return {
-        groupId: currentGroupId!,
+        groupId,
         students,
         roomStatus: roomStatusResponse ?? undefined,
         pickupTimes: pickupTimesMap,
         trackingIndicators,
+        clientRequestVersion,
       };
     },
     {
@@ -676,8 +742,16 @@ function OGSGroupPageContent() {
   // Sync SWR student data with local state
   // Also syncs room status and pickup times to keep UI in sync and prevent loading flash
   useEffect(() => {
-    if (swrStudentsData?.groupId !== currentGroupId) {
+    if (!swrStudentsData || swrStudentsData.groupId !== currentGroupId) {
       return;
+    }
+
+    if (swrStudentsData.clientRequestVersion !== undefined) {
+      recordLatestStudentSnapshotVersion(
+        latestStudentSnapshotVersionByGroupRef.current,
+        swrStudentsData.groupId,
+        swrStudentsData.clientRequestVersion,
+      );
     }
 
     if (swrStudentsData?.students) {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -370,13 +370,12 @@ function OGSGroupPageContent() {
     },
   );
 
-  // One-shot guard (#2057): the BFF seeds students/pickup/roomStatus exactly
-  // once for the fast first paint; afterwards ogs-students-{currentGroupId}
-  // is the sole writer of those states. Without the guard, this effect re-ran
-  // on every selectedGroupId change and re-applied the (now only
-  // periodically refreshed, so possibly minutes-old) BFF snapshot over
-  // fresher SSE-driven data when switching back to the first group.
-  const hasSeededFirstGroupRef = useRef(false);
+  // Apply each BFF snapshot at most once (#2057). This keeps its five-minute
+  // polling fallback useful while the first group stays selected, but prevents
+  // a selectedGroupId change from replaying the same (possibly minutes-old)
+  // snapshot over fresher ogs-students-{currentGroupId} data.
+  const lastHandledDashboardSnapshotRef =
+    useRef<OGSDashboardBFFResponse | null>(null);
 
   // Sync SWR dashboard data with local state
   useEffect(() => {
@@ -429,31 +428,35 @@ function OGSGroupPageContent() {
     // overwrite their current view with the first group's data.
     const firstGroupId = ogsGroups[0]?.id;
 
+    const isNewDashboardSnapshot =
+      lastHandledDashboardSnapshotRef.current !== dashboardData;
+    lastHandledDashboardSnapshotRef.current = dashboardData;
+
     // If the previously selected group no longer exists in the refreshed list
     // (e.g., access revoked, group removed), reset to the first group so
-    // the student data stays in sync with what the UI displays. Allow a
-    // re-seed for this case: the reset can only fire when a NEW BFF response
-    // arrived (this effect's dashboardData dep changed), so its data is fresh
-    // and bridges the gap until the ogs-students fetch for the new group
-    // resolves.
-    if (selectedGroupId && !ogsGroups.some((g) => g.id === selectedGroupId)) {
-      hasSeededFirstGroupRef.current = false;
+    // the student data stays in sync with what the UI displays. The new BFF
+    // snapshot is fresh and bridges the gap until the ogs-students fetch for
+    // the replacement group resolves.
+    const selectedGroupExists =
+      !!selectedGroupId && ogsGroups.some((g) => g.id === selectedGroupId);
+    if (selectedGroupId && !selectedGroupExists) {
       setSelectedGroupId(firstGroupId ?? null);
     }
 
-    if (!selectedGroupId || selectedGroupId === firstGroupId) {
+    const isFirstGroupSelected =
+      !selectedGroupId ||
+      selectedGroupId === firstGroupId ||
+      !selectedGroupExists;
+    if (isFirstGroupSelected) {
       // When no group is explicitly selected yet, lock in the first group's ID
       // so the URL-sync effect won't try to "switch" to it via localStorage.
       if (!selectedGroupId && firstGroupId) {
         setSelectedGroupId(firstGroupId);
       }
 
-      // Seed students/pickup/roomStatus from the BFF exactly once (see
-      // hasSeededFirstGroupRef above) — after that, the SSE-driven
-      // ogs-students-{gid} SWR owns these states.
-      if (!hasSeededFirstGroupRef.current) {
-        hasSeededFirstGroupRef.current = true;
-
+      // Apply only a newly fetched BFF snapshot. Re-renders caused by group
+      // selection keep the SSE-driven ogs-students-{gid} SWR as sole writer.
+      if (isNewDashboardSnapshot) {
         // Map backend students to frontend format (last_name → second_name)
         const mappedStudents = studentsData.map(mapStudentForOgsPage);
         setStudents(mappedStudents);

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { SSEHookOptions } from "~/lib/sse-types";
+import type { SSEEvent, SSEHookOptions } from "~/lib/sse-types";
 import { renderHook } from "@testing-library/react";
 
 // Mock dependencies
@@ -49,6 +49,10 @@ describe("useGlobalSSE", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    // Pin the per-burst flush jitter (#2057) to 0 so the existing
+    // advanceTimersByTime(500) timing assertions stay deterministic. Jitter
+    // bounds get their own explicit tests.
+    vi.spyOn(Math, "random").mockReturnValue(0);
   });
 
   afterEach(() => {
@@ -280,10 +284,19 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("active-supervision-dashboard")
+          (matcher as (key: string) => boolean)(
+            "tenant:active-supervision-dashboard-0",
+          )
         );
       });
       expect(dashboardCall).toBeDefined();
+
+      // #2057: the count-dashboard invalidation is an explicit key list — it
+      // must NOT drag the OGS BFF or staff time tracking into every check-in.
+      const matcher = dashboardCall![0] as (key: string) => boolean;
+      expect(matcher("tenant:dashboard-analytics")).toBe(true);
+      expect(matcher("tenant:ogs-dashboard")).toBe(false);
+      expect(matcher("tenant:staff-dashboard-summary-month")).toBe(false);
     });
 
     it("invalidates dashboard caches on student_checkout event as a fallback", () => {
@@ -471,8 +484,25 @@ describe("useGlobalSSE", () => {
       expect(matcher("tenant:room-detail-12")).toBe(true);
       expect(matcher("tenant:tracking-supervisions-1")).toBe(true);
       expect(matcher("tenant:tracking-indicators-search")).toBe(true);
-      expect(matcher("tenant:dashboard")).toBe(true);
+      // #2057: no bare "dashboard" substring any more — dashboard-analytics
+      // is covered by the count-dashboard block, and the substring dragged
+      // ogs-dashboard + staff-dashboard-summary into every check-in.
+      expect(matcher("tenant:dashboard")).toBe(false);
+      expect(matcher("tenant:ogs-dashboard")).toBe(false);
       expect(matcher("tenant:timetable-week")).toBe(false);
+
+      // active_supervision_changed alone must NOT invalidate the per-group
+      // OGS student lists: it fires tenant-wide alongside every scoped
+      // dashboard_counts_changed, and honoring it would re-broaden every
+      // scoped event (#2057).
+      const ogsStudentsCall = mutateCalls.find((call) => {
+        const m = call[0];
+        return (
+          typeof m === "function" &&
+          (m as (key: string) => boolean)("tenant:ogs-students-5")
+        );
+      });
+      expect(ogsStudentsCall).toBeUndefined();
 
       const studentDetailCall = mutateCalls.find((call) => {
         const matcher = call[0];
@@ -503,10 +533,19 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("active-supervision-dashboard")
+          (matcher as (key: string) => boolean)(
+            "tenant:active-supervision-dashboard-0",
+          )
         );
       });
       expect(dashboardCall).toBeDefined();
+
+      const matcher = dashboardCall![0] as (key: string) => boolean;
+      expect(matcher("tenant:dashboard-analytics")).toBe(true);
+      // #2057: the OGS BFF must not ride the count events — its live data is
+      // covered by the (scoped) ogs-students refetch.
+      expect(matcher("tenant:ogs-dashboard")).toBe(false);
+      expect(matcher("tenant:staff-dashboard-summary-month")).toBe(false);
     });
 
     it("invalidates staff time-account caches after a work-session change", () => {
@@ -578,7 +617,9 @@ describe("useGlobalSSE", () => {
 
       vi.advanceTimersByTime(500);
 
-      // Find the mutate call with the ogs-students matcher
+      // Find the mutate call with the ogs-students matcher. The event carries
+      // no group_ids (old backend / student without OGS group), so the broad
+      // fallback must invalidate every group's list (#2057).
       const mutateCalls = vi.mocked(mutate).mock.calls;
       const ogsStudentCall = mutateCalls.find((call) => {
         const matcher = call[0];
@@ -592,9 +633,22 @@ describe("useGlobalSSE", () => {
       // Matcher must work with tenant-prefixed keys (useSWRAuth adds tenant slug prefix)
       const matcher = ogsStudentCall![0] as (key: string) => boolean;
       expect(matcher("my-tenant:ogs-students-5")).toBe(true);
-      expect(matcher("my-tenant:rooms-list")).toBe(true);
-      expect(matcher("my-tenant:tracking-supervisions-1-42,43")).toBe(true);
-      expect(matcher("my-tenant:tracking-indicators-search-group1")).toBe(true);
+
+      // The cross-group list caches live in their own mutate call since the
+      // ogs-students split (#2057) — same trigger, separate matcher.
+      const listCall = mutateCalls.find((call) => {
+        const m = call[0];
+        return (
+          typeof m === "function" &&
+          (m as (key: string) => boolean)("my-tenant:rooms-list")
+        );
+      });
+      expect(listCall).toBeDefined();
+      const listMatcher = listCall![0] as (key: string) => boolean;
+      expect(listMatcher("my-tenant:tracking-supervisions-1-42,43")).toBe(true);
+      expect(listMatcher("my-tenant:tracking-indicators-search-group1")).toBe(
+        true,
+      );
     });
 
     it("student_checkout without active_group_id invalidates dashboard caches", () => {
@@ -616,10 +670,16 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("active-supervision-dashboard")
+          (matcher as (key: string) => boolean)(
+            "tenant:active-supervision-dashboard-0",
+          )
         );
       });
       expect(dashboardCall).toBeDefined();
+
+      const matcher = dashboardCall![0] as (key: string) => boolean;
+      expect(matcher("tenant:dashboard-analytics")).toBe(true);
+      expect(matcher("tenant:ogs-dashboard")).toBe(false);
     });
 
     it("student_checkout without active_group_id invalidates student-detail cache", () => {
@@ -677,11 +737,18 @@ describe("useGlobalSSE", () => {
       });
       expect(studentListCall).toBeDefined();
 
-      const studentListMatcher = studentListCall![0] as (
-        key: string,
-      ) => boolean;
-      expect(studentListMatcher("my-tenant:search-students--")).toBe(true);
-      expect(studentListMatcher("my-tenant:database-students-list")).toBe(true);
+      // The cross-group list caches live in their own mutate call since the
+      // ogs-students split (#2057) — same trigger, separate matcher.
+      const searchListCall = mutateCalls.find((call) => {
+        const m = call[0];
+        return (
+          typeof m === "function" &&
+          (m as (key: string) => boolean)("my-tenant:search-students--")
+        );
+      });
+      expect(searchListCall).toBeDefined();
+      const searchListMatcher = searchListCall![0] as (key: string) => boolean;
+      expect(searchListMatcher("my-tenant:database-students-list")).toBe(true);
 
       const studentDetailCall = mutateCalls.find((call) => {
         const matcher = call[0];
@@ -1331,6 +1398,232 @@ describe("useGlobalSSE", () => {
       } finally {
         window.removeEventListener("phoenix:notification", listener);
       }
+    });
+  });
+
+  // #2057: scoped invalidation, jitter, and the request-herd regression guard.
+  describe("scoped OGS invalidation (#2057)", () => {
+    /** Fires an event through the captured onMessage callback. */
+    function fire(event: {
+      type: SSEEvent["type"];
+      active_group_id?: string;
+      data?: SSEEvent["data"];
+    }) {
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+      onMessage?.({
+        type: event.type,
+        active_group_id: event.active_group_id ?? "",
+        data: event.data ?? {},
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    /** Every key from the inventory that ANY recorded mutate matcher accepts. */
+    function matchedKeys(inventory: readonly string[]): string[] {
+      const matchers = vi
+        .mocked(mutate)
+        .mock.calls.map((call) => call[0])
+        .filter((m): m is (key: string) => boolean => typeof m === "function");
+      return inventory.filter((key) => matchers.some((m) => m(key)));
+    }
+
+    it("scopes ogs-students invalidation to the event's group_ids", () => {
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "dashboard_counts_changed",
+        data: { group_ids: ["7"] },
+      });
+      vi.advanceTimersByTime(500);
+
+      const keys = matchedKeys([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        // Exact-boundary matching: gid "7" must not hit group 70.
+        "tenant:ogs-students-70",
+        "tenant:ogs-dashboard",
+        "tenant:staff-dashboard-summary-month",
+        "tenant:dashboard-analytics",
+      ]);
+      expect(keys).toEqual([
+        "tenant:ogs-students-7",
+        "tenant:dashboard-analytics",
+      ]);
+    });
+
+    it("falls back to broad ogs-students invalidation when group_ids are absent", () => {
+      // Mixed-version safety: an old backend (or a student without an OGS
+      // group) sends no group_ids — every group's list must still refresh.
+      renderHook(() => useGlobalSSE());
+
+      fire({ type: "dashboard_counts_changed" });
+      vi.advanceTimersByTime(500);
+
+      const keys = matchedKeys([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        "tenant:ogs-dashboard",
+      ]);
+      expect(keys).toEqual(["tenant:ogs-students-7", "tenant:ogs-students-8"]);
+    });
+
+    it("keeps the backpressure fallback scoped: student_checkin with group_ids", () => {
+      // dashboard_counts_changed is best-effort; a delivered scoped
+      // student_checkin may be the only signal — it must invalidate the
+      // affected group without re-broadening.
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "student_checkin",
+        active_group_id: "123",
+        data: { student_id: "42", group_ids: ["7"] },
+      });
+      vi.advanceTimersByTime(500);
+
+      const keys = matchedKeys([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        "tenant:ogs-dashboard",
+        "tenant:student-detail-42",
+      ]);
+      expect(keys).toEqual([
+        "tenant:ogs-students-7",
+        "tenant:student-detail-42",
+      ]);
+    });
+
+    it("student_checkin without group_ids falls back to broad ogs-students invalidation", () => {
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "student_checkin",
+        active_group_id: "123",
+        data: { student_id: "42" },
+      });
+      vi.advanceTimersByTime(500);
+
+      const keys = matchedKeys([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        "tenant:ogs-dashboard",
+      ]);
+      expect(keys).toEqual(["tenant:ogs-students-7", "tenant:ogs-students-8"]);
+    });
+
+    it("bulk_student_checkout scopes to every carried group id", () => {
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "bulk_student_checkout",
+        active_group_id: "123",
+        data: { student_ids: ["42", "77"], group_ids: ["7", "9"] },
+      });
+      vi.advanceTimersByTime(500);
+
+      const keys = matchedKeys([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        "tenant:ogs-students-9",
+        "tenant:ogs-dashboard",
+      ]);
+      expect(keys).toEqual(["tenant:ogs-students-7", "tenant:ogs-students-9"]);
+    });
+
+    it("activity lifecycle events refresh ogs-students broadly and ogs-dashboard structurally", () => {
+      // Session lifecycle changes current_location across groups but carries
+      // no educational scope.
+      renderHook(() => useGlobalSSE());
+
+      fire({ type: "activity_end", active_group_id: "456" });
+      vi.advanceTimersByTime(500);
+
+      const keys = matchedKeys([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        "tenant:ogs-dashboard",
+      ]);
+      expect(keys).toEqual([
+        "tenant:ogs-students-7",
+        "tenant:ogs-students-8",
+        "tenant:ogs-dashboard",
+      ]);
+    });
+
+    it("request-budget guard: one scoped event touches nothing on a tab viewing another group", () => {
+      // The herd regression guard for the acceptance criteria: an OGS tab
+      // viewing group 8 while group 7's student checks in must refetch NOTHING
+      // (previously: 9 Go-API calls via ogs-dashboard + ogs-students-8).
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "dashboard_counts_changed",
+        data: { group_ids: ["7"] },
+      });
+      fire({
+        type: "active_supervision_changed",
+        active_group_id: "123",
+        data: { reason: "student_moved", student_id: "42" },
+      });
+      vi.advanceTimersByTime(500);
+
+      // Mounted-key inventory of an OGS tab viewing group 8.
+      const keys = matchedKeys([
+        "tenant:ogs-dashboard",
+        "tenant:ogs-students-8",
+      ]);
+      expect(keys).toEqual([]);
+    });
+
+    it("spreads the flush by the per-burst jitter", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.999);
+      renderHook(() => useGlobalSSE());
+
+      fire({ type: "dashboard_counts_changed", data: { group_ids: ["7"] } });
+
+      // Not at the bare debounce...
+      vi.advanceTimersByTime(500);
+      expect(mutate).not.toHaveBeenCalled();
+
+      // ...but within DEBOUNCE_MS + FLUSH_JITTER_MS.
+      vi.advanceTimersByTime(1000);
+      expect(mutate).toHaveBeenCalled();
+    });
+
+    it("collapses a jittered burst into a single flush", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      renderHook(() => useGlobalSSE());
+
+      for (let i = 0; i < 5; i++) {
+        fire({ type: "dashboard_counts_changed", data: { group_ids: ["7"] } });
+        vi.advanceTimersByTime(100);
+      }
+      expect(mutate).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1500);
+      const flushes = vi
+        .mocked(mutate)
+        .mock.calls.filter(
+          (call) =>
+            typeof call[0] === "function" &&
+            (call[0] as (key: string) => boolean)("tenant:ogs-students-7"),
+        );
+      expect(flushes).toHaveLength(1);
+    });
+
+    it("caps a sustained event stream at MAX_FLUSH_WAIT_MS", () => {
+      // A morning check-in rush must not starve the flush: the trailing
+      // debounce keeps resetting, but the first flush arrives no later than
+      // MAX_FLUSH_WAIT_MS after the burst began.
+      renderHook(() => useGlobalSSE());
+
+      // Events every 400ms for 2.8s — each re-arms the 500ms debounce, so an
+      // uncapped implementation would not have flushed by t=3000.
+      for (let i = 0; i < 8; i++) {
+        fire({ type: "dashboard_counts_changed", data: { group_ids: ["7"] } });
+        vi.advanceTimersByTime(400);
+      }
+      // t=3200 > MAX_FLUSH_WAIT_MS: the capped flush has fired.
+      expect(mutate).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -40,7 +40,12 @@ vi.mock("~/lib/hooks/use-sse", () => ({
 }));
 
 // Import after mocking
-import { useGlobalSSE } from "../use-global-sse";
+import {
+  useGlobalSSE,
+  DEBOUNCE_MS,
+  FLUSH_JITTER_MS,
+  MAX_FLUSH_WAIT_MS,
+} from "../use-global-sse";
 import { useSSE } from "~/lib/hooks/use-sse";
 import { mutate } from "swr";
 import { useSession } from "next-auth/react";
@@ -1581,11 +1586,11 @@ describe("useGlobalSSE", () => {
       fire({ type: "dashboard_counts_changed", data: { group_ids: ["7"] } });
 
       // Not at the bare debounce...
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(DEBOUNCE_MS);
       expect(mutate).not.toHaveBeenCalled();
 
       // ...but within DEBOUNCE_MS + FLUSH_JITTER_MS.
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(FLUSH_JITTER_MS);
       expect(mutate).toHaveBeenCalled();
     });
 
@@ -1599,7 +1604,7 @@ describe("useGlobalSSE", () => {
       }
       expect(mutate).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(1500);
+      vi.advanceTimersByTime(DEBOUNCE_MS + FLUSH_JITTER_MS);
       const flushes = vi
         .mocked(mutate)
         .mock.calls.filter(
@@ -1616,13 +1621,15 @@ describe("useGlobalSSE", () => {
       // MAX_FLUSH_WAIT_MS after the burst began.
       renderHook(() => useGlobalSSE());
 
-      // Events every 400ms for 2.8s — each re-arms the 500ms debounce, so an
-      // uncapped implementation would not have flushed by t=3000.
-      for (let i = 0; i < 8; i++) {
+      // Events every 400ms past the cap — each re-arms the debounce, so an
+      // uncapped implementation would not have flushed by MAX_FLUSH_WAIT_MS.
+      const step = 400;
+      const steps = Math.ceil(MAX_FLUSH_WAIT_MS / step) + 1;
+      for (let i = 0; i < steps; i++) {
         fire({ type: "dashboard_counts_changed", data: { group_ids: ["7"] } });
-        vi.advanceTimersByTime(400);
+        vi.advanceTimersByTime(step);
       }
-      // t=3200 > MAX_FLUSH_WAIT_MS: the capped flush has fired.
+      // Elapsed > MAX_FLUSH_WAIT_MS: the capped flush has fired.
       expect(mutate).toHaveBeenCalled();
     });
   });

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -103,6 +103,10 @@ function fireSSE(event: SSEEvent) {
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.clearAllMocks();
+  // Pin the per-burst flush jitter (#2057) to 0 so the existing
+  // advanceTimersByTime(500) timing assertions stay deterministic. Jitter
+  // bounds get their own explicit tests.
+  vi.spyOn(Math, "random").mockReturnValue(0);
   mockUseSession.mockReturnValue(authenticatedSession());
   // Re-wire the useSSE mock after clearAllMocks
   mockUseSSE.mockImplementation(
@@ -120,6 +124,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -37,7 +37,29 @@ import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "GlobalSSE" });
 
-const DEBOUNCE_MS = 500;
+export const DEBOUNCE_MS = 500;
+// Bounded random jitter added on top of the debounce (#2057). Every client of
+// a tenant receives the same broadcast at the same instant; without jitter all
+// of them fired their revalidations exactly DEBOUNCE_MS later, producing
+// synchronized request herds (85 req/s bursts, saturated DB pool). The jitter
+// is drawn ONCE per burst so the trailing debounce still collapses a burst
+// into a single flush.
+export const FLUSH_JITTER_MS = 1000;
+// Upper bound on how long a sustained event stream (morning check-in rush) can
+// keep postponing the flush. Measured from the first event of a burst.
+export const MAX_FLUSH_WAIT_MS = 3000;
+
+// The dashboard caches that reflect live check-in/out counts. Deliberately an
+// explicit list instead of the old `key.includes("dashboard")`: that substring
+// also matched "ogs-dashboard" (the OGS page's 5-request BFF, whose live data
+// is already covered by the scoped ogs-students-{gid} refetch) and
+// "staff-dashboard-summary-" (staff time tracking, which has its own
+// staff_time_tracking_changed trigger + refresh interval) — refetching both on
+// every check-in was a large part of the #2057 request herd.
+const DASHBOARD_COUNT_CACHE_KEYS = [
+  "dashboard-analytics",
+  "active-supervision-dashboard-",
+] as const;
 
 // Every cache family derived from work sessions, absences, balance
 // adjustments, month-close snapshots, contractual schedules, or planned
@@ -74,8 +96,11 @@ const STUDENT_SCOPED_KEY_PREFIXES = [
   "care-plan-week-",
 ] as const;
 
+// The per-group student list on the OGS page ("<slug>:ogs-students-7").
+const OGS_STUDENTS_KEY_PREFIX = "ogs-students-";
+
 /**
- * Whether an SWR cache key belongs to exactly this student.
+ * Whether an SWR cache key belongs to exactly this id (student or group).
  *
  * A plain `key.includes("care-plan-day-" + id)` matches every id that merely
  * STARTS with it, so an event for child 1 also revalidated the cached plans of
@@ -84,12 +109,16 @@ const STUDENT_SCOPED_KEY_PREFIXES = [
  * The id must therefore end the key or be followed by "-", and the prefix must
  * start the key or sit right after the tenant separator.
  *
- * Only usable for events whose audience is ALREADY scoped to the child — the
- * group-topic check-in/checkout events. A tenant-wide event (pickup) must not
- * carry a student id at all (GDPR: group_supervisors_only), so it cannot and
- * does not go through here.
+ * Two id spaces go through here, with different privacy rules:
+ * - student ids, only from events whose audience is ALREADY scoped to the
+ *   child (group-topic check-in/checkout events). A tenant-wide event
+ *   (pickup) must not carry a student id at all (GDPR:
+ *   group_supervisors_only).
+ * - educational group ids ("ogs-students-{gid}", #2057), which legitimately
+ *   ride the tenant-wide dashboard_counts_changed event — a group id reveals
+ *   "counts in group X changed", never a child's identity.
  */
-function keyTargetsStudent(
+function keyTargetsId(
   key: string,
   studentId: string,
   prefixes: readonly string[] = STUDENT_SCOPED_KEY_PREFIXES,
@@ -145,8 +174,19 @@ export function useGlobalSSE(): SSEHookState {
     (isStaff || isAdmin);
 
   // Debounce state: collect affected group IDs, flush once after DEBOUNCE_MS
+  // (+ per-burst jitter). pendingGroupIds holds ACTIVE-group ids (activity
+  // session topics); pendingEduGroupIds holds EDUCATIONAL (OGS) group ids from
+  // event.data.group_ids — different tables with overlapping id ranges, never
+  // mix them (#2057).
   const pendingGroupIds = useRef(new Set<string>());
   const pendingStudentIds = useRef(new Set<string>());
+  // Educational group ids whose ogs-students-{gid} caches need revalidation.
+  const pendingEduGroupIds = useRef(new Set<string>());
+  // Set when a count-affecting event arrives WITHOUT educational group scope
+  // (old backend during a mixed-version deploy, a student without an OGS
+  // group, activity lifecycle events). Falls back to the pre-#2057 broad
+  // ogs-students-* invalidation so correctness never depends on the payload.
+  const hasPendingBroadOgsEvent = useRef(false);
   const hasPendingActivityEvent = useRef(false);
   const hasPendingActiveSupervisionEvent = useRef(false);
   const hasPendingDashboardEvent = useRef(false);
@@ -165,6 +205,10 @@ export function useGlobalSSE(): SSEHookState {
   const hasPendingCompanionEvent = useRef(false);
   const hasPendingTimetableEvent = useRef(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Per-burst flush state (#2057): jitter drawn once when a burst starts, and
+  // the burst's start time for the MAX_FLUSH_WAIT_MS cap.
+  const burstStartedAt = useRef(0);
+  const burstJitter = useRef(0);
 
   // SWR cache keys are tenant-prefixed by useSWRAuth (e.g. "tenant-slug:ogs-students-2").
   // All matchers must use includes() instead of startsWith() to match regardless of prefix.
@@ -200,30 +244,71 @@ export function useGlobalSSE(): SSEHookState {
       });
     }
 
-    // Invalidate student list caches so "Meine Gruppe" and students/search
-    // pick up location changes (e.g. Zuhause) without a manual refresh.
-    // Also invalidate tracking indicator caches on active-supervisions
-    // (tracking-supervisions-*) and students/search (tracking-indicators-*).
-    // Triggered by pendingGroupIds (room-level events), pendingStudentIds
-    // (daily checkout sends student_checkout without an active_group_id),
-    // or hasPendingDashboardEvent (dashboard_counts_changed is broadcast
-    // to ALL clients on every check-in/out — ensures search page updates
-    // even when the user doesn't supervise the affected room/group).
+    // Invalidate the per-group OGS student lists ("Meine Gruppe"). Scoped
+    // (#2057): when every pending count event carried its educational group
+    // ids, only those groups' ogs-students-{gid} caches revalidate — a tab
+    // viewing another group refetches nothing. The broad fallback covers
+    // events without group scope (old backend, students without an OGS group,
+    // activity lifecycle) and the structural events (arrival/pickup/student
+    // update) whose payload can never carry a scope.
+    //
+    // Deliberately NOT triggered by pendingGroupIds/pendingStudentIds: those
+    // are fed by the tenant-wide active_supervision_changed too, which fires
+    // alongside every dashboard_counts_changed — keeping them as triggers
+    // would re-broaden every scoped event and save nothing.
+    {
+      const broadOgs =
+        hasPendingBroadOgsEvent.current ||
+        hasPendingArrivalScheduleEvent.current ||
+        // A Gehzeit change moves the pickup time the list rows render
+        // (student list responses carry it for full-access rows).
+        hasPendingPickupScheduleEvent.current ||
+        hasPendingStudentUpdateEvent.current;
+      const scopedEduGroupIds = new Set(pendingEduGroupIds.current);
+      if (broadOgs || scopedEduGroupIds.size > 0) {
+        mutate(
+          (key) =>
+            typeof key === "string" &&
+            (broadOgs
+              ? key.includes(OGS_STUDENTS_KEY_PREFIX)
+              : // Exact-boundary match per group id: gid "1" must not
+                // revalidate "ogs-students-10" (same lesson as the
+                // per-student keys below).
+                [...scopedEduGroupIds].some((gid) =>
+                  keyTargetsId(key, gid, [OGS_STUDENTS_KEY_PREFIX]),
+                )),
+        ).catch((err) => {
+          logger.debug("swr_revalidation_failed", {
+            error: err instanceof Error ? err.message : String(err),
+            scope: "ogs_students",
+          });
+        });
+      }
+    }
+
+    // Invalidate the cross-group student list caches so students/search and
+    // the room views pick up location changes (e.g. Zuhause) without a manual
+    // refresh. Also invalidate tracking indicator caches on
+    // active-supervisions (tracking-supervisions-*) and students/search
+    // (tracking-indicators-*). Triggered by pendingGroupIds (room-level
+    // events), pendingStudentIds (daily checkout sends student_checkout
+    // without an active_group_id), or hasPendingDashboardEvent
+    // (dashboard_counts_changed reaches every client of the tenant on every
+    // check-in/out — ensures search page updates even when the user doesn't
+    // supervise the affected room/group). These caches cannot be scoped by
+    // group id, but each is mounted only on its own page.
     if (
       pendingGroupIds.current.size > 0 ||
       pendingStudentIds.current.size > 0 ||
       hasPendingDashboardEvent.current ||
       hasPendingArrivalScheduleEvent.current ||
-      // A Gehzeit change moves the pickup time the list rows render (student
-      // list responses carry it for full-access rows).
       hasPendingPickupScheduleEvent.current ||
       hasPendingStudentUpdateEvent.current
     ) {
       mutate(
         (key) =>
           typeof key === "string" &&
-          (key.includes("ogs-students-") ||
-            key.includes("database-students-list") ||
+          (key.includes("database-students-list") ||
             key.includes("search-students-") ||
             key.includes("tracking-supervisions-") ||
             key.includes("tracking-indicators-") ||
@@ -245,11 +330,15 @@ export function useGlobalSSE(): SSEHookState {
             // Room overview cards on /rooms use their own direct rooms
             // list cache. A room move changes studentCount there even
             // though the Room entity itself did not change.
+            // (ROOM_LIST_CACHE_KEYS = the three /api/rooms list caches —
+            // NOT room-derived-caches' ROOM_DERIVED_CACHE_KEY_FRAGMENTS,
+            // which contains "ogs-dashboard"/"ogs-students-" and would
+            // silently re-broaden the #2057 scoping if swapped in.)
             ROOM_LIST_CACHE_KEYS.some((cacheKey) => key.includes(cacheKey))),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
-          scope: "ogs_students",
+          scope: "student_lists",
         });
       });
     }
@@ -260,7 +349,7 @@ export function useGlobalSSE(): SSEHookState {
     // and matches the id as a whole segment, never as a prefix of a longer id.
     for (const studentId of pendingStudentIds.current) {
       mutate(
-        (key) => typeof key === "string" && keyTargetsStudent(key, studentId),
+        (key) => typeof key === "string" && keyTargetsId(key, studentId),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -411,10 +500,14 @@ export function useGlobalSSE(): SSEHookState {
       }
     }
 
-    // Invalidate dashboard for activity events, explicit dashboard broadcasts,
-    // and student movement fallbacks. BroadcastToAll is best-effort, so a
-    // delivered student_checkin/student_checkout may be the only signal that
-    // counts changed if dashboard_counts_changed gets dropped under backpressure.
+    // Invalidate the count dashboards for activity events, explicit dashboard
+    // broadcasts, and student movement fallbacks. The tenant broadcast is
+    // best-effort, so a delivered student_checkin/student_checkout may be the
+    // only signal that counts changed if dashboard_counts_changed gets
+    // dropped under backpressure. Matches the explicit
+    // DASHBOARD_COUNT_CACHE_KEYS list — NOT every key containing "dashboard"
+    // (see the constant's comment; the old substring match dragged the OGS
+    // BFF and staff time tracking into every check-in, #2057).
     if (
       pendingGroupIds.current.size > 0 ||
       pendingStudentIds.current.size > 0 ||
@@ -426,11 +519,36 @@ export function useGlobalSSE(): SSEHookState {
       hasPendingStudentUpdateEvent.current
     ) {
       mutate(
-        (key) => typeof key === "string" && key.includes("dashboard"),
+        (key) =>
+          typeof key === "string" &&
+          DASHBOARD_COUNT_CACHE_KEYS.some((cacheKey) => key.includes(cacheKey)),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
           scope: "dashboard",
+        });
+      });
+    }
+
+    // The OGS BFF ("ogs-dashboard") aggregates the group list, substitutions,
+    // and the first group's students/arrival/pickup data. Its live per-group
+    // half is covered by the scoped ogs-students-{gid} refetch above, so it
+    // deliberately does NOT ride the check-in/count events any more (#2057 —
+    // that double fetch was the 9-requests-per-tab herd). It still refetches
+    // on the low-frequency structural events whose writes change its payload:
+    // student edits (name/group membership), arrival plans, and activity
+    // lifecycle (room occupancy of the group room).
+    if (
+      hasPendingStudentUpdateEvent.current ||
+      hasPendingArrivalScheduleEvent.current ||
+      hasPendingActivityEvent.current
+    ) {
+      mutate(
+        (key) => typeof key === "string" && key.includes("ogs-dashboard"),
+      ).catch((err) => {
+        logger.debug("swr_revalidation_failed", {
+          error: err instanceof Error ? err.message : String(err),
+          scope: "ogs_dashboard",
         });
       });
     }
@@ -456,6 +574,10 @@ export function useGlobalSSE(): SSEHookState {
     }
 
     if (hasPendingActiveSupervisionEvent.current) {
+      // No bare "dashboard" substring here (#2057): dashboard-analytics is
+      // already covered by the count-dashboard block above (its trigger list
+      // includes hasPendingActiveSupervisionEvent), and the old substring
+      // dragged ogs-dashboard + staff-dashboard-summary into every check-in.
       mutate(
         (key) =>
           typeof key === "string" &&
@@ -464,8 +586,7 @@ export function useGlobalSSE(): SSEHookState {
             key.includes("timetable-roster-") ||
             key.includes("room-detail-") ||
             key.includes("tracking-supervisions-") ||
-            key.includes("tracking-indicators-") ||
-            key.includes("dashboard")),
+            key.includes("tracking-indicators-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -542,6 +663,8 @@ export function useGlobalSSE(): SSEHookState {
     // Reset pending state
     pendingGroupIds.current.clear();
     pendingStudentIds.current.clear();
+    pendingEduGroupIds.current.clear();
+    hasPendingBroadOgsEvent.current = false;
     hasPendingActivityEvent.current = false;
     hasPendingActiveSupervisionEvent.current = false;
     hasPendingDashboardEvent.current = false;
@@ -555,9 +678,49 @@ export function useGlobalSSE(): SSEHookState {
   }, []);
 
   const scheduleFlush = useCallback(() => {
-    if (debounceTimer.current) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(flushInvalidations, DEBOUNCE_MS);
+    const now = Date.now();
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    } else {
+      // First event of a burst: draw the jitter once and remember the burst
+      // start. Re-drawing per event would make the effective delay drift
+      // upward during a burst; drawing once keeps "burst collapses into one
+      // flush" intact while still spreading DIFFERENT clients across the
+      // jitter window (#2057 — every client receives the same broadcast at
+      // the same instant, so a fixed delay produced synchronized herds).
+      burstStartedAt.current = now;
+      burstJitter.current = Math.random() * FLUSH_JITTER_MS;
+    }
+    // Trailing debounce with an upper bound: a sustained event stream
+    // (morning rush) keeps pushing the flush back, but never beyond
+    // MAX_FLUSH_WAIT_MS after the burst began.
+    const target = Math.min(
+      now + DEBOUNCE_MS + burstJitter.current,
+      burstStartedAt.current + MAX_FLUSH_WAIT_MS,
+    );
+    debounceTimer.current = setTimeout(
+      () => {
+        debounceTimer.current = null;
+        flushInvalidations();
+      },
+      Math.max(0, target - now),
+    );
   }, [flushInvalidations]);
+
+  // Records the educational-group scope of a count-affecting event (#2057):
+  // known group ids feed the scoped ogs-students-{gid} invalidation; a
+  // missing/empty list flags the broad fallback so correctness never depends
+  // on the payload (old backend during a mixed-version deploy, students
+  // without an OGS group).
+  const collectEduGroupScope = useCallback((groupIds: string[] | undefined) => {
+    if (groupIds && groupIds.length > 0) {
+      for (const gid of groupIds) {
+        pendingEduGroupIds.current.add(gid);
+      }
+    } else {
+      hasPendingBroadOgsEvent.current = true;
+    }
+  }, []);
 
   // Handle SSE events by collecting targeted invalidations
   const handleSSEEvent = useCallback(
@@ -573,6 +736,12 @@ export function useGlobalSSE(): SSEHookState {
           if (event.data.student_id) {
             pendingStudentIds.current.add(event.data.student_id);
           }
+          // Scope the ogs-students-{gid} invalidation to the affected
+          // educational groups (#2057). These group-topic events carry the
+          // scope so the invalidation stays scoped even when the companion
+          // dashboard_counts_changed gets dropped under backpressure. An old
+          // backend sends no group_ids → broad fallback.
+          collectEduGroupScope(event.data.group_ids);
           // Daily "nach Hause" checkout emits only student_checkout on the
           // educational group topic without a companion dashboard event.
           if (event.type === "student_checkout" && !event.active_group_id) {
@@ -595,6 +764,7 @@ export function useGlobalSSE(): SSEHookState {
               pendingStudentIds.current.add(id);
             }
           }
+          collectEduGroupScope(event.data.group_ids);
           scheduleFlush();
           break;
         }
@@ -618,6 +788,13 @@ export function useGlobalSSE(): SSEHookState {
             pendingGroupIds.current.add(event.active_group_id);
           }
           hasPendingActivityEvent.current = true;
+          // Session lifecycle changes the current_location of the group's
+          // children but carries no educational group scope — refresh the
+          // OGS lists broadly. Explicit on purpose: the ogs-students clause
+          // no longer listens to pendingGroupIds (see flushInvalidations),
+          // and relying on the id-less companion dashboard event would be an
+          // implicit coupling.
+          hasPendingBroadOgsEvent.current = true;
           scheduleFlush();
           break;
         }
@@ -635,9 +812,15 @@ export function useGlobalSSE(): SSEHookState {
         }
 
         case "dashboard_counts_changed": {
-          // Global event from BroadcastToAll — only refresh dashboard counts,
-          // NOT room/supervision/active caches (those are for activity events).
+          // Tenant-wide broadcast on every check-in/out — only refresh
+          // dashboard counts and the (scoped) OGS student lists, NOT
+          // room/supervision/active caches (those are for activity events).
+          // group_ids carries the affected educational groups (#2057) so the
+          // ogs-students invalidation can skip every other group's tab; an
+          // event without them (old backend, activity lifecycle, student
+          // without OGS group) falls back to the broad refresh.
           hasPendingDashboardEvent.current = true;
+          collectEduGroupScope(event.data.group_ids);
           scheduleFlush();
           break;
         }
@@ -754,7 +937,7 @@ export function useGlobalSSE(): SSEHookState {
         }
       }
     },
-    [scheduleFlush],
+    [scheduleFlush, collectEduGroupScope],
   );
 
   // Use the underlying SSE hook with global event handler.

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -689,7 +689,7 @@ export function useGlobalSSE(): SSEHookState {
       // jitter window (#2057 — every client receives the same broadcast at
       // the same instant, so a fixed delay produced synchronized herds).
       burstStartedAt.current = now;
-      burstJitter.current = Math.random() * FLUSH_JITTER_MS;
+      burstJitter.current = Math.random() * FLUSH_JITTER_MS; // NOSONAR typescript:S2245 non-cryptographic load-spreading jitter, no security context
     }
     // Trailing debounce with an upper bound: a sustained event stream
     // (morning rush) keeps pushing the flush back, but never beyond

--- a/frontend/src/lib/hooks/use-sse.ts
+++ b/frontend/src/lib/hooks/use-sse.ts
@@ -229,7 +229,12 @@ export function useSSE(
           const currentAttempts = reconnectAttemptsRef.current;
 
           if (currentAttempts < maxReconnectAttempts) {
-            const delay = reconnectInterval * Math.pow(2, currentAttempts);
+            // Exponential backoff with proportional jitter (up to +100% of the
+            // base delay): a backend restart drops every client of the
+            // deployment at the same instant, and without jitter they all
+            // reconnected — and revalidated — in synchronized waves (#2057).
+            const base = reconnectInterval * Math.pow(2, currentAttempts);
+            const delay = base + Math.random() * base;
 
             // Update both ref (for next closure) and state (for UI)
             reconnectAttemptsRef.current = currentAttempts + 1;

--- a/frontend/src/lib/hooks/use-sse.ts
+++ b/frontend/src/lib/hooks/use-sse.ts
@@ -234,7 +234,7 @@ export function useSSE(
             // deployment at the same instant, and without jitter they all
             // reconnected — and revalidated — in synchronized waves (#2057).
             const base = reconnectInterval * Math.pow(2, currentAttempts);
-            const delay = base + Math.random() * base;
+            const delay = base + Math.random() * base; // NOSONAR typescript:S2245 non-cryptographic reconnect jitter, no security context
 
             // Update both ref (for next closure) and state (for UI)
             reconnectAttemptsRef.current = currentAttempts + 1;

--- a/frontend/src/lib/sse-types.ts
+++ b/frontend/src/lib/sse-types.ts
@@ -86,6 +86,15 @@ interface SSEEventData {
   // Affected students on a bulk_student_checkout event (whole-session end).
   student_ids?: string[];
 
+  // Affected educational (OGS) group ids on dashboard_counts_changed /
+  // student_checkin / student_checkout / bulk_student_checkout (#2057).
+  // Group ids only — never student identity — so the tenant-wide
+  // dashboard_counts_changed stays GDPR-safe. Clients scope their
+  // ogs-students-{gid} revalidation to these ids; an ABSENT field means
+  // "scope unknown → refresh broadly" (old backends, activity events,
+  // students without an OGS group). The backend never sends an empty array.
+  group_ids?: string[];
+
   // Activity session fields (for activity_start/end/update events)
   activity_name?: string;
   room_id?: string;


### PR DESCRIPTION
Closes #2057

## Problem

Ein `dashboard_counts_changed` ging bei jedem Check-in/out per `BroadcastToAll` an **alle Clients aller Schulen** (Payload leer). Jeder Client invalidierte nach exakt 500 ms sowohl alle `ogs-students-*`-Keys als auch alle Keys mit `dashboard` im Namen. Auf der OGS-Seite sind `ogs-dashboard` (BFF, 5 Go-Calls) und `ogs-students-{gid}` (4 Go-Calls) gleichzeitig aktiv: bis zu 9 Go-API-Calls pro Tab pro Event, synchronisiert über alle Clients (Produktionsbenchmark 2026-07-09: 85 req/s-Bursts, Pool 25/25, p95 741 ms bei 29,6 % CPU).

Zwei bei der Analyse gefundene Verstärker: `BroadcastToAll` ist mandantenübergreifend (jede Schule refetcht bei jeder anderen Schule), und das an denselben Stellen gefeuerte `active_supervision_changed` traf über `key.includes("dashboard")` und die Pending-Sets dieselben Caches noch einmal.

## Lösung

**Backend**
- `dashboard_counts_changed` läuft jetzt über `BroadcastToTenant` und trägt `group_ids` (Bildungsgruppen-IDs der betroffenen Kinder — nur Gruppen-IDs, nie Schülexidentität; GDPR-Kontrakt im Code dokumentiert). Fehlendes Feld = „Scope unbekannt → breit refetchen"; nie ein leeres Array.
- `student_checkin`/`student_checkout`/`bulk_student_checkout` tragen dieselben `group_ids`, damit der Backpressure-Fallback des Clients (Counts-Event verworfen, Checkin-Event zugestellt) ebenfalls scoped bleibt.
- `activity_start`/`activity_end` senden bewusst ohne Scope (Raumbelegung ändert sich gruppenübergreifend → breiter Refresh).
- Abandoned-Session-Cleanup stempelt die Tenant-ID der Session in den Context; der CLI-Pfad verliert seine (jetzt tenant-gebundenen) Broadcasts nicht mehr.

**Frontend (`use-global-sse.ts`)**
- `ogs-students-{gid}` wird nur noch für die im Event genannten Gruppen invalidiert (exakte ID-Grenzen: „1" matcht nicht `ogs-students-10`). Broad-Fallback bei Events ohne Scope, bei Arrival/Pickup/Student-Update und bei Activity-Lifecycle. `active_supervision_changed` triggert diesen Block nicht mehr.
- Beide `key.includes("dashboard")`-Prädikate sind auf eine explizite Liste (`dashboard-analytics`, `active-supervision-dashboard-`) verengt. `ogs-dashboard` und `staff-dashboard-summary-*` reiten nicht mehr auf jedem Check-in mit; `ogs-dashboard` refetcht bei strukturellen Events (student_updated, arrival, activity) plus 5-Minuten-Intervall als Sicherheitsnetz (Gruppen-Übergaben senden bisher KEIN SSE-Event, siehe Follow-ups).
- Flush-Debounce mit begrenztem Zufalls-Jitter (500–1500 ms, einmal pro Burst gezogen) und 3-s-Obergrenze gegen Starvation im Morgen-Burst; SSE-Reconnect-Backoff mit proportionalem Jitter.
- Die OGS-Seite seedet Students/Pickup/RoomStatus genau einmal aus dem BFF; danach ist `ogs-students-{gid}` alleiniger Schreiber (kein Zurückblitzen minutenalter BFF-Daten beim Gruppenwechsel).

## Akzeptanzkriterien

| AC | Nachweis |
|---|---|
| Kein doppelter Students-/Room-/Pickup-Refetch pro OGS-Tab | E2E: Check-in → genau eine Welle (students, room-status, pickup, tracking), kein `/api/ogs-dashboard`-Refetch. Unit: Request-Budget-Test |
| Nicht betroffene Gruppen laden nichts neu | E2E: Tab auf Bärengruppe bei Check-in in Sternengruppe → **0** Requests. Unit: Scoping-Tests inkl. ID-Grenzen |
| Recovery nicht alle nach exakt 500 ms | Per-Burst-Jitter 500–1500 ms + Reconnect-Jitter; Jitter-Bounds-Tests |
| Tests für counts-Event, direkte Check-in/out-Events, Backpressure-Fallback | Neue Suite „scoped OGS invalidation (#2057)" + aktualisierte Bestandstests (Backend: `broadcast_test.go` mit `group_ids`-/Tenant-Assertions) |
| Burst ohne DB-Pool-Waits | Lokal: 4-Scan-Burst → eine Welle, `capacity snapshot` durchgehend `db_wait_count=0`. Staging-Benchmark-Wiederholung steht als Follow-up aus |

## E2E-Verifikation (lokaler Stack, 2 parallele Browser-Sessions)

- Betreuer A (Sternengruppe) + Betreuer B (Bärengruppe), IoT-Check-in via Device-API: A refetcht eine gescopte Welle und zeigt das Kind live im Raum; B bleibt bei 0 Requests.
- 4 Scans in <1 s → eine einzige Welle bei A, weiterhin 0 bei B.
- Session-Ende (Bulk-Checkout + activity_end) → je eine breite Welle pro Client (gewollt).

## Bewusste Trade-offs

- Anwesenheits-Zähler einer NICHT betrachteten Gruppe in der Sidebar aktualisiert sich nur noch über das 5-Minuten-Intervall bzw. beim Gruppenwechsel (vorher: Vollrefetch des BFF bei jedem Check-in irgendeiner Gruppe).
- Bestehende Tests, die das alte Broad-Invalidation-Verhalten festschrieben, wurden gemäß Issue-Auftrag auf den neuen Kontrakt aktualisiert.

## Follow-ups (separate Issues)

1. #2084 `substitution_changed`-SSE-Event für Gruppen-Übergaben (aktuell nur durch das 5-Minuten-Intervall abgedeckt).
2. #2085 `active_supervision_changed` trägt tenantweit eine `student_id`, entgegen dem GDPR-Kommentar zu tenantweiten Events (Bestandsbefund, hier nicht angefasst).
3. #2086 Pickup-Times aus dem `ogs-students`-Composite-Fetcher in einen eigenen, nur bei Pickup-/Arrival-Events invalidierten Key ausgliedern (spart 1 von 4 Calls der verbleibenden Welle).
4. #2087 Staging-Benchmark (85 req/s) wiederholen.
