### PR TITLE
Reject invalid tenant paths before resolution

### DIFF
--- a/frontend/src/app/[tenant]/layout.test.tsx
+++ b/frontend/src/app/[tenant]/layout.test.tsx
@@ -1,13 +1,34 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { notFoundMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn((): never => {
+    throw new Error("NEXT_HTTP_ERROR_FALLBACK;404");
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers({ host: "school-a.localhost:3000" })),
+}));
 
 vi.mock("~/env", () => ({
   env: {
+    API_URL: "http://server:8080",
     NODE_ENV: "development",
     TENANT_DOMAIN: "localhost",
   },
 }));
 
-const { bareTenantHost } = await import("./layout");
+const { bareTenantHost, default: TenantLayout } = await import("./layout");
+
+beforeEach(() => {
+  notFoundMock.mockClear();
+  vi.restoreAllMocks();
+});
 
 describe("bareTenantHost", () => {
   it("strips an invalid local tenant subdomain and keeps the port", () => {
@@ -16,5 +37,69 @@ describe("bareTenantHost", () => {
 
   it("keeps the bare tenant domain unchanged", () => {
     expect(bareTenantHost("localhost:3000")).toBe("localhost:3000");
+  });
+});
+
+describe("TenantLayout", () => {
+  it.each(["wp-trackback.php", "__status", "School-a", "a".repeat(64)])(
+    "returns 404 for invalid tenant path %s without resolving it",
+    async (tenant) => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      await expect(
+        TenantLayout({ children: null, params: Promise.resolve({ tenant }) }),
+      ).rejects.toThrow("NEXT_HTTP_ERROR_FALLBACK;404");
+
+      expect(notFoundMock).toHaveBeenCalledOnce();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns 404 for a reserved tenant path without resolving it", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      TenantLayout({
+        children: null,
+        params: Promise.resolve({ tenant: "operator" }),
+      }),
+    ).rejects.toThrow("NEXT_HTTP_ERROR_FALLBACK;404");
+
+    expect(notFoundMock).toHaveBeenCalledOnce();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("still resolves a syntactically valid tenant path", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: {
+            tenant_id: 1,
+            slug: "school-a",
+            name: "School A",
+            subdomain: "school-a",
+            organization_id: 2,
+            organization_name: "Organization",
+            settings: {},
+            grade_level_max: 4,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      TenantLayout({
+        children: null,
+        params: Promise.resolve({ tenant: "school-a" }),
+      }),
+    ).resolves.toBeTruthy();
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://server:8080/auth/tenant/resolve?slug=school-a",
+      { next: { revalidate: 300, tags: ["tenant-school-a"] } },
+    );
   });
 });

--- a/frontend/src/app/[tenant]/layout.tsx
+++ b/frontend/src/app/[tenant]/layout.tsx
@@ -5,6 +5,7 @@ import { TenantProviders } from "./providers";
 import type { TenantInfo, TenantSettings } from "~/lib/tenant-api";
 import { normalizePresenceMode } from "~/lib/tenant-api";
 import { RESERVED_SLUGS } from "~/lib/reserved-slugs";
+import { isValidTenantSlug } from "~/lib/tenant-slug";
 import { env } from "~/env";
 
 interface TenantResolveResponse {
@@ -128,10 +129,10 @@ export default async function TenantLayout({
 }) {
   const { tenant: tenantSlug } = await params;
 
-  // Block reserved slugs from being resolved as tenants. Without this,
-  // Next.js [tenant] dynamic segment catches paths like "/operator" and
-  // renders the tenant dashboard instead of the operator dashboard.
-  if (RESERVED_SLUGS.has(tenantSlug)) {
+  // The dynamic segment also catches scanner probes such as
+  // /wp-trackback.php. Reject values that cannot be tenant subdomains before
+  // they consume the shared tenant-resolution cache or backend rate limit.
+  if (!isValidTenantSlug(tenantSlug) || RESERVED_SLUGS.has(tenantSlug)) {
     notFound();
   }
 

--- a/frontend/src/lib/tenant-slug.test.ts
+++ b/frontend/src/lib/tenant-slug.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isValidTenantSlug } from "./tenant-slug";
+
+describe("isValidTenantSlug", () => {
+  it.each(["school-a", "a", "1", "abc-123-def", "a".repeat(63)])(
+    "accepts the valid tenant slug %s",
+    (slug) => {
+      expect(isValidTenantSlug(slug)).toBe(true);
+    },
+  );
+
+  it.each([
+    "",
+    "wp-trackback.php",
+    "__status",
+    "School-a",
+    "-school-a",
+    "school-a-",
+    "müller",
+    "a".repeat(64),
+  ])("rejects the invalid tenant slug %s", (slug) => {
+    expect(isValidTenantSlug(slug)).toBe(false);
+  });
+});

--- a/frontend/src/lib/tenant-slug.ts
+++ b/frontend/src/lib/tenant-slug.ts
@@ -1,0 +1,11 @@
+// Tenant resolution uses the school's subdomain, which is a DNS label.
+// Keep this in sync with backend/models/platform/organization.go slugRegex
+// and backend/models/platform/school.go's DNS label length check.
+const TENANT_SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const MAX_TENANT_SLUG_LENGTH = 63;
+
+export function isValidTenantSlug(slug: string): boolean {
+  return (
+    slug.length <= MAX_TENANT_SLUG_LENGTH && TENANT_SLUG_PATTERN.test(slug)
+  );
+}


### PR DESCRIPTION
## Summary
- validate tenant path segments against the backend subdomain syntax before resolution
- return 404 for scanner paths such as `/wp-trackback.php` and `/__status` without calling the backend
- preserve the existing cached resolver request for valid tenant subdomains

## Context
Sentry issue `JAVASCRIPT-NEXTJS-B` reports `Tenant resolution failed with HTTP 429` after scanner probes were interpreted as tenant paths. Invalid paths currently consume the shared anonymous backend rate-limit bucket before the resolver can return 404.

## Tests
- `pnpm vitest run --changed origin/development` (21 tests)
- `pnpm test:run` (12,833 tests)
- `pnpm run check`
- `pnpm depcruise`
- `pnpm knip`
- targeted Prettier check for all changed files