### PR TITLE
fix: keep start page boxes white

### DIFF
--- a/frontend/src/app/start/page.tsx
+++ b/frontend/src/app/start/page.tsx
@@ -71,7 +71,7 @@ export default function StartPage() {
               Wir melden uns danach persönlich und schauen gemeinsam, welche
               Abläufe moto zuerst abbilden soll.
             </p>
-            <div className="mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="relative z-10 mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
               <h2 className="text-lg font-semibold text-gray-950">
                 Was wir zum Start wissen wollen
               </h2>
@@ -91,7 +91,7 @@ export default function StartPage() {
 
           <form
             onSubmit={handleSubmit}
-            className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-8"
+            className="relative z-10 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-8"
           >
             <div>
               <h2 className="text-xl font-semibold text-gray-950">


### PR DESCRIPTION
## Description

The dotted page overlay was rendered above the white card backgrounds on the start page. Both content boxes now use an explicit stacking level, so their backgrounds and form controls stay fully white while the pattern remains visible around them.

## Type of Change

- [x] Bug fix

## Related Issues

None.

## Testing

- [x] Manual testing performed
- [x] Existing unit test passed
- [x] Full frontend check passed
- [x] Pre-push checks passed

Commands run:

- pnpm exec vitest run src/app/start/page.test.tsx
- pnpm run check

The page was also verified locally at desktop size using Docker Compose.

## Security Checklist

- [x] I have followed the security guidelines
- [x] No sensitive information is committed
- [x] Environment variables are unchanged
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

A local before and after check was completed. The screenshot still needs to be attached through the native GitHub attachment upload before marking this PR ready.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review
- [x] No comments were needed for this styling fix
- [x] Documentation changes are not needed
- [x] The help guide update does not apply because this is a pure styling fix
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for merge conflicts

## Additional Notes

Frontend only.