### PR TITLE
fix(ratelimit): bind quotas to stable account identity instead of JWT hash

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -2,9 +2,8 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	jwxjwt "github.com/lestrrat-go/jwx/v3/jwt"
+	"github.com/lestrrat-go/jwx/v3/transform"
 	slogchi "github.com/samber/slog-chi"
 	"github.com/spf13/viper"
 	"github.com/uptrace/bun"
@@ -344,7 +344,7 @@ func setupRateLimiting(router chi.Router, securityLogger *customMiddleware.Secur
 
 	generalRateLimiter := customMiddleware.NewRateLimiter(generalLimit, generalBurst)
 	if tokenAuth, err := projectJWT.NewTokenAuth(); err == nil {
-		generalRateLimiter.SetKeyFunc(tokenAwareRateLimitKey(tokenAuth))
+		generalRateLimiter.SetKeyFunc(identityRateLimitKey(tokenAuth))
 	}
 	if securityLogger != nil {
 		generalRateLimiter.SetLogger(securityLogger)
@@ -352,7 +352,28 @@ func setupRateLimiting(router chi.Router, securityLogger *customMiddleware.Secur
 	router.Use(generalRateLimiter.Middleware())
 }
 
-func tokenAwareRateLimitKey(tokenAuth *projectJWT.TokenAuth) func(*http.Request) string {
+// identityRateLimitKey buckets authenticated requests by their stable quota
+// identity — account ID, scope, and tenant ID from the verified JWT claims —
+// instead of a per-token hash (#2064). Every valid session of the same
+// identity shares one budget, so a re-login or token refresh no longer
+// resets the quota. The key carries only numeric IDs and the scope label,
+// never the raw token, email, or name.
+//
+// Quota-identity rules:
+//   - Same account, same scope, same tenant → one shared budget across all
+//     sessions (browser tabs, refreshed tokens, re-logins).
+//   - A tenant switch mints a JWT with a different tenant_id and gets its
+//     own budget. Different portal scopes ("", "org", "platform", "parent")
+//     are separate budgets too — scope must be in the key because operator
+//     IDs (platform.operators) and account IDs (auth.accounts) are
+//     different ID spaces.
+//   - Requests without a verified identity — missing, expired, or
+//     manipulated JWTs, non-JWT bearer values such as IoT device API keys,
+//     and MFA challenge/enrollment tokens (no "id" claim) — return "" and
+//     the limiter falls back to the trusted client IP. Unverified bearer
+//     values must never produce token-derived buckets: an attacker could
+//     mint arbitrary values and sidestep IP limiting entirely.
+func identityRateLimitKey(tokenAuth *projectJWT.TokenAuth) func(*http.Request) string {
 	return func(r *http.Request) string {
 		tokenString := extractBearerToken(r.Header.Get("Authorization"))
 		if tokenString == "" || tokenAuth == nil || tokenAuth.JwtAuth == nil {
@@ -367,8 +388,19 @@ func tokenAwareRateLimitKey(tokenAuth *projectJWT.TokenAuth) func(*http.Request)
 			return ""
 		}
 
-		sum := sha256.Sum256([]byte(tokenString))
-		return "token:" + hex.EncodeToString(sum[:])
+		claims := map[string]any{}
+		if err := transform.AsMap(token, claims); err != nil {
+			return ""
+		}
+		// JSON numbers decode as float64 (same contract as AppClaims.ParseClaims).
+		accountID, ok := claims["id"].(float64)
+		if !ok || accountID <= 0 {
+			return ""
+		}
+		scope, _ := claims["scope"].(string)
+		tenantID, _ := claims["tenant_id"].(float64)
+
+		return fmt.Sprintf("acct:%d:%s:%d", int64(accountID), scope, int64(tenantID))
 	}
 }
 

--- a/backend/api/base_utility_test.go
+++ b/backend/api/base_utility_test.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +15,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	customMiddleware "github.com/moto-nrw/project-phoenix/middleware"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/realtime"
 	"github.com/spf13/viper"
@@ -284,88 +285,284 @@ func TestRegisterRoutesWithRateLimiting_MountsOperatorInvitationRoutes(t *testin
 	assert.NotEqual(t, http.StatusNotFound, rr.Code)
 }
 
-func TestTokenAwareRateLimitKey_ValidTokenUsesHashedToken(t *testing.T) {
+// The tests below pin the quota-identity contract from #2064: authenticated
+// requests are bucketed by account ID + scope + tenant ID from verified
+// claims, not by a per-token hash. Re-logins and token refreshes therefore
+// share the account's budget instead of minting a fresh one.
+
+func rateLimitTestAuth(t *testing.T) *jwt.TokenAuth {
+	t.Helper()
 	viper.Set("auth_jwt_expiry", 15*time.Minute)
 	viper.Set("auth_jwt_refresh_expiry", 24*time.Hour)
 
 	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
 	require.NoError(t, err)
+	return tokenAuth
+}
 
-	token, err := tokenAuth.CreateJWT(jwt.AppClaims{
-		ID:          42,
-		Sub:         "user@example.com",
-		Roles:       []string{"user"},
-		Permissions: []string{"read"},
+func mintRateLimitJWT(t *testing.T, tokenAuth *jwt.TokenAuth, claims jwt.AppClaims) string {
+	t.Helper()
+	if len(claims.Roles) == 0 {
+		claims.Roles = []string{"user"}
+	}
+	token, err := tokenAuth.CreateJWT(claims)
+	require.NoError(t, err)
+	return token
+}
+
+func rateLimitRequest(token string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req
+}
+
+func TestIdentityRateLimitKey_TwoSessionsSameIdentityShareKey(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	// Two distinct tokens (differing payloads) for the same account/tenant —
+	// the re-login / second-browser-session scenario.
+	sessionA := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 42, Sub: "user@example.com", FirstName: "SessionA", TenantID: 7,
+	})
+	sessionB := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 42, Sub: "user@example.com", FirstName: "SessionB", TenantID: 7,
+	})
+	require.NotEqual(t, sessionA, sessionB,
+		"sessions must be distinct tokens for this test to prove anything")
+
+	keyFunc := identityRateLimitKey(tokenAuth)
+	assert.Equal(t, "acct:42::7", keyFunc(rateLimitRequest(sessionA)))
+	assert.Equal(t, keyFunc(rateLimitRequest(sessionA)), keyFunc(rateLimitRequest(sessionB)))
+}
+
+func TestIdentityRateLimitKey_RefreshTokenSharesAccountBudget(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	access := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 42, Sub: "user@example.com", TenantID: 7,
+	})
+	refresh, err := tokenAuth.CreateRefreshJWT(jwt.RefreshClaims{
+		ID: 42, Token: "opaque-refresh-token", TenantID: 7,
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	sum := sha256.Sum256([]byte(token))
-	expected := "token:" + hex.EncodeToString(sum[:])
-
-	assert.Equal(t, expected, tokenAwareRateLimitKey(tokenAuth)(req))
-	assert.NotContains(t, tokenAwareRateLimitKey(tokenAuth)(req), token)
+	keyFunc := identityRateLimitKey(tokenAuth)
+	assert.Equal(t, keyFunc(rateLimitRequest(access)), keyFunc(rateLimitRequest(refresh)),
+		"a refresh token presented as bearer must land in the same account bucket")
 }
 
-func TestTokenAwareRateLimitKey_InvalidTokenFallsBack(t *testing.T) {
-	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
-	require.NoError(t, err)
+func TestIdentityRateLimitKey_DifferentAccountsHaveDifferentKeys(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
-	req.Header.Set("Authorization", "Bearer not-a-real-token")
+	tokenA := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 42, Sub: "user-a@example.com", TenantID: 7})
+	tokenB := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 43, Sub: "user-b@example.com", TenantID: 7})
 
-	assert.Empty(t, tokenAwareRateLimitKey(tokenAuth)(req))
+	keyFunc := identityRateLimitKey(tokenAuth)
+	assert.NotEqual(t, keyFunc(rateLimitRequest(tokenA)), keyFunc(rateLimitRequest(tokenB)))
 }
 
-func TestTokenAwareRateLimitKey_ExpiredTokenFallsBack(t *testing.T) {
-	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
-	require.NoError(t, err)
+func TestIdentityRateLimitKey_TenantSwitchGetsOwnBudget(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	tenant7 := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 42, Sub: "user@example.com", TenantID: 7})
+	tenant8 := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 42, Sub: "user@example.com", TenantID: 8})
+
+	keyFunc := identityRateLimitKey(tokenAuth)
+	assert.NotEqual(t, keyFunc(rateLimitRequest(tenant7)), keyFunc(rateLimitRequest(tenant8)),
+		"a tenant switch mints a new tenant_id and gets its own budget")
+}
+
+func TestIdentityRateLimitKey_ScopeSeparatesPortals(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	// Operator IDs and account IDs are different ID spaces — the same numeric
+	// ID with different scopes must never share a bucket.
+	tenantToken := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 42, Sub: "staff@example.com", TenantID: 7})
+	operatorToken := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 42, Sub: "op@example.com", Scope: "platform"})
+	parentToken := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{ID: 42, Sub: "parent@example.com", Scope: "parent"})
+
+	keyFunc := identityRateLimitKey(tokenAuth)
+	keys := map[string]bool{
+		keyFunc(rateLimitRequest(tenantToken)):   true,
+		keyFunc(rateLimitRequest(operatorToken)): true,
+		keyFunc(rateLimitRequest(parentToken)):   true,
+	}
+	assert.Len(t, keys, 3, "tenant, platform, and parent scopes must have distinct keys")
+}
+
+func TestIdentityRateLimitKey_KeyContainsNoTokenOrPII(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	token := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 42, Sub: "jane.doe@example.com", Username: "jane.doe@example.com",
+		FirstName: "Jane", LastName: "Doe", TenantID: 7,
+	})
+
+	key := identityRateLimitKey(tokenAuth)(rateLimitRequest(token))
+	assert.Equal(t, "acct:42::7", key)
+	assert.NotContains(t, key, token)
+	assert.NotContains(t, key, "jane.doe@example.com")
+	assert.NotContains(t, key, "Jane")
+	assert.NotContains(t, key, "Doe")
+}
+
+func TestIdentityRateLimitKey_InvalidTokenFallsBack(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	assert.Empty(t, identityRateLimitKey(tokenAuth)(rateLimitRequest("not-a-real-token")))
+}
+
+func TestIdentityRateLimitKey_DeviceAPIKeyFallsBack(t *testing.T) {
+	// IoT devices send an opaque API key as bearer token. It is not a JWT and
+	// cannot be verified here, so device requests must stay on IP limiting —
+	// an unverified bearer value must never open its own bucket.
+	tokenAuth := rateLimitTestAuth(t)
+
+	assert.Empty(t, identityRateLimitKey(tokenAuth)(rateLimitRequest("phx_3f9c2d1a8b7e6f5a4d3c2b1a")))
+}
+
+func TestIdentityRateLimitKey_MissingHeaderFallsBack(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	assert.Empty(t, identityRateLimitKey(tokenAuth)(rateLimitRequest("")))
+}
+
+func TestIdentityRateLimitKey_ExpiredTokenFallsBack(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
 
 	_, token, err := tokenAuth.JwtAuth.Encode(map[string]any{
+		"id":  42,
 		"exp": time.Now().Add(-1 * time.Hour).Unix(),
 		"iat": time.Now().Add(-2 * time.Hour).Unix(),
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/students", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	assert.Empty(t, tokenAwareRateLimitKey(tokenAuth)(req))
+	assert.Empty(t, identityRateLimitKey(tokenAuth)(rateLimitRequest(token)))
 }
 
-func TestTokenAwareRateLimitKey_DifferentValidTokensHaveDifferentKeys(t *testing.T) {
-	viper.Set("auth_jwt_expiry", 15*time.Minute)
-	viper.Set("auth_jwt_refresh_expiry", 24*time.Hour)
-
-	tokenAuth, err := jwt.NewTokenAuthWithSecret("rate-limit-test-secret-32-chars!!")
+func TestIdentityRateLimitKey_TamperedTokenFallsBack(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+	otherAuth, err := jwt.NewTokenAuthWithSecret("a-completely-different-32char-key!!")
 	require.NoError(t, err)
 
-	tokenA, err := tokenAuth.CreateJWT(jwt.AppClaims{
-		ID:          42,
-		Sub:         "user-a@example.com",
-		Roles:       []string{"user"},
-		Permissions: []string{"read"},
+	forged := mintRateLimitJWT(t, otherAuth, jwt.AppClaims{ID: 42, Sub: "user@example.com", TenantID: 7})
+
+	assert.Empty(t, identityRateLimitKey(tokenAuth)(rateLimitRequest(forged)),
+		"a token signed with the wrong secret must not produce an identity key")
+}
+
+func TestIdentityRateLimitKey_TokenWithoutAccountIDFallsBack(t *testing.T) {
+	// MFA challenge/enrollment tokens carry account_id + a pending flag but
+	// no "id" claim — they must fall back to IP limiting.
+	tokenAuth := rateLimitTestAuth(t)
+
+	_, token, err := tokenAuth.JwtAuth.Encode(map[string]any{
+		"account_id":  42,
+		"mfa_pending": true,
+		"exp":         time.Now().Add(5 * time.Minute).Unix(),
+		"iat":         time.Now().Unix(),
 	})
 	require.NoError(t, err)
-	tokenB, err := tokenAuth.CreateJWT(jwt.AppClaims{
-		ID:          43,
-		Sub:         "user-b@example.com",
-		Roles:       []string{"user"},
-		Permissions: []string{"read"},
+
+	assert.Empty(t, identityRateLimitKey(tokenAuth)(rateLimitRequest(token)))
+}
+
+// TestRateLimiting_SameIdentitySharesBudget wires the identity key function
+// into the real limiter middleware and asserts the #2064 acceptance
+// criteria end to end: two valid sessions of one identity drain ONE budget,
+// while a different account and unauthenticated IP traffic stay unaffected.
+func TestRateLimiting_SameIdentitySharesBudget(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	// 1 request/minute refill with burst 3: the refill contributes no tokens
+	// within the test's runtime, so exactly 3 requests per key pass.
+	limiter := customMiddleware.NewRateLimiter(1, 3)
+	limiter.SetKeyFunc(identityRateLimitKey(tokenAuth))
+
+	router := chi.NewRouter()
+	router.Use(limiter.Middleware())
+	router.Get("/api/students", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	})
-	require.NoError(t, err)
 
-	reqA := httptest.NewRequest(http.MethodGet, "/api/students", nil)
-	reqA.RemoteAddr = "192.168.1.1:12345"
-	reqA.Header.Set("Authorization", "Bearer "+tokenA)
-	reqB := httptest.NewRequest(http.MethodGet, "/api/students", nil)
-	reqB.RemoteAddr = "192.168.1.1:12345"
-	reqB.Header.Set("Authorization", "Bearer "+tokenB)
+	sessionA1 := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 42, Sub: "user@example.com", FirstName: "SessionA1", TenantID: 7,
+	})
+	sessionA2 := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 42, Sub: "user@example.com", FirstName: "SessionA2", TenantID: 7,
+	})
+	require.NotEqual(t, sessionA1, sessionA2)
+	otherAccount := mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+		ID: 43, Sub: "other@example.com", TenantID: 7,
+	})
 
-	keyFunc := tokenAwareRateLimitKey(tokenAuth)
-	assert.NotEqual(t, keyFunc(reqA), keyFunc(reqB))
+	do := func(token string) int {
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, rateLimitRequest(token))
+		return rr.Code
+	}
+
+	// Alternating sessions of the same identity drain one shared budget.
+	assert.Equal(t, http.StatusOK, do(sessionA1))
+	assert.Equal(t, http.StatusOK, do(sessionA2))
+	assert.Equal(t, http.StatusOK, do(sessionA1))
+	assert.Equal(t, http.StatusTooManyRequests, do(sessionA2),
+		"the second session must NOT have its own budget")
+	assert.Equal(t, http.StatusTooManyRequests, do(sessionA1))
+
+	// A different account is unaffected by the exhausted budget.
+	assert.Equal(t, http.StatusOK, do(otherAccount))
+
+	// Unauthenticated traffic uses the IP bucket, which is also untouched.
+	assert.Equal(t, http.StatusOK, do(""))
+}
+
+// TestRateLimiting_ConcurrentSessionsShareBudget hammers one identity from
+// two sessions in parallel (run with -race in CI) and asserts the combined
+// allowance equals exactly one burst — no per-session multiplication.
+func TestRateLimiting_ConcurrentSessionsShareBudget(t *testing.T) {
+	tokenAuth := rateLimitTestAuth(t)
+
+	const burst = 10
+	limiter := customMiddleware.NewRateLimiter(1, burst)
+	limiter.SetKeyFunc(identityRateLimitKey(tokenAuth))
+
+	router := chi.NewRouter()
+	router.Use(limiter.Middleware())
+	router.Get("/api/students", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	sessions := []string{
+		mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+			ID: 42, Sub: "user@example.com", FirstName: "SessionA", TenantID: 7,
+		}),
+		mintRateLimitJWT(t, tokenAuth, jwt.AppClaims{
+			ID: 42, Sub: "user@example.com", FirstName: "SessionB", TenantID: 7,
+		}),
+	}
+	require.NotEqual(t, sessions[0], sessions[1])
+
+	var allowed atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, rateLimitRequest(sessions[i%2]))
+			if rr.Code == http.StatusOK {
+				allowed.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.EqualValues(t, burst, allowed.Load(),
+		"50 parallel requests across two sessions of one identity must pass exactly one burst")
 }
 
 // TestOnValueSetCallback_WCEnabled tests that the OnValueSet callback

--- a/backend/middleware/ratelimit.go
+++ b/backend/middleware/ratelimit.go
@@ -11,6 +11,12 @@ import (
 )
 
 // RateLimiter manages rate limiting by request key.
+//
+// Counters are in-memory and per-process: each backend replica enforces the
+// configured limit independently, so with N replicas the effective quota per
+// key is N × limit. Phoenix currently runs a single backend process per
+// environment; before scaling to multiple replicas, a shared store (e.g.
+// Redis) is required if aggregate limits must hold (#2064).
 type RateLimiter struct {
 	visitors map[string]*visitor
 	mu       sync.RWMutex


### PR DESCRIPTION
Closes #2064

## Problem

The general API rate limiter keyed authenticated requests on a SHA-256 hash of the full JWT. Every re-login or token refresh produced a new key and therefore a fresh budget for the same account. The limit protected individual sessions, not the identity behind them.

## Change

`identityRateLimitKey` (previously `tokenAwareRateLimitKey` in `backend/api/base.go`) now derives the key from **verified** claims: `acct:<account_id>:<scope>:<tenant_id>`.

### Quota-identity rules (documented in the code)

| Situation | Behavior |
|---|---|
| Two valid JWTs, same account/scope/tenant (re-login, refresh, second tab) | **One shared budget** |
| Different accounts | Independent budgets |
| Tenant switch (`POST /auth/switch-tenant` mints a new `tenant_id`) | Own budget per tenant |
| Different portal scope (`""`/`org`/`platform`/`parent`) | Own budget per scope — required, since operator IDs (`platform.operators`) and account IDs (`auth.accounts`) are separate ID spaces |
| Missing / expired / tampered JWT | IP fallback |
| Non-JWT bearer values (IoT device API keys) | IP fallback — unverified bearer values must never open their own bucket, or an attacker could mint arbitrary values to sidestep IP limiting |
| MFA challenge/enrollment tokens (carry `account_id`, no `id` claim) | IP fallback |
| Refresh token presented as bearer (`RefreshClaims.ID` = account ID) | Same account bucket |

The key contains only numeric IDs and the scope label — no raw token, no email, no name. `LogRateLimitExceeded` was checked: it logs method/path/IP only, no bearer material.

### Process locality

Documented on `RateLimiter` in `backend/middleware/ratelimit.go`: counters are in-memory and per-process; N replicas mean N × the configured quota. A shared store (e.g. Redis) is a prerequisite for horizontal scaling if aggregate limits must hold.

## Tests

14 new/updated tests in `backend/api/base_utility_test.go` covering the acceptance criteria: shared key across sessions, refresh-token bucket sharing, account isolation, tenant-switch and scope separation, PII-free keys, fallback for invalid/expired/tampered/device/MFA-challenge tokens, plus two middleware-level tests — alternating sessions draining one budget (429 on the shared budget, other account and IP traffic unaffected) and 50 parallel requests across two sessions passing exactly one burst (runs under `-race`).

**Note on modified tests**: `TestTokenAwareRateLimitKey_ValidTokenUsesHashedToken` and `TestTokenAwareRateLimitKey_DifferentValidTokensHaveDifferentKeys` pinned the old per-token behavior that this issue explicitly changes; they were replaced by the identity-contract tests above.

## E2E verification (local stack)

Ran the real server (`docker compose`, `RATE_LIMIT_ENABLED=true`, `RATE_LIMIT_BURST=5`, 60 rpm):

1. Two full operator logins (MFA via mailpit) → two distinct JWTs, plus a third token via `POST /operator/auth/refresh`.
2. Alternating requests across all three tokens: `200 200 200 200 429 429 ...` — exactly burst 5 combined (the refresh call itself consumed 1), then 429 for **every** session of that identity.
3. Unauthenticated request from the same host: 200 (IP bucket untouched).
4. 429 responses carry `Retry-After: 60`.

Before the fix, each token would have had its own budget of 5.

## Unchanged

- Unauthenticated and invalid requests keep the trusted-client-IP key (`internal/clientip` behind `ClientIPFromXFF`).
- The stricter auth-endpoint limiters (`RATE_LIMIT_AUTH_REQUESTS_PER_MINUTE`) stay IP-keyed — no token exists at login time.
- No env vars added or renamed.