### PR TITLE
feat(parent): Eltern-Umfragen mit Antwort pro Kind

### DIFF
--- a/backend/api/announcement/api.go
+++ b/backend/api/announcement/api.go
@@ -59,6 +59,11 @@ func (rs *Resource) Router() chi.Router {
 		r.With(announce, withTx).Post("/{announcementId}/unpublish", rs.unpublish)
 		r.With(announce, withTx).Get("/{announcementId}/stats", rs.stats)
 		r.With(announce, withTx).Get("/{announcementId}/recipients", rs.recipients)
+		// Poll (Umfrage, #1371): evaluation and the manual reminder to the
+		// guardians of children that have not answered.
+		r.With(announce, withTx).Get("/{announcementId}/poll-results", rs.pollResults)
+		r.With(announce, withTx).Get("/{announcementId}/poll-children", rs.pollChildren)
+		r.With(announce, withTx).Post("/{announcementId}/remind", rs.remindUnanswered)
 	})
 
 	return r
@@ -81,6 +86,17 @@ type announcementRequest struct {
 	SendEmail               bool            `json:"send_email"`
 	ExpiresAt               *time.Time      `json:"expires_at,omitempty"`
 	Targets                 []targetRequest `json:"targets"`
+	// Poll fields (#1371). response_type "" or "none" keeps the announcement a
+	// plain Mitteilung; the choice types require options.
+	ResponseType     string     `json:"response_type,omitempty"`
+	ResponseDeadline *time.Time `json:"response_deadline,omitempty"`
+	Options          []string   `json:"options,omitempty"`
+}
+
+// optionResponse is one answer option of a poll.
+type optionResponse struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
 }
 
 type targetResponse struct {
@@ -104,6 +120,9 @@ type announcementResponse struct {
 	CreatedAt               time.Time        `json:"created_at"`
 	UpdatedAt               time.Time        `json:"updated_at"`
 	Targets                 []targetResponse `json:"targets"`
+	ResponseType            string           `json:"response_type"`
+	ResponseDeadline        *time.Time       `json:"response_deadline,omitempty"`
+	Options                 []optionResponse `json:"options"`
 }
 
 type statsResponse struct {
@@ -135,6 +154,17 @@ func toTargetResponses(targets []*usersModels.ParentAnnouncementTarget) []target
 	return out
 }
 
+func toOptionResponses(options []*usersModels.ParentAnnouncementOption) []optionResponse {
+	out := make([]optionResponse, 0, len(options))
+	for _, o := range options {
+		out = append(out, optionResponse{
+			ID:    strconv.FormatInt(o.ID, 10),
+			Label: o.Label,
+		})
+	}
+	return out
+}
+
 func toAnnouncementResponse(a *usersModels.ParentAnnouncement) announcementResponse {
 	return announcementResponse{
 		ID:                      strconv.FormatInt(a.ID, 10),
@@ -151,6 +181,9 @@ func toAnnouncementResponse(a *usersModels.ParentAnnouncement) announcementRespo
 		CreatedAt:               a.CreatedAt,
 		UpdatedAt:               a.UpdatedAt,
 		Targets:                 toTargetResponses(a.Targets),
+		ResponseType:            a.ResponseType,
+		ResponseDeadline:        a.ResponseDeadline,
+		Options:                 toOptionResponses(a.Options),
 	}
 }
 
@@ -165,6 +198,9 @@ func toInput(req announcementRequest) (announcementService.Input, error) {
 		RequiresAcknowledgement: req.RequiresAcknowledgement,
 		SendEmail:               req.SendEmail,
 		ExpiresAt:               req.ExpiresAt,
+		ResponseType:            req.ResponseType,
+		ResponseDeadline:        req.ResponseDeadline,
+		Options:                 req.Options,
 		Targets:                 make([]announcementService.TargetInput, 0, len(req.Targets)),
 	}
 	for _, t := range req.Targets {
@@ -337,6 +373,98 @@ func (rs *Resource) recipients(w http.ResponseWriter, r *http.Request) {
 	common.Respond(w, r, http.StatusOK, out, "Recipients retrieved")
 }
 
+// --- poll (Umfrage) ---
+
+type pollOptionResultResponse struct {
+	OptionID string `json:"option_id"`
+	Label    string `json:"label"`
+	Count    int    `json:"count"`
+}
+
+type pollResultsResponse struct {
+	ChildCount    int                        `json:"child_count"`
+	AnsweredCount int                        `json:"answered_count"`
+	Options       []pollOptionResultResponse `json:"options"`
+}
+
+// pollChildResponse is one reached child with the answer given for them.
+// answer_labels is empty while the answer is still open, which is what the staff
+// list filters on.
+type pollChildResponse struct {
+	StudentID    string     `json:"student_id"`
+	FirstName    string     `json:"first_name"`
+	LastName     string     `json:"last_name"`
+	SchoolClass  string     `json:"school_class"`
+	AnswerLabels []string   `json:"answer_labels"`
+	RespondedAt  *time.Time `json:"responded_at,omitempty"`
+}
+
+func (rs *Resource) pollResults(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseAnnouncementID(w, r)
+	if !ok {
+		return
+	}
+	results, err := rs.Service.PollResults(r.Context(), id)
+	if err != nil {
+		renderAnnouncementError(w, r, err)
+		return
+	}
+	out := pollResultsResponse{
+		ChildCount:    results.ChildCount,
+		AnsweredCount: results.AnsweredCount,
+		Options:       make([]pollOptionResultResponse, 0, len(results.Options)),
+	}
+	for _, o := range results.Options {
+		out.Options = append(out.Options, pollOptionResultResponse{
+			OptionID: strconv.FormatInt(o.OptionID, 10),
+			Label:    o.Label,
+			Count:    o.Count,
+		})
+	}
+	common.Respond(w, r, http.StatusOK, out, "Poll results retrieved")
+}
+
+func (rs *Resource) pollChildren(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseAnnouncementID(w, r)
+	if !ok {
+		return
+	}
+	rows, err := rs.Service.PollChildren(r.Context(), id)
+	if err != nil {
+		renderAnnouncementError(w, r, err)
+		return
+	}
+	out := make([]pollChildResponse, 0, len(rows))
+	for _, c := range rows {
+		labels := c.AnswerLabels
+		if labels == nil {
+			labels = []string{}
+		}
+		out = append(out, pollChildResponse{
+			StudentID:    strconv.FormatInt(c.StudentID, 10),
+			FirstName:    c.FirstName,
+			LastName:     c.LastName,
+			SchoolClass:  c.SchoolClass,
+			AnswerLabels: labels,
+			RespondedAt:  c.RespondedAt,
+		})
+	}
+	common.Respond(w, r, http.StatusOK, out, "Poll children retrieved")
+}
+
+func (rs *Resource) remindUnanswered(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseAnnouncementID(w, r)
+	if !ok {
+		return
+	}
+	count, err := rs.Service.RemindUnanswered(r.Context(), id)
+	if err != nil {
+		renderAnnouncementError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, map[string]int{"reminded_count": count}, "Reminder sent")
+}
+
 func decodeInput(w http.ResponseWriter, r *http.Request) (announcementService.Input, bool) {
 	var req announcementRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -364,6 +492,10 @@ func renderAnnouncementError(w http.ResponseWriter, r *http.Request, err error) 
 		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, "parent_news_disabled"))
 	case errors.Is(err, announcementService.ErrPublishedImmutable):
 		common.RenderError(w, r, common.ErrorConflictWithCode(err, "announcement_published_immutable"))
+	case errors.Is(err, announcementService.ErrNotAPoll):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	case errors.Is(err, announcementService.ErrPollNotOpen):
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "poll_not_open"))
 	case errors.Is(err, announcementService.ErrValidation):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 	default:

--- a/backend/api/announcement/api.go
+++ b/backend/api/announcement/api.go
@@ -382,14 +382,15 @@ type pollOptionResultResponse struct {
 }
 
 type pollResultsResponse struct {
-	ChildCount    int                        `json:"child_count"`
-	AnsweredCount int                        `json:"answered_count"`
-	Options       []pollOptionResultResponse `json:"options"`
+	ChildCount       int                        `json:"child_count"`
+	TargetChildCount int                        `json:"target_child_count"`
+	AnsweredCount    int                        `json:"answered_count"`
+	Options          []pollOptionResultResponse `json:"options"`
 }
 
-// pollChildResponse is one reached child with the answer given for them.
-// answer_labels is empty while the answer is still open, which is what the staff
-// list filters on.
+// pollChildResponse is one reached child with the answer given for them and
+// whether any guardian may currently respond. answer_labels is empty while an
+// answer is still open.
 type pollChildResponse struct {
 	StudentID    string     `json:"student_id"`
 	FirstName    string     `json:"first_name"`
@@ -397,6 +398,7 @@ type pollChildResponse struct {
 	SchoolClass  string     `json:"school_class"`
 	AnswerLabels []string   `json:"answer_labels"`
 	RespondedAt  *time.Time `json:"responded_at,omitempty"`
+	CanAnswer    bool       `json:"can_answer"`
 }
 
 func (rs *Resource) pollResults(w http.ResponseWriter, r *http.Request) {
@@ -410,9 +412,10 @@ func (rs *Resource) pollResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	out := pollResultsResponse{
-		ChildCount:    results.ChildCount,
-		AnsweredCount: results.AnsweredCount,
-		Options:       make([]pollOptionResultResponse, 0, len(results.Options)),
+		ChildCount:       results.ChildCount,
+		TargetChildCount: results.TargetChildCount,
+		AnsweredCount:    results.AnsweredCount,
+		Options:          make([]pollOptionResultResponse, 0, len(results.Options)),
 	}
 	for _, o := range results.Options {
 		out.Options = append(out.Options, pollOptionResultResponse{
@@ -447,6 +450,7 @@ func (rs *Resource) pollChildren(w http.ResponseWriter, r *http.Request) {
 			SchoolClass:  c.SchoolClass,
 			AnswerLabels: labels,
 			RespondedAt:  c.RespondedAt,
+			CanAnswer:    c.CanAnswer,
 		})
 	}
 	common.Respond(w, r, http.StatusOK, out, "Poll children retrieved")

--- a/backend/api/parent/announcement_handlers.go
+++ b/backend/api/parent/announcement_handlers.go
@@ -27,10 +27,57 @@ type AnnouncementResponse struct {
 	ExpiresAt               *time.Time `json:"expires_at,omitempty"`
 	Read                    bool       `json:"read"`
 	Acknowledged            bool       `json:"acknowledged"`
+
+	// Poll fields (#1371). response_type "none" means the other three are absent:
+	// options are the answer choices, children the guardian's own children this
+	// poll reaches (one answer row each), deadline the answer cut-off.
+	ResponseType     string                  `json:"response_type"`
+	ResponseDeadline *time.Time              `json:"response_deadline,omitempty"`
+	Options          []AnnouncementOption    `json:"options,omitempty"`
+	Children         []AnnouncementPollChild `json:"children,omitempty"`
+}
+
+// AnnouncementOption is one answer choice of a poll.
+type AnnouncementOption struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// AnnouncementPollChild is one of the guardian's children the poll reaches,
+// with the option ids currently selected for that child (empty = unanswered).
+type AnnouncementPollChild struct {
+	StudentID       string   `json:"student_id"`
+	FirstName       string   `json:"first_name"`
+	LastName        string   `json:"last_name"`
+	SelectedOptions []string `json:"selected_options"`
 }
 
 func toAnnouncementResponse(item *usersModels.AnnouncementFeedItem) AnnouncementResponse {
+	options := make([]AnnouncementOption, 0, len(item.Options))
+	for _, o := range item.Options {
+		options = append(options, AnnouncementOption{
+			ID:    strconv.FormatInt(o.ID, 10),
+			Label: o.Label,
+		})
+	}
+	children := make([]AnnouncementPollChild, 0, len(item.Children))
+	for _, c := range item.Children {
+		selected := make([]string, 0, len(c.SelectedOptions))
+		for _, id := range c.SelectedOptions {
+			selected = append(selected, strconv.FormatInt(id, 10))
+		}
+		children = append(children, AnnouncementPollChild{
+			StudentID:       strconv.FormatInt(c.StudentID, 10),
+			FirstName:       c.FirstName,
+			LastName:        c.LastName,
+			SelectedOptions: selected,
+		})
+	}
 	return AnnouncementResponse{
+		ResponseType:            item.ResponseType,
+		ResponseDeadline:        item.ResponseDeadline,
+		Options:                 options,
+		Children:                children,
 		ID:                      strconv.FormatInt(item.ID, 10),
 		Title:                   item.Title,
 		Body:                    item.Body,
@@ -125,6 +172,55 @@ func (rs *Resource) markAnnouncementRead(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	common.Respond(w, r, http.StatusOK, map[string]bool{"read": true}, "Announcement marked read")
+}
+
+// respondRequest is the poll answer body: which child the answer is for, the
+// selected option ids (empty withdraws the answer), and the published_at version
+// token every write on the feed carries.
+type respondRequest struct {
+	StudentID   string     `json:"student_id"`
+	OptionIDs   []string   `json:"option_ids"`
+	PublishedAt *time.Time `json:"published_at"`
+}
+
+// respondToAnnouncement records the guardian's answer to a poll for one child.
+func (rs *Resource) respondToAnnouncement(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := rs.parentAccountID(w, r)
+	if !ok {
+		return
+	}
+	announcementID, ok := parseAnnouncementID(w, r)
+	if !ok {
+		return
+	}
+	var req respondRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid request body")))
+		return
+	}
+	if req.PublishedAt == nil || req.PublishedAt.IsZero() {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("published_at is required")))
+		return
+	}
+	studentID, err := strconv.ParseInt(req.StudentID, 10, 64)
+	if err != nil || studentID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid student_id")))
+		return
+	}
+	optionIDs := make([]int64, 0, len(req.OptionIDs))
+	for _, raw := range req.OptionIDs {
+		id, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || id <= 0 {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid option id")))
+			return
+		}
+		optionIDs = append(optionIDs, id)
+	}
+	if err := rs.ParentService.RespondToAnnouncement(r.Context(), accountID, announcementID, studentID, optionIDs, *req.PublishedAt); err != nil {
+		renderParentWriteError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, map[string]bool{"answered": len(optionIDs) > 0}, "Answer recorded")
 }
 
 // acknowledgeAnnouncement records an explicit "gelesen und bestätigt".

--- a/backend/api/parent/api.go
+++ b/backend/api/parent/api.go
@@ -213,6 +213,8 @@ func (rs *Resource) Router() chi.Router {
 		r.Get("/me/news/unread-count", rs.unreadAnnouncementCount)
 		r.Post("/me/news/{announcementId}/read", rs.markAnnouncementRead)
 		r.Post("/me/news/{announcementId}/acknowledge", rs.acknowledgeAnnouncement)
+		// Poll answer, one child per call (#1371).
+		r.Post("/me/news/{announcementId}/respond", rs.respondToAnnouncement)
 		r.Get("/me/children/{studentId}/care-exception", rs.listCareExceptions)
 		r.Post("/me/children/{studentId}/care-exception", rs.submitCareException)
 		r.Delete("/me/children/{studentId}/care-exception", rs.deleteCareException)

--- a/backend/api/parent/child_write_handlers.go
+++ b/backend/api/parent/child_write_handlers.go
@@ -501,6 +501,8 @@ func renderParentWriteError(w http.ResponseWriter, r *http.Request, err error) {
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "announcement_not_a_poll"))
 	case errors.Is(err, parentService.ErrPollClosed):
 		common.RenderError(w, r, common.ErrorConflictWithCode(err, "poll_closed"))
+	case errors.Is(err, parentService.ErrInvalidPollResponse):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "invalid_poll_response"))
 	case errors.Is(err, parentService.ErrChildNotAnswerable):
 		common.RenderError(w, r, common.ErrorNotFound(err))
 	case errors.Is(err, parentService.ErrNoDates),

--- a/backend/api/parent/child_write_handlers.go
+++ b/backend/api/parent/child_write_handlers.go
@@ -497,6 +497,12 @@ func renderParentWriteError(w http.ResponseWriter, r *http.Request, err error) {
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "announcement_ack_not_required"))
 	case errors.Is(err, parentService.ErrAnnouncementStale):
 		common.RenderError(w, r, common.ErrorConflictWithCode(err, "announcement_stale"))
+	case errors.Is(err, parentService.ErrAnnouncementNotAPoll):
+		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "announcement_not_a_poll"))
+	case errors.Is(err, parentService.ErrPollClosed):
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "poll_closed"))
+	case errors.Is(err, parentService.ErrChildNotAnswerable):
+		common.RenderError(w, r, common.ErrorNotFound(err))
 	case errors.Is(err, parentService.ErrNoDates),
 		errors.Is(err, parentService.ErrInvalidStatus),
 		errors.Is(err, parentService.ErrEmptyNote),

--- a/backend/api/parent/me_handlers_test.go
+++ b/backend/api/parent/me_handlers_test.go
@@ -207,6 +207,10 @@ func (f *fakeParentService) AcknowledgeAnnouncement(context.Context, int64, int6
 	return nil
 }
 
+func (f *fakeParentService) RespondToAnnouncement(context.Context, int64, int64, int64, []int64, time.Time) error {
+	return nil
+}
+
 // Feedback board (#1678) — stubs so the fake keeps satisfying parent.Service.
 // The board's own handler tests drive the real service against the database.
 

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -250,6 +250,8 @@ GET /api/notifications/preferences/
 GET /api/notifications/push/public-key
 GET /api/parent-announcements/
 GET /api/parent-announcements/{announcementId}
+GET /api/parent-announcements/{announcementId}/poll-children
+GET /api/parent-announcements/{announcementId}/poll-results
 GET /api/parent-announcements/{announcementId}/recipients
 GET /api/parent-announcements/{announcementId}/stats
 GET /api/platform/announcements/unread
@@ -588,6 +590,7 @@ POST /api/notifications/push/subscriptions
 POST /api/notifications/test
 POST /api/parent-announcements/
 POST /api/parent-announcements/{announcementId}/publish
+POST /api/parent-announcements/{announcementId}/remind
 POST /api/parent-announcements/{announcementId}/unpublish
 POST /api/platform/announcements/{id}/dismiss
 POST /api/platform/announcements/{id}/seen
@@ -759,6 +762,7 @@ POST /parent/me/feedback/{postId}/vote
 POST /parent/me/messages/children/{studentId}
 POST /parent/me/news/{announcementId}/acknowledge
 POST /parent/me/news/{announcementId}/read
+POST /parent/me/news/{announcementId}/respond
 POST /parent/me/push/subscriptions
 PUT /api/active/combined/{id}
 PUT /api/active/groups/{id}

--- a/backend/auth/authorize/guardian_permission.go
+++ b/backend/auth/authorize/guardian_permission.go
@@ -12,6 +12,10 @@ const (
 	GuardianPermissionNotesWrite       = "parent_portal.notes.write"
 	GuardianPermissionEnrollmentsView  = "parent_portal.enrollments.view"
 	GuardianPermissionEnrollmentSubmit = "parent_portal.enrollment.submit"
+	// GuardianPermissionPollResponse allows a guardian to submit or replace a
+	// per-child parent-announcement poll response. It is deliberately separate
+	// from portal access because viewing a poll must not imply voting authority.
+	GuardianPermissionPollResponse = "parent_portal.poll.response"
 	// GuardianPermissionRequestSubmit allows a parent to submit (and withdraw)
 	// structured change-requests — care-schedule changes that OVERWRITE the
 	// child's permanent weekday schedule once staff confirm them. It is
@@ -55,6 +59,7 @@ var fullParentPortalPermissions = []string{
 	GuardianPermissionRequestSubmit,
 	GuardianPermissionEnrollmentsView,
 	GuardianPermissionEnrollmentSubmit,
+	GuardianPermissionPollResponse,
 	GuardianPermissionMasterDataEdit,
 	GuardianPermissionMasterDataRequest,
 	GuardianPermissionGuardianEdit,

--- a/backend/database/migrations/001015249_parent_announcement_polls.go
+++ b/backend/database/migrations/001015249_parent_announcement_polls.go
@@ -1,0 +1,203 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	parentAnnouncementPollsVersion     = "1.15.249"
+	parentAnnouncementPollsDescription = "Add poll (Umfrage) response options and per-child responses to parent announcements"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     parentAnnouncementPollsVersion,
+		Description: parentAnnouncementPollsDescription,
+		DependsOn: []string{
+			parentAnnouncementsVersion, // the announcement tables this extends
+			"1.3.5",                    // users.students (per-child responses)
+			"1.0.1",                    // auth.accounts (who answered)
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return parentAnnouncementPollsUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return parentAnnouncementPollsDown(ctx, db)
+		},
+	)
+}
+
+func parentAnnouncementPollsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.249: Adding parent announcement poll columns and tables...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	// A poll (Umfrage) is an announcement that carries answer options. Everything
+	// else about it — targeting, draft/publish, expiry, e-mail opt-in, push — is
+	// the announcement machinery it inherits, which is why this is columns on the
+	// existing table rather than a parallel entity (#1371).
+	//
+	// response_type = 'none' is a plain Mitteilung (every pre-existing row).
+	// response_deadline is the answer cut-off; it is deliberately separate from
+	// expires_at, which controls VISIBILITY: a school wants the result of a closed
+	// poll to stay readable in the feed after answering has ended.
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE users.parent_announcements
+			ADD COLUMN IF NOT EXISTS response_type     TEXT NOT NULL DEFAULT 'none',
+			ADD COLUMN IF NOT EXISTS response_deadline TIMESTAMPTZ;
+	`)
+	if err != nil {
+		return fmt.Errorf("error adding poll columns to users.parent_announcements: %w", err)
+	}
+
+	// Constraints are added separately (ADD CONSTRAINT has no IF NOT EXISTS) so a
+	// re-run of the migration on a partially applied schema does not fail.
+	_, err = tx.ExecContext(ctx, `
+		DO $$
+		BEGIN
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conname = 'chk_parent_announcements_response_type'
+			) THEN
+				ALTER TABLE users.parent_announcements
+					ADD CONSTRAINT chk_parent_announcements_response_type
+					CHECK (response_type IN ('none','single_choice','multi_choice'));
+			END IF;
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conname = 'chk_parent_announcements_response_deadline'
+			) THEN
+				ALTER TABLE users.parent_announcements
+					ADD CONSTRAINT chk_parent_announcements_response_deadline
+					CHECK (response_deadline IS NULL OR response_type <> 'none');
+			END IF;
+		END $$;
+	`)
+	if err != nil {
+		return fmt.Errorf("error adding poll constraints to users.parent_announcements: %w", err)
+	}
+
+	// One answer option per row. position drives the display order and is unique
+	// per announcement so two options can never render in an ambiguous order.
+	// Options are insert/delete only (replaced wholesale while the announcement is
+	// still a draft), so there is no updated_at column and no trigger.
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS users.parent_announcement_options (
+			id              BIGSERIAL PRIMARY KEY,
+			tenant_id       BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			announcement_id BIGINT NOT NULL REFERENCES users.parent_announcements(id) ON DELETE CASCADE,
+			label           TEXT NOT NULL,
+			position        INT NOT NULL,
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_parent_announcement_options_label_not_blank CHECK (length(btrim(label)) > 0),
+			CONSTRAINT uq_parent_announcement_options_position UNIQUE (announcement_id, position)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_parent_announcement_options_announcement
+			ON users.parent_announcement_options (tenant_id, announcement_id, position);
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating users.parent_announcement_options: %w", err)
+	}
+
+	// One row per (child, chosen option). The answer is PER CHILD, not per
+	// guardian account (#1371 decision): "Kommt Ihr Kind zur Murmelparty" is a
+	// question about the child, and a parent with two children at the OGS answers
+	// once per child. account_id records WHICH guardian answered (two guardians
+	// share one child; last writer wins, the service replaces the child's row set).
+	//
+	// A single_choice poll keeps at most one row per child; multi_choice keeps one
+	// row per selected option. The unique constraint makes a double-submit
+	// idempotent rather than duplicating a vote.
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS users.parent_announcement_responses (
+			id              BIGSERIAL PRIMARY KEY,
+			tenant_id       BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			announcement_id BIGINT NOT NULL REFERENCES users.parent_announcements(id) ON DELETE CASCADE,
+			option_id       BIGINT NOT NULL REFERENCES users.parent_announcement_options(id) ON DELETE CASCADE,
+			student_id      BIGINT NOT NULL REFERENCES users.students(id) ON DELETE CASCADE,
+			account_id      BIGINT NOT NULL REFERENCES auth.accounts(id) ON DELETE CASCADE,
+			responded_at    TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+			CONSTRAINT uq_parent_announcement_responses UNIQUE (announcement_id, student_id, option_id)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_parent_announcement_responses_announcement
+			ON users.parent_announcement_responses (tenant_id, announcement_id);
+		CREATE INDEX IF NOT EXISTS idx_parent_announcement_responses_student
+			ON users.parent_announcement_responses (announcement_id, student_id);
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating users.parent_announcement_responses: %w", err)
+	}
+
+	// RLS — same shape as the announcement tables this extends.
+	for _, table := range []string{"parent_announcement_options", "parent_announcement_responses"} {
+		_, err = tx.ExecContext(ctx, fmt.Sprintf(`
+			ALTER TABLE users.%[1]s ENABLE ROW LEVEL SECURITY;
+			ALTER TABLE users.%[1]s FORCE ROW LEVEL SECURITY;
+
+			DO $$
+			BEGIN
+				IF NOT EXISTS (
+					SELECT 1 FROM pg_policies
+					WHERE schemaname = 'users'
+						AND tablename = '%[1]s'
+						AND policyname = 'tenant_isolation_users_%[1]s'
+				) THEN
+					CREATE POLICY tenant_isolation_users_%[1]s ON users.%[1]s
+						FOR ALL
+						USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+						WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+				END IF;
+			END $$;
+
+			GRANT SELECT, INSERT, UPDATE, DELETE ON users.%[1]s TO phoenix_tenant;
+		`, table))
+		if err != nil {
+			return fmt.Errorf("error enabling RLS on users.%s: %w", table, err)
+		}
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		GRANT USAGE ON SEQUENCE users.parent_announcement_options_id_seq TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE users.parent_announcement_responses_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error granting sequence usage: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func parentAnnouncementPollsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.249: Dropping parent announcement poll tables and columns...")
+
+	if _, err := db.NewRaw(`
+		DROP TABLE IF EXISTS users.parent_announcement_responses CASCADE;
+		DROP TABLE IF EXISTS users.parent_announcement_options CASCADE;
+		ALTER TABLE users.parent_announcements
+			DROP CONSTRAINT IF EXISTS chk_parent_announcements_response_deadline,
+			DROP CONSTRAINT IF EXISTS chk_parent_announcements_response_type,
+			DROP COLUMN IF EXISTS response_deadline,
+			DROP COLUMN IF EXISTS response_type;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("error dropping parent announcement poll objects: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015250_grant_guardian_poll_response_permission.go
+++ b/backend/database/migrations/001015250_grant_guardian_poll_response_permission.go
@@ -1,0 +1,43 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	grantGuardianPollResponsePermissionVersion     = "1.15.250"
+	grantGuardianPollResponsePermissionDescription = "Grant parent_portal.poll.response to full guardian relationships"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     grantGuardianPollResponsePermissionVersion,
+		Description: grantGuardianPollResponsePermissionDescription,
+		DependsOn:   []string{parentAnnouncementPollsVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Migration 1.15.250: Granting parent_portal.poll.response to full guardians...")
+			_, err := db.NewRaw(`
+				UPDATE users.students_guardians
+				SET permissions = COALESCE(permissions, '{}'::jsonb)
+					|| '{"parent_portal.poll.response": true}'::jsonb
+				WHERE guardian_role IN ('primary_guardian', 'legal_guardian', 'co_guardian')
+			`).Exec(ctx)
+			return err
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			fmt.Println("Rolling back migration 1.15.250: removing parent_portal.poll.response key...")
+			_, err := db.NewRaw(`
+				UPDATE users.students_guardians
+				SET permissions = permissions - 'parent_portal.poll.response'
+				WHERE guardian_role IN ('primary_guardian', 'legal_guardian', 'co_guardian')
+			`).Exec(ctx)
+			return err
+		},
+	)
+}

--- a/backend/database/repositories/users/parent_announcement.go
+++ b/backend/database/repositories/users/parent_announcement.go
@@ -238,6 +238,8 @@ func (r *ParentAnnouncementRepository) Update(ctx context.Context, a *users.Pare
 		Set("requires_acknowledgement = ?", a.RequiresAcknowledgement).
 		Set("send_email = ?", a.SendEmail).
 		Set("expires_at = ?", a.ExpiresAt).
+		Set("response_type = ?", a.ResponseType).
+		Set("response_deadline = ?", a.ResponseDeadline).
 		Set("updated_at = ?", now).
 		Where("id = ?", a.ID).
 		Where("published_at IS NULL").
@@ -255,6 +257,26 @@ func (r *ParentAnnouncementRepository) Update(ctx context.Context, a *users.Pare
 	a.UpdatedAt = now
 	if err := r.clearReads(ctx, a.ID); err != nil {
 		return err
+	}
+	// Same reasoning for poll answers: they belong to the RETRACTED wording and
+	// its options. ReplaceOptions deletes the option rows (cascading the answers)
+	// whenever the option set changes, but an edit that keeps the options while
+	// changing the question must not carry the old answers over either.
+	if err := r.clearResponses(ctx, a.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// clearResponses deletes every poll answer for an announcement (RLS-scoped to
+// the current tenant). Used when a draft is (re-)edited, mirroring clearReads.
+func (r *ParentAnnouncementRepository) clearResponses(ctx context.Context, announcementID int64) error {
+	if _, err := base.GetDB(ctx, r.DB).NewDelete().
+		Model((*users.ParentAnnouncementResponse)(nil)).
+		ModelTableExpr("users.parent_announcement_responses").
+		Where("announcement_id = ?", announcementID).
+		Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "clear parent announcement responses", Err: err}
 	}
 	return nil
 }
@@ -644,6 +666,7 @@ func (r *ParentAnnouncementRepository) ListFeedForAccount(ctx context.Context, a
 	sqlStr := `
 		SELECT a.id, a.tenant_id, a.title, a.body, a.priority, a.link_url,
 			a.requires_acknowledgement, a.published_at, a.expires_at,
+			a.response_type, a.response_deadline,
 			COALESCE(sch.name, '') AS school_name,
 			par.read_at AS read_at,
 			par.acknowledged_at AS acknowledged_at
@@ -678,6 +701,11 @@ func (r *ParentAnnouncementRepository) CountUnreadForAccount(ctx context.Context
 	}
 	var count int
 	reached := reachedPredicate("a.id", "a.tenant_id", "?")
+	openPoll := openPollForAccountPredicate("a", "a.tenant_id", "?")
+	// "Outstanding" is unread OR an open poll with a child still unanswered: a
+	// guardian who opened a poll but never answered must keep seeing the badge,
+	// otherwise the reminder value of the count disappears exactly for the people
+	// the school needs an answer from (#1371).
 	sqlStr := `
 		SELECT COUNT(*)
 		FROM users.parent_announcements a
@@ -688,12 +716,12 @@ func (r *ParentAnnouncementRepository) CountUnreadForAccount(ctx context.Context
 			AND a.published_at IS NOT NULL
 			AND a.published_at <= NOW()
 			AND (a.expires_at IS NULL OR a.expires_at > NOW())
-			AND par.read_at IS NULL
+			AND (par.read_at IS NULL OR ` + openPoll + `)
 			AND ` + reached
-	// Arg order mirrors ListFeedForAccount: read-state join (acc), tenant set,
+	// Arg order: read-state join (acc), tenant set, the open-poll predicate's acc,
 	// then reachedPredicate's acc three times (student once, pending twice).
 	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr,
-		accountID, bun.List(tenantIDs), accountID, accountID, accountID,
+		accountID, bun.List(tenantIDs), accountID, accountID, accountID, accountID,
 	).Scan(ctx, &count); err != nil {
 		return 0, &modelBase.DatabaseError{Op: "count unread parent announcements", Err: err}
 	}

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -476,7 +476,8 @@ func (r *ParentAnnouncementRepository) PollChildren(ctx context.Context, tenantI
 			WHERE resp.announcement_id = ? AND resp.tenant_id = ? AND resp.student_id = s.id
 		) ans ON TRUE
 		ORDER BY last_name ASC, first_name ASC, student_id ASC`
-	sqlArgs := append(append(append([]any{}, args...), args...), announcementID, tenantID)
+	sqlArgs := append(append([]any{}, args...), args...)
+	sqlArgs = append(sqlArgs, announcementID, tenantID)
 	var rows []*users.AnnouncementPollChildStatus
 	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr, sqlArgs...).Scan(ctx, &rows); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "parent announcement poll children", Err: err}

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -32,12 +32,13 @@ import (
 // the announcement id expression. accountFilter is either "" (all reached
 // children) or "AND gp.account_id = ?" (only one guardian's children).
 //
-// The join chain mirrors reachedPredicate exactly: a live, non-graduated student
-// whose person is not soft-deleted, a students_guardians link granting
-// parent_portal.access, a guardian profile with a linked account, and an ACTIVE
-// account_tenants membership.
+// The join chain mirrors the normal student-backed announcement audience: a
+// live, non-graduated student whose person is not soft-deleted, a
+// parent_portal.access guardian link, a guardian profile with a linked account,
+// and an ACTIVE account_tenants membership. Staff results must include every
+// child the announcement reaches, even if no guardian may answer the poll.
 func pollAudienceStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
-	return audienceStudentsSQLForPermission(annExpr, tenantExpr, accountFilter, `sg.permissions @> '{"parent_portal.poll.response": true}'::jsonb`)
+	return audienceStudentsSQLForPermission(annExpr, tenantExpr, accountFilter, "")
 }
 
 // audienceStudentsSQLForPermission is the permission-specific variant used by

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -35,7 +35,17 @@ import (
 // whose person is not soft-deleted, a students_guardians link granting
 // parent_portal.access, a guardian profile with a linked account, and an ACTIVE
 // account_tenants membership.
-func audienceStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
+func pollAudienceStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
+	return audienceStudentsSQLForPermission(annExpr, tenantExpr, accountFilter, `sg.permissions @> '{"parent_portal.poll.response": true}'::jsonb`)
+}
+
+// audienceStudentsSQLForPermission is the permission-specific variant used by
+// actions that need stronger authority than merely seeing a child in the
+// portal. permissionPredicate is a trusted SQL predicate over sg.
+func audienceStudentsSQLForPermission(annExpr, tenantExpr, accountFilter, permissionPredicate string) string {
+	if permissionPredicate != "" {
+		permissionPredicate = " AND " + permissionPredicate
+	}
 	return fmt.Sprintf(`
 		SELECT DISTINCT s.id AS student_id
 		FROM users.parent_announcement_targets pt
@@ -50,12 +60,13 @@ func audienceStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
 		AND s.status <> 'alumnus'
 		JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = %[2]s
 			AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+			%[5]s
 		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = %[2]s
 			AND gp.account_id IS NOT NULL %[4]s
 		JOIN auth.account_tenants act ON act.account_id = gp.account_id
 			AND act.tenant_id = gp.tenant_id AND act.status = 'active'
 		WHERE pt.announcement_id = %[1]s AND pt.tenant_id = %[2]s`,
-		annExpr, tenantExpr, activeActivityGroupExists(tenantExpr), accountFilter)
+		annExpr, tenantExpr, activeActivityGroupExists(tenantExpr), accountFilter, permissionPredicate)
 }
 
 // audienceStudentArgs returns the bind args for audienceStudentsSQL("?","?",...)
@@ -103,7 +114,7 @@ func openPollForAccountPredicate(annExpr, tenantExpr, accPlace string) string {
 			JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
 			AND s.status <> 'alumnus'
 			JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = %[2]s
-				AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+				AND sg.permissions @> '{"parent_portal.access": true, "parent_portal.poll.response": true}'::jsonb
 			JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = %[2]s
 				AND gp.account_id = %[3]s
 			JOIN auth.account_tenants act ON act.account_id = gp.account_id
@@ -223,7 +234,7 @@ func (r *ParentAnnouncementRepository) AnswerableChildren(ctx context.Context, a
 		JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
 			AND s.status <> 'alumnus'
 		JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = a.tenant_id
-			AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+			AND sg.permissions @> '{"parent_portal.access": true, "parent_portal.poll.response": true}'::jsonb
 		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = a.tenant_id
 			AND gp.account_id = ?
 		JOIN auth.account_tenants act ON act.account_id = gp.account_id
@@ -249,7 +260,7 @@ func (r *ParentAnnouncementRepository) AnswerableChildren(ctx context.Context, a
 // not reach, nor for a reached child that is not theirs.
 func (r *ParentAnnouncementRepository) AccountMayAnswerForStudent(ctx context.Context, tenantID, announcementID, accountID, studentID int64) (bool, error) {
 	var allowed bool
-	inner := audienceStudentsSQL("?", "?", "AND gp.account_id = ?")
+	inner := audienceStudentsSQLForPermission("?", "?", "AND gp.account_id = ?", `sg.permissions @> '{"parent_portal.poll.response": true}'::jsonb`)
 	sqlStr := "SELECT EXISTS (SELECT 1 FROM (" + inner + ") reached WHERE reached.student_id = ?)"
 	args := append(audienceStudentArgs(announcementID, tenantID, &accountID), studentID)
 	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr, args...).Scan(ctx, &allowed); err != nil {
@@ -264,57 +275,111 @@ func (r *ParentAnnouncementRepository) AccountMayAnswerForStudent(ctx context.Co
 // answers (no deadline, or a deadline in the future). An empty optionIDs
 // withdraws the answer.
 //
-// The guard is evaluated inside the same statement as the writes (mirroring
-// MarkRead's liveVersionGuardCTE) so a correction or a deadline that passes
-// between the service's authorize phase and this write cannot slip an answer in.
-// It returns whether the guard matched; false makes the service answer 409.
-//
-// Option ids are verified to belong to THIS announcement in the insert's SELECT,
-// so a client cannot vote with another poll's option id.
+// A transaction-scoped advisory lock serializes replacements for one poll and
+// child. Each write has its own live/version/relationship/selection guard, so
+// a correction, revocation, or deadline that changes between the delete and
+// insert rolls the transaction back instead of storing a stale answer. It
+// returns whether the guard and selection matched; false makes the service
+// answer 409.
 func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error) {
 	db := base.GetDB(ctx, r.DB)
-	var live bool
-	guard := `WITH guard AS (
-			SELECT 1 FROM users.parent_announcements a
+	// The advisory transaction lock serializes all replacements for this
+	// announcement/child pair.  The response table's option-level uniqueness is
+	// insufficient: two guardians could otherwise both delete and then insert a
+	// different option for the same child.
+	//
+	// Each guarded write repeats audience/relationship authorization and poll
+	// liveness. Revoking poll.response after Phase 1 therefore prevents the
+	// write, rather than leaving a TOCTOU window.
+	if _, err := db.NewRaw(`SELECT pg_advisory_xact_lock(?, ?)`, announcementID, studentID).Exec(ctx); err != nil {
+		return false, &modelBase.DatabaseError{Op: "lock parent announcement response", Err: err}
+	}
+	guard := `
+		WITH guard AS (
+			SELECT a.response_type
+			FROM users.parent_announcements a
+			JOIN users.parent_announcement_targets pt
+				ON pt.announcement_id = a.id AND pt.tenant_id = a.tenant_id
+			JOIN users.students s ON s.id = ? AND s.tenant_id = a.tenant_id AND (
+				pt.target_type = 'school_all'
+				OR (pt.target_type = 'class' AND LOWER(TRIM(s.school_class)) = LOWER(TRIM(pt.target_ref_text)))
+				OR (pt.target_type = 'group' AND s.group_id = pt.target_ref_id)
+				OR (pt.target_type = 'student' AND s.id = pt.target_ref_id)
+				OR ` + activeActivityGroupExists("a.tenant_id") + `
+			)
+			JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL AND s.status <> 'alumnus'
+			JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = a.tenant_id
+				AND sg.permissions @> '{"parent_portal.access": true, "parent_portal.poll.response": true}'::jsonb
+			JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = a.tenant_id
+				AND gp.account_id = ?
+			JOIN auth.account_tenants act ON act.account_id = gp.account_id
+				AND act.tenant_id = gp.tenant_id AND act.status = 'active'
 			WHERE a.id = ? AND a.tenant_id = ?
-				AND a.active
-				AND a.published_at = ?
-				AND a.published_at <= NOW()
+				AND a.active AND a.published_at = ? AND a.published_at <= NOW()
 				AND (a.expires_at IS NULL OR a.expires_at > NOW())
 				AND a.response_type <> 'none'
 				AND (a.response_deadline IS NULL OR a.response_deadline > NOW())
 		)`
-	if err := db.NewRaw(guard+`,
-		del AS (
-			DELETE FROM users.parent_announcement_responses
-			WHERE announcement_id = ? AND student_id = ? AND tenant_id = ?
-				AND EXISTS (SELECT 1 FROM guard)
-		)
-		SELECT EXISTS (SELECT 1 FROM guard)`,
-		announcementID, tenantID, expectedPublishedAt,
+	var live bool
+	if err := db.NewRaw(guard+`, requested AS (
+		SELECT option_id FROM unnest(ARRAY[?]::bigint[]) AS selection(option_id)
+	), selection_valid AS (
+		SELECT EXISTS (SELECT 1 FROM guard)
+			AND (SELECT count(*) FROM requested) = (SELECT count(DISTINCT option_id) FROM requested)
+			AND (SELECT count(*) FROM requested) = (
+				SELECT count(*) FROM requested
+				JOIN users.parent_announcement_options o ON o.id = requested.option_id
+				WHERE o.announcement_id = ? AND o.tenant_id = ?
+			)
+			AND ((SELECT response_type FROM guard LIMIT 1) <> 'single_choice'
+				OR (SELECT count(*) FROM requested) <= 1)
+	), del AS (
+		DELETE FROM users.parent_announcement_responses
+		WHERE announcement_id = ? AND student_id = ? AND tenant_id = ?
+			AND (SELECT selection_valid FROM selection_valid)
+	)
+	SELECT selection_valid FROM selection_valid`,
+		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
+		bun.List(optionIDs), announcementID, tenantID,
 		announcementID, studentID, tenantID,
 	).Scan(ctx, &live); err != nil {
-		return false, &modelBase.DatabaseError{Op: "clear parent announcement response", Err: err}
+		return false, &modelBase.DatabaseError{Op: "replace parent announcement response", Err: err}
 	}
 	if !live || len(optionIDs) == 0 {
 		return live, nil
 	}
-	// Insert the new selection. The SELECT ... FROM options join is what pins the
-	// option ids to this announcement (and this tenant); an id from another poll
-	// simply produces no row rather than a foreign vote.
-	if _, err := db.NewRaw(`
+	// Reapply the complete liveness, relationship, and selection guard to this
+	// insert: if the deadline closes or access is revoked after the delete, this
+	// transaction returns false and the caller rolls the delete back.
+	if err := db.NewRaw(guard+`, requested AS (
+		SELECT option_id FROM unnest(ARRAY[?]::bigint[]) AS selection(option_id)
+	), selection_valid AS (
+		SELECT EXISTS (SELECT 1 FROM guard)
+			AND (SELECT count(*) FROM requested) = (SELECT count(DISTINCT option_id) FROM requested)
+			AND (SELECT count(*) FROM requested) = (
+				SELECT count(*) FROM requested
+				JOIN users.parent_announcement_options o ON o.id = requested.option_id
+				WHERE o.announcement_id = ? AND o.tenant_id = ?
+			)
+			AND ((SELECT response_type FROM guard LIMIT 1) <> 'single_choice'
+				OR (SELECT count(*) FROM requested) <= 1)
+	), ins AS (
 		INSERT INTO users.parent_announcement_responses
 			(tenant_id, announcement_id, option_id, student_id, account_id, responded_at)
 		SELECT ?, ?, o.id, ?, ?, ?
 		FROM users.parent_announcement_options o
 		WHERE o.announcement_id = ? AND o.tenant_id = ? AND o.id IN (?)
-		ON CONFLICT (announcement_id, student_id, option_id) DO NOTHING`,
-		tenantID, announcementID, studentID, accountID, time.Now(),
-		announcementID, tenantID, bun.List(optionIDs),
-	).Exec(ctx); err != nil {
+			AND (SELECT selection_valid FROM selection_valid)
+		ON CONFLICT (announcement_id, student_id, option_id) DO NOTHING
+	)
+	SELECT selection_valid FROM selection_valid`,
+		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
+		bun.List(optionIDs), announcementID, tenantID,
+		tenantID, announcementID, studentID, accountID, time.Now(), announcementID, tenantID, bun.List(optionIDs),
+	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "insert parent announcement response", Err: err}
 	}
-	return true, nil
+	return live, nil
 }
 
 // PollResults returns the per-option tally plus how many children the poll
@@ -322,7 +387,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 // CURRENT audience, so a child who left the school stops counting — the staff
 // "X von Y" can never show more answers than reached children.
 func (r *ParentAnnouncementRepository) PollResults(ctx context.Context, tenantID, announcementID int64) (*users.AnnouncementPollResults, error) {
-	audience := audienceStudentsSQL("?", "?", "")
+	audience := pollAudienceStudentsSQL("?", "?", "")
 	args := audienceStudentArgs(announcementID, tenantID, nil)
 
 	results := &users.AnnouncementPollResults{}
@@ -363,7 +428,7 @@ func (r *ParentAnnouncementRepository) PollResults(ctx context.Context, tenantID
 // This is the per-child list behind PollResults, so staff can chase the missing
 // answers by name.
 func (r *ParentAnnouncementRepository) PollChildren(ctx context.Context, tenantID, announcementID int64) ([]*users.AnnouncementPollChildStatus, error) {
-	audience := audienceStudentsSQL("?", "?", "")
+	audience := pollAudienceStudentsSQL("?", "?", "")
 	args := audienceStudentArgs(announcementID, tenantID, nil)
 	sqlStr := `WITH audience AS (` + audience + `)
 		SELECT s.id AS student_id,
@@ -411,7 +476,7 @@ func (r *ParentAnnouncementRepository) UnansweredReminderRecipients(ctx context.
 		JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
 		AND s.status <> 'alumnus'
 		JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = ?
-			AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+			AND sg.permissions @> '{"parent_portal.access": true, "parent_portal.poll.response": true}'::jsonb
 		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = ?
 			AND gp.account_id IS NOT NULL
 			AND gp.email IS NOT NULL AND length(btrim(gp.email)) > 0

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -292,7 +292,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 	// Each guarded write repeats audience/relationship authorization and poll
 	// liveness. Revoking poll.response after Phase 1 therefore prevents the
 	// write, rather than leaving a TOCTOU window.
-	if _, err := db.NewRaw(`SELECT pg_advisory_xact_lock(?, ?)`, announcementID, studentID).Exec(ctx); err != nil {
+	if err := base.AcquireXactLock(ctx, r.DB, parentAnnouncementResponseLockKey(announcementID, studentID)); err != nil {
 		return false, &modelBase.DatabaseError{Op: "lock parent announcement response", Err: err}
 	}
 	guard := `
@@ -381,6 +381,10 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 		return false, &modelBase.DatabaseError{Op: "insert parent announcement response", Err: err}
 	}
 	return live, nil
+}
+
+func parentAnnouncementResponseLockKey(announcementID, studentID int64) string {
+	return fmt.Sprintf("parent-announcement-response:%d:%d", announcementID, studentID)
 }
 
 // PollResults returns the per-option tally plus how many children the poll

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -167,6 +167,7 @@ func (r *ParentAnnouncementRepository) ReplaceOptions(ctx context.Context, tenan
 	if _, err := db.NewInsert().
 		Model(&options).
 		ModelTableExpr("users.parent_announcement_options").
+		Returning("*").
 		Exec(ctx); err != nil {
 		return &modelBase.DatabaseError{Op: "insert parent announcement options", Err: err}
 	}
@@ -178,7 +179,7 @@ func (r *ParentAnnouncementRepository) ListOptions(ctx context.Context, announce
 	var rows []*users.ParentAnnouncementOption
 	query := base.GetDB(ctx, r.DB).NewSelect().
 		Model(&rows).
-		ModelTableExpr("users.parent_announcement_options AS pao").
+		ModelTableExpr(`users.parent_announcement_options AS "pao"`).
 		Where("pao.announcement_id = ?", announcementID).
 		OrderExpr("pao.position ASC, pao.id ASC")
 	query = base.WithTenantFilter(ctx, query, "pao")
@@ -199,7 +200,7 @@ func (r *ParentAnnouncementRepository) ListOptionsForAnnouncements(ctx context.C
 	var rows []*users.ParentAnnouncementOption
 	if err := base.GetDB(ctx, r.DB).NewSelect().
 		Model(&rows).
-		ModelTableExpr("users.parent_announcement_options AS pao").
+		ModelTableExpr(`users.parent_announcement_options AS "pao"`).
 		Where("pao.announcement_id IN (?)", bun.List(announcementIDs)).
 		OrderExpr("pao.announcement_id ASC, pao.position ASC, pao.id ASC").
 		Scan(ctx); err != nil {

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -349,13 +349,13 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 				WHERE o.announcement_id = ? AND o.tenant_id = ?
 			)
 			AND ((SELECT response_type FROM guard LIMIT 1) <> 'single_choice'
-				OR (SELECT count(*) FROM requested) <= 1)
+				OR (SELECT count(*) FROM requested) <= 1) AS valid
 	), del AS (
 		DELETE FROM users.parent_announcement_responses
 		WHERE announcement_id = ? AND student_id = ? AND tenant_id = ?
-			AND (SELECT selection_valid FROM selection_valid)
+			AND (SELECT valid FROM selection_valid)
 	)
-	SELECT selection_valid FROM selection_valid`,
+	SELECT valid FROM selection_valid`,
 		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
 		pgdialect.Array(optionIDs), announcementID, tenantID,
 		announcementID, studentID, tenantID,
@@ -379,17 +379,17 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 				WHERE o.announcement_id = ? AND o.tenant_id = ?
 			)
 			AND ((SELECT response_type FROM guard LIMIT 1) <> 'single_choice'
-				OR (SELECT count(*) FROM requested) <= 1)
+				OR (SELECT count(*) FROM requested) <= 1) AS valid
 	), ins AS (
 		INSERT INTO users.parent_announcement_responses
 			(tenant_id, announcement_id, option_id, student_id, account_id, responded_at)
 		SELECT ?, ?, o.id, ?, ?, ?
 		FROM users.parent_announcement_options o
 		WHERE o.announcement_id = ? AND o.tenant_id = ? AND o.id IN (?)
-			AND (SELECT selection_valid FROM selection_valid)
+			AND (SELECT valid FROM selection_valid)
 		ON CONFLICT (announcement_id, student_id, option_id) DO NOTHING
 	)
-	SELECT selection_valid FROM selection_valid`,
+	SELECT valid FROM selection_valid`,
 		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
 		pgdialect.Array(optionIDs), announcementID, tenantID,
 		tenantID, announcementID, studentID, accountID, time.Now(), announcementID, tenantID, bun.List(optionIDs),

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -41,6 +41,20 @@ func pollAudienceStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
 	return audienceStudentsSQLForPermission(annExpr, tenantExpr, accountFilter, "")
 }
 
+// pollAnswerableStudentsSQL is the subset of the normal portal-visible
+// audience for which at least one guardian currently has poll.response. It is
+// the completion denominator and reminder source; the broader audience remains
+// available to staff so inaccessible targets are visible rather than appearing
+// as permanently unanswered.
+func pollAnswerableStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
+	return audienceStudentsSQLForPermission(
+		annExpr,
+		tenantExpr,
+		accountFilter,
+		`sg.permissions @> '{"parent_portal.poll.response": true}'::jsonb`,
+	)
+}
+
 // audienceStudentsSQLForPermission is the permission-specific variant used by
 // actions that need stronger authority than merely seeing a child in the
 // portal. permissionPredicate is a trusted SQL predicate over sg.
@@ -389,30 +403,35 @@ func parentAnnouncementResponseLockKey(announcementID, studentID int64) string {
 	return fmt.Sprintf("parent-announcement-response:%d:%d", announcementID, studentID)
 }
 
-// PollResults returns the per-option tally plus how many children the poll
-// reaches and how many of them have answered. Answers are intersected with the
-// CURRENT audience, so a child who left the school stops counting — the staff
-// "X von Y" can never show more answers than reached children.
+// PollResults returns the per-option tally plus how many answerable children
+// the poll reaches and how many of them have answered. TargetChildCount retains
+// the full portal-visible audience so staff can distinguish unavailable
+// respondents from missing answers. Answers are intersected with the CURRENT
+// answerable audience, so a child who left the school or lost response
+// permission stops counting toward completion.
 func (r *ParentAnnouncementRepository) PollResults(ctx context.Context, tenantID, announcementID int64) (*users.AnnouncementPollResults, error) {
-	audience := pollAudienceStudentsSQL("?", "?", "")
+	targetAudience := pollAudienceStudentsSQL("?", "?", "")
+	answerableAudience := pollAnswerableStudentsSQL("?", "?", "")
 	args := audienceStudentArgs(announcementID, tenantID, nil)
 
 	results := &users.AnnouncementPollResults{}
-	countSQL := `WITH audience AS (` + audience + `)
+	countSQL := `WITH target_audience AS (` + targetAudience + `),
+		answerable_audience AS (` + answerableAudience + `)
 		SELECT
-			(SELECT COUNT(*) FROM audience) AS child_count,
+			(SELECT COUNT(*) FROM target_audience) AS target_child_count,
+			(SELECT COUNT(*) FROM answerable_audience) AS child_count,
 			(SELECT COUNT(DISTINCT resp.student_id)
 				FROM users.parent_announcement_responses resp
 				WHERE resp.announcement_id = ? AND resp.tenant_id = ?
-					AND resp.student_id IN (SELECT student_id FROM audience)) AS answered_count`
-	countArgs := append(append([]any{}, args...), announcementID, tenantID)
+					AND resp.student_id IN (SELECT student_id FROM answerable_audience)) AS answered_count`
+	countArgs := append(append(append([]any{}, args...), args...), announcementID, tenantID)
 	if err := base.GetDB(ctx, r.DB).NewRaw(countSQL, countArgs...).
-		Scan(ctx, &results.ChildCount, &results.AnsweredCount); err != nil {
+		Scan(ctx, &results.TargetChildCount, &results.ChildCount, &results.AnsweredCount); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "parent announcement poll counts", Err: err}
 	}
 
 	var options []*users.AnnouncementPollOptionResult
-	optionSQL := `WITH audience AS (` + audience + `)
+	optionSQL := `WITH audience AS (` + answerableAudience + `)
 		SELECT o.id AS option_id, o.label, o.position,
 			COUNT(DISTINCT resp.student_id) AS count
 		FROM users.parent_announcement_options o
@@ -430,20 +449,22 @@ func (r *ParentAnnouncementRepository) PollResults(ctx context.Context, tenantID
 	return results, nil
 }
 
-// PollChildren returns every child the poll reaches with the option labels
-// answered for them (empty array = still open) and when the answer was given.
-// This is the per-child list behind PollResults, so staff can chase the missing
-// answers by name.
+// PollChildren returns every portal-visible child the poll reaches with the
+// option labels answered for them and whether someone may currently answer.
+// This lets staff see inaccessible targets without treating them as overdue.
 func (r *ParentAnnouncementRepository) PollChildren(ctx context.Context, tenantID, announcementID int64) ([]*users.AnnouncementPollChildStatus, error) {
 	audience := pollAudienceStudentsSQL("?", "?", "")
+	answerableAudience := pollAnswerableStudentsSQL("?", "?", "")
 	args := audienceStudentArgs(announcementID, tenantID, nil)
-	sqlStr := `WITH audience AS (` + audience + `)
+	sqlStr := `WITH audience AS (` + audience + `),
+		answerable_audience AS (` + answerableAudience + `)
 		SELECT s.id AS student_id,
 			COALESCE(p.first_name, '') AS first_name,
 			COALESCE(p.last_name, '') AS last_name,
 			COALESCE(s.school_class, '') AS school_class,
 			COALESCE(ans.labels, ARRAY[]::text[]) AS answer_labels,
-			ans.responded_at AS responded_at
+			ans.responded_at AS responded_at,
+			EXISTS (SELECT 1 FROM answerable_audience aa WHERE aa.student_id = s.id) AS can_answer
 		FROM audience
 		JOIN users.students s ON s.id = audience.student_id
 		JOIN users.persons p ON p.id = s.person_id
@@ -455,7 +476,7 @@ func (r *ParentAnnouncementRepository) PollChildren(ctx context.Context, tenantI
 			WHERE resp.announcement_id = ? AND resp.tenant_id = ? AND resp.student_id = s.id
 		) ans ON TRUE
 		ORDER BY last_name ASC, first_name ASC, student_id ASC`
-	sqlArgs := append(append([]any{}, args...), announcementID, tenantID)
+	sqlArgs := append(append(append([]any{}, args...), args...), announcementID, tenantID)
 	var rows []*users.AnnouncementPollChildStatus
 	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr, sqlArgs...).Scan(ctx, &rows); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "parent announcement poll children", Err: err}

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -1,0 +1,434 @@
+package users
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/uptrace/bun"
+)
+
+// This file holds the poll (Umfrage, #1371) half of the parent-announcement
+// repository: answer options, per-child responses, and the staff-facing
+// evaluation. It shares the audience definition with the announcement half —
+// see audienceStudentsSQL below, which is the per-CHILD sibling of the
+// per-ACCOUNT reachedPredicate in parent_announcement.go. The two must stay
+// consistent: a poll's reach is exactly the set of children behind the
+// announcement reach, so "12 von 30 Kindern" can never exceed what the same
+// targets deliver as announcement recipients.
+//
+// The pending_enrollment target has no student behind it, so it contributes to
+// an announcement's account reach but never to a poll's child reach. That is
+// intentional and documented in the UI: an applicant without an enrolled child
+// has no child to answer for.
+
+// audienceStudentsSQL renders "the children this announcement reaches right
+// now" as a SELECT of distinct student ids. tenantExpr is the SQL expression for
+// the tenant (a bound `?` or a column reference like `a.tenant_id`); annExpr is
+// the announcement id expression. accountFilter is either "" (all reached
+// children) or "AND gp.account_id = ?" (only one guardian's children).
+//
+// The join chain mirrors reachedPredicate exactly: a live, non-graduated student
+// whose person is not soft-deleted, a students_guardians link granting
+// parent_portal.access, a guardian profile with a linked account, and an ACTIVE
+// account_tenants membership.
+func audienceStudentsSQL(annExpr, tenantExpr, accountFilter string) string {
+	return fmt.Sprintf(`
+		SELECT DISTINCT s.id AS student_id
+		FROM users.parent_announcement_targets pt
+		JOIN users.students s ON s.tenant_id = %[2]s AND (
+			pt.target_type = 'school_all'
+			OR (pt.target_type = 'class' AND LOWER(TRIM(s.school_class)) = LOWER(TRIM(pt.target_ref_text)))
+			OR (pt.target_type = 'group' AND s.group_id = pt.target_ref_id)
+			OR (pt.target_type = 'student' AND s.id = pt.target_ref_id)
+			OR %[3]s
+		)
+		JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
+		AND s.status <> 'alumnus'
+		JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = %[2]s
+			AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = %[2]s
+			AND gp.account_id IS NOT NULL %[4]s
+		JOIN auth.account_tenants act ON act.account_id = gp.account_id
+			AND act.tenant_id = gp.tenant_id AND act.status = 'active'
+		WHERE pt.announcement_id = %[1]s AND pt.tenant_id = %[2]s`,
+		annExpr, tenantExpr, activeActivityGroupExists(tenantExpr), accountFilter)
+}
+
+// audienceStudentArgs returns the bind args for audienceStudentsSQL("?","?",...)
+// in the textual order the placeholders appear. Keep in lockstep with the SQL
+// above (mirrors reachedArgs):
+//
+//	s.tenant_id = ?          -> tenant
+//	se.tenant_id = ?         -> tenant  (inside the activity_group sub-EXISTS)
+//	sg.tenant_id = ?         -> tenant
+//	gp.tenant_id = ?         -> tenant
+//	[gp.account_id = ?       -> account, only with an account filter]
+//	pt.announcement_id = ?   -> ann
+//	pt.tenant_id = ?         -> tenant
+func audienceStudentArgs(announcementID, tenantID int64, accountID *int64) []any {
+	args := []any{tenantID, tenantID, tenantID, tenantID}
+	if accountID != nil {
+		args = append(args, *accountID)
+	}
+	return append(args, announcementID, tenantID)
+}
+
+// openPollForAccountPredicate builds the SQL boolean "this announcement is an
+// open poll and at least one of account :acc's reached children has no answer
+// yet". annExpr/tenantExpr are SQL expressions (column refs in the feed query),
+// accPlace the account placeholder.
+//
+// It is what makes an answered-but-unread distinction impossible to game in the
+// parent badge: a guardian who read a poll but never answered it still counts as
+// outstanding, because a poll that quietly stops nagging is a poll nobody
+// answers.
+func openPollForAccountPredicate(annExpr, tenantExpr, accPlace string) string {
+	return fmt.Sprintf(`(
+		%[1]s.response_type <> 'none'
+		AND (%[1]s.response_deadline IS NULL OR %[1]s.response_deadline > NOW())
+		AND EXISTS (
+			SELECT 1
+			FROM users.parent_announcement_targets pt
+			JOIN users.students s ON s.tenant_id = %[2]s AND (
+				pt.target_type = 'school_all'
+				OR (pt.target_type = 'class' AND LOWER(TRIM(s.school_class)) = LOWER(TRIM(pt.target_ref_text)))
+				OR (pt.target_type = 'group' AND s.group_id = pt.target_ref_id)
+				OR (pt.target_type = 'student' AND s.id = pt.target_ref_id)
+				OR %[4]s
+			)
+			JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
+			AND s.status <> 'alumnus'
+			JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = %[2]s
+				AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+			JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = %[2]s
+				AND gp.account_id = %[3]s
+			JOIN auth.account_tenants act ON act.account_id = gp.account_id
+				AND act.tenant_id = gp.tenant_id AND act.status = 'active'
+			WHERE pt.announcement_id = %[1]s.id AND pt.tenant_id = %[2]s
+				AND NOT EXISTS (
+					SELECT 1 FROM users.parent_announcement_responses resp
+					WHERE resp.announcement_id = %[1]s.id AND resp.student_id = s.id
+				)
+		)
+	)`, annExpr, tenantExpr, accPlace, activeActivityGroupExists(tenantExpr))
+}
+
+// ReplaceOptions swaps a DRAFT poll's answer options wholesale. It locks the
+// announcement and re-checks published_at IS NULL for the same reason
+// ReplaceTargets does: options are referenced by response rows, so changing them
+// under a published poll would silently re-label answers guardians already gave.
+// A published row returns users.ErrAnnouncementPublished.
+func (r *ParentAnnouncementRepository) ReplaceOptions(ctx context.Context, tenantID, announcementID int64, options []*users.ParentAnnouncementOption) error {
+	db := base.GetDB(ctx, r.DB)
+	var publishedAt *time.Time
+	if err := db.NewSelect().
+		ColumnExpr("published_at").
+		TableExpr("users.parent_announcements").
+		Where("id = ?", announcementID).
+		Where("tenant_id = ?", tenantID).
+		For("UPDATE").
+		Scan(ctx, &publishedAt); err != nil {
+		return &modelBase.DatabaseError{Op: "lock parent announcement for option replace", Err: err}
+	}
+	if publishedAt != nil {
+		return users.ErrAnnouncementPublished
+	}
+	if _, err := db.NewDelete().
+		Model((*users.ParentAnnouncementOption)(nil)).
+		ModelTableExpr("users.parent_announcement_options").
+		Where("announcement_id = ?", announcementID).
+		Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "clear parent announcement options", Err: err}
+	}
+	if len(options) == 0 {
+		return nil
+	}
+	for i, o := range options {
+		o.AnnouncementID = announcementID
+		o.Position = i
+		o.SetTenantID(tenantID)
+	}
+	if _, err := db.NewInsert().
+		Model(&options).
+		ModelTableExpr("users.parent_announcement_options").
+		Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "insert parent announcement options", Err: err}
+	}
+	return nil
+}
+
+// ListOptions returns a poll's options in display order.
+func (r *ParentAnnouncementRepository) ListOptions(ctx context.Context, announcementID int64) ([]*users.ParentAnnouncementOption, error) {
+	var rows []*users.ParentAnnouncementOption
+	query := base.GetDB(ctx, r.DB).NewSelect().
+		Model(&rows).
+		ModelTableExpr("users.parent_announcement_options AS pao").
+		Where("pao.announcement_id = ?", announcementID).
+		OrderExpr("pao.position ASC, pao.id ASC")
+	query = base.WithTenantFilter(ctx, query, "pao")
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list parent announcement options", Err: err}
+	}
+	return rows, nil
+}
+
+// ListOptionsForAnnouncements batches the option lookup for a whole feed page.
+// No tenant filter: the announcement id set is already the caller's authorized
+// scope (the feed query resolved it), and this runs in the cross-tenant admin tx
+// where a per-row tenant filter would exclude everything.
+func (r *ParentAnnouncementRepository) ListOptionsForAnnouncements(ctx context.Context, announcementIDs []int64) ([]*users.ParentAnnouncementOption, error) {
+	if len(announcementIDs) == 0 {
+		return []*users.ParentAnnouncementOption{}, nil
+	}
+	var rows []*users.ParentAnnouncementOption
+	if err := base.GetDB(ctx, r.DB).NewSelect().
+		Model(&rows).
+		ModelTableExpr("users.parent_announcement_options AS pao").
+		Where("pao.announcement_id IN (?)", bun.List(announcementIDs)).
+		OrderExpr("pao.announcement_id ASC, pao.position ASC, pao.id ASC").
+		Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list parent announcement options for feed", Err: err}
+	}
+	return rows, nil
+}
+
+// AnswerableChildren returns, for each of the given announcements, the children
+// of accountID the poll reaches, with the option ids already selected for that
+// child. Cross-tenant (the feed spans schools), so tenant scoping comes from
+// each announcement's own tenant_id rather than a bound tenant.
+func (r *ParentAnnouncementRepository) AnswerableChildren(ctx context.Context, accountID int64, announcementIDs []int64) ([]*users.AnnouncementPollChild, error) {
+	if len(announcementIDs) == 0 {
+		return []*users.AnnouncementPollChild{}, nil
+	}
+	var rows []*users.AnnouncementPollChild
+	sqlStr := fmt.Sprintf(`
+		SELECT DISTINCT a.id AS announcement_id, s.id AS student_id,
+			COALESCE(p.first_name, '') AS first_name,
+			COALESCE(p.last_name, '') AS last_name,
+			COALESCE(sel.options, ARRAY[]::bigint[]) AS selected_options
+		FROM users.parent_announcements a
+		JOIN users.parent_announcement_targets pt
+			ON pt.announcement_id = a.id AND pt.tenant_id = a.tenant_id
+		JOIN users.students s ON s.tenant_id = a.tenant_id AND (
+			pt.target_type = 'school_all'
+			OR (pt.target_type = 'class' AND LOWER(TRIM(s.school_class)) = LOWER(TRIM(pt.target_ref_text)))
+			OR (pt.target_type = 'group' AND s.group_id = pt.target_ref_id)
+			OR (pt.target_type = 'student' AND s.id = pt.target_ref_id)
+			OR %s
+		)
+		JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
+			AND s.status <> 'alumnus'
+		JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = a.tenant_id
+			AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = a.tenant_id
+			AND gp.account_id = ?
+		JOIN auth.account_tenants act ON act.account_id = gp.account_id
+			AND act.tenant_id = gp.tenant_id AND act.status = 'active'
+		LEFT JOIN LATERAL (
+			SELECT array_agg(resp.option_id ORDER BY resp.option_id) AS options
+			FROM users.parent_announcement_responses resp
+			WHERE resp.announcement_id = a.id AND resp.student_id = s.id
+		) sel ON TRUE
+		WHERE a.id IN (?)
+		ORDER BY last_name ASC, first_name ASC, student_id ASC`,
+		activeActivityGroupExists("a.tenant_id"))
+	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr, accountID, bun.List(announcementIDs)).Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list answerable children for parent announcements", Err: err}
+	}
+	return rows, nil
+}
+
+// AccountMayAnswerForStudent reports whether accountID may answer a poll for
+// studentID: the child must be in the poll's live audience AND the account must
+// be a portal-enabled guardian of exactly that child. Both halves come from the
+// same audience query, so a guardian can never answer for a child the poll does
+// not reach, nor for a reached child that is not theirs.
+func (r *ParentAnnouncementRepository) AccountMayAnswerForStudent(ctx context.Context, tenantID, announcementID, accountID, studentID int64) (bool, error) {
+	var allowed bool
+	inner := audienceStudentsSQL("?", "?", "AND gp.account_id = ?")
+	sqlStr := "SELECT EXISTS (SELECT 1 FROM (" + inner + ") reached WHERE reached.student_id = ?)"
+	args := append(audienceStudentArgs(announcementID, tenantID, &accountID), studentID)
+	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr, args...).Scan(ctx, &allowed); err != nil {
+		return false, &modelBase.DatabaseError{Op: "check parent announcement answer permission", Err: err}
+	}
+	return allowed, nil
+}
+
+// SetResponse replaces a child's answer for a poll: it deletes the child's
+// existing rows and inserts one row per selected option, both gated on the
+// announcement still being live at expectedPublishedAt AND still accepting
+// answers (no deadline, or a deadline in the future). An empty optionIDs
+// withdraws the answer.
+//
+// The guard is evaluated inside the same statement as the writes (mirroring
+// MarkRead's liveVersionGuardCTE) so a correction or a deadline that passes
+// between the service's authorize phase and this write cannot slip an answer in.
+// It returns whether the guard matched; false makes the service answer 409.
+//
+// Option ids are verified to belong to THIS announcement in the insert's SELECT,
+// so a client cannot vote with another poll's option id.
+func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error) {
+	db := base.GetDB(ctx, r.DB)
+	var live bool
+	guard := `WITH guard AS (
+			SELECT 1 FROM users.parent_announcements a
+			WHERE a.id = ? AND a.tenant_id = ?
+				AND a.active
+				AND a.published_at = ?
+				AND a.published_at <= NOW()
+				AND (a.expires_at IS NULL OR a.expires_at > NOW())
+				AND a.response_type <> 'none'
+				AND (a.response_deadline IS NULL OR a.response_deadline > NOW())
+		)`
+	if err := db.NewRaw(guard+`,
+		del AS (
+			DELETE FROM users.parent_announcement_responses
+			WHERE announcement_id = ? AND student_id = ? AND tenant_id = ?
+				AND EXISTS (SELECT 1 FROM guard)
+		)
+		SELECT EXISTS (SELECT 1 FROM guard)`,
+		announcementID, tenantID, expectedPublishedAt,
+		announcementID, studentID, tenantID,
+	).Scan(ctx, &live); err != nil {
+		return false, &modelBase.DatabaseError{Op: "clear parent announcement response", Err: err}
+	}
+	if !live || len(optionIDs) == 0 {
+		return live, nil
+	}
+	// Insert the new selection. The SELECT ... FROM options join is what pins the
+	// option ids to this announcement (and this tenant); an id from another poll
+	// simply produces no row rather than a foreign vote.
+	if _, err := db.NewRaw(`
+		INSERT INTO users.parent_announcement_responses
+			(tenant_id, announcement_id, option_id, student_id, account_id, responded_at)
+		SELECT ?, ?, o.id, ?, ?, ?
+		FROM users.parent_announcement_options o
+		WHERE o.announcement_id = ? AND o.tenant_id = ? AND o.id IN (?)
+		ON CONFLICT (announcement_id, student_id, option_id) DO NOTHING`,
+		tenantID, announcementID, studentID, accountID, time.Now(),
+		announcementID, tenantID, bun.List(optionIDs),
+	).Exec(ctx); err != nil {
+		return false, &modelBase.DatabaseError{Op: "insert parent announcement response", Err: err}
+	}
+	return true, nil
+}
+
+// PollResults returns the per-option tally plus how many children the poll
+// reaches and how many of them have answered. Answers are intersected with the
+// CURRENT audience, so a child who left the school stops counting — the staff
+// "X von Y" can never show more answers than reached children.
+func (r *ParentAnnouncementRepository) PollResults(ctx context.Context, tenantID, announcementID int64) (*users.AnnouncementPollResults, error) {
+	audience := audienceStudentsSQL("?", "?", "")
+	args := audienceStudentArgs(announcementID, tenantID, nil)
+
+	results := &users.AnnouncementPollResults{}
+	countSQL := `WITH audience AS (` + audience + `)
+		SELECT
+			(SELECT COUNT(*) FROM audience) AS child_count,
+			(SELECT COUNT(DISTINCT resp.student_id)
+				FROM users.parent_announcement_responses resp
+				WHERE resp.announcement_id = ? AND resp.tenant_id = ?
+					AND resp.student_id IN (SELECT student_id FROM audience)) AS answered_count`
+	countArgs := append(append([]any{}, args...), announcementID, tenantID)
+	if err := base.GetDB(ctx, r.DB).NewRaw(countSQL, countArgs...).
+		Scan(ctx, &results.ChildCount, &results.AnsweredCount); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "parent announcement poll counts", Err: err}
+	}
+
+	var options []*users.AnnouncementPollOptionResult
+	optionSQL := `WITH audience AS (` + audience + `)
+		SELECT o.id AS option_id, o.label, o.position,
+			COUNT(DISTINCT resp.student_id) AS count
+		FROM users.parent_announcement_options o
+		LEFT JOIN users.parent_announcement_responses resp
+			ON resp.option_id = o.id AND resp.announcement_id = o.announcement_id
+			AND resp.student_id IN (SELECT student_id FROM audience)
+		WHERE o.announcement_id = ? AND o.tenant_id = ?
+		GROUP BY o.id, o.label, o.position
+		ORDER BY o.position ASC, o.id ASC`
+	optionArgs := append(append([]any{}, args...), announcementID, tenantID)
+	if err := base.GetDB(ctx, r.DB).NewRaw(optionSQL, optionArgs...).Scan(ctx, &options); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "parent announcement poll option results", Err: err}
+	}
+	results.Options = options
+	return results, nil
+}
+
+// PollChildren returns every child the poll reaches with the option labels
+// answered for them (empty array = still open) and when the answer was given.
+// This is the per-child list behind PollResults, so staff can chase the missing
+// answers by name.
+func (r *ParentAnnouncementRepository) PollChildren(ctx context.Context, tenantID, announcementID int64) ([]*users.AnnouncementPollChildStatus, error) {
+	audience := audienceStudentsSQL("?", "?", "")
+	args := audienceStudentArgs(announcementID, tenantID, nil)
+	sqlStr := `WITH audience AS (` + audience + `)
+		SELECT s.id AS student_id,
+			COALESCE(p.first_name, '') AS first_name,
+			COALESCE(p.last_name, '') AS last_name,
+			COALESCE(s.school_class, '') AS school_class,
+			COALESCE(ans.labels, ARRAY[]::text[]) AS answer_labels,
+			ans.responded_at AS responded_at
+		FROM audience
+		JOIN users.students s ON s.id = audience.student_id
+		JOIN users.persons p ON p.id = s.person_id
+		LEFT JOIN LATERAL (
+			SELECT array_agg(o.label ORDER BY o.position) AS labels,
+				max(resp.responded_at) AS responded_at
+			FROM users.parent_announcement_responses resp
+			JOIN users.parent_announcement_options o ON o.id = resp.option_id
+			WHERE resp.announcement_id = ? AND resp.tenant_id = ? AND resp.student_id = s.id
+		) ans ON TRUE
+		ORDER BY last_name ASC, first_name ASC, student_id ASC`
+	sqlArgs := append(append([]any{}, args...), announcementID, tenantID)
+	var rows []*users.AnnouncementPollChildStatus
+	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr, sqlArgs...).Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "parent announcement poll children", Err: err}
+	}
+	return rows, nil
+}
+
+// UnansweredReminderRecipients returns the distinct guardians (account + address)
+// of children the poll reaches that have NO answer yet. A guardian with two
+// unanswered children appears once — the reminder is one e-mail per person, not
+// per child.
+func (r *ParentAnnouncementRepository) UnansweredReminderRecipients(ctx context.Context, tenantID, announcementID int64) ([]*users.AnnouncementPollReminderRecipient, error) {
+	sqlStr := fmt.Sprintf(`
+		SELECT DISTINCT gp.account_id, lower(gp.email) AS email,
+			COALESCE(gp.first_name, '') AS first_name,
+			COALESCE(gp.last_name, '') AS last_name
+		FROM users.parent_announcement_targets pt
+		JOIN users.students s ON s.tenant_id = ? AND (
+			pt.target_type = 'school_all'
+			OR (pt.target_type = 'class' AND LOWER(TRIM(s.school_class)) = LOWER(TRIM(pt.target_ref_text)))
+			OR (pt.target_type = 'group' AND s.group_id = pt.target_ref_id)
+			OR (pt.target_type = 'student' AND s.id = pt.target_ref_id)
+			OR %s
+		)
+		JOIN users.persons p ON p.id = s.person_id AND p.deleted_at IS NULL
+		AND s.status <> 'alumnus'
+		JOIN users.students_guardians sg ON sg.student_id = s.id AND sg.tenant_id = ?
+			AND sg.permissions @> '{"parent_portal.access": true}'::jsonb
+		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = ?
+			AND gp.account_id IS NOT NULL
+			AND gp.email IS NOT NULL AND length(btrim(gp.email)) > 0
+		JOIN auth.account_tenants act ON act.account_id = gp.account_id
+			AND act.tenant_id = gp.tenant_id AND act.status = 'active'
+		WHERE pt.announcement_id = ? AND pt.tenant_id = ?
+			AND NOT EXISTS (
+				SELECT 1 FROM users.parent_announcement_responses resp
+				WHERE resp.announcement_id = pt.announcement_id
+					AND resp.tenant_id = pt.tenant_id
+					AND resp.student_id = s.id
+			)`, activeActivityGroupExists("?"))
+	var rows []*users.AnnouncementPollReminderRecipient
+	if err := base.GetDB(ctx, r.DB).NewRaw(sqlStr,
+		tenantID, tenantID, tenantID, tenantID, announcementID, tenantID,
+	).Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "parent announcement poll reminder recipients", Err: err}
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -9,6 +9,7 @@ import (
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
 )
 
 // This file holds the poll (Umfrage, #1371) half of the parent-announcement
@@ -322,7 +323,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 		)`
 	var live bool
 	if err := db.NewRaw(guard+`, requested AS (
-		SELECT option_id FROM unnest(ARRAY[?]::bigint[]) AS selection(option_id)
+		SELECT option_id FROM unnest(?::bigint[]) AS selection(option_id)
 	), selection_valid AS (
 		SELECT EXISTS (SELECT 1 FROM guard)
 			AND (SELECT count(*) FROM requested) = (SELECT count(DISTINCT option_id) FROM requested)
@@ -340,7 +341,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 	)
 	SELECT selection_valid FROM selection_valid`,
 		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
-		bun.List(optionIDs), announcementID, tenantID,
+		pgdialect.Array(optionIDs), announcementID, tenantID,
 		announcementID, studentID, tenantID,
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "replace parent announcement response", Err: err}
@@ -352,7 +353,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 	// insert: if the deadline closes or access is revoked after the delete, this
 	// transaction returns false and the caller rolls the delete back.
 	if err := db.NewRaw(guard+`, requested AS (
-		SELECT option_id FROM unnest(ARRAY[?]::bigint[]) AS selection(option_id)
+		SELECT option_id FROM unnest(?::bigint[]) AS selection(option_id)
 	), selection_valid AS (
 		SELECT EXISTS (SELECT 1 FROM guard)
 			AND (SELECT count(*) FROM requested) = (SELECT count(DISTINCT option_id) FROM requested)
@@ -374,7 +375,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 	)
 	SELECT selection_valid FROM selection_valid`,
 		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
-		bun.List(optionIDs), announcementID, tenantID,
+		pgdialect.Array(optionIDs), announcementID, tenantID,
 		tenantID, announcementID, studentID, accountID, time.Now(), announcementID, tenantID, bun.List(optionIDs),
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "insert parent announcement response", Err: err}
@@ -462,7 +463,7 @@ func (r *ParentAnnouncementRepository) PollChildren(ctx context.Context, tenantI
 // per child.
 func (r *ParentAnnouncementRepository) UnansweredReminderRecipients(ctx context.Context, tenantID, announcementID int64) ([]*users.AnnouncementPollReminderRecipient, error) {
 	sqlStr := fmt.Sprintf(`
-		SELECT DISTINCT gp.account_id, lower(gp.email) AS email,
+		SELECT DISTINCT gp.account_id, COALESCE(lower(gp.email), '') AS email,
 			COALESCE(gp.first_name, '') AS first_name,
 			COALESCE(gp.last_name, '') AS last_name
 		FROM users.parent_announcement_targets pt
@@ -479,7 +480,6 @@ func (r *ParentAnnouncementRepository) UnansweredReminderRecipients(ctx context.
 			AND sg.permissions @> '{"parent_portal.access": true, "parent_portal.poll.response": true}'::jsonb
 		JOIN users.guardian_profiles gp ON gp.id = sg.guardian_profile_id AND gp.tenant_id = ?
 			AND gp.account_id IS NOT NULL
-			AND gp.email IS NOT NULL AND length(btrim(gp.email)) > 0
 		JOIN auth.account_tenants act ON act.account_id = gp.account_id
 			AND act.tenant_id = gp.tenant_id AND act.status = 'active'
 		WHERE pt.announcement_id = ? AND pt.tenant_id = ?

--- a/backend/database/repositories/users/parent_announcement_poll_internal_test.go
+++ b/backend/database/repositories/users/parent_announcement_poll_internal_test.go
@@ -1,0 +1,16 @@
+package users
+
+import "testing"
+
+func TestParentAnnouncementResponseLockKey(t *testing.T) {
+	key := parentAnnouncementResponseLockKey(123, 456)
+	if key != "parent-announcement-response:123:456" {
+		t.Fatalf("unexpected lock key %q", key)
+	}
+	if key == parentAnnouncementResponseLockKey(124, 456) {
+		t.Fatal("different announcement IDs must use different lock keys")
+	}
+	if key == parentAnnouncementResponseLockKey(123, 457) {
+		t.Fatal("different student IDs must use different lock keys")
+	}
+}

--- a/backend/models/users/parent_announcement.go
+++ b/backend/models/users/parent_announcement.go
@@ -204,14 +204,16 @@ type AnnouncementPollOptionResult struct {
 	Count    int    `bun:"count" json:"count"`
 }
 
-// AnnouncementPollResults is the staff-facing evaluation of a poll: how many
-// children the poll currently reaches, how many of them have an answer, and the
-// per-option tally. Reach is resolved live against current relationships, so the
-// numbers reflect "right now" rather than a publish-time snapshot.
+// AnnouncementPollResults is the staff-facing evaluation of a poll. ChildCount
+// is the number of currently reached children with at least one guardian who
+// may respond; TargetChildCount is the full portal-visible target audience.
+// Reach is resolved live against current relationships, so the numbers reflect
+// "right now" rather than a publish-time snapshot.
 type AnnouncementPollResults struct {
-	ChildCount    int                             `json:"child_count"`
-	AnsweredCount int                             `json:"answered_count"`
-	Options       []*AnnouncementPollOptionResult `json:"options"`
+	ChildCount       int                             `json:"child_count"`
+	TargetChildCount int                             `json:"target_child_count"`
+	AnsweredCount    int                             `json:"answered_count"`
+	Options          []*AnnouncementPollOptionResult `json:"options"`
 }
 
 // AnnouncementPollChildStatus is one reached child in the staff-facing answer
@@ -223,6 +225,7 @@ type AnnouncementPollChildStatus struct {
 	SchoolClass   string     `bun:"school_class" json:"school_class"`
 	AnswerLabels  []string   `bun:"answer_labels,array" json:"answer_labels"`
 	RespondedAt   *time.Time `bun:"responded_at" json:"responded_at,omitempty"`
+	CanAnswer     bool       `bun:"can_answer" json:"can_answer"`
 	GuardianCount int        `bun:"guardian_count" json:"-"`
 }
 

--- a/backend/models/users/parent_announcement.go
+++ b/backend/models/users/parent_announcement.go
@@ -27,6 +27,27 @@ const (
 	ParentAnnouncementPriorityImportant = "important"
 )
 
+// Response types (mirrors the chk_parent_announcements_response_type
+// constraint). "none" is a plain Mitteilung; the two choice types make the
+// announcement a poll (Umfrage, #1371) that guardians answer PER CHILD.
+const (
+	ParentAnnouncementResponseNone         = "none"
+	ParentAnnouncementResponseSingleChoice = "single_choice"
+	ParentAnnouncementResponseMultiChoice  = "multi_choice"
+)
+
+// ValidAnnouncementResponseType reports whether t is a known response type.
+func ValidAnnouncementResponseType(t string) bool {
+	switch t {
+	case ParentAnnouncementResponseNone,
+		ParentAnnouncementResponseSingleChoice,
+		ParentAnnouncementResponseMultiChoice:
+		return true
+	default:
+		return false
+	}
+}
+
 // Audience target types (mirrors the chk_parent_announcement_targets_type
 // constraint). An announcement's reach is the OR-union of its target rows.
 const (
@@ -73,15 +94,47 @@ type ParentAnnouncement struct {
 	Active                  bool       `bun:"active,notnull" json:"active"`
 	CreatedBy               int64      `bun:"created_by,notnull" json:"created_by"`
 
+	// ResponseType turns the announcement into a poll (Umfrage): "none" is a plain
+	// Mitteilung, single_choice/multi_choice carry Options guardians answer per
+	// child. ResponseDeadline is the answer cut-off and is deliberately NOT
+	// ExpiresAt: a closed poll stays readable in the feed, it just stops accepting
+	// answers.
+	// nullzero+default: an unset ResponseType must fall through to the column
+	// default ('none'), not insert an empty string that trips
+	// chk_parent_announcements_response_type. Any caller constructing a plain
+	// Mitteilung can therefore leave the field alone.
+	ResponseType     string     `bun:"response_type,notnull,nullzero,default:'none'" json:"response_type"`
+	ResponseDeadline *time.Time `bun:"response_deadline" json:"response_deadline,omitempty"`
+
 	// Targets is attached by the repository (ListTargets), never a bun relation:
 	// the parent feed resolves audience in a cross-tenant admin tx where explicit
 	// joins are clearer than relation magic. bun:"-" so it is never persisted.
 	Targets []*ParentAnnouncementTarget `bun:"-" json:"targets,omitempty"`
+	// Options is attached the same way (ListOptions) and is empty for a plain
+	// Mitteilung.
+	Options []*ParentAnnouncementOption `bun:"-" json:"options,omitempty"`
 }
 
 // IsPublished reports whether the announcement has been published (vs draft).
 func (a *ParentAnnouncement) IsPublished() bool {
 	return a.PublishedAt != nil
+}
+
+// IsPoll reports whether the announcement asks guardians a question.
+func (a *ParentAnnouncement) IsPoll() bool {
+	return a.ResponseType == ParentAnnouncementResponseSingleChoice ||
+		a.ResponseType == ParentAnnouncementResponseMultiChoice
+}
+
+// AcceptsResponsesAt reports whether the poll still accepts answers at t: it
+// must be a poll and either have no deadline or one that has not passed.
+// Visibility (active/published/expires_at) is checked separately — a closed poll
+// stays readable.
+func (a *ParentAnnouncement) AcceptsResponsesAt(t time.Time) bool {
+	if !a.IsPoll() {
+		return false
+	}
+	return a.ResponseDeadline == nil || a.ResponseDeadline.After(t)
 }
 
 // ParentAnnouncementTarget is one audience selector on an announcement. The ref
@@ -99,6 +152,87 @@ type ParentAnnouncementTarget struct {
 	TargetRefID    *int64    `bun:"target_ref_id" json:"target_ref_id,omitempty"`
 	TargetRefText  *string   `bun:"target_ref_text" json:"target_ref_text,omitempty"`
 	CreatedAt      time.Time `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+}
+
+// ParentAnnouncementOption is one answer option of a poll. Position drives the
+// display order and is unique per announcement. Options are insert/delete only
+// (replaced wholesale while the announcement is a draft), so the table has no
+// updated_at and this embeds bun.BaseModel rather than base.Model.
+type ParentAnnouncementOption struct {
+	bun.BaseModel `bun:"table:users.parent_announcement_options,alias:pao"`
+	base.TenantModel
+	ID             int64     `bun:"id,pk,autoincrement" json:"id"`
+	AnnouncementID int64     `bun:"announcement_id,notnull" json:"announcement_id"`
+	Label          string    `bun:"label,notnull" json:"label"`
+	Position       int       `bun:"position,notnull" json:"position"`
+	CreatedAt      time.Time `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+}
+
+// ParentAnnouncementResponse is one child's chosen option. The answer is per
+// CHILD, not per guardian account: a parent with two children answers once per
+// child, and the staff-facing result counts children. AccountID records which
+// guardian submitted it (two guardians share a child; the service replaces the
+// child's whole row set, so the last writer wins).
+type ParentAnnouncementResponse struct {
+	bun.BaseModel `bun:"table:users.parent_announcement_responses,alias:par_resp"`
+	base.TenantModel
+	ID             int64     `bun:"id,pk,autoincrement" json:"id"`
+	AnnouncementID int64     `bun:"announcement_id,notnull" json:"announcement_id"`
+	OptionID       int64     `bun:"option_id,notnull" json:"option_id"`
+	StudentID      int64     `bun:"student_id,notnull" json:"student_id"`
+	AccountID      int64     `bun:"account_id,notnull" json:"account_id"`
+	RespondedAt    time.Time `bun:"responded_at,nullzero,notnull,default:current_timestamp" json:"responded_at"`
+}
+
+// AnnouncementPollChild is one child a guardian may answer for, with the option
+// ids currently selected for that child (empty = not answered yet). Used by the
+// parent feed so the portal can render one answer row per child.
+type AnnouncementPollChild struct {
+	AnnouncementID  int64   `bun:"announcement_id" json:"-"`
+	StudentID       int64   `bun:"student_id" json:"-"`
+	FirstName       string  `bun:"first_name" json:"first_name"`
+	LastName        string  `bun:"last_name" json:"last_name"`
+	SelectedOptions []int64 `bun:"selected_options,array" json:"-"`
+}
+
+// AnnouncementPollOptionResult is one option's tally: how many reached children
+// picked it.
+type AnnouncementPollOptionResult struct {
+	OptionID int64  `bun:"option_id" json:"option_id"`
+	Label    string `bun:"label" json:"label"`
+	Position int    `bun:"position" json:"position"`
+	Count    int    `bun:"count" json:"count"`
+}
+
+// AnnouncementPollResults is the staff-facing evaluation of a poll: how many
+// children the poll currently reaches, how many of them have an answer, and the
+// per-option tally. Reach is resolved live against current relationships, so the
+// numbers reflect "right now" rather than a publish-time snapshot.
+type AnnouncementPollResults struct {
+	ChildCount    int                             `json:"child_count"`
+	AnsweredCount int                             `json:"answered_count"`
+	Options       []*AnnouncementPollOptionResult `json:"options"`
+}
+
+// AnnouncementPollChildStatus is one reached child in the staff-facing answer
+// list: who they are and what was answered for them (empty = still open).
+type AnnouncementPollChildStatus struct {
+	StudentID     int64      `bun:"student_id" json:"student_id"`
+	FirstName     string     `bun:"first_name" json:"first_name"`
+	LastName      string     `bun:"last_name" json:"last_name"`
+	SchoolClass   string     `bun:"school_class" json:"school_class"`
+	AnswerLabels  []string   `bun:"answer_labels,array" json:"answer_labels"`
+	RespondedAt   *time.Time `bun:"responded_at" json:"responded_at,omitempty"`
+	GuardianCount int        `bun:"guardian_count" json:"-"`
+}
+
+// AnnouncementPollReminderRecipient is one guardian to remind about a poll they
+// have not answered for a given child: the account, their address and name.
+type AnnouncementPollReminderRecipient struct {
+	AccountID int64  `bun:"account_id"`
+	Email     string `bun:"email"`
+	FirstName string `bun:"first_name"`
+	LastName  string `bun:"last_name"`
 }
 
 // ParentAnnouncementRead is a guardian account's read/ack state for one
@@ -130,9 +264,22 @@ type AnnouncementFeedItem struct {
 	RequiresAcknowledgement bool       `bun:"requires_acknowledgement" json:"requires_acknowledgement"`
 	PublishedAt             *time.Time `bun:"published_at" json:"published_at,omitempty"`
 	ExpiresAt               *time.Time `bun:"expires_at" json:"expires_at,omitempty"`
+	ResponseType            string     `bun:"response_type" json:"response_type"`
+	ResponseDeadline        *time.Time `bun:"response_deadline" json:"response_deadline,omitempty"`
 	SchoolName              string     `bun:"school_name" json:"school_name"`
 	ReadAt                  *time.Time `bun:"read_at" json:"read_at,omitempty"`
 	AcknowledgedAt          *time.Time `bun:"acknowledged_at" json:"acknowledged_at,omitempty"`
+
+	// Options and Children are attached by the service for poll items (bun:"-":
+	// they come from separate batched queries, not this row's columns).
+	Options  []*ParentAnnouncementOption `bun:"-" json:"options,omitempty"`
+	Children []*AnnouncementPollChild    `bun:"-" json:"children,omitempty"`
+}
+
+// IsPoll reports whether the feed item asks the guardian a question.
+func (i *AnnouncementFeedItem) IsPoll() bool {
+	return i.ResponseType == ParentAnnouncementResponseSingleChoice ||
+		i.ResponseType == ParentAnnouncementResponseMultiChoice
 }
 
 // AnnouncementRecipient is one guardian to e-mail when an announcement that
@@ -191,6 +338,41 @@ type ParentAnnouncementRepository interface {
 	// --- targets (tenant tx) ---
 	ReplaceTargets(ctx context.Context, tenantID, announcementID int64, targets []*ParentAnnouncementTarget) error
 	ListTargets(ctx context.Context, announcementID int64) ([]*ParentAnnouncementTarget, error)
+
+	// --- poll options (tenant tx) ---
+	// ReplaceOptions swaps a DRAFT poll's answer options wholesale. Like
+	// ReplaceTargets it locks the announcement and refuses a published row
+	// (ErrAnnouncementPublished), so options can never change under answers that
+	// already reference them.
+	ReplaceOptions(ctx context.Context, tenantID, announcementID int64, options []*ParentAnnouncementOption) error
+	ListOptions(ctx context.Context, announcementID int64) ([]*ParentAnnouncementOption, error)
+	// ListOptionsForAnnouncements batches the option lookup for a feed page
+	// (admin or tenant tx; explicit tenant scoping via the announcement ids).
+	ListOptionsForAnnouncements(ctx context.Context, announcementIDs []int64) ([]*ParentAnnouncementOption, error)
+
+	// --- poll responses ---
+	// AnswerableChildren returns the children of accountID that a poll currently
+	// reaches, each with the option ids selected for that child so far.
+	AnswerableChildren(ctx context.Context, accountID int64, announcementIDs []int64) ([]*AnnouncementPollChild, error)
+	// AccountMayAnswerForStudent reports whether the account is a portal-enabled
+	// guardian of the student AND the poll's audience currently reaches that
+	// child — the authorization for a per-child answer.
+	AccountMayAnswerForStudent(ctx context.Context, tenantID, announcementID, accountID, studentID int64) (bool, error)
+	// SetResponse replaces a child's selected options for a poll (delete + insert
+	// in one statement set). Guarded on the announcement still being live at
+	// expectedPublishedAt and still accepting answers, mirroring MarkRead: it
+	// returns false when the guard missed so the service can answer 409 instead of
+	// a silent 200. An empty optionIDs slice withdraws the answer.
+	SetResponse(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error)
+	// PollResults returns the per-option tally plus reach/answered child counts.
+	PollResults(ctx context.Context, tenantID, announcementID int64) (*AnnouncementPollResults, error)
+	// PollChildren returns every reached child with the labels answered for them
+	// (empty = open), ordered by name — the per-child view behind PollResults.
+	PollChildren(ctx context.Context, tenantID, announcementID int64) ([]*AnnouncementPollChildStatus, error)
+	// UnansweredReminderRecipients returns the distinct guardians (with an
+	// address) of reached children that have NO answer yet — the audience of the
+	// "Erinnerung senden" action.
+	UnansweredReminderRecipients(ctx context.Context, tenantID, announcementID int64) ([]*AnnouncementPollReminderRecipient, error)
 
 	// --- audience resolution (admin or tenant tx; explicit tenant filter) ---
 	// CountAudience returns the number of distinct guardian accounts an

--- a/backend/services/announcement/email.go
+++ b/backend/services/announcement/email.go
@@ -23,6 +23,14 @@ const (
 	// the school logo and the moto logo instead of the plain fallbacks.
 	emailPayloadLogoURL     = "logo_url"
 	emailPayloadMotoLogoURL = "moto_logo_url"
+	// emailPayloadKicker / emailPayloadIntro let a poll (Umfrage) and its reminder
+	// reuse this renderer and template while saying what they are. Both are
+	// optional: a row without them renders exactly like the pre-poll mail, so
+	// outbox rows queued before this change still deliver correctly.
+	emailPayloadKicker = "brand_kicker"
+	emailPayloadIntro  = "intro"
+
+	defaultEmailKicker = "Elternmitteilung"
 )
 
 // EmailConfig is the static config for the announcement e-mail renderer.
@@ -47,6 +55,12 @@ func NewAnnouncementRenderer(cfg EmailConfig) func(context.Context, *platformMod
 		logoURL, _ := row.Payload[emailPayloadLogoURL].(string)
 		motoLogoURL, _ := row.Payload[emailPayloadMotoLogoURL].(string)
 
+		kicker, _ := row.Payload[emailPayloadKicker].(string)
+		if kicker == "" {
+			kicker = defaultEmailKicker
+		}
+		intro, _ := row.Payload[emailPayloadIntro].(string)
+
 		subject := title
 		if schoolName != "" {
 			subject = fmt.Sprintf("%s: %s", schoolName, title)
@@ -59,7 +73,8 @@ func NewAnnouncementRenderer(cfg EmailConfig) func(context.Context, *platformMod
 			Template: "announcement-published.html",
 			Content: map[string]any{
 				"Title":             title,
-				"BrandKicker":       "Elternmitteilung",
+				"Intro":             intro,
+				"BrandKicker":       kicker,
 				"SchoolName":        schoolName,
 				"GuardianFirstName": first,
 				"GuardianLastName":  last,

--- a/backend/services/announcement/poll.go
+++ b/backend/services/announcement/poll.go
@@ -64,6 +64,10 @@ func normalizePollOptions(in *Input) ([]*usersModels.ParentAnnouncementOption, e
 		in.ResponseDeadline = nil
 		return []*usersModels.ParentAnnouncementOption{}, nil
 	}
+	// A poll response is the parent's explicit confirmation. Requiring a second
+	// acknowledgement for the same announcement only creates an impossible-to-
+	// explain extra step in the portal.
+	in.RequiresAcknowledgement = false
 
 	seen := make(map[string]bool, len(in.Options))
 	out := make([]*usersModels.ParentAnnouncementOption, 0, len(in.Options))

--- a/backend/services/announcement/poll.go
+++ b/backend/services/announcement/poll.go
@@ -182,28 +182,36 @@ func (s *service) RemindUnanswered(ctx context.Context, id int64) (int, error) {
 		return 0, nil
 	}
 
-	if err := s.pushPollReminder(ctx, a, recipients); err != nil {
-		return 0, err
-	}
-	queued, err := s.enqueuePollReminderEmails(ctx, a, recipients)
+	pushed, err := s.pushPollReminder(ctx, a, recipients)
 	if err != nil {
 		return 0, err
 	}
+	emailed, err := s.enqueuePollReminderEmails(ctx, a, recipients)
+	if err != nil {
+		return 0, err
+	}
+	delivered := make(map[int64]struct{}, len(pushed)+len(emailed))
+	for _, accountID := range pushed {
+		delivered[accountID] = struct{}{}
+	}
+	for _, accountID := range emailed {
+		delivered[accountID] = struct{}{}
+	}
 	s.logger.Info("parent poll reminder sent",
 		slog.Int64("announcement_id", id),
-		slog.Int("recipient_count", len(recipients)),
-		slog.Int("emails_queued", queued),
+		slog.Int("recipient_count", len(delivered)),
+		slog.Int("emails_queued", len(emailed)),
 	)
-	return len(recipients), nil
+	return len(delivered), nil
 }
 
 // pushPollReminder sends the in-app/web push half of the reminder, narrowed by
 // the guardian's own notification consent. A tenant-level gate (disabled or
 // outside the active window) suppresses it without failing the action — the
 // e-mail still goes out.
-func (s *service) pushPollReminder(ctx context.Context, a *usersModels.ParentAnnouncement, recipients []*usersModels.AnnouncementPollReminderRecipient) error {
+func (s *service) pushPollReminder(ctx context.Context, a *usersModels.ParentAnnouncement, recipients []*usersModels.AnnouncementPollReminderRecipient) ([]int64, error) {
 	if s.notifier == nil {
-		return nil
+		return nil, nil
 	}
 	accountIDs := make([]int64, 0, len(recipients))
 	seen := make(map[int64]struct{}, len(recipients))
@@ -218,16 +226,16 @@ func (s *service) pushPollReminder(ctx context.Context, a *usersModels.ParentAnn
 		accountIDs = append(accountIDs, r.AccountID)
 	}
 	if len(accountIDs) == 0 {
-		return nil
+		return nil, nil
 	}
 	if s.preferences != nil {
 		filtered, err := s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
 		if err != nil {
-			return fmt.Errorf("announcement: filter opted-in reminder recipients: %w", err)
+			return nil, fmt.Errorf("announcement: filter opted-in reminder recipients: %w", err)
 		}
 		accountIDs = filtered
 		if len(accountIDs) == 0 {
-			return nil
+			return nil, nil
 		}
 	}
 	err := s.notifier.Notify(ctx, notifications.Event{
@@ -247,12 +255,12 @@ func (s *service) pushPollReminder(ctx context.Context, a *usersModels.ParentAnn
 			slog.Int64("announcement_id", a.ID),
 			slog.String("reason", err.Error()),
 		)
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		return fmt.Errorf("announcement: notify poll reminder audience: %w", err)
+		return nil, fmt.Errorf("announcement: notify poll reminder audience: %w", err)
 	}
-	return nil
+	return accountIDs, nil
 }
 
 // enqueuePollReminderEmails queues one reminder e-mail per guardian address.
@@ -260,11 +268,11 @@ func (s *service) pushPollReminder(ctx context.Context, a *usersModels.ParentAnn
 // the request tenant tx, a DB error aborts the action rather than half-sending.
 // The mail carries the poll title and a portal link, never the question's
 // options — the answer belongs in the portal, where it is authenticated.
-func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.ParentAnnouncement, recipients []*usersModels.AnnouncementPollReminderRecipient) (int, error) {
+func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.ParentAnnouncement, recipients []*usersModels.AnnouncementPollReminderRecipient) ([]int64, error) {
 	if s.outbox == nil {
 		s.logger.Warn("poll reminder requested but no outbox is wired",
 			slog.Int64("announcement_id", a.ID))
-		return 0, nil
+		return nil, nil
 	}
 	tenantID := a.GetTenantID()
 	if s.preferences != nil {
@@ -278,7 +286,7 @@ func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.
 		// an opt-in (most families have no preference row at all).
 		remaining, err := s.preferences.FilterNotOptedOut(ctx, notifications.TypeParentAnnouncement, accountIDs)
 		if err != nil {
-			return 0, fmt.Errorf("announcement: filter opted-out reminder recipients: %w", err)
+			return nil, fmt.Errorf("announcement: filter opted-out reminder recipients: %w", err)
 		}
 		allowed := make(map[int64]struct{}, len(remaining))
 		for _, accountID := range remaining {
@@ -293,11 +301,11 @@ func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.
 		recipients = filtered
 	}
 	if len(recipients) == 0 {
-		return 0, nil
+		return nil, nil
 	}
 	schoolName, err := s.repo.SchoolName(ctx, tenantID)
 	if err != nil {
-		return 0, fmt.Errorf("announcement: resolve school name: %w", err)
+		return nil, fmt.Errorf("announcement: resolve school name: %w", err)
 	}
 	logoURL := s.resolveSchoolLogoURL(ctx, tenantID)
 	motoLogoURL := emailbranding.MotoLogoURL(s.parentsURL)
@@ -307,7 +315,7 @@ func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.
 			a.ResponseDeadline.Format("02.01.2006"))
 	}
 
-	queued := 0
+	queuedAccountIDs := make([]int64, 0, len(recipients))
 	seenEmails := make(map[string]struct{}, len(recipients))
 	for _, r := range recipients {
 		address := strings.ToLower(strings.TrimSpace(r.Email))
@@ -338,9 +346,9 @@ func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.
 			RelatedEntityType: relatedEntityTypePollReminder,
 			RelatedEntityID:   a.ID,
 		}); err != nil {
-			return 0, fmt.Errorf("announcement: enqueue poll reminder e-mail: %w", err)
+			return nil, fmt.Errorf("announcement: enqueue poll reminder e-mail: %w", err)
 		}
-		queued++
+		queuedAccountIDs = append(queuedAccountIDs, r.AccountID)
 	}
-	return queued, nil
+	return queuedAccountIDs, nil
 }

--- a/backend/services/announcement/poll.go
+++ b/backend/services/announcement/poll.go
@@ -340,9 +340,8 @@ func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.
 				emailPayloadKicker:      pollReminderEmailKicker,
 				emailPayloadIntro:       intro,
 			},
-			// A distinct related type keeps reminders out of the publish-cancel
-			// sweep: cancelling a retracted announcement must not also cancel a
-			// reminder that already went out for a different reason.
+			// Reminders have their own related type so cleanup can cancel pending
+			// reminder mail alongside the announcement's publish mail.
 			RelatedEntityType: relatedEntityTypePollReminder,
 			RelatedEntityID:   a.ID,
 		}); err != nil {

--- a/backend/services/announcement/poll.go
+++ b/backend/services/announcement/poll.go
@@ -1,0 +1,346 @@
+package announcement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/services/emailbranding"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	platformService "github.com/moto-nrw/project-phoenix/services/platform"
+)
+
+// This file holds the poll (Umfrage, #1371) half of the staff announcement
+// service: option validation, the staff-facing evaluation, and the manual
+// reminder to guardians who have not answered.
+
+var (
+	// ErrNotAPoll is returned when a poll-only operation (results, reminder) is
+	// called on a plain Mitteilung. Handler maps it to 400.
+	ErrNotAPoll = errors.New("announcement: not a poll")
+	// ErrPollNotOpen is returned when a reminder is requested for a poll that is
+	// not currently collecting answers — an unpublished draft, or one whose
+	// deadline has passed. Reminding about a closed poll would send parents to a
+	// card they can no longer act on. Handler maps it to 409.
+	ErrPollNotOpen = errors.New("announcement: poll is not open for answers")
+)
+
+const (
+	relatedEntityTypePollReminder = "parent_announcement_poll_reminder"
+
+	pollEmailKicker         = "Umfrage"
+	pollReminderEmailKicker = "Erinnerung"
+)
+
+// normalizePollOptions validates the poll half of the input and returns the
+// option rows to persist. A plain Mitteilung (empty/"none" response type) must
+// carry neither options nor a deadline; a poll needs between minPollOptions and
+// maxPollOptions non-blank, case-insensitively distinct labels and, if it has a
+// deadline, one in the future.
+//
+// It normalizes in place (in.ResponseType is set to the canonical "none" and
+// stray options/deadlines on a non-poll are cleared) so the caller can persist
+// the input as-is.
+func normalizePollOptions(in *Input) ([]*usersModels.ParentAnnouncementOption, error) {
+	if strings.TrimSpace(in.ResponseType) == "" {
+		in.ResponseType = usersModels.ParentAnnouncementResponseNone
+	}
+	if !usersModels.ValidAnnouncementResponseType(in.ResponseType) {
+		return nil, fmt.Errorf("%w: response_type", ErrValidation)
+	}
+	if in.ResponseType == usersModels.ParentAnnouncementResponseNone {
+		// A Mitteilung with leftover poll fields is a client bug, not something to
+		// silently persist: the DB CHECK rejects a deadline without a response type
+		// anyway, and stored orphan options would resurface if the row later became
+		// a poll.
+		if len(in.Options) > 0 {
+			return nil, fmt.Errorf("%w: options require a response_type", ErrValidation)
+		}
+		in.ResponseDeadline = nil
+		return []*usersModels.ParentAnnouncementOption{}, nil
+	}
+
+	seen := make(map[string]bool, len(in.Options))
+	out := make([]*usersModels.ParentAnnouncementOption, 0, len(in.Options))
+	for _, raw := range in.Options {
+		label := strings.TrimSpace(raw)
+		if label == "" {
+			continue
+		}
+		if len([]rune(label)) > maxPollLabelLen {
+			return nil, fmt.Errorf("%w: option label too long", ErrValidation)
+		}
+		key := strings.ToLower(label)
+		if seen[key] {
+			// Two identical options would split the same answer across two bars and
+			// make the result unreadable.
+			return nil, fmt.Errorf("%w: duplicate option %q", ErrValidation, label)
+		}
+		seen[key] = true
+		out = append(out, &usersModels.ParentAnnouncementOption{Label: label, Position: len(out)})
+	}
+	if len(out) < minPollOptions {
+		return nil, fmt.Errorf("%w: a poll needs at least %d options", ErrValidation, minPollOptions)
+	}
+	if len(out) > maxPollOptions {
+		return nil, fmt.Errorf("%w: a poll allows at most %d options", ErrValidation, maxPollOptions)
+	}
+	if in.ResponseDeadline != nil && !in.ResponseDeadline.After(time.Now()) {
+		return nil, fmt.Errorf("%w: response_deadline must be in the future", ErrValidation)
+	}
+	// A deadline after the announcement disappears from the feed would be
+	// unreachable: parents can only answer what they can still see.
+	if in.ResponseDeadline != nil && in.ExpiresAt != nil && in.ResponseDeadline.After(*in.ExpiresAt) {
+		return nil, fmt.Errorf("%w: response_deadline must not be after expires_at", ErrValidation)
+	}
+	return out, nil
+}
+
+// PollResults returns the per-option tally plus reached/answered child counts.
+func (s *service) PollResults(ctx context.Context, id int64) (*usersModels.AnnouncementPollResults, error) {
+	a, err := s.loadPoll(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	results, err := s.repo.PollResults(ctx, a.GetTenantID(), id)
+	if err != nil {
+		return nil, fmt.Errorf("announcement: poll results: %w", err)
+	}
+	return results, nil
+}
+
+// PollChildren returns every reached child with the answer given for them, so
+// staff can chase the open ones by name.
+func (s *service) PollChildren(ctx context.Context, id int64) ([]*usersModels.AnnouncementPollChildStatus, error) {
+	a, err := s.loadPoll(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.repo.PollChildren(ctx, a.GetTenantID(), id)
+	if err != nil {
+		return nil, fmt.Errorf("announcement: poll children: %w", err)
+	}
+	return rows, nil
+}
+
+// loadPoll fetches an announcement and asserts it is a poll.
+func (s *service) loadPoll(ctx context.Context, id int64) (*usersModels.ParentAnnouncement, error) {
+	a, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("announcement: load poll: %w", err)
+	}
+	if a == nil {
+		return nil, ErrNotFound
+	}
+	if !a.IsPoll() {
+		return nil, ErrNotAPoll
+	}
+	return a, nil
+}
+
+// RemindUnanswered notifies the guardians of reached children that still have no
+// answer: one push (subject to the guardian's consent) and one e-mail per
+// person, never per child. It returns how many guardians were reached.
+//
+// This is deliberately a MANUAL action rather than an automatic scheduler job:
+// schools want to decide when to nudge, and an unattended reminder loop would be
+// the single most effective way to teach parents to mute the app.
+func (s *service) RemindUnanswered(ctx context.Context, id int64) (int, error) {
+	a, err := s.loadPoll(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+	if !a.IsPublished() || !a.Active {
+		return 0, ErrPollNotOpen
+	}
+	now := time.Now()
+	if a.ExpiresAt != nil && !a.ExpiresAt.After(now) {
+		return 0, ErrPollNotOpen
+	}
+	if !a.AcceptsResponsesAt(now) {
+		return 0, ErrPollNotOpen
+	}
+	enabled, err := s.newsEnabled(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("announcement: resolve news flag: %w", err)
+	}
+	if !enabled {
+		return 0, ErrNewsDisabled
+	}
+
+	tenantID := a.GetTenantID()
+	recipients, err := s.repo.UnansweredReminderRecipients(ctx, tenantID, id)
+	if err != nil {
+		return 0, fmt.Errorf("announcement: poll reminder recipients: %w", err)
+	}
+	if len(recipients) == 0 {
+		return 0, nil
+	}
+
+	if err := s.pushPollReminder(ctx, a, recipients); err != nil {
+		return 0, err
+	}
+	queued, err := s.enqueuePollReminderEmails(ctx, a, recipients)
+	if err != nil {
+		return 0, err
+	}
+	s.logger.Info("parent poll reminder sent",
+		slog.Int64("announcement_id", id),
+		slog.Int("recipient_count", len(recipients)),
+		slog.Int("emails_queued", queued),
+	)
+	return len(recipients), nil
+}
+
+// pushPollReminder sends the in-app/web push half of the reminder, narrowed by
+// the guardian's own notification consent. A tenant-level gate (disabled or
+// outside the active window) suppresses it without failing the action — the
+// e-mail still goes out.
+func (s *service) pushPollReminder(ctx context.Context, a *usersModels.ParentAnnouncement, recipients []*usersModels.AnnouncementPollReminderRecipient) error {
+	if s.notifier == nil {
+		return nil
+	}
+	accountIDs := make([]int64, 0, len(recipients))
+	seen := make(map[int64]struct{}, len(recipients))
+	for _, r := range recipients {
+		if r.AccountID <= 0 {
+			continue
+		}
+		if _, exists := seen[r.AccountID]; exists {
+			continue
+		}
+		seen[r.AccountID] = struct{}{}
+		accountIDs = append(accountIDs, r.AccountID)
+	}
+	if len(accountIDs) == 0 {
+		return nil
+	}
+	if s.preferences != nil {
+		filtered, err := s.preferences.FilterOptedIn(ctx, notifications.TypeParentAnnouncement, accountIDs)
+		if err != nil {
+			return fmt.Errorf("announcement: filter opted-in reminder recipients: %w", err)
+		}
+		accountIDs = filtered
+		if len(accountIDs) == 0 {
+			return nil
+		}
+	}
+	err := s.notifier.Notify(ctx, notifications.Event{
+		Type:     parentAnnouncementNotificationType,
+		Title:    parentPollReminderNotificationTitle,
+		Body:     parentPollReminderNotificationBody,
+		DeepLink: "/",
+		Priority: notifications.PriorityNormal,
+		Audience: notifications.Audience{
+			TenantID:           a.GetTenantID(),
+			Scope:              notifications.ScopeGuardian,
+			GuardianAccountIDs: accountIDs,
+		},
+	})
+	if errors.Is(err, notifications.ErrDisabled) || errors.Is(err, notifications.ErrOutsideActiveWindow) {
+		s.logger.Info("parent poll reminder push suppressed by tenant notification gate",
+			slog.Int64("announcement_id", a.ID),
+			slog.String("reason", err.Error()),
+		)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("announcement: notify poll reminder audience: %w", err)
+	}
+	return nil
+}
+
+// enqueuePollReminderEmails queues one reminder e-mail per guardian address.
+// Same transactional-outbox contract as the publish mails: rows are written in
+// the request tenant tx, a DB error aborts the action rather than half-sending.
+// The mail carries the poll title and a portal link, never the question's
+// options — the answer belongs in the portal, where it is authenticated.
+func (s *service) enqueuePollReminderEmails(ctx context.Context, a *usersModels.ParentAnnouncement, recipients []*usersModels.AnnouncementPollReminderRecipient) (int, error) {
+	if s.outbox == nil {
+		s.logger.Warn("poll reminder requested but no outbox is wired",
+			slog.Int64("announcement_id", a.ID))
+		return 0, nil
+	}
+	tenantID := a.GetTenantID()
+	if s.preferences != nil {
+		accountIDs := make([]int64, 0, len(recipients))
+		for _, r := range recipients {
+			if r.AccountID > 0 {
+				accountIDs = append(accountIDs, r.AccountID)
+			}
+		}
+		// Mirrors the publish path: honour an explicit opt-out, but do not require
+		// an opt-in (most families have no preference row at all).
+		remaining, err := s.preferences.FilterNotOptedOut(ctx, notifications.TypeParentAnnouncement, accountIDs)
+		if err != nil {
+			return 0, fmt.Errorf("announcement: filter opted-out reminder recipients: %w", err)
+		}
+		allowed := make(map[int64]struct{}, len(remaining))
+		for _, accountID := range remaining {
+			allowed[accountID] = struct{}{}
+		}
+		filtered := make([]*usersModels.AnnouncementPollReminderRecipient, 0, len(recipients))
+		for _, r := range recipients {
+			if _, ok := allowed[r.AccountID]; ok {
+				filtered = append(filtered, r)
+			}
+		}
+		recipients = filtered
+	}
+	if len(recipients) == 0 {
+		return 0, nil
+	}
+	schoolName, err := s.repo.SchoolName(ctx, tenantID)
+	if err != nil {
+		return 0, fmt.Errorf("announcement: resolve school name: %w", err)
+	}
+	logoURL := s.resolveSchoolLogoURL(ctx, tenantID)
+	motoLogoURL := emailbranding.MotoLogoURL(s.parentsURL)
+	intro := "für Ihr Kind fehlt noch eine Rückmeldung zu dieser Umfrage. Sie können sie im Eltern-Portal abgeben."
+	if a.ResponseDeadline != nil {
+		intro = fmt.Sprintf("für Ihr Kind fehlt noch eine Rückmeldung zu dieser Umfrage. Bitte antworten Sie bis zum %s im Eltern-Portal.",
+			a.ResponseDeadline.Format("02.01.2006"))
+	}
+
+	queued := 0
+	seenEmails := make(map[string]struct{}, len(recipients))
+	for _, r := range recipients {
+		address := strings.ToLower(strings.TrimSpace(r.Email))
+		if address == "" {
+			continue
+		}
+		if _, exists := seenEmails[address]; exists {
+			continue
+		}
+		seenEmails[address] = struct{}{}
+		if _, err := s.outbox.Enqueue(ctx, platformService.EnqueueRequest{
+			Kind: platformModels.EmailKindParentAnnouncement,
+			Payload: map[string]any{
+				emailPayloadRecipient:   address,
+				emailPayloadFirstName:   r.FirstName,
+				emailPayloadLastName:    r.LastName,
+				emailPayloadTitle:       a.Title,
+				emailPayloadSchoolName:  schoolName,
+				emailPayloadPortalURL:   s.parentsURL,
+				emailPayloadLogoURL:     logoURL,
+				emailPayloadMotoLogoURL: motoLogoURL,
+				emailPayloadKicker:      pollReminderEmailKicker,
+				emailPayloadIntro:       intro,
+			},
+			// A distinct related type keeps reminders out of the publish-cancel
+			// sweep: cancelling a retracted announcement must not also cancel a
+			// reminder that already went out for a different reason.
+			RelatedEntityType: relatedEntityTypePollReminder,
+			RelatedEntityID:   a.ID,
+		}); err != nil {
+			return 0, fmt.Errorf("announcement: enqueue poll reminder e-mail: %w", err)
+		}
+		queued++
+	}
+	return queued, nil
+}

--- a/backend/services/announcement/poll.go
+++ b/backend/services/announcement/poll.go
@@ -182,11 +182,11 @@ func (s *service) RemindUnanswered(ctx context.Context, id int64) (int, error) {
 		return 0, nil
 	}
 
-	pushed, err := s.pushPollReminder(ctx, a, recipients)
+	emailed, err := s.enqueuePollReminderEmails(ctx, a, recipients)
 	if err != nil {
 		return 0, err
 	}
-	emailed, err := s.enqueuePollReminderEmails(ctx, a, recipients)
+	pushed, err := s.pushPollReminder(ctx, a, recipients)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/services/announcement/poll_internal_test.go
+++ b/backend/services/announcement/poll_internal_test.go
@@ -64,6 +64,20 @@ func TestNormalizePollOptions_TrimsAndPositionsOptions(t *testing.T) {
 	}
 }
 
+func TestNormalizePollOptions_ClearsAcknowledgementForPoll(t *testing.T) {
+	in := Input{
+		ResponseType:            usersModels.ParentAnnouncementResponseSingleChoice,
+		Options:                 []string{"Ja", "Nein"},
+		RequiresAcknowledgement: true,
+	}
+	if _, err := normalizePollOptions(&in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if in.RequiresAcknowledgement {
+		t.Fatal("expected a poll response to replace acknowledgement")
+	}
+}
+
 func TestNormalizePollOptions_RejectsDuplicateLabels(t *testing.T) {
 	in := Input{
 		ResponseType: usersModels.ParentAnnouncementResponseSingleChoice,

--- a/backend/services/announcement/poll_internal_test.go
+++ b/backend/services/announcement/poll_internal_test.go
@@ -163,3 +163,37 @@ func TestAcceptsResponsesAt(t *testing.T) {
 		t.Fatal("a poll past its deadline must not accept answers")
 	}
 }
+
+// A poll cannot target open applications: those guardians have no enrolled
+// child, so there would be nothing for them to answer for.
+func TestNormalizeInput_RejectsPendingEnrollmentTargetForPoll(t *testing.T) {
+	in := Input{
+		Title:        "Kommt Ihr Kind?",
+		Body:         "Bitte um Rückmeldung.",
+		ResponseType: usersModels.ParentAnnouncementResponseSingleChoice,
+		Targets: []TargetInput{
+			{TargetType: usersModels.AnnouncementTargetPendingEnrollment},
+		},
+	}
+	if _, err := normalizeInput(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+// The same target stays valid for a plain Mitteilung, which applicants can read.
+func TestNormalizeInput_AllowsPendingEnrollmentTargetForAnnouncement(t *testing.T) {
+	in := Input{
+		Title: "Anmeldung läuft",
+		Body:  "Die Anmeldephase endet am Freitag.",
+		Targets: []TargetInput{
+			{TargetType: usersModels.AnnouncementTargetPendingEnrollment},
+		},
+	}
+	targets, err := normalizeInput(&in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected the target to survive, got %d", len(targets))
+	}
+}

--- a/backend/services/announcement/poll_internal_test.go
+++ b/backend/services/announcement/poll_internal_test.go
@@ -1,0 +1,165 @@
+package announcement
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// Unit tests for normalizePollOptions — the validation that decides whether an
+// announcement is a plain Mitteilung or a well-formed poll (#1371). Pure input
+// handling, no database.
+
+func TestNormalizePollOptions_PlainAnnouncementStaysPlain(t *testing.T) {
+	in := Input{}
+	options, err := normalizePollOptions(&in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(options) != 0 {
+		t.Fatalf("expected no options, got %d", len(options))
+	}
+	if in.ResponseType != usersModels.ParentAnnouncementResponseNone {
+		t.Fatalf("expected response type to normalize to none, got %q", in.ResponseType)
+	}
+}
+
+func TestNormalizePollOptions_ClearsDeadlineOnPlainAnnouncement(t *testing.T) {
+	deadline := time.Now().Add(48 * time.Hour)
+	in := Input{ResponseDeadline: &deadline}
+	if _, err := normalizePollOptions(&in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if in.ResponseDeadline != nil {
+		t.Fatal("expected a deadline without a response type to be cleared")
+	}
+}
+
+func TestNormalizePollOptions_RejectsOptionsWithoutResponseType(t *testing.T) {
+	in := Input{Options: []string{"Ja", "Nein"}}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestNormalizePollOptions_TrimsAndPositionsOptions(t *testing.T) {
+	in := Input{
+		ResponseType: usersModels.ParentAnnouncementResponseSingleChoice,
+		Options:      []string{"  Ja  ", "Nein", "   "},
+	}
+	options, err := normalizePollOptions(&in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("expected the blank option to be dropped, got %d options", len(options))
+	}
+	if options[0].Label != "Ja" || options[0].Position != 0 {
+		t.Fatalf("unexpected first option %+v", options[0])
+	}
+	if options[1].Label != "Nein" || options[1].Position != 1 {
+		t.Fatalf("unexpected second option %+v", options[1])
+	}
+}
+
+func TestNormalizePollOptions_RejectsDuplicateLabels(t *testing.T) {
+	in := Input{
+		ResponseType: usersModels.ParentAnnouncementResponseSingleChoice,
+		Options:      []string{"Ja", "ja"},
+	}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected duplicate labels to be rejected, got %v", err)
+	}
+}
+
+func TestNormalizePollOptions_RejectsTooFewOptions(t *testing.T) {
+	in := Input{
+		ResponseType: usersModels.ParentAnnouncementResponseSingleChoice,
+		Options:      []string{"Ja"},
+	}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected a single option to be rejected, got %v", err)
+	}
+}
+
+func TestNormalizePollOptions_RejectsTooManyOptions(t *testing.T) {
+	labels := make([]string, 0, maxPollOptions+1)
+	for i := 0; i <= maxPollOptions; i++ {
+		labels = append(labels, string(rune('A'+i)))
+	}
+	in := Input{
+		ResponseType: usersModels.ParentAnnouncementResponseMultiChoice,
+		Options:      labels,
+	}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected more than %d options to be rejected, got %v", maxPollOptions, err)
+	}
+}
+
+func TestNormalizePollOptions_RejectsPastDeadline(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	in := Input{
+		ResponseType:     usersModels.ParentAnnouncementResponseSingleChoice,
+		Options:          []string{"Ja", "Nein"},
+		ResponseDeadline: &past,
+	}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected a past deadline to be rejected, got %v", err)
+	}
+}
+
+// A deadline after the announcement stops being visible would be unreachable:
+// parents can only answer a card they can still see.
+func TestNormalizePollOptions_RejectsDeadlineAfterExpiry(t *testing.T) {
+	expires := time.Now().Add(24 * time.Hour)
+	deadline := expires.Add(time.Hour)
+	in := Input{
+		ResponseType:     usersModels.ParentAnnouncementResponseSingleChoice,
+		Options:          []string{"Ja", "Nein"},
+		ExpiresAt:        &expires,
+		ResponseDeadline: &deadline,
+	}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected a deadline after expiry to be rejected, got %v", err)
+	}
+}
+
+func TestNormalizePollOptions_RejectsUnknownResponseType(t *testing.T) {
+	in := Input{ResponseType: "ranking", Options: []string{"Ja", "Nein"}}
+	if _, err := normalizePollOptions(&in); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected an unknown response type to be rejected, got %v", err)
+	}
+}
+
+// AcceptsResponsesAt is what gates every answer write; a closed poll must stop
+// accepting while staying readable.
+func TestAcceptsResponsesAt(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+
+	plain := &usersModels.ParentAnnouncement{ResponseType: usersModels.ParentAnnouncementResponseNone}
+	if plain.AcceptsResponsesAt(now) {
+		t.Fatal("a plain announcement must not accept answers")
+	}
+	open := &usersModels.ParentAnnouncement{ResponseType: usersModels.ParentAnnouncementResponseSingleChoice}
+	if !open.AcceptsResponsesAt(now) {
+		t.Fatal("a poll without a deadline must accept answers")
+	}
+	stillOpen := &usersModels.ParentAnnouncement{
+		ResponseType:     usersModels.ParentAnnouncementResponseSingleChoice,
+		ResponseDeadline: &future,
+	}
+	if !stillOpen.AcceptsResponsesAt(now) {
+		t.Fatal("a poll before its deadline must accept answers")
+	}
+	closed := &usersModels.ParentAnnouncement{
+		ResponseType:     usersModels.ParentAnnouncementResponseSingleChoice,
+		ResponseDeadline: &past,
+	}
+	if closed.AcceptsResponsesAt(now) {
+		t.Fatal("a poll past its deadline must not accept answers")
+	}
+}

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -458,7 +458,7 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	if a.Priority == usersModels.ParentAnnouncementPriorityImportant {
 		priority = notifications.PriorityHigh
 	}
-	accountIDs := make([]int64, 0)
+	var accountIDs []int64
 	seen := make(map[int64]struct{})
 	if a.IsPoll() {
 		recipients, err := s.repo.UnansweredReminderRecipients(ctx, a.GetTenantID(), a.ID)

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -453,25 +453,45 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	if s.notifier == nil {
 		return nil
 	}
-	recipients, err := s.repo.AudienceRecipients(ctx, a.GetTenantID(), a.ID)
-	if err != nil {
-		return fmt.Errorf("resolve guardian recipients: %w", err)
-	}
+	var err error
 	priority := notifications.PriorityNormal
 	if a.Priority == usersModels.ParentAnnouncementPriorityImportant {
 		priority = notifications.PriorityHigh
 	}
-	accountIDs := make([]int64, 0, len(recipients))
-	seen := make(map[int64]struct{}, len(recipients))
-	for _, recipient := range recipients {
-		if recipient.AccountID <= 0 {
-			continue
+	accountIDs := make([]int64, 0)
+	seen := make(map[int64]struct{})
+	if a.IsPoll() {
+		recipients, err := s.repo.UnansweredReminderRecipients(ctx, a.GetTenantID(), a.ID)
+		if err != nil {
+			return fmt.Errorf("resolve poll guardian recipients: %w", err)
 		}
-		if _, exists := seen[recipient.AccountID]; exists {
-			continue
+		accountIDs = make([]int64, 0, len(recipients))
+		for _, recipient := range recipients {
+			if recipient.AccountID <= 0 {
+				continue
+			}
+			if _, exists := seen[recipient.AccountID]; exists {
+				continue
+			}
+			seen[recipient.AccountID] = struct{}{}
+			accountIDs = append(accountIDs, recipient.AccountID)
 		}
-		seen[recipient.AccountID] = struct{}{}
-		accountIDs = append(accountIDs, recipient.AccountID)
+	} else {
+		recipients, err := s.repo.AudienceRecipients(ctx, a.GetTenantID(), a.ID)
+		if err != nil {
+			return fmt.Errorf("resolve guardian recipients: %w", err)
+		}
+		accountIDs = make([]int64, 0, len(recipients))
+		for _, recipient := range recipients {
+			if recipient.AccountID <= 0 {
+				continue
+			}
+			if _, exists := seen[recipient.AccountID]; exists {
+				continue
+			}
+			seen[recipient.AccountID] = struct{}{}
+			accountIDs = append(accountIDs, recipient.AccountID)
+		}
 	}
 	if len(accountIDs) == 0 {
 		return nil
@@ -548,9 +568,27 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 		return nil
 	}
 	tenantID := a.GetTenantID()
-	recipients, err := s.repo.ResolveAudienceEmails(ctx, tenantID, a.ID)
-	if err != nil {
-		return fmt.Errorf("announcement: resolve audience e-mails: %w", err)
+	var recipients []*usersModels.AnnouncementRecipient
+	if a.IsPoll() {
+		pollRecipients, err := s.repo.UnansweredReminderRecipients(ctx, tenantID, a.ID)
+		if err != nil {
+			return fmt.Errorf("announcement: resolve poll e-mail recipients: %w", err)
+		}
+		recipients = make([]*usersModels.AnnouncementRecipient, 0, len(pollRecipients))
+		for _, recipient := range pollRecipients {
+			recipients = append(recipients, &usersModels.AnnouncementRecipient{
+				AccountID: recipient.AccountID,
+				Email:     recipient.Email,
+				FirstName: recipient.FirstName,
+				LastName:  recipient.LastName,
+			})
+		}
+	} else {
+		var err error
+		recipients, err = s.repo.ResolveAudienceEmails(ctx, tenantID, a.ID)
+		if err != nil {
+			return fmt.Errorf("announcement: resolve audience e-mails: %w", err)
+		}
 	}
 	if len(recipients) == 0 {
 		return nil

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -690,10 +690,10 @@ func (s *service) resolveSchoolLogoURL(ctx context.Context, tenantID int64) stri
 	return emailbranding.SchoolLogoURL(s.parentsURL, raw)
 }
 
-// cancelPendingEmails cancels any not-yet-sent announcement e-mails queued for
-// this announcement. Called when it is retracted (unpublish) or deleted: a
-// published announcement that opted into e-mail may have queued outbox rows the
-// worker hasn't drained yet, and those carry the OLD title + portal link.
+// cancelPendingEmails cancels any not-yet-sent announcement and poll-reminder
+// e-mails queued for this announcement. Called when it is retracted (unpublish)
+// or deleted: both kinds of mail carry a portal link that must not be delivered
+// after the announcement is no longer available.
 // Leaving them would deliver a notification for an announcement staff has already
 // pulled — and, on the documented unpublish -> edit -> republish correction path,
 // a stale e-mail followed by a second corrected one. The cancel runs in the same
@@ -706,9 +706,13 @@ func (s *service) cancelPendingEmails(ctx context.Context, id int64) error {
 	if s.outbox == nil {
 		return nil
 	}
-	cancelled, err := s.outbox.CancelPendingByRelatedEntity(ctx, relatedEntityTypeAnnouncement, id, "announcement retracted before send")
-	if err != nil {
-		return fmt.Errorf("announcement: cancel pending e-mails: %w", err)
+	cancelled := int64(0)
+	for _, relatedType := range []string{relatedEntityTypeAnnouncement, relatedEntityTypePollReminder} {
+		n, err := s.outbox.CancelPendingByRelatedEntity(ctx, relatedType, id, "announcement no longer available")
+		if err != nil {
+			return fmt.Errorf("announcement: cancel pending e-mails: %w", err)
+		}
+		cancelled += n
 	}
 	if cancelled > 0 {
 		s.logger.Info("parent announcement pending e-mails cancelled",

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -395,6 +395,9 @@ func (s *service) Publish(ctx context.Context, id int64) (*usersModels.ParentAnn
 		if a.ExpiresAt != nil && !a.ExpiresAt.After(now) {
 			return nil, fmt.Errorf("%w: expires_at is already in the past", ErrValidation)
 		}
+		if a.ResponseDeadline != nil && !a.ResponseDeadline.After(now) {
+			return nil, fmt.Errorf("%w: response_deadline is already in the past", ErrValidation)
+		}
 		// Atomic publish: PublishIfDraft's UPDATE is guarded by
 		// published_at IS NULL, so only ONE of two concurrent publishes flips the
 		// row. Enqueue the opt-in e-mails only for that winner — a double-click or
@@ -423,6 +426,9 @@ func (s *service) Publish(ctx context.Context, id int64) (*usersModels.ParentAnn
 			// with a 5xx: the tenant tx rolls back the flip and staff can retry.
 			if fresh.ExpiresAt != nil && !fresh.ExpiresAt.After(now) {
 				return nil, fmt.Errorf("announcement: draft expired concurrently during publish; rolled back")
+			}
+			if fresh.ResponseDeadline != nil && !fresh.ResponseDeadline.After(now) {
+				return nil, fmt.Errorf("announcement: draft response deadline elapsed concurrently during publish; rolled back")
 			}
 			s.logger.Info("parent announcement published", slog.Int64("announcement_id", id))
 			if err := s.notifyAnnouncementGuardians(ctx, fresh); err != nil {

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -39,6 +39,13 @@ const (
 	maxBodyLen    = 4000
 	maxLinkURLLen = 2000
 
+	// Poll (Umfrage) option bounds. Two options is the minimum that asks
+	// anything ("Ja"/"Nein"); the upper bound keeps the parent card readable on a
+	// phone and the result bars meaningful.
+	minPollOptions  = 2
+	maxPollOptions  = 10
+	maxPollLabelLen = 120
+
 	// relatedEntityTypeAnnouncement links an outbox row back to its announcement.
 	// Shared by the enqueue and cancel paths so they never drift apart.
 	relatedEntityTypeAnnouncement = "parent_announcement"
@@ -46,6 +53,14 @@ const (
 	parentAnnouncementNotificationType  = "parent_announcement"
 	parentAnnouncementNotificationTitle = "Neue Elternmitteilung"
 	parentAnnouncementNotificationBody  = "Eine neue Mitteilung ist im Elternportal verfügbar."
+
+	// Polls reuse the announcement notification type (one guardian consent switch
+	// covers both — a school broadcast is a school broadcast) but say what they
+	// are, so a parent can tell a question from an information at a glance.
+	parentPollNotificationTitle         = "Neue Umfrage"
+	parentPollNotificationBody          = "Eine Schule bittet um Ihre Rückmeldung im Elternportal."
+	parentPollReminderNotificationTitle = "Erinnerung: Umfrage offen"
+	parentPollReminderNotificationBody  = "Für Ihr Kind fehlt noch eine Rückmeldung im Elternportal."
 )
 
 // Sentinel errors mapped to HTTP status by the handler.
@@ -80,6 +95,14 @@ type Input struct {
 	SendEmail               bool          `json:"send_email"`
 	ExpiresAt               *time.Time    `json:"expires_at,omitempty"`
 	Targets                 []TargetInput `json:"targets"`
+
+	// ResponseType turns the announcement into a poll (Umfrage): "" / "none" is a
+	// plain Mitteilung, single_choice/multi_choice require Options. Options are
+	// the answer labels in display order; ResponseDeadline is the optional answer
+	// cut-off (independent of ExpiresAt, which controls visibility).
+	ResponseType     string     `json:"response_type"`
+	ResponseDeadline *time.Time `json:"response_deadline,omitempty"`
+	Options          []string   `json:"options,omitempty"`
 }
 
 // Service is the staff-facing parent-announcement contract.
@@ -93,6 +116,15 @@ type Service interface {
 	Unpublish(ctx context.Context, id int64) (*usersModels.ParentAnnouncement, error)
 	Stats(ctx context.Context, id int64) (*usersModels.AnnouncementStats, error)
 	Recipients(ctx context.Context, id int64) ([]*usersModels.AnnouncementRecipientStatus, error)
+
+	// --- poll (Umfrage) ---
+	// PollResults returns the per-option tally plus reached/answered child counts.
+	PollResults(ctx context.Context, id int64) (*usersModels.AnnouncementPollResults, error)
+	// PollChildren returns every reached child with the answer given for them.
+	PollChildren(ctx context.Context, id int64) ([]*usersModels.AnnouncementPollChildStatus, error)
+	// RemindUnanswered notifies the guardians of children that have not answered
+	// yet and reports how many were reached.
+	RemindUnanswered(ctx context.Context, id int64) (int, error)
 }
 
 // ServiceConfig is the dependency bundle. Outbox, Notifier and ParentsURL are
@@ -150,6 +182,30 @@ func (s *service) List(ctx context.Context, includeInactive bool) ([]*usersModel
 	if err != nil {
 		return nil, fmt.Errorf("announcement: list: %w", err)
 	}
+	// Attach poll options in one batched query so the staff list can render an
+	// Umfrage row (its options) without an N+1 fetch per announcement.
+	ids := make([]int64, 0, len(rows))
+	byID := make(map[int64]*usersModels.ParentAnnouncement, len(rows))
+	for _, a := range rows {
+		if !a.IsPoll() {
+			continue
+		}
+		ids = append(ids, a.ID)
+		byID[a.ID] = a
+		a.Options = []*usersModels.ParentAnnouncementOption{}
+	}
+	if len(ids) == 0 {
+		return rows, nil
+	}
+	options, err := s.repo.ListOptionsForAnnouncements(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("announcement: list options: %w", err)
+	}
+	for _, o := range options {
+		if a, ok := byID[o.AnnouncementID]; ok {
+			a.Options = append(a.Options, o)
+		}
+	}
 	return rows, nil
 }
 
@@ -166,6 +222,13 @@ func (s *service) Get(ctx context.Context, id int64) (*usersModels.ParentAnnounc
 		return nil, fmt.Errorf("announcement: get targets: %w", err)
 	}
 	a.Targets = targets
+	if a.IsPoll() {
+		options, err := s.repo.ListOptions(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("announcement: get options: %w", err)
+		}
+		a.Options = options
+	}
 	return a, nil
 }
 
@@ -181,6 +244,10 @@ func (s *service) Create(ctx context.Context, createdBy int64, in Input) (*users
 	if err != nil {
 		return nil, err
 	}
+	options, err := normalizePollOptions(&in)
+	if err != nil {
+		return nil, err
+	}
 
 	a := &usersModels.ParentAnnouncement{
 		Title:                   in.Title,
@@ -190,6 +257,8 @@ func (s *service) Create(ctx context.Context, createdBy int64, in Input) (*users
 		RequiresAcknowledgement: in.RequiresAcknowledgement,
 		SendEmail:               in.SendEmail,
 		ExpiresAt:               in.ExpiresAt,
+		ResponseType:            in.ResponseType,
+		ResponseDeadline:        in.ResponseDeadline,
 		Active:                  true,
 		CreatedBy:               createdBy,
 	}
@@ -199,11 +268,17 @@ func (s *service) Create(ctx context.Context, createdBy int64, in Input) (*users
 	if err := s.repo.ReplaceTargets(ctx, a.GetTenantID(), a.ID, targets); err != nil {
 		return nil, fmt.Errorf("announcement: set targets: %w", err)
 	}
+	if err := s.repo.ReplaceOptions(ctx, a.GetTenantID(), a.ID, options); err != nil {
+		return nil, fmt.Errorf("announcement: set options: %w", err)
+	}
 	a.Targets = targets
+	a.Options = options
 	s.logger.Info("parent announcement created",
 		slog.Int64("announcement_id", a.ID),
 		slog.Int64("created_by", createdBy),
 		slog.Int("target_count", len(targets)),
+		slog.String("response_type", a.ResponseType),
+		slog.Int("option_count", len(options)),
 	)
 	return a, nil
 }
@@ -226,6 +301,10 @@ func (s *service) Update(ctx context.Context, id int64, in Input) (*usersModels.
 	if err != nil {
 		return nil, err
 	}
+	options, err := normalizePollOptions(&in)
+	if err != nil {
+		return nil, err
+	}
 
 	a.Title = in.Title
 	a.Body = in.Body
@@ -234,6 +313,8 @@ func (s *service) Update(ctx context.Context, id int64, in Input) (*usersModels.
 	a.RequiresAcknowledgement = in.RequiresAcknowledgement
 	a.SendEmail = in.SendEmail
 	a.ExpiresAt = in.ExpiresAt
+	a.ResponseType = in.ResponseType
+	a.ResponseDeadline = in.ResponseDeadline
 	if err := s.repo.Update(ctx, a); err != nil {
 		// The write is guarded by published_at IS NULL: if the draft was
 		// published between the load above and here, no row matched. Surface the
@@ -253,7 +334,16 @@ func (s *service) Update(ctx context.Context, id int64, in Input) (*usersModels.
 		}
 		return nil, fmt.Errorf("announcement: update targets: %w", err)
 	}
+	if err := s.repo.ReplaceOptions(ctx, a.GetTenantID(), a.ID, options); err != nil {
+		// Same draft guard as ReplaceTargets: a publish that slipped in between
+		// makes the option swap refuse rather than re-label answers.
+		if errors.Is(err, usersModels.ErrAnnouncementPublished) {
+			return nil, ErrPublishedImmutable
+		}
+		return nil, fmt.Errorf("announcement: update options: %w", err)
+	}
 	a.Targets = targets
+	a.Options = options
 	return a, nil
 }
 
@@ -404,10 +494,14 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 		}
 	}
 
+	title, body := parentAnnouncementNotificationTitle, parentAnnouncementNotificationBody
+	if a.IsPoll() {
+		title, body = parentPollNotificationTitle, parentPollNotificationBody
+	}
 	err = s.notifier.Notify(ctx, notifications.Event{
 		Type:     parentAnnouncementNotificationType,
-		Title:    parentAnnouncementNotificationTitle,
-		Body:     parentAnnouncementNotificationBody,
+		Title:    title,
+		Body:     body,
 		DeepLink: "/",
 		Priority: priority,
 		Audience: notifications.Audience{
@@ -526,6 +620,18 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 	// logo (header) and the moto logo (footer) instead of the plain fallbacks.
 	logoURL := s.resolveSchoolLogoURL(ctx, tenantID)
 	motoLogoURL := emailbranding.MotoLogoURL(s.parentsURL)
+	// A poll says so in the mail: the kicker and intro differ, the rest of the
+	// template (and the deliberate absence of the body) is identical.
+	kicker := defaultEmailKicker
+	intro := ""
+	if a.IsPoll() {
+		kicker = pollEmailKicker
+		intro = "wir bitten Sie um eine kurze Rückmeldung. Die Umfrage finden Sie im Eltern-Portal."
+		if a.ResponseDeadline != nil {
+			intro = fmt.Sprintf("wir bitten Sie um eine kurze Rückmeldung bis zum %s. Die Umfrage finden Sie im Eltern-Portal.",
+				a.ResponseDeadline.Format("02.01.2006"))
+		}
+	}
 	queued := 0
 	for _, rcpt := range recipients {
 		// Deliberately NO announcement body here: e-mail is the least trusted
@@ -542,6 +648,8 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 				emailPayloadPortalURL:   s.parentsURL,
 				emailPayloadLogoURL:     logoURL,
 				emailPayloadMotoLogoURL: motoLogoURL,
+				emailPayloadKicker:      kicker,
+				emailPayloadIntro:       intro,
 			},
 			RelatedEntityType: relatedEntityTypeAnnouncement,
 			RelatedEntityID:   a.ID,

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -829,8 +829,17 @@ func normalizeInput(in *Input) ([]*usersModels.ParentAnnouncementTarget, error) 
 				return nil, fmt.Errorf("%w: %s target needs ref_id", ErrValidation, t.TargetType)
 			}
 			target.TargetRefID = t.RefID
-		case usersModels.AnnouncementTargetSchoolAll, usersModels.AnnouncementTargetPendingEnrollment:
+		case usersModels.AnnouncementTargetSchoolAll:
 			// no ref
+		case usersModels.AnnouncementTargetPendingEnrollment:
+			// A poll is answered per CHILD, and an open application has no
+			// enrolled child yet — the applicant would see a question with no
+			// answer row. The staff form hides the option for polls; refuse it
+			// here too so the API cannot create that dead end.
+			if in.ResponseType == usersModels.ParentAnnouncementResponseSingleChoice ||
+				in.ResponseType == usersModels.ParentAnnouncementResponseMultiChoice {
+				return nil, fmt.Errorf("%w: pending_enrollment cannot be targeted by a poll", ErrValidation)
+			}
 		}
 		key := dedupeKey(target)
 		if seen[key] {

--- a/backend/services/announcement/service.go
+++ b/backend/services/announcement/service.go
@@ -460,38 +460,20 @@ func (s *service) notifyAnnouncementGuardians(ctx context.Context, a *usersModel
 	}
 	var accountIDs []int64
 	seen := make(map[int64]struct{})
-	if a.IsPoll() {
-		recipients, err := s.repo.UnansweredReminderRecipients(ctx, a.GetTenantID(), a.ID)
-		if err != nil {
-			return fmt.Errorf("resolve poll guardian recipients: %w", err)
+	recipients, err := s.repo.AudienceRecipients(ctx, a.GetTenantID(), a.ID)
+	if err != nil {
+		return fmt.Errorf("resolve guardian recipients: %w", err)
+	}
+	accountIDs = make([]int64, 0, len(recipients))
+	for _, recipient := range recipients {
+		if recipient.AccountID <= 0 {
+			continue
 		}
-		accountIDs = make([]int64, 0, len(recipients))
-		for _, recipient := range recipients {
-			if recipient.AccountID <= 0 {
-				continue
-			}
-			if _, exists := seen[recipient.AccountID]; exists {
-				continue
-			}
-			seen[recipient.AccountID] = struct{}{}
-			accountIDs = append(accountIDs, recipient.AccountID)
+		if _, exists := seen[recipient.AccountID]; exists {
+			continue
 		}
-	} else {
-		recipients, err := s.repo.AudienceRecipients(ctx, a.GetTenantID(), a.ID)
-		if err != nil {
-			return fmt.Errorf("resolve guardian recipients: %w", err)
-		}
-		accountIDs = make([]int64, 0, len(recipients))
-		for _, recipient := range recipients {
-			if recipient.AccountID <= 0 {
-				continue
-			}
-			if _, exists := seen[recipient.AccountID]; exists {
-				continue
-			}
-			seen[recipient.AccountID] = struct{}{}
-			accountIDs = append(accountIDs, recipient.AccountID)
-		}
+		seen[recipient.AccountID] = struct{}{}
+		accountIDs = append(accountIDs, recipient.AccountID)
 	}
 	if len(accountIDs) == 0 {
 		return nil
@@ -569,26 +551,10 @@ func (s *service) enqueueAnnouncementEmails(ctx context.Context, a *usersModels.
 	}
 	tenantID := a.GetTenantID()
 	var recipients []*usersModels.AnnouncementRecipient
-	if a.IsPoll() {
-		pollRecipients, err := s.repo.UnansweredReminderRecipients(ctx, tenantID, a.ID)
-		if err != nil {
-			return fmt.Errorf("announcement: resolve poll e-mail recipients: %w", err)
-		}
-		recipients = make([]*usersModels.AnnouncementRecipient, 0, len(pollRecipients))
-		for _, recipient := range pollRecipients {
-			recipients = append(recipients, &usersModels.AnnouncementRecipient{
-				AccountID: recipient.AccountID,
-				Email:     recipient.Email,
-				FirstName: recipient.FirstName,
-				LastName:  recipient.LastName,
-			})
-		}
-	} else {
-		var err error
-		recipients, err = s.repo.ResolveAudienceEmails(ctx, tenantID, a.ID)
-		if err != nil {
-			return fmt.Errorf("announcement: resolve audience e-mails: %w", err)
-		}
+	var err error
+	recipients, err = s.repo.ResolveAudienceEmails(ctx, tenantID, a.ID)
+	if err != nil {
+		return fmt.Errorf("announcement: resolve audience e-mails: %w", err)
 	}
 	if len(recipients) == 0 {
 		return nil

--- a/backend/services/announcement/service_methods_internal_test.go
+++ b/backend/services/announcement/service_methods_internal_test.go
@@ -32,6 +32,55 @@ type mockRepo struct {
 	schoolNameFn    func(ctx context.Context, tenantID int64) (string, error)
 	audienceFn      func(ctx context.Context, tenantID, announcementID int64) ([]*usersModels.AnnouncementRecipientStatus, error)
 	statsFn         func(ctx context.Context, tenantID, announcementID int64) (*usersModels.AnnouncementStats, error)
+
+	// Poll (#1371). replaceOptions defaults to a no-op when nil so the pre-poll
+	// tests, which never set it, keep exercising Create/Update unchanged.
+	replaceOptions    func(ctx context.Context, tenantID, announcementID int64, options []*usersModels.ParentAnnouncementOption) error
+	listOptionsFn     func(ctx context.Context, announcementID int64) ([]*usersModels.ParentAnnouncementOption, error)
+	pollResultsFn     func(ctx context.Context, tenantID, announcementID int64) (*usersModels.AnnouncementPollResults, error)
+	pollChildrenFn    func(ctx context.Context, tenantID, announcementID int64) ([]*usersModels.AnnouncementPollChildStatus, error)
+	pollReminderFn    func(ctx context.Context, tenantID, announcementID int64) ([]*usersModels.AnnouncementPollReminderRecipient, error)
+	setResponseFn     func(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error)
+	answerChildrenFn  func(ctx context.Context, accountID int64, announcementIDs []int64) ([]*usersModels.AnnouncementPollChild, error)
+	mayAnswerFn       func(ctx context.Context, tenantID, announcementID, accountID, studentID int64) (bool, error)
+	listOptionsFeedFn func(ctx context.Context, announcementIDs []int64) ([]*usersModels.ParentAnnouncementOption, error)
+}
+
+func (m *mockRepo) ReplaceOptions(ctx context.Context, tenantID, announcementID int64, options []*usersModels.ParentAnnouncementOption) error {
+	if m.replaceOptions == nil {
+		return nil
+	}
+	return m.replaceOptions(ctx, tenantID, announcementID, options)
+}
+func (m *mockRepo) ListOptions(ctx context.Context, announcementID int64) ([]*usersModels.ParentAnnouncementOption, error) {
+	if m.listOptionsFn == nil {
+		return nil, nil
+	}
+	return m.listOptionsFn(ctx, announcementID)
+}
+func (m *mockRepo) ListOptionsForAnnouncements(ctx context.Context, announcementIDs []int64) ([]*usersModels.ParentAnnouncementOption, error) {
+	if m.listOptionsFeedFn == nil {
+		return nil, nil
+	}
+	return m.listOptionsFeedFn(ctx, announcementIDs)
+}
+func (m *mockRepo) AnswerableChildren(ctx context.Context, accountID int64, announcementIDs []int64) ([]*usersModels.AnnouncementPollChild, error) {
+	return m.answerChildrenFn(ctx, accountID, announcementIDs)
+}
+func (m *mockRepo) AccountMayAnswerForStudent(ctx context.Context, tenantID, announcementID, accountID, studentID int64) (bool, error) {
+	return m.mayAnswerFn(ctx, tenantID, announcementID, accountID, studentID)
+}
+func (m *mockRepo) SetResponse(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error) {
+	return m.setResponseFn(ctx, tenantID, announcementID, studentID, accountID, optionIDs, expectedPublishedAt)
+}
+func (m *mockRepo) PollResults(ctx context.Context, tenantID, announcementID int64) (*usersModels.AnnouncementPollResults, error) {
+	return m.pollResultsFn(ctx, tenantID, announcementID)
+}
+func (m *mockRepo) PollChildren(ctx context.Context, tenantID, announcementID int64) ([]*usersModels.AnnouncementPollChildStatus, error) {
+	return m.pollChildrenFn(ctx, tenantID, announcementID)
+}
+func (m *mockRepo) UnansweredReminderRecipients(ctx context.Context, tenantID, announcementID int64) ([]*usersModels.AnnouncementPollReminderRecipient, error) {
+	return m.pollReminderFn(ctx, tenantID, announcementID)
 }
 
 func (m *mockRepo) Create(ctx context.Context, a *usersModels.ParentAnnouncement) error {

--- a/backend/services/announcement/service_publish_internal_test.go
+++ b/backend/services/announcement/service_publish_internal_test.go
@@ -36,6 +36,12 @@ func (f *fakeAnnouncementRepo) FindByID(_ context.Context, _ int64) (*usersModel
 	return f.announcement, nil
 }
 
+// ReplaceOptions is a no-op: these tests drive plain Mitteilungen, whose option
+// set is empty, but Update/Create call it unconditionally (#1371).
+func (f *fakeAnnouncementRepo) ReplaceOptions(_ context.Context, _, _ int64, _ []*usersModels.ParentAnnouncementOption) error {
+	return nil
+}
+
 func (f *fakeAnnouncementRepo) Update(_ context.Context, _ *usersModels.ParentAnnouncement) error {
 	f.updateCalls++
 	return nil

--- a/backend/services/announcement/service_publish_internal_test.go
+++ b/backend/services/announcement/service_publish_internal_test.go
@@ -23,6 +23,7 @@ type fakeAnnouncementRepo struct {
 	announcement *usersModels.ParentAnnouncement
 	recipients   []*usersModels.AnnouncementRecipient
 	audience     []*usersModels.AnnouncementRecipientStatus
+	reminders    []*usersModels.AnnouncementPollReminderRecipient
 	updateCalls  int
 	publishCalls int
 	deleteCalls  int
@@ -97,6 +98,10 @@ func (f *fakeAnnouncementRepo) SchoolName(_ context.Context, _ int64) (string, e
 	return "OGS Testschule", nil
 }
 
+func (f *fakeAnnouncementRepo) UnansweredReminderRecipients(_ context.Context, _, _ int64) ([]*usersModels.AnnouncementPollReminderRecipient, error) {
+	return f.reminders, nil
+}
+
 // fakeSettings answers the parent-news feature flag; everything else panics.
 type fakeSettings struct {
 	configService.SettingsService
@@ -114,8 +119,8 @@ func (f *fakeSettings) GetLoginImageURL(_ context.Context, _ int64) (string, err
 
 // fakeOutbox captures enqueued e-mails.
 type fakeOutbox struct {
-	requests    []platformService.EnqueueRequest
-	cancelCalls int
+	requests           []platformService.EnqueueRequest
+	cancelRelatedTypes []string
 }
 
 type fakeNotifier struct {
@@ -133,8 +138,8 @@ func (f *fakeOutbox) Enqueue(_ context.Context, req platformService.EnqueueReque
 	return &platformModels.EmailOutbox{}, nil
 }
 
-func (f *fakeOutbox) CancelPendingByRelatedEntity(_ context.Context, _ string, _ int64, _ string) (int64, error) {
-	f.cancelCalls++
+func (f *fakeOutbox) CancelPendingByRelatedEntity(_ context.Context, relatedType string, _ int64, _ string) (int64, error) {
+	f.cancelRelatedTypes = append(f.cancelRelatedTypes, relatedType)
 	return 0, nil
 }
 
@@ -224,8 +229,8 @@ func TestUnpublish_CancelsPendingEmails(t *testing.T) {
 	if _, err := svc.Unpublish(context.Background(), published.ID); err != nil {
 		t.Fatalf("unpublish failed: %v", err)
 	}
-	if outbox.cancelCalls != 1 {
-		t.Fatalf("expected unpublish to cancel pending e-mails once, got %d", outbox.cancelCalls)
+	if got, want := outbox.cancelRelatedTypes, []string{relatedEntityTypeAnnouncement, relatedEntityTypePollReminder}; !slices.Equal(got, want) {
+		t.Fatalf("unpublish cancelled related types %v, want %v", got, want)
 	}
 }
 
@@ -240,11 +245,44 @@ func TestDelete_CancelsPendingEmails(t *testing.T) {
 	if err := svc.Delete(context.Background(), published.ID); err != nil {
 		t.Fatalf("delete failed: %v", err)
 	}
-	if outbox.cancelCalls != 1 {
-		t.Fatalf("expected delete to cancel pending e-mails once, got %d", outbox.cancelCalls)
+	if got, want := outbox.cancelRelatedTypes, []string{relatedEntityTypeAnnouncement, relatedEntityTypePollReminder}; !slices.Equal(got, want) {
+		t.Fatalf("delete cancelled related types %v, want %v", got, want)
 	}
 	if repo.deleteCalls != 1 {
 		t.Fatalf("expected exactly one repo delete, got %d", repo.deleteCalls)
+	}
+}
+
+func TestRemindUnanswered_KeepsNoEmailGuardianForPush(t *testing.T) {
+	poll := draftAnnouncement(false)
+	poll.ResponseType = usersModels.ParentAnnouncementResponseSingleChoice
+	now := time.Now()
+	poll.PublishedAt = &now
+	repo := &fakeAnnouncementRepo{
+		announcement: poll,
+		reminders: []*usersModels.AnnouncementPollReminderRecipient{
+			{AccountID: 101, Email: ""},
+		},
+	}
+	notifier := &fakeNotifier{}
+	svc := NewService(ServiceConfig{
+		Repo:       repo,
+		Settings:   &fakeSettings{enabled: true},
+		Notifier:   notifier,
+		Outbox:     &fakeOutbox{},
+		ParentsURL: "https://parents.example.test",
+		Logger:     slog.Default(),
+	})
+
+	delivered, err := svc.RemindUnanswered(context.Background(), poll.ID)
+	if err != nil {
+		t.Fatalf("remind unanswered: %v", err)
+	}
+	if delivered != 1 {
+		t.Fatalf("expected one push recipient, got %d", delivered)
+	}
+	if len(notifier.events) != 1 || !slices.Equal(notifier.events[0].Audience.GuardianAccountIDs, []int64{101}) {
+		t.Fatalf("unexpected push recipients: %+v", notifier.events)
 	}
 }
 

--- a/backend/services/announcement/service_publish_internal_test.go
+++ b/backend/services/announcement/service_publish_internal_test.go
@@ -43,6 +43,10 @@ func (f *fakeAnnouncementRepo) ReplaceOptions(_ context.Context, _, _ int64, _ [
 	return nil
 }
 
+func (f *fakeAnnouncementRepo) ListOptions(_ context.Context, _ int64) ([]*usersModels.ParentAnnouncementOption, error) {
+	return nil, nil
+}
+
 func (f *fakeAnnouncementRepo) Update(_ context.Context, _ *usersModels.ParentAnnouncement) error {
 	f.updateCalls++
 	return nil
@@ -392,6 +396,40 @@ func TestPublish_NotifiesTargetedGuardiansWithoutAnnouncementContent(t *testing.
 		event.Priority != notifications.PriorityNormal ||
 		event.DeepLink != "/" {
 		t.Fatalf("unexpected guardian notification metadata: %+v", event)
+	}
+}
+
+func TestPublish_PollNotifiesOnlyResponsePermittedGuardians(t *testing.T) {
+	poll := draftAnnouncement(true)
+	poll.ResponseType = usersModels.ParentAnnouncementResponseSingleChoice
+	repo := &fakeAnnouncementRepo{
+		announcement: poll,
+		// The general audience contains a portal-visible guardian who may not
+		// respond. Poll publication must ignore that broader audience.
+		audience: []*usersModels.AnnouncementRecipientStatus{{AccountID: 999}},
+		reminders: []*usersModels.AnnouncementPollReminderRecipient{
+			{AccountID: 101, Email: "permitted@example.test"},
+		},
+	}
+	notifier := &fakeNotifier{}
+	outbox := &fakeOutbox{}
+	svc := NewService(ServiceConfig{
+		Repo:       repo,
+		Settings:   &fakeSettings{enabled: true},
+		Notifier:   notifier,
+		Outbox:     outbox,
+		ParentsURL: "https://parents.example.test",
+		Logger:     slog.Default(),
+	})
+
+	if _, err := svc.Publish(context.Background(), poll.ID); err != nil {
+		t.Fatalf("publish poll: %v", err)
+	}
+	if len(notifier.events) != 1 || !slices.Equal(notifier.events[0].Audience.GuardianAccountIDs, []int64{101}) {
+		t.Fatalf("unexpected poll push audience: %+v", notifier.events)
+	}
+	if len(outbox.requests) != 1 || outbox.requests[0].Payload[emailPayloadRecipient] != "permitted@example.test" {
+		t.Fatalf("unexpected poll e-mail audience: %+v", outbox.requests)
 	}
 }
 

--- a/backend/services/announcement/service_publish_internal_test.go
+++ b/backend/services/announcement/service_publish_internal_test.go
@@ -399,14 +399,18 @@ func TestPublish_NotifiesTargetedGuardiansWithoutAnnouncementContent(t *testing.
 	}
 }
 
-func TestPublish_PollNotifiesOnlyResponsePermittedGuardians(t *testing.T) {
+func TestPublish_PollNotifiesAllTargetedGuardians(t *testing.T) {
 	poll := draftAnnouncement(true)
 	poll.ResponseType = usersModels.ParentAnnouncementResponseSingleChoice
 	repo := &fakeAnnouncementRepo{
 		announcement: poll,
 		// The general audience contains a portal-visible guardian who may not
-		// respond. Poll publication must ignore that broader audience.
+		// respond. Publication still reaches them; response permission matters
+		// only for manual unanswered reminders.
 		audience: []*usersModels.AnnouncementRecipientStatus{{AccountID: 999}},
+		recipients: []*usersModels.AnnouncementRecipient{
+			{AccountID: 999, Email: "viewer@example.test"},
+		},
 		reminders: []*usersModels.AnnouncementPollReminderRecipient{
 			{AccountID: 101, Email: "permitted@example.test"},
 		},
@@ -425,10 +429,10 @@ func TestPublish_PollNotifiesOnlyResponsePermittedGuardians(t *testing.T) {
 	if _, err := svc.Publish(context.Background(), poll.ID); err != nil {
 		t.Fatalf("publish poll: %v", err)
 	}
-	if len(notifier.events) != 1 || !slices.Equal(notifier.events[0].Audience.GuardianAccountIDs, []int64{101}) {
+	if len(notifier.events) != 1 || !slices.Equal(notifier.events[0].Audience.GuardianAccountIDs, []int64{999}) {
 		t.Fatalf("unexpected poll push audience: %+v", notifier.events)
 	}
-	if len(outbox.requests) != 1 || outbox.requests[0].Payload[emailPayloadRecipient] != "permitted@example.test" {
+	if len(outbox.requests) != 1 || outbox.requests[0].Payload[emailPayloadRecipient] != "viewer@example.test" {
 		t.Fatalf("unexpected poll e-mail audience: %+v", outbox.requests)
 	}
 }

--- a/backend/services/announcement/service_publish_internal_test.go
+++ b/backend/services/announcement/service_publish_internal_test.go
@@ -121,6 +121,7 @@ func (f *fakeSettings) GetLoginImageURL(_ context.Context, _ int64) (string, err
 type fakeOutbox struct {
 	requests           []platformService.EnqueueRequest
 	cancelRelatedTypes []string
+	enqueueErr         error
 }
 
 type fakeNotifier struct {
@@ -134,6 +135,9 @@ func (f *fakeNotifier) Notify(_ context.Context, event notifications.Event) erro
 }
 
 func (f *fakeOutbox) Enqueue(_ context.Context, req platformService.EnqueueRequest) (*platformModels.EmailOutbox, error) {
+	if f.enqueueErr != nil {
+		return nil, f.enqueueErr
+	}
 	f.requests = append(f.requests, req)
 	return &platformModels.EmailOutbox{}, nil
 }
@@ -283,6 +287,36 @@ func TestRemindUnanswered_KeepsNoEmailGuardianForPush(t *testing.T) {
 	}
 	if len(notifier.events) != 1 || !slices.Equal(notifier.events[0].Audience.GuardianAccountIDs, []int64{101}) {
 		t.Fatalf("unexpected push recipients: %+v", notifier.events)
+	}
+}
+
+func TestRemindUnanswered_DoesNotPushWhenEmailQueueingFails(t *testing.T) {
+	poll := draftAnnouncement(false)
+	poll.ResponseType = usersModels.ParentAnnouncementResponseSingleChoice
+	now := time.Now()
+	poll.PublishedAt = &now
+	repo := &fakeAnnouncementRepo{
+		announcement: poll,
+		reminders: []*usersModels.AnnouncementPollReminderRecipient{
+			{AccountID: 101, Email: "parent@example.test"},
+		},
+	}
+	notifier := &fakeNotifier{}
+	svc := NewService(ServiceConfig{
+		Repo:       repo,
+		Settings:   &fakeSettings{enabled: true},
+		Notifier:   notifier,
+		Outbox:     &fakeOutbox{enqueueErr: errors.New("outbox unavailable")},
+		ParentsURL: "https://parents.example.test",
+		Logger:     slog.Default(),
+	})
+
+	_, err := svc.RemindUnanswered(context.Background(), poll.ID)
+	if err == nil {
+		t.Fatal("expected reminder to fail when e-mail queueing fails")
+	}
+	if len(notifier.events) != 0 {
+		t.Fatalf("expected no push before e-mail queueing succeeds, got %d", len(notifier.events))
 	}
 }
 

--- a/backend/services/parent/parent_announcement_poll_test.go
+++ b/backend/services/parent/parent_announcement_poll_test.go
@@ -1,0 +1,234 @@
+package parent_test
+
+// Integration tests for the poll (Umfrage, #1371) half of the parent
+// announcement feed: the per-child answer write with its audience/deadline
+// guards, and the staff-facing evaluation the same repository serves. Uses a
+// real guardian->student chain so the per-child authorization and the audience
+// resolution exercise the repository SQL, not a mock.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	parentService "github.com/moto-nrw/project-phoenix/services/parent"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// seedPublishedPoll creates a school-wide poll with the given options, publishes
+// it, and returns it with its persisted PublishedAt and option rows attached.
+func seedPublishedPoll(
+	t *testing.T,
+	ctx context.Context,
+	repo usersModels.ParentAnnouncementRepository,
+	createdBy, tenantID int64,
+	deadline *time.Time,
+	labels ...string,
+) *usersModels.ParentAnnouncement {
+	t.Helper()
+	a := &usersModels.ParentAnnouncement{
+		Title:            "Murmelparty",
+		Body:             "Kommt Ihr Kind zur Murmelparty?",
+		Priority:         usersModels.ParentAnnouncementPriorityInfo,
+		ResponseType:     usersModels.ParentAnnouncementResponseSingleChoice,
+		ResponseDeadline: deadline,
+		Active:           true,
+		CreatedBy:        createdBy,
+	}
+	a.SetTenantID(tenantID)
+	require.NoError(t, repo.Create(ctx, a))
+	require.NoError(t, repo.ReplaceTargets(ctx, tenantID, a.ID,
+		[]*usersModels.ParentAnnouncementTarget{{TargetType: usersModels.AnnouncementTargetSchoolAll}}))
+
+	options := make([]*usersModels.ParentAnnouncementOption, 0, len(labels))
+	for i, label := range labels {
+		options = append(options, &usersModels.ParentAnnouncementOption{Label: label, Position: i})
+	}
+	require.NoError(t, repo.ReplaceOptions(ctx, tenantID, a.ID, options))
+
+	now := time.Now()
+	require.NoError(t, repo.SetPublished(ctx, a.ID, &now))
+	t.Cleanup(func() { _ = repo.Delete(ctx, a.ID) })
+
+	// Re-read so PublishedAt matches the DB value to the microsecond — the
+	// service's version guard compares with Equal().
+	persisted, err := repo.FindByID(ctx, a.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	a.PublishedAt = persisted.PublishedAt
+	stored, err := repo.ListOptions(ctx, a.ID)
+	require.NoError(t, err)
+	a.Options = stored
+	return a
+}
+
+func TestAnnouncementPoll_AnswerAppearsInFeedAndResults(t *testing.T) {
+	svc, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	poll := seedPublishedPoll(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, nil, "Ja", "Nein")
+	require.Len(t, poll.Options, 2)
+
+	ctx := context.Background()
+
+	// The feed carries the question, its options and the one child this guardian
+	// may answer for — unanswered at first.
+	feed, err := svc.ListAnnouncements(ctx, chain.AccountID)
+	require.NoError(t, err)
+	item := findFeedItem(t, feed, poll.ID)
+	assert.Equal(t, usersModels.ParentAnnouncementResponseSingleChoice, item.ResponseType)
+	require.Len(t, item.Options, 2)
+	require.Len(t, item.Children, 1)
+	assert.Equal(t, chain.StudentID, item.Children[0].StudentID)
+	assert.Empty(t, item.Children[0].SelectedOptions)
+
+	// Answering stamps the child's selection.
+	yes := poll.Options[0].ID
+	require.NoError(t, svc.RespondToAnnouncement(ctx, chain.AccountID, poll.ID, chain.StudentID, []int64{yes}, *poll.PublishedAt))
+
+	feed, err = svc.ListAnnouncements(ctx, chain.AccountID)
+	require.NoError(t, err)
+	item = findFeedItem(t, feed, poll.ID)
+	require.Len(t, item.Children, 1)
+	assert.Equal(t, []int64{yes}, item.Children[0].SelectedOptions)
+
+	// The staff evaluation counts children, and the answered child drops out of
+	// the reminder audience.
+	results, err := repos.ParentAnnouncement.PollResults(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, results.ChildCount)
+	assert.Equal(t, 1, results.AnsweredCount)
+	require.Len(t, results.Options, 2)
+	assert.Equal(t, 1, results.Options[0].Count)
+	assert.Equal(t, 0, results.Options[1].Count)
+
+	children, err := repos.ParentAnnouncement.PollChildren(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	assert.Equal(t, []string{"Ja"}, children[0].AnswerLabels)
+
+	pending, err := repos.ParentAnnouncement.UnansweredReminderRecipients(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	assert.Empty(t, pending, "an answered child must not be reminded")
+}
+
+// Re-answering replaces the previous selection rather than adding a second vote:
+// a single-choice poll must never count one child twice.
+func TestAnnouncementPoll_ReAnswerReplacesSelection(t *testing.T) {
+	svc, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	poll := seedPublishedPoll(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, nil, "Ja", "Nein")
+	ctx := context.Background()
+
+	require.NoError(t, svc.RespondToAnnouncement(ctx, chain.AccountID, poll.ID, chain.StudentID, []int64{poll.Options[0].ID}, *poll.PublishedAt))
+	require.NoError(t, svc.RespondToAnnouncement(ctx, chain.AccountID, poll.ID, chain.StudentID, []int64{poll.Options[1].ID}, *poll.PublishedAt))
+
+	results, err := repos.ParentAnnouncement.PollResults(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, results.AnsweredCount)
+	assert.Equal(t, 0, results.Options[0].Count, "the first answer must be replaced")
+	assert.Equal(t, 1, results.Options[1].Count)
+
+	// An empty selection withdraws the answer entirely.
+	require.NoError(t, svc.RespondToAnnouncement(ctx, chain.AccountID, poll.ID, chain.StudentID, nil, *poll.PublishedAt))
+	results, err = repos.ParentAnnouncement.PollResults(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, results.AnsweredCount)
+}
+
+// The deadline is the answer cut-off, checked in the same statement as the
+// write. A closed poll rejects the answer instead of silently dropping it.
+func TestAnnouncementPoll_ClosedPollRejectsAnswer(t *testing.T) {
+	svc, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	future := time.Now().Add(time.Hour)
+	poll := seedPublishedPoll(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, &future, "Ja", "Nein")
+
+	// Move the deadline into the past with a direct write: the service refuses to
+	// SET one there, but a poll closing while a parent has the page open is
+	// exactly the state this guard exists for.
+	past := time.Now().Add(-time.Minute)
+	_, err := db.NewUpdate().
+		TableExpr("users.parent_announcements").
+		Set("response_deadline = ?", past).
+		Where("id = ?", poll.ID).
+		Exec(context.Background())
+	require.NoError(t, err)
+
+	respondErr := svc.RespondToAnnouncement(context.Background(), chain.AccountID, poll.ID, chain.StudentID, []int64{poll.Options[0].ID}, *poll.PublishedAt)
+	assert.ErrorIs(t, respondErr, parentService.ErrPollClosed)
+}
+
+// A guardian may not answer for a child that is not theirs.
+func TestAnnouncementPoll_ForeignChildIsRejected(t *testing.T) {
+	svc, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+	other := testpkg.CreateTestStudent(t, db, "Mila", "Fremd", "2b")
+	defer testpkg.CleanupActivityFixtures(t, db, other.ID)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	poll := seedPublishedPoll(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, nil, "Ja", "Nein")
+
+	err := svc.RespondToAnnouncement(context.Background(), chain.AccountID, poll.ID, other.ID, []int64{poll.Options[0].ID}, *poll.PublishedAt)
+	assert.ErrorIs(t, err, parentService.ErrChildNotAnswerable)
+}
+
+// A plain Mitteilung accepts no answers at all.
+func TestAnnouncementPoll_PlainAnnouncementRejectsAnswer(t *testing.T) {
+	svc, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	ann := seedPublishedAnnouncement(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, false)
+
+	err := svc.RespondToAnnouncement(context.Background(), chain.AccountID, ann.ID, chain.StudentID, nil, *ann.PublishedAt)
+	assert.ErrorIs(t, err, parentService.ErrAnnouncementNotAPoll)
+}
+
+// The unread badge keeps counting an open poll the guardian has already read but
+// not answered — that is the whole point of the reminder.
+func TestAnnouncementPoll_UnansweredPollStaysInUnreadCount(t *testing.T) {
+	svc, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	poll := seedPublishedPoll(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, nil, "Ja", "Nein")
+	ctx := context.Background()
+
+	require.NoError(t, svc.MarkAnnouncementRead(ctx, chain.AccountID, poll.ID, *poll.PublishedAt))
+	count, err := svc.UnreadAnnouncementCount(ctx, chain.AccountID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "a read but unanswered poll must stay outstanding")
+
+	require.NoError(t, svc.RespondToAnnouncement(ctx, chain.AccountID, poll.ID, chain.StudentID, []int64{poll.Options[0].ID}, *poll.PublishedAt))
+	count, err = svc.UnreadAnnouncementCount(ctx, chain.AccountID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "answering clears the outstanding state")
+}
+
+func findFeedItem(t *testing.T, feed []*usersModels.AnnouncementFeedItem, id int64) *usersModels.AnnouncementFeedItem {
+	t.Helper()
+	for _, item := range feed {
+		if item.ID == id {
+			return item
+		}
+	}
+	t.Fatalf("announcement %d not found in feed", id)
+	return nil
+}

--- a/backend/services/parent/parent_announcement_poll_test.go
+++ b/backend/services/parent/parent_announcement_poll_test.go
@@ -119,6 +119,39 @@ func TestAnnouncementPoll_AnswerAppearsInFeedAndResults(t *testing.T) {
 	assert.Empty(t, pending, "an answered child must not be reminded")
 }
 
+// A portal-visible child without a guardian who may answer remains visible to
+// staff, but cannot make completion or reminders look permanently outstanding.
+func TestAnnouncementPoll_IneligibleChildIsNotOutstanding(t *testing.T) {
+	_, db, repos := buildAnnouncementService(t, true)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	seedCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	poll := seedPublishedPoll(t, seedCtx, repos.ParentAnnouncement, chain.AccountID, chain.TenantID, nil, "Ja", "Nein")
+	_, err := db.NewUpdate().
+		TableExpr("users.students_guardians").
+		Set("permissions = ?", `{"parent_portal.access": true}`).
+		Where("student_id = ?", chain.StudentID).
+		Where("guardian_profile_id = ?", chain.GuardianProfileID).
+		Exec(context.Background())
+	require.NoError(t, err)
+
+	results, err := repos.ParentAnnouncement.PollResults(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, results.TargetChildCount)
+	assert.Zero(t, results.ChildCount)
+	assert.Zero(t, results.AnsweredCount)
+
+	children, err := repos.ParentAnnouncement.PollChildren(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	assert.False(t, children[0].CanAnswer)
+
+	pending, err := repos.ParentAnnouncement.UnansweredReminderRecipients(seedCtx, chain.TenantID, poll.ID)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
 // Re-answering replaces the previous selection rather than adding a second vote:
 // a single-choice poll must never count one child twice.
 func TestAnnouncementPoll_ReAnswerReplacesSelection(t *testing.T) {

--- a/backend/services/parent/parent_announcement_service.go
+++ b/backend/services/parent/parent_announcement_service.go
@@ -35,6 +35,18 @@ var (
 	// first), so it never reveals an announcement to a non-audience caller or one
 	// whose school disabled the feature.
 	ErrAnnouncementStale = errors.New("parent: announcement changed since it was loaded")
+	// ErrAnnouncementNotAPoll is returned when an answer is submitted for an
+	// announcement that asks no question. Handler maps it to 400.
+	ErrAnnouncementNotAPoll = errors.New("parent: announcement does not accept answers")
+	// ErrPollClosed is returned when the answer deadline has passed. Handler maps
+	// it to 409 so the portal refetches and shows the closed state instead of
+	// silently dropping the answer.
+	ErrPollClosed = errors.New("parent: the answer deadline for this poll has passed")
+	// ErrChildNotAnswerable is returned when the guardian may not answer for the
+	// given child — not their child, or a child this poll does not reach. It
+	// collapses with "unknown child" on purpose so a parent token cannot probe
+	// student ids. Handler maps it to 404.
+	ErrChildNotAnswerable = errors.New("parent: no answerable child for this poll")
 )
 
 // ListAnnouncements returns the guardian's parent-news feed: published, active,
@@ -60,11 +72,51 @@ func (s *service) ListAnnouncements(ctx context.Context, accountID int64) ([]*us
 			return err
 		}
 		out = rows
-		return nil
+		return s.attachPollData(adminCtx, accountID, rows)
 	}); txErr != nil {
 		return nil, fmt.Errorf("parent: list announcements: %w", txErr)
 	}
 	return out, nil
+}
+
+// attachPollData loads the answer options and the guardian's answerable children
+// for the poll items of a feed page, in two batched queries rather than one per
+// item. Plain Mitteilungen are skipped entirely, so a feed without polls costs
+// nothing extra.
+func (s *service) attachPollData(ctx context.Context, accountID int64, items []*usersModels.AnnouncementFeedItem) error {
+	pollIDs := make([]int64, 0, len(items))
+	byID := make(map[int64]*usersModels.AnnouncementFeedItem, len(items))
+	for _, item := range items {
+		if !item.IsPoll() {
+			continue
+		}
+		pollIDs = append(pollIDs, item.ID)
+		byID[item.ID] = item
+		item.Options = []*usersModels.ParentAnnouncementOption{}
+		item.Children = []*usersModels.AnnouncementPollChild{}
+	}
+	if len(pollIDs) == 0 {
+		return nil
+	}
+	options, err := s.AnnouncementRepo.ListOptionsForAnnouncements(ctx, pollIDs)
+	if err != nil {
+		return fmt.Errorf("parent: load poll options: %w", err)
+	}
+	for _, o := range options {
+		if item, ok := byID[o.AnnouncementID]; ok {
+			item.Options = append(item.Options, o)
+		}
+	}
+	children, err := s.AnnouncementRepo.AnswerableChildren(ctx, accountID, pollIDs)
+	if err != nil {
+		return fmt.Errorf("parent: load answerable children: %w", err)
+	}
+	for _, c := range children {
+		if item, ok := byID[c.AnnouncementID]; ok {
+			item.Children = append(item.Children, c)
+		}
+	}
+	return nil
 }
 
 // UnreadAnnouncementCount returns how many feed announcements the guardian has
@@ -226,6 +278,105 @@ func (s *service) stampAnnouncement(ctx context.Context, accountID, announcement
 		if !applied {
 			return ErrAnnouncementStale
 		}
+		return nil
+	})
+}
+
+// RespondToAnnouncement records the guardian's answer to a poll for ONE child.
+// optionIDs replaces the child's previous selection; an empty slice withdraws
+// the answer. The resolution mirrors stampAnnouncement — audience/feature-flag
+// checks collapse to 404 before any other 4xx so a parent token can neither
+// enumerate announcement ids nor probe student ids — and adds the poll-specific
+// checks: it must be a poll, the deadline must not have passed, and the account
+// must be a portal-enabled guardian of a child the poll actually reaches.
+func (s *service) RespondToAnnouncement(ctx context.Context, accountID, announcementID, studentID int64, optionIDs []int64, expectedPublishedAt time.Time) error {
+	if accountID <= 0 || announcementID <= 0 || studentID <= 0 {
+		return fmt.Errorf("parent: account_id, announcement_id and student_id must be positive")
+	}
+	var announcementTenantID int64
+	var announcementPublishedAt time.Time
+	var isPoll bool
+	var deadline *time.Time
+	if err := tenant.WithAdminTx(ctx, s.DB, func(adminCtx context.Context, _ bun.Tx) error {
+		a, err := s.AnnouncementRepo.FindByID(adminCtx, announcementID)
+		if err != nil {
+			return fmt.Errorf("parent: load announcement: %w", err)
+		}
+		if a == nil || !announcementIsLive(a) {
+			return ErrAnnouncementNotFound
+		}
+		// Authorize the CHILD, not just the account: AccountMayAnswerForStudent
+		// checks the guardian link and the poll's audience in one query, so a
+		// guardian can neither answer for someone else's child nor for a child the
+		// poll does not target.
+		allowed, err := s.AnnouncementRepo.AccountMayAnswerForStudent(adminCtx, a.GetTenantID(), announcementID, accountID, studentID)
+		if err != nil {
+			return fmt.Errorf("parent: check answer permission: %w", err)
+		}
+		if !allowed {
+			// A guardian outside the audience entirely must not be able to tell
+			// "wrong child" from "no such announcement", so both are 404 — but a
+			// guardian who IS in the audience gets the more useful child error.
+			matched, matchErr := s.AnnouncementRepo.AccountMatchesAnnouncement(adminCtx, a.GetTenantID(), announcementID, accountID)
+			if matchErr != nil {
+				return fmt.Errorf("parent: match announcement audience: %w", matchErr)
+			}
+			if !matched {
+				return ErrAnnouncementNotFound
+			}
+			return ErrChildNotAnswerable
+		}
+		announcementTenantID = a.GetTenantID()
+		announcementPublishedAt = *a.PublishedAt
+		isPoll = a.IsPoll()
+		deadline = a.ResponseDeadline
+		return nil
+	}); err != nil {
+		return err
+	}
+	// Same fail-closed feature check as the read/ack path: a school that turned
+	// parent news off must stop collecting answers, not just stop showing them.
+	if s.Settings == nil {
+		return ErrAnnouncementNotFound
+	}
+	on, err := s.Settings.ResolveBoolForTenant(ctx, announcementTenantID, configModel.KeyParentNewsEnabled)
+	if err != nil {
+		s.Logger.Warn("parent: resolve parent_news_enabled failed, refusing poll answer",
+			slog.Int64("tenant_id", announcementTenantID),
+			slog.Int64("announcement_id", announcementID),
+			slog.String("error", err.Error()),
+		)
+		return ErrAnnouncementNotFound
+	}
+	if !on {
+		return ErrAnnouncementNotFound
+	}
+	if !announcementPublishedAt.Equal(expectedPublishedAt) {
+		return ErrAnnouncementStale
+	}
+	if !isPoll {
+		return ErrAnnouncementNotAPoll
+	}
+	if deadline != nil && !deadline.After(time.Now()) {
+		return ErrPollClosed
+	}
+	// Phase 2: the write re-evaluates liveness, version AND deadline inside the
+	// same statement, so a deadline that passes between here and the write cannot
+	// let a late answer through. A missed guard is a 409, never a silent 200.
+	return tenant.WithAdminTx(ctx, s.DB, func(adminCtx context.Context, _ bun.Tx) error {
+		applied, err := s.AnnouncementRepo.SetResponse(adminCtx, announcementTenantID, announcementID, studentID, accountID, optionIDs, expectedPublishedAt)
+		if err != nil {
+			return err
+		}
+		if !applied {
+			return ErrAnnouncementStale
+		}
+		s.Logger.Info("parent answered announcement poll",
+			slog.Int64("account_id", accountID),
+			slog.Int64("announcement_id", announcementID),
+			slog.Int64("student_id", studentID),
+			slog.Int("option_count", len(optionIDs)),
+		)
 		return nil
 	})
 }

--- a/backend/services/parent/parent_announcement_service.go
+++ b/backend/services/parent/parent_announcement_service.go
@@ -42,6 +42,11 @@ var (
 	// it to 409 so the portal refetches and shows the closed state instead of
 	// silently dropping the answer.
 	ErrPollClosed = errors.New("parent: the answer deadline for this poll has passed")
+	// ErrInvalidPollResponse is returned when a selection is not made up of this
+	// poll's options, repeats an option, or violates the poll's response type.
+	// Handler maps it to 400; importantly, validation happens before a prior
+	// answer can be replaced.
+	ErrInvalidPollResponse = errors.New("parent: invalid poll response")
 	// ErrChildNotAnswerable is returned when the guardian may not answer for the
 	// given child — not their child, or a child this poll does not reach. It
 	// collapses with "unknown child" on purpose so a parent token cannot probe
@@ -296,6 +301,7 @@ func (s *service) RespondToAnnouncement(ctx context.Context, accountID, announce
 	var announcementTenantID int64
 	var announcementPublishedAt time.Time
 	var isPoll bool
+	var responseType string
 	var deadline *time.Time
 	if err := tenant.WithAdminTx(ctx, s.DB, func(adminCtx context.Context, _ bun.Tx) error {
 		a, err := s.AnnouncementRepo.FindByID(adminCtx, announcementID)
@@ -329,6 +335,7 @@ func (s *service) RespondToAnnouncement(ctx context.Context, accountID, announce
 		announcementTenantID = a.GetTenantID()
 		announcementPublishedAt = *a.PublishedAt
 		isPoll = a.IsPoll()
+		responseType = a.ResponseType
 		deadline = a.ResponseDeadline
 		return nil
 	}); err != nil {
@@ -360,6 +367,13 @@ func (s *service) RespondToAnnouncement(ctx context.Context, accountID, announce
 	if deadline != nil && !deadline.After(time.Now()) {
 		return ErrPollClosed
 	}
+	options, err := s.AnnouncementRepo.ListOptions(ctx, announcementID)
+	if err != nil {
+		return fmt.Errorf("parent: load poll options: %w", err)
+	}
+	if !validPollSelection(responseType, options, optionIDs) {
+		return ErrInvalidPollResponse
+	}
 	// Phase 2: the write re-evaluates liveness, version AND deadline inside the
 	// same statement, so a deadline that passes between here and the write cannot
 	// let a late answer through. A missed guard is a 409, never a silent 200.
@@ -379,6 +393,31 @@ func (s *service) RespondToAnnouncement(ctx context.Context, accountID, announce
 		)
 		return nil
 	})
+}
+
+func validPollSelection(responseType string, options []*usersModels.ParentAnnouncementOption, optionIDs []int64) bool {
+	if responseType != usersModels.ParentAnnouncementResponseSingleChoice &&
+		responseType != usersModels.ParentAnnouncementResponseMultiChoice {
+		return false
+	}
+	if len(optionIDs) == 0 {
+		return true
+	}
+	optionSet := make(map[int64]struct{}, len(options))
+	for _, option := range options {
+		optionSet[option.ID] = struct{}{}
+	}
+	seen := make(map[int64]struct{}, len(optionIDs))
+	for _, optionID := range optionIDs {
+		if _, exists := optionSet[optionID]; !exists {
+			return false
+		}
+		if _, duplicate := seen[optionID]; duplicate {
+			return false
+		}
+		seen[optionID] = struct{}{}
+	}
+	return responseType != usersModels.ParentAnnouncementResponseSingleChoice || len(optionIDs) == 1
 }
 
 // newsEnabledTenants returns the distinct tenants a guardian can receive news

--- a/backend/services/parent/parent_announcement_service.go
+++ b/backend/services/parent/parent_announcement_service.go
@@ -367,9 +367,16 @@ func (s *service) RespondToAnnouncement(ctx context.Context, accountID, announce
 	if deadline != nil && !deadline.After(time.Now()) {
 		return ErrPollClosed
 	}
-	options, err := s.AnnouncementRepo.ListOptions(ctx, announcementID)
-	if err != nil {
-		return fmt.Errorf("parent: load poll options: %w", err)
+	var options []*usersModels.ParentAnnouncementOption
+	if err := tenant.WithAdminTx(ctx, s.DB, func(adminCtx context.Context, _ bun.Tx) error {
+		var err error
+		options, err = s.AnnouncementRepo.ListOptions(adminCtx, announcementID)
+		if err != nil {
+			return fmt.Errorf("parent: load poll options: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if !validPollSelection(responseType, options, optionIDs) {
 		return ErrInvalidPollResponse

--- a/backend/services/parent/parent_service.go
+++ b/backend/services/parent/parent_service.go
@@ -296,6 +296,13 @@ type Service interface {
 	// only for an announcement that requires acknowledgement. Same audience and
 	// stale-version guards as MarkAnnouncementRead.
 	AcknowledgeAnnouncement(ctx context.Context, accountID, announcementID int64, expectedPublishedAt time.Time) error
+
+	// RespondToAnnouncement records the guardian's answer to a poll (Umfrage) for
+	// ONE child: optionIDs replaces whatever was selected for that child, an empty
+	// slice withdraws the answer. Authorized per child (the account must be a
+	// portal-enabled guardian of a child the poll reaches), with the same
+	// stale-version guard as MarkAnnouncementRead plus the answer deadline (#1371).
+	RespondToAnnouncement(ctx context.Context, accountID, announcementID, studentID int64, optionIDs []int64, expectedPublishedAt time.Time) error
 }
 
 // ChildFeatureFlags reports the resolved per-tenant parent-portal feature

--- a/backend/templates/email/announcement-published.html
+++ b/backend/templates/email/announcement-published.html
@@ -7,10 +7,14 @@
 
     <p>Guten Tag{{if .GuardianFirstName}} {{.GuardianFirstName}} {{.GuardianLastName}}{{end}},</p>
 
+    {{if .Intro}}
+    <p>{{.Intro}}</p>
+    {{else}}
     <p>{{if .SchoolName}}die {{.SchoolName}} hat{{else}}wir haben{{end}} eine neue Mitteilung für Sie. Den vollständigen Inhalt finden Sie im Eltern-Portal.</p>
+    {{end}}
 
     {{if .PortalURL}}
-    <p style="margin-top: 24px;">Zur Mitteilung:</p>
+    <p style="margin-top: 24px;">Zum Eltern-Portal:</p>
 
     <div class="button-wrapper" style="text-align: center;">
         <a class="button" href="{{.PortalURL}}">Zum Eltern-Portal</a>

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -630,7 +630,11 @@ function ParentAnnouncementsContent() {
       )}
 
       {reminderNotice && (
-        <div className="mb-4 rounded-lg border border-[#83CD2D]/40 bg-[#83CD2D]/10 p-4 text-sm text-[#4d7719]">
+        // Opaque tints, not alpha on the brand green: the page background is a
+        // dotted pattern, and a translucent banner lets the dots show through,
+        // which reads as a rendering glitch. The hexes are #83CD2D composited
+        // over white at 10% (fill) and 40% (border).
+        <div className="mb-4 rounded-lg border border-[#CDEBAB] bg-[#F3FAEA] p-4 text-sm text-[#4d7719]">
           {reminderNotice}
         </div>
       )}
@@ -1092,223 +1096,245 @@ function AnnouncementFormModal({
       footer={footer}
       size="xl"
     >
-      <div className="space-y-5">
+      <div className="space-y-4">
         <WizardStepper steps={WIZARD_STEPS} current={step} />
 
         {step === 0 ? (
-          <div className="space-y-5">
-            <Input
-              label={isPollForm ? "Frage" : "Titel"}
-              name="announcement-title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder={
-                isPollForm
-                  ? "z. B. Kommt Ihr Kind zur Murmelparty?"
-                  : "z. B. Sommerfest am Freitag"
-              }
-            />
+          // Two columns from lg up: writing (question + text + link) on the
+          // left, configuration (answers, dates, delivery) on the right. As one
+          // stack the form was a narrow ribbon down the middle of a 900px modal
+          // that scrolled for content which fits side by side. Below lg the
+          // columns stack in the same order.
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] lg:gap-6">
+            <div className="space-y-4">
+              <Input
+                label={isPollForm ? "Frage" : "Titel"}
+                name="announcement-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder={
+                  isPollForm
+                    ? "z. B. Kommt Ihr Kind zur Murmelparty?"
+                    : "z. B. Sommerfest am Freitag"
+                }
+              />
 
-            <div>
-              <label
-                htmlFor="announcement-body"
-                className="mb-2 block text-sm font-medium text-gray-700"
-              >
-                Text
-              </label>
-              <textarea
-                id="announcement-body"
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
-                rows={5}
-                maxLength={4000}
-                placeholder="Inhalt der Mitteilung... Links im Text werden für Eltern klickbar."
-                className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
+              <div>
+                <label
+                  htmlFor="announcement-body"
+                  className="mb-2 block text-sm font-medium text-gray-700"
+                >
+                  Text
+                </label>
+                <textarea
+                  id="announcement-body"
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  rows={7}
+                  maxLength={4000}
+                  placeholder="Inhalt der Mitteilung... Links im Text werden für Eltern klickbar."
+                  className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
+                />
+              </div>
+
+              <Input
+                label="Link (optional)"
+                name="announcement-link"
+                type="url"
+                value={linkUrl}
+                onChange={(e) => setLinkUrl(e.target.value)}
+                placeholder="https://..."
               />
             </div>
 
-            <Input
-              label="Link (optional)"
-              name="announcement-link"
-              type="url"
-              value={linkUrl}
-              onChange={(e) => setLinkUrl(e.target.value)}
-              placeholder="https://..."
-            />
-
-            {isPollForm && (
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
-                <span className="block text-sm font-medium text-gray-700">
-                  Antwortmöglichkeiten
-                </span>
-                <p className="mt-0.5 text-xs text-gray-500">
-                  Eltern antworten für jedes Kind einzeln.
-                </p>
-
-                <ul className="mt-3 space-y-2">
-                  {options.map((option, index) => (
-                    // Options have no id before saving, so the index is the only
-                    // stable key here; the list is short and edited in place.
-                    // eslint-disable-next-line react/no-array-index-key
-                    <li key={index} className="flex items-center gap-2">
-                      <Input
-                        name={`announcement-option-${index}`}
-                        value={option}
-                        onChange={(e) => setOptionAt(index, e.target.value)}
-                        placeholder={`Antwort ${index + 1}`}
-                        aria-label={`Antwortmöglichkeit ${index + 1}`}
-                        className="flex-1"
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => removeOptionAt(index)}
-                        disabled={options.length <= 2}
-                        aria-label={`Antwortmöglichkeit ${index + 1} entfernen`}
-                      >
-                        <X className="size-4" aria-hidden />
-                      </Button>
-                    </li>
-                  ))}
-                </ul>
-
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="compact"
-                  onClick={() => setOptions((prev) => [...prev, ""])}
-                  disabled={options.length >= 10}
-                  className="mt-2 gap-1.5"
-                >
-                  <Plus className="size-4" aria-hidden />
-                  Antwort hinzufügen
-                </Button>
-
-                <label
-                  htmlFor="announcement-multi"
-                  className="mt-4 flex cursor-pointer items-start gap-3"
-                >
-                  <Checkbox
-                    id="announcement-multi"
-                    checked={multiChoice}
-                    onChange={(e) => setMultiChoice(e.target.checked)}
-                  />
-                  <span>
-                    <span className="block text-sm font-medium text-gray-700">
-                      Mehrfachauswahl erlauben
-                    </span>
-                    <span className="block text-xs text-gray-500">
-                      Eltern können pro Kind mehrere Antworten auswählen.
-                    </span>
-                  </span>
-                </label>
-              </div>
-            )}
-
-            <div className="grid gap-5 sm:grid-cols-2">
+            <div className="space-y-4">
               {isPollForm && (
-                <div>
-                  <span className="mb-1.5 block text-sm font-medium text-gray-700">
-                    Antwortfrist (optional)
+                <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                  <span className="block text-sm font-medium text-gray-700">
+                    Antwortmöglichkeiten
                   </span>
-                  <DatePicker
-                    value={deadline}
-                    onChange={setDeadline}
-                    placeholder="Keine Frist"
-                    dropdownPlacement="down"
-                  />
-                  <p className="mt-1 text-xs text-gray-500">
-                    Danach ist die Umfrage geschlossen, bleibt aber lesbar.
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    Eltern antworten für jedes Kind einzeln.
                   </p>
+
+                  {/* Two per row: an answer is a word or two, so a full-width
+                    field per option is mostly empty space and pushes the rest
+                    of the form below the fold. */}
+                  <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+                    {options.map((option, index) => (
+                      // Options have no id before saving, so the index is the only
+                      // stable key here; the list is short and edited in place.
+                      // eslint-disable-next-line react/no-array-index-key
+                      <li key={index} className="flex items-center gap-2">
+                        <Input
+                          name={`announcement-option-${index}`}
+                          value={option}
+                          onChange={(e) => setOptionAt(index, e.target.value)}
+                          placeholder={`Antwort ${index + 1}`}
+                          aria-label={`Antwortmöglichkeit ${index + 1}`}
+                          className="flex-1"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeOptionAt(index)}
+                          disabled={options.length <= 2}
+                          aria-label={`Antwortmöglichkeit ${index + 1} entfernen`}
+                        >
+                          <X className="size-4" aria-hidden />
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="compact"
+                    onClick={() => setOptions((prev) => [...prev, ""])}
+                    disabled={options.length >= 10}
+                    className="mt-2 gap-1.5"
+                  >
+                    <Plus className="size-4" aria-hidden />
+                    Antwort hinzufügen
+                  </Button>
+
+                  <label
+                    htmlFor="announcement-multi"
+                    className="mt-4 flex cursor-pointer items-start gap-3"
+                  >
+                    <Checkbox
+                      id="announcement-multi"
+                      checked={multiChoice}
+                      onChange={(e) => setMultiChoice(e.target.checked)}
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-gray-700">
+                        Mehrfachauswahl erlauben
+                      </span>
+                      <span className="block text-xs text-gray-500">
+                        Eltern können pro Kind mehrere Antworten auswählen.
+                      </span>
+                    </span>
+                  </label>
                 </div>
               )}
-              <div>
-                <span
-                  id="announcement-priority-label"
-                  className="mb-1.5 block text-sm font-medium text-gray-700"
-                >
-                  Priorität
-                </span>
-                <div
-                  className="flex flex-wrap gap-2"
-                  role="group"
-                  aria-labelledby="announcement-priority-label"
-                >
-                  {PRIORITY_OPTIONS.map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => setPriority(opt.value)}
-                      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-                        priority === opt.value
-                          ? "bg-gray-900 text-white"
-                          : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                      }`}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
+
+              {/* One row for every small setting, so no half-empty grid row is
+                left over: a poll adds the Antwortfrist as a third column
+                instead of a second line. */}
+              <div className="grid gap-4 sm:grid-cols-2">
+                {isPollForm && (
+                  <div>
+                    <span className="mb-1.5 block text-sm font-medium text-gray-700">
+                      Antwortfrist (optional)
+                    </span>
+                    <DatePicker
+                      value={deadline}
+                      onChange={setDeadline}
+                      placeholder="Keine Frist"
+                      dropdownPlacement="down"
+                    />
+                  </div>
+                )}
+                <div>
+                  <span
+                    id="announcement-priority-label"
+                    className="mb-1.5 block text-sm font-medium text-gray-700"
+                  >
+                    Priorität
+                  </span>
+                  <div
+                    className="flex flex-wrap gap-2"
+                    role="group"
+                    aria-labelledby="announcement-priority-label"
+                  >
+                    {PRIORITY_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setPriority(opt.value)}
+                        className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                          priority === opt.value
+                            ? "bg-gray-900 text-white"
+                            : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <span className="mb-1.5 block text-sm font-medium text-gray-700">
+                    Ablaufdatum (optional)
+                  </span>
+                  <DatePicker
+                    value={expiresAt}
+                    onChange={setExpiresAt}
+                    placeholder="Kein Ablaufdatum"
+                    dropdownPlacement="down"
+                  />
                 </div>
               </div>
 
-              <div>
-                <span className="mb-1.5 block text-sm font-medium text-gray-700">
-                  Ablaufdatum (optional)
-                </span>
-                <DatePicker
-                  value={expiresAt}
-                  onChange={setExpiresAt}
-                  placeholder="Kein Ablaufdatum"
-                  dropdownPlacement="down"
-                />
-              </div>
-            </div>
+              {isPollForm && (
+                <p className="-mt-2 text-xs text-gray-500">
+                  Nach der Antwortfrist ist die Umfrage geschlossen, bleibt aber
+                  lesbar.
+                </p>
+              )}
 
-            <div className="grid gap-3 sm:grid-cols-2">
-              {/* A poll answer already IS the confirmation — offering a second,
+              {/* Stacked, not side by side: these sit in the narrower settings
+                  column, where two columns would break each label across three
+                  lines. */}
+              <div className="space-y-3">
+                {/* A poll answer already IS the confirmation — offering a second,
                   weaker "gelesen" checkbox on top only muddies the result. */}
-              {!isPollForm && (
+                {!isPollForm && (
+                  <label
+                    htmlFor="announcement-ack"
+                    className="flex cursor-pointer items-start gap-3"
+                  >
+                    <Checkbox
+                      id="announcement-ack"
+                      checked={requiresAck}
+                      onChange={(e) => setRequiresAck(e.target.checked)}
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-gray-700">
+                        Lesebestätigung erforderlich
+                      </span>
+                      <span className="block text-xs text-gray-500">
+                        Eltern bestätigen ausdrücklich, dass sie die Mitteilung
+                        gelesen haben.
+                      </span>
+                    </span>
+                  </label>
+                )}
+
                 <label
-                  htmlFor="announcement-ack"
+                  htmlFor="announcement-email"
                   className="flex cursor-pointer items-start gap-3"
                 >
                   <Checkbox
-                    id="announcement-ack"
-                    checked={requiresAck}
-                    onChange={(e) => setRequiresAck(e.target.checked)}
+                    id="announcement-email"
+                    checked={sendEmail}
+                    onChange={(e) => setSendEmail(e.target.checked)}
                   />
                   <span>
                     <span className="block text-sm font-medium text-gray-700">
-                      Lesebestätigung erforderlich
+                      Eltern zusätzlich per E-Mail benachrichtigen
                     </span>
                     <span className="block text-xs text-gray-500">
-                      Eltern bestätigen ausdrücklich, dass sie die Mitteilung
-                      gelesen haben.
+                      Beim Veröffentlichen erhalten die erreichten Eltern eine
+                      E-Mail mit Titel und Link ins Elternportal.
                     </span>
                   </span>
                 </label>
-              )}
-
-              <label
-                htmlFor="announcement-email"
-                className="flex cursor-pointer items-start gap-3"
-              >
-                <Checkbox
-                  id="announcement-email"
-                  checked={sendEmail}
-                  onChange={(e) => setSendEmail(e.target.checked)}
-                />
-                <span>
-                  <span className="block text-sm font-medium text-gray-700">
-                    Eltern zusätzlich per E-Mail benachrichtigen
-                  </span>
-                  <span className="block text-xs text-gray-500">
-                    Beim Veröffentlichen erhalten die erreichten Eltern eine
-                    E-Mail mit Titel und Link ins Elternportal.
-                  </span>
-                </span>
-              </label>
+              </div>
             </div>
           </div>
         ) : (

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -38,7 +38,7 @@ import { SegmentedControl } from "~/components/ui/segmented-control";
 import type { SegmentedControlItem } from "~/components/ui/segmented-control";
 import { LinkifiedText } from "~/components/ui/linkified-text";
 import { LOCATION_COLORS } from "~/lib/location-helper";
-import { formatDate } from "~/lib/date-helpers";
+import { endOfBerlinDayISO, formatDate } from "~/lib/date-helpers";
 import { createLogger } from "~/lib/logger";
 import { useSWRAuth } from "~/lib/swr";
 import { groupService, studentService } from "~/lib/api";
@@ -176,18 +176,6 @@ function summarizeTargets(targets: AnnouncementTarget[]): string {
       return `${count} ${TARGET_TYPE_PLURAL[type]}`;
     })
     .join(", ");
-}
-
-/** End of the chosen calendar day as an instant. expires_at is a TIMESTAMPTZ. */
-function endOfDayISO(date: Date): string {
-  return new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-    23,
-    59,
-    59,
-  ).toISOString();
 }
 
 /** Returns a German validation error for a non-empty link, or null when ok. */
@@ -989,7 +977,7 @@ function AnnouncementFormModal({
       // polls, so a value left over from a converted draft must not leak).
       requires_acknowledgement: isPollForm ? false : requiresAck,
       send_email: sendEmail,
-      expires_at: expiresAt ? endOfDayISO(expiresAt) : null,
+      expires_at: expiresAt ? endOfBerlinDayISO(expiresAt) : null,
       targets,
       response_type: isPollForm
         ? multiChoice
@@ -998,7 +986,8 @@ function AnnouncementFormModal({
         : "none",
       // The chosen day is the LAST day parents can answer, so the cut-off is
       // its end — not midnight, which would close the poll a day early.
-      response_deadline: isPollForm && deadline ? endOfDayISO(deadline) : null,
+      response_deadline:
+        isPollForm && deadline ? endOfBerlinDayISO(deadline) : null,
       options: isPollForm ? options : undefined,
     };
 

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -3,14 +3,17 @@
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import {
   BarChart3,
+  BellRing,
   Check,
   ExternalLink,
+  ListChecks,
   Megaphone,
   Pencil,
   Plus,
   Send,
   Trash2,
   Undo2,
+  X,
 } from "lucide-react";
 
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
@@ -32,6 +35,8 @@ import { DatePicker } from "~/components/ui/date-picker";
 import { Loading } from "~/components/ui/loading";
 import { MultiCheckboxSelect } from "~/components/ui/multi-checkbox-select";
 import { WizardStepper } from "~/components/ui/wizard-stepper";
+import { SegmentedControl } from "~/components/ui/segmented-control";
+import type { SegmentedControlItem } from "~/components/ui/segmented-control";
 import { LinkifiedText } from "~/components/ui/linkified-text";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 import { formatDate } from "~/lib/date-helpers";
@@ -47,7 +52,11 @@ import {
   fetchAnnouncements,
   fetchAnnouncementRecipients,
   fetchAnnouncementStats,
+  fetchPollChildren,
+  fetchPollResults,
+  isPoll,
   publishAnnouncement,
+  remindUnanswered,
   unpublishAnnouncement,
   updateAnnouncement,
 } from "~/lib/parent-announcements-api";
@@ -56,10 +65,13 @@ import type {
   AnnouncementInput,
   AnnouncementPriority,
   AnnouncementRecipient,
+  AnnouncementResponseType,
   AnnouncementStats,
   AnnouncementStatus,
   AnnouncementTarget,
   AnnouncementTargetType,
+  PollChild,
+  PollResults,
 } from "~/lib/parent-announcements-api";
 
 const logger = createLogger({ component: "ParentAnnouncementsPage" });
@@ -79,6 +91,52 @@ const STATUS_META: Record<
   draft: { label: "Entwurf", color: LOCATION_COLORS.UNKNOWN },
   published: { label: "Veröffentlicht", color: LOCATION_COLORS.GROUP_ROOM },
   expired: { label: "Abgelaufen", color: LOCATION_COLORS.SCHOOLYARD },
+};
+
+/**
+ * The two things this page manages. Both are the same entity in the backend
+ * (an Umfrage is an announcement with answer options, #1371) — the split is a
+ * UI one, because writing an information and asking a question are different
+ * jobs with different follow-up work (Statistik vs Auswertung).
+ */
+type AnnouncementKind = "announcement" | "poll";
+
+const KIND_ITEMS: ReadonlyArray<SegmentedControlItem<AnnouncementKind>> = [
+  { value: "announcement", label: "Mitteilungen" },
+  { value: "poll", label: "Umfragen" },
+];
+
+const KIND_COPY: Record<
+  AnnouncementKind,
+  {
+    title: string;
+    action: string;
+    ariaLabel: string;
+    emptyTitle: string;
+    emptyBody: string;
+  }
+> = {
+  announcement: {
+    title: "Elternmitteilungen",
+    action: "Mitteilung",
+    ariaLabel: "Neue Elternmitteilung erstellen",
+    emptyTitle: "Keine Mitteilungen",
+    emptyBody: "Erstellen Sie eine neue Mitteilung für die Eltern.",
+  },
+  poll: {
+    title: "Elternumfragen",
+    action: "Umfrage",
+    ariaLabel: "Neue Umfrage erstellen",
+    emptyTitle: "Keine Umfragen",
+    emptyBody:
+      "Stellen Sie den Eltern eine Frage, zum Beispiel ob ihr Kind zum Sommerfest kommt.",
+  },
+};
+
+const RESPONSE_TYPE_LABEL: Record<AnnouncementResponseType, string> = {
+  none: "Keine Rückmeldung",
+  single_choice: "Eine Antwort",
+  multi_choice: "Mehrere Antworten",
 };
 
 const TARGET_TYPE_PLURAL: Record<AnnouncementTargetType, string> = {
@@ -171,6 +229,7 @@ export default function ParentAnnouncementsPage() {
 }
 
 function ParentAnnouncementsContent() {
+  const [kind, setKind] = useState<AnnouncementKind>("announcement");
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | AnnouncementStatus>(
     "all",
@@ -189,6 +248,9 @@ function ParentAnnouncementsContent() {
   );
   const [unpublishError, setUnpublishError] = useState("");
   const [pendingActionId, setPendingActionId] = useState<string | null>(null);
+  // Confirmation for the poll reminder, shown above the list because the detail
+  // modal closes right after sending.
+  const [reminderNotice, setReminderNotice] = useState("");
 
   const {
     data: announcements,
@@ -225,11 +287,33 @@ function ParentAnnouncementsContent() {
   const filtered = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
     return list.filter((a) => {
+      if (isPoll(a) !== (kind === "poll")) return false;
       if (statusFilter !== "all" && a.status !== statusFilter) return false;
       if (term && !a.title.toLowerCase().includes(term)) return false;
       return true;
     });
-  }, [list, searchTerm, statusFilter]);
+  }, [list, kind, searchTerm, statusFilter]);
+
+  // Counts for the tab labels: both lists come from one fetch, so switching
+  // tabs costs nothing and the user sees where the work is.
+  const kindCounts = useMemo(
+    () => ({
+      announcement: list.filter((a) => !isPoll(a)).length,
+      poll: list.filter((a) => isPoll(a)).length,
+    }),
+    [list],
+  );
+
+  const kindItems = useMemo(
+    () =>
+      KIND_ITEMS.map((item) => ({
+        ...item,
+        label: `${item.label} (${kindCounts[item.value]})`,
+      })),
+    [kindCounts],
+  );
+
+  const copy = KIND_COPY[kind];
 
   const filterConfigs: FilterConfig[] = useMemo(
     () => [
@@ -395,7 +479,8 @@ function ParentAnnouncementsContent() {
     },
     {
       key: "dates",
-      header: "Veröffentlicht / Ablauf",
+      header:
+        kind === "poll" ? "Veröffentlicht / Frist" : "Veröffentlicht / Ablauf",
       render: (row) => (
         <div className="text-xs text-gray-600">
           <p>
@@ -403,7 +488,11 @@ function ParentAnnouncementsContent() {
               ? `Veröffentlicht ${formatDate(row.published_at)}`
               : "Noch nicht veröffentlicht"}
           </p>
-          {row.expires_at && <p>Läuft ab {formatDate(row.expires_at)}</p>}
+          {row.response_deadline ? (
+            <p>Antwort bis {formatDate(row.response_deadline)}</p>
+          ) : (
+            row.expires_at && <p>Läuft ab {formatDate(row.expires_at)}</p>
+          )}
         </div>
       ),
     },
@@ -489,9 +578,14 @@ function ParentAnnouncementsContent() {
   return (
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch
-        title="Elternmitteilungen"
+        title={copy.title}
         badge={{
-          icon: <Megaphone className="h-5 w-5 text-gray-600" aria-hidden />,
+          icon:
+            kind === "poll" ? (
+              <ListChecks className="h-5 w-5 text-gray-600" aria-hidden />
+            ) : (
+              <Megaphone className="h-5 w-5 text-gray-600" aria-hidden />
+            ),
           count: filtered.length,
         }}
         search={{
@@ -511,18 +605,33 @@ function ParentAnnouncementsContent() {
             variant="primary"
             size="md"
             onClick={openCreate}
-            aria-label="Neue Elternmitteilung erstellen"
+            aria-label={copy.ariaLabel}
             className="gap-1.5"
           >
             <Plus className="h-4 w-4" aria-hidden />
-            Elternmitteilung
+            {copy.action}
           </Button>
         }
       />
 
+      <div className="mb-4">
+        <SegmentedControl
+          items={kindItems}
+          value={kind}
+          onChange={setKind}
+          ariaLabel="Mitteilungen oder Umfragen"
+        />
+      </div>
+
       {loadError && (
         <div className="mb-4 rounded-lg border border-[#FF3130]/30 bg-[#FF3130]/10 p-4 text-sm text-[#CC2626]">
           Elternmitteilungen konnten nicht geladen werden.
+        </div>
+      )}
+
+      {reminderNotice && (
+        <div className="mb-4 rounded-lg border border-[#83CD2D]/40 bg-[#83CD2D]/10 p-4 text-sm text-[#4d7719]">
+          {reminderNotice}
         </div>
       )}
 
@@ -531,14 +640,16 @@ function ParentAnnouncementsContent() {
       ) : filtered.length === 0 ? (
         <div className="py-12 text-center">
           <div className="flex flex-col items-center gap-4">
-            <Megaphone className="h-12 w-12 text-gray-400" aria-hidden />
+            {kind === "poll" ? (
+              <ListChecks className="h-12 w-12 text-gray-400" aria-hidden />
+            ) : (
+              <Megaphone className="h-12 w-12 text-gray-400" aria-hidden />
+            )}
             <div>
               <h3 className="text-lg font-medium text-gray-900">
-                Keine Elternmitteilungen
+                {copy.emptyTitle}
               </h3>
-              <p className="text-gray-600">
-                Erstellen Sie eine neue Mitteilung für die Eltern.
-              </p>
+              <p className="text-gray-600">{copy.emptyBody}</p>
             </div>
           </div>
         </div>
@@ -576,6 +687,7 @@ function ParentAnnouncementsContent() {
       {isFormOpen && (
         <AnnouncementFormModal
           announcement={editing}
+          kind={editing ? (isPoll(editing) ? "poll" : "announcement") : kind}
           groups={groups ?? []}
           activities={activities ?? []}
           schoolClasses={schoolClasses ?? []}
@@ -596,6 +708,14 @@ function ParentAnnouncementsContent() {
           groups={groups ?? []}
           activities={activities ?? []}
           onClose={() => setDetailFor(null)}
+          onReminded={(count) => {
+            setReminderNotice(
+              count === 0
+                ? "Alle erreichten Kinder haben bereits geantwortet — es wurde niemand erinnert."
+                : `${count} ${count === 1 ? "Elternteil wurde" : "Eltern wurden"} an die offene Umfrage erinnert.`,
+            );
+            setDetailFor(null);
+          }}
         />
       )}
 
@@ -700,6 +820,12 @@ function ParentAnnouncementsContent() {
 
 interface AnnouncementFormModalProps {
   readonly announcement: Announcement | null;
+  /**
+   * Which of the two things is being written. Decided by the caller (the active
+   * tab for a new entry, the entry's own type when editing) so the modal never
+   * has to guess and a poll can never silently lose its options.
+   */
+  readonly kind: AnnouncementKind;
   readonly groups: Group[];
   readonly activities: Activity[];
   readonly schoolClasses: string[];
@@ -723,6 +849,7 @@ const WIZARD_STEPS = ["Inhalt", "Empfänger"] as const;
  */
 function AnnouncementFormModal({
   announcement,
+  kind,
   groups,
   activities,
   schoolClasses,
@@ -731,6 +858,7 @@ function AnnouncementFormModal({
   onRefresh,
 }: AnnouncementFormModalProps) {
   const isEdit = announcement !== null;
+  const isPollForm = kind === "poll";
   const [step, setStep] = useState(0);
   // Tracks the id of the draft once it exists in the backend. Seeded from an
   // existing draft when editing; set after a create so that a publish-retry
@@ -758,6 +886,27 @@ function AnnouncementFormModal({
   );
   const [studentNames, setStudentNames] = useState<Record<string, string>>({});
 
+  // Poll state. A fresh poll starts as the question schools ask most often, so
+  // the common case is two clicks away instead of two text fields.
+  const [multiChoice, setMultiChoice] = useState(
+    announcement?.response_type === "multi_choice",
+  );
+  const [options, setOptions] = useState<string[]>(() => {
+    const existing = announcement?.options?.map((o) => o.label) ?? [];
+    if (existing.length > 0) return existing;
+    return isPollForm ? ["Ja", "Nein"] : [];
+  });
+  const [deadline, setDeadline] = useState<Date | null>(
+    announcement?.response_deadline
+      ? new Date(announcement.response_deadline)
+      : null,
+  );
+
+  const setOptionAt = (index: number, value: string) =>
+    setOptions((prev) => prev.map((o, i) => (i === index ? value : o)));
+  const removeOptionAt = (index: number) =>
+    setOptions((prev) => prev.filter((_, i) => i !== index));
+
   const [submitting, setSubmitting] = useState<"draft" | "publish" | null>(
     null,
   );
@@ -776,6 +925,24 @@ function AnnouncementFormModal({
     if (linkProblem) {
       setFormError(linkProblem);
       return false;
+    }
+    if (isPollForm) {
+      const filled = options.map((o) => o.trim()).filter(Boolean);
+      if (filled.length < 2) {
+        setFormError("Bitte mindestens zwei Antwortmöglichkeiten angeben.");
+        return false;
+      }
+      const seen = new Set(filled.map((o) => o.toLowerCase()));
+      if (seen.size !== filled.length) {
+        setFormError("Antwortmöglichkeiten dürfen sich nicht wiederholen.");
+        return false;
+      }
+      if (deadline && expiresAt && deadline > expiresAt) {
+        setFormError(
+          "Die Antwortfrist darf nicht nach dem Ablaufdatum liegen — sonst können Eltern nicht mehr antworten.",
+        );
+        return false;
+      }
     }
     setFormError("");
     return true;
@@ -801,10 +968,23 @@ function AnnouncementFormModal({
       body: body.trim(),
       priority,
       link_url: trimmedLink ? trimmedLink : null,
-      requires_acknowledgement: requiresAck,
+      // A poll never also carries a read confirmation (the field is hidden for
+      // polls, so a value left over from a converted draft must not leak).
+      requires_acknowledgement: isPollForm ? false : requiresAck,
       send_email: sendEmail,
       expires_at: expiresAt ? endOfDayISO(expiresAt) : null,
       targets,
+      response_type: isPollForm
+        ? multiChoice
+          ? "multi_choice"
+          : "single_choice"
+        : "none",
+      // The chosen day is the LAST day parents can answer, so the cut-off is
+      // its end — not midnight, which would close the poll a day early.
+      response_deadline: isPollForm && deadline ? endOfDayISO(deadline) : null,
+      options: isPollForm
+        ? options.map((o) => o.trim()).filter(Boolean)
+        : undefined,
     };
 
     setSubmitting(publish ? "publish" : "draft");
@@ -900,7 +1080,15 @@ function AnnouncementFormModal({
     <FormModal
       isOpen
       onClose={onClose}
-      title={isEdit ? "Elternmitteilung bearbeiten" : "Neue Elternmitteilung"}
+      title={
+        isPollForm
+          ? isEdit
+            ? "Umfrage bearbeiten"
+            : "Neue Umfrage"
+          : isEdit
+            ? "Elternmitteilung bearbeiten"
+            : "Neue Elternmitteilung"
+      }
       footer={footer}
       size="xl"
     >
@@ -910,11 +1098,15 @@ function AnnouncementFormModal({
         {step === 0 ? (
           <div className="space-y-5">
             <Input
-              label="Titel"
+              label={isPollForm ? "Frage" : "Titel"}
               name="announcement-title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="z. B. Sommerfest am Freitag"
+              placeholder={
+                isPollForm
+                  ? "z. B. Kommt Ihr Kind zur Murmelparty?"
+                  : "z. B. Sommerfest am Freitag"
+              }
             />
 
             <div>
@@ -944,7 +1136,93 @@ function AnnouncementFormModal({
               placeholder="https://..."
             />
 
+            {isPollForm && (
+              <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                <span className="block text-sm font-medium text-gray-700">
+                  Antwortmöglichkeiten
+                </span>
+                <p className="mt-0.5 text-xs text-gray-500">
+                  Eltern antworten für jedes Kind einzeln.
+                </p>
+
+                <ul className="mt-3 space-y-2">
+                  {options.map((option, index) => (
+                    // Options have no id before saving, so the index is the only
+                    // stable key here; the list is short and edited in place.
+                    // eslint-disable-next-line react/no-array-index-key
+                    <li key={index} className="flex items-center gap-2">
+                      <Input
+                        name={`announcement-option-${index}`}
+                        value={option}
+                        onChange={(e) => setOptionAt(index, e.target.value)}
+                        placeholder={`Antwort ${index + 1}`}
+                        aria-label={`Antwortmöglichkeit ${index + 1}`}
+                        className="flex-1"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeOptionAt(index)}
+                        disabled={options.length <= 2}
+                        aria-label={`Antwortmöglichkeit ${index + 1} entfernen`}
+                      >
+                        <X className="size-4" aria-hidden />
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="compact"
+                  onClick={() => setOptions((prev) => [...prev, ""])}
+                  disabled={options.length >= 10}
+                  className="mt-2 gap-1.5"
+                >
+                  <Plus className="size-4" aria-hidden />
+                  Antwort hinzufügen
+                </Button>
+
+                <label
+                  htmlFor="announcement-multi"
+                  className="mt-4 flex cursor-pointer items-start gap-3"
+                >
+                  <Checkbox
+                    id="announcement-multi"
+                    checked={multiChoice}
+                    onChange={(e) => setMultiChoice(e.target.checked)}
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-700">
+                      Mehrfachauswahl erlauben
+                    </span>
+                    <span className="block text-xs text-gray-500">
+                      Eltern können pro Kind mehrere Antworten auswählen.
+                    </span>
+                  </span>
+                </label>
+              </div>
+            )}
+
             <div className="grid gap-5 sm:grid-cols-2">
+              {isPollForm && (
+                <div>
+                  <span className="mb-1.5 block text-sm font-medium text-gray-700">
+                    Antwortfrist (optional)
+                  </span>
+                  <DatePicker
+                    value={deadline}
+                    onChange={setDeadline}
+                    placeholder="Keine Frist"
+                    dropdownPlacement="down"
+                  />
+                  <p className="mt-1 text-xs text-gray-500">
+                    Danach ist die Umfrage geschlossen, bleibt aber lesbar.
+                  </p>
+                </div>
+              )}
               <div>
                 <span
                   id="announcement-priority-label"
@@ -988,25 +1266,29 @@ function AnnouncementFormModal({
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">
-              <label
-                htmlFor="announcement-ack"
-                className="flex cursor-pointer items-start gap-3"
-              >
-                <Checkbox
-                  id="announcement-ack"
-                  checked={requiresAck}
-                  onChange={(e) => setRequiresAck(e.target.checked)}
-                />
-                <span>
-                  <span className="block text-sm font-medium text-gray-700">
-                    Lesebestätigung erforderlich
+              {/* A poll answer already IS the confirmation — offering a second,
+                  weaker "gelesen" checkbox on top only muddies the result. */}
+              {!isPollForm && (
+                <label
+                  htmlFor="announcement-ack"
+                  className="flex cursor-pointer items-start gap-3"
+                >
+                  <Checkbox
+                    id="announcement-ack"
+                    checked={requiresAck}
+                    onChange={(e) => setRequiresAck(e.target.checked)}
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-700">
+                      Lesebestätigung erforderlich
+                    </span>
+                    <span className="block text-xs text-gray-500">
+                      Eltern bestätigen ausdrücklich, dass sie die Mitteilung
+                      gelesen haben.
+                    </span>
                   </span>
-                  <span className="block text-xs text-gray-500">
-                    Eltern bestätigen ausdrücklich, dass sie die Mitteilung
-                    gelesen haben.
-                  </span>
-                </span>
-              </label>
+                </label>
+              )}
 
               <label
                 htmlFor="announcement-email"
@@ -1040,6 +1322,7 @@ function AnnouncementFormModal({
             onSetStudentName={(id, name) =>
               setStudentNames((prev) => ({ ...prev, [id]: name }))
             }
+            kindLabel={isPollForm ? "diese Umfrage" : "diese Mitteilung"}
           />
         )}
 
@@ -1096,6 +1379,8 @@ interface TargetingStepProps {
   readonly studentNames: Record<string, string>;
   readonly onChange: (targets: AnnouncementTarget[]) => void;
   readonly onSetStudentName: (id: string, name: string) => void;
+  /** Names the thing being addressed in the heading (Mitteilung vs Umfrage). */
+  readonly kindLabel: string;
 }
 
 function TargetingStep({
@@ -1106,6 +1391,7 @@ function TargetingStep({
   studentNames,
   onChange,
   onSetStudentName,
+  kindLabel,
 }: TargetingStepProps) {
   // Single source of truth is `targets`; each control derives its selection
   // from it and rebuilds it on change.
@@ -1195,7 +1481,7 @@ function TargetingStep({
     <div className="space-y-4">
       <div>
         <h4 className="text-sm font-semibold text-gray-900">
-          Wer soll diese Mitteilung erhalten?
+          Wer soll {kindLabel} erhalten?
         </h4>
         <p className="mt-0.5 text-xs text-gray-500">
           Mehrere Zielgruppen lassen sich kombinieren; jedes Elternteil erhält
@@ -1600,6 +1886,196 @@ interface DetailModalProps {
   readonly groups: Group[];
   readonly activities: Activity[];
   readonly onClose: () => void;
+  /** Called with the number of guardians reached by a poll reminder. */
+  readonly onReminded: (count: number) => void;
+}
+
+/**
+ * Poll evaluation: one bar per option over the reached children, plus the
+ * per-child list so staff can chase the open answers by name, plus the manual
+ * reminder. Counts are children, not parents — that is the number the school
+ * plans with.
+ */
+function PollResultsPanel({
+  announcement,
+  onReminded,
+}: {
+  readonly announcement: Announcement;
+  readonly onReminded: (count: number) => void;
+}) {
+  const [results, setResults] = useState<PollResults | null>(null);
+  const [children, setChildren] = useState<PollChild[] | null>(null);
+  const [error, setError] = useState("");
+  const [onlyOpen, setOnlyOpen] = useState(false);
+  const [reminding, setReminding] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError("");
+    Promise.all([
+      fetchPollResults(announcement.id),
+      fetchPollChildren(announcement.id),
+    ])
+      .then(([resultsData, childrenData]) => {
+        if (cancelled) return;
+        setResults(resultsData);
+        setChildren(childrenData);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Umfrageergebnis konnte nicht geladen werden";
+        setError(message);
+        logger.error("announcement_poll_results_failed", { error: message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [announcement.id]);
+
+  const deadlinePassed =
+    announcement.response_deadline !== undefined &&
+    new Date(announcement.response_deadline) <= new Date();
+  const canRemind =
+    announcement.status === "published" &&
+    !deadlinePassed &&
+    (results?.answered_count ?? 0) < (results?.child_count ?? 0);
+
+  const handleRemind = async () => {
+    setReminding(true);
+    setError("");
+    try {
+      const count = await remindUnanswered(announcement.id);
+      onReminded(count);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Erinnerung konnte nicht gesendet werden";
+      setError(message);
+      logger.error("announcement_poll_reminder_failed", { error: message });
+    } finally {
+      setReminding(false);
+    }
+  };
+
+  const visibleChildren = (children ?? []).filter(
+    (child) => !onlyOpen || child.answer_labels.length === 0,
+  );
+
+  return (
+    <div>
+      <h4 className="mb-1.5 flex items-center gap-1.5 text-sm font-semibold text-gray-900">
+        <ListChecks className="h-4 w-4 text-gray-500" aria-hidden />
+        Auswertung
+      </h4>
+
+      {error && <p className="mb-2 text-sm text-[#CC2626]">{error}</p>}
+
+      {results === null || children === null ? (
+        <Loading fullPage={false} />
+      ) : (
+        <>
+          <p className="text-sm text-gray-700">
+            {results.answered_count} von {results.child_count}{" "}
+            {results.child_count === 1 ? "Kind" : "Kindern"} beantwortet
+          </p>
+
+          <ul className="mt-3 space-y-2">
+            {results.options.map((option) => {
+              const share =
+                results.child_count > 0
+                  ? Math.round((option.count / results.child_count) * 100)
+                  : 0;
+              return (
+                <li key={option.option_id}>
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="truncate text-sm text-gray-800">
+                      {option.label}
+                    </span>
+                    <span className="shrink-0 text-sm font-semibold text-gray-900">
+                      {option.count}
+                    </span>
+                  </div>
+                  <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${share}%`,
+                        backgroundColor: LOCATION_COLORS.GROUP_ROOM,
+                      }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+
+          {children.length > 0 && (
+            <div className="mt-4">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <span className="text-xs font-medium text-gray-700">
+                  Antworten pro Kind
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="compact"
+                  onClick={() => setOnlyOpen((prev) => !prev)}
+                >
+                  {onlyOpen ? "Alle anzeigen" : "Nur offene"}
+                </Button>
+              </div>
+              <ul className="max-h-56 divide-y divide-gray-100 overflow-y-auto rounded-lg border border-gray-200">
+                {visibleChildren.map((child) => (
+                  <li
+                    key={child.student_id}
+                    className="flex items-center justify-between gap-3 px-3 py-2"
+                  >
+                    <span className="min-w-0 truncate text-sm text-gray-800">
+                      {child.first_name} {child.last_name}
+                      {child.school_class && (
+                        <span className="text-gray-500">
+                          {" "}
+                          · {child.school_class}
+                        </span>
+                      )}
+                    </span>
+                    {child.answer_labels.length > 0 ? (
+                      <span className="shrink-0 text-xs font-medium text-[#4d7719]">
+                        {child.answer_labels.join(", ")}
+                      </span>
+                    ) : (
+                      <span className="shrink-0 text-xs text-gray-500">
+                        Offen
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {canRemind && (
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={() => void handleRemind()}
+              isLoading={reminding}
+              loadingText="Wird gesendet..."
+              className="mt-4 gap-1.5"
+            >
+              <BellRing className="size-4" aria-hidden />
+              Eltern ohne Antwort erinnern
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
 /**
@@ -1612,6 +2088,7 @@ function DetailModal({
   groups,
   activities,
   onClose,
+  onReminded,
 }: DetailModalProps) {
   const [stats, setStats] = useState<AnnouncementStats | null>(null);
   const [recipients, setRecipients] = useState<AnnouncementRecipient[] | null>(
@@ -1623,7 +2100,14 @@ function DetailModal({
   >("all");
   const [nameFilter, setNameFilter] = useState("");
 
+  // A published poll renders its Auswertung instead of the read/ack statistics
+  // (see below), so it must not pay for the two requests behind them either.
+  const showReadStats = !(
+    isPoll(announcement) && announcement.status !== "draft"
+  );
+
   useEffect(() => {
+    if (!showReadStats) return;
     let cancelled = false;
     setError("");
     Promise.all([
@@ -1654,9 +2138,10 @@ function DetailModal({
     return () => {
       cancelled = true;
     };
-  }, [announcement.id]);
+  }, [announcement.id, showReadStats]);
 
   const isPublished = announcement.status !== "draft";
+  const poll = isPoll(announcement);
   const chips = targetChips(announcement.targets, groups, activities);
 
   return (
@@ -1714,54 +2199,73 @@ function DetailModal({
             ))}
           </div>
           <p className="mt-2 text-xs text-gray-500">
-            {announcement.requires_acknowledgement
-              ? "Lesebestätigung erforderlich"
-              : "Keine Lesebestätigung erforderlich"}
+            {poll
+              ? RESPONSE_TYPE_LABEL[announcement.response_type]
+              : announcement.requires_acknowledgement
+                ? "Lesebestätigung erforderlich"
+                : "Keine Lesebestätigung erforderlich"}
             {" · "}
             {announcement.send_email
               ? "E-Mail-Benachrichtigung aktiviert"
               : "Keine E-Mail-Benachrichtigung"}
+            {poll && announcement.response_deadline && (
+              <> · Antwort bis {formatDate(announcement.response_deadline)}</>
+            )}
           </p>
         </div>
 
-        <div>
-          <h4 className="mb-1.5 flex items-center gap-1.5 text-sm font-semibold text-gray-900">
-            <BarChart3 className="h-4 w-4 text-gray-500" aria-hidden />
-            {isPublished ? "Statistik" : "Aktuelle Reichweite"}
-          </h4>
-          {error ? (
-            <p className="text-sm text-[#CC2626]">{error}</p>
-          ) : stats === null || recipients === null ? (
-            <Loading fullPage={false} />
-          ) : (
-            <>
-              <p className="text-sm text-gray-700">
-                {isPublished ? (
-                  <>
-                    {stats.read_count} von {stats.target_count} gelesen
-                    {announcement.requires_acknowledgement &&
-                      ` · ${stats.acknowledged_count} von ${stats.target_count} bestätigt`}
-                  </>
-                ) : (
-                  <>
-                    Erreicht aktuell {stats.target_count}{" "}
-                    {stats.target_count === 1 ? "Elternteil" : "Eltern"}.
-                  </>
+        {poll && (
+          <PollResultsPanel
+            announcement={announcement}
+            onReminded={onReminded}
+          />
+        )}
+
+        {/* A published poll shows its Auswertung instead of the read/ack
+            statistics: the two count different things (children vs guardian
+            accounts), and two different denominators in one modal is a support
+            ticket waiting to happen. A DRAFT poll still shows the reach, which
+            is the number staff check before publishing. */}
+        {showReadStats && (
+          <div>
+            <h4 className="mb-1.5 flex items-center gap-1.5 text-sm font-semibold text-gray-900">
+              <BarChart3 className="h-4 w-4 text-gray-500" aria-hidden />
+              {isPublished ? "Statistik" : "Aktuelle Reichweite"}
+            </h4>
+            {error ? (
+              <p className="text-sm text-[#CC2626]">{error}</p>
+            ) : stats === null || recipients === null ? (
+              <Loading fullPage={false} />
+            ) : (
+              <>
+                <p className="text-sm text-gray-700">
+                  {isPublished ? (
+                    <>
+                      {stats.read_count} von {stats.target_count} gelesen
+                      {announcement.requires_acknowledgement &&
+                        ` · ${stats.acknowledged_count} von ${stats.target_count} bestätigt`}
+                    </>
+                  ) : (
+                    <>
+                      Erreicht aktuell {stats.target_count}{" "}
+                      {stats.target_count === 1 ? "Elternteil" : "Eltern"}.
+                    </>
+                  )}
+                </p>
+                {recipients.length > 0 && (
+                  <RecipientList
+                    recipients={recipients}
+                    showStatus={isPublished}
+                    statusFilter={statusFilter}
+                    onStatusFilter={setStatusFilter}
+                    nameFilter={nameFilter}
+                    onNameFilter={setNameFilter}
+                  />
                 )}
-              </p>
-              {recipients.length > 0 && (
-                <RecipientList
-                  recipients={recipients}
-                  showStatus={isPublished}
-                  statusFilter={statusFilter}
-                  onStatusFilter={setStatusFilter}
-                  nameFilter={nameFilter}
-                  onNameFilter={setNameFilter}
-                />
-              )}
-            </>
-          )}
-        </div>
+              </>
+            )}
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -38,7 +38,11 @@ import { SegmentedControl } from "~/components/ui/segmented-control";
 import type { SegmentedControlItem } from "~/components/ui/segmented-control";
 import { LinkifiedText } from "~/components/ui/linkified-text";
 import { LOCATION_COLORS } from "~/lib/location-helper";
-import { endOfBerlinDayISO, formatDate } from "~/lib/date-helpers";
+import {
+  berlinDayFromISO,
+  endOfBerlinDayISO,
+  formatDate,
+} from "~/lib/date-helpers";
 import { createLogger } from "~/lib/logger";
 import { useSWRAuth } from "~/lib/swr";
 import { groupService, studentService } from "~/lib/api";
@@ -869,8 +873,11 @@ function AnnouncementFormModal({
     announcement?.requires_acknowledgement ?? false,
   );
   const [sendEmail, setSendEmail] = useState(announcement?.send_email ?? false);
+  // Both cut-offs were written as the END of a Berlin day, so they have to be
+  // read back as that Berlin day — a plain `new Date(...)` shows the following
+  // day east of Berlin and re-saving would move the date by one day.
   const [expiresAt, setExpiresAt] = useState<Date | null>(
-    announcement?.expires_at ? new Date(announcement.expires_at) : null,
+    announcement?.expires_at ? berlinDayFromISO(announcement.expires_at) : null,
   );
   const [targets, setTargets] = useState<AnnouncementTarget[]>(
     announcement?.targets ?? [],
@@ -893,7 +900,7 @@ function AnnouncementFormModal({
   });
   const [deadline, setDeadline] = useState<Date | null>(
     announcement?.response_deadline
-      ? new Date(announcement.response_deadline)
+      ? berlinDayFromISO(announcement.response_deadline)
       : null,
   );
 

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -1168,15 +1168,7 @@ function AnnouncementFormModal({
                       // Rows have no id before saving; the list is short and
                       // edited in place, so the index is the stable key.
                       // eslint-disable-next-line react/no-array-index-key
-                      <li key={index} className="flex items-center gap-3">
-                        {/* Shows what the parents will see: a circle for one
-                            answer, a box when several may be picked. */}
-                        <span
-                          aria-hidden
-                          className={`h-5 w-5 shrink-0 border-2 border-gray-300 ${
-                            multiChoice ? "rounded-sm" : "rounded-full"
-                          }`}
-                        />
+                      <li key={index} className="flex items-center gap-2">
                         {/* Input's className lands on the control, not on its
                             wrapper, so the wrapper carries the flex sizing. */}
                         <div className="min-w-0 flex-1">
@@ -1193,9 +1185,8 @@ function AnnouncementFormModal({
                         <button
                           type="button"
                           onClick={() => removeOptionAt(index)}
-                          disabled={optionRows.length <= 2}
                           aria-label={`Antwort ${index + 1} entfernen`}
-                          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[#FF3130]/20 bg-white text-[#CC2626] shadow-sm transition-colors hover:bg-[#FF3130]/10 focus-visible:ring-2 focus-visible:ring-[#FF3130]/30 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[#FF3130]/20 bg-white text-[#CC2626] shadow-sm transition-colors hover:bg-[#FF3130]/10 focus-visible:ring-2 focus-visible:ring-[#FF3130]/30 focus-visible:outline-none"
                         >
                           <Trash2 className="h-4 w-4" aria-hidden />
                         </button>

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -1935,10 +1935,10 @@ interface DetailModalProps {
 }
 
 /**
- * Poll evaluation: one bar per option over the reached children, plus the
- * per-child list so staff can chase the open answers by name, plus the manual
- * reminder. Counts are children, not parents — that is the number the school
- * plans with.
+ * Poll evaluation: one bar per option over the children with an eligible
+ * respondent, plus the full per-child list so staff can distinguish open
+ * answers from children who currently cannot answer. Counts are children, not
+ * parents — that is the number the school plans with.
  */
 function PollResultsPanel({
   announcement,
@@ -2006,7 +2006,8 @@ function PollResultsPanel({
   };
 
   const visibleChildren = (children ?? []).filter(
-    (child) => !onlyOpen || child.answer_labels.length === 0,
+    (child) =>
+      !onlyOpen || (child.can_answer && child.answer_labels.length === 0),
   );
 
   return (
@@ -2028,6 +2029,15 @@ function PollResultsPanel({
             {results.answered_count} von {results.child_count}{" "}
             {results.child_count === 1 ? "Kind" : "Kindern"} beantwortet
           </p>
+          {results.target_child_count > results.child_count && (
+            <p className="mt-1 text-xs text-gray-500">
+              {results.target_child_count - results.child_count}{" "}
+              {results.target_child_count - results.child_count === 1
+                ? "weiteres Zielkind hat"
+                : "weitere Zielkinder haben"}{" "}
+              derzeit keine antwortberechtigte Person.
+            </p>
+          )}
 
           <ul className="mt-3 space-y-2">
             {results.options.map((option) => {
@@ -2093,9 +2103,13 @@ function PollResultsPanel({
                       <span className="shrink-0 text-xs font-medium text-[#4d7719]">
                         {child.answer_labels.join(", ")}
                       </span>
-                    ) : (
+                    ) : child.can_answer ? (
                       <span className="shrink-0 text-xs text-gray-500">
                         Offen
+                      </span>
+                    ) : (
+                      <span className="shrink-0 text-xs text-gray-500">
+                        Nicht beantwortbar
                       </span>
                     )}
                   </li>

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -1355,6 +1355,7 @@ function AnnouncementFormModal({
               setStudentNames((prev) => ({ ...prev, [id]: name }))
             }
             kindLabel={isPollForm ? "diese Umfrage" : "diese Mitteilung"}
+            allowPendingEnrollment={!isPollForm}
           />
         )}
 
@@ -1413,6 +1414,12 @@ interface TargetingStepProps {
   readonly onSetStudentName: (id: string, name: string) => void;
   /** Names the thing being addressed in the heading (Mitteilung vs Umfrage). */
   readonly kindLabel: string;
+  /**
+   * Offene Anmeldungen reach applicants who have no enrolled child yet — so a
+   * poll would show them a question they cannot answer (answers are per child).
+   * Polls therefore hide the option; the backend refuses it as well.
+   */
+  readonly allowPendingEnrollment: boolean;
 }
 
 function TargetingStep({
@@ -1424,6 +1431,7 @@ function TargetingStep({
   onChange,
   onSetStudentName,
   kindLabel,
+  allowPendingEnrollment,
 }: TargetingStepProps) {
   // Single source of truth is `targets`; each control derives its selection
   // from it and rebuilds it on change.
@@ -1527,11 +1535,15 @@ function TargetingStep({
           active={schoolAll}
           onClick={() => toggleSimple("school_all", !schoolAll)}
         />
-        <CheckPill
-          label="Offene Anmeldungen"
-          active={pendingEnrollment}
-          onClick={() => toggleSimple("pending_enrollment", !pendingEnrollment)}
-        />
+        {allowPendingEnrollment && (
+          <CheckPill
+            label="Offene Anmeldungen"
+            active={pendingEnrollment}
+            onClick={() =>
+              toggleSimple("pending_enrollment", !pendingEnrollment)
+            }
+          />
+        )}
       </div>
 
       {!schoolAll && (

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -894,13 +894,14 @@ function AnnouncementFormModal({
   const [multiChoice, setMultiChoice] = useState(
     announcement?.response_type === "multi_choice",
   );
-  // One answer per line, the same way the enrollment form builder edits the
-  // options of a select field. A row of small inputs with remove buttons is
-  // more chrome than a two-word answer deserves.
-  const [optionsDraft, setOptionsDraft] = useState(() => {
+  // Each answer is its own row, mirroring the "Feste Auswahlzeiten" editor in
+  // the enrollment form builder: an input plus a remove button, added through
+  // an explicit button. Answers are a fixed set the parents pick from, so they
+  // have to look like a set — not like free text.
+  const [optionRows, setOptionRows] = useState<string[]>(() => {
     const existing = announcement?.options?.map((o) => o.label) ?? [];
-    if (existing.length > 0) return existing.join("\n");
-    return isPollForm ? "Ja\nNein" : "";
+    if (existing.length > 0) return existing;
+    return isPollForm ? ["Ja", "Nein"] : [];
   });
   const [deadline, setDeadline] = useState<Date | null>(
     announcement?.response_deadline
@@ -908,14 +909,17 @@ function AnnouncementFormModal({
       : null,
   );
 
+  // The persisted set: trimmed, blanks dropped. Rows stay editable as typed.
   const options = useMemo(
-    () =>
-      optionsDraft
-        .split("\n")
-        .map((line) => line.trim())
-        .filter(Boolean),
-    [optionsDraft],
+    () => optionRows.map((row) => row.trim()).filter(Boolean),
+    [optionRows],
   );
+
+  const setOptionAt = (index: number, value: string) =>
+    setOptionRows((prev) => prev.map((row, i) => (i === index ? value : row)));
+  const addOption = () => setOptionRows((prev) => [...prev, ""]);
+  const removeOptionAt = (index: number) =>
+    setOptionRows((prev) => prev.filter((_, i) => i !== index));
 
   const [submitting, setSubmitting] = useState<"draft" | "publish" | null>(
     null,
@@ -1159,18 +1163,59 @@ function AnnouncementFormModal({
                   Antwortmöglichkeiten
                 </h3>
                 <div>
-                  <textarea
-                    id="announcement-options"
-                    value={optionsDraft}
-                    onChange={(e) => setOptionsDraft(e.target.value)}
-                    rows={4}
-                    aria-label="Antwortmöglichkeiten, eine pro Zeile"
-                    placeholder={"Eine Antwort pro Zeile\nJa\nNein"}
-                    className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
-                  />
+                  <ul className="space-y-2">
+                    {optionRows.map((option, index) => (
+                      // Rows have no id before saving; the list is short and
+                      // edited in place, so the index is the stable key.
+                      // eslint-disable-next-line react/no-array-index-key
+                      <li key={index} className="flex items-center gap-3">
+                        {/* Shows what the parents will see: a circle for one
+                            answer, a box when several may be picked. */}
+                        <span
+                          aria-hidden
+                          className={`h-5 w-5 shrink-0 border-2 border-gray-300 ${
+                            multiChoice ? "rounded-sm" : "rounded-full"
+                          }`}
+                        />
+                        {/* Input's className lands on the control, not on its
+                            wrapper, so the wrapper carries the flex sizing. */}
+                        <div className="min-w-0 flex-1">
+                          <Input
+                            controlSize="compact"
+                            name={`announcement-option-${index}`}
+                            value={option}
+                            onChange={(e) => setOptionAt(index, e.target.value)}
+                            placeholder={`Antwort ${index + 1}`}
+                            aria-label={`Antwort ${index + 1}`}
+                            maxLength={120}
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeOptionAt(index)}
+                          disabled={optionRows.length <= 2}
+                          aria-label={`Antwort ${index + 1} entfernen`}
+                          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[#FF3130]/20 bg-white text-[#CC2626] shadow-sm transition-colors hover:bg-[#FF3130]/10 focus-visible:ring-2 focus-visible:ring-[#FF3130]/30 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <button
+                    type="button"
+                    onClick={addOption}
+                    disabled={optionRows.length >= 10}
+                    className="mt-3 inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <Plus className="h-4 w-4" aria-hidden />
+                    Antwort hinzufügen
+                  </button>
+
                   <p className="mt-2 text-xs text-gray-500">
-                    Eine Antwort pro Zeile, zwei bis zehn Antworten. Eltern
-                    antworten für jedes Kind einzeln.
+                    Zwei bis zehn Antworten. Eltern antworten für jedes Kind
+                    einzeln.
                   </p>
                 </div>
 

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -1220,7 +1220,7 @@ function AnnouncementFormModal({
                     onChange={(e) => setMultiChoice(e.target.checked)}
                   />
                   <span className="text-sm text-gray-800">
-                    Mehrfachauswahl erlauben
+                    <span className="block">Mehrfachauswahl erlauben</span>
                     <span className="block text-xs text-gray-500">
                       Eltern können pro Kind mehrere Antworten auswählen.
                     </span>
@@ -1315,7 +1315,7 @@ function AnnouncementFormModal({
                     onChange={(e) => setRequiresAck(e.target.checked)}
                   />
                   <span className="text-sm text-gray-800">
-                    Lesebestätigung erforderlich
+                    <span className="block">Lesebestätigung erforderlich</span>
                     <span className="block text-xs text-gray-500">
                       Eltern bestätigen ausdrücklich, dass sie die Mitteilung
                       gelesen haben.
@@ -1334,7 +1334,9 @@ function AnnouncementFormModal({
                   onChange={(e) => setSendEmail(e.target.checked)}
                 />
                 <span className="text-sm text-gray-800">
-                  Eltern zusätzlich per E-Mail benachrichtigen
+                  <span className="block">
+                    Eltern zusätzlich per E-Mail benachrichtigen
+                  </span>
                   <span className="block text-xs text-gray-500">
                     Beim Veröffentlichen erhalten die erreichten Eltern eine
                     E-Mail mit Titel und Link ins Elternportal.

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -2019,7 +2019,9 @@ function PollResultsPanel({
       {error && <p className="mb-2 text-sm text-[#CC2626]">{error}</p>}
 
       {results === null || children === null ? (
-        <Loading fullPage={false} />
+        error ? null : (
+          <Loading fullPage={false} />
+        )
       ) : (
         <>
           <p className="text-sm text-gray-700">

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -13,7 +13,6 @@ import {
   Send,
   Trash2,
   Undo2,
-  X,
 } from "lucide-react";
 
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
@@ -895,10 +894,13 @@ function AnnouncementFormModal({
   const [multiChoice, setMultiChoice] = useState(
     announcement?.response_type === "multi_choice",
   );
-  const [options, setOptions] = useState<string[]>(() => {
+  // One answer per line, the same way the enrollment form builder edits the
+  // options of a select field. A row of small inputs with remove buttons is
+  // more chrome than a two-word answer deserves.
+  const [optionsDraft, setOptionsDraft] = useState(() => {
     const existing = announcement?.options?.map((o) => o.label) ?? [];
-    if (existing.length > 0) return existing;
-    return isPollForm ? ["Ja", "Nein"] : [];
+    if (existing.length > 0) return existing.join("\n");
+    return isPollForm ? "Ja\nNein" : "";
   });
   const [deadline, setDeadline] = useState<Date | null>(
     announcement?.response_deadline
@@ -906,10 +908,14 @@ function AnnouncementFormModal({
       : null,
   );
 
-  const setOptionAt = (index: number, value: string) =>
-    setOptions((prev) => prev.map((o, i) => (i === index ? value : o)));
-  const removeOptionAt = (index: number) =>
-    setOptions((prev) => prev.filter((_, i) => i !== index));
+  const options = useMemo(
+    () =>
+      optionsDraft
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+    [optionsDraft],
+  );
 
   const [submitting, setSubmitting] = useState<"draft" | "publish" | null>(
     null,
@@ -931,13 +937,16 @@ function AnnouncementFormModal({
       return false;
     }
     if (isPollForm) {
-      const filled = options.map((o) => o.trim()).filter(Boolean);
-      if (filled.length < 2) {
+      if (options.length < 2) {
         setFormError("Bitte mindestens zwei Antwortmöglichkeiten angeben.");
         return false;
       }
-      const seen = new Set(filled.map((o) => o.toLowerCase()));
-      if (seen.size !== filled.length) {
+      if (options.length > 10) {
+        setFormError("Bitte höchstens zehn Antwortmöglichkeiten angeben.");
+        return false;
+      }
+      const seen = new Set(options.map((o) => o.toLowerCase()));
+      if (seen.size !== options.length) {
         setFormError("Antwortmöglichkeiten dürfen sich nicht wiederholen.");
         return false;
       }
@@ -986,9 +995,7 @@ function AnnouncementFormModal({
       // The chosen day is the LAST day parents can answer, so the cut-off is
       // its end — not midnight, which would close the poll a day early.
       response_deadline: isPollForm && deadline ? endOfDayISO(deadline) : null,
-      options: isPollForm
-        ? options.map((o) => o.trim()).filter(Boolean)
-        : undefined,
+      options: isPollForm ? options : undefined,
     };
 
     setSubmitting(publish ? "publish" : "draft");
@@ -1100,142 +1107,136 @@ function AnnouncementFormModal({
         <WizardStepper steps={WIZARD_STEPS} current={step} />
 
         {step === 0 ? (
-          // One vertical stack, every row spanning the full modal width. The
-          // dead space this form used to have came from half-empty grid rows,
-          // not from the stacking — so the settings sit in one filled row and
-          // the answer fields pair up, instead of splitting the form in two.
-          <div className="space-y-4">
-            <Input
-              label={isPollForm ? "Frage" : "Titel"}
-              name="announcement-title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder={
-                isPollForm
-                  ? "z. B. Kommt Ihr Kind zur Murmelparty?"
-                  : "z. B. Sommerfest am Freitag"
-              }
-            />
-
-            <div>
-              <label
-                htmlFor="announcement-body"
-                className="mb-2 block text-sm font-medium text-gray-700"
-              >
-                Text
-              </label>
-              <textarea
-                id="announcement-body"
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
-                rows={5}
-                maxLength={4000}
-                placeholder="Inhalt der Mitteilung... Links im Text werden für Eltern klickbar."
-                className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
+          // Sections with quiet uppercase headers, every control on the full
+          // width — the same form language as the Vertretungsplan slide-over.
+          // No nested cards and no per-option input rows: at this size they
+          // read as clutter, not as structure.
+          <div className="space-y-6">
+            <section className="space-y-4">
+              <Input
+                label={isPollForm ? "Frage" : "Titel"}
+                name="announcement-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder={
+                  isPollForm
+                    ? "z. B. Kommt Ihr Kind zur Murmelparty?"
+                    : "z. B. Sommerfest am Freitag"
+                }
               />
-            </div>
 
-            <Input
-              label="Link (optional)"
-              name="announcement-link"
-              type="url"
-              value={linkUrl}
-              onChange={(e) => setLinkUrl(e.target.value)}
-              placeholder="https://..."
-            />
+              <div>
+                <label
+                  htmlFor="announcement-body"
+                  className="mb-2 block text-sm font-medium text-gray-700"
+                >
+                  Text
+                </label>
+                <textarea
+                  id="announcement-body"
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  rows={5}
+                  maxLength={4000}
+                  placeholder="Inhalt der Mitteilung... Links im Text werden für Eltern klickbar."
+                  className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
+                />
+              </div>
+
+              <Input
+                label="Link (optional)"
+                name="announcement-link"
+                type="url"
+                value={linkUrl}
+                onChange={(e) => setLinkUrl(e.target.value)}
+                placeholder="https://..."
+              />
+            </section>
 
             {isPollForm && (
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
-                <span className="block text-sm font-medium text-gray-700">
+              <section className="space-y-3">
+                <h3 className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
                   Antwortmöglichkeiten
-                </span>
-                <p className="mt-0.5 text-xs text-gray-500">
-                  Eltern antworten für jedes Kind einzeln.
-                </p>
-
-                {/* Two per row: an answer is a word or two, so a full-width
-                    field per option is mostly empty space and pushes the rest
-                    of the form below the fold. */}
-                <ul className="mt-3 grid gap-2 sm:grid-cols-2">
-                  {options.map((option, index) => (
-                    // Options have no id before saving, so the index is the only
-                    // stable key here; the list is short and edited in place.
-                    // eslint-disable-next-line react/no-array-index-key
-                    <li key={index} className="flex items-center gap-2">
-                      <Input
-                        name={`announcement-option-${index}`}
-                        value={option}
-                        onChange={(e) => setOptionAt(index, e.target.value)}
-                        placeholder={`Antwort ${index + 1}`}
-                        aria-label={`Antwortmöglichkeit ${index + 1}`}
-                        className="flex-1"
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => removeOptionAt(index)}
-                        disabled={options.length <= 2}
-                        aria-label={`Antwortmöglichkeit ${index + 1} entfernen`}
-                      >
-                        <X className="size-4" aria-hidden />
-                      </Button>
-                    </li>
-                  ))}
-                </ul>
-
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="compact"
-                  onClick={() => setOptions((prev) => [...prev, ""])}
-                  disabled={options.length >= 10}
-                  className="mt-2 gap-1.5"
-                >
-                  <Plus className="size-4" aria-hidden />
-                  Antwort hinzufügen
-                </Button>
+                </h3>
+                <div>
+                  <textarea
+                    id="announcement-options"
+                    value={optionsDraft}
+                    onChange={(e) => setOptionsDraft(e.target.value)}
+                    rows={4}
+                    aria-label="Antwortmöglichkeiten, eine pro Zeile"
+                    placeholder={"Eine Antwort pro Zeile\nJa\nNein"}
+                    className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
+                  />
+                  <p className="mt-2 text-xs text-gray-500">
+                    Eine Antwort pro Zeile, zwei bis zehn Antworten. Eltern
+                    antworten für jedes Kind einzeln.
+                  </p>
+                </div>
 
                 <label
                   htmlFor="announcement-multi"
-                  className="mt-4 flex cursor-pointer items-start gap-3"
+                  className="flex cursor-pointer items-start gap-3"
                 >
                   <Checkbox
                     id="announcement-multi"
                     checked={multiChoice}
                     onChange={(e) => setMultiChoice(e.target.checked)}
                   />
-                  <span>
-                    <span className="block text-sm font-medium text-gray-700">
-                      Mehrfachauswahl erlauben
-                    </span>
+                  <span className="text-sm text-gray-800">
+                    Mehrfachauswahl erlauben
                     <span className="block text-xs text-gray-500">
                       Eltern können pro Kind mehrere Antworten auswählen.
                     </span>
                   </span>
                 </label>
-              </div>
+              </section>
             )}
 
-            {/* One row for every small setting, so no half-empty grid row is
-                left over: a poll adds the Antwortfrist as a third column
-                instead of a second line. */}
-            <div
-              className={`grid gap-4 sm:grid-cols-2 ${isPollForm ? "lg:grid-cols-3" : ""}`}
-            >
-              {isPollForm && (
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+                Zeitraum
+              </h3>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {isPollForm && (
+                  <div>
+                    <span className="mb-1.5 block text-sm font-medium text-gray-700">
+                      Antwortfrist (optional)
+                    </span>
+                    <DatePicker
+                      value={deadline}
+                      onChange={setDeadline}
+                      placeholder="Keine Frist"
+                      dropdownPlacement="down"
+                    />
+                    <p className="mt-1.5 text-xs text-gray-500">
+                      Danach ist die Umfrage geschlossen, bleibt aber lesbar.
+                    </p>
+                  </div>
+                )}
                 <div>
                   <span className="mb-1.5 block text-sm font-medium text-gray-700">
-                    Antwortfrist (optional)
+                    Ablaufdatum (optional)
                   </span>
                   <DatePicker
-                    value={deadline}
-                    onChange={setDeadline}
-                    placeholder="Keine Frist"
+                    value={expiresAt}
+                    onChange={setExpiresAt}
+                    placeholder="Kein Ablaufdatum"
                     dropdownPlacement="down"
                   />
+                  <p className="mt-1.5 text-xs text-gray-500">
+                    Danach wird {isPollForm ? "die Umfrage" : "die Mitteilung"}{" "}
+                    für Eltern ausgeblendet.
+                  </p>
                 </div>
-              )}
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+                Veröffentlichung
+              </h3>
+
               <div>
                 <span
                   id="announcement-priority-label"
@@ -1265,27 +1266,6 @@ function AnnouncementFormModal({
                 </div>
               </div>
 
-              <div>
-                <span className="mb-1.5 block text-sm font-medium text-gray-700">
-                  Ablaufdatum (optional)
-                </span>
-                <DatePicker
-                  value={expiresAt}
-                  onChange={setExpiresAt}
-                  placeholder="Kein Ablaufdatum"
-                  dropdownPlacement="down"
-                />
-              </div>
-            </div>
-
-            {isPollForm && (
-              <p className="-mt-2 text-xs text-gray-500">
-                Nach der Antwortfrist ist die Umfrage geschlossen, bleibt aber
-                lesbar.
-              </p>
-            )}
-
-            <div className="grid gap-3 sm:grid-cols-2">
               {/* A poll answer already IS the confirmation — offering a second,
                   weaker "gelesen" checkbox on top only muddies the result. */}
               {!isPollForm && (
@@ -1298,10 +1278,8 @@ function AnnouncementFormModal({
                     checked={requiresAck}
                     onChange={(e) => setRequiresAck(e.target.checked)}
                   />
-                  <span>
-                    <span className="block text-sm font-medium text-gray-700">
-                      Lesebestätigung erforderlich
-                    </span>
+                  <span className="text-sm text-gray-800">
+                    Lesebestätigung erforderlich
                     <span className="block text-xs text-gray-500">
                       Eltern bestätigen ausdrücklich, dass sie die Mitteilung
                       gelesen haben.
@@ -1312,27 +1290,22 @@ function AnnouncementFormModal({
 
               <label
                 htmlFor="announcement-email"
-                // A poll hides the Lesebestätigung, so this is the only box in
-                // the row — let it span both columns instead of leaving half of
-                // the row empty.
-                className={`flex cursor-pointer items-start gap-3 ${isPollForm ? "sm:col-span-2" : ""}`}
+                className="flex cursor-pointer items-start gap-3"
               >
                 <Checkbox
                   id="announcement-email"
                   checked={sendEmail}
                   onChange={(e) => setSendEmail(e.target.checked)}
                 />
-                <span>
-                  <span className="block text-sm font-medium text-gray-700">
-                    Eltern zusätzlich per E-Mail benachrichtigen
-                  </span>
+                <span className="text-sm text-gray-800">
+                  Eltern zusätzlich per E-Mail benachrichtigen
                   <span className="block text-xs text-gray-500">
                     Beim Veröffentlichen erhalten die erreichten Eltern eine
                     E-Mail mit Titel und Link ins Elternportal.
                   </span>
                 </span>
               </label>
-            </div>
+            </section>
           </div>
         ) : (
           <TargetingStep

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -1100,241 +1100,238 @@ function AnnouncementFormModal({
         <WizardStepper steps={WIZARD_STEPS} current={step} />
 
         {step === 0 ? (
-          // Two columns from lg up: writing (question + text + link) on the
-          // left, configuration (answers, dates, delivery) on the right. As one
-          // stack the form was a narrow ribbon down the middle of a 900px modal
-          // that scrolled for content which fits side by side. Below lg the
-          // columns stack in the same order.
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] lg:gap-6">
-            <div className="space-y-4">
-              <Input
-                label={isPollForm ? "Frage" : "Titel"}
-                name="announcement-title"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={
-                  isPollForm
-                    ? "z. B. Kommt Ihr Kind zur Murmelparty?"
-                    : "z. B. Sommerfest am Freitag"
-                }
-              />
+          // One vertical stack, every row spanning the full modal width. The
+          // dead space this form used to have came from half-empty grid rows,
+          // not from the stacking — so the settings sit in one filled row and
+          // the answer fields pair up, instead of splitting the form in two.
+          <div className="space-y-4">
+            <Input
+              label={isPollForm ? "Frage" : "Titel"}
+              name="announcement-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={
+                isPollForm
+                  ? "z. B. Kommt Ihr Kind zur Murmelparty?"
+                  : "z. B. Sommerfest am Freitag"
+              }
+            />
 
-              <div>
-                <label
-                  htmlFor="announcement-body"
-                  className="mb-2 block text-sm font-medium text-gray-700"
-                >
-                  Text
-                </label>
-                <textarea
-                  id="announcement-body"
-                  value={body}
-                  onChange={(e) => setBody(e.target.value)}
-                  rows={7}
-                  maxLength={4000}
-                  placeholder="Inhalt der Mitteilung... Links im Text werden für Eltern klickbar."
-                  className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
-                />
-              </div>
-
-              <Input
-                label="Link (optional)"
-                name="announcement-link"
-                type="url"
-                value={linkUrl}
-                onChange={(e) => setLinkUrl(e.target.value)}
-                placeholder="https://..."
+            <div>
+              <label
+                htmlFor="announcement-body"
+                className="mb-2 block text-sm font-medium text-gray-700"
+              >
+                Text
+              </label>
+              <textarea
+                id="announcement-body"
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={5}
+                maxLength={4000}
+                placeholder="Inhalt der Mitteilung... Links im Text werden für Eltern klickbar."
+                className="block w-full rounded-lg border-0 bg-white px-4 py-3 text-base text-gray-900 shadow-sm ring-1 ring-gray-200 transition-all duration-200 ring-inset placeholder:text-gray-400 focus:outline-none focus:ring-inset focus-visible:ring-2 focus-visible:ring-gray-400"
               />
             </div>
 
-            <div className="space-y-4">
-              {isPollForm && (
-                <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
-                  <span className="block text-sm font-medium text-gray-700">
-                    Antwortmöglichkeiten
-                  </span>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    Eltern antworten für jedes Kind einzeln.
-                  </p>
+            <Input
+              label="Link (optional)"
+              name="announcement-link"
+              type="url"
+              value={linkUrl}
+              onChange={(e) => setLinkUrl(e.target.value)}
+              placeholder="https://..."
+            />
 
-                  {/* Two per row: an answer is a word or two, so a full-width
+            {isPollForm && (
+              <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                <span className="block text-sm font-medium text-gray-700">
+                  Antwortmöglichkeiten
+                </span>
+                <p className="mt-0.5 text-xs text-gray-500">
+                  Eltern antworten für jedes Kind einzeln.
+                </p>
+
+                {/* Two per row: an answer is a word or two, so a full-width
                     field per option is mostly empty space and pushes the rest
                     of the form below the fold. */}
-                  <ul className="mt-3 grid gap-2 sm:grid-cols-2">
-                    {options.map((option, index) => (
-                      // Options have no id before saving, so the index is the only
-                      // stable key here; the list is short and edited in place.
-                      // eslint-disable-next-line react/no-array-index-key
-                      <li key={index} className="flex items-center gap-2">
-                        <Input
-                          name={`announcement-option-${index}`}
-                          value={option}
-                          onChange={(e) => setOptionAt(index, e.target.value)}
-                          placeholder={`Antwort ${index + 1}`}
-                          aria-label={`Antwortmöglichkeit ${index + 1}`}
-                          className="flex-1"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => removeOptionAt(index)}
-                          disabled={options.length <= 2}
-                          aria-label={`Antwortmöglichkeit ${index + 1} entfernen`}
-                        >
-                          <X className="size-4" aria-hidden />
-                        </Button>
-                      </li>
-                    ))}
-                  </ul>
-
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="compact"
-                    onClick={() => setOptions((prev) => [...prev, ""])}
-                    disabled={options.length >= 10}
-                    className="mt-2 gap-1.5"
-                  >
-                    <Plus className="size-4" aria-hidden />
-                    Antwort hinzufügen
-                  </Button>
-
-                  <label
-                    htmlFor="announcement-multi"
-                    className="mt-4 flex cursor-pointer items-start gap-3"
-                  >
-                    <Checkbox
-                      id="announcement-multi"
-                      checked={multiChoice}
-                      onChange={(e) => setMultiChoice(e.target.checked)}
-                    />
-                    <span>
-                      <span className="block text-sm font-medium text-gray-700">
-                        Mehrfachauswahl erlauben
-                      </span>
-                      <span className="block text-xs text-gray-500">
-                        Eltern können pro Kind mehrere Antworten auswählen.
-                      </span>
-                    </span>
-                  </label>
-                </div>
-              )}
-
-              {/* One row for every small setting, so no half-empty grid row is
-                left over: a poll adds the Antwortfrist as a third column
-                instead of a second line. */}
-              <div className="grid gap-4 sm:grid-cols-2">
-                {isPollForm && (
-                  <div>
-                    <span className="mb-1.5 block text-sm font-medium text-gray-700">
-                      Antwortfrist (optional)
-                    </span>
-                    <DatePicker
-                      value={deadline}
-                      onChange={setDeadline}
-                      placeholder="Keine Frist"
-                      dropdownPlacement="down"
-                    />
-                  </div>
-                )}
-                <div>
-                  <span
-                    id="announcement-priority-label"
-                    className="mb-1.5 block text-sm font-medium text-gray-700"
-                  >
-                    Priorität
-                  </span>
-                  <div
-                    className="flex flex-wrap gap-2"
-                    role="group"
-                    aria-labelledby="announcement-priority-label"
-                  >
-                    {PRIORITY_OPTIONS.map((opt) => (
-                      <button
-                        key={opt.value}
+                <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+                  {options.map((option, index) => (
+                    // Options have no id before saving, so the index is the only
+                    // stable key here; the list is short and edited in place.
+                    // eslint-disable-next-line react/no-array-index-key
+                    <li key={index} className="flex items-center gap-2">
+                      <Input
+                        name={`announcement-option-${index}`}
+                        value={option}
+                        onChange={(e) => setOptionAt(index, e.target.value)}
+                        placeholder={`Antwort ${index + 1}`}
+                        aria-label={`Antwortmöglichkeit ${index + 1}`}
+                        className="flex-1"
+                      />
+                      <Button
                         type="button"
-                        onClick={() => setPriority(opt.value)}
-                        className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-                          priority === opt.value
-                            ? "bg-gray-900 text-white"
-                            : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                        }`}
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeOptionAt(index)}
+                        disabled={options.length <= 2}
+                        aria-label={`Antwortmöglichkeit ${index + 1} entfernen`}
                       >
-                        {opt.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                        <X className="size-4" aria-hidden />
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
 
-                <div>
-                  <span className="mb-1.5 block text-sm font-medium text-gray-700">
-                    Ablaufdatum (optional)
-                  </span>
-                  <DatePicker
-                    value={expiresAt}
-                    onChange={setExpiresAt}
-                    placeholder="Kein Ablaufdatum"
-                    dropdownPlacement="down"
-                  />
-                </div>
-              </div>
-
-              {isPollForm && (
-                <p className="-mt-2 text-xs text-gray-500">
-                  Nach der Antwortfrist ist die Umfrage geschlossen, bleibt aber
-                  lesbar.
-                </p>
-              )}
-
-              {/* Stacked, not side by side: these sit in the narrower settings
-                  column, where two columns would break each label across three
-                  lines. */}
-              <div className="space-y-3">
-                {/* A poll answer already IS the confirmation — offering a second,
-                  weaker "gelesen" checkbox on top only muddies the result. */}
-                {!isPollForm && (
-                  <label
-                    htmlFor="announcement-ack"
-                    className="flex cursor-pointer items-start gap-3"
-                  >
-                    <Checkbox
-                      id="announcement-ack"
-                      checked={requiresAck}
-                      onChange={(e) => setRequiresAck(e.target.checked)}
-                    />
-                    <span>
-                      <span className="block text-sm font-medium text-gray-700">
-                        Lesebestätigung erforderlich
-                      </span>
-                      <span className="block text-xs text-gray-500">
-                        Eltern bestätigen ausdrücklich, dass sie die Mitteilung
-                        gelesen haben.
-                      </span>
-                    </span>
-                  </label>
-                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="compact"
+                  onClick={() => setOptions((prev) => [...prev, ""])}
+                  disabled={options.length >= 10}
+                  className="mt-2 gap-1.5"
+                >
+                  <Plus className="size-4" aria-hidden />
+                  Antwort hinzufügen
+                </Button>
 
                 <label
-                  htmlFor="announcement-email"
-                  className="flex cursor-pointer items-start gap-3"
+                  htmlFor="announcement-multi"
+                  className="mt-4 flex cursor-pointer items-start gap-3"
                 >
                   <Checkbox
-                    id="announcement-email"
-                    checked={sendEmail}
-                    onChange={(e) => setSendEmail(e.target.checked)}
+                    id="announcement-multi"
+                    checked={multiChoice}
+                    onChange={(e) => setMultiChoice(e.target.checked)}
                   />
                   <span>
                     <span className="block text-sm font-medium text-gray-700">
-                      Eltern zusätzlich per E-Mail benachrichtigen
+                      Mehrfachauswahl erlauben
                     </span>
                     <span className="block text-xs text-gray-500">
-                      Beim Veröffentlichen erhalten die erreichten Eltern eine
-                      E-Mail mit Titel und Link ins Elternportal.
+                      Eltern können pro Kind mehrere Antworten auswählen.
                     </span>
                   </span>
                 </label>
               </div>
+            )}
+
+            {/* One row for every small setting, so no half-empty grid row is
+                left over: a poll adds the Antwortfrist as a third column
+                instead of a second line. */}
+            <div
+              className={`grid gap-4 sm:grid-cols-2 ${isPollForm ? "lg:grid-cols-3" : ""}`}
+            >
+              {isPollForm && (
+                <div>
+                  <span className="mb-1.5 block text-sm font-medium text-gray-700">
+                    Antwortfrist (optional)
+                  </span>
+                  <DatePicker
+                    value={deadline}
+                    onChange={setDeadline}
+                    placeholder="Keine Frist"
+                    dropdownPlacement="down"
+                  />
+                </div>
+              )}
+              <div>
+                <span
+                  id="announcement-priority-label"
+                  className="mb-1.5 block text-sm font-medium text-gray-700"
+                >
+                  Priorität
+                </span>
+                <div
+                  className="flex flex-wrap gap-2"
+                  role="group"
+                  aria-labelledby="announcement-priority-label"
+                >
+                  {PRIORITY_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setPriority(opt.value)}
+                      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                        priority === opt.value
+                          ? "bg-gray-900 text-white"
+                          : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <span className="mb-1.5 block text-sm font-medium text-gray-700">
+                  Ablaufdatum (optional)
+                </span>
+                <DatePicker
+                  value={expiresAt}
+                  onChange={setExpiresAt}
+                  placeholder="Kein Ablaufdatum"
+                  dropdownPlacement="down"
+                />
+              </div>
+            </div>
+
+            {isPollForm && (
+              <p className="-mt-2 text-xs text-gray-500">
+                Nach der Antwortfrist ist die Umfrage geschlossen, bleibt aber
+                lesbar.
+              </p>
+            )}
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              {/* A poll answer already IS the confirmation — offering a second,
+                  weaker "gelesen" checkbox on top only muddies the result. */}
+              {!isPollForm && (
+                <label
+                  htmlFor="announcement-ack"
+                  className="flex cursor-pointer items-start gap-3"
+                >
+                  <Checkbox
+                    id="announcement-ack"
+                    checked={requiresAck}
+                    onChange={(e) => setRequiresAck(e.target.checked)}
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-gray-700">
+                      Lesebestätigung erforderlich
+                    </span>
+                    <span className="block text-xs text-gray-500">
+                      Eltern bestätigen ausdrücklich, dass sie die Mitteilung
+                      gelesen haben.
+                    </span>
+                  </span>
+                </label>
+              )}
+
+              <label
+                htmlFor="announcement-email"
+                // A poll hides the Lesebestätigung, so this is the only box in
+                // the row — let it span both columns instead of leaving half of
+                // the row empty.
+                className={`flex cursor-pointer items-start gap-3 ${isPollForm ? "sm:col-span-2" : ""}`}
+              >
+                <Checkbox
+                  id="announcement-email"
+                  checked={sendEmail}
+                  onChange={(e) => setSendEmail(e.target.checked)}
+                />
+                <span>
+                  <span className="block text-sm font-medium text-gray-700">
+                    Eltern zusätzlich per E-Mail benachrichtigen
+                  </span>
+                  <span className="block text-xs text-gray-500">
+                    Beim Veröffentlichen erhalten die erreichten Eltern eine
+                    E-Mail mit Titel und Link ins Elternportal.
+                  </span>
+                </span>
+              </label>
             </div>
           </div>
         ) : (

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -41,6 +41,7 @@ import { LOCATION_COLORS } from "~/lib/location-helper";
 import {
   berlinDayFromISO,
   endOfBerlinDayISO,
+  formatBerlinDate,
   formatDate,
 } from "~/lib/date-helpers";
 import { createLogger } from "~/lib/logger";
@@ -480,9 +481,9 @@ function ParentAnnouncementsContent() {
               : "Noch nicht veröffentlicht"}
           </p>
           {row.response_deadline ? (
-            <p>Antwort bis {formatDate(row.response_deadline)}</p>
+            <p>Antwort bis {formatBerlinDate(row.response_deadline)}</p>
           ) : (
-            row.expires_at && <p>Läuft ab {formatDate(row.expires_at)}</p>
+            row.expires_at && <p>Läuft ab {formatBerlinDate(row.expires_at)}</p>
           )}
         </div>
       ),
@@ -1702,7 +1703,7 @@ function AnnouncementCard({
             ? ` · ${formatDate(announcement.published_at)}`
             : " · Entwurf"}
           {announcement.expires_at &&
-            ` · bis ${formatDate(announcement.expires_at)}`}
+            ` · bis ${formatBerlinDate(announcement.expires_at)}`}
         </p>
       </button>
       <div className="flex items-center justify-between gap-2 border-t border-gray-100 bg-gray-50/60 px-2 py-1.5">
@@ -2222,7 +2223,7 @@ function DetailModal({
               ? `Veröffentlicht ${formatDate(announcement.published_at)}`
               : "Noch nicht veröffentlicht"}
             {announcement.expires_at &&
-              ` · Läuft ab ${formatDate(announcement.expires_at)}`}
+              ` · Läuft ab ${formatBerlinDate(announcement.expires_at)}`}
           </span>
         </div>
 
@@ -2267,7 +2268,10 @@ function DetailModal({
               ? "E-Mail-Benachrichtigung aktiviert"
               : "Keine E-Mail-Benachrichtigung"}
             {poll && announcement.response_deadline && (
-              <> · Antwort bis {formatDate(announcement.response_deadline)}</>
+              <>
+                {" "}
+                · Antwort bis {formatBerlinDate(announcement.response_deadline)}
+              </>
             )}
           </p>
         </div>

--- a/frontend/src/app/api/parent-announcements/[announcementId]/poll-children/route.ts
+++ b/frontend/src/app/api/parent-announcements/[announcementId]/poll-children/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from "next/server";
+import { apiGet } from "~/lib/api-helpers.server";
+import { createGetHandler } from "~/lib/route-wrapper.server";
+
+/**
+ * Proxy GET /api/parent-announcements/{id}/poll-children → backend: every child
+ * the Umfrage reaches with the answer given for them (empty = still open).
+ */
+export const GET = createGetHandler(
+  async (
+    _request: NextRequest,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const id = params.announcementId as string;
+    if (!id) throw new Error("Announcement ID is required");
+    const response = await apiGet<{ data: unknown }>(
+      `/api/parent-announcements/${id}/poll-children`,
+      token,
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/parent-announcements/[announcementId]/poll-results/route.ts
+++ b/frontend/src/app/api/parent-announcements/[announcementId]/poll-results/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from "next/server";
+import { apiGet } from "~/lib/api-helpers.server";
+import { createGetHandler } from "~/lib/route-wrapper.server";
+
+/** Proxy GET /api/parent-announcements/{id}/poll-results → backend (Umfrage tally). */
+export const GET = createGetHandler(
+  async (
+    _request: NextRequest,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const id = params.announcementId as string;
+    if (!id) throw new Error("Announcement ID is required");
+    const response = await apiGet<{ data: unknown }>(
+      `/api/parent-announcements/${id}/poll-results`,
+      token,
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/parent-announcements/[announcementId]/remind/route.ts
+++ b/frontend/src/app/api/parent-announcements/[announcementId]/remind/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers.server";
+import { createPostHandler } from "~/lib/route-wrapper.server";
+
+/**
+ * Proxy POST /api/parent-announcements/{id}/remind → backend: notify the
+ * guardians of children that have not answered the Umfrage yet.
+ */
+export const POST = createPostHandler(
+  async (
+    _request: NextRequest,
+    _body: unknown,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const id = params.announcementId as string;
+    if (!id) throw new Error("Announcement ID is required");
+    const response = await apiPost<{ data: unknown }>(
+      `/api/parent-announcements/${id}/remind`,
+      token,
+      {},
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/parent/me/news/[announcementId]/respond/route.ts
+++ b/frontend/src/app/api/parent/me/news/[announcementId]/respond/route.ts
@@ -1,0 +1,22 @@
+import { proxyPost } from "~/lib/parent/route-wrapper.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+interface RespondResult {
+  answered: boolean;
+}
+
+interface RespondBody {
+  student_id?: string;
+  option_ids?: string[];
+  published_at?: string;
+}
+
+/**
+ * Proxy POST /api/parent/me/news/{announcementId}/respond → backend. Records the
+ * guardian's answer to an Umfrage for ONE child (#1371); the backend authorizes
+ * the child, verifies the published_at version and enforces the answer deadline.
+ */
+export const POST = proxyPost<RespondResult, RespondBody>(
+  (params) =>
+    `/parent/me/news/${requirePathSegmentParam(params, "announcementId")}/respond`,
+);

--- a/frontend/src/app/parents/news/page.tsx
+++ b/frontend/src/app/parents/news/page.tsx
@@ -114,7 +114,12 @@ export default function ParentNewsPage() {
         <ul className="space-y-3">
           {items.map((item) => (
             <li key={item.id}>
-              <NewsCard item={item} onOpen={(opened) => setOpenId(opened.id)} />
+              <NewsCard
+                item={item}
+                onOpen={(opened) => setOpenId(opened.id)}
+                onUpdated={applyState}
+                onStale={refetchOnStale}
+              />
             </li>
           ))}
         </ul>

--- a/frontend/src/app/parents/news/page.tsx
+++ b/frontend/src/app/parents/news/page.tsx
@@ -114,12 +114,7 @@ export default function ParentNewsPage() {
         <ul className="space-y-3">
           {items.map((item) => (
             <li key={item.id}>
-              <NewsCard
-                item={item}
-                onOpen={(opened) => setOpenId(opened.id)}
-                onUpdated={applyState}
-                onStale={refetchOnStale}
-              />
+              <NewsCard item={item} onOpen={(opened) => setOpenId(opened.id)} />
             </li>
           ))}
         </ul>

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
@@ -185,7 +185,7 @@ describe("breadcrumb-utils", () => {
         expect(getPageTitle("/messages")).toBe("Nachrichten");
         expect(getPageTitle("/messages/thread-1")).toBe("Nachrichten");
         expect(getPageTitle("/parent-announcements")).toBe(
-          "Elternmitteilungen",
+          "Mitteilungen und Umfragen",
         );
         expect(getPageTitle("/meal-plan")).toBe("Essensplan");
         expect(getPageTitle("/suggestions")).toBe("Feedback");
@@ -453,7 +453,7 @@ describe("breadcrumb-utils", () => {
           "Änderungsanfragen",
         );
         expect(getSectionBreadcrumb("/parent-announcements")?.pageLabel).toBe(
-          "Elternmitteilungen",
+          "Mitteilungen und Umfragen",
         );
         expect(getSectionBreadcrumb("/meal-plan")?.pageLabel).toBe(
           "Essensplan",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1488,7 +1488,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Eine kurze Frage an ausgewählte Elterngruppen, die pro Kind beantwortet wird – zum Beispiel „Kommt Ihr Kind zur Murmelparty?“. Die Antworten laufen aggregiert in der App zusammen, sodass Sie mit einer verlässlichen Zahl planen können.",
         steps: [
           "In der Seitenleiste den Bereich `Eltern` aufklappen, `Mitteilungen und Umfragen` öffnen, oben auf `Umfragen` wechseln und auf `Umfrage` tippen.",
-          "Schritt `Inhalt`: Unter `Frage` die Frage eingeben und im Text ergänzen, worum es geht. Die `Antwortmöglichkeiten` sind mit `Ja` und `Nein` vorbelegt; über `Antwort hinzufügen` kommen weitere dazu (bis zu zehn), das `×` entfernt eine.",
+          "Schritt `Inhalt`: Unter `Frage` die Frage eingeben und im Text ergänzen, worum es geht. Die `Antwortmöglichkeiten` sind mit `Ja` und `Nein` vorbelegt; über `Antwort hinzufügen` kommen weitere dazu (bis zu zehn), das Papierkorb-Symbol entfernt eine. Zwei Antworten sind das Minimum.",
           "Sollen Eltern mehrere Antworten gleichzeitig auswählen dürfen (z. B. mehrere mögliche Termine), `Mehrfachauswahl erlauben` aktivieren.",
           "Optional eine `Antwortfrist` setzen. Nach Ablauf nimmt die Umfrage keine Antworten mehr an, bleibt für die Eltern aber lesbar.",
           "Schritt `Empfänger`: wie bei einer Mitteilung die Zielgruppe wählen (ganze Schule, Klassen, Gruppen, AGs oder einzelne Kinder), dann `Veröffentlichen`.",
@@ -1497,7 +1497,7 @@ export const appChapters: readonly GuideChapter[] = [
         ],
         callout: {
           title: "Pro Kind, nicht pro Konto",
-          body: "Eltern beantworten die Umfrage für jedes ihrer Kinder einzeln, und die Auswertung zählt Kinder. Das ist die Zahl, mit der Sie planen. Bezugspersonen ohne betreutes Kind (z. B. mit einer noch offenen Anmeldung) können deshalb nicht antworten.",
+          body: "Eltern sehen die Umfrage unter `Neuigkeiten` mit dem Hinweis `Antwort erforderlich`, öffnen sie und antworten dort für jedes ihrer Kinder einzeln; gespeichert wird erst mit `Antwort speichern`. Die Auswertung zählt entsprechend Kinder, nicht Konten – das ist die Zahl, mit der Sie planen. Bezugspersonen ohne betreutes Kind (z. B. mit einer noch offenen Anmeldung) können nicht antworten.",
           tone: "blue",
         },
         screenshot:

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -16,6 +16,7 @@ import {
   GraduationCap,
   KeyRound,
   LayoutDashboard,
+  ListChecks,
   Megaphone,
   MessageSquare,
   MonitorPlay,
@@ -1462,9 +1463,9 @@ export const appChapters: readonly GuideChapter[] = [
         title: "Elternmitteilungen",
         icon: Megaphone,
         summary:
-          "Mitteilungen an ausgewählte Elterngruppen senden (Rundinformationen statt Einzelnachrichten). Eltern sehen sie als Neuigkeiten im Elternportal. Anders als die Nachrichten ist das eine Einbahn-Information ohne Antwortmöglichkeit; für Rückfragen nutzen Eltern den normalen Nachrichten-Chat.",
+          "Mitteilungen an ausgewählte Elterngruppen senden (Rundinformationen statt Einzelnachrichten). Eltern sehen sie als Neuigkeiten im Elternportal. Eine Mitteilung ist eine Einbahn-Information; wenn Sie eine Rückmeldung brauchen, nutzen Sie den Bereich `Umfragen` auf derselben Seite. Für individuelle Rückfragen nutzen Eltern den normalen Nachrichten-Chat.",
         steps: [
-          "In der Seitenleiste den Bereich `Eltern` aufklappen, `Elternmitteilungen` öffnen und auf `Elternmitteilung` tippen.",
+          "In der Seitenleiste den Bereich `Eltern` aufklappen, `Mitteilungen und Umfragen` öffnen und auf `Mitteilung` tippen.",
           "Schritt `Inhalt`: Titel und Text eingeben. Optional: einen Link ergänzen, Priorität `Wichtig` setzen, ein Ablaufdatum wählen (danach wird die Mitteilung ausgeblendet), `Lesebestätigung erforderlich` und `Eltern zusätzlich per E-Mail benachrichtigen` aktivieren. Die E-Mail enthält nur den Titel und einen Link ins Elternportal.",
           "Schritt `Empfänger`: Zielgruppe wählen: ganze Schule, einzelne Klassen, Gruppen, AGs/Betreuungsangebote, einzelne Kinder oder Eltern mit offener Anmeldung. Mehrere Zielgruppen lassen sich kombinieren; ein Elternteil erhält die Mitteilung höchstens einmal.",
           "Mit `Als Entwurf speichern` für später sichern oder mit `Veröffentlichen` direkt an die Eltern geben. Veröffentlichte Mitteilungen erscheinen sofort im Elternportal der erreichten Eltern.",
@@ -1478,6 +1479,29 @@ export const appChapters: readonly GuideChapter[] = [
         },
         screenshot:
           "Übersicht der Elternmitteilungen mit Status (Entwurf, veröffentlicht, abgelaufen) und der Aktion „Neue Elternmitteilung“.",
+      },
+      {
+        id: "elternumfragen",
+        title: "Elternumfragen",
+        icon: ListChecks,
+        summary:
+          "Eine kurze Frage an ausgewählte Elterngruppen, die pro Kind beantwortet wird – zum Beispiel „Kommt Ihr Kind zur Murmelparty?“. Die Antworten laufen aggregiert in der App zusammen, sodass Sie mit einer verlässlichen Zahl planen können.",
+        steps: [
+          "In der Seitenleiste den Bereich `Eltern` aufklappen, `Mitteilungen und Umfragen` öffnen, oben auf `Umfragen` wechseln und auf `Umfrage` tippen.",
+          "Schritt `Inhalt`: Unter `Frage` die Frage eingeben und im Text ergänzen, worum es geht. Die `Antwortmöglichkeiten` sind mit `Ja` und `Nein` vorbelegt; über `Antwort hinzufügen` kommen weitere dazu (bis zu zehn), das `×` entfernt eine.",
+          "Sollen Eltern mehrere Antworten gleichzeitig auswählen dürfen (z. B. mehrere mögliche Termine), `Mehrfachauswahl erlauben` aktivieren.",
+          "Optional eine `Antwortfrist` setzen. Nach Ablauf nimmt die Umfrage keine Antworten mehr an, bleibt für die Eltern aber lesbar.",
+          "Schritt `Empfänger`: wie bei einer Mitteilung die Zielgruppe wählen (ganze Schule, Klassen, Gruppen, AGs oder einzelne Kinder), dann `Veröffentlichen`.",
+          "Ein Tipp auf die Umfrage öffnet die `Auswertung`: pro Antwortmöglichkeit ein Balken mit der Anzahl Kinder, darunter die Liste aller erreichten Kinder mit ihrer Antwort. Über `Nur offene` sehen Sie, wer noch fehlt.",
+          "Mit `Eltern ohne Antwort erinnern` erhalten genau die Bezugspersonen eine Erinnerung, deren Kind noch keine Antwort hat – niemand sonst wird benachrichtigt.",
+        ],
+        callout: {
+          title: "Pro Kind, nicht pro Konto",
+          body: "Eltern beantworten die Umfrage für jedes ihrer Kinder einzeln, und die Auswertung zählt Kinder. Das ist die Zahl, mit der Sie planen. Bezugspersonen ohne betreutes Kind (z. B. mit einer noch offenen Anmeldung) können deshalb nicht antworten.",
+          tone: "blue",
+        },
+        screenshot:
+          "Auswertung einer Umfrage: Balken je Antwortmöglichkeit mit Anzahl Kinder, darunter die Liste der Kinder mit Antwort oder „Offen“ und die Schaltfläche „Eltern ohne Antwort erinnern“.",
       },
       {
         id: "essensplan",

--- a/frontend/src/components/parent/news/news-components.test.tsx
+++ b/frontend/src/components/parent/news/news-components.test.tsx
@@ -1,0 +1,228 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NewsCard, isOpenPoll } from "./news-components";
+import type { ParentAnnouncement } from "~/lib/parent-api";
+import * as parentApi from "~/lib/parent-api";
+
+// Poll (Umfrage, #1371) behaviour of the parent news card: the answer buttons
+// live ON the card, one row per child, and a closed poll stops accepting taps.
+
+function poll(overrides: Partial<ParentAnnouncement> = {}): ParentAnnouncement {
+  return {
+    id: "42",
+    title: "Kommt Ihr Kind zur Murmelparty?",
+    body: "Am Freitag ab 15 Uhr.",
+    priority: "info",
+    requires_acknowledgement: false,
+    school_name: "OGS Am Berg",
+    published_at: "2026-07-01T08:00:00Z",
+    read: true,
+    acknowledged: false,
+    response_type: "single_choice",
+    options: [
+      { id: "1", label: "Ja" },
+      { id: "2", label: "Nein" },
+    ],
+    children: [
+      {
+        student_id: "10",
+        first_name: "Felix",
+        last_name: "Schneider",
+        selected_options: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("NewsCard poll answering", () => {
+  it("submits the tapped option for the child and marks it answered", async () => {
+    const respond = vi
+      .spyOn(parentApi, "respondToAnnouncement")
+      .mockResolvedValue(undefined);
+    const onUpdated = vi.fn();
+
+    render(<NewsCard item={poll()} onOpen={vi.fn()} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+
+    await waitFor(() => {
+      expect(respond).toHaveBeenCalledWith(
+        "42",
+        "10",
+        ["1"],
+        "2026-07-01T08:00:00Z",
+      );
+    });
+    // Optimistic patch: the card shows the new selection before the round trip.
+    expect(onUpdated).toHaveBeenCalledWith("42", {
+      children: [
+        expect.objectContaining({ student_id: "10", selected_options: ["1"] }),
+      ],
+    });
+  });
+
+  it("withdraws the answer when the selected option is tapped again", async () => {
+    const respond = vi
+      .spyOn(parentApi, "respondToAnnouncement")
+      .mockResolvedValue(undefined);
+
+    render(
+      <NewsCard
+        item={poll({
+          children: [
+            {
+              student_id: "10",
+              first_name: "Felix",
+              last_name: "Schneider",
+              selected_options: ["1"],
+            },
+          ],
+        })}
+        onOpen={vi.fn()}
+        onUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+
+    await waitFor(() => {
+      expect(respond).toHaveBeenCalledWith(
+        "42",
+        "10",
+        [],
+        "2026-07-01T08:00:00Z",
+      );
+    });
+  });
+
+  it("adds to the selection instead of replacing it in multi choice", async () => {
+    const respond = vi
+      .spyOn(parentApi, "respondToAnnouncement")
+      .mockResolvedValue(undefined);
+
+    render(
+      <NewsCard
+        item={poll({
+          response_type: "multi_choice",
+          children: [
+            {
+              student_id: "10",
+              first_name: "Felix",
+              last_name: "Schneider",
+              selected_options: ["1"],
+            },
+          ],
+        })}
+        onOpen={vi.fn()}
+        onUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Nein" }));
+
+    await waitFor(() => {
+      expect(respond).toHaveBeenCalledWith(
+        "42",
+        "10",
+        ["1", "2"],
+        "2026-07-01T08:00:00Z",
+      );
+    });
+  });
+
+  it("disables the options and shows the closed badge past the deadline", () => {
+    render(
+      <NewsCard
+        item={poll({ response_deadline: "2020-01-01T00:00:00Z" })}
+        onOpen={vi.fn()}
+        onUpdated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Umfrage geschlossen")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Ja" })).toBeDisabled();
+  });
+
+  it("reverts the optimistic patch when the write fails", async () => {
+    vi.spyOn(parentApi, "respondToAnnouncement").mockRejectedValue(
+      new Error("boom"),
+    );
+    const onUpdated = vi.fn();
+
+    render(<NewsCard item={poll()} onOpen={vi.fn()} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+
+    await waitFor(() => {
+      // Second call restores the pre-tap children array.
+      expect(onUpdated).toHaveBeenLastCalledWith("42", {
+        children: [
+          expect.objectContaining({ student_id: "10", selected_options: [] }),
+        ],
+      });
+    });
+    expect(
+      await screen.findByText("Aktion fehlgeschlagen. Bitte erneut versuchen."),
+    ).toBeInTheDocument();
+  });
+
+  it("names each child when the guardian has more than one", () => {
+    render(
+      <NewsCard
+        item={poll({
+          children: [
+            {
+              student_id: "10",
+              first_name: "Felix",
+              last_name: "Schneider",
+              selected_options: [],
+            },
+            {
+              student_id: "11",
+              first_name: "Mila",
+              last_name: "Schneider",
+              selected_options: ["1"],
+            },
+          ],
+        })}
+        onOpen={vi.fn()}
+        onUpdated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Felix")).toBeInTheDocument();
+    expect(screen.getByText("Mila")).toBeInTheDocument();
+    // Two children, two option sets.
+    expect(screen.getAllByRole("button", { name: "Ja" })).toHaveLength(2);
+  });
+});
+
+describe("isOpenPoll", () => {
+  it("is true only while an answer is still owed and possible", () => {
+    expect(isOpenPoll(poll())).toBe(true);
+    expect(
+      isOpenPoll(
+        poll({
+          children: [
+            {
+              student_id: "10",
+              first_name: "Felix",
+              last_name: "Schneider",
+              selected_options: ["1"],
+            },
+          ],
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isOpenPoll(poll({ response_deadline: "2020-01-01T00:00:00Z" })),
+    ).toBe(false);
+    expect(isOpenPoll(poll({ response_type: "none" }))).toBe(false);
+  });
+});

--- a/frontend/src/components/parent/news/news-components.test.tsx
+++ b/frontend/src/components/parent/news/news-components.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -209,31 +210,37 @@ describe("Umfrage answering in the detail view", () => {
     vi.spyOn(parentApi, "respondToAnnouncement")
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error("boom"));
-    const onUpdated = vi.fn();
     const onClose = vi.fn();
+    const initial = poll({
+      children: [
+        {
+          student_id: "10",
+          first_name: "Felix",
+          last_name: "Schneider",
+          selected_options: [],
+        },
+        {
+          student_id: "11",
+          first_name: "Mila",
+          last_name: "Schneider",
+          selected_options: [],
+        },
+      ],
+    });
+    function StatefulModal() {
+      const [item, setItem] = useState(initial);
+      return (
+        <NewsDetailModal
+          item={item}
+          onClose={onClose}
+          onUpdated={(_id, patch) =>
+            setItem((current) => ({ ...current, ...patch }))
+          }
+        />
+      );
+    }
 
-    render(
-      <NewsDetailModal
-        item={poll({
-          children: [
-            {
-              student_id: "10",
-              first_name: "Felix",
-              last_name: "Schneider",
-              selected_options: [],
-            },
-            {
-              student_id: "11",
-              first_name: "Mila",
-              last_name: "Schneider",
-              selected_options: [],
-            },
-          ],
-        })}
-        onClose={onClose}
-        onUpdated={onUpdated}
-      />,
-    );
+    render(<StatefulModal />);
 
     const yesButtons = screen.getAllByRole("button", { name: "Ja" });
     const noButtons = screen.getAllByRole("button", { name: "Nein" });
@@ -244,15 +251,9 @@ describe("Umfrage answering in the detail view", () => {
     fireEvent.click(screen.getByRole("button", { name: "Antwort speichern" }));
 
     await waitFor(() => {
-      expect(onUpdated).toHaveBeenCalledWith("42", {
-        children: [
-          expect.objectContaining({
-            student_id: "10",
-            selected_options: ["1"],
-          }),
-          expect.objectContaining({ student_id: "11", selected_options: [] }),
-        ],
-      });
+      expect(
+        screen.getAllByRole("button", { name: "Nein" })[1],
+      ).toHaveAttribute("aria-pressed", "true");
     });
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/parent/news/news-components.test.tsx
+++ b/frontend/src/components/parent/news/news-components.test.tsx
@@ -47,9 +47,10 @@ describe("Umfrage answering in the detail view", () => {
       .spyOn(parentApi, "respondToAnnouncement")
       .mockResolvedValue(undefined);
     const onUpdated = vi.fn();
+    const onClose = vi.fn();
 
     render(
-      <NewsDetailModal item={poll()} onClose={vi.fn()} onUpdated={onUpdated} />,
+      <NewsDetailModal item={poll()} onClose={onClose} onUpdated={onUpdated} />,
     );
 
     // Picking an option must not write anything yet.
@@ -76,6 +77,8 @@ describe("Umfrage answering in the detail view", () => {
         expect.objectContaining({ student_id: "10", selected_options: ["1"] }),
       ],
     });
+    // A successful write closes the dialog, like every other parent modal.
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
   it("keeps the save button disabled while nothing changed", () => {
@@ -180,9 +183,10 @@ describe("Umfrage answering in the detail view", () => {
       new Error("boom"),
     );
     const onUpdated = vi.fn();
+    const onClose = vi.fn();
 
     render(
-      <NewsDetailModal item={poll()} onClose={vi.fn()} onUpdated={onUpdated} />,
+      <NewsDetailModal item={poll()} onClose={onClose} onUpdated={onUpdated} />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Ja" }));
@@ -191,8 +195,10 @@ describe("Umfrage answering in the detail view", () => {
     expect(
       await screen.findByText("Aktion fehlgeschlagen. Bitte erneut versuchen."),
     ).toBeInTheDocument();
-    // Nothing was committed, and the choice stays on screen so it can be retried.
+    // Nothing was committed, the dialog stays open, and the choice stays on
+    // screen so it can be retried.
     expect(onUpdated).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Ja" })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/frontend/src/components/parent/news/news-components.test.tsx
+++ b/frontend/src/components/parent/news/news-components.test.tsx
@@ -1,12 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { NewsCard, isOpenPoll } from "./news-components";
+import { NewsCard, NewsDetailModal, isOpenPoll } from "./news-components";
 import type { ParentAnnouncement } from "~/lib/parent-api";
 import * as parentApi from "~/lib/parent-api";
 
-// Poll (Umfrage, #1371) behaviour of the parent news card: the answer buttons
-// live ON the card, one row per child, and a closed poll stops accepting taps.
+// Poll (Umfrage, #1371) behaviour in the parent portal: the feed card only
+// flags that an answer is due, the detail view is where it is given — one row
+// per child, saved explicitly, and refused once the poll is closed.
 
 function poll(overrides: Partial<ParentAnnouncement> = {}): ParentAnnouncement {
   return {
@@ -40,16 +41,27 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("NewsCard poll answering", () => {
-  it("submits the tapped option for the child and marks it answered", async () => {
+describe("Umfrage answering in the detail view", () => {
+  it("selects locally and only writes once the answer is saved", async () => {
     const respond = vi
       .spyOn(parentApi, "respondToAnnouncement")
       .mockResolvedValue(undefined);
     const onUpdated = vi.fn();
 
-    render(<NewsCard item={poll()} onOpen={vi.fn()} onUpdated={onUpdated} />);
+    render(
+      <NewsDetailModal item={poll()} onClose={vi.fn()} onUpdated={onUpdated} />,
+    );
 
+    // Picking an option must not write anything yet.
     fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+    expect(respond).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Ja" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Noch nicht gespeichert")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Antwort speichern" }));
 
     await waitFor(() => {
       expect(respond).toHaveBeenCalledWith(
@@ -59,12 +71,20 @@ describe("NewsCard poll answering", () => {
         "2026-07-01T08:00:00Z",
       );
     });
-    // Optimistic patch: the card shows the new selection before the round trip.
     expect(onUpdated).toHaveBeenCalledWith("42", {
       children: [
         expect.objectContaining({ student_id: "10", selected_options: ["1"] }),
       ],
     });
+  });
+
+  it("keeps the save button disabled while nothing changed", () => {
+    render(
+      <NewsDetailModal item={poll()} onClose={vi.fn()} onUpdated={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Antwort speichern" }),
+    ).toBeDisabled();
   });
 
   it("withdraws the answer when the selected option is tapped again", async () => {
@@ -73,7 +93,7 @@ describe("NewsCard poll answering", () => {
       .mockResolvedValue(undefined);
 
     render(
-      <NewsCard
+      <NewsDetailModal
         item={poll({
           children: [
             {
@@ -84,12 +104,13 @@ describe("NewsCard poll answering", () => {
             },
           ],
         })}
-        onOpen={vi.fn()}
+        onClose={vi.fn()}
         onUpdated={vi.fn()}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+    fireEvent.click(screen.getByRole("button", { name: "Antwort speichern" }));
 
     await waitFor(() => {
       expect(respond).toHaveBeenCalledWith(
@@ -107,7 +128,7 @@ describe("NewsCard poll answering", () => {
       .mockResolvedValue(undefined);
 
     render(
-      <NewsCard
+      <NewsDetailModal
         item={poll({
           response_type: "multi_choice",
           children: [
@@ -119,12 +140,13 @@ describe("NewsCard poll answering", () => {
             },
           ],
         })}
-        onOpen={vi.fn()}
+        onClose={vi.fn()}
         onUpdated={vi.fn()}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Nein" }));
+    fireEvent.click(screen.getByRole("button", { name: "Antwort speichern" }));
 
     await waitFor(() => {
       expect(respond).toHaveBeenCalledWith(
@@ -138,43 +160,56 @@ describe("NewsCard poll answering", () => {
 
   it("disables the options and shows the closed badge past the deadline", () => {
     render(
-      <NewsCard
+      <NewsDetailModal
         item={poll({ response_deadline: "2020-01-01T00:00:00Z" })}
-        onOpen={vi.fn()}
+        onClose={vi.fn()}
         onUpdated={vi.fn()}
       />,
     );
 
     expect(screen.getByText("Umfrage geschlossen")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Ja" })).toBeDisabled();
+    // Nothing left to save, so the action is gone entirely.
+    expect(
+      screen.queryByRole("button", { name: "Antwort speichern" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("reverts the optimistic patch when the write fails", async () => {
+  it("keeps the selection and reports the error when saving fails", async () => {
     vi.spyOn(parentApi, "respondToAnnouncement").mockRejectedValue(
       new Error("boom"),
     );
     const onUpdated = vi.fn();
 
-    render(<NewsCard item={poll()} onOpen={vi.fn()} onUpdated={onUpdated} />);
+    render(
+      <NewsDetailModal item={poll()} onClose={vi.fn()} onUpdated={onUpdated} />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+    fireEvent.click(screen.getByRole("button", { name: "Antwort speichern" }));
 
-    await waitFor(() => {
-      // Second call restores the pre-tap children array.
-      expect(onUpdated).toHaveBeenLastCalledWith("42", {
-        children: [
-          expect.objectContaining({ student_id: "10", selected_options: [] }),
-        ],
-      });
-    });
     expect(
       await screen.findByText("Aktion fehlgeschlagen. Bitte erneut versuchen."),
     ).toBeInTheDocument();
+    // Nothing was committed, and the choice stays on screen so it can be retried.
+    expect(onUpdated).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Ja" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("flags an open poll on the feed card without answering there", () => {
+    render(<NewsCard item={poll()} onOpen={vi.fn()} />);
+    expect(screen.getByText("Antwort erforderlich")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Ja" }),
+    ).not.toBeInTheDocument();
   });
 
   it("names each child when the guardian has more than one", () => {
     render(
-      <NewsCard
+      <NewsDetailModal
         item={poll({
           children: [
             {
@@ -191,7 +226,7 @@ describe("NewsCard poll answering", () => {
             },
           ],
         })}
-        onOpen={vi.fn()}
+        onClose={vi.fn()}
         onUpdated={vi.fn()}
       />,
     );

--- a/frontend/src/components/parent/news/news-components.test.tsx
+++ b/frontend/src/components/parent/news/news-components.test.tsx
@@ -205,6 +205,90 @@ describe("Umfrage answering in the detail view", () => {
     );
   });
 
+  it("reconciles earlier child responses when a later save fails", async () => {
+    vi.spyOn(parentApi, "respondToAnnouncement")
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"));
+    const onUpdated = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <NewsDetailModal
+        item={poll({
+          children: [
+            {
+              student_id: "10",
+              first_name: "Felix",
+              last_name: "Schneider",
+              selected_options: [],
+            },
+            {
+              student_id: "11",
+              first_name: "Mila",
+              last_name: "Schneider",
+              selected_options: [],
+            },
+          ],
+        })}
+        onClose={onClose}
+        onUpdated={onUpdated}
+      />,
+    );
+
+    const yesButtons = screen.getAllByRole("button", { name: "Ja" });
+    const noButtons = screen.getAllByRole("button", { name: "Nein" });
+    expect(yesButtons[0]).toBeDefined();
+    expect(noButtons[1]).toBeDefined();
+    fireEvent.click(yesButtons[0]!);
+    fireEvent.click(noButtons[1]!);
+    fireEvent.click(screen.getByRole("button", { name: "Antwort speichern" }));
+
+    await waitFor(() => {
+      expect(onUpdated).toHaveBeenCalledWith("42", {
+        children: [
+          expect.objectContaining({
+            student_id: "10",
+            selected_options: ["1"],
+          }),
+          expect.objectContaining({ student_id: "11", selected_options: [] }),
+        ],
+      });
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("resets drafts when a corrected poll has different options", () => {
+    const { rerender } = render(
+      <NewsDetailModal item={poll()} onClose={vi.fn()} onUpdated={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Ja" }));
+    expect(
+      screen.getByRole("button", { name: "Antwort speichern" }),
+    ).toBeEnabled();
+
+    rerender(
+      <NewsDetailModal
+        item={poll({
+          published_at: "2026-07-02T08:00:00Z",
+          options: [
+            { id: "3", label: "Vielleicht" },
+            { id: "4", label: "Nein" },
+          ],
+        })}
+        onClose={vi.fn()}
+        onUpdated={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Ja" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Antwort speichern" }),
+    ).toBeDisabled();
+  });
+
   it("flags an open poll on the feed card without answering there", () => {
     render(<NewsCard item={poll()} onOpen={vi.fn()} />);
     expect(screen.getByText("Antwort erforderlich")).toBeInTheDocument();

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -183,8 +183,12 @@ function usePollAnswers(
   };
 
   const isDirty = (child: ParentAnnouncementPollChild): boolean => {
-    const saved = [...child.selected_options].sort().join(",");
-    const current = [...selectionFor(child)].sort().join(",");
+    const saved = [...child.selected_options]
+      .sort((a, b) => a.localeCompare(b))
+      .join(",");
+    const current = [...selectionFor(child)]
+      .sort((a, b) => a.localeCompare(b))
+      .join(",");
     return saved !== current;
   };
   const dirtyChildren = children.filter(isDirty);

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -184,8 +184,8 @@ function usePollAnswers(
   };
   const dirtyChildren = children.filter(isDirty);
 
-  const save = async () => {
-    if (!item.published_at || dirtyChildren.length === 0) return;
+  const save = async (): Promise<boolean> => {
+    if (!item.published_at || dirtyChildren.length === 0) return false;
     setSaving(true);
     setError(null);
     try {
@@ -204,6 +204,7 @@ function usePollAnswers(
         })),
       });
       refreshUnreadBadge();
+      return true;
     } catch (err: unknown) {
       logger.error("parent_news_poll_answer_failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -212,6 +213,7 @@ function usePollAnswers(
         onStale?.(item.id);
       }
       setError(t("newsActionError"));
+      return false;
     } finally {
       setSaving(false);
     }
@@ -420,6 +422,9 @@ export function NewsDetailModal({
       await acknowledgeAnnouncement(item.id, item.published_at);
       onUpdated(item.id, { read: true, acknowledged: true });
       refreshUnreadBadge();
+      // Done — like every other parent-portal modal, a successful write closes
+      // the dialog and hands the confirmation back to the list behind it.
+      onClose();
     } catch (err: unknown) {
       logger.error("parent_news_acknowledge_failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -434,7 +439,7 @@ export function NewsDetailModal({
     } finally {
       setBusy(false);
     }
-  }, [item.id, item.published_at, onUpdated, onStale, t]);
+  }, [item.id, item.published_at, onUpdated, onStale, onClose, t]);
 
   // A stale announcement can't be acknowledged (the backend rejects the write),
   // so hide the button and surface the stale banner instead.
@@ -456,7 +461,11 @@ export function NewsDetailModal({
             <Button
               type="button"
               size="md"
-              onClick={() => void poll.save()}
+              onClick={() => {
+                void poll.save().then((saved) => {
+                  if (saved) onClose();
+                });
+              }}
               disabled={!poll.canSave || poll.saving}
               isLoading={poll.saving}
               loadingText={t("newsPollSaving")}

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -144,6 +144,12 @@ function usePollAnswers(
   const savedSignature = children
     .map((c) => `${c.student_id}:${[...c.selected_options].sort().join(",")}`)
     .join("|");
+  const pollVersionSignature = [
+    item.id,
+    item.published_at ?? "",
+    item.response_type,
+    ...(item.options ?? []).map((option) => `${option.id}:${option.label}`),
+  ].join("|");
   const [draft, setDraft] = useState<Record<string, string[]>>(() =>
     Object.fromEntries(
       children.map((c) => [c.student_id, [...c.selected_options]]),
@@ -159,7 +165,7 @@ function usePollAnswers(
     // children is derived from item; savedSignature captures the values that
     // matter, so it is the dependency rather than a new array identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [savedSignature]);
+  }, [savedSignature, pollVersionSignature]);
 
   const selectionFor = (child: ParentAnnouncementPollChild): string[] =>
     draft[child.student_id] ?? [];
@@ -188,6 +194,7 @@ function usePollAnswers(
     if (!item.published_at || dirtyChildren.length === 0) return false;
     setSaving(true);
     setError(null);
+    const savedSelections = new Map<string, string[]>();
     try {
       for (const child of dirtyChildren) {
         await respondToAnnouncement(
@@ -196,13 +203,19 @@ function usePollAnswers(
           selectionFor(child),
           item.published_at,
         );
+        savedSelections.set(child.student_id, selectionFor(child));
+        // Responses are persisted one child at a time. Reconcile each success
+        // immediately, so a later failure leaves the parent with the saved
+        // responses shown as saved and only the remaining child to retry.
+        onUpdated(item.id, {
+          children: children.map((candidate) => ({
+            ...candidate,
+            selected_options:
+              savedSelections.get(candidate.student_id) ??
+              candidate.selected_options,
+          })),
+        });
       }
-      onUpdated(item.id, {
-        children: children.map((c) => ({
-          ...c,
-          selected_options: selectionFor(c),
-        })),
-      });
       refreshUnreadBadge();
       return true;
     } catch (err: unknown) {

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, ChevronRight, ExternalLink } from "lucide-react";
+import { Check, ChevronRight, ExternalLink, ListChecks } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Modal } from "~/components/ui/modal";
@@ -19,8 +19,10 @@ import { createLogger } from "~/lib/logger";
 import {
   ParentApiError,
   type ParentAnnouncement,
+  type ParentAnnouncementPollChild,
   acknowledgeAnnouncement,
   markAnnouncementRead,
+  respondToAnnouncement,
 } from "~/lib/parent-api";
 
 const logger = createLogger({ component: "ParentNews" });
@@ -42,12 +44,53 @@ function isStaleAnnouncementError(err: unknown): boolean {
   );
 }
 
+/** True when the announcement asks a question the parent can still answer. */
+function isPoll(item: ParentAnnouncement): boolean {
+  return item.response_type !== "none";
+}
+
+function isPollClosed(item: ParentAnnouncement): boolean {
+  return (
+    item.response_deadline !== undefined &&
+    new Date(item.response_deadline) <= new Date()
+  );
+}
+
+/**
+ * True when this is a survey that is still collecting answers AND at least one
+ * of the guardian's children has none yet — the "you still owe the school an
+ * answer" state the dashboard sorts on.
+ */
+export function isOpenPoll(item: ParentAnnouncement): boolean {
+  if (!isPoll(item) || isPollClosed(item)) return false;
+  return (item.children ?? []).some(
+    (child) => child.selected_options.length === 0,
+  );
+}
+
 function NewsBadges({
   item,
 }: Readonly<{ item: ParentAnnouncement }>): React.ReactNode {
   const t = useTranslations("parentDashboard");
+  const poll = isPoll(item);
   return (
     <>
+      {poll && (
+        <span className="inline-flex items-center gap-1 rounded-full bg-[#5080D8]/10 px-2 py-0.5 text-xs font-semibold text-[#5080D8]">
+          <ListChecks className="h-3 w-3" aria-hidden="true" />
+          {t("newsPoll")}
+        </span>
+      )}
+      {poll && item.response_deadline && !isPollClosed(item) && (
+        <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-700">
+          {t("newsPollDeadline", { date: formatDate(item.response_deadline) })}
+        </span>
+      )}
+      {poll && isPollClosed(item) && (
+        <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-500">
+          {t("newsPollClosed")}
+        </span>
+      )}
       {!item.read && (
         <span className="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-xs font-semibold text-white">
           {t("newsNew")}
@@ -68,22 +111,157 @@ function NewsBadges({
   );
 }
 
+/**
+ * The answer control of an Umfrage: one row per child the poll reaches, each
+ * with the options as toggle buttons (#1371).
+ *
+ * It lives directly on the feed card, not only behind the detail modal: an
+ * answer that costs one tap gets given, an answer that costs three taps does
+ * not — and the school needs the number.
+ */
+function PollAnswerBlock({
+  item,
+  onUpdated,
+  onStale,
+  compact = false,
+}: Readonly<{
+  item: ParentAnnouncement;
+  onUpdated: (id: string, patch: Partial<ParentAnnouncement>) => void;
+  onStale?: (id: string) => void;
+  /** Card variant: tighter spacing, no heading. */
+  compact?: boolean;
+}>) {
+  const t = useTranslations("parentDashboard");
+  const [busyChild, setBusyChild] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const children = item.children ?? [];
+  const options = item.options ?? [];
+  const closed = isPollClosed(item);
+  const multi = item.response_type === "multi_choice";
+
+  const submit = async (
+    child: ParentAnnouncementPollChild,
+    optionId: string,
+  ) => {
+    if (closed || !item.published_at) return;
+    const selected = child.selected_options;
+    const next = multi
+      ? selected.includes(optionId)
+        ? selected.filter((id) => id !== optionId)
+        : [...selected, optionId]
+      : selected.includes(optionId)
+        ? [] // tapping the chosen option again withdraws the answer
+        : [optionId];
+
+    setBusyChild(child.student_id);
+    setError(null);
+    // Optimistic: the button state flips immediately and is reverted below if
+    // the write fails, so a slow connection never feels like a dead tap.
+    const previous = children;
+    onUpdated(item.id, {
+      children: children.map((c) =>
+        c.student_id === child.student_id
+          ? { ...c, selected_options: next }
+          : c,
+      ),
+    });
+    try {
+      await respondToAnnouncement(
+        item.id,
+        child.student_id,
+        next,
+        item.published_at,
+      );
+      refreshUnreadBadge();
+    } catch (err: unknown) {
+      logger.error("parent_news_poll_answer_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      onUpdated(item.id, { children: previous });
+      if (isStaleAnnouncementError(err)) {
+        onStale?.(item.id);
+      }
+      setError(t("newsActionError"));
+    } finally {
+      setBusyChild(null);
+    }
+  };
+
+  if (children.length === 0 || options.length === 0) return null;
+
+  return (
+    <div className={compact ? "space-y-2" : "space-y-3"}>
+      {multi && <p className="text-xs text-gray-500">{t("newsPollMulti")}</p>}
+      {children.map((child) => {
+        const answered = child.selected_options.length > 0;
+        return (
+          <div key={child.student_id}>
+            <div className="flex items-center justify-between gap-2">
+              {/* With one child the name is noise — the card is already about
+                  that family. With several it is the whole point. */}
+              {children.length > 1 && (
+                <span className="truncate text-xs font-medium text-gray-700">
+                  {child.first_name}
+                </span>
+              )}
+              <span
+                className={`ml-auto text-xs ${answered ? "text-[#4d7719]" : "text-gray-500"}`}
+              >
+                {answered ? t("newsPollAnswered") : t("newsPollOpen")}
+              </span>
+            </div>
+            <div className="mt-1.5 flex flex-wrap gap-2">
+              {options.map((option) => {
+                const active = child.selected_options.includes(option.id);
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    disabled={closed || busyChild === child.student_id}
+                    aria-pressed={active}
+                    onClick={() => void submit(child, option.id)}
+                    className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60 ${
+                      active
+                        ? "bg-[#83CD2D] text-white"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+      {error && (
+        <p
+          role="alert"
+          className="rounded-lg bg-[#FF31301A] px-3 py-2 text-sm text-[#CC2626]"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
 /** Compact feed card: badges, title, school + date, two preview lines. */
 export function NewsCard({
   item,
   onOpen,
+  onUpdated,
+  onStale,
 }: Readonly<{
   item: ParentAnnouncement;
   onOpen: (item: ParentAnnouncement) => void;
+  /** Required for polls: answering happens inline on the card. */
+  onUpdated?: (id: string, patch: Partial<ParentAnnouncement>) => void;
+  onStale?: (id: string) => void;
 }>) {
-  return (
-    <button
-      type="button"
-      onClick={() => onOpen(item)}
-      className={`flex w-full items-center gap-3 rounded-xl border bg-white p-4 text-left shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 ${
-        item.read ? "border-gray-200" : "border-gray-300"
-      }`}
-    >
+  const summary = (
+    <>
       <span className="min-w-0 flex-1">
         <span className="flex flex-wrap items-center gap-2">
           <NewsBadges item={item} />
@@ -103,6 +281,44 @@ export function NewsCard({
         className="h-5 w-5 shrink-0 text-gray-400"
         aria-hidden="true"
       />
+    </>
+  );
+
+  const borderClass = item.read ? "border-gray-200" : "border-gray-300";
+
+  // A poll card cannot be one big <button>: the answer buttons would nest
+  // inside it. So the summary stays a button and the answers sit beside it.
+  if (isPoll(item) && onUpdated) {
+    return (
+      <div
+        className={`rounded-xl border bg-white p-4 shadow-sm ${borderClass}`}
+      >
+        <button
+          type="button"
+          onClick={() => onOpen(item)}
+          className="flex w-full items-center gap-3 text-left"
+        >
+          {summary}
+        </button>
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          <PollAnswerBlock
+            item={item}
+            onUpdated={onUpdated}
+            onStale={onStale}
+            compact
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(item)}
+      className={`flex w-full items-center gap-3 rounded-xl border bg-white p-4 text-left shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 ${borderClass}`}
+    >
+      {summary}
     </button>
   );
 }
@@ -245,6 +461,16 @@ export function NewsDetailModal({
           >
             {actionError}
           </p>
+        )}
+
+        {isPoll(item) && (
+          <div className="border-t border-gray-100 pt-3">
+            <PollAnswerBlock
+              item={item}
+              onUpdated={onUpdated}
+              onStale={onStale}
+            />
+          </div>
         )}
 
         {needsAck && (

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -13,6 +13,7 @@ import { Check, ChevronRight, ExternalLink, ListChecks } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Modal } from "~/components/ui/modal";
+import { Button } from "~/components/ui/button";
 import { LinkifiedText } from "~/components/ui/linkified-text";
 import { formatDate } from "~/lib/date-helpers";
 import { createLogger } from "~/lib/logger";
@@ -117,31 +118,24 @@ function NewsBadges({
 }
 
 /**
- * The answer control of an Umfrage: one row per child the poll reaches, each
- * with the options as toggle buttons plus an explicit save (#1371).
+ * The answer state of an Umfrage, lifted out of the rendering so the modal can
+ * put "Antwort speichern" in its footer bar — where every other modal in the
+ * parent portal puts its primary action (#1371).
  *
  * Selecting is local; nothing is sent until the guardian saves. A tap that
  * writes straight through reads as a slip waiting to happen — the answer is a
  * commitment the school plans with, so it gets a deliberate confirmation.
- *
- * It lives in the detail view, where the guardian has the full question in
- * front of them rather than a two-line preview in a list.
  */
-function PollAnswerBlock({
-  item,
-  onUpdated,
-  onStale,
-}: Readonly<{
-  item: ParentAnnouncement;
-  onUpdated: (id: string, patch: Partial<ParentAnnouncement>) => void;
-  onStale?: (id: string) => void;
-}>) {
+function usePollAnswers(
+  item: ParentAnnouncement,
+  onUpdated: (id: string, patch: Partial<ParentAnnouncement>) => void,
+  onStale?: (id: string) => void,
+) {
   const t = useTranslations("parentDashboard");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const children = item.children ?? [];
-  const options = item.options ?? [];
   const closed = isPollClosed(item);
   const multi = item.response_type === "multi_choice";
 
@@ -223,27 +217,47 @@ function PollAnswerBlock({
     }
   };
 
+  return {
+    children,
+    options: item.options ?? [],
+    closed,
+    multi,
+    saving,
+    error,
+    selectionFor,
+    toggle,
+    isDirty,
+    canSave: dirtyChildren.length > 0,
+    save,
+  };
+}
+
+/** One card per child: name, saved state, and the answer options. */
+function PollAnswerRows({
+  poll,
+}: Readonly<{ poll: ReturnType<typeof usePollAnswers> }>) {
+  const t = useTranslations("parentDashboard");
+  const { children, options, closed, multi, saving } = poll;
   if (children.length === 0 || options.length === 0) return null;
 
   return (
     <div className="space-y-3">
-      {multi && <p className="text-xs text-gray-500">{t("newsPollMulti")}</p>}
+      {multi && <p className="text-sm text-gray-600">{t("newsPollMulti")}</p>}
       {children.map((child) => {
-        const selected = selectionFor(child);
+        const selected = poll.selectionFor(child);
         const answered = child.selected_options.length > 0;
-        const dirty = isDirty(child);
+        const dirty = poll.isDirty(child);
         return (
-          <div key={child.student_id}>
-            <div className="flex items-center justify-between gap-2">
-              {/* With one child the name is noise — the card is already about
-                  that family. With several it is the whole point. */}
-              {children.length > 1 && (
-                <span className="truncate text-xs font-medium text-gray-700">
-                  {child.first_name}
-                </span>
-              )}
+          <div
+            key={child.student_id}
+            className="rounded-xl border border-gray-200 p-3"
+          >
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <p className="truncate text-sm font-semibold text-gray-900">
+                {child.first_name}
+              </p>
               <span
-                className={`ml-auto text-xs ${
+                className={`shrink-0 text-xs ${
                   dirty
                     ? "text-[#B45309]"
                     : answered
@@ -258,7 +272,7 @@ function PollAnswerBlock({
                     : t("newsPollOpen")}
               </span>
             </div>
-            <div className="mt-1.5 flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2">
               {options.map((option) => {
                 const active = selected.includes(option.id);
                 return (
@@ -267,7 +281,7 @@ function PollAnswerBlock({
                     type="button"
                     disabled={closed || saving}
                     aria-pressed={active}
-                    onClick={() => toggle(child, option.id)}
+                    onClick={() => poll.toggle(child, option.id)}
                     className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60 ${
                       active
                         ? "bg-[#83CD2D] text-white"
@@ -282,26 +296,6 @@ function PollAnswerBlock({
           </div>
         );
       })}
-
-      {!closed && (
-        <button
-          type="button"
-          disabled={dirtyChildren.length === 0 || saving}
-          onClick={() => void save()}
-          className="inline-flex h-9 items-center justify-center rounded-lg bg-gray-900 px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          {saving ? t("newsPollSaving") : t("newsPollSave")}
-        </button>
-      )}
-
-      {error && (
-        <p
-          role="alert"
-          className="rounded-lg bg-[#FF31301A] px-3 py-2 text-sm text-[#CC2626]"
-        >
-          {error}
-        </p>
-      )}
     </div>
   );
 }
@@ -376,6 +370,7 @@ export function NewsDetailModal({
   const [actionError, setActionError] = useState<string | null>(null);
   const [stale, setStale] = useState(false);
   const markedRef = useRef(false);
+  const poll = usePollAnswers(item, onUpdated, onStale);
 
   // Reset the per-version local flags when the id or published_at (the version
   // token) changes. On the stale-correction path the parent refetches the feed
@@ -447,7 +442,43 @@ export function NewsDetailModal({
     item.requires_acknowledgement && !item.acknowledged && !stale;
 
   return (
-    <Modal isOpen onClose={onClose} title={item.title}>
+    <Modal
+      isOpen
+      onClose={onClose}
+      title={item.title}
+      closeLabel={t("newsClose")}
+      footer={
+        <>
+          <Button type="button" variant="outline" size="md" onClick={onClose}>
+            {t("newsClose")}
+          </Button>
+          {isPoll(item) && !poll.closed && !stale && (
+            <Button
+              type="button"
+              size="md"
+              onClick={() => void poll.save()}
+              disabled={!poll.canSave || poll.saving}
+              isLoading={poll.saving}
+              loadingText={t("newsPollSaving")}
+            >
+              {t("newsPollSave")}
+            </Button>
+          )}
+          {needsAck && (
+            <Button
+              type="button"
+              size="md"
+              className="gap-1.5"
+              onClick={() => void handleAcknowledge()}
+              disabled={busy}
+            >
+              <Check className="h-4 w-4" aria-hidden="true" />
+              {t("newsAcknowledge")}
+            </Button>
+          )}
+        </>
+      }
+    >
       <div className="space-y-4">
         <div className="flex flex-wrap items-center gap-2">
           <NewsBadges item={item} />
@@ -491,29 +522,16 @@ export function NewsDetailModal({
           </p>
         )}
 
-        {isPoll(item) && (
-          <div className="border-t border-gray-100 pt-3">
-            <PollAnswerBlock
-              item={item}
-              onUpdated={onUpdated}
-              onStale={onStale}
-            />
-          </div>
+        {poll.error && (
+          <p
+            role="alert"
+            className="rounded-lg bg-[#FF31301A] px-3 py-2 text-sm text-[#CC2626]"
+          >
+            {poll.error}
+          </p>
         )}
 
-        {needsAck && (
-          <div className="border-t border-gray-100 pt-3">
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => void handleAcknowledge()}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800 disabled:opacity-60"
-            >
-              <Check className="h-4 w-4" aria-hidden="true" />
-              {t("newsAcknowledge")}
-            </button>
-          </div>
-        )}
+        {isPoll(item) && <PollAnswerRows poll={poll} />}
       </div>
     </Modal>
   );

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -139,11 +139,10 @@ function usePollAnswers(
   const closed = isPollClosed(item);
   const multi = item.response_type === "multi_choice";
 
-  // What is selected on screen, per child. Seeded from the saved answers and
-  // reset whenever those change (a refetch, or our own save landing).
-  const savedSignature = children
-    .map((c) => `${c.student_id}:${[...c.selected_options].sort().join(",")}`)
-    .join("|");
+  // What is selected on screen, per child. A corrected poll is a new immutable
+  // version, so reset drafts for a changed version/options. Ordinary response
+  // updates do not reset them: while a multi-child save is in progress, one
+  // child may have persisted while another still needs a retry.
   const pollVersionSignature = [
     item.id,
     item.published_at ?? "",
@@ -162,10 +161,10 @@ function usePollAnswers(
       ),
     );
     setError(null);
-    // children is derived from item; savedSignature captures the values that
-    // matter, so it is the dependency rather than a new array identity.
+    // The version includes every option id and label, rather than the children:
+    // response updates must preserve drafts for unresolved children.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [savedSignature, pollVersionSignature]);
+  }, [pollVersionSignature]);
 
   const selectionFor = (child: ParentAnnouncementPollChild): string[] =>
     draft[child.student_id] ?? [];

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -15,7 +15,7 @@ import { useTranslations } from "next-intl";
 import { Modal } from "~/components/ui/modal";
 import { Button } from "~/components/ui/button";
 import { LinkifiedText } from "~/components/ui/linkified-text";
-import { formatDate } from "~/lib/date-helpers";
+import { formatBerlinDate, formatDate } from "~/lib/date-helpers";
 import { createLogger } from "~/lib/logger";
 import {
   ParentApiError,
@@ -89,7 +89,9 @@ function NewsBadges({
       )}
       {poll && item.response_deadline && !isPollClosed(item) && (
         <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-700">
-          {t("newsPollDeadline", { date: formatDate(item.response_deadline) })}
+          {t("newsPollDeadline", {
+            date: formatBerlinDate(item.response_deadline),
+          })}
         </span>
       )}
       {poll && isPollClosed(item) && (

--- a/frontend/src/components/parent/news/news-components.tsx
+++ b/frontend/src/components/parent/news/news-components.tsx
@@ -81,6 +81,11 @@ function NewsBadges({
           {t("newsPoll")}
         </span>
       )}
+      {isOpenPoll(item) && (
+        <span className="inline-flex items-center rounded-full bg-[#FEF4E7] px-2 py-0.5 text-xs font-semibold text-[#B45309]">
+          {t("newsPollNeedsAnswer")}
+        </span>
+      )}
       {poll && item.response_deadline && !isPollClosed(item) && (
         <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-700">
           {t("newsPollDeadline", { date: formatDate(item.response_deadline) })}
@@ -113,26 +118,26 @@ function NewsBadges({
 
 /**
  * The answer control of an Umfrage: one row per child the poll reaches, each
- * with the options as toggle buttons (#1371).
+ * with the options as toggle buttons plus an explicit save (#1371).
  *
- * It lives directly on the feed card, not only behind the detail modal: an
- * answer that costs one tap gets given, an answer that costs three taps does
- * not — and the school needs the number.
+ * Selecting is local; nothing is sent until the guardian saves. A tap that
+ * writes straight through reads as a slip waiting to happen — the answer is a
+ * commitment the school plans with, so it gets a deliberate confirmation.
+ *
+ * It lives in the detail view, where the guardian has the full question in
+ * front of them rather than a two-line preview in a list.
  */
 function PollAnswerBlock({
   item,
   onUpdated,
   onStale,
-  compact = false,
 }: Readonly<{
   item: ParentAnnouncement;
   onUpdated: (id: string, patch: Partial<ParentAnnouncement>) => void;
   onStale?: (id: string) => void;
-  /** Card variant: tighter spacing, no heading. */
-  compact?: boolean;
 }>) {
   const t = useTranslations("parentDashboard");
-  const [busyChild, setBusyChild] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const children = item.children ?? [];
@@ -140,61 +145,93 @@ function PollAnswerBlock({
   const closed = isPollClosed(item);
   const multi = item.response_type === "multi_choice";
 
-  const submit = async (
-    child: ParentAnnouncementPollChild,
-    optionId: string,
-  ) => {
-    if (closed || !item.published_at) return;
-    const selected = child.selected_options;
+  // What is selected on screen, per child. Seeded from the saved answers and
+  // reset whenever those change (a refetch, or our own save landing).
+  const savedSignature = children
+    .map((c) => `${c.student_id}:${[...c.selected_options].sort().join(",")}`)
+    .join("|");
+  const [draft, setDraft] = useState<Record<string, string[]>>(() =>
+    Object.fromEntries(
+      children.map((c) => [c.student_id, [...c.selected_options]]),
+    ),
+  );
+  useEffect(() => {
+    setDraft(
+      Object.fromEntries(
+        children.map((c) => [c.student_id, [...c.selected_options]]),
+      ),
+    );
+    setError(null);
+    // children is derived from item; savedSignature captures the values that
+    // matter, so it is the dependency rather than a new array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedSignature]);
+
+  const selectionFor = (child: ParentAnnouncementPollChild): string[] =>
+    draft[child.student_id] ?? [];
+
+  const toggle = (child: ParentAnnouncementPollChild, optionId: string) => {
+    if (closed) return;
+    const selected = selectionFor(child);
     const next = multi
       ? selected.includes(optionId)
         ? selected.filter((id) => id !== optionId)
         : [...selected, optionId]
       : selected.includes(optionId)
-        ? [] // tapping the chosen option again withdraws the answer
+        ? [] // tapping the chosen option again clears it
         : [optionId];
+    setDraft((prev) => ({ ...prev, [child.student_id]: next }));
+  };
 
-    setBusyChild(child.student_id);
+  const isDirty = (child: ParentAnnouncementPollChild): boolean => {
+    const saved = [...child.selected_options].sort().join(",");
+    const current = [...selectionFor(child)].sort().join(",");
+    return saved !== current;
+  };
+  const dirtyChildren = children.filter(isDirty);
+
+  const save = async () => {
+    if (!item.published_at || dirtyChildren.length === 0) return;
+    setSaving(true);
     setError(null);
-    // Optimistic: the button state flips immediately and is reverted below if
-    // the write fails, so a slow connection never feels like a dead tap.
-    const previous = children;
-    onUpdated(item.id, {
-      children: children.map((c) =>
-        c.student_id === child.student_id
-          ? { ...c, selected_options: next }
-          : c,
-      ),
-    });
     try {
-      await respondToAnnouncement(
-        item.id,
-        child.student_id,
-        next,
-        item.published_at,
-      );
+      for (const child of dirtyChildren) {
+        await respondToAnnouncement(
+          item.id,
+          child.student_id,
+          selectionFor(child),
+          item.published_at,
+        );
+      }
+      onUpdated(item.id, {
+        children: children.map((c) => ({
+          ...c,
+          selected_options: selectionFor(c),
+        })),
+      });
       refreshUnreadBadge();
     } catch (err: unknown) {
       logger.error("parent_news_poll_answer_failed", {
         error: err instanceof Error ? err.message : String(err),
       });
-      onUpdated(item.id, { children: previous });
       if (isStaleAnnouncementError(err)) {
         onStale?.(item.id);
       }
       setError(t("newsActionError"));
     } finally {
-      setBusyChild(null);
+      setSaving(false);
     }
   };
 
   if (children.length === 0 || options.length === 0) return null;
 
   return (
-    <div className={compact ? "space-y-2" : "space-y-3"}>
+    <div className="space-y-3">
       {multi && <p className="text-xs text-gray-500">{t("newsPollMulti")}</p>}
       {children.map((child) => {
+        const selected = selectionFor(child);
         const answered = child.selected_options.length > 0;
+        const dirty = isDirty(child);
         return (
           <div key={child.student_id}>
             <div className="flex items-center justify-between gap-2">
@@ -206,21 +243,31 @@ function PollAnswerBlock({
                 </span>
               )}
               <span
-                className={`ml-auto text-xs ${answered ? "text-[#4d7719]" : "text-gray-500"}`}
+                className={`ml-auto text-xs ${
+                  dirty
+                    ? "text-[#B45309]"
+                    : answered
+                      ? "text-[#4d7719]"
+                      : "text-gray-500"
+                }`}
               >
-                {answered ? t("newsPollAnswered") : t("newsPollOpen")}
+                {dirty
+                  ? t("newsPollUnsaved")
+                  : answered
+                    ? t("newsPollAnswered")
+                    : t("newsPollOpen")}
               </span>
             </div>
             <div className="mt-1.5 flex flex-wrap gap-2">
               {options.map((option) => {
-                const active = child.selected_options.includes(option.id);
+                const active = selected.includes(option.id);
                 return (
                   <button
                     key={option.id}
                     type="button"
-                    disabled={closed || busyChild === child.student_id}
+                    disabled={closed || saving}
                     aria-pressed={active}
-                    onClick={() => void submit(child, option.id)}
+                    onClick={() => toggle(child, option.id)}
                     className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-60 ${
                       active
                         ? "bg-[#83CD2D] text-white"
@@ -235,6 +282,18 @@ function PollAnswerBlock({
           </div>
         );
       })}
+
+      {!closed && (
+        <button
+          type="button"
+          disabled={dirtyChildren.length === 0 || saving}
+          onClick={() => void save()}
+          className="inline-flex h-9 items-center justify-center rounded-lg bg-gray-900 px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {saving ? t("newsPollSaving") : t("newsPollSave")}
+        </button>
+      )}
+
       {error && (
         <p
           role="alert"
@@ -247,21 +306,28 @@ function PollAnswerBlock({
   );
 }
 
-/** Compact feed card: badges, title, school + date, two preview lines. */
+/**
+ * Compact feed card: badges, title, school + date, two preview lines.
+ *
+ * A poll is NOT answered here — the card only flags that an answer is due and
+ * opens the detail view. Answering in a list, next to four other items, is how
+ * you tap the wrong card; the detail view shows the full question first.
+ */
 export function NewsCard({
   item,
   onOpen,
-  onUpdated,
-  onStale,
 }: Readonly<{
   item: ParentAnnouncement;
   onOpen: (item: ParentAnnouncement) => void;
-  /** Required for polls: answering happens inline on the card. */
-  onUpdated?: (id: string, patch: Partial<ParentAnnouncement>) => void;
-  onStale?: (id: string) => void;
 }>) {
-  const summary = (
-    <>
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(item)}
+      className={`flex w-full items-center gap-3 rounded-xl border bg-white p-4 text-left shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 ${
+        item.read ? "border-gray-200" : "border-gray-300"
+      }`}
+    >
       <span className="min-w-0 flex-1">
         <span className="flex flex-wrap items-center gap-2">
           <NewsBadges item={item} />
@@ -281,44 +347,6 @@ export function NewsCard({
         className="h-5 w-5 shrink-0 text-gray-400"
         aria-hidden="true"
       />
-    </>
-  );
-
-  const borderClass = item.read ? "border-gray-200" : "border-gray-300";
-
-  // A poll card cannot be one big <button>: the answer buttons would nest
-  // inside it. So the summary stays a button and the answers sit beside it.
-  if (isPoll(item) && onUpdated) {
-    return (
-      <div
-        className={`rounded-xl border bg-white p-4 shadow-sm ${borderClass}`}
-      >
-        <button
-          type="button"
-          onClick={() => onOpen(item)}
-          className="flex w-full items-center gap-3 text-left"
-        >
-          {summary}
-        </button>
-        <div className="mt-3 border-t border-gray-100 pt-3">
-          <PollAnswerBlock
-            item={item}
-            onUpdated={onUpdated}
-            onStale={onStale}
-            compact
-          />
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={() => onOpen(item)}
-      className={`flex w-full items-center gap-3 rounded-xl border bg-white p-4 text-left shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 ${borderClass}`}
-    >
-      {summary}
     </button>
   );
 }

--- a/frontend/src/components/parent/parent-dashboard.tsx
+++ b/frontend/src/components/parent/parent-dashboard.tsx
@@ -17,6 +17,7 @@ import {
 import {
   NewsCard,
   NewsDetailModal,
+  isOpenPoll,
 } from "~/components/parent/news/news-components";
 import { NotificationPreferencesSection } from "~/components/settings/notification-preferences-section";
 import { PushNotificationSection } from "~/components/settings/push-notification-section";
@@ -383,7 +384,12 @@ function StartNewsPanel() {
       });
   }, []);
 
-  const visible = items.slice(0, NEWS_PANEL_LIMIT);
+  // Open surveys first: the dashboard panel only shows a handful of items, and
+  // a survey that scrolled out of the panel is a survey nobody answers (#1371).
+  // Within each group the server order (newest published first) is preserved.
+  const visible = [...items]
+    .sort((a, b) => Number(isOpenPoll(b)) - Number(isOpenPoll(a)))
+    .slice(0, NEWS_PANEL_LIMIT);
   const openItem = items.find((item) => item.id === openId) ?? null;
 
   if (!newsEnabled) return null;
@@ -423,6 +429,8 @@ function StartNewsPanel() {
                 <NewsCard
                   item={item}
                   onOpen={(opened) => setOpenId(opened.id)}
+                  onUpdated={applyState}
+                  onStale={refetchOnStale}
                 />
               </li>
             ))}

--- a/frontend/src/components/parent/parent-dashboard.tsx
+++ b/frontend/src/components/parent/parent-dashboard.tsx
@@ -429,8 +429,6 @@ function StartNewsPanel() {
                 <NewsCard
                   item={item}
                   onOpen={(opened) => setOpenId(opened.id)}
-                  onUpdated={applyState}
-                  onStale={refetchOnStale}
                 />
               </li>
             ))}

--- a/frontend/src/i18n/messages/de.json
+++ b/frontend/src/i18n/messages/de.json
@@ -128,6 +128,7 @@
     "newsPollSaving": "Wird gespeichert …",
     "newsPollUnsaved": "Noch nicht gespeichert",
     "newsPollNeedsAnswer": "Antwort erforderlich",
+    "newsClose": "Schließen",
     "newEnrollment": "Neue Anmeldung"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/de.json
+++ b/frontend/src/i18n/messages/de.json
@@ -124,6 +124,10 @@
     "newsPollMulti": "Mehrfachauswahl möglich",
     "newsPollOpen": "Antwort offen",
     "newsPollAnswered": "Antwort gespeichert",
+    "newsPollSave": "Antwort speichern",
+    "newsPollSaving": "Wird gespeichert …",
+    "newsPollUnsaved": "Noch nicht gespeichert",
+    "newsPollNeedsAnswer": "Antwort erforderlich",
     "newEnrollment": "Neue Anmeldung"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/de.json
+++ b/frontend/src/i18n/messages/de.json
@@ -118,6 +118,12 @@
     "newsRead": "Gelesen",
     "newsActionError": "Aktion fehlgeschlagen. Bitte erneut versuchen.",
     "newsStaleError": "Diese Mitteilung ist nicht mehr aktuell. Bitte laden Sie die Seite neu.",
+    "newsPoll": "Umfrage",
+    "newsPollDeadline": "Antwort bis {date}",
+    "newsPollClosed": "Umfrage geschlossen",
+    "newsPollMulti": "Mehrfachauswahl möglich",
+    "newsPollOpen": "Antwort offen",
+    "newsPollAnswered": "Antwort gespeichert",
     "newEnrollment": "Neue Anmeldung"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -118,6 +118,12 @@
     "newsRead": "Read",
     "newsActionError": "Action failed. Please try again.",
     "newsStaleError": "This announcement is no longer current. Please reload the page.",
+    "newsPoll": "Survey",
+    "newsPollDeadline": "Reply by {date}",
+    "newsPollClosed": "Survey closed",
+    "newsPollMulti": "Multiple answers possible",
+    "newsPollOpen": "Answer pending",
+    "newsPollAnswered": "Answer saved",
     "newEnrollment": "New enrollment"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -124,6 +124,10 @@
     "newsPollMulti": "Multiple answers possible",
     "newsPollOpen": "Answer pending",
     "newsPollAnswered": "Answer saved",
+    "newsPollSave": "Save answer",
+    "newsPollSaving": "Saving …",
+    "newsPollUnsaved": "Not saved yet",
+    "newsPollNeedsAnswer": "Answer required",
     "newEnrollment": "New enrollment"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -128,6 +128,7 @@
     "newsPollSaving": "Saving …",
     "newsPollUnsaved": "Not saved yet",
     "newsPollNeedsAnswer": "Answer required",
+    "newsClose": "Close",
     "newEnrollment": "New enrollment"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/ru.json
+++ b/frontend/src/i18n/messages/ru.json
@@ -118,6 +118,12 @@
     "newsRead": "Прочитано",
     "newsActionError": "Не удалось выполнить действие. Повторите попытку.",
     "newsStaleError": "Это объявление больше не актуально. Пожалуйста, обновите страницу.",
+    "newsPoll": "Опрос",
+    "newsPollDeadline": "Ответ до {date}",
+    "newsPollClosed": "Опрос завершён",
+    "newsPollMulti": "Можно выбрать несколько вариантов",
+    "newsPollOpen": "Ответ не дан",
+    "newsPollAnswered": "Ответ сохранён",
     "newEnrollment": "Новая заявка"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/ru.json
+++ b/frontend/src/i18n/messages/ru.json
@@ -128,6 +128,7 @@
     "newsPollSaving": "Сохранение …",
     "newsPollUnsaved": "Ещё не сохранено",
     "newsPollNeedsAnswer": "Требуется ответ",
+    "newsClose": "Закрыть",
     "newEnrollment": "Новая заявка"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/ru.json
+++ b/frontend/src/i18n/messages/ru.json
@@ -124,6 +124,10 @@
     "newsPollMulti": "Можно выбрать несколько вариантов",
     "newsPollOpen": "Ответ не дан",
     "newsPollAnswered": "Ответ сохранён",
+    "newsPollSave": "Сохранить ответ",
+    "newsPollSaving": "Сохранение …",
+    "newsPollUnsaved": "Ещё не сохранено",
+    "newsPollNeedsAnswer": "Требуется ответ",
     "newEnrollment": "Новая заявка"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/sq.json
+++ b/frontend/src/i18n/messages/sq.json
@@ -124,6 +124,10 @@
     "newsPollMulti": "Mund të zgjidhni disa përgjigje",
     "newsPollOpen": "Përgjigje në pritje",
     "newsPollAnswered": "Përgjigja u ruajt",
+    "newsPollSave": "Ruaj përgjigjen",
+    "newsPollSaving": "Po ruhet …",
+    "newsPollUnsaved": "Ende e paruajtur",
+    "newsPollNeedsAnswer": "Kërkohet përgjigje",
     "newEnrollment": "Regjistrim i ri"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/sq.json
+++ b/frontend/src/i18n/messages/sq.json
@@ -118,6 +118,12 @@
     "newsRead": "Lexuar",
     "newsActionError": "Veprimi dështoi. Provoni përsëri.",
     "newsStaleError": "Ky njoftim nuk është më aktual. Ju lutemi, ringarkoni faqen.",
+    "newsPoll": "Sondazh",
+    "newsPollDeadline": "Përgjigjuni deri më {date}",
+    "newsPollClosed": "Sondazhi është mbyllur",
+    "newsPollMulti": "Mund të zgjidhni disa përgjigje",
+    "newsPollOpen": "Përgjigje në pritje",
+    "newsPollAnswered": "Përgjigja u ruajt",
     "newEnrollment": "Regjistrim i ri"
   },
   "parentEnroll": {

--- a/frontend/src/i18n/messages/sq.json
+++ b/frontend/src/i18n/messages/sq.json
@@ -128,6 +128,7 @@
     "newsPollSaving": "Po ruhet …",
     "newsPollUnsaved": "Ende e paruajtur",
     "newsPollNeedsAnswer": "Kërkohet përgjigje",
+    "newsClose": "Mbyll",
     "newEnrollment": "Regjistrim i ri"
   },
   "parentEnroll": {

--- a/frontend/src/lib/date-helpers.test.ts
+++ b/frontend/src/lib/date-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   isValidISODate,
   todayISO,
   berlinTodayISO,
+  endOfBerlinDayISO,
   formatChatTime,
   formatChatDateTime,
 } from "./date-helpers";
@@ -93,6 +94,20 @@ describe("berlinTodayISO", () => {
       day: "2-digit",
     }).format(new Date()); // en-CA formats as YYYY-MM-DD
     expect(berlinTodayISO()).toBe(expected);
+  });
+});
+
+describe("endOfBerlinDayISO", () => {
+  it("uses the CEST end of day for a selected summer date", () => {
+    expect(endOfBerlinDayISO(new Date(2026, 6, 20))).toBe(
+      "2026-07-20T21:59:59.000Z",
+    );
+  });
+
+  it("uses the CET end of day for a selected winter date", () => {
+    expect(endOfBerlinDayISO(new Date(2026, 0, 20))).toBe(
+      "2026-01-20T22:59:59.000Z",
+    );
   });
 });
 

--- a/frontend/src/lib/date-helpers.test.ts
+++ b/frontend/src/lib/date-helpers.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
+  berlinDayFromISO,
   groupByDate,
   formatDate,
   formatTime,
@@ -108,6 +109,52 @@ describe("endOfBerlinDayISO", () => {
     expect(endOfBerlinDayISO(new Date(2026, 0, 20))).toBe(
       "2026-01-20T22:59:59.000Z",
     );
+  });
+});
+
+describe("berlinDayFromISO", () => {
+  // The tests below run in a browser timezone east of Berlin, where a Berlin
+  // end-of-day instant already falls on the next local calendar day.
+  const withTimezone = (tz: string, run: () => void) => {
+    const previous = process.env.TZ;
+    process.env.TZ = tz;
+    try {
+      run();
+    } finally {
+      process.env.TZ = previous;
+    }
+  };
+
+  afterEach(() => {
+    expect(process.env.TZ).toBe("Europe/Berlin");
+  });
+
+  it("keeps the Berlin day of a summer cut-off east of Berlin", () => {
+    withTimezone("Europe/Moscow", () => {
+      // 23:59:59 CEST on 20.07. — 02:59 the next morning in Moscow
+      const day = berlinDayFromISO("2026-07-20T21:59:59.000Z");
+      expect(toISODate(day!)).toBe("2026-07-20");
+    });
+  });
+
+  it("keeps the Berlin day of a winter cut-off east of Berlin", () => {
+    withTimezone("Europe/Kyiv", () => {
+      // 23:59:59 CET on 20.01. — 00:59 the next morning in Kyiv
+      const day = berlinDayFromISO("2026-01-20T22:59:59.000Z");
+      expect(toISODate(day!)).toBe("2026-01-20");
+    });
+  });
+
+  it("round-trips through endOfBerlinDayISO without moving the day", () => {
+    // Reopening an unchanged draft and saving it must not extend the cut-off.
+    withTimezone("Asia/Tokyo", () => {
+      const stored = "2026-07-20T21:59:59.000Z";
+      expect(endOfBerlinDayISO(berlinDayFromISO(stored)!)).toBe(stored);
+    });
+  });
+
+  it("returns null for an unparseable value", () => {
+    expect(berlinDayFromISO("nicht-datum")).toBeNull();
   });
 });
 

--- a/frontend/src/lib/date-helpers.test.ts
+++ b/frontend/src/lib/date-helpers.test.ts
@@ -15,6 +15,7 @@ import {
   endOfBerlinDayISO,
   formatChatTime,
   formatChatDateTime,
+  formatBerlinDate,
 } from "./date-helpers";
 
 describe("toISODate", () => {
@@ -155,6 +156,47 @@ describe("berlinDayFromISO", () => {
 
   it("returns null for an unparseable value", () => {
     expect(berlinDayFromISO("nicht-datum")).toBeNull();
+  });
+});
+
+describe("formatBerlinDate", () => {
+  // A cut-off written by endOfBerlinDayISO is 23:59:59 Berlin. East of Berlin
+  // that instant already belongs to the next LOCAL day, so rendering it in the
+  // viewer's timezone would advertise a deadline that has in fact passed.
+  const withTimezone = (tz: string, run: () => void) => {
+    const previous = process.env.TZ;
+    process.env.TZ = tz;
+    try {
+      run();
+    } finally {
+      process.env.TZ = previous;
+    }
+  };
+
+  afterEach(() => {
+    expect(process.env.TZ).toBe("Europe/Berlin");
+  });
+
+  it("keeps the Berlin day of a summer cut-off east of Berlin", () => {
+    withTimezone("Europe/Moscow", () => {
+      expect(formatBerlinDate("2026-07-20T21:59:59.000Z")).toBe("20.07.2026");
+    });
+  });
+
+  it("keeps the Berlin day of a winter cut-off east of Berlin", () => {
+    withTimezone("Asia/Tokyo", () => {
+      expect(formatBerlinDate("2026-01-20T22:59:59.000Z")).toBe("20.01.2026");
+    });
+  });
+
+  it("keeps the Berlin day west of Berlin", () => {
+    withTimezone("America/Los_Angeles", () => {
+      expect(formatBerlinDate("2026-07-20T21:59:59.000Z")).toBe("20.07.2026");
+    });
+  });
+
+  it("falls back to the raw input for an unparseable value", () => {
+    expect(formatBerlinDate("nicht-datum")).toBe("nicht-datum");
   });
 });
 

--- a/frontend/src/lib/date-helpers.ts
+++ b/frontend/src/lib/date-helpers.ts
@@ -100,6 +100,25 @@ export function berlinTodayISO(at: Date = new Date()): string {
 }
 
 /**
+ * The Berlin calendar day an instant falls on, as a Date at LOCAL midnight —
+ * the shape the date pickers render and `endOfBerlinDayISO` reads back.
+ *
+ * Use this to seed a date picker from a cut-off written by
+ * `endOfBerlinDayISO`. Loading it with a plain `new Date(iso)` shows the
+ * FOLLOWING day in any browser east of Berlin (23:59 Berlin is already past
+ * midnight there), so saving an otherwise untouched form would silently push
+ * the date one day out.
+ *
+ * Returns null for an unparseable value so a malformed timestamp renders as
+ * "no date" instead of throwing inside the picker.
+ */
+export function berlinDayFromISO(value: string): Date | null {
+  const instant = new Date(value);
+  if (Number.isNaN(instant.getTime())) return null;
+  return parseISODate(berlinTodayISO(instant));
+}
+
+/**
  * Serializes the selected calendar day as 23:59:59 in the school's
  * Europe/Berlin timezone. The Date carries calendar fields from the date
  * picker, so those fields deliberately remain local to the person selecting

--- a/frontend/src/lib/date-helpers.ts
+++ b/frontend/src/lib/date-helpers.ts
@@ -29,7 +29,7 @@ const CHAT_DAY_MONTH_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   timeZone: "Europe/Berlin",
 });
 
-const CHAT_DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+const BERLIN_DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   day: "2-digit",
   month: "2-digit",
   year: "numeric",
@@ -209,6 +209,26 @@ export function formatDate(dateString: string, includeWeekday = false): string {
 }
 
 /**
+ * Format an instant as the German calendar date of the school's timezone
+ * ("20.07.2026"), regardless of where the viewer sits.
+ *
+ * Use this — not `formatDate` — for a cut-off that was written with
+ * `endOfBerlinDayISO` (Antwortfrist, Ablaufdatum). Such a value is a calendar
+ * day carried as 23:59:59 Berlin; rendering it in the viewer's local timezone
+ * shows the FOLLOWING day east of Berlin, so a guardian in Moscow would read a
+ * deadline that has in fact already passed. Plain instants (published_at,
+ * created_at) keep using `formatDate`.
+ *
+ * Falls back to the raw input for an unparseable value, matching the chat
+ * formatters — a malformed timestamp must not blank the surrounding line.
+ */
+export function formatBerlinDate(dateString: string): string {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return dateString;
+  return BERLIN_DATE_FORMATTER.format(date);
+}
+
+/**
  * Format a time string to German locale format
  * @param dateString ISO date string
  * @returns Formatted time string (e.g., "14:30")
@@ -246,7 +266,7 @@ export function formatChatDateTime(iso: string | undefined): string {
   if (!iso) return "";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  return `${CHAT_DATE_FORMATTER.format(date)}, ${CHAT_TIME_FORMATTER.format(date)}`;
+  return `${BERLIN_DATE_FORMATTER.format(date)}, ${CHAT_TIME_FORMATTER.format(date)}`;
 }
 
 /**

--- a/frontend/src/lib/date-helpers.ts
+++ b/frontend/src/lib/date-helpers.ts
@@ -12,6 +12,17 @@ const BERLIN_DATE_PARTS_FORMATTER = new Intl.DateTimeFormat("en-US", {
   day: "2-digit",
 });
 
+const BERLIN_DATE_TIME_PARTS_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  timeZone: "Europe/Berlin",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
+
 const CHAT_DAY_MONTH_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   day: "2-digit",
   month: "2-digit",
@@ -86,6 +97,31 @@ export function berlinTodayISO(at: Date = new Date()): string {
   const parts = BERLIN_DATE_PARTS_FORMATTER.formatToParts(at);
   const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
   return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+/**
+ * Serializes the selected calendar day as 23:59:59 in the school's
+ * Europe/Berlin timezone. The Date carries calendar fields from the date
+ * picker, so those fields deliberately remain local to the person selecting
+ * the day; only the resulting deadline instant is pinned to Berlin.
+ */
+export function endOfBerlinDayISO(date: Date): string {
+  const nominalUtc = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59),
+  );
+  const parts = BERLIN_DATE_TIME_PARTS_FORMATTER.formatToParts(nominalUtc);
+  const get = (type: string) =>
+    Number(parts.find((part) => part.type === type)?.value ?? "0");
+  const berlinWallClockAsUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
+  const berlinOffsetMs = berlinWallClockAsUtc - nominalUtc.getTime();
+  return new Date(nominalUtc.getTime() - berlinOffsetMs).toISOString();
 }
 
 /**

--- a/frontend/src/lib/parent-announcements-api.test.ts
+++ b/frontend/src/lib/parent-announcements-api.test.ts
@@ -342,6 +342,7 @@ describe("poll endpoints", () => {
   it("fetches the tally and falls back to empty results", async () => {
     const expected = {
       child_count: 12,
+      target_child_count: 14,
       answered_count: 5,
       options: [{ option_id: "1", label: "Ja", count: 4 }],
     };
@@ -357,6 +358,7 @@ describe("poll endpoints", () => {
     mockFetch(async () => jsonResponse({}));
     await expect(fetchPollResults("7")).resolves.toStrictEqual({
       child_count: 0,
+      target_child_count: 0,
       answered_count: 0,
       options: [],
     });

--- a/frontend/src/lib/parent-announcements-api.test.ts
+++ b/frontend/src/lib/parent-announcements-api.test.ts
@@ -6,7 +6,11 @@ import {
   fetchAnnouncementRecipients,
   fetchAnnouncementStats,
   fetchAnnouncements,
+  fetchPollChildren,
+  fetchPollResults,
+  isPoll,
   publishAnnouncement,
+  remindUnanswered,
   unpublishAnnouncement,
   updateAnnouncement,
   type Announcement,
@@ -28,6 +32,10 @@ function announcement(overrides: Partial<Announcement> = {}): Announcement {
     created_at: "2026-07-01T08:00:00Z",
     updated_at: "2026-07-01T08:00:00Z",
     targets: [{ target_type: "school_all" }],
+    // A plain Mitteilung: the backend always sends these two, polls override
+    // them (#1371).
+    response_type: "none",
+    options: [],
     ...overrides,
   };
 }
@@ -290,6 +298,109 @@ describe("error handling", () => {
     mockFetch(async () => jsonResponse({ message: "nope" }, { status: 500 }));
     await expect(fetchAnnouncementStats("7")).rejects.toThrow(
       "Statistik konnte nicht geladen werden",
+    );
+  });
+});
+
+// --- Umfragen (#1371) -------------------------------------------------------
+
+describe("poll endpoints", () => {
+  it("creates a poll with its options and deadline", async () => {
+    let seenBody: unknown;
+    mockFetch(async (_input, init) => {
+      seenBody = JSON.parse(String(init?.body));
+      return jsonResponse({
+        data: announcement({
+          response_type: "single_choice",
+          options: [
+            { id: "1", label: "Ja" },
+            { id: "2", label: "Nein" },
+          ],
+        }),
+      });
+    });
+
+    const created = await createAnnouncement({
+      ...validInput,
+      response_type: "single_choice",
+      response_deadline: "2026-07-20T21:59:59Z",
+      options: ["Ja", "Nein"],
+    });
+
+    expect(seenBody).toMatchObject({
+      response_type: "single_choice",
+      response_deadline: "2026-07-20T21:59:59Z",
+      options: ["Ja", "Nein"],
+    });
+    expect(isPoll(created)).toBe(true);
+  });
+
+  it("treats an announcement without a response type as a plain Mitteilung", () => {
+    expect(isPoll(announcement())).toBe(false);
+  });
+
+  it("fetches the tally and falls back to empty results", async () => {
+    const expected = {
+      child_count: 12,
+      answered_count: 5,
+      options: [{ option_id: "1", label: "Ja", count: 4 }],
+    };
+    let seenURL = "";
+    mockFetch(async (input) => {
+      seenURL = typeof input === "string" ? input : input.toString();
+      return jsonResponse({ data: expected });
+    });
+
+    await expect(fetchPollResults("7")).resolves.toStrictEqual(expected);
+    expect(seenURL).toBe("/api/parent-announcements/7/poll-results");
+
+    mockFetch(async () => jsonResponse({}));
+    await expect(fetchPollResults("7")).resolves.toStrictEqual({
+      child_count: 0,
+      answered_count: 0,
+      options: [],
+    });
+  });
+
+  it("fetches the per-child answer list", async () => {
+    const expected = [
+      {
+        student_id: "10",
+        first_name: "Felix",
+        last_name: "Schneider",
+        school_class: "1a",
+        answer_labels: ["Ja"],
+        responded_at: "2026-07-02T10:00:00Z",
+      },
+    ];
+    let seenURL = "";
+    mockFetch(async (input) => {
+      seenURL = typeof input === "string" ? input : input.toString();
+      return jsonResponse({ data: expected });
+    });
+
+    await expect(fetchPollChildren("7")).resolves.toStrictEqual(expected);
+    expect(seenURL).toBe("/api/parent-announcements/7/poll-children");
+  });
+
+  it("POSTs the reminder and returns how many guardians it reached", async () => {
+    let seenURL = "";
+    let seenMethod: string | undefined;
+    mockFetch(async (input, init) => {
+      seenURL = typeof input === "string" ? input : input.toString();
+      seenMethod = init?.method;
+      return jsonResponse({ data: { reminded_count: 8 } });
+    });
+
+    await expect(remindUnanswered("7")).resolves.toBe(8);
+    expect(seenURL).toBe("/api/parent-announcements/7/remind");
+    expect(seenMethod).toBe("POST");
+  });
+
+  it("surfaces the German fallback when the reminder fails", async () => {
+    mockFetch(async () => jsonResponse({}, { status: 409 }));
+    await expect(remindUnanswered("7")).rejects.toThrow(
+      "Erinnerung konnte nicht gesendet werden",
     );
   });
 });

--- a/frontend/src/lib/parent-announcements-api.ts
+++ b/frontend/src/lib/parent-announcements-api.ts
@@ -22,6 +22,18 @@ export interface AnnouncementTarget {
   ref_text?: string;
 }
 
+/**
+ * "none" is a plain Mitteilung; the two choice types make it an Umfrage that
+ * parents answer per child (#1371).
+ */
+export type AnnouncementResponseType =
+  "none" | "single_choice" | "multi_choice";
+
+export interface AnnouncementOption {
+  id: string;
+  label: string;
+}
+
 export interface Announcement {
   id: string;
   title: string;
@@ -37,6 +49,37 @@ export interface Announcement {
   created_at: string;
   updated_at: string;
   targets: AnnouncementTarget[];
+  response_type: AnnouncementResponseType;
+  response_deadline?: string;
+  options: AnnouncementOption[];
+}
+
+/** True when the announcement asks the parents a question. */
+export function isPoll(announcement: Announcement): boolean {
+  return announcement.response_type !== "none";
+}
+
+/** One option's tally: how many reached children picked it. */
+export interface PollOptionResult {
+  option_id: string;
+  label: string;
+  count: number;
+}
+
+export interface PollResults {
+  child_count: number;
+  answered_count: number;
+  options: PollOptionResult[];
+}
+
+/** One reached child with the answer given for them (empty = still open). */
+export interface PollChild {
+  student_id: string;
+  first_name: string;
+  last_name: string;
+  school_class: string;
+  answer_labels: string[];
+  responded_at?: string;
 }
 
 export interface AnnouncementStats {
@@ -66,6 +109,11 @@ export interface AnnouncementInput {
   send_email: boolean;
   expires_at?: string | null;
   targets: AnnouncementTarget[];
+  /** Omit or "none" for a plain Mitteilung; a choice type requires options. */
+  response_type?: AnnouncementResponseType;
+  response_deadline?: string | null;
+  /** Answer labels in display order — the backend assigns the option ids. */
+  options?: string[];
 }
 
 interface ApiResponse<T> {
@@ -194,6 +242,41 @@ export async function fetchAnnouncementStats(
     "Statistik konnte nicht geladen werden",
   );
   return data ?? { target_count: 0, read_count: 0, acknowledged_count: 0 };
+}
+
+export async function fetchPollResults(id: string): Promise<PollResults> {
+  const data = await request<PollResults>(
+    `${BASE}/${encodeURIComponent(id)}/poll-results`,
+    undefined,
+    "Umfrageergebnis konnte nicht geladen werden",
+  );
+  return data ?? { child_count: 0, answered_count: 0, options: [] };
+}
+
+export async function fetchPollChildren(id: string): Promise<PollChild[]> {
+  const data = await request<PollChild[]>(
+    `${BASE}/${encodeURIComponent(id)}/poll-children`,
+    undefined,
+    "Antwortliste konnte nicht geladen werden",
+  );
+  return data ?? [];
+}
+
+/**
+ * Notifies the guardians of children without an answer. Returns how many people
+ * were reached so the UI can say "8 Eltern erinnert" instead of a silent OK.
+ */
+export async function remindUnanswered(id: string): Promise<number> {
+  const data = await request<{ reminded_count: number }>(
+    `${BASE}/${encodeURIComponent(id)}/remind`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    },
+    "Erinnerung konnte nicht gesendet werden",
+  );
+  return data?.reminded_count ?? 0;
 }
 
 export async function fetchAnnouncementRecipients(

--- a/frontend/src/lib/parent-announcements-api.ts
+++ b/frontend/src/lib/parent-announcements-api.ts
@@ -68,6 +68,7 @@ interface PollOptionResult {
 
 export interface PollResults {
   child_count: number;
+  target_child_count: number;
   answered_count: number;
   options: PollOptionResult[];
 }
@@ -80,6 +81,7 @@ export interface PollChild {
   school_class: string;
   answer_labels: string[];
   responded_at?: string;
+  can_answer: boolean;
 }
 
 export interface AnnouncementStats {
@@ -250,7 +252,14 @@ export async function fetchPollResults(id: string): Promise<PollResults> {
     undefined,
     "Umfrageergebnis konnte nicht geladen werden",
   );
-  return data ?? { child_count: 0, answered_count: 0, options: [] };
+  return (
+    data ?? {
+      child_count: 0,
+      target_child_count: 0,
+      answered_count: 0,
+      options: [],
+    }
+  );
 }
 
 export async function fetchPollChildren(id: string): Promise<PollChild[]> {

--- a/frontend/src/lib/parent-announcements-api.ts
+++ b/frontend/src/lib/parent-announcements-api.ts
@@ -29,7 +29,7 @@ export interface AnnouncementTarget {
 export type AnnouncementResponseType =
   "none" | "single_choice" | "multi_choice";
 
-export interface AnnouncementOption {
+interface AnnouncementOption {
   id: string;
   label: string;
 }
@@ -60,7 +60,7 @@ export function isPoll(announcement: Announcement): boolean {
 }
 
 /** One option's tally: how many reached children picked it. */
-export interface PollOptionResult {
+interface PollOptionResult {
   option_id: string;
   label: string;
   count: number;

--- a/frontend/src/lib/parent-api.test.ts
+++ b/frontend/src/lib/parent-api.test.ts
@@ -1014,6 +1014,8 @@ function mkAnnouncement(
     published_at: "2026-07-01T08:00:00Z",
     read: false,
     acknowledged: false,
+    // A plain Mitteilung; the Umfrage tests override this (#1371).
+    response_type: "none",
     ...overrides,
   };
 }

--- a/frontend/src/lib/parent-api.ts
+++ b/frontend/src/lib/parent-api.ts
@@ -671,6 +671,27 @@ export interface ParentAnnouncement {
   readonly expires_at?: string; // ISO timestamp
   readonly read: boolean;
   readonly acknowledged: boolean;
+
+  // Umfrage fields (#1371). "none" is a plain Mitteilung; a choice type comes
+  // with the answer options and the guardian's own children this poll reaches
+  // (one answer row per child).
+  readonly response_type: "none" | "single_choice" | "multi_choice";
+  readonly response_deadline?: string; // ISO timestamp
+  readonly options?: readonly ParentAnnouncementOption[];
+  readonly children?: readonly ParentAnnouncementPollChild[];
+}
+
+export interface ParentAnnouncementOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+/** One of the guardian's children, with the options selected for that child. */
+export interface ParentAnnouncementPollChild {
+  readonly student_id: string;
+  readonly first_name: string;
+  readonly last_name: string;
+  readonly selected_options: readonly string[];
 }
 
 // A child's full conversation (messages oldest-first). `thread_id` is empty
@@ -763,6 +784,28 @@ export async function acknowledgeAnnouncement(
   await postJson<{ acknowledged: boolean }>(
     `/api/parent/me/news/${encodeURIComponent(announcementId)}/acknowledge`,
     { published_at: publishedAt },
+  );
+}
+
+/**
+ * Records the guardian's answer to an Umfrage for ONE child (#1371).
+ * `optionIds` replaces whatever was selected for that child; an empty array
+ * withdraws the answer. Same `publishedAt` version guard as the read/ack calls,
+ * plus the server-side answer deadline.
+ */
+export async function respondToAnnouncement(
+  announcementId: string,
+  studentId: string,
+  optionIds: readonly string[],
+  publishedAt: string,
+): Promise<void> {
+  await postJson<{ answered: boolean }>(
+    `/api/parent/me/news/${encodeURIComponent(announcementId)}/respond`,
+    {
+      student_id: studentId,
+      option_ids: optionIds,
+      published_at: publishedAt,
+    },
   );
 }
 

--- a/frontend/src/lib/parent-api.ts
+++ b/frontend/src/lib/parent-api.ts
@@ -681,7 +681,7 @@ export interface ParentAnnouncement {
   readonly children?: readonly ParentAnnouncementPollChild[];
 }
 
-export interface ParentAnnouncementOption {
+interface ParentAnnouncementOption {
   readonly id: string;
   readonly label: string;
 }

--- a/frontend/src/lib/section-navigation.ts
+++ b/frontend/src/lib/section-navigation.ts
@@ -109,8 +109,11 @@ export const PARENT_SUB_PAGES: readonly ParentSubPage[] = [
     feature: "changeRequests",
   },
   {
+    // One entry, two jobs: the page itself splits Mitteilungen from Umfragen
+    // (#1371). Both are the same broadcast workflow, so a second nav item would
+    // only make staff guess which one they need.
     href: "/parent-announcements",
-    label: "Elternmitteilungen",
+    label: "Mitteilungen und Umfragen",
     feature: "announcements",
   },
   { href: "/meal-plan", label: "Essensplan", feature: "mealPlan" },


### PR DESCRIPTION
Closes #1371

Eine Umfrage ist eine Elternmitteilung mit Antwortmöglichkeiten. Sie erbt Zielgruppen, Entwurf und Veröffentlichen, Ablauf, E-Mail-Opt-in und Push, statt ein zweites Broadcast-Subsystem daneben zu stellen. Getrennt ist nur, was sich wirklich unterscheidet: eigener Tab beim Anlegen, eigene Auswertung, eigene Antwortfrist.

## Entscheidungen

**Antworten sind pro Kind, nicht pro Konto.** „Kommt Ihr Kind zur Murmelparty" ist eine Frage über das Kind, und die Auswertung zählt Kinder. Das ist die Zahl, mit der die OGS plant. Eltern mit zwei Kindern antworten zweimal.

**Ein Sidebar-Eintrag, zwei Ansichten.** „Mitteilungen und Umfragen" mit einem Umschalter innen. Zwei Einträge wären falsch, es ist derselbe Arbeitsschritt: Text schreiben, Zielgruppe wählen, senden.

**Eltern antworten in der Detailansicht, nicht in der Liste.** Die Karte zeigt nur „Antwort erforderlich" und öffnet die Ansicht mit der vollständigen Frage. Gespeichert wird bewusst über „Antwort speichern", nicht schon beim Antippen einer Option.

**Keine automatische Kalender-Verknüpfung und keine automatischen Erinnerungen.** Terminbezogene Zusagen bleiben beim bestehenden Kalender-RSVP; erinnert wird manuell, damit Schulen entscheiden, wann sie nachfassen.

## Was drin ist

Auf Schulseite: Umfrage anlegen mit zwei bis zehn Antworten, optionaler Mehrfachauswahl und optionaler Antwortfrist (unabhängig vom Ablaufdatum, damit eine geschlossene Umfrage lesbar bleibt). Auswertung mit einem Balken je Antwort, der Liste aller erreichten Kinder und dem Filter „Nur offene". Erinnerung an genau die Bezugspersonen, deren Kind noch nicht geantwortet hat.

Auf Elternseite: die Umfrage erscheint unter Neuigkeiten mit dem Hinweis „Antwort erforderlich", eine Antwortzeile je Kind, Speichern über die Fußzeile des Modals. Der Ungelesen-Zähler bleibt bei einer offenen Umfrage stehen, auch wenn sie gelesen wurde. Eine Umfrage, die aufhört zu erinnern, wird nicht beantwortet.

Nebenbei mitgefixt: die Detailansicht der einfachen Mitteilungen aus #1669 hatte ihre Aktionen mitten im Inhalt statt in der Fußzeile und schloss nach dem Bestätigen nicht. Beides folgt jetzt dem Muster der übrigen Modals im Elternportal.

## Berechtigungen

Antworten hängt an der eigenen Guardian-Berechtigung `parent_portal.poll.response`, nicht an `parent_portal.access`. Wer eine Umfrage sehen darf, darf damit noch nicht abstimmen. Migration 1.15.250 verteilt sie an `primary_guardian`, `legal_guardian` und `co_guardian`; Abholpersonen und Notfallkontakte sehen die Umfrage, stimmen aber nicht ab.

Die Auswertung macht das sichtbar statt es zu verstecken: `child_count` sind die Kinder mit antwortberechtigter Person, `target_child_count` die volle Zielgruppe. Kinder ohne Berechtigte stehen als „Nicht beantwortbar" in der Liste, nicht für immer als „Offen".

Die Zielgruppe „Offene Anmeldungen" ist bei Umfragen weder auswählbar noch über die API zulässig: diese Personen haben kein betreutes Kind und könnten deshalb nicht antworten.

## Migrationen

`1.15.249` legt `response_type` und `response_deadline` an `users.parent_announcements` an, dazu `parent_announcement_options` und `parent_announcement_responses` mit RLS wie die bestehenden Tabellen. `1.15.250` verteilt die neue Berechtigung.

Achtung beim Merge-Zeitpunkt: die Präfixe 246 bis 248 gehören `feat/1665-post-enrollment-offering-changes`. Kommt dort noch etwas dazu, müssen unsere Nummern wandern, sonst paniced der `MigrationRegistry` beim Start.

## Tests

Backend: Integrationstests für Antwort pro Kind, Ersetzen einer Antwort, abgelaufene Frist, fremdes Kind, Berechtigung, Zähler und Erinnerungs-Audienz; dazu Unit-Tests für die Eingabeprüfung. Frontend: Vitest für die Antwort-Interaktion, das Speichern, den Fehlerfall und den Hinweis auf der Karte. `pnpm run check`, knip und depcruise laufen sauber durch.

## Screenshots

<details>
<summary>Screens aus dem Durchlauf</summary>
<img width="1512" height="982" alt="01-staff-umfragen-liste" src="https://github.com/user-attachments/assets/d6fe9abe-b08c-49af-ae1e-c32ecc291c02" />
<img width="1512" height="982" alt="02-staff-umfrage-anlegen" src="https://github.com/user-attachments/assets/6c896ebd-c105-4d89-a30c-ec2f25ee593b" />
<img width="1512" height="982" alt="03-staff-umfrage-empfänger" src="https://github.com/user-attachments/assets/23307b08-5503-4bff-9ab1-cc6362461a25" />
<img width="430" height="932" alt="04-eltern-liste-antwort-erforderlich" src="https://github.com/user-attachments/assets/21ba9b3e-4ce3-48b3-98dd-8dd03826640f" />
<img width="430" height="932" alt="05-eltern-detail-offen" src="https://github.com/user-attachments/assets/f89ff76e-dbd0-4e4d-9ced-90a9439656c2" />
<img width="430" height="932" alt="06-eltern-detail-ungespeichert" src="https://github.com/user-attachments/assets/802cf721-109e-4795-96fb-4a337638bc11" />
<img width="430" height="932" alt="07-eltern-liste-nach-antwort" src="https://github.com/user-attachments/assets/bdc434e8-4c02-4c55-9d97-49baa3307164" />
<img width="1512" height="982" alt="08-staff-auswertung" src="https://github.com/user-attachments/assets/077b8198-89d0-4b81-8f84-930992c50ab1" />
<img width="1512" height="982" alt="09-staff-erinnerung" src="https://github.com/user-attachments/assets/ff17d236-3c9a-4e6f-8016-046e5a8bf8f0" />
<img width="1512" height="982" alt="10-staff-mitteilung-anlegen" src="https://github.com/user-attachments/assets/96f8e960-6f0c-4f88-89c4-df90740fefce" />
<img width="430" height="932" alt="11-eltern-mitteilung-detail" src="https://github.com/user-attachments/assets/71098e1b-2f73-48b1-a19b-f21fbfe7280a" />

</details>

## Offen

Das Hilfe-Kapitel hat noch keinen Screenshot, nur eine Bildunterschrift. Und der Zurückziehen-Dialog sagt nicht, dass damit die bereits gegebenen Antworten verworfen werden. Beides blockiert nichts.
