### PR TITLE
CI: skip draft PRs, take Sonar off the gate critical path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
       - develop
       - development
   pull_request:
+    # ready_for_review is NOT a default activity type. Without it, a PR taken
+    # out of draft would get no CI at all, because every job below skips while
+    # the PR is a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions: {}
 
 concurrency:
@@ -18,7 +22,11 @@ defaults:
     shell: bash
 
 jobs:
+  # Draft PRs run no CI. lint/test skip implicitly via `needs: detect-changes`;
+  # env-sync-check and ci-gate carry the same guard explicitly. The full suite
+  # runs on the ready_for_review event.
   detect-changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -67,11 +75,51 @@ jobs:
       run-frontend: ${{ needs.detect-changes.outputs.run-frontend == 'true' }}
       is-pr: ${{ github.event_name == 'pull_request' }}
       base_ref: ${{ github.base_ref }}
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  # Deliberately NOT a ci-gate dependency. Sonar needs the coverage artifacts,
+  # so it can only start once test finishes; keeping it in the gate added its
+  # full runtime to every run's critical path. It still runs on every push and
+  # non-draft PR and reports through its own SonarCloud check.
+  sonarcloud:
+    needs: [detect-changes, test]
+    # always(): analyse failing runs too, matching the previous behaviour from
+    # when this job lived in test.yml.
+    if: >-
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.detect-changes.outputs.run-backend == 'true' || needs.detect-changes.outputs.run-frontend == 'true')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Required for SonarCloud PR analysis and SCM blame
+
+      - name: Download backend coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-backend
+          path: backend/
+        continue-on-error: true
+
+      - name: Download frontend coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-frontend
+          path: frontend/coverage/
+        continue-on-error: true
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # Verify all environments have matching env var keys (no secrets needed)
   env-sync-check:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -103,7 +151,9 @@ jobs:
           echo "All .sops.env files are encrypted"
 
   ci-gate:
-    if: always()
+    if: >-
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs: [lint, test, env-sync-check]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,6 @@ on:
       base_ref:
         type: string
         default: ""
-    secrets:
-      SONAR_TOKEN:
-        description: "SonarCloud authentication token"
-        required: true
 
 defaults:
   run:
@@ -235,35 +231,3 @@ jobs:
           path: frontend/coverage/lcov.info
           retention-days: 7
         if: always()
-
-  sonarcloud:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-    needs: [test-backend, test-frontend]
-    if: ${{ always() && (inputs.run-backend || inputs.run-frontend) }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0 # Required for SonarCloud PR analysis and SCM blame
-
-      - name: Download backend coverage
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-backend
-          path: backend/
-        continue-on-error: true
-
-      - name: Download frontend coverage
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-frontend
-          path: frontend/coverage/
-        continue-on-error: true
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Zwei unabhängige Änderungen an CI-Kosten und Latenz. Alle Zahlen sind gemessen, nicht geschätzt: Grundlage ist eine Woche Job-Level-Daten aus der Actions-API (511 Runs, 5.223 Jobs, 26.07. bis 02.08.).

## Warum

Die Blacksmith-Rechnung ist von $16 (Feb) auf $162 (Aug) gestiegen. Die Auswertung ergab zwei Befunde:

1. **42,6% aller PR-CI-Minuten** entfallen auf PRs, die noch im Draft stehen (169 von 392 PR-Runs; 27 von 60 PRs hatten eine Draft-Phase).
2. Der Median-Run dauert **5,1 Minuten**, 92% der Runs liegen über 3 Minuten, obwohl kein einzelner Job länger als 2,4 Minuten läuft. Grund: `sonarcloud` hängt via `needs` hinter den Test-Jobs und blockiert `ci-gate`.

Segment-Messung (Median, n=60):

| Segment | Zeit | Anteil |
|---|---|---|
| Orchestrierung (wf-start, detect-changes, ci-gate) | 32s | 11% |
| CI-Block: test-backend (144s) -> sonarcloud (120s) | 250s | 87% |

## Änderung 1: CI auf Draft-PRs überspringen

Alle Top-Level-Jobs bekommen einen Draft-Guard. `lint` und `test` erben ihn implizit über `needs: detect-changes`.

**Der kritische Teil**: `ready_for_review` musste zu den `pull_request`-Activity-Types ergänzt werden. Es gehört nicht zu den Defaults (`opened`, `synchronize`, `reopened`). Ohne diese Zeile bekäme ein PR, den man aus dem Draft holt, bis zum nächsten Push gar keine CI.

## Änderung 2: `sonarcloud` aus `ci-gate` herauslösen

Der Job wandert unverändert von `test.yml` nach `main.yml` und steht bewusst nicht in `ci-gate`s `needs`.

Sonar läuft weiterhin auf jedem Push und jedem Nicht-Draft-PR und meldet über seinen eigenen SonarCloud-Check. Analyse und New-Code-Gate bleiben unangetastet. Die `development`-Analyse bleibt bewusst erhalten: die PR-Analyse vergleicht gegen den letzten Scan des Ziel-Branches, ein veralteter Baseline-Scan würde Altlasten aus `development` fälschlich als neu in PRs anzeigen ([Sonar-Doku](https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/pull-request-analysis)).

Nebenwirkung: `test.yml` braucht das `SONAR_TOKEN`-Secret nicht mehr, die Deklaration und die Übergabe entfallen.

## Erwartete Wirkung

| | vorher | nachher |
|---|---|---|
| CI-Haken grün nach | ~4,8 Min | **~2,4 Min** |
| Runner-Ausgaben | ~$193/Monat | **~$139/Monat** |

## Verworfene Alternativen

Zwei weitere Ideen wurden geprüft und wieder fallengelassen:

- **`-coverpkg=./...` aus dem Test-Lauf entfernen.** Das Flag kostet Laufzeit, ist bei uns aber tragend: die Abdeckung von `services/` und `database/repositories/` stammt grossteils aus Integrationstests in `backend/test/`. Ohne das Flag instrumentiert Go nur das jeweils getestete Paket, die gemeldete Coverage bräche ein und das 80%-Gate würde falsch anschlagen.
- **Lint-Jobs auf `push` überspringen** (74% der development-Runs testen denselben Baum, den der PR schon geprüft hat). Spart nur $9/Monat und opfert dafür genau die Checks, die ausschliesslich beim Merge anschlagen können: `TestNoDuplicateMigrationVersions` (zwei PRs vergeben dieselbe Migrationsversion, einzeln beide grün), `pnpm typecheck`, `knip` und golangci-lints `unused`. Schlechter Tausch.

## Verifikation

- `actionlint` über alle Workflows: keine neuen Befunde. Die einzige Änderung ist, dass die bekannte "unknown label blacksmith-4vcpu"-Meldung von `test.yml` nach `main.yml` wandert (39 Befunde vorher, 39 nachher).
- YAML-Parse-Check aller vier Workflows OK.
- Dieser PR testet die Änderung selbst: er fasst `.github/**` an, triggert damit den `ci`-Filter und läuft unter dem neuen `main.yml`.

## Hinweis ausserhalb dieses PRs

Bei der Analyse aufgefallen, hier bewusst nicht geändert: auf `development` ist aktuell **kein einziger Status-Check verpflichtend** (`required_status_checks.contexts: []`, nur 1 Review). Und `build.yml` deployt nach Staging, ohne auf `main.yml` zu warten. Ob `ci-gate` ein Required Check werden soll, ist eine eigene Entscheidung.