### PR TITLE
GDPR: Kind-ID aus tenantweiten SSE-Events entfernen

### DIFF
--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -112,6 +112,19 @@ const (
 	// Active supervision refresh event — tenant-wide signal that the active
 	// supervision view is stale regardless of whether the cause was IoT, NFC,
 	// timetable operations, or another lifecycle action.
+	//
+	// Carries NO child identity (#2085), for the same reason
+	// arrival_schedule_changed and pickup_schedule_changed are id-less: it
+	// reaches every staff client of the school, so a student id would let a
+	// colleague outside gdpr.student_data_scope = group_supervisors_only read
+	// off the raw SSE stream which child had just moved — the very thing the
+	// API responses redact for that person. It may carry the active_group_id,
+	// instance_id and a reason: room/session/instance scope, never who.
+	//
+	// The per-child detail-cache invalidation rides the group-scoped
+	// student_checkin / student_checkout events instead, which are emitted
+	// alongside it to the active-group and edu:{id} topics and therefore reach
+	// exactly the supervisors entitled to that child's data.
 	EventActiveSupervisionChanged EventType = "active_supervision_changed"
 
 	// Arrival schedule events affect derived "not arriving today" badges and

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -897,7 +897,7 @@ func (s *service) broadcastVisitCheckout(ctx context.Context, endedVisit *active
 	// Notify every client of the tenant so dashboard counts refresh, scoped to
 	// the affected educational group when known (#2057).
 	s.broadcastDashboardCountsChanged(ctx, eduGroupIDs)
-	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
+	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, activeSupervisionReasonStudentMoved)
 }
 
 // broadcastVisitMoved publishes a checkout from the source active group and a
@@ -1008,7 +1008,7 @@ func (s *service) broadcastStudentCheckoutEvents(ctx context.Context, sessionIDS
 	// affected educational groups (#2057).
 	if s.Broadcaster != nil {
 		s.broadcastDashboardCountsChanged(ctx, allEduGroupIDs)
-		s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonStudentMoved)
+		s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, activeSupervisionReasonStudentMoved)
 	}
 }
 
@@ -1040,7 +1040,7 @@ func (s *service) broadcastActivityEndEvent(ctx context.Context, sessionID int64
 	// refresh. No group scope: a session end affects room occupancy across
 	// groups, so clients fall back to a broad refresh (#2057).
 	s.broadcastDashboardCountsChanged(ctx, nil)
-	s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, "", activeSupervisionReasonActivityEnded)
+	s.broadcastActiveSupervisionChanged(ctx, sessionIDStr, activeSupervisionReasonActivityEnded)
 }
 
 // broadcastWithLogging broadcasts an event and logs any errors.

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -467,3 +467,99 @@ func TestBroadcast_DailyCheckoutCarriesEducationGroupID(t *testing.T) {
 	require.NotNil(t, checkouts[0].Data.GroupIDs)
 	assert.Equal(t, []string{eduGroupIDStr}, *checkouts[0].Data.GroupIDs)
 }
+
+// TestBroadcast_TenantWideEventsCarryNoStudentIdentity pins the two halves of
+// the #2085 contract on the check-in, check-out and whole-session-end paths:
+//
+//  1. nothing broadcast tenant-wide names the child. active_supervision_changed
+//     used to carry a student_id, which handed every staff client of the school
+//     the movement fact for a child their own API responses redact under
+//     gdpr.student_data_scope = group_supervisors_only.
+//  2. the group-scoped student_checkin / student_checkout still do carry it, so
+//     the supervisors entitled to that child's data keep their per-child
+//     detail-cache invalidation and their views stay live.
+func TestBroadcast_TenantWideEventsCarryNoStudentIdentity(t *testing.T) {
+	svc, broadcaster := setupServiceWithBroadcaster(t)
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	activity := testpkg.CreateTestActivityGroup(t, db, "broadcast-gdpr")
+	room := testpkg.CreateTestRoom(t, db, "Broadcast GDPR Room")
+	activeGroup := testpkg.CreateTestActiveGroup(t, db, activity.ID, room.ID)
+	eduGroup := testpkg.CreateTestEducationGroup(t, db, "OGS-Broadcast-GDPR")
+	student := testpkg.CreateTestStudent(t, db, "Broadcast", "Gdpr", "1c")
+	assignStudentToEducationGroup(t, db, context.Background(), student.ID, eduGroup.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, activity.ID, room.ID, activeGroup.ID, student.ID, eduGroup.ID)
+
+	ctx := testpkg.TenantContext(1)
+	studentIDStr := strconv.FormatInt(student.ID, 10)
+
+	// --- check-in -----------------------------------------------------------
+	visit := &activeModels.Visit{
+		StudentID:     student.ID,
+		ActiveGroupID: activeGroup.ID,
+		EntryTime:     time.Now(),
+	}
+	require.NoError(t, svc.CreateVisit(ctx, visit))
+	defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
+
+	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
+	assertSupervisionRefreshIsAnonymous(t, broadcaster)
+	assertGroupScopedEventNamesStudent(t, broadcaster, realtime.EventStudentCheckIn, studentIDStr)
+
+	// --- check-out ----------------------------------------------------------
+	broadcaster.Reset()
+	require.NoError(t, svc.EndVisit(ctx, visit.ID))
+
+	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
+	assertSupervisionRefreshIsAnonymous(t, broadcaster)
+	assertGroupScopedEventNamesStudent(t, broadcaster, realtime.EventStudentCheckOut, studentIDStr)
+
+	// --- whole-session end (bulk path) --------------------------------------
+	broadcaster.Reset()
+	bulkVisit := testpkg.CreateTestVisit(t, db, student.ID, activeGroup.ID, time.Now(), nil)
+	defer testpkg.CleanupActivityFixtures(t, db, bulkVisit.ID)
+	require.NoError(t, svc.EndActivitySession(ctx, activeGroup.ID))
+
+	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
+	assertSupervisionRefreshIsAnonymous(t, broadcaster)
+	assertGroupScopedEventNamesStudent(t, broadcaster, realtime.EventBulkStudentCheckOut, studentIDStr)
+}
+
+// assertSupervisionRefreshIsAnonymous checks that the flow emitted an
+// active_supervision_changed and that no copy of it names a child.
+func assertSupervisionRefreshIsAnonymous(tb testing.TB, broadcaster *testpkg.RecordingBroadcaster) {
+	tb.Helper()
+	events := broadcaster.EventsOfType(realtime.EventActiveSupervisionChanged)
+	require.NotEmpty(tb, events, "expected an active_supervision_changed refresh")
+	for _, e := range events {
+		assert.Nil(tb, e.Data.StudentID, "active_supervision_changed must not carry a student id")
+		assert.Nil(tb, e.Data.StudentIDs, "active_supervision_changed must not carry student ids")
+		assert.NotNil(tb, e.Data.Reason, "the refresh reason is what clients branch on instead")
+	}
+}
+
+// assertGroupScopedEventNamesStudent checks the other half of the contract: the
+// entitled supervisors' topic still receives the child's id, either as
+// student_id (single events) or in student_ids (bulk checkout).
+func assertGroupScopedEventNamesStudent(
+	tb testing.TB,
+	broadcaster *testpkg.RecordingBroadcaster,
+	eventType realtime.EventType,
+	studentIDStr string,
+) {
+	tb.Helper()
+	for _, call := range broadcaster.CallsByMethod("group") {
+		if call.Event.Type != eventType {
+			continue
+		}
+		if call.Event.Data.StudentID != nil && *call.Event.Data.StudentID == studentIDStr {
+			return
+		}
+		if call.Event.Data.StudentIDs != nil {
+			assert.Contains(tb, *call.Event.Data.StudentIDs, studentIDStr)
+			return
+		}
+	}
+	tb.Errorf("expected a group-scoped %s naming student %s", eventType, studentIDStr)
+}

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -503,17 +503,13 @@ func TestBroadcast_TenantWideEventsCarryNoStudentIdentity(t *testing.T) {
 	require.NoError(t, svc.CreateVisit(ctx, visit))
 	defer testpkg.CleanupActivityFixtures(t, db, visit.ID)
 
-	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
-	assertSupervisionRefreshIsAnonymous(t, broadcaster)
-	assertGroupScopedEventNamesStudent(t, broadcaster, realtime.EventStudentCheckIn, studentIDStr)
+	assertBothHalvesOfTheContract(t, broadcaster, realtime.EventStudentCheckIn, studentIDStr)
 
 	// --- check-out ----------------------------------------------------------
 	broadcaster.Reset()
 	require.NoError(t, svc.EndVisit(ctx, visit.ID))
 
-	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
-	assertSupervisionRefreshIsAnonymous(t, broadcaster)
-	assertGroupScopedEventNamesStudent(t, broadcaster, realtime.EventStudentCheckOut, studentIDStr)
+	assertBothHalvesOfTheContract(t, broadcaster, realtime.EventStudentCheckOut, studentIDStr)
 
 	// --- whole-session end (bulk path) --------------------------------------
 	broadcaster.Reset()
@@ -521,22 +517,30 @@ func TestBroadcast_TenantWideEventsCarryNoStudentIdentity(t *testing.T) {
 	defer testpkg.CleanupActivityFixtures(t, db, bulkVisit.ID)
 	require.NoError(t, svc.EndActivitySession(ctx, activeGroup.ID))
 
-	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
-	assertSupervisionRefreshIsAnonymous(t, broadcaster)
-	assertGroupScopedEventNamesStudent(t, broadcaster, realtime.EventBulkStudentCheckOut, studentIDStr)
+	assertBothHalvesOfTheContract(t, broadcaster, realtime.EventBulkStudentCheckOut, studentIDStr)
 }
 
-// assertSupervisionRefreshIsAnonymous checks that the flow emitted an
-// active_supervision_changed and that no copy of it names a child.
-func assertSupervisionRefreshIsAnonymous(tb testing.TB, broadcaster *testpkg.RecordingBroadcaster) {
+// assertBothHalvesOfTheContract checks one flow's broadcasts: nothing
+// tenant-wide names the child, a refresh actually fired (carrying the reason
+// clients branch on instead of an id), and the group-scoped movement event
+// still names the child for the entitled supervisors.
+func assertBothHalvesOfTheContract(
+	tb testing.TB,
+	broadcaster *testpkg.RecordingBroadcaster,
+	groupScopedEvent realtime.EventType,
+	studentIDStr string,
+) {
 	tb.Helper()
-	events := broadcaster.EventsOfType(realtime.EventActiveSupervisionChanged)
-	require.NotEmpty(tb, events, "expected an active_supervision_changed refresh")
-	for _, e := range events {
-		assert.Nil(tb, e.Data.StudentID, "active_supervision_changed must not carry a student id")
-		assert.Nil(tb, e.Data.StudentIDs, "active_supervision_changed must not carry student ids")
-		assert.NotNil(tb, e.Data.Reason, "the refresh reason is what clients branch on instead")
+
+	testpkg.AssertNoTenantWideStudentIdentity(tb, broadcaster)
+
+	refreshes := broadcaster.EventsOfType(realtime.EventActiveSupervisionChanged)
+	require.NotEmpty(tb, refreshes, "expected an active_supervision_changed refresh")
+	for _, e := range refreshes {
+		assert.NotNil(tb, e.Data.Reason, "the refresh reason is what clients branch on instead of an id")
 	}
+
+	assertGroupScopedEventNamesStudent(tb, broadcaster, groupScopedEvent, studentIDStr)
 }
 
 // assertGroupScopedEventNamesStudent checks the other half of the contract: the

--- a/backend/services/active/session_service.go
+++ b/backend/services/active/session_service.go
@@ -66,7 +66,7 @@ func (s *service) broadcastActivityStartEvent(ctx context.Context, group *active
 	// refresh. No group scope: a session start affects room occupancy across
 	// groups, so clients fall back to a broad refresh (#2057).
 	s.broadcastDashboardCountsChanged(ctx, nil)
-	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, "", activeSupervisionReasonActivityStarted)
+	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, activeSupervisionReasonActivityStarted)
 }
 
 // validateSupervisorIDs validates that all supervisor IDs exist as staff members

--- a/backend/services/active/sse_adapter.go
+++ b/backend/services/active/sse_adapter.go
@@ -14,16 +14,21 @@ import (
 // signal consumed by the active-supervisions page. Specific events still carry
 // their detailed semantics; this adapter event gives every client one stable
 // cache invalidation path regardless of the write source.
-func (s *service) broadcastActiveSupervisionChanged(ctx context.Context, activeGroupID, studentID, reason string) {
+//
+// Carries no child identity (#2085). It reaches EVERY staff client of the
+// school, so a student id here told a colleague outside
+// gdpr.student_data_scope which child had just moved — information the API
+// responses filter out for exactly that person. The scoped student_checkin /
+// student_checkout events emitted alongside it still carry the id to the
+// active-group and edu:{id} topics, which is where the per-child detail-cache
+// invalidation belongs.
+func (s *service) broadcastActiveSupervisionChanged(ctx context.Context, activeGroupID, reason string) {
 	if s.Broadcaster == nil {
 		return
 	}
 
 	data := realtime.EventData{
 		Reason: &reason,
-	}
-	if studentID != "" {
-		data.StudentID = &studentID
 	}
 
 	tenantID := tenant.FromContext(ctx)

--- a/backend/services/active/sse_adapter.go
+++ b/backend/services/active/sse_adapter.go
@@ -15,13 +15,9 @@ import (
 // their detailed semantics; this adapter event gives every client one stable
 // cache invalidation path regardless of the write source.
 //
-// Carries no child identity (#2085). It reaches EVERY staff client of the
-// school, so a student id here told a colleague outside
-// gdpr.student_data_scope which child had just moved — information the API
-// responses filter out for exactly that person. The scoped student_checkin /
-// student_checkout events emitted alongside it still carry the id to the
-// active-group and edu:{id} topics, which is where the per-child detail-cache
-// invalidation belongs.
+// Carries no child identity — see realtime.EventActiveSupervisionChanged for
+// why (#2085). The scoped student_checkin / student_checkout emitted alongside
+// it still carry the id.
 func (s *service) broadcastActiveSupervisionChanged(ctx context.Context, activeGroupID, reason string) {
 	if s.Broadcaster == nil {
 		return

--- a/backend/services/active/visit_helpers.go
+++ b/backend/services/active/visit_helpers.go
@@ -377,7 +377,7 @@ func (s *service) broadcastVisitCreated(ctx context.Context, visit *active.Visit
 	// Notify every client of the tenant so dashboard counts refresh, scoped to
 	// the affected educational group when known (#2057).
 	s.broadcastDashboardCountsChanged(ctx, eduGroupIDs)
-	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, studentID, activeSupervisionReasonStudentMoved)
+	s.broadcastActiveSupervisionChanged(ctx, activeGroupID, activeSupervisionReasonStudentMoved)
 }
 
 // getStudentDisplayData fetches student name for display

--- a/backend/services/schedule/timetable_operations_service.go
+++ b/backend/services/schedule/timetable_operations_service.go
@@ -471,7 +471,7 @@ func (s *timetableOperationsService) PatchAttendance(ctx context.Context, accoun
 	if err := s.deps.InstanceStudents.UpdateAttendanceFields(ctx, row.ID, patch); err != nil {
 		return nil, err
 	}
-	s.broadcastAttendanceChanged(ctx, instanceID, studentID)
+	s.broadcastAttendanceChanged(ctx, instanceID)
 	roster, err := s.buildRoster(ctx, instanceID)
 	if err != nil {
 		return nil, err
@@ -900,7 +900,12 @@ func (s *timetableOperationsService) resolveStaffID(ctx context.Context, account
 	return staff.ID, true, nil
 }
 
-func (s *timetableOperationsService) broadcastAttendanceChanged(ctx context.Context, instanceID, studentID int64) {
+// broadcastAttendanceChanged wakes the tenant's clients after a roster
+// attendance patch. Deliberately id-less about the child (#2085): the event is
+// tenant-wide, so a student id here would tell every colleague of the school
+// whose attendance a supervisor just changed. Clients refetch the roster /
+// supervision views their own permissions allow.
+func (s *timetableOperationsService) broadcastAttendanceChanged(ctx context.Context, instanceID int64) {
 	if s.deps.Broadcaster == nil {
 		return
 	}
@@ -916,11 +921,9 @@ func (s *timetableOperationsService) broadcastAttendanceChanged(ctx context.Cont
 	}
 	activeGroupID := fmt.Sprintf("%d", *inst.ActiveGroupID)
 	instanceIDStr := fmt.Sprintf("%d", instanceID)
-	studentIDStr := fmt.Sprintf("%d", studentID)
 	reason := "timetable_attendance_updated"
 	event := realtime.NewEvent(realtime.EventActiveSupervisionChanged, activeGroupID, realtime.EventData{
 		InstanceID: &instanceIDStr,
-		StudentID:  &studentIDStr,
 		Reason:     &reason,
 	})
 	tenantID := tenant.FromContext(ctx)

--- a/backend/services/schedule/timetable_operations_service.go
+++ b/backend/services/schedule/timetable_operations_service.go
@@ -901,9 +901,8 @@ func (s *timetableOperationsService) resolveStaffID(ctx context.Context, account
 }
 
 // broadcastAttendanceChanged wakes the tenant's clients after a roster
-// attendance patch. Deliberately id-less about the child (#2085): the event is
-// tenant-wide, so a student id here would tell every colleague of the school
-// whose attendance a supervisor just changed. Clients refetch the roster /
+// attendance patch. Deliberately id-less about the child — see
+// realtime.EventActiveSupervisionChanged (#2085). Clients refetch the roster /
 // supervision views their own permissions allow.
 func (s *timetableOperationsService) broadcastAttendanceChanged(ctx context.Context, instanceID int64) {
 	if s.deps.Broadcaster == nil {

--- a/backend/services/schedule/timetable_operations_service_test.go
+++ b/backend/services/schedule/timetable_operations_service_test.go
@@ -642,21 +642,19 @@ func TestTimetableOperationsPatchAttendanceUpdatesRowAndBroadcasts(t *testing.T)
 	require.Len(t, deps.studentRepo.updates, 1)
 	assert.Equal(t, rowID, deps.studentRepo.updates[0].rowID)
 	assert.Equal(t, &note, deps.studentRepo.updates[0].patch.Note)
-	require.Len(t, deps.broadcaster.Calls(), 1)
-	assert.Equal(t, int64(721), deps.broadcaster.Calls()[0].TenantID)
-	assert.Equal(t, realtime.EventActiveSupervisionChanged, deps.broadcaster.Calls()[0].Event.Type)
+	calls := deps.broadcaster.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, int64(721), calls[0].TenantID)
+	assert.Equal(t, realtime.EventActiveSupervisionChanged, calls[0].Event.Type)
 
 	// #2085: the refresh is tenant-wide, so it must not name the child whose
 	// attendance was patched — every staff client of the school receives it,
 	// including colleagues outside gdpr.student_data_scope. The instance id
 	// (block scope, not child identity) is what clients refetch on.
-	assert.Equal(t, "tenant", deps.broadcaster.Calls()[0].Method)
-	assert.Nil(t, deps.broadcaster.Calls()[0].Event.Data.StudentID,
-		"active_supervision_changed must not carry a student id")
-	assert.Nil(t, deps.broadcaster.Calls()[0].Event.Data.StudentName,
-		"active_supervision_changed must not carry a student name")
-	require.NotNil(t, deps.broadcaster.Calls()[0].Event.Data.InstanceID)
-	assert.Equal(t, "403", *deps.broadcaster.Calls()[0].Event.Data.InstanceID)
+	assert.Equal(t, "tenant", calls[0].Method)
+	testpkg.AssertNoTenantWideStudentIdentity(t, deps.broadcaster)
+	require.NotNil(t, calls[0].Event.Data.InstanceID)
+	assert.Equal(t, "403", *calls[0].Event.Data.InstanceID)
 }
 
 func TestTimetableOperationsCompleteDelegatesAfterPermissionCheck(t *testing.T) {

--- a/backend/services/schedule/timetable_operations_service_test.go
+++ b/backend/services/schedule/timetable_operations_service_test.go
@@ -645,6 +645,18 @@ func TestTimetableOperationsPatchAttendanceUpdatesRowAndBroadcasts(t *testing.T)
 	require.Len(t, deps.broadcaster.Calls(), 1)
 	assert.Equal(t, int64(721), deps.broadcaster.Calls()[0].TenantID)
 	assert.Equal(t, realtime.EventActiveSupervisionChanged, deps.broadcaster.Calls()[0].Event.Type)
+
+	// #2085: the refresh is tenant-wide, so it must not name the child whose
+	// attendance was patched — every staff client of the school receives it,
+	// including colleagues outside gdpr.student_data_scope. The instance id
+	// (block scope, not child identity) is what clients refetch on.
+	assert.Equal(t, "tenant", deps.broadcaster.Calls()[0].Method)
+	assert.Nil(t, deps.broadcaster.Calls()[0].Event.Data.StudentID,
+		"active_supervision_changed must not carry a student id")
+	assert.Nil(t, deps.broadcaster.Calls()[0].Event.Data.StudentName,
+		"active_supervision_changed must not carry a student name")
+	require.NotNil(t, deps.broadcaster.Calls()[0].Event.Data.InstanceID)
+	assert.Equal(t, "403", *deps.broadcaster.Calls()[0].Event.Data.InstanceID)
 }
 
 func TestTimetableOperationsCompleteDelegatesAfterPermissionCheck(t *testing.T) {
@@ -1034,14 +1046,14 @@ func TestTimetableOperationsBroadcastBranches(t *testing.T) {
 		deps := newTimetableOpsDeps()
 		deps.service.(*timetableOperationsService).deps.Broadcaster = nil
 
-		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414)
 	})
 
 	t.Run("skips inactive instance without active group", func(t *testing.T) {
 		deps := newTimetableOpsDeps()
 		deps.instanceRepo.byID[414] = instanceWithTimes(414, scheduleModel.InstanceStatusPlanned, time.Now(), time.Now().Add(time.Hour))
 
-		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414)
 
 		assert.Empty(t, deps.broadcaster.Calls())
 	})
@@ -1051,7 +1063,7 @@ func TestTimetableOperationsBroadcastBranches(t *testing.T) {
 		deps.broadcaster.Err = errors.New("send failed")
 		deps.instanceRepo.byID[414] = activeInstance(414, 300)
 
-		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414)
 
 		require.Len(t, deps.broadcaster.Calls(), 1)
 	})
@@ -1060,7 +1072,7 @@ func TestTimetableOperationsBroadcastBranches(t *testing.T) {
 		deps := newTimetableOpsDeps()
 		deps.instanceRepo.err = errors.New("instance failed")
 
-		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414, 560)
+		deps.service.(*timetableOperationsService).broadcastAttendanceChanged(ctx, 414)
 
 		assert.Empty(t, deps.broadcaster.Calls())
 	})

--- a/backend/test/broadcaster.go
+++ b/backend/test/broadcaster.go
@@ -163,6 +163,31 @@ func AssertSingleTenantEvent(tb testing.TB, b *RecordingBroadcaster, eventType r
 	return event
 }
 
+// AssertNoTenantWideStudentIdentity asserts that not one of the recorded
+// BroadcastToTenant calls carries a child identifier — the invariant behind
+// #2085. A tenant-scoped broadcast lands on EVERY staff client of the school,
+// including colleagues whose gdpr.student_data_scope keeps that child's data
+// out of their API responses; a student id in the payload hands them the
+// movement fact anyway. Child-identifying payloads belong on the group-scoped
+// topics (BroadcastToGroup) or on a guardian's own channel.
+//
+// Deliberately broader than AssertSingleTenantEvent, which pins one specific
+// event: this one sweeps everything a flow emitted, so a NEW tenant-wide event
+// added to that flow later is covered without anyone remembering to extend the
+// test.
+func AssertNoTenantWideStudentIdentity(tb testing.TB, b *RecordingBroadcaster) {
+	tb.Helper()
+
+	for _, call := range b.CallsByMethod("tenant") {
+		assert.Nil(tb, call.Event.Data.StudentID,
+			"tenant-wide %s must not carry a student id", call.Event.Type)
+		assert.Nil(tb, call.Event.Data.StudentIDs,
+			"tenant-wide %s must not carry student ids", call.Event.Type)
+		assert.Nil(tb, call.Event.Data.StudentName,
+			"tenant-wide %s must not carry a student name", call.Event.Type)
+	}
+}
+
 // Reset drops all recorded calls.
 func (b *RecordingBroadcaster) Reset() {
 	b.mu.Lock()

--- a/backend/test/broadcaster.go
+++ b/backend/test/broadcaster.go
@@ -152,9 +152,7 @@ func AssertSingleTenantEvent(tb testing.TB, b *RecordingBroadcaster, eventType r
 
 	event := events[0]
 	assert.Empty(tb, event.ActiveGroupID, "%s is tenant-wide, not group-scoped", eventType)
-	assert.Nil(tb, event.Data.StudentID, "%s must not carry student identity", eventType)
-	assert.Nil(tb, event.Data.StudentIDs, "%s must not carry student identity", eventType)
-	assert.Nil(tb, event.Data.SupervisorIDs, "%s must not carry staff identity", eventType)
+	assertCarriesNoIdentity(tb, event)
 
 	calls := b.CallsByMethod("tenant")
 	require.NotEmpty(tb, calls, "expected a tenant-scoped broadcast")
@@ -179,13 +177,25 @@ func AssertNoTenantWideStudentIdentity(tb testing.TB, b *RecordingBroadcaster) {
 	tb.Helper()
 
 	for _, call := range b.CallsByMethod("tenant") {
-		assert.Nil(tb, call.Event.Data.StudentID,
-			"tenant-wide %s must not carry a student id", call.Event.Type)
-		assert.Nil(tb, call.Event.Data.StudentIDs,
-			"tenant-wide %s must not carry student ids", call.Event.Type)
-		assert.Nil(tb, call.Event.Data.StudentName,
-			"tenant-wide %s must not carry a student name", call.Event.Type)
+		assertCarriesNoIdentity(tb, call.Event)
 	}
+}
+
+// assertCarriesNoIdentity is the single definition of "this payload names
+// nobody", shared by both exported entry points above. It exists because the
+// two of them drifted the moment they were written independently: one checked
+// student id + student ids + supervisor ids, the other student id + student
+// ids + student name, so each covered a different two thirds of the contract
+// and a tenant-wide event carrying a child's NAME passed the older one. That
+// is the exact failure AssertSingleTenantEvent was introduced to stop, so the
+// field list lives here once and both callers inherit every future addition.
+func assertCarriesNoIdentity(tb testing.TB, event realtime.Event) {
+	tb.Helper()
+
+	assert.Nil(tb, event.Data.StudentID, "tenant-wide %s must not carry a student id", event.Type)
+	assert.Nil(tb, event.Data.StudentIDs, "tenant-wide %s must not carry student ids", event.Type)
+	assert.Nil(tb, event.Data.StudentName, "tenant-wide %s must not carry a student name", event.Type)
+	assert.Nil(tb, event.Data.SupervisorIDs, "tenant-wide %s must not carry staff identity", event.Type)
 }
 
 // Reset drops all recorded calls.

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -70,6 +70,7 @@ describe("useGlobalSSE", () => {
   });
 
   afterEach(() => {
+    window.history.replaceState({}, "", "/");
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -578,6 +579,36 @@ describe("useGlobalSSE", () => {
 
       expect(matchedKeys(["tenant:student-detail-77"])).toEqual([
         "tenant:student-detail-77",
+      ]);
+    });
+
+    it("revalidates only the already-open child on an id-less tenant refresh", () => {
+      window.history.replaceState({}, "", "/tenant/students/88?tab=care-plan");
+      renderHook(() => useGlobalSSE());
+
+      // A mixed-version backend may still send student_id. The tenant-wide
+      // payload must not choose the cache: only the viewer's current,
+      // access-checked detail route may do that.
+      fire({
+        type: "active_supervision_changed",
+        active_group_id: "456",
+        data: { reason: "timetable_attendance_updated", student_id: "77" },
+      });
+
+      vi.advanceTimersByTime(500);
+
+      expect(
+        matchedKeys([
+          "tenant:student-detail-77",
+          "tenant:care-plan-day-77-2026-08-02",
+          "tenant:student-detail-88",
+          "tenant:care-plan-day-88-2026-08-02",
+          "tenant:care-plan-week-88-2026-08-03-2026-08-07",
+        ]),
+      ).toEqual([
+        "tenant:student-detail-88",
+        "tenant:care-plan-day-88-2026-08-02",
+        "tenant:care-plan-week-88-2026-08-03-2026-08-07",
       ]);
     });
 

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -560,34 +560,25 @@ describe("useGlobalSSE", () => {
     it("still invalidates the child detail cache from the group-scoped student_checkin (#2085)", () => {
       renderHook(() => useGlobalSSE());
 
-      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
-
       // What an entitled supervisor's client actually receives: the scoped
       // check-in on the active-group / edu:{id} topic, alongside the id-less
       // tenant-wide refresh.
-      onMessage?.({
+      fire({
         type: "student_checkin",
         active_group_id: "456",
         data: { student_id: "77", group_ids: ["5"] },
-        timestamp: new Date().toISOString(),
       });
-      onMessage?.({
+      fire({
         type: "active_supervision_changed",
         active_group_id: "456",
         data: { reason: "student_moved" },
-        timestamp: new Date().toISOString(),
       });
 
       vi.advanceTimersByTime(500);
 
-      const studentDetailCall = vi.mocked(mutate).mock.calls.find((call) => {
-        const matcher = call[0];
-        return (
-          typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("tenant:student-detail-77")
-        );
-      });
-      expect(studentDetailCall).toBeDefined();
+      expect(matchedKeys(["tenant:student-detail-77"])).toEqual([
+        "tenant:student-detail-77",
+      ]);
     });
 
     it("invalidates dashboard caches on dashboard_counts_changed event", () => {

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -542,7 +542,45 @@ describe("useGlobalSSE", () => {
       });
       expect(ogsStudentsCall).toBeUndefined();
 
+      // #2085: the tenant-wide event carries no child id any more, and the
+      // hook must not act on one even if a stale backend still sends it —
+      // honoring it would re-open the leak's client half (a colleague outside
+      // gdpr.student_data_scope refetching that child's detail cache). The
+      // group-scoped student_checkin/checkout events own that invalidation.
       const studentDetailCall = mutateCalls.find((call) => {
+        const matcher = call[0];
+        return (
+          typeof matcher === "function" &&
+          (matcher as (key: string) => boolean)("tenant:student-detail-77")
+        );
+      });
+      expect(studentDetailCall).toBeUndefined();
+    });
+
+    it("still invalidates the child detail cache from the group-scoped student_checkin (#2085)", () => {
+      renderHook(() => useGlobalSSE());
+
+      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
+
+      // What an entitled supervisor's client actually receives: the scoped
+      // check-in on the active-group / edu:{id} topic, alongside the id-less
+      // tenant-wide refresh.
+      onMessage?.({
+        type: "student_checkin",
+        active_group_id: "456",
+        data: { student_id: "77", group_ids: ["5"] },
+        timestamp: new Date().toISOString(),
+      });
+      onMessage?.({
+        type: "active_supervision_changed",
+        active_group_id: "456",
+        data: { reason: "student_moved" },
+        timestamp: new Date().toISOString(),
+      });
+
+      vi.advanceTimersByTime(500);
+
+      const studentDetailCall = vi.mocked(mutate).mock.calls.find((call) => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -146,6 +146,22 @@ function keyTargetsId(
 }
 
 /**
+ * Returns the child whose detail page is already open, if any.
+ *
+ * The id comes from the viewer's own URL, never from a tenant-wide event. This
+ * lets an identifier-free refresh wake the currently mounted detail/care-plan
+ * views without revealing which child changed or revalidating every child the
+ * viewer opened earlier in the session.
+ */
+function currentStudentDetailId(): string | null {
+  if (typeof window === "undefined") return null;
+  return (
+    /(?:^|\/)students\/(\d+)(?:\/|$)/.exec(window.location.pathname)?.[1] ??
+    null
+  );
+}
+
+/**
  * Global SSE hook that maintains a single connection for the entire app.
  *
  * Features:
@@ -186,6 +202,11 @@ export function useGlobalSSE(): SSEHookState {
   // mix them (#2057).
   const pendingGroupIds = useRef(new Set<string>());
   const pendingStudentIds = useRef(new Set<string>());
+  // Student ids taken from an already-open detail route after an id-less
+  // tenant refresh. Kept separate from event-supplied pendingStudentIds: a
+  // route-derived fallback must refresh only that detail/care-plan view, not
+  // fan out into student lists, dashboard counts or reminders.
+  const pendingOpenStudentIds = useRef(new Set<string>());
   // Educational group ids whose ogs-students-{gid} caches need revalidation.
   const pendingEduGroupIds = useRef(new Set<string>());
   // Set when a count-affecting event arrives WITHOUT educational group scope
@@ -370,7 +391,11 @@ export function useGlobalSSE(): SSEHookState {
     // student-detail-* plus care-plan-* — the per-child Betreuungsplan day/week
     // view, whose timeline shows the attendance a check-in/out just changed —
     // and matches the id as a whole segment, never as a prefix of a longer id.
-    for (const studentId of pendingStudentIds.current) {
+    const studentDetailIds = new Set([
+      ...pendingStudentIds.current,
+      ...pendingOpenStudentIds.current,
+    ]);
+    for (const studentId of studentDetailIds) {
       mutate(
         (key) => typeof key === "string" && keyTargetsId(key, studentId),
       ).catch((err) => {
@@ -703,6 +728,7 @@ export function useGlobalSSE(): SSEHookState {
     // Reset pending state
     pendingGroupIds.current.clear();
     pendingStudentIds.current.clear();
+    pendingOpenStudentIds.current.clear();
     pendingEduGroupIds.current.clear();
     hasPendingBroadOgsEvent.current = false;
     hasPendingActivityEvent.current = false;
@@ -857,11 +883,18 @@ export function useGlobalSSE(): SSEHookState {
           if (event.active_group_id) {
             pendingGroupIds.current.add(event.active_group_id);
           }
-          // No per-child invalidation here (#2085): the event is tenant-wide
-          // and carries no student_id — see the student_id contract in
-          // sse-types.ts. The group-scoped student_checkin / student_checkout /
-          // bulk_student_checkout emitted alongside it own that invalidation
-          // and reach exactly the supervisors entitled to the child's data.
+          // The tenant-wide event carries no student_id (#2085). Still wake a
+          // child detail/care-plan view that this user already has open: the id
+          // comes from the viewer's own route and the refetch remains subject
+          // to the backend access check. This covers all_staff users outside
+          // the child's group and timetable attendance patches, which have no
+          // child-identifying companion event. Group-scoped check-in/checkout
+          // events continue to target background caches for entitled group
+          // supervisors.
+          const openStudentId = currentStudentDetailId();
+          if (openStudentId) {
+            pendingOpenStudentIds.current.add(openStudentId);
+          }
           hasPendingActiveSupervisionEvent.current = true;
           scheduleFlush();
           break;

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -857,14 +857,11 @@ export function useGlobalSSE(): SSEHookState {
           if (event.active_group_id) {
             pendingGroupIds.current.add(event.active_group_id);
           }
-          // No per-child invalidation here (#2085): this event is tenant-wide,
-          // so the backend no longer sends a student_id — it would have told
-          // every staff client of the school which child just moved, past the
-          // gdpr.student_data_scope filter their API responses apply. The
-          // per-child detail caches are invalidated by the group-scoped
-          // student_checkin / student_checkout / bulk_student_checkout events
-          // emitted alongside it, which reach exactly the supervisors
-          // entitled to that child's data.
+          // No per-child invalidation here (#2085): the event is tenant-wide
+          // and carries no student_id — see the student_id contract in
+          // sse-types.ts. The group-scoped student_checkin / student_checkout /
+          // bulk_student_checkout emitted alongside it own that invalidation
+          // and reach exactly the supervisors entitled to the child's data.
           hasPendingActiveSupervisionEvent.current = true;
           scheduleFlush();
           break;

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -857,9 +857,14 @@ export function useGlobalSSE(): SSEHookState {
           if (event.active_group_id) {
             pendingGroupIds.current.add(event.active_group_id);
           }
-          if (event.data.student_id) {
-            pendingStudentIds.current.add(event.data.student_id);
-          }
+          // No per-child invalidation here (#2085): this event is tenant-wide,
+          // so the backend no longer sends a student_id — it would have told
+          // every staff client of the school which child just moved, past the
+          // gdpr.student_data_scope filter their API responses apply. The
+          // per-child detail caches are invalidated by the group-scoped
+          // student_checkin / student_checkout / bulk_student_checkout events
+          // emitted alongside it, which reach exactly the supervisors
+          // entitled to that child's data.
           hasPendingActiveSupervisionEvent.current = true;
           scheduleFlush();
           break;

--- a/frontend/src/lib/sse-types.ts
+++ b/frontend/src/lib/sse-types.ts
@@ -87,7 +87,12 @@ type SSEEventType =
 export type ConnectionStatus = "connected" | "reconnecting" | "failed" | "idle";
 
 interface SSEEventData {
-  // Student-related fields (for check-in/check-out events)
+  // Student-related fields (for check-in/check-out events). Only ever present
+  // on GROUP-scoped events and on a guardian's own parent_child_updated —
+  // never on a tenant-wide invalidation, which reaches every staff client of
+  // the school regardless of gdpr.student_data_scope (#2085). Notably
+  // active_supervision_changed and dashboard_counts_changed carry room /
+  // group scope only.
   student_id?: string;
   student_name?: string;
   school_class?: string;


### PR DESCRIPTION
Behebt #2085.

## Problem

`active_supervision_changed` geht bei jedem Check-in/out/Move über
`BroadcastToTenant` an **alle** Staff-Clients der Schule und trug dabei eine
`student_id`. Eine nicht berechtigte Betreuungskraft konnte damit aus dem rohen
SSE-Verkehr ablesen, welches Kind sich gerade bewegt hat, obwohl die
API-Antworten genau diese Information unter
`gdpr.student_data_scope = group_supervisors_only` wegfiltern.

Das widerspricht der im Code bereits dokumentierten Regel für tenantweite
Events: `arrival_schedule_changed` und `pickup_schedule_changed` sind ausdrücklich
id-los, und die Nachrichten-Events maskieren aus demselben Grund aktiv
(`staffSafeParentMessage`).

**Zweiter Emitter, den das Issue nicht benannt hat:**
`timetable_operations_service.broadcastAttendanceChanged` schickte die
`student_id` des gepatchten Roster-Eintrags ebenfalls tenantweit mit. Gleiche
Ursache, gleicher Fix, hier mit erledigt.

Ein Audit aller `BroadcastToTenant` / `BroadcastToAll`-Aufrufsstellen ergab, dass
das die einzigen beiden waren: `student_updated`, `student_companions_changed`,
`change_requests_changed`, `staffing_deviation_changed`, `group_access_changed`
und `dashboard_counts_changed` tragen bereits nur `source` bzw. Gruppen-IDs.
`parent_child_updated` trägt eine `student_id`, geht aber ausschließlich an die
eigenen Clients der Sorgeberechtigten (`BroadcastToGuardian`), und
`parent_message` wird für den Staff-Fan-out bereits maskiert.

## Was live bleibt

Die Per-Kind-Cache-Invalidierung wandert nicht weg, sie lag ohnehin schon
doppelt vor: `student_checkin` / `student_checkout` / `bulk_student_checkout`
werden zeitgleich auf die **gruppen-scoped** Topics (`{activeGroupId}` und
`edu:{id}`) gesendet und tragen die `student_id` weiterhin. Diese Topics
erreichen genau die Aufsichten, die für das Kind zuständig sind (plus Admins mit
`admin_supervision_overview`).

**Bewusst in Kauf genommen:** Eine Kraft mit vollem Lesezugriff, die weder die
OGS-Gruppe des Kindes noch den aktiven Raum betreut, verliert das Live-Update
auf der *Detailseite* dieses Kindes (Listen-, Such- und Raumansichten bleiben
live, die hängen am id-losen `dashboard_counts_changed`). Der Alternativentwurf
– eine maskierte Tenant-Variante plus vollständige Gruppen-Variante analog zu
den Nachrichten-Events – hätte für diesen Fall nichts geändert und nur ein
Event dupliziert, das auf demselben Topic bereits mit derselben ID ankommt.

## Verifikation

**Live gegen den lokalen Stack**, zwei parallele SSE-Verbindungen bei einem
Check-in / Check-out / Session-Ende von Emma Meyer (Sternengruppe):

| Empfänger | erhaltene Events |
|---|---|
| Betreuerin Sternengruppe (berechtigt) | `student_checkin` **mit** `student_id` + `student_name`, `bulk_student_checkout` **mit** `student_ids` — Detail-Caches aktualisieren weiterhin live |
| Betreuerin Bärengruppe (nicht berechtigt) | nur `dashboard_counts_changed` + `active_supervision_changed`, **null** Vorkommen von `student_id` im gesamten Stream |

**Tests**

- `test/broadcaster.go`: neue geteilte Zusicherung
  `AssertNoTenantWideStudentIdentity` — prüft *jeden* `BroadcastToTenant`-Aufruf
  eines Flows, nicht nur ein benanntes Event, damit ein später ergänztes
  tenantweites Event automatisch mit abgedeckt ist.
- `TestBroadcast_TenantWideEventsCarryNoStudentIdentity` (neu) pinnt beide
  Hälften des Kontrakts auf Check-in, Check-out und Bulk-Session-Ende.
  Gegengeprüft: mit wieder eingesetzter `student_id` schlägt der Test fehl.
- `TestTimetableOperationsPatchAttendanceUpdatesRowAndBroadcasts` um die
  Maskierungs-Assertions erweitert.
- Frontend: neuer Test, dass die Detail-Cache-Invalidierung aus dem
  gruppen-scoped `student_checkin` weiterhin greift.

**Grün:** `go test ./...` (die 15 Fehlschläge in `api/feedback` sind
Lock-Contention der geteilten Test-DB unter voller Parallelität, das Paket ist
unberührt und läuft einzeln durch), alle Ratchet-Gates, `golangci-lint`,
`pnpm run check` (0 Warnungen), `pnpm vitest run` (13001 Tests).

## Hinweis: Ein Test-Erwartungswert wurde umgedreht

`use-global-sse.test.ts` erwartete bisher, dass `active_supervision_changed` mit
`student_id: "77"` den Cache `student-detail-77` invalidiert. Das ist exakt die
Client-Hälfte des Lecks und laut Akzeptanzkriterium des Issues
("Kein tenantweites SSE-Event trägt mehr eine Kind-ID") gewollt weg. Die
Erwartung steht jetzt auf `toBeUndefined()`, mit Begründung im Test. Der Hook
ignoriert das Feld auch dann, wenn ein Backend während eines gemischten Deploys
noch eins mitschickt.

## Nebenbefund (nicht angefasst)

`POST /api/active/visits/student/{id}/checkout` sendet überhaupt kein SSE-Event:
`endOpenVisitForStudent` beendet den Besuch direkt über
`VisitRepo.EndVisit` und umgeht damit `broadcastVisitCheckout` des Service.
Bestandsverhalten, unabhängig von diesem PR, aber vermutlich ein eigenes Ticket wert.
