### PR TITLE
Gehzeit-Aenderungen erreichen die Aufsichtsansicht

### DIFF
--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -1043,14 +1043,13 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("arrival-search-X")
+          (matcher as (key: string) => boolean)("arrival-supervisions-X")
         );
       });
       expect(arrivalCall).toBeDefined();
 
       const matcher = arrivalCall![0] as (key: string) => boolean;
       expect(matcher("tenant:arrival-supervisions-1")).toBe(true);
-      expect(matcher("tenant:arrival-ogs-groups-1")).toBe(true);
       expect(matcher("tenant:arrival-data-42")).toBe(true);
       expect(matcher("tenant:unrelated-key")).toBe(false);
 

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -687,6 +687,67 @@ describe("useGlobalSSE — companion announcements", () => {
     }
   });
 
+  // The two tests below pin the Aktuelle-Aufsicht bulk time caches. Unlike the
+  // OGS group view — whose aggregated ogs-students-{gid} response carries the
+  // pickup times, so any trigger refreshes them together (#2056) — this page
+  // still fetches pickup and arrival under their own keys. Those keys embed
+  // the room's student-id list and disable focus revalidation, so an SSE
+  // invalidation is their ONLY live update path: nothing but a roster change
+  // or Berlin midnight rotates the key on its own.
+  const AUFSICHT_PICKUP_KEY = "t1:pickup-supervisions-2026-07-22-7,8,9";
+  const AUFSICHT_ARRIVAL_KEY = "t1:arrival-supervisions-2026-07-22-7,8,9";
+
+  it("refreshes the Aufsicht pickup cache on pickup_schedule_changed", () => {
+    renderHook(() => useGlobalSSE());
+
+    // A staff Gehzeit write (weekly plan or date exception) emits only this
+    // event — see api/students/pickup_schedule_handlers.go. The supervising
+    // staff member watching the room is exactly who must see the new time.
+    fireSSE(makeEvent("pickup_schedule_changed", {}));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const matchers = mockMutate.mock.calls
+      .map(([matcher]) => matcher)
+      .filter(
+        (matcher): matcher is (key: unknown) => boolean =>
+          typeof matcher === "function",
+      );
+    expect(
+      matchers.some((matcher) => matcher(AUFSICHT_PICKUP_KEY)),
+      "pickup_schedule_changed must invalidate the Aufsicht pickup cache",
+    ).toBe(true);
+  });
+
+  it("refreshes both Aufsicht time caches on student_updated", () => {
+    renderHook(() => useGlobalSSE());
+
+    // A parent care exception (submit AND delete) rewrites that day's pickup
+    // and arrival override under student_updated alone, and an approved care
+    // request rewrites the weekly pickup plan while announcing only
+    // student_updated + arrival_schedule_changed. Both writes can target a
+    // child already standing in the room, so neither rotates the roster-keyed
+    // cache key.
+    fireSSE(makeEvent("student_updated", { student_id: "7" }));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const matchers = mockMutate.mock.calls
+      .map(([matcher]) => matcher)
+      .filter(
+        (matcher): matcher is (key: unknown) => boolean =>
+          typeof matcher === "function",
+      );
+    for (const key of [AUFSICHT_PICKUP_KEY, AUFSICHT_ARRIVAL_KEY]) {
+      expect(
+        matchers.some((matcher) => matcher(key)),
+        `student_updated must invalidate ${key}`,
+      ).toBe(true);
+    }
+  });
+
   it("does not revalidate another child whose id merely starts with the event's", () => {
     renderHook(() => useGlobalSSE());
 

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -697,13 +697,14 @@ describe("useGlobalSSE — companion announcements", () => {
   const AUFSICHT_PICKUP_KEY = "t1:pickup-supervisions-2026-07-22-7,8,9";
   const AUFSICHT_ARRIVAL_KEY = "t1:arrival-supervisions-2026-07-22-7,8,9";
 
-  it("refreshes the Aufsicht pickup cache on pickup_schedule_changed", () => {
+  // Fires one event, flushes the burst debounce, and asserts that some matcher
+  // handed to mutate() claims each key.
+  function expectEventInvalidates(
+    event: Parameters<typeof fireSSE>[0],
+    keys: readonly string[],
+  ) {
     renderHook(() => useGlobalSSE());
-
-    // A staff Gehzeit write (weekly plan or date exception) emits only this
-    // event — see api/students/pickup_schedule_handlers.go. The supervising
-    // staff member watching the room is exactly who must see the new time.
-    fireSSE(makeEvent("pickup_schedule_changed", {}));
+    fireSSE(event);
     act(() => {
       vi.advanceTimersByTime(500);
     });
@@ -714,38 +715,34 @@ describe("useGlobalSSE — companion announcements", () => {
         (matcher): matcher is (key: unknown) => boolean =>
           typeof matcher === "function",
       );
-    expect(
-      matchers.some((matcher) => matcher(AUFSICHT_PICKUP_KEY)),
-      "pickup_schedule_changed must invalidate the Aufsicht pickup cache",
-    ).toBe(true);
+    for (const key of keys) {
+      expect(
+        matchers.some((matcher) => matcher(key)),
+        `${event.type} must invalidate ${key}`,
+      ).toBe(true);
+    }
+  }
+
+  it("refreshes the Aufsicht pickup cache on pickup_schedule_changed", () => {
+    // A staff Gehzeit write (weekly plan or date exception) emits only this
+    // event — see api/students/pickup_schedule_handlers.go. The supervising
+    // staff member watching the room is exactly who must see the new time.
+    expectEventInvalidates(makeEvent("pickup_schedule_changed", {}), [
+      AUFSICHT_PICKUP_KEY,
+    ]);
   });
 
   it("refreshes both Aufsicht time caches on student_updated", () => {
-    renderHook(() => useGlobalSSE());
-
     // A parent care exception (submit AND delete) rewrites that day's pickup
     // and arrival override under student_updated alone, and an approved care
     // request rewrites the weekly pickup plan while announcing only
     // student_updated + arrival_schedule_changed. Both writes can target a
     // child already standing in the room, so neither rotates the roster-keyed
     // cache key.
-    fireSSE(makeEvent("student_updated", { student_id: "7" }));
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-
-    const matchers = mockMutate.mock.calls
-      .map(([matcher]) => matcher)
-      .filter(
-        (matcher): matcher is (key: unknown) => boolean =>
-          typeof matcher === "function",
-      );
-    for (const key of [AUFSICHT_PICKUP_KEY, AUFSICHT_ARRIVAL_KEY]) {
-      expect(
-        matchers.some((matcher) => matcher(key)),
-        `student_updated must invalidate ${key}`,
-      ).toBe(true);
-    }
+    expectEventInvalidates(makeEvent("student_updated", { student_id: "7" }), [
+      AUFSICHT_PICKUP_KEY,
+      AUFSICHT_ARRIVAL_KEY,
+    ]);
   });
 
   it("does not revalidate another child whose id merely starts with the event's", () => {

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -493,9 +493,12 @@ export function useGlobalSSE(): SSEHookState {
       mutate(
         (key) =>
           typeof key === "string" &&
-          (key.includes("arrival-search-") ||
-            key.includes("arrival-supervisions-") ||
-            key.includes("arrival-ogs-groups-") ||
+          // No "arrival-search-"/"arrival-ogs-groups-" clauses: the Kindersuche
+          // and the OGS group view never fetched arrival under keys of their
+          // own. Both read it inline from their list responses, which the
+          // student-list and ogs-students blocks above already invalidate on
+          // this event.
+          (key.includes("arrival-supervisions-") ||
             key.includes("arrival-data-") ||
             // the Betreuungsplan day/week view shows the resolved arrival slot
             key.includes("care-plan-day-") ||

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -101,6 +101,68 @@ const STUDENT_SCOPED_KEY_PREFIXES = [
 // The per-group student list on the OGS page ("<slug>:ogs-students-7").
 const OGS_STUDENTS_KEY_PREFIX = "ogs-students-";
 
+// Every cache family that renders a child's resolved PICKUP (Gehzeit) time.
+// "pickup-supervisions-" is the Aktuelle-Aufsicht card row, whose key embeds
+// the room's student-id list — nothing but a roster change or Berlin midnight
+// rotates it, and it disables focus revalidation, so this list is its only
+// live update path.
+const PICKUP_TIME_CACHE_KEY_PARTS = [
+  "care-plan-day-",
+  "care-plan-week-",
+  "pickup-data-",
+  "pickup-supervisions-",
+  "student-detail-",
+] as const;
+
+// The arrival counterpart. No "arrival-search-"/"arrival-ogs-groups-" entries:
+// the Kindersuche and the OGS group view never fetched arrival under keys of
+// their own, they read it inline from their list responses, which the
+// student-list and ogs-students blocks invalidate on the same event.
+const ARRIVAL_TIME_CACHE_KEY_PARTS = [
+  "arrival-supervisions-",
+  "arrival-data-",
+  "care-plan-day-",
+  "care-plan-week-",
+] as const;
+
+// What a student_updated write can invalidate. It covers both time families on
+// purpose: a parent care-exception (submit AND delete) rewrites that day's
+// pickup and arrival override but announces ONLY student_updated — no
+// pickup_schedule_changed, no arrival_schedule_changed
+// (services/parent/parent_write_service.go SubmitCareException). An approved
+// care request is the mirror gap: it emits arrival_schedule_changed but also
+// rewrites the weekly PICKUP plan. Every one of these caches disables focus
+// revalidation, so without this list an open page keeps showing the superseded
+// time until a manual reload.
+const STUDENT_UPDATE_CACHE_KEY_PARTS = [
+  "student-detail-",
+  "student-status-days-",
+  "care-plan-day-",
+  "care-plan-week-",
+  "pickup-data-",
+  "arrival-data-",
+  "pickup-supervisions-",
+  "arrival-supervisions-",
+] as const;
+
+/**
+ * Revalidates every cached key that contains one of `parts`.
+ *
+ * `scope` only labels the debug line when SWR rejects — invalidation itself is
+ * fire-and-forget, exactly like the inline calls this replaces.
+ */
+function revalidateKeyParts(parts: readonly string[], scope: string): void {
+  mutate(
+    (key) =>
+      typeof key === "string" && parts.some((part) => key.includes(part)),
+  ).catch((err) => {
+    logger.debug("swr_revalidation_failed", {
+      error: err instanceof Error ? err.message : String(err),
+      scope,
+    });
+  });
+}
+
 /**
  * Whether an SWR cache key belongs to exactly this id (student or group).
  *
@@ -407,39 +469,7 @@ export function useGlobalSSE(): SSEHookState {
     }
 
     if (hasPendingStudentUpdateEvent.current) {
-      mutate(
-        (key) =>
-          typeof key === "string" &&
-          (key.includes("student-detail-") ||
-            key.includes("student-status-days-") ||
-            key.includes("care-plan-day-") ||
-            key.includes("care-plan-week-") ||
-            // The staff detail header's "Heutige Abholung"/arrival slots. Parent
-            // care-exception writes (submit AND delete) change the pickup and
-            // arrival override for a day but announce ONLY student_updated —
-            // no pickup_schedule_changed, no arrival_schedule_changed
-            // (services/parent/parent_write_service.go SubmitCareException).
-            // An approved care request is the mirror gap: it emits
-            // arrival_schedule_changed but also rewrites the weekly PICKUP
-            // plan. Both keys disable focus revalidation, so without them an
-            // open detail page keeps showing the superseded time until a
-            // manual reload.
-            key.includes("pickup-data-") ||
-            key.includes("arrival-data-") ||
-            // Same write, same staleness, other page: the Aktuelle-Aufsicht
-            // cards render the day's resolved Gehzeit/Ankunft from their own
-            // bulk caches, also with focus revalidation off. Their keys embed
-            // the room's student-id list, so they only refetch when the roster
-            // changes — a parent's care exception for a child already in the
-            // room would otherwise stay invisible for the whole session.
-            key.includes("pickup-supervisions-") ||
-            key.includes("arrival-supervisions-")),
-      ).catch((err) => {
-        logger.debug("swr_revalidation_failed", {
-          error: err instanceof Error ? err.message : String(err),
-          scope: "student_detail",
-        });
-      });
+      revalidateKeyParts(STUDENT_UPDATE_CACHE_KEY_PARTS, "student_detail");
 
       // A renamed or reassigned child changes what the OTHER children's
       // Laufgemeinschaft entries show, without changing a single link — so no
@@ -490,25 +520,7 @@ export function useGlobalSSE(): SSEHookState {
     // Arrival schedule changes affect derived "Kommt heute nicht" badges and
     // arrival rows. These keys are independent from attendance/location caches.
     if (hasPendingArrivalScheduleEvent.current) {
-      mutate(
-        (key) =>
-          typeof key === "string" &&
-          // No "arrival-search-"/"arrival-ogs-groups-" clauses: the Kindersuche
-          // and the OGS group view never fetched arrival under keys of their
-          // own. Both read it inline from their list responses, which the
-          // student-list and ogs-students blocks above already invalidate on
-          // this event.
-          (key.includes("arrival-supervisions-") ||
-            key.includes("arrival-data-") ||
-            // the Betreuungsplan day/week view shows the resolved arrival slot
-            key.includes("care-plan-day-") ||
-            key.includes("care-plan-week-")),
-      ).catch((err) => {
-        logger.debug("swr_revalidation_failed", {
-          error: err instanceof Error ? err.message : String(err),
-          scope: "arrival_schedule",
-        });
-      });
+      revalidateKeyParts(ARRIVAL_TIME_CACHE_KEY_PARTS, "arrival_schedule");
     }
 
     // Pickup (Gehzeit) plan or exception changed. The per-child Betreuungsplan
@@ -525,29 +537,7 @@ export function useGlobalSSE(): SSEHookState {
     // is one re-check per open detail/care-plan page; each refetch is
     // server-access-filtered, so an out-of-scope staffer gets nothing back.
     if (hasPendingPickupScheduleEvent.current) {
-      mutate(
-        (key) =>
-          typeof key === "string" &&
-          (key.includes("care-plan-day-") ||
-            key.includes("care-plan-week-") ||
-            // the detail header's "Gehzeit heute" slot
-            key.includes("pickup-data-") ||
-            // The Aktuelle-Aufsicht student cards, whose PickupTimeRow drives
-            // the "Abholung überfällig" urgency colouring. Its key is
-            // "pickup-supervisions-{date}-{studentIds}", so nothing but a
-            // roster change or Berlin midnight rotates it — and the cache
-            // disables focus revalidation. Without this clause a colleague's
-            // Gehzeit edit stayed invisible to the supervising staff member
-            // for the rest of the session, which is precisely the surface
-            // that needs to act on it.
-            key.includes("pickup-supervisions-") ||
-            key.includes("student-detail-")),
-      ).catch((err) => {
-        logger.debug("swr_revalidation_failed", {
-          error: err instanceof Error ? err.message : String(err),
-          scope: "pickup_schedule",
-        });
-      });
+      revalidateKeyParts(PICKUP_TIME_CACHE_KEY_PARTS, "pickup_schedule");
     }
 
     // The Betreuungszeiten editor (CareScheduleManager) holds its arrival/pickup

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -418,13 +418,22 @@ export function useGlobalSSE(): SSEHookState {
             // care-exception writes (submit AND delete) change the pickup and
             // arrival override for a day but announce ONLY student_updated —
             // no pickup_schedule_changed, no arrival_schedule_changed
-            // (services/parent/parent_write_service.go). An approved care
-            // request is the mirror gap: it emits arrival_schedule_changed but
-            // also rewrites the weekly PICKUP plan. Both keys disable focus
-            // revalidation, so without them an open detail page keeps showing
-            // the superseded time until a manual reload.
+            // (services/parent/parent_write_service.go SubmitCareException).
+            // An approved care request is the mirror gap: it emits
+            // arrival_schedule_changed but also rewrites the weekly PICKUP
+            // plan. Both keys disable focus revalidation, so without them an
+            // open detail page keeps showing the superseded time until a
+            // manual reload.
             key.includes("pickup-data-") ||
-            key.includes("arrival-data-")),
+            key.includes("arrival-data-") ||
+            // Same write, same staleness, other page: the Aktuelle-Aufsicht
+            // cards render the day's resolved Gehzeit/Ankunft from their own
+            // bulk caches, also with focus revalidation off. Their keys embed
+            // the room's student-id list, so they only refetch when the roster
+            // changes — a parent's care exception for a child already in the
+            // room would otherwise stay invisible for the whole session.
+            key.includes("pickup-supervisions-") ||
+            key.includes("arrival-supervisions-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),
@@ -520,6 +529,15 @@ export function useGlobalSSE(): SSEHookState {
             key.includes("care-plan-week-") ||
             // the detail header's "Gehzeit heute" slot
             key.includes("pickup-data-") ||
+            // The Aktuelle-Aufsicht student cards, whose PickupTimeRow drives
+            // the "Abholung überfällig" urgency colouring. Its key is
+            // "pickup-supervisions-{date}-{studentIds}", so nothing but a
+            // roster change or Berlin midnight rotates it — and the cache
+            // disables focus revalidation. Without this clause a colleague's
+            // Gehzeit edit stayed invisible to the supervising staff member
+            // for the rest of the session, which is precisely the surface
+            // that needs to act on it.
+            key.includes("pickup-supervisions-") ||
             key.includes("student-detail-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {


### PR DESCRIPTION
## Warum dieser PR anders aussieht als das Issue

Die Voraussetzung von #2086 gilt nicht mehr. Das Issue wurde am 01.08. um 13:51 Uhr geschrieben, PR #2094 ist am selben Tag um 20:30 Uhr gemerged worden und hat den beschriebenen Composite-Fetcher komplett ersetzt.

Stand heute auf `development`, geprueft in `ogs-groups/page.tsx`:

| Akzeptanzkriterium | Stand |
| --- | --- |
| Check-in-Revalidierung macht 3 statt 4 Backend-Calls | Erfuellt und uebertroffen: es ist **1** Call. Die aggregierte `ogs-students-{gid}`-Projektion liefert Kinder, Raumstatus, Abholzeiten, Tracking-Indikatoren und Uebergaben in einer Antwort. |
| Abholzeiten aktualisieren bei Gehzeit-Aenderung und Rosterwechsel | Erfuellt. `pickup_schedule_changed` setzt `broadOgs`, damit wird `ogs-students-*` invalidiert und die Abholzeiten kommen in derselben Antwort mit. |
| Kein Pickup-Flash der vorherigen Gruppe beim Gruppenwechsel | Erfuellt, doppelt abgesichert: `switchToGroup` leert `pickupTimes` (Zeile 624), und der Sync-Effect wendet die Live-Abschnitte nur an, wenn `selectedGroupId === liveData.groupId` (Zeile 391). |
| `use-global-sse.ts` invalidiert den neuen Key | Gegenstandslos, es gibt keinen neuen Key. |

Ein Aufsplitten waere heute ein Rueckschritt: es wuerde aus einem Request wieder zwei machen, und es braeuchte genau die Key-Abhaengigkeit vom aufgeloesten Roster, die das Issue selbst als Haken benannt hat.

## Was stattdessen drin ist

Bei der Pruefung ist aufgefallen, dass die Seite **Aktuelle Aufsicht** noch die Bauform hat, die das Issue fuer die OGS-Ansicht vorgeschlagen hatte: eigene Keys pro Datenart. Und sie zeigt genau die Schwaeche, gegen die das Issue mit Akzeptanzkriterium 2 absichern wollte, naemlich einen Key, den niemand invalidiert.

`pickup-supervisions-{Datum}-{Kind-IDs}` (`active-supervisions/page.tsx:1450`) stand in keiner Invalidierungsliste in `use-global-sse.ts`, laeuft aber mit `revalidateOnFocus: false`. Der Key dreht sich nur bei Rosterwechsel oder um Berliner Mitternacht. Eine SSE-Invalidierung war also der einzige Live-Weg dorthin, und den gab es nicht.

Drei Schreibpfade blieben dadurch unsichtbar, bis das Kind den Raum verliess:

1. **Gehzeit-Schreibung durch Personal** (Wochenplan oder Datums-Ausnahme) sendet ausschliesslich `pickup_schedule_changed` — `api/students/pickup_schedule_handlers.go`, sieben Aufrufstellen.
2. **Betreuungsausnahme der Eltern** aendert Abhol- *und* Ankunftszeit des Tages, meldet aber nur `student_updated` — `services/parent/parent_write_service.go`, `SubmitCareException`.
3. **Genehmigter Betreuungsantrag** schreibt den Wochenplan der Abholung und meldet `student_updated` + `arrival_schedule_changed` — `services/schedule/care_request_service.go`.

Alle drei betreffen typischerweise ein Kind, das bereits im Raum steht. Die Kind-ID-Liste im Key aendert sich also nicht, und der Betreuer sah die alte Zeit.

Der Fix haengt `pickup-supervisions-` an `pickup_schedule_changed` und beide Aufsichts-Keys an `student_updated`. Das ist dieselbe Begruendung, die `pickup-data-`/`arrival-data-` fuer die Kinddetailseite an dieser Stelle schon stehen hat, nur konsequent auf die zweite betroffene Seite angewendet.

Die Arrival-Seite war zur Haelfte versorgt: `arrival-supervisions-` haengt seit April an `arrival_schedule_changed`, aber nicht an `student_updated`. Der Elternpfad war dort also genauso blind. Mit erledigt, gleicher Fehler, gleiche Zeile.

Die OGS-Gruppenansicht ist nicht betroffen, sie ist durch das Aggregat aus #2056 korrekt by construction. Das ist der eigentliche Punkt: die aggregierte Bauform kann diesen Fehler nicht haben, die aufgesplittete schon.

## Zweiter Commit: toter Code

`arrival-search-` und `arrival-ogs-groups-` wurden seit ihrer Einfuehrung (179f16e83, April 2026) von keiner Stelle als SWR-Key erzeugt. Geprueft ueber die gesamte Historie, nicht nur den aktuellen Stand:

```
git log --oneline -S'arrival-ogs-groups' --all      # nur der Einfuehrungs-Commit + sein Test
rg 'arrival-search|arrival-ogs-groups' frontend/src # nur use-global-sse.ts selbst
```

Die Kindersuche und die OGS-Ansicht lesen die Ankunftszeit inline aus ihrer Listenantwort, genau das war der Zweck jenes Commits ("enrich list with arrival times"). Beide Listen haengen bereits ueber `search-students-` und `ogs-students-` an `arrival_schedule_changed`.

**Hinweis zur Testaenderung:** eine Zusicherung im Bestandstest hat geprueft, dass der Matcher auf `arrival-ogs-groups-1` trifft, also auf einen Key, den kein Code bilden kann. Das ist keine Geschaeftsregel, sondern eine Zusicherung ueber toten Code. Der Suchtreffer fuer den Arrival-Aufruf laeuft jetzt ueber `arrival-supervisions-`, das tatsaechlich erzeugt wird.

## Pruefung

- Beide neuen Tests **schlagen ohne den Fix fehl** und laufen mit ihm durch. Gegengeprueft per `git stash` auf der Quelldatei, damit hier keine Zusicherung steht, die ohnehin gruen waere.
- `pnpm run check` ohne Befund.
- Gesamte Frontend-Suite: 943 Dateien, 13004 Tests, alle gruen.
- Backend-Emitter fuer alle drei Schreibpfade im Code nachgelesen, nicht aus den Kommentaren uebernommen.

Keine sichtbare Aenderung an der Oberflaeche ausser der, um die es geht: die Zeit stimmt jetzt ohne Reload.

Closes #2086
