### PR TITLE
Kindersuche: Listen-Payload verschlanken und SSE-Invalidierung eingrenzen

### DIFF
--- a/backend/api/students/list_helpers.go
+++ b/backend/api/students/list_helpers.go
@@ -1,6 +1,7 @@
 package students
 
 import (
+	"fmt"
 	"maps"
 	"net/http"
 	"slices"
@@ -58,11 +59,30 @@ type studentListParams struct {
 	// filters run in memory after the fetch, so a paginated page would hide
 	// matching children past the page boundary and silently shorten the list.
 	fetchAll bool
+	// slimView selects the Kindersuche wire projection (#2097). Purely a
+	// marshalling choice made after filtering and pagination — see
+	// list_projection.go.
+	slimView bool
 }
 
 // studentAccessContext is an alias for the shared common.StudentAccessContext
 // so existing call sites in this package keep working unchanged.
 type studentAccessContext = common.StudentAccessContext
+
+// parseStudentListView resolves the `view` query parameter. Empty and "full"
+// keep the historical projection; only "slim" opts into the Kindersuche shape
+// (#2097). An unknown value is rejected instead of silently serving the full
+// payload, so a typo in a caller surfaces immediately.
+func parseStudentListView(value string) (bool, error) {
+	switch value {
+	case "", StudentListViewFull:
+		return false, nil
+	case StudentListViewSlim:
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid view %q: must be %q or %q", value, StudentListViewFull, StudentListViewSlim)
+	}
+}
 
 // parseStudentListParams extracts query parameters from the request
 func parseStudentListParams(r *http.Request) *studentListParams {

--- a/backend/api/students/list_projection.go
+++ b/backend/api/students/list_projection.go
@@ -1,0 +1,131 @@
+package students
+
+import "time"
+
+// Values accepted by the `view` query parameter of GET /api/students.
+const (
+	// StudentListViewFull is the historical full StudentResponse projection and
+	// stays the default — every existing consumer keeps its payload unchanged.
+	StudentListViewFull = "full"
+	// StudentListViewSlim is the Kindersuche projection (#2097).
+	StudentListViewSlim = "slim"
+)
+
+// SlimStudentResponse is the list projection for the Kindersuche
+// (frontend students/search): every field its cards, client-side
+// filters/sorting/grouping and the presence badge actually read, and nothing
+// else.
+//
+// Why (#2097): the full StudentResponse ships ~55 fields, including the
+// address block, health info, supervisor notes, the four weekday departure
+// maps, guardian contacts, enrollment consent timestamps and row timestamps.
+// The Kindersuche renders none of them — the child detail page fetches the
+// full record separately — yet the page requests up to 1000 rows in one trip,
+// which measured 51.9 KB on average and 198.4 KB at peak in production
+// (benchmark 2026-07-30, #2063).
+//
+// This is a WIRE projection only: the handler still builds, filters, sorts and
+// paginates full StudentResponse values, so day-planning, administrative
+// filters and access redaction behave identically in both views. Only the
+// final marshalling differs.
+//
+// Adding a field here is cheap; removing one is a breaking change for the
+// Kindersuche. Before adding, check that the page actually reads it —
+// TestListStudents_SlimProjection pins the forbidden set.
+type SlimStudentResponse struct {
+	ID          int64  `json:"id"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	SchoolClass string `json:"school_class"`
+
+	// Live location + the badge context it is rendered with. The *_since
+	// timestamps are part of StudentLocationContext (frontend
+	// lib/location-helper.ts): the cards do not pass showLocationSince today,
+	// but the badge reads them, so dropping them would silently break the
+	// "seit HH:MM" label the moment a card enables it. They cost <1% of the
+	// payload (only set for children who are actually present/absent).
+	Location       string     `json:"current_location"`
+	LocationSince  *time.Time `json:"location_since,omitempty"`
+	RoomColor      *string    `json:"current_room_color,omitempty"`
+	GroupID        int64      `json:"group_id,omitempty"`
+	GroupName      string     `json:"group_name,omitempty"`
+	Sick           bool       `json:"sick"`
+	SickSince      *time.Time `json:"sick_since,omitempty"`
+	Excused        bool       `json:"excused"`
+	ExcusedSince   *time.Time `json:"excused_since,omitempty"`
+	ClassTrip      bool       `json:"class_trip"`
+	ClassTripSince *time.Time `json:"class_trip_since,omitempty"`
+
+	// Day planning. day_planning_reason is deliberately absent: the page
+	// renders day_planning_label and derives everything else from status.
+	DayPlanningStatus  string  `json:"day_planning_status,omitempty"`
+	DayPlanningLabel   string  `json:"day_planning_label,omitempty"`
+	PendingExcusedNote *string `json:"pending_excused_note,omitempty"`
+
+	// Planned + actual times (the arrival/pickup rows and their sort/group
+	// modes). Only populated for full-access rows and when the caller passes
+	// include_pickup_times / include_arrival_times.
+	PickupStatus       string  `json:"pickup_status,omitempty"`
+	PickupTime         *string `json:"pickup_time,omitempty"`
+	PickupIsException  bool    `json:"pickup_is_exception,omitempty"`
+	PickupNotes        string  `json:"pickup_notes,omitempty"`
+	ArrivalTime        *string `json:"arrival_time,omitempty"`
+	ArrivalIsException bool    `json:"arrival_is_exception,omitempty"`
+	ArrivalNotes       string  `json:"arrival_notes,omitempty"`
+	ActualArrivalTime  *string `json:"actual_arrival_time,omitempty"`
+	ActualPickupTime   *string `json:"actual_pickup_time,omitempty"`
+
+	// "Nach Laufgemeinschaft" grouping; only with include_companions=true.
+	CompanionStudentIDs []int64 `json:"companion_student_ids,omitempty"`
+
+	// Photo + consent. photo_consent_given is carried because the page probes
+	// its PRESENCE (not its value) to decide whether the "Fotoerlaubnis" filter
+	// is offered at all — omitting it would silently remove that filter.
+	PhotoURL          string `json:"photo_url,omitempty"`
+	PhotoConsentGiven *bool  `json:"photo_consent_given,omitempty"`
+
+	HasFullAccess bool `json:"has_full_access"`
+}
+
+// slimStudentResponses projects the fully built, filtered and paginated list
+// onto the Kindersuche wire shape.
+func slimStudentResponses(responses []StudentResponse) []SlimStudentResponse {
+	slim := make([]SlimStudentResponse, len(responses))
+	for i := range responses {
+		r := &responses[i]
+		slim[i] = SlimStudentResponse{
+			ID:                  r.ID,
+			FirstName:           r.FirstName,
+			LastName:            r.LastName,
+			SchoolClass:         r.SchoolClass,
+			Location:            r.Location,
+			LocationSince:       r.LocationSince,
+			RoomColor:           r.RoomColor,
+			GroupID:             r.GroupID,
+			GroupName:           r.GroupName,
+			Sick:                r.Sick,
+			SickSince:           r.SickSince,
+			Excused:             r.Excused,
+			ExcusedSince:        r.ExcusedSince,
+			ClassTrip:           r.ClassTrip,
+			ClassTripSince:      r.ClassTripSince,
+			DayPlanningStatus:   r.DayPlanningStatus,
+			DayPlanningLabel:    r.DayPlanningLabel,
+			PendingExcusedNote:  r.PendingExcusedNote,
+			PickupStatus:        r.PickupStatus,
+			PickupTime:          r.PickupTime,
+			PickupIsException:   r.PickupIsException,
+			PickupNotes:         r.PickupNotes,
+			ArrivalTime:         r.ArrivalTime,
+			ArrivalIsException:  r.ArrivalIsException,
+			ArrivalNotes:        r.ArrivalNotes,
+			ActualArrivalTime:   r.ActualArrivalTime,
+			ActualPickupTime:    r.ActualPickupTime,
+			CompanionStudentIDs: r.CompanionStudentIDs,
+			PhotoURL:            r.PhotoURL,
+			PhotoConsentGiven:   r.PhotoConsentGiven,
+			HasFullAccess:       r.HasFullAccess,
+		}
+	}
+	return slim
+}

--- a/backend/api/students/list_projection_internal_test.go
+++ b/backend/api/students/list_projection_internal_test.go
@@ -1,0 +1,206 @@
+package students
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// fullyPopulatedStudentResponse sets every field of the full projection to a
+// non-zero value, so `omitempty` cannot hide a field the slim projection
+// wrongly keeps (or wrongly drops).
+func fullyPopulatedStudentResponse() StudentResponse {
+	now := time.Now()
+	str := func(s string) *string { return &s }
+	id := int64(4711)
+	yes := true
+
+	return StudentResponse{
+		ID:                       id,
+		PersonID:                 id + 1,
+		FirstName:                "Emma",
+		LastName:                 "Meyer",
+		TagID:                    "TAG-1",
+		Birthday:                 "2019-02-02",
+		SchoolClass:              "1a",
+		Location:                 "Gruppenraum",
+		LocationSince:            &now,
+		RoomColor:                str("#83CD2D"),
+		GuardianName:             "Erika Mustermann",
+		GuardianContact:          "0221 1234567",
+		GuardianEmail:            "erika@example.com",
+		GuardianPhone:            "+49 170 1234567",
+		GroupID:                  id + 2,
+		GroupName:                "Sternengruppe",
+		AddressStreet:            "Musterstrasse 12a",
+		AddressCity:              "Koeln",
+		AddressPostalCode:        "50667",
+		ExtraInfo:                "Geschwisterkind",
+		HealthInfo:               "Laktoseintoleranz",
+		SupervisorNotes:          "Braucht mehr Zeit",
+		PickupStatus:             "Wird abgeholt",
+		PickupDays:               users.PickupDays{"mon": true},
+		PickupTime:               str("15:30"),
+		PickupIsException:        true,
+		PickupNotes:              "Oma holt ab",
+		ArrivalTime:              str("08:00"),
+		ArrivalIsException:       true,
+		ArrivalNotes:             "Arzttermin",
+		ActualArrivalTime:        str("08:05"),
+		ActualPickupTime:         str("15:35"),
+		DepartureDays:            users.DepartureDays{"mon": "pickup"},
+		AllowedDepartureModes:    users.AllowedDepartureModes{"mon": {"pickup"}},
+		DepartureCompanionNote:   "geht mit Nachbarskind",
+		CompanionStudentIDs:      []int64{id + 3},
+		CompanionsChanged:        &yes,
+		Bus:                      true,
+		BusDays:                  users.BusDays{"mon": true},
+		Sick:                     true,
+		SickSince:                &now,
+		Excused:                  true,
+		ExcusedSince:             &now,
+		ClassTrip:                true,
+		ClassTripSince:           &now,
+		DayPlanningStatus:        "comes_today",
+		DayPlanningReason:        "care_day",
+		DayPlanningLabel:         "kommt heute",
+		PendingExcusedNote:       str("Arzttermin"),
+		PhotoURL:                 "/api/students/4711/photo",
+		PhotoConsentGiven:        &yes,
+		PhotoConsentGivenAt:      &now,
+		PhotoConsentGivenBy:      &id,
+		AGBAcceptedAt:            &now,
+		DataProcessingAcceptedAt: &now,
+		EmailContactAcceptedAt:   &now,
+		HasFullAccess:            true,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}
+}
+
+// TestSlimStudentResponseWireContract pins the exact key set the Kindersuche
+// projection puts on the wire (#2097). It fails both ways: a field silently
+// re-added (payload creep) and a field the page reads silently dropped.
+func TestSlimStudentResponseWireContract(t *testing.T) {
+	slim := slimStudentResponses([]StudentResponse{fullyPopulatedStudentResponse()})
+	require.Len(t, slim, 1)
+
+	encoded, err := json.Marshal(slim[0])
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+	keys := make([]string, 0, len(decoded))
+	for key := range decoded {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	want := []string{
+		"actual_arrival_time",
+		"actual_pickup_time",
+		"arrival_is_exception",
+		"arrival_notes",
+		"arrival_time",
+		"class_trip",
+		"class_trip_since",
+		"companion_student_ids",
+		"current_location",
+		"current_room_color",
+		"day_planning_label",
+		"day_planning_status",
+		"excused",
+		"excused_since",
+		"first_name",
+		"group_id",
+		"group_name",
+		"has_full_access",
+		"id",
+		"last_name",
+		"location_since",
+		"pending_excused_note",
+		"photo_consent_given",
+		"photo_url",
+		"pickup_is_exception",
+		"pickup_notes",
+		"pickup_status",
+		"pickup_time",
+		"school_class",
+		"sick",
+		"sick_since",
+	}
+	assert.Equal(t, want, keys,
+		"the Kindersuche wire contract changed — update the page and this list together (#2097)")
+}
+
+// TestSlimStudentResponseCopiesValues guards against a copy-paste slip in the
+// projection: every kept field must carry the full response's value, not a
+// zero value or a neighbouring field.
+func TestSlimStudentResponseCopiesValues(t *testing.T) {
+	full := fullyPopulatedStudentResponse()
+	slim := slimStudentResponses([]StudentResponse{full})
+	require.Len(t, slim, 1)
+	got := slim[0]
+
+	assert.Equal(t, full.ID, got.ID)
+	assert.Equal(t, full.FirstName, got.FirstName)
+	assert.Equal(t, full.LastName, got.LastName)
+	assert.Equal(t, full.SchoolClass, got.SchoolClass)
+	assert.Equal(t, full.Location, got.Location)
+	assert.Equal(t, full.LocationSince, got.LocationSince)
+	assert.Equal(t, full.RoomColor, got.RoomColor)
+	assert.Equal(t, full.GroupID, got.GroupID)
+	assert.Equal(t, full.GroupName, got.GroupName)
+	assert.Equal(t, full.Sick, got.Sick)
+	assert.Equal(t, full.SickSince, got.SickSince)
+	assert.Equal(t, full.Excused, got.Excused)
+	assert.Equal(t, full.ExcusedSince, got.ExcusedSince)
+	assert.Equal(t, full.ClassTrip, got.ClassTrip)
+	assert.Equal(t, full.ClassTripSince, got.ClassTripSince)
+	assert.Equal(t, full.DayPlanningStatus, got.DayPlanningStatus)
+	assert.Equal(t, full.DayPlanningLabel, got.DayPlanningLabel)
+	assert.Equal(t, full.PendingExcusedNote, got.PendingExcusedNote)
+	assert.Equal(t, full.PickupStatus, got.PickupStatus)
+	assert.Equal(t, full.PickupTime, got.PickupTime)
+	assert.Equal(t, full.PickupIsException, got.PickupIsException)
+	assert.Equal(t, full.PickupNotes, got.PickupNotes)
+	assert.Equal(t, full.ArrivalTime, got.ArrivalTime)
+	assert.Equal(t, full.ArrivalIsException, got.ArrivalIsException)
+	assert.Equal(t, full.ArrivalNotes, got.ArrivalNotes)
+	assert.Equal(t, full.ActualArrivalTime, got.ActualArrivalTime)
+	assert.Equal(t, full.ActualPickupTime, got.ActualPickupTime)
+	assert.Equal(t, full.CompanionStudentIDs, got.CompanionStudentIDs)
+	assert.Equal(t, full.PhotoURL, got.PhotoURL)
+	assert.Equal(t, full.PhotoConsentGiven, got.PhotoConsentGiven)
+	assert.Equal(t, full.HasFullAccess, got.HasFullAccess)
+}
+
+// TestParseStudentListView covers the query-parameter contract.
+func TestParseStudentListView(t *testing.T) {
+	for _, tc := range []struct {
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{value: "", want: false},
+		{value: StudentListViewFull, want: false},
+		{value: StudentListViewSlim, want: true},
+		{value: "compact", wantErr: true},
+		{value: "SLIM", wantErr: true},
+	} {
+		got, err := parseStudentListView(tc.value)
+		if tc.wantErr {
+			assert.Error(t, err, "view %q must be rejected", tc.value)
+			continue
+		}
+		require.NoError(t, err, "view %q", tc.value)
+		assert.Equal(t, tc.want, got, "view %q", tc.value)
+	}
+}

--- a/backend/api/students/list_projection_test.go
+++ b/backend/api/students/list_projection_test.go
@@ -1,0 +1,233 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// listStudentsPerms mirrors the permission the list route requires.
+var listStudentsPerms = []string{"admin:*"}
+
+// fillWideStudentFields writes the personal/administrative columns a real
+// production row carries. Without them omitempty hides most of the full
+// projection and a payload comparison would measure nothing.
+//
+// bus_days / pickup_days / departure_days / allowed_departure_modes are
+// `scanonly` on the model, so they are written with raw SQL here exactly like
+// the repository reads them.
+func fillWideStudentFields(t *testing.T, db *bun.DB, studentID, personID int64) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := db.NewRaw(`UPDATE users.students SET
+			guardian_name = 'Erika Mustermann',
+			guardian_contact = '0221 1234567',
+			guardian_email = 'erika.mustermann@example.com',
+			guardian_phone = '+49 170 1234567',
+			address_street = 'Musterstrasse 12a',
+			address_city = 'Koeln',
+			address_postal_code = '50667',
+			extra_info = 'Geschwisterkind in Klasse 2b, kommt meist mit dem Rad',
+			health_info = 'Laktoseintoleranz, Notfallmedikament im Gruppenraum',
+			supervisor_notes = 'Braucht manchmal etwas mehr Zeit bei Uebergaengen',
+			pickup_status = 'Wird abgeholt',
+			bus_days = '{"mon":true,"tue":true,"wed":true,"thu":true,"fri":true}'::jsonb,
+			pickup_days = '{"mon":true,"tue":true,"wed":true,"thu":true,"fri":true}'::jsonb,
+			departure_days = '{"mon":"pickup","tue":"pickup","wed":"pickup","thu":"pickup","fri":"pickup"}'::jsonb,
+			allowed_departure_modes = '{"mon":["pickup"],"tue":["pickup"],"wed":["pickup"],"thu":["pickup"],"fri":["pickup"]}'::jsonb,
+			agb_accepted_at = now(),
+			data_processing_accepted_at = now(),
+			email_contact_accepted_at = now()
+		WHERE id = ?`, studentID).Exec(ctx)
+	require.NoError(t, err, "failed to fill wide student fields")
+
+	_, err = db.NewRaw(`UPDATE users.persons SET birthday = DATE '2019-02-02' WHERE id = ?`, personID).Exec(ctx)
+	require.NoError(t, err, "failed to set person birthday")
+}
+
+// listStudentIDs decodes the id of every row in a paginated students response.
+func listStudentIDs(t *testing.T, body []byte) []int64 {
+	t.Helper()
+
+	var envelope struct {
+		Data []struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &envelope))
+
+	ids := make([]int64, 0, len(envelope.Data))
+	for _, row := range envelope.Data {
+		ids = append(ids, row.ID)
+	}
+	return ids
+}
+
+// TestListStudents_SlimProjection is the payload guard for #2097: the
+// Kindersuche list must never carry the wide personal fields its cards,
+// filters and grouping modes do not read. The child detail page fetches the
+// full record separately.
+func TestListStudents_SlimProjection(t *testing.T) {
+	tc := setupTestContext(t)
+
+	student := testpkg.CreateTestStudent(t, tc.db, "Slim", "Kind", "SL1")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+	fillWideStudentFields(t, tc.db, student.ID, student.PersonID)
+
+	req := testutil.NewRequest("GET", "/?view=slim&include_pickup_times=true&include_arrival_times=true", nil)
+	rr := authExec(t, tc, req, testutil.AdminTestClaims(1), listStudentsPerms)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	body := rr.Body.String()
+	for _, forbidden := range []string{
+		"person_id", "tag_id", "birthday",
+		"guardian_name", "guardian_contact", "guardian_email", "guardian_phone",
+		"address_street", "address_city", "address_postal_code",
+		"extra_info", "health_info", "supervisor_notes",
+		"bus_days", "pickup_days", "departure_days", "allowed_departure_modes",
+		"departure_companion_note",
+		"day_planning_reason",
+		"photo_consent_given_at", "photo_consent_given_by",
+		"agb_accepted_at", "data_processing_accepted_at", "email_contact_accepted_at",
+		"created_at", "updated_at",
+		`"bus":`,
+	} {
+		assert.NotContains(t, body, forbidden,
+			"slim student list must not ship unrendered field %q (#2097)", forbidden)
+	}
+
+	// Everything the Kindersuche cards, filters and badges do read.
+	for _, required := range []string{
+		"id", "first_name", "last_name", "school_class",
+		"current_location", "sick", "excused", "class_trip", "has_full_access",
+	} {
+		assert.Contains(t, body, required, "slim student list must include %q", required)
+	}
+}
+
+// TestListStudents_FullViewKeepsWideProjection pins the default: only an
+// explicit view=slim changes the wire shape, so the other nine consumers of
+// GET /api/students (room detail, companion picker, roster search, …) keep the
+// payload they read today.
+func TestListStudents_FullViewKeepsWideProjection(t *testing.T) {
+	tc := setupTestContext(t)
+
+	student := testpkg.CreateTestStudent(t, tc.db, "Wide", "Kind", "WD1")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)
+	fillWideStudentFields(t, tc.db, student.ID, student.PersonID)
+
+	for _, view := range []string{"", "?view=full"} {
+		path := "/" + view
+		req := testutil.NewRequest("GET", path, nil)
+		rr := authExec(t, tc, req, testutil.AdminTestClaims(1), listStudentsPerms)
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+		body := rr.Body.String()
+		for _, required := range []string{
+			"health_info", "supervisor_notes", "extra_info",
+			"guardian_email", "address_street", "pickup_days",
+			"allowed_departure_modes", "created_at",
+		} {
+			assert.Contains(t, body, required,
+				"GET /students%s must keep the full projection", path)
+		}
+	}
+}
+
+// TestListStudents_InvalidView rejects an unknown view instead of silently
+// serving the full payload — a typo in a caller must surface immediately.
+func TestListStudents_InvalidView(t *testing.T) {
+	tc := setupTestContext(t)
+
+	req := testutil.NewRequest("GET", "/?view=compact", nil)
+	rr := authExec(t, tc, req, testutil.AdminTestClaims(1), listStudentsPerms)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, "body: %s", rr.Body.String())
+}
+
+// TestListStudents_SlimViewSameRows proves the projection is a WIRE change
+// only: both views return the same children in the same order, so filtering,
+// day planning and pagination are untouched.
+func TestListStudents_SlimViewSameRows(t *testing.T) {
+	tc := setupTestContext(t)
+
+	var studentIDs []int64
+	for i := range 5 {
+		student := testpkg.CreateTestStudent(t, tc.db, "SameRows", fmt.Sprintf("Kind%d", i), "SR1")
+		fillWideStudentFields(t, tc.db, student.ID, student.PersonID)
+		studentIDs = append(studentIDs, student.ID)
+	}
+	defer testpkg.CleanupActivityFixtures(t, tc.db, studentIDs...)
+
+	query := "search=SameRows&include_pickup_times=true&include_arrival_times=true&page_size=100"
+
+	fullRR := authExec(t, tc, testutil.NewRequest("GET", "/?"+query, nil), testutil.AdminTestClaims(1), listStudentsPerms)
+	require.Equal(t, http.StatusOK, fullRR.Code, "body: %s", fullRR.Body.String())
+
+	slimRR := authExec(t, tc, testutil.NewRequest("GET", "/?"+query+"&view=slim", nil), testutil.AdminTestClaims(1), listStudentsPerms)
+	require.Equal(t, http.StatusOK, slimRR.Code, "body: %s", slimRR.Body.String())
+
+	fullIDs := listStudentIDs(t, fullRR.Body.Bytes())
+	require.Len(t, fullIDs, len(studentIDs))
+	assert.Equal(t, fullIDs, listStudentIDs(t, slimRR.Body.Bytes()),
+		"view=slim must not change which children are returned or their order")
+}
+
+// TestListStudents_SlimPayloadBudget bounds the wire size of the Kindersuche
+// list. Production measured 51.9 KB on average and 198.4 KB at peak for this
+// endpoint (benchmark 2026-07-30, #2063) because the page requests up to 1000
+// rows of the full projection in one trip.
+func TestListStudents_SlimPayloadBudget(t *testing.T) {
+	tc := setupTestContext(t)
+
+	var studentIDs []int64
+	const listSize = 30
+	for i := range listSize {
+		student := testpkg.CreateTestStudent(t, tc.db, "Budget", fmt.Sprintf("Produktionskind%02d", i), "BG1")
+		fillWideStudentFields(t, tc.db, student.ID, student.PersonID)
+		studentIDs = append(studentIDs, student.ID)
+	}
+	defer testpkg.CleanupActivityFixtures(t, tc.db, studentIDs...)
+
+	query := "search=Produktionskind&include_pickup_times=true&include_arrival_times=true&page_size=100"
+
+	measure := func(view string) int {
+		path := "/?" + query
+		if view != "" {
+			path += "&view=" + view
+		}
+		rr := authExec(t, tc, testutil.NewRequest("GET", path, nil), testutil.AdminTestClaims(1), listStudentsPerms)
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+		require.Len(t, listStudentIDs(t, rr.Body.Bytes()), listSize)
+		return rr.Body.Len()
+	}
+
+	fullSize := measure("")
+	slimSize := measure("slim")
+	t.Logf("payload budget: %d students → full %d bytes (%.0f B/child), slim %d bytes (%.0f B/child), −%.0f%%",
+		listSize, fullSize, float64(fullSize)/listSize, slimSize, float64(slimSize)/listSize,
+		100*(1-float64(slimSize)/float64(fullSize)))
+
+	// Budget: ≤ 350 bytes per child plus 1 KB envelope. A production list of
+	// 1000 children must stay well under the ~198 KB observed on the full
+	// projection. Raise only with a written justification.
+	const maxBytes = 1024 + listSize*350
+	assert.LessOrEqual(t, slimSize, maxBytes, "slim student list exceeded its payload budget (#2097)")
+
+	// The projection must actually earn its keep: at least a third off the
+	// full payload for the same rows.
+	assert.LessOrEqual(t, slimSize, fullSize*2/3,
+		"view=slim must cut at least a third of the full-projection payload")
+}

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -77,6 +77,12 @@ func (rs *Resource) parseAndGetStudentIncludingAlumni(w http.ResponseWriter, r *
 func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 	// Parse query parameters and determine access
 	params := parseStudentListParams(r)
+	slimView, viewErr := parseStudentListView(r.URL.Query().Get("view"))
+	if viewErr != nil {
+		renderError(w, r, common.ErrorInvalidRequest(viewErr))
+		return
+	}
+	params.slimView = slimView
 	// Resolved BEFORE the fetch: the room/location pre-filters below query
 	// today's live active.visits state, so a non-today planning request has to
 	// be rejected before that query runs, not after it (#1939).
@@ -169,7 +175,14 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	common.RespondPaginated(w, r, http.StatusOK, responses, common.PaginationParams{Page: params.page, PageSize: params.pageSize, Total: totalCount}, "Students retrieved successfully")
+	pagination := common.PaginationParams{Page: params.page, PageSize: params.pageSize, Total: totalCount}
+	// Projection happens last, after every filter, sort and pagination step has
+	// run on the full responses — the two views differ on the wire only (#2097).
+	if params.slimView {
+		common.RespondPaginated(w, r, http.StatusOK, slimStudentResponses(responses), pagination, "Students retrieved successfully")
+		return
+	}
+	common.RespondPaginated(w, r, http.StatusOK, responses, pagination, "Students retrieved successfully")
 }
 
 // enrichPaginatedPlanningTimes layers the planning-date time data onto the final

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -1941,6 +1941,62 @@ describe("StudentSearchPage", () => {
       });
     });
 
+    it.each([
+      { rawGroupId: "007", expectedGroupId: "7", expectedScope: "g7" },
+      { rawGroupId: "0", expectedGroupId: "", expectedScope: "gall" },
+      {
+        rawGroupId: "not-a-group",
+        expectedGroupId: "",
+        expectedScope: "gall",
+      },
+    ])(
+      "normalizes URL group_id '$rawGroupId' to the backend-effective SSE scope",
+      async ({ rawGroupId, expectedGroupId, expectedScope }) => {
+        mockSearchParams.set("group_id", rawGroupId);
+        const { studentService } = await import("~/lib/api");
+        const swrModule = await import("~/lib/swr");
+        const studentKeys: string[] = [];
+        const fetcher = captureStudentsFetcher(swrModule);
+
+        vi.mocked(swrModule.useSWRAuth).mockImplementation(
+          (key, swrFetcher) => {
+            if (typeof key === "string" && key.startsWith("search-students-")) {
+              studentKeys.push(key);
+              if (swrFetcher) {
+                fetcher.current = swrFetcher as () => Promise<unknown>;
+              }
+            }
+            if (key === "search-rooms-list") {
+              return {
+                data: [],
+                isLoading: false,
+                error: null,
+              } as ReturnType<typeof swrModule.useSWRAuth>;
+            }
+            return {
+              data: { students: mockStudents },
+              isLoading: false,
+              error: null,
+            } as ReturnType<typeof swrModule.useSWRAuth>;
+          },
+        );
+
+        render(<StudentSearchPage />);
+
+        await waitFor(() => {
+          expect(
+            studentKeys.some((key) =>
+              key.startsWith(`search-students-${expectedScope}-`),
+            ),
+          ).toBe(true);
+        });
+        await fetcher.current!();
+        expect(studentService.getStudents).toHaveBeenCalledWith(
+          expect.objectContaining({ groupId: expectedGroupId }),
+        );
+      },
+    );
+
     it("requests the slim list projection (#2097)", async () => {
       // The page renders no address, health info, supervisor note, guardian
       // contact or departure map — shipping them costs ~78% of the payload on

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -1903,6 +1903,62 @@ describe("StudentSearchPage", () => {
       });
     });
 
+    it("leads the students SWR cache key with the group scope (#2097)", async () => {
+      // The SSE flush reads the page's group filter back out of this key to
+      // decide whether a check-in in some other group concerns this view, so
+      // the scope segment must sit before the free-text term (which may itself
+      // contain dashes). See lib/swr/search-students-key.
+      mockSearchParams.set("group_id", "7");
+      const swrModule = await import("~/lib/swr");
+      const studentKeys: string[] = [];
+
+      vi.mocked(swrModule.useSWRAuth).mockImplementation((key) => {
+        if (key === "search-rooms-list") {
+          return {
+            data: [],
+            isLoading: false,
+            error: null,
+          } as ReturnType<typeof swrModule.useSWRAuth>;
+        }
+
+        if (typeof key === "string" && key.startsWith("search-students-")) {
+          studentKeys.push(key);
+        }
+
+        return {
+          data: { students: mockStudents },
+          isLoading: false,
+          error: null,
+        } as ReturnType<typeof swrModule.useSWRAuth>;
+      });
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => {
+        expect(
+          studentKeys.some((key) => key.startsWith("search-students-g7-")),
+        ).toBe(true);
+      });
+    });
+
+    it("requests the slim list projection (#2097)", async () => {
+      // The page renders no address, health info, supervisor note, guardian
+      // contact or departure map — shipping them costs ~78% of the payload on
+      // a list that fetches up to 1000 rows in one trip.
+      const { studentService } = await import("~/lib/api");
+      const swrModule = await import("~/lib/swr");
+      const fetcher = captureStudentsFetcher(swrModule);
+
+      render(<StudentSearchPage />);
+
+      await waitFor(() => expect(fetcher.current).not.toBeNull());
+      await fetcher.current!();
+
+      expect(studentService.getStudents).toHaveBeenCalledWith(
+        expect.objectContaining({ view: "slim" }),
+      );
+    });
+
     it("delegates Buskind filtering to a single backend request (#1492)", async () => {
       // Previously the page fetched every page client-side and filtered locally.
       // The backend now filters + paginates server-side, so the fetcher makes a

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -70,6 +70,7 @@ import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled"
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
 import { SEARCH_ROOMS_LIST_CACHE_KEY } from "~/lib/swr/room-derived-caches";
 import {
+  normalizeSearchStudentsGroupId,
   SEARCH_STUDENTS_KEY_PREFIX,
   searchStudentsGroupScope,
 } from "~/lib/swr/search-students-key";
@@ -351,7 +352,7 @@ function normalizeStoredFilters(
         ? ""
         : (params.get("year") ?? ""),
     school_class: params.get("school_class") ?? "",
-    group_id: params.get("group_id") ?? "",
+    group_id: normalizeSearchStudentsGroupId(params.get("group_id") ?? ""),
     room_id: params.get("room_id") ?? "",
     room_name: params.get("room_id") ? (params.get("room_name") ?? "") : "",
     bus:
@@ -923,7 +924,7 @@ function SearchPageContent() {
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(""); // Debounced version for SWR key
   const [selectedGroup, setSelectedGroup] = useState(
-    initialFilterParams.get("group_id") ?? "",
+    normalizeSearchStudentsGroupId(initialFilterParams.get("group_id") ?? ""),
   );
   const [selectedSchoolClass, setSelectedSchoolClass] = useState(
     initialFilterParams.get("school_class") ?? "",
@@ -1022,7 +1023,9 @@ function SearchPageContent() {
         compactStoredFilters(normalizeStoredFilters(filters)),
       );
 
-      setSelectedGroup(params.get("group_id") ?? "");
+      setSelectedGroup(
+        normalizeSearchStudentsGroupId(params.get("group_id") ?? ""),
+      );
       setSelectedSchoolClass(params.get("school_class") ?? "");
       setSelectedYear(
         validQueryValue(
@@ -1447,8 +1450,9 @@ function SearchPageContent() {
 
   const updateSelectedGroup = useCallback(
     (value: string) => {
-      setSelectedGroup(value);
-      updateUrlParams({ group_id: value });
+      const normalizedGroupId = normalizeSearchStudentsGroupId(value);
+      setSelectedGroup(normalizedGroupId);
+      updateUrlParams({ group_id: normalizedGroupId });
     },
     [updateUrlParams],
   );

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -69,6 +69,10 @@ import { usePresenceMode } from "~/lib/tenant-context";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { useSWRAuth, useImmutableSWR } from "~/lib/swr";
 import { SEARCH_ROOMS_LIST_CACHE_KEY } from "~/lib/swr/room-derived-caches";
+import {
+  SEARCH_STUDENTS_KEY_PREFIX,
+  searchStudentsGroupScope,
+} from "~/lib/swr/search-students-key";
 import { activeService } from "~/lib/active-api";
 import type { TrackingIndicatorsResponse } from "~/lib/active-helpers";
 import { TrackingIndicators } from "~/components/students/tracking-indicators";
@@ -1324,7 +1328,13 @@ function SearchPageContent() {
   // is unchanged but the request semantics flip (date omitted, live
   // attendance included) — without the mode in the key SWR would keep
   // serving the stale future-planning response under live controls (#1939).
-  const studentsCacheKey = `search-students-${debouncedSearchTerm}-${selectedGroup}-${selectedSchoolClass}-${effectiveRoomId}-${dayStatusFilter}-${selectedDate}-${isToday ? "today" : "planning"}-${photoConsentFeatureState}-${busFilter}-${requestedPhotoConsentFilter}-${wantsCompanions}-${pickupStatusFilter}`;
+  //
+  // The group filter leads the key as a fixed `g{id}`/`gall` scope segment
+  // (#2097) so the SSE flush can read it back and skip a refetch when a
+  // check-in event names a group this view does not show. It has to sit BEFORE
+  // the free-text term: the term may contain dashes ("Anna-Lena"), so no
+  // segment after it can be located positionally. See lib/swr/search-students-key.
+  const studentsCacheKey = `${SEARCH_STUDENTS_KEY_PREFIX}${searchStudentsGroupScope(selectedGroup)}-${debouncedSearchTerm}-${selectedSchoolClass}-${effectiveRoomId}-${dayStatusFilter}-${selectedDate}-${isToday ? "today" : "planning"}-${photoConsentFeatureState}-${busFilter}-${requestedPhotoConsentFilter}-${wantsCompanions}-${pickupStatusFilter}`;
 
   // Fetch students with SWR (automatic deduplication, cancellation, and revalidation)
   const {
@@ -1368,6 +1378,13 @@ function SearchPageContent() {
         includePickupTimes: true,
         includeArrivalTimes: true,
         includeCompanions: wantsCompanions,
+        // Slim wire projection (#2097): this page requests up to 1000 rows in
+        // one trip, and the full StudentResponse ships address, health info,
+        // supervisor notes, guardian contacts, the weekday departure maps and
+        // consent/row timestamps that no card, filter or grouping mode here
+        // reads — the child detail page fetches the full record itself.
+        // Measured 78% smaller for the same rows.
+        view: "slim" as const,
       };
 
       const result = await studentService.getStudents(filters);

--- a/frontend/src/app/api/students/route.test.ts
+++ b/frontend/src/app/api/students/route.test.ts
@@ -186,6 +186,73 @@ describe("GET /api/students", () => {
     expect(json.data.pagination).toEqual(mockResponse.pagination);
   });
 
+  it("keeps slim responses slim after mapping them for the browser", async () => {
+    const mockResponse = {
+      data: [
+        {
+          id: 7,
+          first_name: "Anna",
+          last_name: "Muster",
+          school_class: "2a",
+          current_location: "Raum 3",
+          location_since: "2026-08-03T08:00:00Z",
+          current_room_color: "#83CD2D",
+          group_id: 9,
+          group_name: "Füchse",
+          sick: false,
+          excused: false,
+          class_trip: false,
+          pickup_time: "15:30",
+          companion_student_ids: [8],
+          photo_consent_given: true,
+          has_full_access: true,
+          // A defensive probe: even an unexpectedly wide backend response
+          // must not make the proxy synthesize or forward full-detail fields.
+          bus_days: { mon: true },
+          guardian_name: "Nicht für die Liste",
+        },
+      ],
+      pagination: {
+        current_page: 1,
+        page_size: 1000,
+        total_pages: 1,
+        total_records: 1,
+      },
+    };
+    mockApiGet.mockResolvedValueOnce(mockResponse);
+
+    const request = createMockRequest("/api/students?view=slim");
+    const response = await GET(request, createMockContext());
+    const json = await parseJsonResponse<{
+      data: { data: Array<Record<string, unknown>> };
+    }>(response);
+    const student = json.data.data[0]!;
+
+    expect(student).toEqual(
+      expect.objectContaining({
+        id: "7",
+        name: "Anna Muster",
+        second_name: "Muster",
+        group_id: "9",
+        companion_student_ids: ["8"],
+      }),
+    );
+    for (const omittedField of [
+      "bus_days",
+      "pickup_days",
+      "departure_days",
+      "allowed_departure_modes",
+      "guardian_name",
+      "address_street",
+      "health_info",
+      "supervisor_notes",
+      "created_at",
+      "updated_at",
+    ]) {
+      expect(student).not.toHaveProperty(omittedField);
+    }
+  });
+
   it("handles null response gracefully", async () => {
     mockApiGet.mockResolvedValueOnce(null);
 

--- a/frontend/src/app/api/students/route.ts
+++ b/frontend/src/app/api/students/route.ts
@@ -8,8 +8,11 @@ import {
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "StudentsRoute" });
-import type { Student } from "~/lib/student-helpers";
-import { mapStudentResponse } from "~/lib/student-helpers";
+import type { BackendSlimStudent, Student } from "~/lib/student-helpers";
+import {
+  mapSlimStudentResponse,
+  mapStudentResponse,
+} from "~/lib/student-helpers";
 import {
   shouldCreatePrivacyConsent,
   updatePrivacyConsent,
@@ -63,7 +66,7 @@ interface StudentResponseFromBackend {
  */
 interface ApiStudentsResponse {
   status: string;
-  data: StudentResponseFromBackend[];
+  data: Array<StudentResponseFromBackend | BackendSlimStudent>;
   pagination: {
     current_page: number;
     page_size: number;
@@ -118,6 +121,7 @@ export const GET = createGetHandler(
         ? Math.min(parsedPageSize, MAX_PAGE_SIZE)
         : DEFAULT_PAGE_SIZE;
     queryParams.set("page_size", String(pageSize));
+    const isSlimView = queryParams.get("view") === "slim";
 
     const endpoint = `/api/students${queryParams.toString() ? "?" + queryParams.toString() : ""}`;
 
@@ -142,11 +146,10 @@ export const GET = createGetHandler(
       // Check for the paginated response structure from backend
       if ("data" in response && Array.isArray(response.data)) {
         // Map the backend response format to the frontend format using the consistent mapping function
-        const mappedStudents = response.data.map(
-          (student: StudentResponseFromBackend) => {
-            const mapped = mapStudentResponse(student);
-            return mapped;
-          },
+        const mappedStudents = response.data.map((student) =>
+          isSlimView
+            ? mapSlimStudentResponse(student as BackendSlimStudent)
+            : mapStudentResponse(student as StudentResponseFromBackend),
         );
 
         return {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -263,6 +263,14 @@ function buildStudentQueryParams(filters?: {
   includePickupTimes?: boolean;
   includeArrivalTimes?: boolean;
   includeCompanions?: boolean;
+  /**
+   * Wire projection (#2097). "slim" drops every field the Kindersuche does not
+   * render — address, health info, supervisor notes, guardian contacts, the
+   * weekday departure maps, consent and row timestamps — and cuts the response
+   * by ~78% for the same rows. Omit for the full projection every other
+   * consumer of this endpoint reads.
+   */
+  view?: "slim";
 }): URLSearchParams {
   const params = new URLSearchParams();
   if (filters?.search) params.append("search", filters.search);
@@ -295,6 +303,7 @@ function buildStudentQueryParams(filters?: {
   // Companion links ("läuft mit") for the shown day, so the Kindersuche can
   // group by Laufgemeinschaft. Opt-in: it costs an extra query per page.
   if (filters?.includeCompanions) params.append("include_companions", "true");
+  if (filters?.view) params.append("view", filters.view);
   return params;
 }
 
@@ -960,6 +969,8 @@ export const studentService = {
     includePickupTimes?: boolean;
     includeArrivalTimes?: boolean;
     includeCompanions?: boolean;
+    /** Wire projection (#2097) — see buildStudentQueryParams. */
+    view?: "slim";
     token?: string; // Optional: pass token to skip getSession()
   }): Promise<StudentsResult> => {
     const params = buildStudentQueryParams(filters);

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -1763,6 +1763,23 @@ describe("useGlobalSSE", () => {
       expect(matchedKeys(searchKeys)).toEqual(searchKeys);
     });
 
+    it("refreshes every Kindersuche view on a group-access change", () => {
+      // A handover or leader change rewrites the viewer's own has_full_access
+      // for whole groups. It carries no group id and the affected tab is keyed
+      // on a different group than the changed one, so this one stays broad.
+      // Before #2097 it rode along on any check-in in the school; the scoping
+      // removed that crutch, so it needs its own trigger.
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "group_access_changed",
+        data: { source: "group_transfer" },
+      });
+      vi.advanceTimersByTime(500);
+
+      expect(matchedKeys(searchKeys)).toEqual(searchKeys);
+    });
+
     it("request-budget guard: a foreign group's check-in leaves a filtered Kindersuche tab alone", () => {
       // The acceptance criterion of #2097: a check-in in group 7 (with the
       // tenant-wide active_supervision_changed that always accompanies it)

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -836,17 +836,26 @@ describe("useGlobalSSE", () => {
       expect(studentListCall).toBeDefined();
 
       // The cross-group list caches live in their own mutate call since the
-      // ogs-students split (#2057) — same trigger, separate matcher.
+      // ogs-students split (#2057) — same trigger, separate matcher. The
+      // Kindersuche got its own matcher on top with the group scoping (#2097),
+      // so the two families are looked up separately here.
       const searchListCall = mutateCalls.find((call) => {
         const m = call[0];
         return (
           typeof m === "function" &&
-          (m as (key: string) => boolean)("my-tenant:search-students--")
+          (m as (key: string) => boolean)("my-tenant:search-students-gall-")
         );
       });
       expect(searchListCall).toBeDefined();
-      const searchListMatcher = searchListCall![0] as (key: string) => boolean;
-      expect(searchListMatcher("my-tenant:database-students-list")).toBe(true);
+
+      const databaseListCall = mutateCalls.find((call) => {
+        const m = call[0];
+        return (
+          typeof m === "function" &&
+          (m as (key: string) => boolean)("my-tenant:database-students-list")
+        );
+      });
+      expect(databaseListCall).toBeDefined();
 
       const studentDetailCall = mutateCalls.find((call) => {
         const matcher = call[0];
@@ -1702,6 +1711,77 @@ describe("useGlobalSSE", () => {
       }
       // Elapsed > MAX_FLUSH_WAIT_MS: the capped flush has fired.
       expect(mutate).toHaveBeenCalled();
+    });
+  });
+
+  // #2097: the Kindersuche list rides the same group_ids scope. Its keys carry
+  // the page's group filter as a leading "g{id}"/"gall" segment, so a view
+  // filtered to another group can be skipped.
+  describe("scoped Kindersuche invalidation (#2097)", () => {
+    // A tab filtered to group 8, a tab filtered to group 80 (boundary probe),
+    // and an unfiltered "Alle Gruppen" tab. Search terms may contain dashes,
+    // which is exactly why the scope segment leads the key.
+    const searchKeys = [
+      "tenant:search-students-g7-Anna-Lena--------",
+      "tenant:search-students-g8---------",
+      "tenant:search-students-g80---------",
+      "tenant:search-students-gall---------",
+    ];
+
+    it("scopes the Kindersuche list to the event's group_ids", () => {
+      renderHook(() => useGlobalSSE());
+
+      fire({ type: "dashboard_counts_changed", data: { group_ids: ["7"] } });
+      vi.advanceTimersByTime(500);
+
+      // The group-7 view refetches; group 8 and the boundary-probe group 80 do
+      // not. The unfiltered view renders every child of the school with a live
+      // location badge, so it still refetches.
+      expect(matchedKeys(searchKeys)).toEqual([
+        "tenant:search-students-g7-Anna-Lena--------",
+        "tenant:search-students-gall---------",
+      ]);
+    });
+
+    it("falls back to a broad Kindersuche refresh when group_ids are absent", () => {
+      renderHook(() => useGlobalSSE());
+
+      fire({ type: "dashboard_counts_changed" });
+      vi.advanceTimersByTime(500);
+
+      expect(matchedKeys(searchKeys)).toEqual(searchKeys);
+    });
+
+    it("keeps tenant-wide plan changes broad", () => {
+      // arrival/pickup/student_updated carry no group scope and rewrite the
+      // times the list rows render.
+      renderHook(() => useGlobalSSE());
+
+      fire({ type: "pickup_schedule_changed" });
+      vi.advanceTimersByTime(500);
+
+      expect(matchedKeys(searchKeys)).toEqual(searchKeys);
+    });
+
+    it("request-budget guard: a foreign group's check-in leaves a filtered Kindersuche tab alone", () => {
+      // The acceptance criterion of #2097: a check-in in group 7 (with the
+      // tenant-wide active_supervision_changed that always accompanies it)
+      // must not refetch a Kindersuche tab filtered to group 8.
+      renderHook(() => useGlobalSSE());
+
+      fire({
+        type: "student_checkin",
+        active_group_id: "123",
+        data: { student_id: "42", group_ids: ["7"] },
+      });
+      fire({
+        type: "active_supervision_changed",
+        active_group_id: "123",
+        data: { reason: "student_moved", student_id: "42" },
+      });
+      vi.advanceTimersByTime(500);
+
+      expect(matchedKeys(["tenant:search-students-g8---------"])).toEqual([]);
     });
   });
 

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -585,7 +585,7 @@ describe("useGlobalSSE — companion announcements", () => {
       );
     // Tenant-prefixed by useSWRAuth, hence the prefix in the probe key.
     expect(
-      matchers.some((matcher) => matcher("t1:search-students--all-")),
+      matchers.some((matcher) => matcher("t1:search-students-gall-all-")),
     ).toBe(true);
   });
 
@@ -651,7 +651,7 @@ describe("useGlobalSSE — companion announcements", () => {
       "t1:student-detail-s1",
       "t1:pickup-data-s2",
       "t1:student-detail-s2",
-      "t1:search-students--all-",
+      "t1:search-students-gall-all-",
     ]) {
       expect(
         matchers.some((matcher) => matcher(key)),

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -31,6 +31,11 @@ import { berlinTodayISO } from "~/lib/date-helpers";
 import { dispatchPhoenixNotification } from "~/lib/notification-events";
 import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 import {
+  SEARCH_STUDENTS_ALL_GROUPS_KEY,
+  SEARCH_STUDENTS_GROUP_KEY_PREFIX,
+  SEARCH_STUDENTS_KEY_PREFIX,
+} from "~/lib/swr/search-students-key";
+import {
   notifyStudentCompanionDisplayChanged,
   notifyStudentCompanionsChanged,
 } from "~/lib/student-companion-api";
@@ -392,7 +397,48 @@ export function useGlobalSSE(): SSEHookState {
       }
     }
 
-    // Invalidate the cross-group student list caches so students/search and
+    // The Kindersuche list. Scoped by educational group id (#2097), mirroring
+    // the ogs-students block above: a check-in/checkout/count event names the
+    // groups it touched, and a view filtered to another group renders none of
+    // those children, so it refetches nothing. An unfiltered view
+    // ("search-students-gall-…") shows every child of the school with a live
+    // location badge, so a check-in in ANY group does change a visible row and
+    // it keeps refetching — the payload it refetches is the slim projection.
+    //
+    // Deliberately NOT triggered by pendingGroupIds/pendingStudentIds: those
+    // carry ACTIVE-group and student ids fed by the tenant-wide
+    // active_supervision_changed, which fires alongside every
+    // dashboard_counts_changed. Keeping them would re-broaden every scoped
+    // event and save nothing (same lesson as #2057). Supervision changes do not
+    // move a child or alter has_full_access — that is decided by the viewer's
+    // EDUCATION groups (services/usercontext/student_access.go).
+    {
+      const broadSearch =
+        hasPendingBroadOgsEvent.current ||
+        hasPendingArrivalScheduleEvent.current ||
+        hasPendingPickupScheduleEvent.current ||
+        hasPendingStudentUpdateEvent.current;
+      const scopedEduGroupIds = new Set(pendingEduGroupIds.current);
+      if (broadSearch || scopedEduGroupIds.size > 0) {
+        mutate(
+          (key) =>
+            typeof key === "string" &&
+            key.includes(SEARCH_STUDENTS_KEY_PREFIX) &&
+            (broadSearch ||
+              key.includes(SEARCH_STUDENTS_ALL_GROUPS_KEY) ||
+              [...scopedEduGroupIds].some((gid) =>
+                keyTargetsId(key, gid, [SEARCH_STUDENTS_GROUP_KEY_PREFIX]),
+              )),
+        ).catch((err) => {
+          logger.debug("swr_revalidation_failed", {
+            error: err instanceof Error ? err.message : String(err),
+            scope: "search_students",
+          });
+        });
+      }
+    }
+
+    // Invalidate the cross-group student list caches so the database list and
     // the room views pick up location changes (e.g. Zuhause) without a manual
     // refresh. Also invalidate tracking indicator caches on
     // active-supervisions (tracking-supervisions-*) and students/search
@@ -400,7 +446,7 @@ export function useGlobalSSE(): SSEHookState {
     // events), pendingStudentIds (daily checkout sends student_checkout
     // without an active_group_id), or hasPendingDashboardEvent
     // (dashboard_counts_changed reaches every client of the tenant on every
-    // check-in/out — ensures search page updates even when the user doesn't
+    // check-in/out — ensures these pages update even when the user doesn't
     // supervise the affected room/group). These caches cannot be scoped by
     // group id, but each is mounted only on its own page.
     if (
@@ -415,7 +461,6 @@ export function useGlobalSSE(): SSEHookState {
         (key) =>
           typeof key === "string" &&
           (key.includes("database-students-list") ||
-            key.includes("search-students-") ||
             key.includes("tracking-supervisions-") ||
             key.includes("tracking-indicators-") ||
             // Live "Kinder im Raum" view on /rooms/{id}. Cache key shape is
@@ -508,7 +553,8 @@ export function useGlobalSSE(): SSEHookState {
       // deleted child, and every grouping the delete changed, until something
       // unrelated revalidates the list.
       mutate(
-        (key) => typeof key === "string" && key.includes("search-students-"),
+        (key) =>
+          typeof key === "string" && key.includes(SEARCH_STUDENTS_KEY_PREFIX),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {
           error: err instanceof Error ? err.message : String(err),

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -417,7 +417,18 @@ export function useGlobalSSE(): SSEHookState {
         hasPendingBroadOgsEvent.current ||
         hasPendingArrivalScheduleEvent.current ||
         hasPendingPickupScheduleEvent.current ||
-        hasPendingStudentUpdateEvent.current;
+        hasPendingStudentUpdateEvent.current ||
+        // A group handover or leader change rewrites GetMyGroups and with it
+        // the has_full_access of every row (services/usercontext/
+        // student_access.go), which decides whether a card shows absence,
+        // times and the precise location at all. Broad, never scoped: the
+        // event deliberately carries no group id, and the recipient's tab is
+        // keyed on the group they were already viewing, not on the changed
+        // one (#2084). Until #2097 this rode along on every check-in in the
+        // school via hasPendingDashboardEvent; with the scoping above that
+        // crutch is gone, so the trigger has to be explicit. Rare event, so
+        // the extra refetch costs nothing in practice.
+        hasPendingGroupAccessEvent.current;
       const scopedEduGroupIds = new Set(pendingEduGroupIds.current);
       if (broadSearch || scopedEduGroupIds.size > 0) {
         mutate(

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -529,6 +529,41 @@ export interface BackendStudent {
   updated_at: string;
 }
 
+/** Backend wire shape for `GET /api/students?view=slim`. */
+export interface BackendSlimStudent {
+  id: number;
+  first_name: string;
+  last_name: string;
+  school_class: string;
+  current_location: string;
+  location_since?: string;
+  current_room_color?: string | null;
+  group_id?: number;
+  group_name?: string;
+  sick: boolean;
+  sick_since?: string;
+  excused: boolean;
+  excused_since?: string;
+  class_trip: boolean;
+  class_trip_since?: string;
+  day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_label?: string;
+  pending_excused_note?: string;
+  pickup_status?: string;
+  pickup_time?: string;
+  pickup_is_exception?: boolean;
+  pickup_notes?: string;
+  arrival_time?: string;
+  arrival_is_exception?: boolean;
+  arrival_notes?: string;
+  actual_arrival_time?: string;
+  actual_pickup_time?: string;
+  companion_student_ids?: number[];
+  photo_url?: string;
+  photo_consent_given?: boolean;
+  has_full_access: boolean;
+}
+
 // Supervisor contact information
 export interface SupervisorContact {
   id: number;
@@ -794,6 +829,55 @@ export function mapStudentResponse(
   }
 
   return mapped;
+}
+
+/**
+ * Maps the Kindersuche projection without rebuilding the omitted full-detail
+ * fields. In particular, this must not synthesize empty weekday departure
+ * maps because the route serializes the mapped value back to the browser.
+ */
+export function mapSlimStudentResponse(
+  backendStudent: BackendSlimStudent,
+): Student {
+  const firstName = backendStudent.first_name || "";
+  const lastName = backendStudent.last_name || "";
+
+  return {
+    id: String(backendStudent.id),
+    name: `${firstName} ${lastName}`.trim(),
+    first_name: backendStudent.first_name,
+    second_name: backendStudent.last_name,
+    school_class: backendStudent.school_class,
+    group_name: backendStudent.group_name,
+    group_id: backendStudent.group_id
+      ? String(backendStudent.group_id)
+      : undefined,
+    current_location: normalizeLocation(backendStudent.current_location),
+    location_since: backendStudent.location_since,
+    current_room_color: backendStudent.current_room_color,
+    sick: backendStudent.sick,
+    sick_since: backendStudent.sick_since,
+    excused: backendStudent.excused,
+    excused_since: backendStudent.excused_since,
+    class_trip: backendStudent.class_trip,
+    class_trip_since: backendStudent.class_trip_since,
+    day_planning_status: backendStudent.day_planning_status,
+    day_planning_label: backendStudent.day_planning_label,
+    pending_excused_note: backendStudent.pending_excused_note,
+    pickup_status: backendStudent.pickup_status,
+    pickup_time: backendStudent.pickup_time,
+    pickup_is_exception: backendStudent.pickup_is_exception,
+    pickup_notes: backendStudent.pickup_notes,
+    arrival_time: backendStudent.arrival_time,
+    arrival_is_exception: backendStudent.arrival_is_exception,
+    arrival_notes: backendStudent.arrival_notes,
+    actual_arrival_time: backendStudent.actual_arrival_time,
+    actual_pickup_time: backendStudent.actual_pickup_time,
+    companion_student_ids: backendStudent.companion_student_ids?.map(String),
+    photo_url: backendStudent.photo_url,
+    photo_consent_given: backendStudent.photo_consent_given,
+    has_full_access: backendStudent.has_full_access,
+  };
 }
 
 // Map array of students

--- a/frontend/src/lib/swr/room-derived-caches.ts
+++ b/frontend/src/lib/swr/room-derived-caches.ts
@@ -44,7 +44,9 @@
  *     refresh
  *   - `ogs-students-${groupId}` — OGS-Groups aggregated live view (#2056;
  *     `ogs-students-auto` on a cold start before a group is selected)
- *   - `search-students-${term}-${groupFilter}` — Students Search list
+ *   - `search-students-g${groupFilter}-${term}-…` — Students Search list
+ *     (the leading group scope segment is the #2097 SSE scoping anchor, see
+ *     `lib/swr/search-students-key.ts`)
  */
 export const ROOM_DERIVED_CACHE_KEY_FRAGMENTS: readonly string[] = [
   "active-supervision-dashboard-",

--- a/frontend/src/lib/swr/search-students-key.ts
+++ b/frontend/src/lib/swr/search-students-key.ts
@@ -33,11 +33,27 @@ export const SEARCH_STUDENTS_GROUP_KEY_PREFIX = `${SEARCH_STUDENTS_KEY_PREFIX}g`
 /** The scope segment of an unfiltered ("Alle Gruppen") Kindersuche view. */
 export const SEARCH_STUDENTS_ALL_GROUPS_KEY = `${SEARCH_STUDENTS_GROUP_KEY_PREFIX}all-`;
 
+const MAX_INT64 = 9_223_372_036_854_775_807n;
+
+/**
+ * Mirrors the backend's effective `group_id` filter: only positive signed
+ * 64-bit integers filter the list. Canonicalizing here keeps `007` scoped to
+ * group 7, while zero, negative, overflowing and non-numeric values use the
+ * unfiltered scope.
+ */
+export function normalizeSearchStudentsGroupId(groupId: string): string {
+  if (!/^\+?\d+$/.test(groupId)) return "";
+
+  const parsed = BigInt(groupId);
+  return parsed > 0n && parsed <= MAX_INT64 ? parsed.toString() : "";
+}
+
 /**
  * The scope segment for a group filter value ("" = Alle Gruppen).
  *
  * Group ids are numeric, so `g{id}` can never collide with `gall`.
  */
 export function searchStudentsGroupScope(groupId: string): string {
-  return `g${groupId === "" ? "all" : groupId}`;
+  const normalizedGroupId = normalizeSearchStudentsGroupId(groupId);
+  return `g${normalizedGroupId === "" ? "all" : normalizedGroupId}`;
 }

--- a/frontend/src/lib/swr/search-students-key.ts
+++ b/frontend/src/lib/swr/search-students-key.ts
@@ -1,0 +1,43 @@
+/**
+ * The Kindersuche list cache key and its group scope (#2097).
+ *
+ * **Why the key carries a scope segment.** `search-students-*` used to hang on
+ * every tenant-wide `dashboard_counts_changed`, so a single check-in anywhere
+ * in the school made every open Kindersuche tab refetch the whole list. #2057
+ * gave the check-in/checkout/count events an educational `group_ids` scope; to
+ * use it here the invalidation matcher must be able to read the page's group
+ * filter back out of its own cache key.
+ *
+ * Parsing it positionally is not possible: the key's first dynamic segment is
+ * the free-text search term, which may itself contain dashes ("Anna-Lena").
+ * So the scope is encoded in a fixed, unambiguous segment right after the
+ * prefix — `search-students-g7-…` for the group filter "7",
+ * `search-students-gall-…` when no group is selected — and matched with the
+ * same whole-segment `keyTargetsId` boundary rule the `ogs-students-{gid}`
+ * keys use ("g7" must never match "g70").
+ *
+ * A view with no group filter still refetches on every check-in: it renders
+ * every child of the school with a live location badge, so a check-in in ANY
+ * group changes a visible row. Only the group-filtered views can be narrowed.
+ */
+
+/** Prefix shared by every Kindersuche list cache key. */
+export const SEARCH_STUDENTS_KEY_PREFIX = "search-students-";
+
+/**
+ * Prefix up to (excluding) the group id, for whole-segment id matching:
+ * `keyTargetsId(key, groupId, [SEARCH_STUDENTS_GROUP_KEY_PREFIX])`.
+ */
+export const SEARCH_STUDENTS_GROUP_KEY_PREFIX = `${SEARCH_STUDENTS_KEY_PREFIX}g`;
+
+/** The scope segment of an unfiltered ("Alle Gruppen") Kindersuche view. */
+export const SEARCH_STUDENTS_ALL_GROUPS_KEY = `${SEARCH_STUDENTS_GROUP_KEY_PREFIX}all-`;
+
+/**
+ * The scope segment for a group filter value ("" = Alle Gruppen).
+ *
+ * Group ids are numeric, so `g{id}` can never collide with `gall`.
+ */
+export function searchStudentsGroupScope(groupId: string): string {
+  return `g${groupId === "" ? "all" : groupId}`;
+}


### PR DESCRIPTION
Schliesst #2097.

Zwei Kostentreiber der Kindersuche, beide gemessen statt geschaetzt.

## 1. Payload: neue Listen-Projektion `view=slim`

`GET /api/students` liefert bisher immer die volle `StudentResponse` (rund 55 Felder). Die Kindersuche holt bis zu 1000 Zeilen in einem Request (der Next.js-Proxy setzt `page_size` auf 1000) und rendert davon weder Adresse, Gesundheitsinfo, Betreuer-Notizen, Sorgeberechtigten-Kontakte, die vier Wochentags-Abholkarten (`bus_days`/`pickup_days`/`departure_days`/`allowed_departure_modes`) noch Consent- und Zeilen-Zeitstempel. Die Detailseite holt den vollen Datensatz ohnehin selbst.

Der neue Query-Parameter `view=slim` liefert genau die Felder, die Karten, Filter, Sortierung, Gruppierung und das Anwesenheits-Badge lesen. Weggelassen werden: `person_id`, `tag_id`, `birthday`, `guardian_*`, `address_*`, `extra_info`, `health_info`, `supervisor_notes`, die vier Abholkarten, `departure_companion_note`, `day_planning_reason`, `photo_consent_given_at/by`, `agb_accepted_at`, `data_processing_accepted_at`, `email_contact_accepted_at`, `created_at`, `updated_at`.

Bewusst drin geblieben:
- `location_since` / `sick_since` / `excused_since` / `class_trip_since` gehoeren zum `StudentLocationContext`, den das Badge der Karte konsumiert. Die Seite setzt `showLocationSince` heute nicht, aber ohne die Felder verliert das Badge sein "seit HH:MM" stillschweigend, sobald es jemand aktiviert. Kosten unter 1 % der Antwort.
- `photo_consent_given`, weil die Seite dessen **Anwesenheit** (nicht den Wert) prueft, um den Filter "Fotoerlaubnis" ueberhaupt anzubieten.

Die Projektion greift ganz am Ende, nach Filterung, Tagesplanung, administrativen Filtern und Paginierung. Beide Ansichten liefern dieselben Kinder in derselben Reihenfolge, nur die Serialisierung unterscheidet sich. Ohne Parameter (oder mit `view=full`) bleibt die Antwort byte-identisch, damit die neun anderen Konsumenten des Endpunkts (Raumdetail, Laufgemeinschafts-Picker, Aufsichts-Suche, Nachrichten-Modal, Betreuungsplan, Terminformular, Eltern-Mitteilungen) nichts merken. Ein unbekannter `view`-Wert ist ein 400 statt einer stillen Volllieferung.

## 2. SSE: Invalidierung auf den Gruppen-Scope eingegrenzt

`search-students-*` hing an jedem tenantweiten `dashboard_counts_changed`, also an jedem Check-in der Schule. Der Cache-Key traegt den Gruppenfilter jetzt als festes Segment direkt hinter dem Praefix (`search-students-g7-...` bzw. `-gall-...`), damit der SSE-Flush ihn zurueckliest. Positionell ginge das nicht: das erste dynamische Segment ist der Suchbegriff, der selbst Bindestriche enthalten darf ("Anna-Lena"). Gematcht wird mit derselben `keyTargetsId`-Grenzregel wie `ogs-students-{gid}`, damit "g7" nicht "g70" trifft.

`pendingGroupIds`/`pendingStudentIds` loesen die Kindersuche bewusst nicht mehr aus. Die tragen Aktiv-Gruppen- und Kind-IDs aus dem tenantweiten `active_supervision_changed`, das neben jedem `dashboard_counts_changed` feuert, und wuerden jedes gescopte Event wieder verbreitern (dieselbe Lehre wie #2057). Aufsichtswechsel verschieben kein Kind und aendern `has_full_access` nicht, das entscheiden die Bildungsgruppen des Betrachters (`services/usercontext/student_access.go`).

**Dokumentierte Entscheidung zur ungefilterten Ansicht:** "Alle Gruppen" laedt weiter bei jedem Check-in nach. Sie rendert jedes Kind der Schule mit Live-Ortsbadge, ein Check-in irgendwo aendert also wirklich eine sichtbare Zeile. Sie holt dafuer jetzt die schlanke Projektion, der Refetch kostet also rund 58 % weniger.

## Messung

Payload, Dev-Datenbank, 107 Kinder, identische Query:

| | Bytes | pro Kind |
|---|---|---|
| `view=full` (Status quo) | 89 543 | 837 B |
| `view=slim` | 37 366 | 349 B |
| | **-58,3 %** | |

Mit produktionsnah gefuellten Feldern (Backend-Test, 30 Kinder mit Adresse, Gesundheitsinfo, Notizen, Abholkarten, Consent): **1412 -> 316 Byte pro Kind, -78 %**.

Refetches pro Check-in, gegen den lokalen Stack gemessen (Tab auf Gruppe 2 gefiltert, Check-in per `POST /api/active/visits/student/{id}/checkin`, SSE-Zustellung mit einer zweiten EventSource im Tab verifiziert):

| Schritt | Event | `/api/students`-Requests |
|---|---|---|
| A: Check-in Kind aus Gruppe 1 | `dashboard_counts_changed` `group_ids:["1"]` zugestellt | 5 -> 5 (kein Refetch) |
| B: Check-in Kind aus Gruppe 2 | `group_ids:["2"]` | 5 -> 6 (Refetch) |
| A': Check-in weiteres Kind aus Gruppe 1 | `group_ids:["1"]` | 6 -> 6 (kein Refetch) |
| Ungefilterte Ansicht, Check-in Gruppe 1 | `group_ids:["1"]` | 8 -> 9 (Refetch, so gewollt) |

Vorher haette jeder dieser Faelle die volle Liste nachgeladen.

**Ehrlicher Rest:** auf einen fremden Check-in feuert die Seite weiterhin zwei `POST /api/active/tracking-indicators` (Antwort hier 55 Byte fuer 20 Kinder; waechst mit der Zahl konfigurierter Indikatoren). Der Voll-Refetch der Liste ist weg, still ist die Seite nicht. Ein eigener Scope fuer `tracking-indicators-*` waere eine eigene Aenderung.

## Tests

Backend (`api/students`):
- `TestSlimStudentResponseWireContract` friert die exakte Schluesselmenge der Projektion ein, faellt in beide Richtungen (heimlich wieder aufgenommenes Feld, heimlich verlorenes Feld).
- `TestSlimStudentResponseCopiesValues` prueft jeden uebernommenen Wert gegen die volle Antwort.
- `TestListStudents_SlimProjection` prueft die verbotenen Felder am echten HTTP-Body.
- `TestListStudents_FullViewKeepsWideProjection` pinnt den Default fuer die anderen Konsumenten.
- `TestListStudents_SlimViewSameRows` beweist, dass beide Ansichten dieselben Kinder in derselben Reihenfolge liefern.
- `TestListStudents_SlimPayloadBudget` setzt das Budget (<= 350 B/Kind + 1 KB Rumpf) und verlangt mindestens ein Drittel Ersparnis gegenueber der vollen Ansicht.
- `TestListStudents_InvalidView`, `TestParseStudentListView` fuer den Parameter-Kontrakt.

Frontend:
- Vier neue Tests in `use-global-sse.test.ts` im ausschliessenden `matchedKeys`-Stil (deckt Ueber-Invalidierung auf, nicht nur Unter-Invalidierung), inklusive Grenzprobe g8/g80 und dem Budget-Guard aus dem Akzeptanzkriterium.
- Zwei neue Tests in `students/search/page.test.tsx`: Key traegt das Gruppen-Scope voran, Seite fordert `view=slim` an.
- `pnpm run test:run` gruen (13 010 Tests), `pnpm run check` gruen, `pnpm knip` gruen, `golangci-lint` gruen, Architektur-Ratchets gruen, `TestRouteTableGolden` unveraendert (ein Query-Parameter aendert die Route-Tabelle nicht).

## Angepasster Bestandstest

`use-global-sse.test.ts` -> "student_updated invalidates student list, detail, status-day, and dashboard caches" hat den Mutate-Call ueber einen `search-students-`-Key gesucht und danach am **selben** Matcher geprueft, dass er auch `database-students-list` trifft. Beide Invalidierungen gelten unveraendert weiter, sie liegen jetzt nur in zwei Matchern (genau wie #2057 es fuer `ogs-students-` gemacht hat). Der Test sucht die beiden Familien jetzt getrennt, die fachliche Aussage bleibt identisch.

## Nebenbefund, nicht in diesem PR behoben

- Der Web-Checkout (`POST /api/active/visits/student/{id}/checkout`) sendet gar kein SSE-Event, waehrend der Check-in `dashboard_counts_changed` + `active_supervision_changed` sendet. Ein Checkout durch eine Kollegin bleibt in offenen Tabs also unsichtbar. Bestand, unabhaengig von dieser Aenderung.
- `group_access_changed` invalidiert `search-students-*` nicht, obwohl es die Bildungsgruppen des Betrachters und damit `has_full_access` aendert. Ebenfalls Bestand, hier nicht angefasst, um die Trigger-Menge nicht zu erweitern.

Offen bleibt Punkt 1 des Issues (Neumessung nach #2060) - die Zahlen hier stammen aus der lokalen Umgebung und dem Backend-Budget-Test, nicht aus der isolierten Testumgebung.
