### PR TITLE
Erinnerungs-Leerzustand und Testbenachrichtigung verbessern

### DIFF
--- a/backend/api/notifications/api.go
+++ b/backend/api/notifications/api.go
@@ -1,7 +1,7 @@
 // Package notifications exposes the notification abstraction (#1624) over
-// HTTP. Its single endpoint lets an admin fire a test notification to verify
-// the tenant's setup end to end; real producers (reminders, #669) call the
-// service directly.
+// HTTP. Its test endpoint lets staff fire a notification to their own account
+// to verify the tenant's setup end to end; real producers (reminders, #669)
+// call the service directly.
 package notifications
 
 import (
@@ -11,8 +11,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
-	"github.com/moto-nrw/project-phoenix/auth/authorize"
-	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -48,9 +46,9 @@ func (rs *Resource) Router() chi.Router {
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
 	common.ProtectedTenantGroup(r, rs.db, func(r chi.Router, withTx common.Middleware) {
-		// config:update — the same permission that guards the feature flag —
-		// so exactly the admins who can enable notifications can test them.
-		r.With(authorize.RequiresPermission(permissions.ConfigUpdate), withTx).Post("/test", rs.sendTestNotification)
+		// The event is scoped to the logged-in staff account, so a valid tenant
+		// session is sufficient. No user can trigger a test for someone else.
+		r.With(withTx).Post("/test", rs.sendTestNotification)
 
 		// Push subscription management for the logged-in staff user's own
 		// devices — no extra permission beyond a valid tenant session.
@@ -74,9 +72,9 @@ func (rs *Resource) Router() chi.Router {
 }
 
 // sendTestNotification fires a fixed, display-safe test event only to the
-// requesting admin. This verifies the notification setup (feature flag on, SSE
-// connected, toast rendering) without broadcasting an unsolicited test to
-// other staff.
+// requesting staff account. This verifies the notification setup (feature flag
+// on, SSE connected, toast rendering) without broadcasting an unsolicited test
+// to other staff.
 func (rs *Resource) sendTestNotification(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/backend/api/notifications/api_internal_test.go
+++ b/backend/api/notifications/api_internal_test.go
@@ -8,12 +8,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	notificationsService "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	testutil.SeedTestJWTConfig()
+}
 
 // captureService records the event the handler dispatched.
 type captureService struct {
@@ -118,6 +123,29 @@ func TestSendTestNotificationNilService(t *testing.T) {
 	rs.sendTestNotification(rec, newTestRequest(41))
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestTestNotificationRouteAllowsStaffWithoutConfigUpdate(t *testing.T) {
+	db, _ := testutil.SetupAPITest(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	svc := &captureService{}
+	router := NewResource(svc, nil, nil, db).Router()
+	claims := testutil.TeacherTestClaims(73)
+	require.NotContains(t, claims.Permissions, "config:update")
+	req := testutil.NewAuthenticatedRequest(
+		t,
+		http.MethodPost,
+		"/test",
+		nil,
+		testutil.WithJWTBearer(testutil.MintTestJWT(t, claims)),
+	)
+
+	rec := testutil.ExecuteRequest(router, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.True(t, svc.called)
+	assert.Equal(t, []int64{73}, svc.gotEvent.Audience.StaffAccountIDs)
 }
 
 func TestSubscribePushClassifiesServiceErrors(t *testing.T) {

--- a/frontend/src/app/[tenant]/(protected)/reminders/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/reminders/page.test.tsx
@@ -7,11 +7,6 @@ vi.mock("~/lib/hooks/use-reminders", () => ({
   useReminders: () => mockUseReminders(),
 }));
 
-const { mockRedirect } = vi.hoisted(() => ({ mockRedirect: vi.fn() }));
-vi.mock("next/navigation", () => ({
-  redirect: mockRedirect,
-}));
-
 import RemindersPage from "./page";
 
 function set(value: {
@@ -35,10 +30,37 @@ beforeEach(() => {
 });
 
 describe("RemindersPage", () => {
-  it("shows the empty state when nothing is due", () => {
-    set({ reminders: [], count: 0 });
+  it("shows the activation hint when reminder types are disabled", () => {
+    set({
+      reminders: [],
+      count: 0,
+      data: { reminders: [], count: 0, enabled: false },
+    });
     render(<RemindersPage />);
     expect(screen.getByText("Keine aktiven Erinnerungen")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Erinnerungstypen werden in den Einstellungen/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Erinnerungen aktiviert/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a compact success status when reminders are enabled but none are active", () => {
+    set({
+      reminders: [],
+      count: 0,
+      data: { reminders: [], count: 0, enabled: true },
+    });
+    render(<RemindersPage />);
+    expect(
+      screen.getByText(
+        "Erinnerungen aktiviert. Aktuell gibt es keine aktiven Erinnerungen.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Erinnerungstypen werden in den Einstellungen/),
+    ).not.toBeInTheDocument();
   });
 
   it("groups reminders by type and colors only overdue red", () => {
@@ -91,33 +113,5 @@ describe("RemindersPage", () => {
     expect(
       screen.getByLabelText("Erinnerungen werden geladen…"),
     ).toBeInTheDocument();
-    expect(mockRedirect).not.toHaveBeenCalled();
-  });
-
-  it("does not redirect while data has not loaded yet (no data)", () => {
-    set({ reminders: [], count: 0 });
-    render(<RemindersPage />);
-    expect(mockRedirect).not.toHaveBeenCalled();
-  });
-
-  it("redirects to the dashboard when the feature is disabled", () => {
-    set({
-      reminders: [],
-      count: 0,
-      data: { reminders: [], count: 0, enabled: false },
-    });
-    render(<RemindersPage />);
-    expect(mockRedirect).toHaveBeenCalledWith("/test-tenant/dashboard");
-  });
-
-  it("renders the page when the feature is enabled", () => {
-    set({
-      reminders: [],
-      count: 0,
-      data: { reminders: [], count: 0, enabled: true },
-    });
-    render(<RemindersPage />);
-    expect(screen.getByText("Keine aktiven Erinnerungen")).toBeInTheDocument();
-    expect(mockRedirect).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/reminders/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/reminders/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { redirect } from "next/navigation";
-import { useTenantAwarePath } from "~/lib/tenant-path";
 import { Alert } from "~/components/ui/alert";
 import { Loading } from "~/components/ui/loading";
 import { useReminders } from "~/lib/hooks/use-reminders";
@@ -35,21 +33,7 @@ function ReminderRow({ reminder }: { reminder: Reminder }) {
 }
 
 export default function RemindersPage() {
-  const tenantPath = useTenantAwarePath();
   const { reminders, count, error, isLoading, data } = useReminders();
-
-  // Feature gate for direct URL entry. The header bell is the only discoverable
-  // way here and it hides when the tenant has no reminder type enabled, so the
-  // only way to land on this page with the feature off is a bookmark or typed
-  // URL. Send those to the dashboard once we have a definitive answer.
-  //
-  // Key off the raw `data` (loaded and enabled === false), NOT the derived
-  // `enabled`: during the initial load / no-token window `enabled` is falsy too,
-  // and redirecting then would bounce users off a page whose feature is on.
-  const featureDisabled = data?.enabled === false;
-  if (featureDisabled) {
-    redirect(tenantPath("/dashboard"));
-  }
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-6">
@@ -69,17 +53,24 @@ export default function RemindersPage() {
 
       {isLoading && !reminders.length ? (
         <Loading message="Erinnerungen werden geladen…" fullPage={false} />
-      ) : error && !data ? null : count === 0 ? ( // here would read like a successful empty result, which it is not. // whole story. Rendering the "Keine aktiven Erinnerungen" empty state // First load failed with nothing cached: the error alert above is the
-        <div className="rounded-2xl border border-gray-200 bg-white p-10 text-center shadow-sm">
-          <p className="font-medium text-gray-900">
-            Keine aktiven Erinnerungen
-          </p>
-          <p className="mt-1 text-sm text-gray-500">
-            Sobald eine Abholung näher rückt oder eine Aktivität startet,
-            erscheint sie hier. Erinnerungstypen werden in den Einstellungen
-            unter „Erinnerungen" aktiviert.
-          </p>
-        </div>
+      ) : error && !data ? null : count === 0 ? (
+        data?.enabled === false ? (
+          <div className="rounded-2xl border border-gray-200 bg-white p-10 text-center shadow-sm">
+            <p className="font-medium text-gray-900">
+              Keine aktiven Erinnerungen
+            </p>
+            <p className="mt-1 text-sm text-gray-500">
+              Sobald eine Abholung näher rückt oder eine Aktivität startet,
+              erscheint sie hier. Erinnerungstypen werden in den Einstellungen
+              unter „Erinnerungen“ aktiviert.
+            </p>
+          </div>
+        ) : (
+          <Alert
+            type="success"
+            message="Erinnerungen aktiviert. Aktuell gibt es keine aktiven Erinnerungen."
+          />
+        )
       ) : (
         <div className="space-y-6">
           {REMINDER_SECTIONS.map((section) => {

--- a/frontend/src/app/api/notifications/test/route.test.ts
+++ b/frontend/src/app/api/notifications/test/route.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockApiPost } = vi.hoisted(() => ({
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock("~/lib/api-helpers.server", () => ({
+  apiPost: mockApiPost,
+}));
+vi.mock("~/lib/route-wrapper.server", () => ({
+  createPostHandler: (handler: Function) => handler,
+}));
+
+const { POST } = await import("./route");
+
+describe("/api/notifications/test proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts to the backend route with the current tenant token", async () => {
+    await (POST as Function)({}, {}, "test-token");
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      "/api/notifications/test",
+      "test-token",
+    );
+  });
+});

--- a/frontend/src/app/api/notifications/test/route.ts
+++ b/frontend/src/app/api/notifications/test/route.ts
@@ -3,7 +3,7 @@ import { createPostHandler } from "~/lib/route-wrapper.server";
 
 /**
  * POST /api/notifications/test — proxy to the backend test-notification
- * trigger (#1624). Lets an admin verify the notification setup end to end:
+ * trigger (#1624). Lets a staff user verify their notification setup end to end:
  * feature flag on → backend dispatch → SSE → in-app toast.
  */
 export const POST = createPostHandler<null, Record<string, never>>(

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -732,7 +732,7 @@ export const appChapters: readonly GuideChapter[] = [
         ],
         callout: {
           title: "Nichts zu sehen?",
-          body: "Erinnerungen sind im Auslieferungszustand komplett aus. Welche Arten erscheinen (und mit welcher Vorlaufzeit), schaltet ein Admin unter `Einstellungen` -> `Erinnerungen` ein. Solange keine Art aktiv ist oder gerade nichts ansteht, bleibt die Seite leer. Im selben Reiter steht auch die `Terminerinnerung für Eltern`: die betrifft nicht die Glocke, sondern die E-Mail, die Eltern vor einem Termin bekommen.",
+          body: "Erinnerungen sind im Auslieferungszustand komplett aus. Dann zeigt die Seite einen großen Hinweis auf die Aktivierung unter `Einstellungen` -> `Erinnerungen`. Sind Erinnerungstypen aktiviert, aber gerade keine Einträge offen, bestätigt stattdessen ein kompakter grüner Hinweis den aktiven Zustand. Im selben Reiter steht auch die `Terminerinnerung für Eltern`: die betrifft nicht die Glocke, sondern die E-Mail, die Eltern vor einem Termin bekommen.",
           tone: "blue",
         },
         screenshot:
@@ -1674,6 +1674,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Zuerst im Profil unter `Benachrichtigungen` auswählen, worüber informiert werden soll (siehe Schritt davor).",
           "Im selben Profil den Abschnitt `Push-Benachrichtigungen` öffnen.",
           "`Aktivieren` antippen und die Browser-Nachfrage mit `Erlauben` bestätigen.",
+          "Sobald Push aktiv ist, mit `Testbenachrichtigung senden` prüfen, ob die Benachrichtigung auf diesem Gerät ankommt.",
           "Fertig: Die ausgewählten Hinweise erscheinen jetzt als Benachrichtigung auf diesem Gerät.",
         ],
         callout: {
@@ -1681,7 +1682,7 @@ export const appChapters: readonly GuideChapter[] = [
           body: "Auf iPhone und iPad funktioniert das nur in der zum Home-Bildschirm hinzugefügten App (siehe die Schritte oben). Im normalen Safari-Tab bietet Apple keine Push-Benachrichtigungen an. Zusätzlich muss die Schule die Benachrichtigungen in den Einstellungen eingeschaltet haben.",
         },
         screenshot:
-          "Profilseite mit dem Abschnitt Push-Benachrichtigungen und der Schaltfläche Aktivieren.",
+          "Profilseite mit dem aktiven Abschnitt Push-Benachrichtigungen und der Schaltfläche Testbenachrichtigung senden.",
       },
     ],
   },

--- a/frontend/src/components/settings/push-notification-section.test.tsx
+++ b/frontend/src/components/settings/push-notification-section.test.tsx
@@ -158,11 +158,11 @@ describe("PushNotificationSection", () => {
     });
 
     const { rerender } = render(<PushNotificationSection portal="tenant" />);
-    expect(
-      await screen.findByRole("button", {
-        name: "Testbenachrichtigung senden",
-      }),
-    ).toBeInTheDocument();
+    const testButton = await screen.findByRole("button", {
+      name: "Testbenachrichtigung senden",
+    });
+    expect(testButton).toHaveClass("h-8", "text-xs", "bg-transparent");
+    expect(testButton).not.toHaveClass("ring-1", "shadow-md");
 
     rerender(<PushNotificationSection portal="parent" />);
     await waitFor(() =>

--- a/frontend/src/components/settings/push-notification-section.test.tsx
+++ b/frontend/src/components/settings/push-notification-section.test.tsx
@@ -10,8 +10,12 @@ const pushApi = vi.hoisted(() => ({
   subscribePush: vi.fn(),
   unsubscribePush: vi.fn(),
 }));
+const notificationApi = vi.hoisted(() => ({
+  sendTestNotification: vi.fn(),
+}));
 
 vi.mock("~/lib/push-api", () => pushApi);
+vi.mock("~/lib/notification-api", () => notificationApi);
 
 function stubNotificationPermission(permission: NotificationPermission) {
   vi.stubGlobal("Notification", { permission });
@@ -24,6 +28,7 @@ describe("PushNotificationSection", () => {
     pushApi.needsIOSInstall.mockReturnValue(false);
     pushApi.isPushSupported.mockReturnValue(true);
     pushApi.syncExistingPushSubscription.mockResolvedValue(null);
+    notificationApi.sendTestNotification.mockResolvedValue(undefined);
     stubNotificationPermission("default");
   });
 
@@ -144,6 +149,98 @@ describe("PushNotificationSection", () => {
     );
     expect(
       await screen.findByRole("button", { name: "Aktivieren" }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a test notification only for an active tenant subscription", async () => {
+    pushApi.syncExistingPushSubscription.mockResolvedValue({
+      endpoint: "https://push.example/e",
+    });
+
+    const { rerender } = render(<PushNotificationSection portal="tenant" />);
+    expect(
+      await screen.findByRole("button", {
+        name: "Testbenachrichtigung senden",
+      }),
+    ).toBeInTheDocument();
+
+    rerender(<PushNotificationSection portal="parent" />);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", {
+          name: "Testbenachrichtigung senden",
+        }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("sends a test notification and confirms success", async () => {
+    pushApi.syncExistingPushSubscription.mockResolvedValue({
+      endpoint: "https://push.example/e",
+    });
+
+    render(<PushNotificationSection />);
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Testbenachrichtigung senden",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(notificationApi.sendTestNotification).toHaveBeenCalledOnce(),
+    );
+    expect(
+      await screen.findByText("Testbenachrichtigung wurde gesendet."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables competing actions while the test request is pending", async () => {
+    pushApi.syncExistingPushSubscription.mockResolvedValue({
+      endpoint: "https://push.example/e",
+    });
+    let finishRequest: (() => void) | undefined;
+    notificationApi.sendTestNotification.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRequest = resolve;
+        }),
+    );
+
+    render(<PushNotificationSection />);
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Testbenachrichtigung senden",
+      }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Wird gesendet…" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Deaktivieren" })).toBeDisabled();
+
+    finishRequest?.();
+    await screen.findByText("Testbenachrichtigung wurde gesendet.");
+  });
+
+  it("surfaces test notification errors", async () => {
+    pushApi.syncExistingPushSubscription.mockResolvedValue({
+      endpoint: "https://push.example/e",
+    });
+    notificationApi.sendTestNotification.mockRejectedValue(
+      new Error("Ihre Schule hat Benachrichtigungen derzeit deaktiviert."),
+    );
+
+    render(<PushNotificationSection />);
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Testbenachrichtigung senden",
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Ihre Schule hat Benachrichtigungen derzeit deaktiviert.",
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/settings/push-notification-section.tsx
+++ b/frontend/src/components/settings/push-notification-section.tsx
@@ -5,6 +5,7 @@ import { BellRing } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { createLogger } from "~/lib/logger";
+import { sendTestNotification } from "~/lib/notification-api";
 import {
   isPushConfigurationMissing,
   isPushSupported,
@@ -40,6 +41,7 @@ export function PushNotificationSection({
 }: PushNotificationSectionProps) {
   const [state, setState] = useState<PushState>("loading");
   const [busy, setBusy] = useState(false);
+  const [testing, setTesting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 
@@ -116,6 +118,29 @@ export function PushNotificationSection({
           : "Benachrichtigungen konnten nicht deaktiviert werden.",
       );
     } finally {
+      setBusy(false);
+    }
+  };
+
+  const sendTest = async () => {
+    setBusy(true);
+    setTesting(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await sendTestNotification();
+      setMessage("Testbenachrichtigung wurde gesendet.");
+    } catch (err) {
+      logger.error("test_notification_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Testbenachrichtigung konnte nicht gesendet werden. Prüfen Sie die Verbindung und versuchen Sie es erneut.",
+      );
+    } finally {
+      setTesting(false);
       setBusy(false);
     }
   };
@@ -203,10 +228,26 @@ export function PushNotificationSection({
       )}
 
       {state === "subscribed" && (
-        <p className="text-sm text-gray-600">
-          Benachrichtigungen sind auf diesem Gerät aktiv. Erinnerungen kommen
-          auch bei geschlossener App an.
-        </p>
+        <div>
+          <p className="text-sm text-gray-600">
+            Benachrichtigungen sind auf diesem Gerät aktiv. Erinnerungen kommen
+            auch bei geschlossener App an.
+          </p>
+          {portal === "tenant" && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-4"
+              isLoading={testing}
+              loadingText="Wird gesendet…"
+              disabled={busy}
+              onClick={() => void sendTest()}
+            >
+              Testbenachrichtigung senden
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/settings/push-notification-section.tsx
+++ b/frontend/src/components/settings/push-notification-section.tsx
@@ -236,9 +236,9 @@ export function PushNotificationSection({
           {portal === "tenant" && (
             <Button
               type="button"
-              variant="outline"
-              size="sm"
-              className="mt-4"
+              variant="ghost"
+              size="compact"
+              className="-ms-2.5 mt-2"
               isLoading={testing}
               loadingText="Wird gesendet…"
               disabled={busy}

--- a/frontend/src/contexts/ToastContext.test.tsx
+++ b/frontend/src/contexts/ToastContext.test.tsx
@@ -144,7 +144,9 @@ describe("ToastContext", () => {
         </ToastProvider>,
       );
 
-      fireEvent.click(await screen.findByRole("button", { name: "Öffnen" }));
+      const action = await screen.findByRole("button", { name: "Öffnen" });
+      expect(action).toHaveClass("self-center");
+      fireEvent.click(action);
 
       expect(onAction).toHaveBeenCalledOnce();
     });

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -310,7 +310,7 @@ function ToastRow({
             <button
               type="button"
               onClick={handleAction}
-              className={`flex-shrink-0 text-sm font-semibold ${desktopStyles.text} underline underline-offset-2 transition-opacity hover:opacity-70`}
+              className={`flex-shrink-0 self-center text-sm font-semibold ${desktopStyles.text} underline underline-offset-2 transition-opacity hover:opacity-70`}
             >
               {item.action.label}
             </button>

--- a/frontend/src/lib/notification-api.test.ts
+++ b/frontend/src/lib/notification-api.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendTestNotification } from "./notification-api";
+
+describe("sendTestNotification", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts an empty JSON body to the tenant proxy", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await sendTestNotification();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/notifications/test", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+  });
+
+  it("explains when the school has disabled notifications", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 409 }),
+    );
+
+    await expect(sendTestNotification()).rejects.toThrow(
+      "Ihre Schule hat Benachrichtigungen derzeit deaktiviert.",
+    );
+  });
+
+  it("uses a safe generic message for other failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    await expect(sendTestNotification()).rejects.toThrow(
+      "Testbenachrichtigung konnte nicht gesendet werden. Prüfen Sie die Verbindung und versuchen Sie es erneut.",
+    );
+  });
+
+  it("uses the same safe message when the request cannot be sent", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"));
+
+    await expect(sendTestNotification()).rejects.toThrow(
+      "Testbenachrichtigung konnte nicht gesendet werden. Prüfen Sie die Verbindung und versuchen Sie es erneut.",
+    );
+  });
+});

--- a/frontend/src/lib/notification-api.ts
+++ b/frontend/src/lib/notification-api.ts
@@ -1,0 +1,29 @@
+const TEST_NOTIFICATION_URL = "/api/notifications/test";
+
+const TEST_NOTIFICATION_DISABLED_MESSAGE =
+  "Ihre Schule hat Benachrichtigungen derzeit deaktiviert.";
+const TEST_NOTIFICATION_ERROR_MESSAGE =
+  "Testbenachrichtigung konnte nicht gesendet werden. Prüfen Sie die Verbindung und versuchen Sie es erneut.";
+
+/** Sends a fixed test notification to the logged-in staff account. */
+export async function sendTestNotification(): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(TEST_NOTIFICATION_URL, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+  } catch {
+    throw new Error(TEST_NOTIFICATION_ERROR_MESSAGE);
+  }
+
+  if (response.ok) return;
+
+  throw new Error(
+    response.status === 409
+      ? TEST_NOTIFICATION_DISABLED_MESSAGE
+      : TEST_NOTIFICATION_ERROR_MESSAGE,
+  );
+}


### PR DESCRIPTION
## Zusammenfassung
- unterscheidet auf der Erinnerungsseite zwischen deaktivierten Erinnerungstypen und einem aktivierten Zustand ohne offene Einträge
- ergänzt im Profil bei aktivem Push-Abo eine Testbenachrichtigung für das eigene Konto
- erlaubt den Testversand für alle angemeldeten Mitarbeitenden, ohne die Tenant- oder Empfängergrenze zu erweitern
- richtet die Toast-Aktion bei mehrzeiligem Text vertikal mittig aus
- aktualisiert den In-App-Hilfe-Guide

## Tests
- `cd frontend && pnpm run check`
- `cd frontend && pnpm exec vitest run 'src/app/[tenant]/(protected)/reminders/page.test.tsx' src/app/api/notifications/test/route.test.ts src/lib/notification-api.test.ts src/components/settings/push-notification-section.test.tsx src/components/notifications/notification-bridge.test.tsx src/contexts/ToastContext.test.tsx` (38 Tests)
- `cd frontend && pnpm run generate:guides` (4 Exporte)
- `cd backend && APP_ENV=test TEST_DB_DSN=... go test ./...`
- `cd backend && go vet ./api/notifications ./services/notifications/...`
- Pre-Push: dependency-cruise, knip, frontend check, Go deadcode/vet, golangci-lint

## End-to-End
Mit `agent-browser` gegen eine isolierte Docker-Compose-Instanz geprüft:
- deaktivierte Erinnerungstypen zeigen den ausführlichen Aktivierungshinweis
- aktivierte Erinnerungstypen ohne Einträge zeigen den kompakten grünen Status
- Push-Abo lässt sich aktivieren; Testversand liefert HTTP 200, Erfolgsstatus und In-App-Toast
- Testversand funktioniert auch als normales Mitarbeiterkonto ohne `config:update`
- Test-Button bleibt im Elternportal und ohne aktives Push-Abo verborgen
