### PR TITLE
feat(time-tracking): Eröffnungssalden für Stundenkonto und Urlaub (#2132)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -493,6 +493,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Groups = groupsAPI.NewResource(api.Services.Education, api.Services.Active, api.Services.Users, api.Services.UserContext, db)
 	api.Guardians = guardiansAPI.NewResource(api.Services.Guardian, api.Services.GuardianInvitation, api.Services.Users, api.Services.Education, api.Services.UserContext, db)
 	api.Import = importAPI.NewResource(api.Services.Import, api.Services.StaffImport, api.Services.Users, db)
+	api.Import.SetOpeningBalanceImportFactory(api.Services.OpeningBalanceImport)
 	api.Activities = activitiesAPI.NewResource(api.Services.Activities, api.Services.Schedule, api.Services.Users, api.Services.UserContext, db)
 	api.Staff = staffAPI.NewResource(api.Services.Users, api.Services.StaffOffboarding, api.Services.Education, api.Services.Auth, api.Services.WorkSession, api.Services.StaffAbsence, api.Services.WorkTimeMonth, api.Services.StaffBalanceAdjust, api.Services.StaffMonthClose, api.Services.StaffOverview, api.Services.TimeTrackingAuditLog, api.Services.StaffTimeExport, db, logger.With("handler", "staff"))
 	api.WorkTimeModels = worktimemodelsAPI.NewResource(api.Services.WorkTimeModels, db, logger.With("handler", "work-time-models"))

--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -38,8 +38,18 @@ const (
 type Resource struct {
 	studentImportService *importService.ImportService[importModels.StudentImportRow]
 	staffImportService   *importService.ImportService[importModels.StaffImportRow]
-	personService        userSvc.PersonService
-	db                   *bun.DB
+	// openingBalanceImportFactory builds a request-scoped opening balance
+	// import service (#2132) — Stichtag/Begründung/actor come from the
+	// upload form. Wired via SetOpeningBalanceImportFactory.
+	openingBalanceImportFactory importService.OpeningBalanceImportFactory
+	personService               userSvc.PersonService
+	db                          *bun.DB
+}
+
+// SetOpeningBalanceImportFactory wires the opening balance import (#2132).
+// Setter injection so existing NewResource call sites stay unchanged.
+func (rs *Resource) SetOpeningBalanceImportFactory(factory importService.OpeningBalanceImportFactory) {
+	rs.openingBalanceImportFactory = factory
 }
 
 // NewResource creates a new import resource
@@ -84,6 +94,17 @@ func (rs *Resource) Router() chi.Router {
 			// Note: no withTx here — the handler manages its own WithTenantTx
 			// to control commit/rollback based on import results.
 			r.With(authorize.RequiresPermission("users:create")).Post("/import", rs.importStudents)
+		})
+
+		// Opening balance (Eröffnungssalden) import endpoints (#2132).
+		// Stundenkonto and vacation takeover values are payroll data —
+		// everything sits behind time_tracking:manage.
+		r.Route("/opening-balances", func(r chi.Router) {
+			r.With(authorize.RequiresPermission("time_tracking:manage"), withTx).Get("/template", rs.DownloadOpeningBalanceTemplate)
+			r.With(authorize.RequiresPermission("time_tracking:manage"), withTx).Post("/preview", rs.PreviewOpeningBalanceImport)
+			// Note: no withTx here — the handler manages its own WithTenantTx
+			// to control commit/rollback based on import results.
+			r.With(authorize.RequiresPermission("time_tracking:manage")).Post("/import", rs.ImportOpeningBalances)
 		})
 
 		// Staff (Mitarbeiter) import endpoints

--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -32,6 +32,16 @@ const (
 	testLastNameMueller  = "Müller"
 	testAddressMusterstr = "Musterstr. 1"
 	hintYesNo            = "Ja / Nein"
+
+	// Route paths shared by every import domain (S1192)
+	routeTemplate = "/template"
+	routePreview  = "/preview"
+	routeImport   = "/import"
+
+	// Permissions (S1192)
+	permUsersRead          = "users:read"
+	permUsersCreate        = "users:create"
+	permTimeTrackingManage = "time_tracking:manage"
 )
 
 // Resource defines the import resource
@@ -85,40 +95,40 @@ func (rs *Resource) Router() chi.Router {
 		// Student import endpoints
 		r.Route("/students", func(r chi.Router) {
 			// Template download - requires UsersRead
-			r.With(authorize.RequiresPermission("users:read"), withTx).Get("/template", rs.downloadStudentTemplate)
+			r.With(authorize.RequiresPermission(permUsersRead), withTx).Get(routeTemplate, rs.downloadStudentTemplate)
 
 			// Preview - requires UsersCreate
-			r.With(authorize.RequiresPermission("users:create"), withTx).Post("/preview", rs.previewStudentImport)
+			r.With(authorize.RequiresPermission(permUsersCreate), withTx).Post(routePreview, rs.previewStudentImport)
 
 			// Actual import - requires UsersCreate
 			// Note: no withTx here — the handler manages its own WithTenantTx
 			// to control commit/rollback based on import results.
-			r.With(authorize.RequiresPermission("users:create")).Post("/import", rs.importStudents)
+			r.With(authorize.RequiresPermission(permUsersCreate)).Post(routeImport, rs.importStudents)
 		})
 
 		// Opening balance (Eröffnungssalden) import endpoints (#2132).
 		// Stundenkonto and vacation takeover values are payroll data —
 		// everything sits behind time_tracking:manage.
 		r.Route("/opening-balances", func(r chi.Router) {
-			r.With(authorize.RequiresPermission("time_tracking:manage"), withTx).Get("/template", rs.DownloadOpeningBalanceTemplate)
-			r.With(authorize.RequiresPermission("time_tracking:manage"), withTx).Post("/preview", rs.PreviewOpeningBalanceImport)
+			r.With(authorize.RequiresPermission(permTimeTrackingManage), withTx).Get(routeTemplate, rs.DownloadOpeningBalanceTemplate)
+			r.With(authorize.RequiresPermission(permTimeTrackingManage), withTx).Post(routePreview, rs.PreviewOpeningBalanceImport)
 			// Note: no withTx here — the handler manages its own WithTenantTx
 			// to control commit/rollback based on import results.
-			r.With(authorize.RequiresPermission("time_tracking:manage")).Post("/import", rs.ImportOpeningBalances)
+			r.With(authorize.RequiresPermission(permTimeTrackingManage)).Post(routeImport, rs.ImportOpeningBalances)
 		})
 
 		// Staff (Mitarbeiter) import endpoints
 		r.Route("/teachers", func(r chi.Router) {
 			// Template download - requires UsersRead
-			r.With(authorize.RequiresPermission("users:read"), withTx).Get("/template", rs.DownloadStaffTemplate)
+			r.With(authorize.RequiresPermission(permUsersRead), withTx).Get(routeTemplate, rs.DownloadStaffTemplate)
 
 			// Preview - requires UsersCreate
-			r.With(authorize.RequiresPermission("users:create"), withTx).Post("/preview", rs.PreviewStaffImport)
+			r.With(authorize.RequiresPermission(permUsersCreate), withTx).Post(routePreview, rs.PreviewStaffImport)
 
 			// Actual import - requires UsersCreate
 			// Note: no withTx here — the handler manages its own WithTenantTx
 			// to control commit/rollback based on import results.
-			r.With(authorize.RequiresPermission("users:create")).Post("/import", rs.ImportStaff)
+			r.With(authorize.RequiresPermission(permUsersCreate)).Post(routeImport, rs.ImportStaff)
 		})
 	})
 

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -128,14 +128,26 @@ func writeOpeningBalanceHinweiseSheet(f *excelize.File) {
 }
 
 // openingBalanceRequestContext bundles the per-request import parameters
-// parsed from the upload form.
+// parsed from the upload form. The acting staff member is resolved separately
+// (resolveOpeningBalanceDecider) because that lookup is tenant-scoped and the
+// real-import handler owns its transaction.
 type openingBalanceRequestContext struct {
 	Rows          []importModels.OpeningBalanceImportRow
 	Filename      string
 	EffectiveDate timezone.Date
 	Note          string
-	DecidedBy     int64
 	AccountID     int64
+}
+
+// resolveOpeningBalanceDecider maps the authenticated account to its staff
+// row. The query is tenant-scoped, so it MUST run inside a tenant transaction
+// — outside one the RLS role is missing and the lookup fails.
+func (rs *Resource) resolveOpeningBalanceDecider(ctx context.Context, accountID int64) (int64, error) {
+	staffID, err := rs.personService.ResolveStaffIDByAccountID(ctx, accountID)
+	if err != nil {
+		return 0, fmt.Errorf("kein Mitarbeiterprofil für dieses Konto: %w", err)
+	}
+	return staffID, nil
 }
 
 // parseOpeningBalanceRequest validates the upload, parses the file, and reads
@@ -179,18 +191,12 @@ func (rs *Resource) parseOpeningBalanceRequest(w http.ResponseWriter, r *http.Re
 		common.RenderError(w, r, common.ErrorUnauthorized(err))
 		return nil, false
 	}
-	decidedBy, err := rs.personService.ResolveStaffIDByAccountID(r.Context(), accountID)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorUnauthorized(fmt.Errorf("kein Mitarbeiterprofil für dieses Konto")))
-		return nil, false
-	}
 
 	return &openingBalanceRequestContext{
 		Rows:          rows,
 		Filename:      header.Filename,
 		EffectiveDate: effectiveDate,
 		Note:          note,
-		DecidedBy:     decidedBy,
 		AccountID:     accountID,
 	}, true
 }
@@ -206,7 +212,15 @@ func (rs *Resource) PreviewOpeningBalanceImport(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, reqCtx.DecidedBy)
+	// The preview route carries the tenant-tx middleware, so the tenant-scoped
+	// staff lookup can run directly here.
+	decidedBy, err := rs.resolveOpeningBalanceDecider(r.Context(), reqCtx.AccountID)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+
+	svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, decidedBy)
 	result, err := svc.Import(r.Context(), importModels.ImportRequest[importModels.OpeningBalanceImportRow]{
 		Rows:            reqCtx.Rows,
 		Mode:            importModels.ImportModeCreate,
@@ -238,10 +252,23 @@ func (rs *Resource) ImportOpeningBalances(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, reqCtx.DecidedBy)
 	tenantID := tenant.FromContext(r.Context())
-	var result *importModels.ImportResult[importModels.OpeningBalanceImportRow]
+	var (
+		result       *importModels.ImportResult[importModels.OpeningBalanceImportRow]
+		svc          *importService.ImportService[importModels.OpeningBalanceImportRow]
+		deciderError error
+	)
+	// This route deliberately carries no tenant-tx middleware (it owns its
+	// transaction), so the tenant-scoped staff lookup has to happen INSIDE the
+	// transaction — outside it the RLS role is missing and the lookup fails.
 	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		decidedBy, err := rs.resolveOpeningBalanceDecider(ctx, reqCtx.AccountID)
+		if err != nil {
+			deciderError = err
+			return err
+		}
+		svc = rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, decidedBy)
+
 		var txErr error
 		result, txErr = svc.Import(ctx, importModels.ImportRequest[importModels.OpeningBalanceImportRow]{
 			Rows:            reqCtx.Rows,
@@ -253,6 +280,10 @@ func (rs *Resource) ImportOpeningBalances(w http.ResponseWriter, r *http.Request
 		})
 		return txErr
 	}); err != nil {
+		if deciderError != nil {
+			common.RenderError(w, r, common.ErrorUnauthorized(deciderError))
+			return
+		}
 		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
 		return
 	}

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -180,6 +180,10 @@ func (rs *Resource) parseOpeningBalanceRequest(w http.ResponseWriter, r *http.Re
 		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("ungültiger Stichtag (erwartet JJJJ-MM-TT)")))
 		return nil, false
 	}
+	if !effectiveDate.Before(timezone.TodayDate()) {
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("stichtag muss vor dem heutigen Tag liegen")))
+		return nil, false
+	}
 	note := strings.TrimSpace(r.FormValue("note"))
 	if note == "" {
 		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("begründung ist erforderlich")))

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -184,6 +184,10 @@ func (rs *Resource) parseOpeningBalanceRequest(w http.ResponseWriter, r *http.Re
 		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("stichtag muss vor dem heutigen Tag liegen")))
 		return nil, false
 	}
+	if effectiveDate.Year != timezone.TodayDate().Year {
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("stichtag muss im aktuellen Urlaubsjahr liegen")))
+		return nil, false
+	}
 	note := strings.TrimSpace(r.FormValue("note"))
 	if note == "" {
 		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("begründung ist erforderlich")))

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -1,0 +1,272 @@
+package importapi
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/uptrace/bun"
+	"github.com/xuri/excelize/v2"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	importService "github.com/moto-nrw/project-phoenix/services/import"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// getOpeningBalanceHeaders returns the header row for the opening balance
+// import template (#2132). Header keys must normalize to the columns
+// MapOpeningBalanceRow reads — units belong in the Hinweise sheet, not here.
+func getOpeningBalanceHeaders() []string {
+	return []string{"Personalnummer (optional)", "Vorname", "Nachname", "Stundensaldo", "Jahresanspruch", "Vorjahresübertrag", "Resturlaub"}
+}
+
+// getOpeningBalanceExamples returns example data rows for the template.
+func getOpeningBalanceExamples() [][]any {
+	return [][]any{
+		{"1001", "Anna", "Lehmann", "12,5", "30", "2", "14,5"},
+		{"", "Bernd", "Schulz", "-3,25", "", "", "8"},
+		{"1003", "Clara", "Weber", "", "28", "0", "28"},
+	}
+}
+
+// DownloadOpeningBalanceTemplate handles the template download (CSV or Excel).
+func (rs *Resource) DownloadOpeningBalanceTemplate(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("format") == "xlsx" {
+		rs.downloadOpeningBalanceTemplateXLSX(w, r)
+		return
+	}
+	rs.downloadOpeningBalanceTemplateCSV(w, r)
+}
+
+func (rs *Resource) downloadOpeningBalanceTemplateCSV(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition", "attachment; filename=eroeffnungssalden-import-vorlage.csv")
+
+	csvWriter := csv.NewWriter(w)
+	if err := csvWriter.Write(getOpeningBalanceHeaders()); err != nil {
+		slog.Default().Error("Error writing CSV headers", slog.String("error", err.Error()))
+		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
+		return
+	}
+	for _, row := range getOpeningBalanceExamples() {
+		strRow := make([]string, len(row))
+		for i, v := range row {
+			strRow[i] = fmt.Sprintf("%v", v)
+		}
+		if err := csvWriter.Write(strRow); err != nil {
+			slog.Default().Error("Error writing CSV row", slog.String("error", err.Error()))
+		}
+	}
+	csvWriter.Flush()
+}
+
+func (rs *Resource) downloadOpeningBalanceTemplateXLSX(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	w.Header().Set("Content-Disposition", "attachment; filename=eroeffnungssalden-import-vorlage.xlsx")
+
+	f := excelize.NewFile()
+	defer func() {
+		if err := f.Close(); err != nil {
+			slog.Default().Error("Error closing Excel file", slog.String("error", err.Error()))
+		}
+	}()
+
+	sheetName := "Eröffnungssalden"
+	if err := setupExcelSheet(f, sheetName); err != nil {
+		slog.Default().Error("Error setting up sheet", slog.String("error", err.Error()))
+		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
+		return
+	}
+
+	headers := getOpeningBalanceHeaders()
+	writeExcelHeaders(f, sheetName, headers)
+	writeExcelExampleRows(f, sheetName, getOpeningBalanceExamples())
+	setExcelColumnWidths(f, sheetName, len(headers), 20)
+	writeOpeningBalanceHinweiseSheet(f)
+
+	if err := f.Write(w); err != nil {
+		slog.Default().Error("Error writing Excel file", slog.String("error", err.Error()))
+		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
+	}
+}
+
+// writeOpeningBalanceHinweiseSheet adds a "Hinweise" sheet describing the columns.
+func writeOpeningBalanceHinweiseSheet(f *excelize.File) {
+	sheetName := "Hinweise"
+	if _, err := f.NewSheet(sheetName); err != nil {
+		slog.Default().Error("Error creating Hinweise sheet", slog.String("error", err.Error()))
+		return
+	}
+
+	rows := [][]string{
+		{"Spalte", "Pflicht?", "Beschreibung"},
+		{"Personalnummer", "Nein", "Eindeutige Zuordnung — empfohlen, wenn Namen mehrfach vorkommen"},
+		{"Vorname", "Ja", "Vorname der Person (muss bereits in moto angelegt sein)"},
+		{"Nachname", "Ja", "Nachname der Person"},
+		{"Stundensaldo", "Nein", "Stundenkonto-Stand zum Stichtag in Stunden, auch negativ (z. B. 12,5 oder -3,25). Leer = keine Übernahme"},
+		{"Jahresanspruch", "Nein", "Urlaubsanspruch des laufenden Jahres in Tagen. Leer = unverändert"},
+		{"Vorjahresübertrag", "Nein", "Übertrag aus dem Vorjahr in Tagen. Leer = unverändert"},
+		{"Resturlaub", "Nein", "Resturlaub zum Stichtag in Tagen. moto errechnet daraus die vor der Einführung genommenen Tage. Leer = keine Übernahme"},
+		{"", "", ""},
+		{"Hinweis", "", "Stichtag und Begründung werden beim Hochladen einmal für die ganze Datei angegeben."},
+		{"Hinweis", "", "Pro Person ist nur eine Übernahme möglich. Korrekturen laufen über Löschen und Neuanlegen in der Personalakte."},
+	}
+	for rowIdx, row := range rows {
+		for colIdx, val := range row {
+			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+1)
+			_ = f.SetCellValue(sheetName, cell, val)
+		}
+	}
+	_ = f.SetColWidth(sheetName, "A", "A", 18)
+	_ = f.SetColWidth(sheetName, "B", "B", 10)
+	_ = f.SetColWidth(sheetName, "C", "C", 90)
+}
+
+// openingBalanceRequestContext bundles the per-request import parameters
+// parsed from the upload form.
+type openingBalanceRequestContext struct {
+	Rows          []importModels.OpeningBalanceImportRow
+	Filename      string
+	EffectiveDate timezone.Date
+	Note          string
+	DecidedBy     int64
+	AccountID     int64
+}
+
+// parseOpeningBalanceRequest validates the upload, parses the file, and reads
+// the shared Stichtag + Begründung form fields.
+func (rs *Resource) parseOpeningBalanceRequest(w http.ResponseWriter, r *http.Request) (*openingBalanceRequestContext, bool) {
+	file, header, isExcel, ok := rs.openValidatedUploadFile(w, r)
+	if !ok {
+		return nil, false
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			slog.Default().Error("failed to close file", slog.String("error", err.Error()))
+		}
+	}()
+
+	var rows []importModels.OpeningBalanceImportRow
+	var err error
+	if isExcel {
+		rows, err = importService.ParseOpeningBalanceXLSX(file)
+	} else {
+		rows, err = importService.ParseOpeningBalanceCSV(file)
+	}
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("Datei-Fehler: %s", err.Error())))
+		return nil, false
+	}
+
+	effectiveDate, err := timezone.ParseDate(r.FormValue("effective_date"))
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("ungültiger Stichtag (erwartet JJJJ-MM-TT)")))
+		return nil, false
+	}
+	note := strings.TrimSpace(r.FormValue("note"))
+	if note == "" {
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("Begründung ist erforderlich")))
+		return nil, false
+	}
+
+	accountID, err := getAccountIDFromContext(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return nil, false
+	}
+	decidedBy, err := rs.personService.ResolveStaffIDByAccountID(r.Context(), accountID)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(fmt.Errorf("kein Mitarbeiterprofil für dieses Konto")))
+		return nil, false
+	}
+
+	return &openingBalanceRequestContext{
+		Rows:          rows,
+		Filename:      header.Filename,
+		EffectiveDate: effectiveDate,
+		Note:          note,
+		DecidedBy:     decidedBy,
+		AccountID:     accountID,
+	}, true
+}
+
+// PreviewOpeningBalanceImport handles the dry-run preview.
+func (rs *Resource) PreviewOpeningBalanceImport(w http.ResponseWriter, r *http.Request) {
+	if rs.openingBalanceImportFactory == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("opening balance import is not configured")))
+		return
+	}
+	reqCtx, ok := rs.parseOpeningBalanceRequest(w, r)
+	if !ok {
+		return
+	}
+
+	svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, reqCtx.DecidedBy)
+	result, err := svc.Import(r.Context(), importModels.ImportRequest[importModels.OpeningBalanceImportRow]{
+		Rows:            reqCtx.Rows,
+		Mode:            importModels.ImportModeCreate,
+		DryRun:          true,
+		StopOnError:     false,
+		UserID:          reqCtx.AccountID,
+		SkipInvalidRows: false,
+	})
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau fehlgeschlagen: %s", err.Error())))
+		return
+	}
+
+	// GDPR Compliance: Audit log for preview (Article 30)
+	svc.RecordAudit("opening_balance", reqCtx.Filename, result, reqCtx.AccountID, true, tenant.FromContext(r.Context()))
+
+	common.Respond(w, r, http.StatusOK, result, "Import-Vorschau erfolgreich")
+}
+
+// ImportOpeningBalances handles the actual import. The handler owns its
+// tenant transaction so partial failures roll back per the import result.
+func (rs *Resource) ImportOpeningBalances(w http.ResponseWriter, r *http.Request) {
+	if rs.openingBalanceImportFactory == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("opening balance import is not configured")))
+		return
+	}
+	reqCtx, ok := rs.parseOpeningBalanceRequest(w, r)
+	if !ok {
+		return
+	}
+
+	svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, reqCtx.DecidedBy)
+	tenantID := tenant.FromContext(r.Context())
+	var result *importModels.ImportResult[importModels.OpeningBalanceImportRow]
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		var txErr error
+		result, txErr = svc.Import(ctx, importModels.ImportRequest[importModels.OpeningBalanceImportRow]{
+			Rows:            reqCtx.Rows,
+			Mode:            importModels.ImportModeCreate,
+			DryRun:          false,
+			StopOnError:     false,
+			UserID:          reqCtx.AccountID,
+			SkipInvalidRows: true,
+		})
+		return txErr
+	}); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
+		return
+	}
+
+	slog.Default().Info("Opening balance import completed",
+		slog.Int("created", result.CreatedCount),
+		slog.Int("errors", result.ErrorCount),
+		slog.String("filename", reqCtx.Filename))
+
+	// GDPR Compliance: Audit log for actual import (Article 30)
+	svc.RecordAudit("opening_balance", reqCtx.Filename, result, reqCtx.AccountID, false, tenantID)
+
+	message := fmt.Sprintf("Import abgeschlossen: %d übernommen, %d Fehler",
+		result.CreatedCount, result.ErrorCount)
+
+	common.Respond(w, r, http.StatusOK, result, message)
+}

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -182,7 +182,7 @@ func (rs *Resource) parseOpeningBalanceRequest(w http.ResponseWriter, r *http.Re
 	}
 	note := strings.TrimSpace(r.FormValue("note"))
 	if note == "" {
-		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("Begründung ist erforderlich")))
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("begründung ist erforderlich")))
 		return nil, false
 	}
 

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -242,8 +242,12 @@ func (rs *Resource) PreviewOpeningBalanceImport(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// GDPR Compliance: Audit log for preview (Article 30)
-	svc.RecordAudit("opening_balance", reqCtx.Filename, result, reqCtx.AccountID, true, tenant.FromContext(r.Context()))
+	// GDPR Compliance: Audit log for preview (Article 30). The route's tenant
+	// transaction supplies the RLS context required by the audit repository.
+	if err := svc.RecordAuditInTransaction(r.Context(), "opening_balance", reqCtx.Filename, result, reqCtx.AccountID, true, tenant.FromContext(r.Context())); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau konnte nicht protokolliert werden: %w", err)))
+		return
+	}
 
 	common.Respond(w, r, http.StatusOK, result, "Import-Vorschau erfolgreich")
 }
@@ -286,7 +290,10 @@ func (rs *Resource) ImportOpeningBalances(w http.ResponseWriter, r *http.Request
 			UserID:          reqCtx.AccountID,
 			SkipInvalidRows: true,
 		})
-		return txErr
+		if txErr != nil {
+			return txErr
+		}
+		return svc.RecordAuditInTransaction(ctx, "opening_balance", reqCtx.Filename, result, reqCtx.AccountID, false, tenantID)
 	}); err != nil {
 		if deciderError != nil {
 			common.RenderError(w, r, common.ErrorUnauthorized(deciderError))
@@ -300,9 +307,6 @@ func (rs *Resource) ImportOpeningBalances(w http.ResponseWriter, r *http.Request
 		slog.Int("created", result.CreatedCount),
 		slog.Int("errors", result.ErrorCount),
 		slog.String("filename", reqCtx.Filename))
-
-	// GDPR Compliance: Audit log for actual import (Article 30)
-	svc.RecordAudit("opening_balance", reqCtx.Filename, result, reqCtx.AccountID, false, tenantID)
 
 	message := fmt.Sprintf("Import abgeschlossen: %d übernommen, %d Fehler",
 		result.CreatedCount, result.ErrorCount)

--- a/backend/api/staff/api.go
+++ b/backend/api/staff/api.go
@@ -152,6 +152,11 @@ func (rs *Resource) Router() chi.Router {
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/time-tracking/adjustments", rs.createBalanceAdjustment)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Delete("/{id}/time-tracking/adjustments/{adjustmentId}", rs.deleteBalanceAdjustment)
 		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/time-tracking/reset", rs.resetStaffBalance)
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/time-tracking/opening", rs.createOpeningBalance)
+
+		// Vacation takeover at the moto introduction (#2132)
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Post("/{id}/vacation/opening", rs.setVacationOpening)
+		r.With(authorize.RequiresPermission(permissions.TimeTrackingManage), withTx).Delete("/{id}/vacation/opening", rs.deleteVacationOpening)
 
 		// Monatsabschluss (#1417): freezing the carry chain is school-wide,
 		// reopening is per staff member. Static segments before /{id} are

--- a/backend/api/staff/balance_adjustment_handlers.go
+++ b/backend/api/staff/balance_adjustment_handlers.go
@@ -175,7 +175,7 @@ func (rs *Resource) deleteBalanceAdjustment(w http.ResponseWriter, r *http.Reque
 // a migrated Stundenkonto may start negative.
 type openingBalanceRequest struct {
 	EffectiveDate  string `json:"effective_date"`
-	BalanceMinutes int    `json:"balance_minutes"`
+	BalanceMinutes *int   `json:"balance_minutes"`
 	Note           string `json:"note"`
 }
 
@@ -199,12 +199,16 @@ func (rs *Resource) createOpeningBalance(w http.ResponseWriter, r *http.Request)
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}
+	if req.BalanceMinutes == nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("balance_minutes is required")))
+		return
+	}
 	effectiveDate, err := timezone.ParseDate(req.EffectiveDate)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid effective_date format, expected YYYY-MM-DD")))
 		return
 	}
-	adjustment, err := rs.BalanceAdjustService.CreateOpeningBalance(r.Context(), staffID, decidedBy, effectiveDate, req.BalanceMinutes, req.Note)
+	adjustment, err := rs.BalanceAdjustService.CreateOpeningBalance(r.Context(), staffID, decidedBy, effectiveDate, *req.BalanceMinutes, req.Note)
 	if err != nil {
 		tenant.MarkRollback(r.Context())
 		renderBalanceAdjustmentError(w, r, err)

--- a/backend/api/staff/balance_adjustment_handlers.go
+++ b/backend/api/staff/balance_adjustment_handlers.go
@@ -38,6 +38,10 @@ func renderBalanceAdjustmentError(w http.ResponseWriter, r *http.Request, err er
 		common.RenderError(w, r, common.ErrorInvalidRequestWithCode(err, "adjustment_in_closed_month"))
 		return
 	}
+	if errors.Is(err, activeSvc.ErrOpeningAlreadyExists) {
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "opening_balance_already_exists"))
+		return
+	}
 	common.RenderError(w, r, common.RenderWithRules(err, balanceAdjustmentErrorRules, common.ErrorInternalServer))
 }
 
@@ -164,6 +168,49 @@ func (rs *Resource) deleteBalanceAdjustment(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	common.Respond(w, r, http.StatusOK, nil, "Balance adjustment deleted")
+}
+
+// openingBalanceRequest is the wire shape for POST
+// /api/staff/{id}/time-tracking/opening (#2132). BalanceMinutes is SIGNED —
+// a migrated Stundenkonto may start negative.
+type openingBalanceRequest struct {
+	EffectiveDate  string `json:"effective_date"`
+	BalanceMinutes int    `json:"balance_minutes"`
+	Note           string `json:"note"`
+}
+
+// createOpeningBalance handles POST /api/staff/{id}/time-tracking/opening
+func (rs *Resource) createOpeningBalance(w http.ResponseWriter, r *http.Request) {
+	staffID, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if !rs.requireBalanceAdjustmentStaff(w, r, staffID) {
+		return
+	}
+	decidedBy, err := rs.resolveEditorStaffID(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	var req openingBalanceRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	effectiveDate, err := timezone.ParseDate(req.EffectiveDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid effective_date format, expected YYYY-MM-DD")))
+		return
+	}
+	adjustment, err := rs.BalanceAdjustService.CreateOpeningBalance(r.Context(), staffID, decidedBy, effectiveDate, req.BalanceMinutes, req.Note)
+	if err != nil {
+		tenant.MarkRollback(r.Context())
+		renderBalanceAdjustmentError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusCreated, adjustment, "Opening balance created")
 }
 
 // resetStaffBalance handles POST /api/staff/{id}/time-tracking/reset

--- a/backend/api/staff/opening_request_test.go
+++ b/backend/api/staff/opening_request_test.go
@@ -1,0 +1,29 @@
+package staff
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpeningBalanceRequest_RequiresBalanceMinutes(t *testing.T) {
+	var request openingBalanceRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"effective_date":"2026-03-01"}`), &request))
+	assert.Nil(t, request.BalanceMinutes)
+
+	require.NoError(t, json.Unmarshal([]byte(`{"effective_date":"2026-03-01","balance_minutes":0}`), &request))
+	require.NotNil(t, request.BalanceMinutes)
+	assert.Zero(t, *request.BalanceMinutes)
+}
+
+func TestVacationOpeningRequest_RequiresRemainingDays(t *testing.T) {
+	var request setVacationOpeningRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"effective_date":"2026-03-01"}`), &request))
+	assert.Nil(t, request.RemainingDays)
+
+	require.NoError(t, json.Unmarshal([]byte(`{"effective_date":"2026-03-01","remaining_days":0}`), &request))
+	require.NotNil(t, request.RemainingDays)
+	assert.Zero(t, *request.RemainingDays)
+}

--- a/backend/api/staff/time_tracking_handlers.go
+++ b/backend/api/staff/time_tracking_handlers.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -287,7 +286,7 @@ func parseInt64Param(r *http.Request, name string) (int64, error) {
 func parseYearQuery(r *http.Request) (int, error) {
 	yearStr := r.URL.Query().Get("year")
 	if yearStr == "" {
-		return time.Now().Year(), nil
+		return timezone.TodayDate().Year, nil
 	}
 	year, err := strconv.Atoi(yearStr)
 	if err != nil || year < 2000 || year > 2100 {

--- a/backend/api/staff/time_tracking_handlers.go
+++ b/backend/api/staff/time_tracking_handlers.go
@@ -258,10 +258,14 @@ func (rs *Resource) setStaffVacationQuota(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if body.Year == 0 {
-		body.Year = time.Now().Year()
+		body.Year = timezone.TodayDate().Year
 	}
 	if err := rs.StaffAbsenceService.UpsertVacationQuota(r.Context(), staffID, body.Year, body.EntitledDays, body.CarryoverDays); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		if errors.Is(err, activeSvc.ErrVacationQuotaInvalid) {
+			common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		} else {
+			common.RenderError(w, r, common.ErrorInternalServer(err))
+		}
 		return
 	}
 	summary, err := rs.StaffAbsenceService.GetVacationQuotaSummary(r.Context(), staffID, body.Year)

--- a/backend/api/staff/time_tracking_handlers_internal_test.go
+++ b/backend/api/staff/time_tracking_handlers_internal_test.go
@@ -1,0 +1,19 @@
+package staff
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseYearQuery_DefaultsToBerlinCalendarYear(t *testing.T) {
+	req := httptest.NewRequest("GET", "/staff/42/vacation/opening", nil)
+
+	year, err := parseYearQuery(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, timezone.TodayDate().Year, year)
+}

--- a/backend/api/staff/vacation_opening_handlers.go
+++ b/backend/api/staff/vacation_opening_handlers.go
@@ -1,0 +1,105 @@
+package staff
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// renderVacationOpeningError classifies the vacation takeover sentinels
+// (#2132): caller mistakes → 400, missing rows → 404, duplicate takeover or
+// double-count risk → 409 with a stable code.
+func renderVacationOpeningError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, activeSvc.ErrVacationOpeningExists):
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "vacation_opening_already_exists"))
+	case errors.Is(err, activeSvc.ErrVacationOpeningAbsencesBeforeCutoff):
+		common.RenderError(w, r, common.ErrorConflictWithCode(err, "vacation_opening_absences_before_cutoff"))
+	case errors.Is(err, activeSvc.ErrVacationOpeningNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, activeSvc.ErrVacationOpeningInvalid):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	default:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+	}
+}
+
+// setVacationOpeningRequest is the wire shape for POST
+// /api/staff/{id}/vacation/opening (#2132). The admin enters the Resturlaub
+// as of the Stichtag; the backend derives the pre-introduction days.
+type setVacationOpeningRequest struct {
+	EffectiveDate string  `json:"effective_date"`
+	RemainingDays float64 `json:"remaining_days"`
+	Note          string  `json:"note"`
+}
+
+// setVacationOpening handles POST /api/staff/{id}/vacation/opening
+func (rs *Resource) setVacationOpening(w http.ResponseWriter, r *http.Request) {
+	staffID, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if !rs.requireBalanceAdjustmentStaff(w, r, staffID) {
+		return
+	}
+	decidedBy, err := rs.resolveEditorStaffID(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	var req setVacationOpeningRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	effectiveDate, err := timezone.ParseDate(req.EffectiveDate)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid effective_date format, expected YYYY-MM-DD")))
+		return
+	}
+	opening, err := rs.StaffAbsenceService.SetVacationOpening(r.Context(), staffID, decidedBy, activeSvc.SetVacationOpeningRequest{
+		EffectiveDate: effectiveDate,
+		RemainingDays: req.RemainingDays,
+		Note:          req.Note,
+	})
+	if err != nil {
+		tenant.MarkRollback(r.Context())
+		renderVacationOpeningError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusCreated, opening, "Vacation opening created")
+}
+
+// deleteVacationOpening handles DELETE /api/staff/{id}/vacation/opening?year=YYYY
+func (rs *Resource) deleteVacationOpening(w http.ResponseWriter, r *http.Request) {
+	staffID, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if !rs.requireBalanceAdjustmentStaff(w, r, staffID) {
+		return
+	}
+	year, err := parseYearQuery(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	deletedBy, err := rs.resolveEditorStaffID(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	if err := rs.StaffAbsenceService.DeleteVacationOpening(r.Context(), staffID, deletedBy, year); err != nil {
+		tenant.MarkRollback(r.Context())
+		renderVacationOpeningError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, nil, "Vacation opening deleted")
+}

--- a/backend/api/staff/vacation_opening_handlers.go
+++ b/backend/api/staff/vacation_opening_handlers.go
@@ -33,9 +33,9 @@ func renderVacationOpeningError(w http.ResponseWriter, r *http.Request, err erro
 // /api/staff/{id}/vacation/opening (#2132). The admin enters the Resturlaub
 // as of the Stichtag; the backend derives the pre-introduction days.
 type setVacationOpeningRequest struct {
-	EffectiveDate string  `json:"effective_date"`
-	RemainingDays float64 `json:"remaining_days"`
-	Note          string  `json:"note"`
+	EffectiveDate string   `json:"effective_date"`
+	RemainingDays *float64 `json:"remaining_days"`
+	Note          string   `json:"note"`
 }
 
 // setVacationOpening handles POST /api/staff/{id}/vacation/opening
@@ -58,6 +58,10 @@ func (rs *Resource) setVacationOpening(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}
+	if req.RemainingDays == nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("remaining_days is required")))
+		return
+	}
 	effectiveDate, err := timezone.ParseDate(req.EffectiveDate)
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid effective_date format, expected YYYY-MM-DD")))
@@ -65,7 +69,7 @@ func (rs *Resource) setVacationOpening(w http.ResponseWriter, r *http.Request) {
 	}
 	opening, err := rs.StaffAbsenceService.SetVacationOpening(r.Context(), staffID, decidedBy, activeSvc.SetVacationOpeningRequest{
 		EffectiveDate: effectiveDate,
-		RemainingDays: req.RemainingDays,
+		RemainingDays: *req.RemainingDays,
 		Note:          req.Note,
 	})
 	if err != nil {

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -42,6 +42,7 @@ DELETE /api/staff-shifts/{id}
 DELETE /api/staff/{id}
 DELETE /api/staff/{id}/absences/{absenceId}
 DELETE /api/staff/{id}/time-tracking/adjustments/{adjustmentId}
+DELETE /api/staff/{id}/vacation/opening
 DELETE /api/students/{id}
 DELETE /api/students/{id}/arrival-exceptions/{exceptionId}
 DELETE /api/students/{id}/arrival-notes/{noteId}
@@ -206,6 +207,7 @@ GET /api/guardians/{id}
 GET /api/guardians/{id}/delete-preview
 GET /api/guardians/{id}/phone-numbers/
 GET /api/guardians/{id}/students
+GET /api/import/opening-balances/template
 GET /api/import/students/template
 GET /api/import/teachers/template
 GET /api/iot/*/
@@ -567,6 +569,8 @@ POST /api/guardians/students/{studentId}/invite
 POST /api/guardians/{id}/invite
 POST /api/guardians/{id}/phone-numbers/
 POST /api/guardians/{id}/phone-numbers/{phoneId}/set-primary
+POST /api/import/opening-balances/import
+POST /api/import/opening-balances/preview
 POST /api/import/students/import
 POST /api/import/students/preview
 POST /api/import/teachers/import
@@ -625,8 +629,10 @@ POST /api/staff/{id}/absences
 POST /api/staff/{id}/stammdaten/bank-steuer/reveal
 POST /api/staff/{id}/time-tracking/adjustments
 POST /api/staff/{id}/time-tracking/month-close/reopen
+POST /api/staff/{id}/time-tracking/opening
 POST /api/staff/{id}/time-tracking/reset
 POST /api/staff/{id}/time-tracking/sessions
+POST /api/staff/{id}/vacation/opening
 POST /api/students/
 POST /api/students/arrival-schedules/bulk
 POST /api/students/arrival-times/bulk

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -317,6 +317,9 @@ func (m *mockStaffAbsenceService) SetVacationOpening(_ context.Context, _, _ int
 func (m *mockStaffAbsenceService) DeleteVacationOpening(_ context.Context, _, _ int64, _ int) error {
 	return nil
 }
+func (m *mockStaffAbsenceService) ValidateVacationOpeningAbsencesBefore(_ context.Context, _ int64, _ timezone.Date) error {
+	return nil
+}
 func (m *mockStaffAbsenceService) ListPendingRequests(_ context.Context) ([]*activeSvc.StaffAbsenceResponse, error) {
 	return nil, nil
 }

--- a/backend/api/time-tracking/api_test.go
+++ b/backend/api/time-tracking/api_test.go
@@ -304,6 +304,19 @@ func (m *mockStaffAbsenceService) GetVacationQuotaSummary(_ context.Context, _ i
 func (m *mockStaffAbsenceService) UpsertVacationQuota(_ context.Context, _ int64, _ int, _, _ float64) error {
 	return nil
 }
+
+// Vacation takeover (#2132). The staff-facing time-tracking API never calls
+// these — the takeover is admin-only — so the mock just satisfies the
+// interface.
+func (m *mockStaffAbsenceService) GetVacationOpening(_ context.Context, _ int64, _ int) (*activeModels.StaffVacationOpening, error) {
+	return nil, nil
+}
+func (m *mockStaffAbsenceService) SetVacationOpening(_ context.Context, _, _ int64, _ activeSvc.SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error) {
+	return nil, nil
+}
+func (m *mockStaffAbsenceService) DeleteVacationOpening(_ context.Context, _, _ int64, _ int) error {
+	return nil
+}
 func (m *mockStaffAbsenceService) ListPendingRequests(_ context.Context) ([]*activeSvc.StaffAbsenceResponse, error) {
 	return nil, nil
 }

--- a/backend/database/migrations/001015257_opening_balances.go
+++ b/backend/database/migrations/001015257_opening_balances.go
@@ -1,0 +1,166 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	openingBalancesVersion     = "1.15.257"
+	openingBalancesDescription = "Opening balances for Stundenkonto and vacation at go-live (#2132)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     openingBalancesVersion,
+		Description: openingBalancesDescription,
+		DependsOn: []string{
+			staffMasterDataContractDatesVersion,
+			staffBalanceAdjustmentTenantFKsVersion,
+		},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return openingBalancesUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return openingBalancesDown(ctx, db)
+		},
+	)
+}
+
+// openingBalancesUp enables go-live opening balances (#2132):
+//
+//  1. The Stundenkonto ledger learns a fourth transaction type 'opening' — a
+//     signed rebaseline booking whose resulting balance may be negative
+//     (migrated accounts start where the old system left them). The partial
+//     unique index allows exactly one opening per staff member: a takeover is
+//     a one-time event; corrections go through delete + re-create so the
+//     deletion tombstone keeps the history.
+//
+//  2. active.staff_vacation_openings records vacation days taken BEFORE the
+//     moto introduction (per staff and calendar year). The row itself is the
+//     audit record — Stichtag, note, decided_by, decided_at — mirroring
+//     staff_balance_adjustments. Remaining vacation subtracts taken_before
+//     alongside in-app absences, so the Jahresanspruch stays untouched.
+//     entered_remaining_days documents what the admin actually typed
+//     (Resturlaub zum Stichtag) from which taken_before was derived.
+func openingBalancesUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.257: Opening balances for Stundenkonto and vacation...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE active.staff_balance_adjustments
+			DROP CONSTRAINT IF EXISTS chk_sba_type;
+		ALTER TABLE active.staff_balance_adjustments
+			ADD CONSTRAINT chk_sba_type CHECK (type IN ('payout','comp_time','reset','opening'));
+
+		CREATE UNIQUE INDEX IF NOT EXISTS uq_sba_opening_per_staff
+			ON active.staff_balance_adjustments (tenant_id, staff_id)
+			WHERE type = 'opening';
+
+		CREATE TABLE IF NOT EXISTS active.staff_vacation_openings (
+			id                     BIGSERIAL PRIMARY KEY,
+			tenant_id              BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			staff_id               BIGINT NOT NULL,
+			year                   INT NOT NULL,
+			effective_date         DATE NOT NULL,
+			taken_before_days      NUMERIC(5,1) NOT NULL,
+			entered_remaining_days NUMERIC(5,1) NOT NULL,
+			note                   TEXT NOT NULL DEFAULT '',
+			decided_by             BIGINT NOT NULL,
+			decided_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT uq_svo_staff_year UNIQUE (tenant_id, staff_id, year),
+			CONSTRAINT chk_svo_year CHECK (year BETWEEN 2000 AND 2100),
+			CONSTRAINT fk_svo_staff_tenant
+				FOREIGN KEY (tenant_id, staff_id)
+				REFERENCES users.staff(tenant_id, id)
+				ON DELETE CASCADE,
+			CONSTRAINT fk_svo_decided_by_tenant
+				FOREIGN KEY (tenant_id, decided_by)
+				REFERENCES users.staff(tenant_id, id)
+				ON DELETE RESTRICT
+		);
+
+		ALTER TABLE active.staff_vacation_openings ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE active.staff_vacation_openings FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_active_staff_vacation_openings ON active.staff_vacation_openings;
+		CREATE POLICY tenant_isolation_active_staff_vacation_openings ON active.staff_vacation_openings
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, DELETE ON active.staff_vacation_openings TO phoenix_tenant;
+		-- The row is its own audit record: corrections are delete + re-create
+		-- (with a deletion tombstone), never an in-place UPDATE. 1.14.1's
+		-- default privileges would grant UPDATE, so revoke it explicitly.
+		REVOKE UPDATE ON active.staff_vacation_openings FROM phoenix_tenant;
+		GRANT USAGE ON SEQUENCE active.staff_vacation_openings_id_seq TO phoenix_tenant;
+
+		-- Deleted vacation openings leave the same append-only tombstone the
+		-- ledger and absences use (#1417).
+		ALTER TABLE audit.time_tracking_deletions
+			DROP CONSTRAINT IF EXISTS time_tracking_deletions_source_check;
+		ALTER TABLE audit.time_tracking_deletions
+			ADD CONSTRAINT time_tracking_deletions_source_check
+				CHECK (source IN ('balance_adjustment', 'absence', 'vacation_opening'));
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating opening balance structures: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func openingBalancesDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.257: Removing opening balance structures...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM audit.time_tracking_deletions WHERE source = 'vacation_opening';
+		ALTER TABLE audit.time_tracking_deletions
+			DROP CONSTRAINT IF EXISTS time_tracking_deletions_source_check;
+		ALTER TABLE audit.time_tracking_deletions
+			ADD CONSTRAINT time_tracking_deletions_source_check
+				CHECK (source IN ('balance_adjustment', 'absence'));
+
+		DROP TABLE IF EXISTS active.staff_vacation_openings CASCADE;
+
+		DROP INDEX IF EXISTS active.uq_sba_opening_per_staff;
+		DELETE FROM active.staff_balance_adjustments WHERE type = 'opening';
+		ALTER TABLE active.staff_balance_adjustments
+			DROP CONSTRAINT IF EXISTS chk_sba_type;
+		ALTER TABLE active.staff_balance_adjustments
+			ADD CONSTRAINT chk_sba_type CHECK (type IN ('payout','comp_time','reset'));
+	`)
+	if err != nil {
+		return fmt.Errorf("error removing opening balance structures: %w", err)
+	}
+	return tx.Commit()
+}

--- a/backend/database/migrations/001015261_opening_balances.go
+++ b/backend/database/migrations/001015261_opening_balances.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	openingBalancesVersion     = "1.15.257"
+	openingBalancesVersion     = "1.15.261"
 	openingBalancesDescription = "Opening balances for Stundenkonto and vacation at go-live (#2132)"
 )
 
@@ -51,7 +51,7 @@ func init() {
 //     entered_remaining_days documents what the admin actually typed
 //     (Resturlaub zum Stichtag) from which taken_before was derived.
 func openingBalancesUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.257: Opening balances for Stundenkonto and vacation...")
+	fmt.Println("Migration 1.15.261: Opening balances for Stundenkonto and vacation...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -130,7 +130,7 @@ func openingBalancesUp(ctx context.Context, db *bun.DB) error {
 }
 
 func openingBalancesDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.257: Removing opening balance structures...")
+	fmt.Println("Rolling back migration 1.15.261: Removing opening balance structures...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {

--- a/backend/database/repositories/active/staff_vacation_opening.go
+++ b/backend/database/repositories/active/staff_vacation_opening.go
@@ -36,7 +36,7 @@ func NewStaffVacationOpeningRepository(db *bun.DB) active.StaffVacationOpeningRe
 // model columns with the struct-derived singular alias, which the plural
 // table name does not match.
 func (r *StaffVacationOpeningRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*active.StaffVacationOpening, error) {
-	return r.Repository.ListWithOptions(ctx, options)
+	return r.ListWithOptions(ctx, options)
 }
 
 func (r *StaffVacationOpeningRepository) GetByStaffAndYear(ctx context.Context, staffID int64, year int) (*active.StaffVacationOpening, error) {

--- a/backend/database/repositories/active/staff_vacation_opening.go
+++ b/backend/database/repositories/active/staff_vacation_opening.go
@@ -31,27 +31,12 @@ func NewStaffVacationOpeningRepository(db *bun.DB) active.StaffVacationOpeningRe
 	return &StaffVacationOpeningRepository{Repository: repo, db: db}
 }
 
-// List mirrors StaffVacationQuotaRepository.List, but with the explicit
-// aliased table expression: unlike the quota table (whose singular name
-// happens to equal bun's struct-derived default alias) the plural table name
-// needs the alias or every column qualification points nowhere.
+// List delegates to the generic ListWithOptions, which builds the aliased
+// table expression itself. That alias is load-bearing here: bun qualifies
+// model columns with the struct-derived singular alias, which the plural
+// table name does not match.
 func (r *StaffVacationOpeningRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*active.StaffVacationOpening, error) {
-	var rows []*active.StaffVacationOpening
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&rows).
-		ModelTableExpr(tableStaffVacationOpeningAliased)
-
-	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
-		query = query.Where("tenant_id = ?", tenantID)
-	}
-	if options != nil {
-		query = options.ApplyToQuery(query)
-	}
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, &modelBase.DatabaseError{Op: "list vacation openings", Err: err}
-	}
-	return rows, nil
+	return r.Repository.ListWithOptions(ctx, options)
 }
 
 func (r *StaffVacationOpeningRepository) GetByStaffAndYear(ctx context.Context, staffID int64, year int) (*active.StaffVacationOpening, error) {

--- a/backend/database/repositories/active/staff_vacation_opening.go
+++ b/backend/database/repositories/active/staff_vacation_opening.go
@@ -1,0 +1,105 @@
+package active
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+const (
+	tableStaffVacationOpening = "active.staff_vacation_openings"
+	// bun qualifies model columns with the struct-derived default alias
+	// (singular). The plural table name does NOT match it, so every custom
+	// query must alias explicitly — quoted, per the BUN alias rule.
+	tableStaffVacationOpeningAliased = tableStaffVacationOpening + ` AS "staff_vacation_opening"`
+)
+
+type StaffVacationOpeningRepository struct {
+	*base.Repository[*active.StaffVacationOpening]
+	db *bun.DB
+}
+
+func NewStaffVacationOpeningRepository(db *bun.DB) active.StaffVacationOpeningRepository {
+	repo := base.NewRepository[*active.StaffVacationOpening](db, tableStaffVacationOpening, "StaffVacationOpening")
+	repo.TenantScoped = true
+	return &StaffVacationOpeningRepository{Repository: repo, db: db}
+}
+
+// List mirrors StaffVacationQuotaRepository.List, but with the explicit
+// aliased table expression: unlike the quota table (whose singular name
+// happens to equal bun's struct-derived default alias) the plural table name
+// needs the alias or every column qualification points nowhere.
+func (r *StaffVacationOpeningRepository) List(ctx context.Context, options *modelBase.QueryOptions) ([]*active.StaffVacationOpening, error) {
+	var rows []*active.StaffVacationOpening
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(tableStaffVacationOpeningAliased)
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+	if options != nil {
+		query = options.ApplyToQuery(query)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list vacation openings", Err: err}
+	}
+	return rows, nil
+}
+
+func (r *StaffVacationOpeningRepository) GetByStaffAndYear(ctx context.Context, staffID int64, year int) (*active.StaffVacationOpening, error) {
+	opening := &active.StaffVacationOpening{}
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(opening).
+		ModelTableExpr(tableStaffVacationOpeningAliased).
+		Where("staff_id = ?", staffID).
+		Where("year = ?", year).
+		Limit(1)
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || err.Error() == "sql: no rows in result set" {
+			return nil, nil
+		}
+		return nil, &modelBase.DatabaseError{Op: "get vacation opening by staff+year", Err: err}
+	}
+	return opening, nil
+}
+
+func (r *StaffVacationOpeningRepository) GetByStaffIDsAndYear(ctx context.Context, staffIDs []int64, year int) (map[int64]*active.StaffVacationOpening, error) {
+	result := make(map[int64]*active.StaffVacationOpening, len(staffIDs))
+	if len(staffIDs) == 0 {
+		// bun renders an empty IN list as invalid SQL.
+		return result, nil
+	}
+
+	var openings []*active.StaffVacationOpening
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&openings).
+		ModelTableExpr(tableStaffVacationOpeningAliased).
+		Where("staff_id IN (?)", bun.List(staffIDs)).
+		Where("year = ?", year)
+
+	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "get vacation openings by staff IDs+year", Err: err}
+	}
+	for _, opening := range openings {
+		result[opening.StaffID] = opening
+	}
+	return result, nil
+}

--- a/backend/database/repositories/audit/time_tracking_audit_log.go
+++ b/backend/database/repositories/audit/time_tracking_audit_log.go
@@ -118,6 +118,19 @@ var auditLogBranches = map[string]string{
 			) AS detail
 		FROM audit.time_tracking_deletions d
 		WHERE d.tenant_id = %s`,
+	auditModels.AuditLogSourceVacationOpening: `
+		SELECT vo.decided_at AS occurred_at, 'vacation_opening' AS source, vo.id AS entry_id,
+			vo.staff_id AS staff_id, ARRAY[vo.staff_id] AS staff_ids,
+			vo.decided_by AS actor_staff_id, FALSE AS actor_is_system,
+			vo.note AS reason,
+			jsonb_build_object(
+				'opening_id', vo.id, 'year', vo.year,
+				'effective_date', to_char(vo.effective_date, 'YYYY-MM-DD'),
+				'taken_before_days', vo.taken_before_days,
+				'entered_remaining_days', vo.entered_remaining_days
+			) AS detail
+		FROM active.staff_vacation_openings vo
+		WHERE vo.tenant_id = %s`,
 	auditModels.AuditLogSourcePersonnelNumber: `
 		SELECT c.occurred_at AS occurred_at, 'personnel_number' AS source, c.id AS entry_id,
 			c.staff_id AS staff_id, ARRAY[c.staff_id] AS staff_ids,

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -139,6 +139,7 @@ type Factory struct {
 	StaffAbsence          activeModels.StaffAbsenceRepository
 	StaffAbsenceAudit     activeModels.StaffAbsenceAuditRepository
 	StaffVacationQuota    activeModels.StaffVacationQuotaRepository
+	StaffVacationOpening  activeModels.StaffVacationOpeningRepository
 	StaffBalanceAdjust    activeModels.StaffBalanceAdjustmentRepository
 	StaffMonthSnapshot    activeModels.StaffMonthBalanceSnapshotRepository
 
@@ -346,6 +347,7 @@ func NewFactory(db *bun.DB) *Factory {
 		StaffAbsence:          active.NewStaffAbsenceRepository(db),
 		StaffAbsenceAudit:     active.NewStaffAbsenceAuditRepository(db),
 		StaffVacationQuota:    active.NewStaffVacationQuotaRepository(db),
+		StaffVacationOpening:  active.NewStaffVacationOpeningRepository(db),
 		StaffBalanceAdjust:    active.NewStaffBalanceAdjustmentRepository(db),
 		StaffMonthSnapshot:    active.NewStaffMonthBalanceSnapshotRepository(db),
 

--- a/backend/models/active/repository.go
+++ b/backend/models/active/repository.go
@@ -464,6 +464,20 @@ type StaffVacationQuotaRepository interface {
 	Upsert(ctx context.Context, quota *StaffVacationQuota) error
 }
 
+// StaffVacationOpeningRepository manages per-staff vacation takeover rows
+// (#2132). One row per staff and year, append-only at the service level —
+// corrections are delete + re-create with a deletion tombstone.
+type StaffVacationOpeningRepository interface {
+	base.Repository[*StaffVacationOpening]
+
+	// GetByStaffAndYear returns the opening row for a staff/year, or nil.
+	GetByStaffAndYear(ctx context.Context, staffID int64, year int) (*StaffVacationOpening, error)
+
+	// GetByStaffIDsAndYear is GetByStaffAndYear batched over many staff
+	// members, keyed by staff ID. Missing rows are absent from the map.
+	GetByStaffIDsAndYear(ctx context.Context, staffIDs []int64, year int) (map[int64]*StaffVacationOpening, error)
+}
+
 // WorkSessionBreakRepository defines operations for managing work session breaks
 type WorkSessionBreakRepository interface {
 	base.Repository[*WorkSessionBreak]

--- a/backend/models/active/staff_balance_adjustment.go
+++ b/backend/models/active/staff_balance_adjustment.go
@@ -16,10 +16,14 @@ import (
 //     (the day-based variant is the comp_time ABSENCE type, which reduces
 //     the balance via its uncredited Soll — never both for the same grant)
 //   - reset:     school-year reset; delta = carryover − closing balance
+//   - opening:   go-live opening balance (#2132); delta = target − closing
+//     balance as of the Stichtag. The only type whose resulting balance may
+//     be negative — migrated accounts start where the old system left them.
 const (
 	BalanceAdjustmentTypePayout   = "payout"
 	BalanceAdjustmentTypeCompTime = "comp_time"
 	BalanceAdjustmentTypeReset    = "reset"
+	BalanceAdjustmentTypeOpening  = "opening"
 )
 
 // ValidBalanceAdjustmentTypes lists all valid balance adjustment types.
@@ -27,6 +31,7 @@ var ValidBalanceAdjustmentTypes = []string{
 	BalanceAdjustmentTypePayout,
 	BalanceAdjustmentTypeCompTime,
 	BalanceAdjustmentTypeReset,
+	BalanceAdjustmentTypeOpening,
 }
 
 // StaffBalanceAdjustment is one Stundenkonto correction transaction (#1420).

--- a/backend/models/active/staff_balance_adjustment_test.go
+++ b/backend/models/active/staff_balance_adjustment_test.go
@@ -1,0 +1,72 @@
+package active
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validBalanceAdjustment() *StaffBalanceAdjustment {
+	return &StaffBalanceAdjustment{
+		StaffID:       42,
+		Type:          BalanceAdjustmentTypePayout,
+		MinutesDelta:  -120,
+		EffectiveDate: timezone.NewDate(2026, time.March, 1),
+		DecidedBy:     43,
+	}
+}
+
+func TestStaffBalanceAdjustmentValidate_AcceptsEveryType(t *testing.T) {
+	for _, adjustmentType := range ValidBalanceAdjustmentTypes {
+		adjustment := validBalanceAdjustment()
+		adjustment.Type = adjustmentType
+
+		assert.NoError(t, adjustment.Validate(), "type %q must be accepted", adjustmentType)
+	}
+	// The go-live takeover (#2132) is one of them.
+	assert.Contains(t, ValidBalanceAdjustmentTypes, BalanceAdjustmentTypeOpening)
+}
+
+func TestStaffBalanceAdjustmentValidate_Rejects(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*StaffBalanceAdjustment)
+		errMsg string
+	}{
+		{
+			name:   "missing staff",
+			mutate: func(a *StaffBalanceAdjustment) { a.StaffID = 0 },
+			errMsg: "staff ID is required",
+		},
+		{
+			name:   "unknown type",
+			mutate: func(a *StaffBalanceAdjustment) { a.Type = "opening_balance" },
+			errMsg: "invalid balance adjustment type",
+		},
+		{
+			name:   "missing effective date",
+			mutate: func(a *StaffBalanceAdjustment) { a.EffectiveDate = timezone.Date{} },
+			errMsg: "effective_date is required",
+		},
+		{
+			name:   "missing decided by",
+			mutate: func(a *StaffBalanceAdjustment) { a.DecidedBy = 0 },
+			errMsg: "decided_by is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adjustment := validBalanceAdjustment()
+			tc.mutate(adjustment)
+
+			err := adjustment.Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}

--- a/backend/models/active/staff_vacation_opening.go
+++ b/backend/models/active/staff_vacation_opening.go
@@ -1,0 +1,64 @@
+package active
+
+import (
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// Validation bounds for a vacation opening. NUMERIC(5,1) caps the magnitude;
+// the business range is far smaller, but the takeover derives taken_before
+// from entitled + carryover − entered rest, so both signs are legitimate.
+const (
+	maxOpeningDays = 999.0
+)
+
+// StaffVacationOpening records vacation days a staff member had already taken
+// before the moto introduction (#2132), per calendar year. The row itself is
+// the audit record — Stichtag, note, decided_by, decided_at — mirroring
+// StaffBalanceAdjustment. Remaining vacation subtracts TakenBeforeDays
+// alongside in-app absences, so the Jahresanspruch stays untouched and later
+// entitlement corrections shift the Resturlaub coherently.
+//
+// TakenBeforeDays is SIGNED: an entered Resturlaub above entitled + carryover
+// yields a negative value (extra credit brought over from the old system).
+// EnteredRemainingDays documents what the admin actually typed.
+type StaffVacationOpening struct {
+	base.Model `bun:"schema:active,table:staff_vacation_openings"`
+	base.TenantModel
+	StaffID              int64         `bun:"staff_id,notnull" json:"staff_id"`
+	Year                 int           `bun:"year,notnull" json:"year"`
+	EffectiveDate        timezone.Date `bun:"effective_date,notnull,type:date" json:"effective_date"`
+	TakenBeforeDays      float64       `bun:"taken_before_days,notnull" json:"taken_before_days"`
+	EnteredRemainingDays float64       `bun:"entered_remaining_days,notnull" json:"entered_remaining_days"`
+	Note                 string        `bun:"note,notnull,default:''" json:"note"`
+	DecidedBy            int64         `bun:"decided_by,notnull" json:"decided_by"`
+	DecidedAt            time.Time     `bun:"decided_at,notnull,default:current_timestamp" json:"decided_at"`
+}
+
+func (o *StaffVacationOpening) Validate() error {
+	if o.StaffID <= 0 {
+		return errors.New("staff_id is required")
+	}
+	if o.Year < minQuotaYear || o.Year > maxQuotaYear {
+		return errors.New("year out of range")
+	}
+	if o.EffectiveDate.IsZero() {
+		return errors.New("effective_date is required")
+	}
+	if o.EffectiveDate.Year != o.Year {
+		return errors.New("effective_date must lie in the opening year")
+	}
+	if o.TakenBeforeDays < -maxOpeningDays || o.TakenBeforeDays > maxOpeningDays {
+		return errors.New("taken_before_days out of range")
+	}
+	if o.EnteredRemainingDays < -maxOpeningDays || o.EnteredRemainingDays > maxOpeningDays {
+		return errors.New("entered_remaining_days out of range")
+	}
+	if o.DecidedBy <= 0 {
+		return errors.New("decided_by is required")
+	}
+	return nil
+}

--- a/backend/models/active/staff_vacation_opening.go
+++ b/backend/models/active/staff_vacation_opening.go
@@ -2,11 +2,16 @@ package active
 
 import (
 	"errors"
+	"math"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/base"
 )
+
+func hasOneDecimalPlace(value float64) bool {
+	return math.Abs(value*10-math.Round(value*10)) < 1e-9
+}
 
 // Validation bounds for a vacation opening. NUMERIC(5,1) caps the magnitude;
 // the business range is far smaller, but the takeover derives taken_before
@@ -56,6 +61,9 @@ func (o *StaffVacationOpening) Validate() error {
 	}
 	if o.EnteredRemainingDays < -maxOpeningDays || o.EnteredRemainingDays > maxOpeningDays {
 		return errors.New("entered_remaining_days out of range")
+	}
+	if !hasOneDecimalPlace(o.TakenBeforeDays) || !hasOneDecimalPlace(o.EnteredRemainingDays) {
+		return errors.New("vacation opening days must have at most one decimal place")
 	}
 	if o.DecidedBy <= 0 {
 		return errors.New("decided_by is required")

--- a/backend/models/active/staff_vacation_opening_test.go
+++ b/backend/models/active/staff_vacation_opening_test.go
@@ -1,0 +1,159 @@
+package active
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Vacation takeover model validation (#2132). The row is the audit record of
+// the go-live handover, so every guard below is what keeps an unusable
+// takeover out of the ledger.
+
+func validVacationOpening() *StaffVacationOpening {
+	return &StaffVacationOpening{
+		StaffID:              42,
+		Year:                 2026,
+		EffectiveDate:        timezone.NewDate(2026, time.March, 1),
+		TakenBeforeDays:      7.5,
+		EnteredRemainingDays: 22.5,
+		Note:                 "Übernahme aus Altsystem",
+		DecidedBy:            43,
+	}
+}
+
+func TestStaffVacationOpeningValidate_Valid(t *testing.T) {
+	require.NoError(t, validVacationOpening().Validate())
+}
+
+func TestStaffVacationOpeningValidate_NegativeTakenBeforeIsAllowed(t *testing.T) {
+	// Resturlaub above entitled + carryover: extra credit carried over from
+	// the old system. Legitimate, so it must not be rejected.
+	opening := validVacationOpening()
+	opening.TakenBeforeDays = -3.5
+	opening.EnteredRemainingDays = 33.5
+
+	assert.NoError(t, opening.Validate())
+}
+
+func TestStaffVacationOpeningValidate_Rejects(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*StaffVacationOpening)
+		errMsg string
+	}{
+		{
+			name:   "missing staff",
+			mutate: func(o *StaffVacationOpening) { o.StaffID = 0 },
+			errMsg: "staff_id is required",
+		},
+		{
+			name:   "year below range",
+			mutate: func(o *StaffVacationOpening) { o.Year = 1999 },
+			errMsg: "year out of range",
+		},
+		{
+			name:   "year above range",
+			mutate: func(o *StaffVacationOpening) { o.Year = 2101 },
+			errMsg: "year out of range",
+		},
+		{
+			name:   "missing effective date",
+			mutate: func(o *StaffVacationOpening) { o.EffectiveDate = timezone.Date{} },
+			errMsg: "effective_date is required",
+		},
+		{
+			name: "effective date in another year",
+			mutate: func(o *StaffVacationOpening) {
+				o.EffectiveDate = timezone.NewDate(2025, time.March, 1)
+			},
+			errMsg: "effective_date must lie in the opening year",
+		},
+		{
+			name:   "taken before below range",
+			mutate: func(o *StaffVacationOpening) { o.TakenBeforeDays = -1000 },
+			errMsg: "taken_before_days out of range",
+		},
+		{
+			name:   "taken before above range",
+			mutate: func(o *StaffVacationOpening) { o.TakenBeforeDays = 1000 },
+			errMsg: "taken_before_days out of range",
+		},
+		{
+			name:   "entered remaining out of range",
+			mutate: func(o *StaffVacationOpening) { o.EnteredRemainingDays = 1000 },
+			errMsg: "entered_remaining_days out of range",
+		},
+		{
+			name:   "more than one decimal place in taken before",
+			mutate: func(o *StaffVacationOpening) { o.TakenBeforeDays = 7.25 },
+			errMsg: "vacation opening days must have at most one decimal place",
+		},
+		{
+			name:   "more than one decimal place in entered remaining",
+			mutate: func(o *StaffVacationOpening) { o.EnteredRemainingDays = 22.25 },
+			errMsg: "vacation opening days must have at most one decimal place",
+		},
+		{
+			name:   "missing decided by",
+			mutate: func(o *StaffVacationOpening) { o.DecidedBy = 0 },
+			errMsg: "decided_by is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opening := validVacationOpening()
+			tc.mutate(opening)
+
+			err := opening.Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
+func TestHasOneDecimalPlace(t *testing.T) {
+	assert.True(t, hasOneDecimalPlace(0))
+	assert.True(t, hasOneDecimalPlace(12))
+	assert.True(t, hasOneDecimalPlace(12.5))
+	assert.True(t, hasOneDecimalPlace(-3.5))
+	assert.False(t, hasOneDecimalPlace(12.25))
+	assert.False(t, hasOneDecimalPlace(-0.05))
+}
+
+// The quota is the takeover's reference value (entitled + carryover −
+// remaining = taken before), so its own precision guard matters just as much.
+func TestStaffVacationQuotaValidate(t *testing.T) {
+	valid := &StaffVacationQuota{StaffID: 42, Year: 2026, EntitledDays: 30, CarryoverDays: 2.5}
+	require.NoError(t, valid.Validate())
+
+	tests := []struct {
+		name   string
+		mutate func(*StaffVacationQuota)
+		errMsg string
+	}{
+		{"missing staff", func(q *StaffVacationQuota) { q.StaffID = 0 }, "staff_id is required"},
+		{"year out of range", func(q *StaffVacationQuota) { q.Year = 1999 }, "year out of range"},
+		{"entitled out of range", func(q *StaffVacationQuota) { q.EntitledDays = -1 }, "entitled_days out of range"},
+		{"carryover out of range", func(q *StaffVacationQuota) { q.CarryoverDays = -1 }, "carryover_days out of range"},
+		{"quarter day entitled", func(q *StaffVacationQuota) { q.EntitledDays = 30.25 }, "at most one decimal place"},
+		{"quarter day carryover", func(q *StaffVacationQuota) { q.CarryoverDays = 2.25 }, "at most one decimal place"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			quota := &StaffVacationQuota{StaffID: 42, Year: 2026, EntitledDays: 30, CarryoverDays: 2.5}
+			tc.mutate(quota)
+
+			err := quota.Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}

--- a/backend/models/active/staff_vacation_quota.go
+++ b/backend/models/active/staff_vacation_quota.go
@@ -38,5 +38,8 @@ func (q *StaffVacationQuota) Validate() error {
 	if q.CarryoverDays < minQuotaDays || q.CarryoverDays > maxQuotaDays {
 		return errors.New("carryover_days out of range")
 	}
+	if !hasOneDecimalPlace(q.EntitledDays) || !hasOneDecimalPlace(q.CarryoverDays) {
+		return errors.New("vacation quota days must have at most one decimal place")
+	}
 	return nil
 }

--- a/backend/models/audit/time_tracking_audit_log.go
+++ b/backend/models/audit/time_tracking_audit_log.go
@@ -18,6 +18,7 @@ const (
 	AuditLogSourceMonthReopen     = "month_reopen"
 	AuditLogSourceDeletion        = "deletion"
 	AuditLogSourcePersonnelNumber = "personnel_number"
+	AuditLogSourceVacationOpening = "vacation_opening"
 )
 
 // ValidAuditLogSources lists every accepted `sources` filter value.
@@ -29,6 +30,7 @@ var ValidAuditLogSources = []string{
 	AuditLogSourceMonthReopen,
 	AuditLogSourceDeletion,
 	AuditLogSourcePersonnelNumber,
+	AuditLogSourceVacationOpening,
 }
 
 // TimeTrackingAuditLogEntry is one event in the merged feed: the common

--- a/backend/models/audit/time_tracking_deletion.go
+++ b/backend/models/audit/time_tracking_deletion.go
@@ -13,6 +13,7 @@ import (
 const (
 	TimeTrackingDeletionSourceBalanceAdjustment = "balance_adjustment"
 	TimeTrackingDeletionSourceAbsence           = "absence"
+	TimeTrackingDeletionSourceVacationOpening   = "vacation_opening"
 )
 
 // TimeTrackingDeletion is an append-only tombstone for a deleted balance
@@ -36,7 +37,9 @@ func (d *TimeTrackingDeletion) Validate() error {
 	if d.StaffID <= 0 {
 		return errors.New("staff_id is required")
 	}
-	if d.Source != TimeTrackingDeletionSourceBalanceAdjustment && d.Source != TimeTrackingDeletionSourceAbsence {
+	if d.Source != TimeTrackingDeletionSourceBalanceAdjustment &&
+		d.Source != TimeTrackingDeletionSourceAbsence &&
+		d.Source != TimeTrackingDeletionSourceVacationOpening {
 		return errors.New("invalid deletion source")
 	}
 	if d.SourceID <= 0 {

--- a/backend/models/import/opening_balance.go
+++ b/backend/models/import/opening_balance.go
@@ -1,0 +1,23 @@
+package importpkg
+
+// OpeningBalanceImportRow is one line of the go-live opening balance import
+// (#2132): Stundenkonto and vacation takeover values for one staff member.
+// The raw string fields mirror the file columns; the typed fields are
+// resolved during validation. Every value column is optional — an empty cell
+// skips that side for the row.
+type OpeningBalanceImportRow struct {
+	PersonnelNumber   string `json:"personnel_number"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
+	HoursBalance      string `json:"hours_balance"`
+	VacationEntitled  string `json:"vacation_entitled"`
+	VacationCarryover string `json:"vacation_carryover"`
+	VacationRemaining string `json:"vacation_remaining"`
+
+	// Resolved during validation, not part of the file.
+	StaffID               int64    `json:"staff_id,omitempty"`
+	HoursBalanceMinutes   *int     `json:"hours_balance_minutes,omitempty"`
+	VacationEntitledDays  *float64 `json:"vacation_entitled_days,omitempty"`
+	VacationCarryoverDays *float64 `json:"vacation_carryover_days,omitempty"`
+	VacationRemainingDays *float64 `json:"vacation_remaining_days,omitempty"`
+}

--- a/backend/models/import/types.go
+++ b/backend/models/import/types.go
@@ -32,6 +32,15 @@ type BatchValidator[T any] interface {
 	ValidateBatch(ctx context.Context, rows []T) map[int][]ValidationError
 }
 
+// ProcessingOrderer can be implemented by imports that must create rows in a
+// deterministic order. The returned indexes always refer to the original
+// upload order, so row numbers in validation errors remain accurate.
+//
+// It is used only for real imports; previews preserve upload order.
+type ProcessingOrderer[T any] interface {
+	ProcessingOrder(rows []T) []int
+}
+
 // ImportMode defines how to handle existing records
 type ImportMode string
 

--- a/backend/services/active/staff_absence_service.go
+++ b/backend/services/active/staff_absence_service.go
@@ -699,6 +699,9 @@ func (s *staffAbsenceService) UpdateAbsence(ctx context.Context, staffID int64, 
 	if err := validateSingleDayHalfDayAbsence(absence.AbsenceType, absence.HalfDay, absence.DateStart, absence.DateEnd); err != nil {
 		return nil, err
 	}
+	if err := s.rejectVacationBeforeOpening(ctx, absence); err != nil {
+		return nil, err
+	}
 
 	// Check for overlapping absences (excluding self)
 	if err := s.checkOverlapExcludingSelf(ctx, staffID, absenceID, absence.DateStart, absence.DateEnd); err != nil {
@@ -1149,6 +1152,9 @@ func (s *staffAbsenceService) ApproveAbsence(ctx context.Context, absenceID int6
 	if absence.Status != activeModels.AbsenceStatusRequested &&
 		absence.Status != activeModels.AbsenceStatusQuestion {
 		return nil, fmt.Errorf("only requested absences can be approved")
+	}
+	if err := s.rejectVacationBeforeOpening(ctx, absence); err != nil {
+		return nil, err
 	}
 	fromStatus := absence.Status
 	now := time.Now()

--- a/backend/services/active/staff_absence_service.go
+++ b/backend/services/active/staff_absence_service.go
@@ -22,6 +22,9 @@ import (
 // only a time-tracking manager may create, change, or delete.
 var ErrManagerControlledAbsence = errors.New("absence type is manager-controlled")
 
+// ErrVacationQuotaInvalid marks invalid quota input supplied by a caller.
+var ErrVacationQuotaInvalid = errors.New("invalid vacation quota")
+
 // ErrCompTimeExceedsBalance prevents a comp_time absence from deducting more
 // daily-target minutes than the Stundenkonto has accrued before the absence
 // starts — the same overdraft guard the balance adjustments enforce (#1420).
@@ -1487,6 +1490,9 @@ func (s *staffAbsenceService) UpsertVacationQuota(ctx context.Context, staffID i
 	quota.CreatedAt = now
 	quota.UpdatedAt = now
 	quota.SetTenantID(tenant.FromContext(ctx))
+	if err := quota.Validate(); err != nil {
+		return fmt.Errorf("%w: %s", ErrVacationQuotaInvalid, err.Error())
+	}
 	if err := s.quotaRepo.Upsert(ctx, quota); err != nil {
 		return err
 	}

--- a/backend/services/active/staff_absence_service.go
+++ b/backend/services/active/staff_absence_service.go
@@ -88,9 +88,16 @@ type VacationQuotaSummary struct {
 	Year          int     `json:"year"`
 	EntitledDays  float64 `json:"entitled_days"`
 	CarryoverDays float64 `json:"carryover_days"`
-	TakenDays     float64 `json:"taken_days"`
-	ReservedDays  float64 `json:"reserved_days"`
-	RemainingDays float64 `json:"remaining_days"`
+	// TakenBeforeDays is the vacation takeover from the moto introduction
+	// (#2132): days already taken before the Stichtag in the old system.
+	// 0 without an opening row (or before its Stichtag).
+	TakenBeforeDays float64 `json:"taken_before_days"`
+	TakenDays       float64 `json:"taken_days"`
+	ReservedDays    float64 `json:"reserved_days"`
+	RemainingDays   float64 `json:"remaining_days"`
+	// Opening carries the takeover row for the summary's year, if any —
+	// Stichtag, entered Resturlaub, note, actor for the admin UI.
+	Opening *activeModels.StaffVacationOpening `json:"opening,omitempty"`
 }
 
 // StaffAbsenceService defines operations for staff absence management
@@ -133,6 +140,11 @@ type StaffAbsenceService interface {
 	CancelAbsence(ctx context.Context, staffID int64, actorAccountID int64, absenceID int64) error
 	GetVacationQuotaSummary(ctx context.Context, staffID int64, year int) (*VacationQuotaSummary, error)
 	UpsertVacationQuota(ctx context.Context, staffID int64, year int, entitled, carryover float64) error
+	// Vacation takeover at the moto introduction (#2132): one row per staff
+	// and year; corrections are delete + re-create (deletion tombstone).
+	GetVacationOpening(ctx context.Context, staffID int64, year int) (*activeModels.StaffVacationOpening, error)
+	SetVacationOpening(ctx context.Context, staffID, decidedBy int64, req SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error)
+	DeleteVacationOpening(ctx context.Context, staffID, deletedBy int64, year int) error
 	ListPendingRequests(ctx context.Context) ([]*StaffAbsenceResponse, error)
 }
 
@@ -146,8 +158,11 @@ type staffAbsenceService struct {
 	absenceRepo     activeModels.StaffAbsenceRepository
 	workSessionRepo activeModels.WorkSessionRepository
 	quotaRepo       activeModels.StaffVacationQuotaRepository
-	auditRepo       activeModels.StaffAbsenceAuditRepository
-	settings        monthSettingsResolver
+	// openingRepo carries the vacation takeover rows (#2132); setter
+	// injection (SetVacationOpeningRepository), nil in bare unit fixtures.
+	openingRepo activeModels.StaffVacationOpeningRepository
+	auditRepo   activeModels.StaffAbsenceAuditRepository
+	settings    monthSettingsResolver
 	// monthService provides the daily-target and closing-balance math for
 	// the comp_time overdraft guard; nil in bare-constructed unit tests.
 	monthService    WorkTimeMonthService
@@ -1339,7 +1354,14 @@ func (s *staffAbsenceService) GetVacationQuotaSummary(ctx context.Context, staff
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch year absences: %w", err)
 	}
-	return computeVacationQuotaSummary(staffID, year, entitled, carryover, absences), nil
+	var opening *activeModels.StaffVacationOpening
+	if s.openingRepo != nil {
+		opening, err = s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch vacation opening: %w", err)
+		}
+	}
+	return computeVacationQuotaSummary(staffID, year, entitled, carryover, absences, opening), nil
 }
 
 // computeVacationQuotaSummary is the pure tail of GetVacationQuotaSummary: the
@@ -1351,6 +1373,7 @@ func computeVacationQuotaSummary(
 	year int,
 	entitled, carryover float64,
 	absences []*activeModels.StaffAbsence,
+	opening *activeModels.StaffVacationOpening,
 ) *VacationQuotaSummary {
 	return computeVacationQuotaSummaryThrough(
 		staffID,
@@ -1359,6 +1382,7 @@ func computeVacationQuotaSummary(
 		carryover,
 		timezone.NewDate(year, time.December, 31),
 		absences,
+		opening,
 	)
 }
 
@@ -1371,11 +1395,22 @@ func computeVacationQuotaSummaryThrough(
 	entitled, carryover float64,
 	through timezone.Date,
 	absences []*activeModels.StaffAbsence,
+	opening *activeModels.StaffVacationOpening,
 ) *VacationQuotaSummary {
 	yearStart := timezone.NewDate(year, time.January, 1)
 	yearEnd := timezone.NewDate(year, time.December, 31)
 	if through.Before(yearEnd) {
 		yearEnd = through
+	}
+
+	// The takeover (#2132) counts only in its own year and only from its
+	// Stichtag on — a historical view that ends before the introduction
+	// keeps the pre-moto arithmetic.
+	takenBefore := 0.0
+	if opening != nil && opening.Year == year && !through.Before(opening.EffectiveDate) {
+		takenBefore = opening.TakenBeforeDays
+	} else {
+		opening = nil
 	}
 
 	taken, reserved := 0.0, 0.0
@@ -1396,13 +1431,15 @@ func computeVacationQuotaSummaryThrough(
 	}
 
 	return &VacationQuotaSummary{
-		StaffID:       staffID,
-		Year:          year,
-		EntitledDays:  entitled,
-		CarryoverDays: carryover,
-		TakenDays:     taken,
-		ReservedDays:  reserved,
-		RemainingDays: entitled + carryover - taken - reserved,
+		StaffID:         staffID,
+		Year:            year,
+		EntitledDays:    entitled,
+		CarryoverDays:   carryover,
+		TakenBeforeDays: takenBefore,
+		TakenDays:       taken,
+		ReservedDays:    reserved,
+		RemainingDays:   entitled + carryover - takenBefore - taken - reserved,
+		Opening:         opening,
 	}
 }
 

--- a/backend/services/active/staff_absence_service.go
+++ b/backend/services/active/staff_absence_service.go
@@ -148,6 +148,10 @@ type StaffAbsenceService interface {
 	GetVacationOpening(ctx context.Context, staffID int64, year int) (*activeModels.StaffVacationOpening, error)
 	SetVacationOpening(ctx context.Context, staffID, decidedBy int64, req SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error)
 	DeleteVacationOpening(ctx context.Context, staffID, deletedBy int64, year int) error
+	// ValidateVacationOpeningAbsencesBefore is the read-only half of the
+	// takeover guard, used by the bulk import's dry-run preview. Part of the
+	// contract because the import lives in another package.
+	ValidateVacationOpeningAbsencesBefore(ctx context.Context, staffID int64, effectiveDate timezone.Date) error
 	ListPendingRequests(ctx context.Context) ([]*StaffAbsenceResponse, error)
 }
 

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -25,6 +25,7 @@ import (
 // ============================================================================
 
 type absStaffAbsenceRepoMock struct {
+	lockStaffAbsenceWritesFunc func(ctx context.Context, staffID int64) error
 	createFunc                 func(ctx context.Context, entity *activeModels.StaffAbsence) error
 	findByIDFunc               func(ctx context.Context, id any) (*activeModels.StaffAbsence, error)
 	updateFunc                 func(ctx context.Context, entity *activeModels.StaffAbsence) error
@@ -37,7 +38,10 @@ type absStaffAbsenceRepoMock struct {
 	listByStatusesFunc         func(ctx context.Context, statuses []string) ([]*activeModels.StaffAbsence, error)
 }
 
-func (m *absStaffAbsenceRepoMock) LockStaffAbsenceWrites(context.Context, int64) error {
+func (m *absStaffAbsenceRepoMock) LockStaffAbsenceWrites(ctx context.Context, staffID int64) error {
+	if m.lockStaffAbsenceWritesFunc != nil {
+		return m.lockStaffAbsenceWritesFunc(ctx, staffID)
+	}
 	return nil
 }
 
@@ -333,6 +337,24 @@ func absSetupService() (*staffAbsenceService, *absStaffAbsenceRepoMock, *absWork
 		deletionRepo: noopDeletionAuditRepo{},
 	}
 	return svc, absRepo, workRepo
+}
+
+func TestValidateVacationOpeningAbsencesBefore_DoesNotLockPreview(t *testing.T) {
+	svc, absRepo, _ := absSetupService()
+	lockCalls := 0
+	absRepo.lockStaffAbsenceWritesFunc = func(context.Context, int64) error {
+		lockCalls++
+		return nil
+	}
+
+	err := svc.ValidateVacationOpeningAbsencesBefore(
+		context.Background(),
+		42,
+		timezone.NewDate(2026, time.March, 1),
+	)
+
+	require.NoError(t, err)
+	assert.Zero(t, lockCalls)
 }
 
 // ============================================================================

--- a/backend/services/active/staff_absence_service_test.go
+++ b/backend/services/active/staff_absence_service_test.go
@@ -1519,6 +1519,22 @@ func TestAbsGetVacationQuotaSummary_SplitsCrossYearVacation(t *testing.T) {
 	assert.Equal(t, 28.0, summary.RemainingDays)
 }
 
+func TestAbsUpsertVacationQuota_RejectsInvalidPrecision(t *testing.T) {
+	quotaRepo := &absVacationQuotaRepoMock{}
+	upsertCalled := false
+	quotaRepo.upsertFunc = func(context.Context, *activeModels.StaffVacationQuota) error {
+		upsertCalled = true
+		return nil
+	}
+	svc := &staffAbsenceService{quotaRepo: quotaRepo}
+
+	err := svc.UpsertVacationQuota(context.Background(), 42, 2026, 30.25, 0)
+
+	require.ErrorIs(t, err, ErrVacationQuotaInvalid)
+	assert.Contains(t, err.Error(), "at most one decimal place")
+	assert.False(t, upsertCalled)
+}
+
 // Generic query helper stubs (interface additions for the issue #585
 // cleanup refactor) — unused by these tests.
 func (m *absStaffAbsenceRepoMock) CountWithOptions(context.Context, *base.QueryOptions) (int, error) {

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -44,12 +44,21 @@ var (
 	// validation message. Wraps ErrAdjustmentInvalid so existing errors.Is
 	// call sites keep matching.
 	ErrAdjustmentInClosedMonth = fmt.Errorf("%w: effective month is closed", ErrAdjustmentInvalid)
+	// ErrOpeningAlreadyExists marks a second opening balance for the same
+	// staff member (#2132) — HTTP 409. A takeover is a one-time event;
+	// corrections go through delete + re-create so the deletion tombstone
+	// keeps the history.
+	ErrOpeningAlreadyExists = errors.New("opening balance already exists for this staff member")
 )
 
 const (
 	// resetUniqueConstraintName is the partial unique index guarding one reset
 	// per staff and effective date (migration 1.15.219).
 	resetUniqueConstraintName = "uq_sba_reset_per_day"
+
+	// openingUniqueConstraintName is the partial unique index guarding one
+	// opening balance per staff member (migration 1.15.257).
+	openingUniqueConstraintName = "uq_sba_opening_per_staff"
 
 	// These bounds mirror the privileged admin UI. They are business limits,
 	// not presentation hints: direct API callers must not bypass them.
@@ -86,6 +95,11 @@ type StaffBalanceAdjustmentService interface {
 	// run inside the ambient tenant transaction (advisory lock + unique
 	// index serialize concurrent resets).
 	ResetBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, carryoverMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error)
+	// CreateOpeningBalance writes an 'opening' transaction whose delta turns
+	// the closing balance as of effectiveDate into balanceMinutes (#2132).
+	// balanceMinutes is SIGNED — a migrated account may start negative. One
+	// opening per staff member, ever; corrections are delete + re-create.
+	CreateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error)
 	// SetSnapshotReader injects the frozen-month reader (#1417) after
 	// construction; nil means no month counts as frozen, so existing unit
 	// fixtures stay valid.
@@ -230,7 +244,7 @@ func (s *staffBalanceAdjustmentService) CreateAdjustment(ctx context.Context, st
 	if err := s.rejectFrozenMonth(ctx, staffID, req.EffectiveDate); err != nil {
 		return nil, err
 	}
-	resets, err := s.listResetsOnOrAfter(ctx, staffID, req.EffectiveDate)
+	resets, err := s.listRebaselinesOnOrAfter(ctx, staffID, req.EffectiveDate)
 	if err != nil {
 		return nil, err
 	}
@@ -406,18 +420,19 @@ func (s *staffBalanceAdjustmentService) ResetBalance(ctx context.Context, staffI
 	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
 		return nil, err
 	}
-	resets, err := s.listResetsOnOrAfter(ctx, staffID, effectiveDate)
+	resets, err := s.listRebaselinesOnOrAfter(ctx, staffID, effectiveDate)
 	if err != nil {
 		return nil, err
 	}
 	if len(resets) > 0 {
-		if resets[0].EffectiveDate == effectiveDate {
+		if resets[0].EffectiveDate == effectiveDate && resets[0].Type == activeModels.BalanceAdjustmentTypeReset {
 			return nil, fmt.Errorf("%w: %s", ErrBalanceAlreadyReset, effectiveDate.String())
 		}
 		return nil, fmt.Errorf(
-			"%w: reset date %s is before existing reset %s",
+			"%w: reset date %s is not after existing %s booking %s",
 			ErrAdjustmentHasDependentReset,
 			effectiveDate.String(),
+			resets[0].Type,
 			resets[0].EffectiveDate.String(),
 		)
 	}
@@ -474,8 +489,109 @@ func (s *staffBalanceAdjustmentService) ResetBalance(ctx context.Context, staffI
 	return adjustment, nil
 }
 
+// CreateOpeningBalance writes the go-live opening booking (#2132): a signed
+// rebaseline that turns the closing balance as of effectiveDate into
+// balanceMinutes. Unlike ResetBalance there is no lower bound and no
+// reduction-capacity check — a migrated account legitimately starts negative
+// when the staff member owed hours in the previous system.
+func (s *staffBalanceAdjustmentService) CreateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error) {
+	if err := validateAdjustmentCommon(staffID, decidedBy, effectiveDate, note); err != nil {
+		return nil, err
+	}
+	if balanceMinutes < -maxBalanceCarryoverMinutes || balanceMinutes > maxBalanceCarryoverMinutes {
+		return nil, fmt.Errorf(
+			"%w: balance_minutes must be between %d and %d",
+			ErrAdjustmentInvalid,
+			-maxBalanceCarryoverMinutes,
+			maxBalanceCarryoverMinutes,
+		)
+	}
+	// Same reasoning as the reset: the Stichtag needs a closed cutoff so the
+	// stored delta cannot go stale before the day ends.
+	if !effectiveDate.Before(timezone.TodayDate()) {
+		return nil, fmt.Errorf("%w: effective_date must be before today", ErrAdjustmentInvalid)
+	}
+	if err := s.rejectPreAccountDate(ctx, effectiveDate); err != nil {
+		return nil, err
+	}
+	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
+		return nil, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
+		return nil, err
+	}
+	existing, err := s.listOpenings(ctx, staffID)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) > 0 {
+		return nil, fmt.Errorf("%w: booked %s", ErrOpeningAlreadyExists, existing[0].EffectiveDate.String())
+	}
+	rebaselines, err := s.listRebaselinesOnOrAfter(ctx, staffID, effectiveDate)
+	if err != nil {
+		return nil, err
+	}
+	if len(rebaselines) > 0 {
+		return nil, fmt.Errorf(
+			"%w: opening date %s is not after existing %s booking %s",
+			ErrAdjustmentHasDependentReset,
+			effectiveDate.String(),
+			rebaselines[0].Type,
+			rebaselines[0].EffectiveDate.String(),
+		)
+	}
+
+	previousBalance, err := s.monthService.GetClosingBalanceAsOf(ctx, staffID, effectiveDate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute balance for opening: %w", err)
+	}
+	delta := int64(balanceMinutes) - int64(previousBalance)
+	if delta < minPostgresInteger || delta > maxPostgresInteger {
+		return nil, fmt.Errorf("%w: calculated opening delta is outside the supported range", ErrAdjustmentInvalid)
+	}
+
+	adjustment := &activeModels.StaffBalanceAdjustment{
+		StaffID:       staffID,
+		Type:          activeModels.BalanceAdjustmentTypeOpening,
+		MinutesDelta:  int(delta),
+		EffectiveDate: effectiveDate,
+		Note:          note,
+		DecidedBy:     decidedBy,
+		DecidedAt:     time.Now(),
+	}
+	if err := s.adjustmentRepo.Create(ctx, adjustment); err != nil {
+		if modelBase.IsUniqueViolationOn(err, openingUniqueConstraintName) {
+			return nil, fmt.Errorf("%w: %s", ErrOpeningAlreadyExists, effectiveDate.String())
+		}
+		return nil, fmt.Errorf("failed to create opening balance: %w", err)
+	}
+	s.getLogger().Info("opening balance created",
+		"staff_id", staffID,
+		"effective_date", effectiveDate.String(),
+		"balance_minutes", balanceMinutes,
+		"minutes_delta", adjustment.MinutesDelta,
+		"decided_by", decidedBy,
+	)
+	s.broadcastTimeTrackingChanged(ctx)
+	return adjustment, nil
+}
+
+// listOpenings lists all opening bookings for a staff member regardless of
+// date — the one-opening-ever guard (#2132).
+func (s *staffBalanceAdjustmentService) listOpenings(ctx context.Context, staffID int64) ([]*activeModels.StaffBalanceAdjustment, error) {
+	options := modelBase.NewQueryOptions()
+	options.Filter.
+		Equal("staff_id", staffID).
+		Equal("type", activeModels.BalanceAdjustmentTypeOpening)
+	openings, err := s.adjustmentRepo.List(ctx, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing opening balances: %w", err)
+	}
+	return openings, nil
+}
+
 func (s *staffBalanceAdjustmentService) hasDependentReset(ctx context.Context, adjustment *activeModels.StaffBalanceAdjustment) (bool, error) {
-	resets, err := s.listResetsOnOrAfter(ctx, adjustment.StaffID, adjustment.EffectiveDate)
+	resets, err := s.listRebaselinesOnOrAfter(ctx, adjustment.StaffID, adjustment.EffectiveDate)
 	if err != nil {
 		return false, err
 	}
@@ -488,11 +604,16 @@ func (s *staffBalanceAdjustmentService) hasDependentReset(ctx context.Context, a
 	return false, nil
 }
 
-func (s *staffBalanceAdjustmentService) listResetsOnOrAfter(ctx context.Context, staffID int64, effectiveDate timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
+// listRebaselinesOnOrAfter lists reset AND opening bookings from
+// effectiveDate onward. Both types persisted a delta computed from the
+// history before their Stichtag, so any write dated on/before them would
+// silently shift the balance they pinned — the shared dependent-booking
+// guard treats them identically (#1420, #2132).
+func (s *staffBalanceAdjustmentService) listRebaselinesOnOrAfter(ctx context.Context, staffID int64, effectiveDate timezone.Date) ([]*activeModels.StaffBalanceAdjustment, error) {
 	options := modelBase.NewQueryOptions()
 	options.Filter.
 		Equal("staff_id", staffID).
-		Equal("type", activeModels.BalanceAdjustmentTypeReset).
+		In("type", activeModels.BalanceAdjustmentTypeReset, activeModels.BalanceAdjustmentTypeOpening).
 		GreaterThanOrEqual("effective_date", effectiveDate)
 	sorting := &modelBase.Sorting{}
 	sorting.AddField("effective_date", modelBase.SortAsc)

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -330,8 +330,14 @@ func (s *staffBalanceAdjustmentService) DeleteAdjustment(ctx context.Context, st
 	if dependent {
 		return fmt.Errorf("%w: adjustment id %d", ErrAdjustmentHasDependentReset, adjustmentID)
 	}
-	if err := s.validatePositiveAdjustmentDeletion(ctx, adjustment); err != nil {
-		return err
+	// An opening balance is a migration rebaseline and may legitimately be
+	// replaced by a negative opening. Its documented correction workflow is
+	// delete + re-create, so do not reject the transient deletion solely
+	// because later consumption would make the account negative.
+	if adjustment.Type != activeModels.BalanceAdjustmentTypeOpening {
+		if err := s.validatePositiveAdjustmentDeletion(ctx, adjustment); err != nil {
+			return err
+		}
 	}
 	// Tombstone first, delete second, same transaction: a deleted booking
 	// must stay visible in the audit log (#1417).

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -495,65 +495,15 @@ func (s *staffBalanceAdjustmentService) ResetBalance(ctx context.Context, staffI
 // reduction-capacity check — a migrated account legitimately starts negative
 // when the staff member owed hours in the previous system.
 func (s *staffBalanceAdjustmentService) CreateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error) {
-	if err := validateAdjustmentCommon(staffID, decidedBy, effectiveDate, note); err != nil {
-		return nil, err
-	}
-	if balanceMinutes < -maxBalanceCarryoverMinutes || balanceMinutes > maxBalanceCarryoverMinutes {
-		return nil, fmt.Errorf(
-			"%w: balance_minutes must be between %d and %d",
-			ErrAdjustmentInvalid,
-			-maxBalanceCarryoverMinutes,
-			maxBalanceCarryoverMinutes,
-		)
-	}
-	// Same reasoning as the reset: the Stichtag needs a closed cutoff so the
-	// stored delta cannot go stale before the day ends.
-	if !effectiveDate.Before(timezone.TodayDate()) {
-		return nil, fmt.Errorf("%w: effective_date must be before today", ErrAdjustmentInvalid)
-	}
-	if err := s.rejectPreAccountDate(ctx, effectiveDate); err != nil {
-		return nil, err
-	}
-	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
-		return nil, fmt.Errorf("failed to lock staff balance writes: %w", err)
-	}
-	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
-		return nil, err
-	}
-	existing, err := s.listOpenings(ctx, staffID)
+	delta, err := s.validateOpeningBalance(ctx, staffID, decidedBy, effectiveDate, balanceMinutes, note)
 	if err != nil {
 		return nil, err
-	}
-	if len(existing) > 0 {
-		return nil, fmt.Errorf("%w: booked %s", ErrOpeningAlreadyExists, existing[0].EffectiveDate.String())
-	}
-	rebaselines, err := s.listRebaselinesOnOrAfter(ctx, staffID, effectiveDate)
-	if err != nil {
-		return nil, err
-	}
-	if len(rebaselines) > 0 {
-		return nil, fmt.Errorf(
-			"%w: opening date %s is not after existing %s booking %s",
-			ErrAdjustmentHasDependentReset,
-			effectiveDate.String(),
-			rebaselines[0].Type,
-			rebaselines[0].EffectiveDate.String(),
-		)
-	}
-
-	previousBalance, err := s.monthService.GetClosingBalanceAsOf(ctx, staffID, effectiveDate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compute balance for opening: %w", err)
-	}
-	delta := int64(balanceMinutes) - int64(previousBalance)
-	if delta < minPostgresInteger || delta > maxPostgresInteger {
-		return nil, fmt.Errorf("%w: calculated opening delta is outside the supported range", ErrAdjustmentInvalid)
 	}
 
 	adjustment := &activeModels.StaffBalanceAdjustment{
 		StaffID:       staffID,
 		Type:          activeModels.BalanceAdjustmentTypeOpening,
-		MinutesDelta:  int(delta),
+		MinutesDelta:  delta,
 		EffectiveDate: effectiveDate,
 		Note:          note,
 		DecidedBy:     decidedBy,
@@ -574,6 +524,72 @@ func (s *staffBalanceAdjustmentService) CreateOpeningBalance(ctx context.Context
 	)
 	s.broadcastTimeTrackingChanged(ctx)
 	return adjustment, nil
+}
+
+// ValidateOpeningBalance runs the same read-only booking guards used by
+// CreateOpeningBalance. Import previews use it to report constraints before
+// an operator commits the file.
+func (s *staffBalanceAdjustmentService) ValidateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) error {
+	_, err := s.validateOpeningBalance(ctx, staffID, decidedBy, effectiveDate, balanceMinutes, note)
+	return err
+}
+
+func (s *staffBalanceAdjustmentService) validateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (int, error) {
+	if err := validateAdjustmentCommon(staffID, decidedBy, effectiveDate, note); err != nil {
+		return 0, err
+	}
+	if balanceMinutes < -maxBalanceCarryoverMinutes || balanceMinutes > maxBalanceCarryoverMinutes {
+		return 0, fmt.Errorf(
+			"%w: balance_minutes must be between %d and %d",
+			ErrAdjustmentInvalid,
+			-maxBalanceCarryoverMinutes,
+			maxBalanceCarryoverMinutes,
+		)
+	}
+	// Same reasoning as the reset: the Stichtag needs a closed cutoff so the
+	// stored delta cannot go stale before the day ends.
+	if !effectiveDate.Before(timezone.TodayDate()) {
+		return 0, fmt.Errorf("%w: effective_date must be before today", ErrAdjustmentInvalid)
+	}
+	if err := s.rejectPreAccountDate(ctx, effectiveDate); err != nil {
+		return 0, err
+	}
+	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
+		return 0, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	}
+	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
+		return 0, err
+	}
+	existing, err := s.listOpenings(ctx, staffID)
+	if err != nil {
+		return 0, err
+	}
+	if len(existing) > 0 {
+		return 0, fmt.Errorf("%w: booked %s", ErrOpeningAlreadyExists, existing[0].EffectiveDate.String())
+	}
+	rebaselines, err := s.listRebaselinesOnOrAfter(ctx, staffID, effectiveDate)
+	if err != nil {
+		return 0, err
+	}
+	if len(rebaselines) > 0 {
+		return 0, fmt.Errorf(
+			"%w: opening date %s is not after existing %s booking %s",
+			ErrAdjustmentHasDependentReset,
+			effectiveDate.String(),
+			rebaselines[0].Type,
+			rebaselines[0].EffectiveDate.String(),
+		)
+	}
+
+	previousBalance, err := s.monthService.GetClosingBalanceAsOf(ctx, staffID, effectiveDate)
+	if err != nil {
+		return 0, fmt.Errorf("failed to compute balance for opening: %w", err)
+	}
+	delta := int64(balanceMinutes) - int64(previousBalance)
+	if delta < minPostgresInteger || delta > maxPostgresInteger {
+		return 0, fmt.Errorf("%w: calculated opening delta is outside the supported range", ErrAdjustmentInvalid)
+	}
+	return int(delta), nil
 }
 
 // listOpenings lists all opening bookings for a staff member regardless of

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -57,7 +57,7 @@ const (
 	resetUniqueConstraintName = "uq_sba_reset_per_day"
 
 	// openingUniqueConstraintName is the partial unique index guarding one
-	// opening balance per staff member (migration 1.15.257).
+	// opening balance per staff member (migration 1.15.261).
 	openingUniqueConstraintName = "uq_sba_opening_per_staff"
 
 	// These bounds mirror the privileged admin UI. They are business limits,

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -501,7 +501,7 @@ func (s *staffBalanceAdjustmentService) ResetBalance(ctx context.Context, staffI
 // reduction-capacity check — a migrated account legitimately starts negative
 // when the staff member owed hours in the previous system.
 func (s *staffBalanceAdjustmentService) CreateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error) {
-	delta, err := s.validateOpeningBalance(ctx, staffID, decidedBy, effectiveDate, balanceMinutes, note)
+	delta, err := s.validateOpeningBalance(ctx, staffID, decidedBy, effectiveDate, balanceMinutes, note, true)
 	if err != nil {
 		return nil, err
 	}
@@ -532,15 +532,16 @@ func (s *staffBalanceAdjustmentService) CreateOpeningBalance(ctx context.Context
 	return adjustment, nil
 }
 
-// ValidateOpeningBalance runs the same read-only booking guards used by
-// CreateOpeningBalance. Import previews use it to report constraints before
-// an operator commits the file.
+// ValidateOpeningBalance runs the read-only booking guards used by
+// CreateOpeningBalance. It deliberately does not take the transaction-scoped
+// staff lock: bulk imports validate every uploaded row before their sorted
+// creation pass, and file-order locks here could deadlock concurrent imports.
 func (s *staffBalanceAdjustmentService) ValidateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) error {
-	_, err := s.validateOpeningBalance(ctx, staffID, decidedBy, effectiveDate, balanceMinutes, note)
+	_, err := s.validateOpeningBalance(ctx, staffID, decidedBy, effectiveDate, balanceMinutes, note, false)
 	return err
 }
 
-func (s *staffBalanceAdjustmentService) validateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (int, error) {
+func (s *staffBalanceAdjustmentService) validateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string, lockWrites bool) (int, error) {
 	if err := validateAdjustmentCommon(staffID, decidedBy, effectiveDate, note); err != nil {
 		return 0, err
 	}
@@ -560,8 +561,10 @@ func (s *staffBalanceAdjustmentService) validateOpeningBalance(ctx context.Conte
 	if err := s.rejectPreAccountDate(ctx, effectiveDate); err != nil {
 		return 0, err
 	}
-	if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
-		return 0, fmt.Errorf("failed to lock staff balance writes: %w", err)
+	if lockWrites {
+		if err := s.adjustmentRepo.LockStaffBalanceWrites(ctx, staffID); err != nil {
+			return 0, fmt.Errorf("failed to lock staff balance writes: %w", err)
+		}
 	}
 	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
 		return 0, err

--- a/backend/services/active/staff_balance_adjustment_service.go
+++ b/backend/services/active/staff_balance_adjustment_service.go
@@ -100,6 +100,11 @@ type StaffBalanceAdjustmentService interface {
 	// balanceMinutes is SIGNED — a migrated account may start negative. One
 	// opening per staff member, ever; corrections are delete + re-create.
 	CreateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error)
+	// ValidateOpeningBalance runs CreateOpeningBalance's read-only guards
+	// without booking, so the bulk import's dry-run preview can report a
+	// rejection per row. Part of the contract because the import lives in
+	// another package.
+	ValidateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) error
 	// SetSnapshotReader injects the frozen-month reader (#1417) after
 	// construction; nil means no month counts as frozen, so existing unit
 	// fixtures stay valid.
@@ -569,25 +574,8 @@ func (s *staffBalanceAdjustmentService) validateOpeningBalance(ctx context.Conte
 	if err := s.rejectFrozenMonth(ctx, staffID, effectiveDate); err != nil {
 		return 0, err
 	}
-	existing, err := s.listOpenings(ctx, staffID)
-	if err != nil {
+	if err := s.rejectConflictingRebaselines(ctx, staffID, effectiveDate); err != nil {
 		return 0, err
-	}
-	if len(existing) > 0 {
-		return 0, fmt.Errorf("%w: booked %s", ErrOpeningAlreadyExists, existing[0].EffectiveDate.String())
-	}
-	rebaselines, err := s.listRebaselinesOnOrAfter(ctx, staffID, effectiveDate)
-	if err != nil {
-		return 0, err
-	}
-	if len(rebaselines) > 0 {
-		return 0, fmt.Errorf(
-			"%w: opening date %s is not after existing %s booking %s",
-			ErrAdjustmentHasDependentReset,
-			effectiveDate.String(),
-			rebaselines[0].Type,
-			rebaselines[0].EffectiveDate.String(),
-		)
 	}
 
 	previousBalance, err := s.monthService.GetClosingBalanceAsOf(ctx, staffID, effectiveDate)
@@ -599,6 +587,34 @@ func (s *staffBalanceAdjustmentService) validateOpeningBalance(ctx context.Conte
 		return 0, fmt.Errorf("%w: calculated opening delta is outside the supported range", ErrAdjustmentInvalid)
 	}
 	return int(delta), nil
+}
+
+// rejectConflictingRebaselines enforces the two "already rebaselined" guards
+// of an opening booking: exactly one opening ever exists per staff member, and
+// no reset/opening may already sit on or after the new Stichtag — both stored
+// a delta derived from the history the new booking would rewrite (#2132).
+func (s *staffBalanceAdjustmentService) rejectConflictingRebaselines(ctx context.Context, staffID int64, effectiveDate timezone.Date) error {
+	existing, err := s.listOpenings(ctx, staffID)
+	if err != nil {
+		return err
+	}
+	if len(existing) > 0 {
+		return fmt.Errorf("%w: booked %s", ErrOpeningAlreadyExists, existing[0].EffectiveDate.String())
+	}
+	rebaselines, err := s.listRebaselinesOnOrAfter(ctx, staffID, effectiveDate)
+	if err != nil {
+		return err
+	}
+	if len(rebaselines) > 0 {
+		return fmt.Errorf(
+			"%w: opening date %s is not after existing %s booking %s",
+			ErrAdjustmentHasDependentReset,
+			effectiveDate.String(),
+			rebaselines[0].Type,
+			rebaselines[0].EffectiveDate.String(),
+		)
+	}
+	return nil
 }
 
 // listOpenings lists all opening bookings for a staff member regardless of

--- a/backend/services/active/staff_opening_balance_mock_test.go
+++ b/backend/services/active/staff_opening_balance_mock_test.go
@@ -1,0 +1,215 @@
+package active
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Opening balance (#2132) unit tests over the recording harness from
+// staff_balance_adjustment_service_mock_test.go.
+
+func TestStaffBalanceAdjustmentService_OpeningAllowsNegativeTarget(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	events := []string{}
+	repo := &recordingBalanceAdjustmentRepo{events: &events}
+	month := &recordingBalanceMonthService{events: &events, balance: 0}
+	service := newRecordingBalanceAdjustmentService(&events, repo, month)
+
+	effectiveDate := timezone.TodayDate().AddDays(-1)
+	adjustment, err := service.CreateOpeningBalance(
+		context.Background(),
+		staffID,
+		decidedBy,
+		effectiveDate,
+		-330, // -5,5 h from the previous system
+		"Übernahme aus Altsystem",
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, adjustment)
+	assert.Equal(t, activeModels.BalanceAdjustmentTypeOpening, adjustment.Type)
+	assert.Equal(t, -330, adjustment.MinutesDelta)
+	assert.Equal(t, effectiveDate, adjustment.EffectiveDate)
+	// The whole point of the opening type: a negative resulting balance must
+	// NOT consult the reduction-capacity guard.
+	assert.NotContains(t, events, "capacity")
+	assert.Contains(t, events, "lock")
+	assert.Contains(t, events, "create")
+}
+
+func TestStaffBalanceAdjustmentService_OpeningDeltaTargetsEnteredBalance(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	events := []string{}
+	repo := &recordingBalanceAdjustmentRepo{events: &events}
+	// Sessions already recorded before the takeover: live balance 90 min.
+	month := &recordingBalanceMonthService{events: &events, balance: 90}
+	service := newRecordingBalanceAdjustmentService(&events, repo, month)
+
+	adjustment, err := service.CreateOpeningBalance(
+		context.Background(),
+		staffID,
+		decidedBy,
+		timezone.TodayDate().AddDays(-1),
+		750, // target 12,5 h
+		"Übernahme aus Altsystem",
+	)
+
+	require.NoError(t, err)
+	// delta = target − live balance as of the Stichtag.
+	assert.Equal(t, 660, adjustment.MinutesDelta)
+}
+
+func TestStaffBalanceAdjustmentService_OpeningRejectsSecondOpening(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	events := []string{}
+	existing := &activeModels.StaffBalanceAdjustment{
+		StaffID:       staffID,
+		Type:          activeModels.BalanceAdjustmentTypeOpening,
+		EffectiveDate: timezone.TodayDate().AddDays(-10),
+	}
+	repo := &recordingBalanceAdjustmentRepo{events: &events, resets: []*activeModels.StaffBalanceAdjustment{existing}}
+	month := &recordingBalanceMonthService{events: &events}
+	service := newRecordingBalanceAdjustmentService(&events, repo, month)
+
+	_, err := service.CreateOpeningBalance(
+		context.Background(),
+		staffID,
+		decidedBy,
+		timezone.TodayDate().AddDays(-1),
+		600,
+		"Zweiter Versuch",
+	)
+
+	require.ErrorIs(t, err, ErrOpeningAlreadyExists)
+	assert.NotContains(t, events, "create")
+}
+
+func TestStaffBalanceAdjustmentService_OpeningRejectsOpenDay(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	for _, effectiveDate := range []timezone.Date{
+		timezone.TodayDate(),
+		timezone.TodayDate().AddDays(1),
+	} {
+		events := []string{}
+		service := newRecordingBalanceAdjustmentService(
+			&events,
+			&recordingBalanceAdjustmentRepo{events: &events},
+			nil,
+		)
+
+		_, err := service.CreateOpeningBalance(
+			context.Background(),
+			staffID,
+			decidedBy,
+			effectiveDate,
+			600,
+			"Übernahme",
+		)
+
+		require.ErrorIs(t, err, ErrAdjustmentInvalid)
+		assert.Contains(t, err.Error(), "effective_date must be before today")
+		assert.Empty(t, events, "an open cutoff must fail before locking or reading")
+	}
+}
+
+func TestStaffBalanceAdjustmentService_OpeningRejectsOutOfRangeTarget(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	for _, balanceMinutes := range []int{maxBalanceCarryoverMinutes + 1, -maxBalanceCarryoverMinutes - 1} {
+		events := []string{}
+		service := newRecordingBalanceAdjustmentService(
+			&events,
+			&recordingBalanceAdjustmentRepo{events: &events},
+			nil,
+		)
+
+		_, err := service.CreateOpeningBalance(
+			context.Background(),
+			staffID,
+			decidedBy,
+			timezone.TodayDate().AddDays(-1),
+			balanceMinutes,
+			"Übernahme",
+		)
+
+		require.ErrorIs(t, err, ErrAdjustmentInvalid)
+		assert.Empty(t, events)
+	}
+}
+
+// typeFilteringBalanceAdjustmentRepo refines the recording repo: List answers
+// per call like the real repository would — no rows for the opening-duplicate
+// lookup, the seeded rows for the rebaseline lookup. The shared recording
+// repo returns one static list for every List call, which cannot distinguish
+// the two guards CreateOpeningBalance runs back to back.
+type typeFilteringBalanceAdjustmentRepo struct {
+	*recordingBalanceAdjustmentRepo
+	listCalls int
+}
+
+func (r *typeFilteringBalanceAdjustmentRepo) List(ctx context.Context, options *modelBase.QueryOptions) ([]*activeModels.StaffBalanceAdjustment, error) {
+	r.listCalls++
+	if r.listCalls == 1 {
+		*r.events = append(*r.events, "list")
+		return nil, nil
+	}
+	return r.recordingBalanceAdjustmentRepo.List(ctx, options)
+}
+
+func TestStaffBalanceAdjustmentService_OpeningRejectsExistingLaterReset(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	events := []string{}
+	laterReset := &activeModels.StaffBalanceAdjustment{
+		StaffID:       staffID,
+		Type:          activeModels.BalanceAdjustmentTypeReset,
+		EffectiveDate: timezone.TodayDate().AddDays(-2),
+	}
+	repo := &typeFilteringBalanceAdjustmentRepo{
+		recordingBalanceAdjustmentRepo: &recordingBalanceAdjustmentRepo{events: &events, resets: []*activeModels.StaffBalanceAdjustment{laterReset}},
+	}
+	month := &recordingBalanceMonthService{events: &events}
+	service := NewStaffBalanceAdjustmentService(
+		repo,
+		month,
+		&wtmMockSettings{accountStart: "2026-06-01"},
+		slog.New(slog.DiscardHandler),
+	)
+
+	_, err := service.CreateOpeningBalance(
+		context.Background(),
+		staffID,
+		decidedBy,
+		timezone.TodayDate().AddDays(-5),
+		600,
+		"Übernahme",
+	)
+
+	// No opening exists yet, but a reset on a later date must still trip the
+	// dependent-booking guard.
+	require.ErrorIs(t, err, ErrAdjustmentHasDependentReset)
+	assert.NotContains(t, events, "create")
+}

--- a/backend/services/active/staff_opening_balance_mock_test.go
+++ b/backend/services/active/staff_opening_balance_mock_test.go
@@ -2,8 +2,10 @@ package active
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
@@ -212,4 +214,222 @@ func TestStaffBalanceAdjustmentService_OpeningRejectsExistingLaterReset(t *testi
 	// dependent-booking guard.
 	require.ErrorIs(t, err, ErrAdjustmentHasDependentReset)
 	assert.NotContains(t, events, "create")
+}
+
+// failingBalanceAdjustmentRepo injects repository failures into the guard
+// chain of an opening booking.
+type failingBalanceAdjustmentRepo struct {
+	*recordingBalanceAdjustmentRepo
+	listErr   error
+	createErr error
+}
+
+func (r *failingBalanceAdjustmentRepo) List(ctx context.Context, options *modelBase.QueryOptions) ([]*activeModels.StaffBalanceAdjustment, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.recordingBalanceAdjustmentRepo.List(ctx, options)
+}
+
+func (r *failingBalanceAdjustmentRepo) Create(ctx context.Context, adjustment *activeModels.StaffBalanceAdjustment) error {
+	if r.createErr != nil {
+		*r.events = append(*r.events, "create")
+		return r.createErr
+	}
+	return r.recordingBalanceAdjustmentRepo.Create(ctx, adjustment)
+}
+
+// failingBalanceMonthService fails the as-of balance read the opening delta
+// is computed from.
+type failingBalanceMonthService struct {
+	*recordingBalanceMonthService
+	err error
+}
+
+func (s *failingBalanceMonthService) GetClosingBalanceAsOf(ctx context.Context, staffID int64, date timezone.Date) (int, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.recordingBalanceMonthService.GetClosingBalanceAsOf(ctx, staffID, date)
+}
+
+func newOpeningTestService(events *[]string, repo activeModels.StaffBalanceAdjustmentRepository, month WorkTimeMonthService) StaffBalanceAdjustmentService {
+	_ = events
+	return NewStaffBalanceAdjustmentService(
+		repo,
+		month,
+		&wtmMockSettings{accountStart: "2026-06-01"},
+		slog.New(slog.DiscardHandler),
+	)
+}
+
+func TestStaffBalanceAdjustmentService_OpeningRejectsInvalidRequests(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+	yesterday := timezone.TodayDate().AddDays(-1)
+
+	tests := []struct {
+		name          string
+		staffID       int64
+		decidedBy     int64
+		effectiveDate timezone.Date
+		minutes       int
+		note          string
+		wantMsg       string
+	}{
+		{
+			name: "missing staff", staffID: 0, decidedBy: decidedBy,
+			effectiveDate: yesterday, minutes: 600, note: "Übernahme",
+			wantMsg: "staff id is required",
+		},
+		{
+			name: "missing actor", staffID: staffID, decidedBy: 0,
+			effectiveDate: yesterday, minutes: 600, note: "Übernahme",
+			wantMsg: "decided_by is required",
+		},
+		{
+			name: "missing Stichtag", staffID: staffID, decidedBy: decidedBy,
+			effectiveDate: timezone.Date{}, minutes: 600, note: "Übernahme",
+			wantMsg: "effective_date is required",
+		},
+		{
+			name: "missing Begründung", staffID: staffID, decidedBy: decidedBy,
+			effectiveDate: yesterday, minutes: 600, note: "   ",
+			wantMsg: "note is required",
+		},
+		{
+			// The Stichtag needs a closed day, or the stored delta goes stale
+			// as the day's sessions keep coming in.
+			name: "Stichtag today", staffID: staffID, decidedBy: decidedBy,
+			effectiveDate: timezone.TodayDate(), minutes: 600, note: "Übernahme",
+			wantMsg: "must be before today",
+		},
+		{
+			name: "target above the carryover bound", staffID: staffID, decidedBy: decidedBy,
+			effectiveDate: yesterday, minutes: maxBalanceCarryoverMinutes + 1, note: "Übernahme",
+			wantMsg: "balance_minutes must be between",
+		},
+		{
+			name: "target below the carryover bound", staffID: staffID, decidedBy: decidedBy,
+			effectiveDate: yesterday, minutes: -maxBalanceCarryoverMinutes - 1, note: "Übernahme",
+			wantMsg: "balance_minutes must be between",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []string{}
+			repo := &recordingBalanceAdjustmentRepo{events: &events}
+			service := newOpeningTestService(&events, repo, &recordingBalanceMonthService{events: &events})
+
+			_, err := service.CreateOpeningBalance(context.Background(), tc.staffID, tc.decidedBy, tc.effectiveDate, tc.minutes, tc.note)
+
+			require.ErrorIs(t, err, ErrAdjustmentInvalid)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+			assert.NotContains(t, events, "create")
+		})
+	}
+}
+
+func TestStaffBalanceAdjustmentService_OpeningRejectsDateBeforeAccountStart(t *testing.T) {
+	events := []string{}
+	repo := &recordingBalanceAdjustmentRepo{events: &events}
+	service := newOpeningTestService(&events, repo, &recordingBalanceMonthService{events: &events})
+
+	// Account start is 2026-06-01; a Stichtag before it would sit outside
+	// every carry chain and silently never move the Stundenkonto.
+	_, err := service.CreateOpeningBalance(
+		context.Background(), 41, 42,
+		timezone.NewDate(2026, time.May, 31), 600, "Übernahme",
+	)
+
+	require.Error(t, err)
+	assert.NotContains(t, events, "create")
+}
+
+func TestStaffBalanceAdjustmentService_OpeningPropagatesRepositoryFailures(t *testing.T) {
+	boom := errors.New("db down")
+	yesterday := timezone.TodayDate().AddDays(-1)
+
+	t.Run("existing-booking lookup", func(t *testing.T) {
+		events := []string{}
+		repo := &failingBalanceAdjustmentRepo{
+			recordingBalanceAdjustmentRepo: &recordingBalanceAdjustmentRepo{events: &events},
+			listErr:                        boom,
+		}
+		service := newOpeningTestService(&events, repo, &recordingBalanceMonthService{events: &events})
+
+		_, err := service.CreateOpeningBalance(context.Background(), 41, 42, yesterday, 600, "Übernahme")
+
+		require.Error(t, err)
+		assert.NotContains(t, events, "create")
+	})
+
+	t.Run("as-of balance", func(t *testing.T) {
+		events := []string{}
+		repo := &recordingBalanceAdjustmentRepo{events: &events}
+		month := &failingBalanceMonthService{
+			recordingBalanceMonthService: &recordingBalanceMonthService{events: &events},
+			err:                          boom,
+		}
+		service := newOpeningTestService(&events, repo, month)
+
+		_, err := service.CreateOpeningBalance(context.Background(), 41, 42, yesterday, 600, "Übernahme")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to compute balance for opening")
+	})
+
+	t.Run("insert", func(t *testing.T) {
+		events := []string{}
+		repo := &failingBalanceAdjustmentRepo{
+			recordingBalanceAdjustmentRepo: &recordingBalanceAdjustmentRepo{events: &events},
+			createErr:                      boom,
+		}
+		service := newOpeningTestService(&events, repo, &recordingBalanceMonthService{events: &events})
+
+		_, err := service.CreateOpeningBalance(context.Background(), 41, 42, yesterday, 600, "Übernahme")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create opening balance")
+	})
+}
+
+// TestStaffBalanceAdjustmentService_ValidateOpeningTakesNoLock pins the
+// contract the bulk import relies on: the preview runs the same guards but
+// must not take the per-staff lock, or concurrent imports could deadlock on
+// file order.
+func TestStaffBalanceAdjustmentService_ValidateOpeningTakesNoLock(t *testing.T) {
+	events := []string{}
+	repo := &recordingBalanceAdjustmentRepo{events: &events}
+	service := newOpeningTestService(&events, repo, &recordingBalanceMonthService{events: &events})
+
+	err := service.ValidateOpeningBalance(
+		context.Background(), 41, 42,
+		timezone.TodayDate().AddDays(-1), -330, "Übernahme",
+	)
+
+	require.NoError(t, err)
+	assert.NotContains(t, events, "lock")
+	assert.NotContains(t, events, "create", "validation must not book anything")
+}
+
+func TestStaffBalanceAdjustmentService_ValidateOpeningReportsTheSameRejection(t *testing.T) {
+	events := []string{}
+	existing := &activeModels.StaffBalanceAdjustment{
+		StaffID:       41,
+		Type:          activeModels.BalanceAdjustmentTypeOpening,
+		EffectiveDate: timezone.TodayDate().AddDays(-30),
+	}
+	repo := &recordingBalanceAdjustmentRepo{events: &events, resets: []*activeModels.StaffBalanceAdjustment{existing}}
+	service := newOpeningTestService(&events, repo, &recordingBalanceMonthService{events: &events})
+
+	err := service.ValidateOpeningBalance(
+		context.Background(), 41, 42,
+		timezone.TodayDate().AddDays(-1), 600, "Übernahme",
+	)
+
+	require.ErrorIs(t, err, ErrOpeningAlreadyExists)
 }

--- a/backend/services/active/staff_overview_service.go
+++ b/backend/services/active/staff_overview_service.go
@@ -162,7 +162,10 @@ type staffOverviewService struct {
 	shiftRepo      scheduleModels.StaffShiftRepository
 	settings       monthSettingsResolver
 	holidayReader  HolidayDatesReader
-	logger         *slog.Logger
+	// openingRepo carries the vacation takeover rows (#2132); setter
+	// injection (SetVacationOpeningReader), nil in bare unit fixtures.
+	openingRepo activeModels.StaffVacationOpeningRepository
+	logger      *slog.Logger
 
 	// todayFunc is a test hook; production uses timezone.TodayDate.
 	todayFunc func() timezone.Date
@@ -426,6 +429,10 @@ func (s *staffOverviewService) GetTimeTrackingOverview(ctx context.Context, filt
 	if err != nil {
 		return nil, fmt.Errorf("failed to prefetch vacation absences: %w", err)
 	}
+	openings, err := s.prefetchVacationOpenings(ctx, staffIDs, key.Year)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, staff := range staffMembers {
 		summary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
@@ -449,6 +456,7 @@ func (s *staffOverviewService) GetTimeTrackingOverview(ctx context.Context, filt
 				vacationThrough,
 				quotas[staff.ID],
 				vacationAbsences[staff.ID],
+				openings[staff.ID],
 			),
 		}
 		if staff.EmploymentType != nil {
@@ -480,12 +488,31 @@ func (s *staffOverviewService) remainingVacationDays(
 	through timezone.Date,
 	quota *activeModels.StaffVacationQuota,
 	absences []*activeModels.StaffAbsence,
+	opening *activeModels.StaffVacationOpening,
 ) float64 {
 	entitled, carryover := defaultEntitledDays, 0.0
 	if quota != nil {
 		entitled, carryover = quota.EntitledDays, quota.CarryoverDays
 	}
-	return computeVacationQuotaSummaryThrough(staffID, year, entitled, carryover, through, absences).RemainingDays
+	return computeVacationQuotaSummaryThrough(staffID, year, entitled, carryover, through, absences, opening).RemainingDays
+}
+
+// SetVacationOpeningReader wires the vacation takeover reader (#2132).
+// Setter injection so the 12-parameter constructor and its unit fixtures
+// stay unchanged; nil means the overview ignores takeovers.
+func (s *staffOverviewService) SetVacationOpeningReader(repo activeModels.StaffVacationOpeningRepository) {
+	s.openingRepo = repo
+}
+
+func (s *staffOverviewService) prefetchVacationOpenings(ctx context.Context, staffIDs []int64, year int) (map[int64]*activeModels.StaffVacationOpening, error) {
+	if s.openingRepo == nil {
+		return map[int64]*activeModels.StaffVacationOpening{}, nil
+	}
+	openings, err := s.openingRepo.GetByStaffIDsAndYear(ctx, staffIDs, year)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prefetch vacation openings: %w", err)
+	}
+	return openings, nil
 }
 
 // resolveOverviewMonth turns the requested year/month into the month to

--- a/backend/services/active/staff_time_export.go
+++ b/backend/services/active/staff_time_export.go
@@ -56,7 +56,7 @@ type TimeExportRequest struct {
 // MonthExportRow is one staff member's month as the payroll file shows it.
 // Every minute value is copied from the MonthSummary of the very same code
 // path the Monatskarte uses — no arithmetic happens on the way here except
-// splitting the adjustment sum by type (payout / comp_time / reset are the
+// splitting the adjustment sum by type (payout / comp_time / reset / opening are the
 // categories that later become Lohnarten).
 type MonthExportRow struct {
 	StaffID        int64
@@ -83,6 +83,7 @@ type MonthExportRow struct {
 	PayoutMinutes   int
 	CompTimeMinutes int
 	ResetMinutes    int
+	OpeningMinutes  int
 
 	BalanceMinutes int
 	// ClosingBalanceMinutes is the AUTHORITATIVE month-end carry: the frozen

--- a/backend/services/active/staff_time_export.go
+++ b/backend/services/active/staff_time_export.go
@@ -80,11 +80,10 @@ type MonthExportRow struct {
 	VacationDays            float64
 	TrainingDays            float64
 
-	PayoutMinutes       int
-	CompTimeMinutes     int
-	ResetMinutes        int
-	OpeningMinutes      int
-	OpeningCarryMinutes int
+	PayoutMinutes   int
+	CompTimeMinutes int
+	ResetMinutes    int
+	OpeningMinutes  int
 
 	BalanceMinutes int
 	// ClosingBalanceMinutes is the AUTHORITATIVE month-end carry: the frozen

--- a/backend/services/active/staff_time_export.go
+++ b/backend/services/active/staff_time_export.go
@@ -80,10 +80,11 @@ type MonthExportRow struct {
 	VacationDays            float64
 	TrainingDays            float64
 
-	PayoutMinutes   int
-	CompTimeMinutes int
-	ResetMinutes    int
-	OpeningMinutes  int
+	PayoutMinutes       int
+	CompTimeMinutes     int
+	ResetMinutes        int
+	OpeningMinutes      int
+	OpeningCarryMinutes int
 
 	BalanceMinutes int
 	// ClosingBalanceMinutes is the AUTHORITATIVE month-end carry: the frozen

--- a/backend/services/active/staff_time_export_datev.go
+++ b/backend/services/active/staff_time_export_datev.go
@@ -81,10 +81,11 @@ func datevCategoryValue(category configSvc.PayrollCategoryStatus, row MonthExpor
 	case "regelarbeit":
 		minutes = row.ActualMinutes
 	case "plus_stunden":
-		// Only a positive month balance is a Plus-Stunden booking; a negative
-		// month is an account matter, not a payroll line.
-		if row.BalanceMinutes > 0 {
-			minutes = row.BalanceMinutes
+		// An opening is a non-payroll go-live rebaseline. Exclude its delta
+		// from the generic Plus-Stunden line; CSV/XLSX expose it explicitly.
+		payrollBalance := row.BalanceMinutes - row.OpeningMinutes
+		if payrollBalance > 0 {
+			minutes = payrollBalance
 		}
 	case "auszahlung":
 		minutes = -row.PayoutMinutes

--- a/backend/services/active/staff_time_export_datev.go
+++ b/backend/services/active/staff_time_export_datev.go
@@ -83,7 +83,7 @@ func datevCategoryValue(category configSvc.PayrollCategoryStatus, row MonthExpor
 	case "plus_stunden":
 		// An opening is a non-payroll go-live rebaseline. Exclude its delta
 		// from the generic Plus-Stunden line; CSV/XLSX expose it explicitly.
-		payrollBalance := row.BalanceMinutes - row.OpeningCarryMinutes
+		payrollBalance := row.BalanceMinutes - row.OpeningMinutes
 		if payrollBalance > 0 {
 			minutes = payrollBalance
 		}

--- a/backend/services/active/staff_time_export_datev.go
+++ b/backend/services/active/staff_time_export_datev.go
@@ -83,7 +83,7 @@ func datevCategoryValue(category configSvc.PayrollCategoryStatus, row MonthExpor
 	case "plus_stunden":
 		// An opening is a non-payroll go-live rebaseline. Exclude its delta
 		// from the generic Plus-Stunden line; CSV/XLSX expose it explicitly.
-		payrollBalance := row.BalanceMinutes - row.OpeningMinutes
+		payrollBalance := row.BalanceMinutes - row.OpeningCarryMinutes
 		if payrollBalance > 0 {
 			minutes = payrollBalance
 		}

--- a/backend/services/active/staff_time_export_datev.go
+++ b/backend/services/active/staff_time_export_datev.go
@@ -81,9 +81,10 @@ func datevCategoryValue(category configSvc.PayrollCategoryStatus, row MonthExpor
 	case "regelarbeit":
 		minutes = row.ActualMinutes
 	case "plus_stunden":
-		// An opening is a non-payroll go-live rebaseline. Exclude its delta
-		// from the generic Plus-Stunden line; CSV/XLSX expose it explicitly.
-		payrollBalance := row.BalanceMinutes - row.OpeningCarryMinutes
+		// An opening is a non-payroll go-live rebaseline. BalanceMinutes is
+		// the current month's delta, so only exclude an opening booked in this
+		// export month; CSV/XLSX expose it explicitly.
+		payrollBalance := row.BalanceMinutes - row.OpeningMinutes
 		if payrollBalance > 0 {
 			minutes = payrollBalance
 		}

--- a/backend/services/active/staff_time_export_datev_internal_test.go
+++ b/backend/services/active/staff_time_export_datev_internal_test.go
@@ -3,8 +3,20 @@ package active
 import (
 	"testing"
 
+	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDatevCategoryValue_ExcludesCarriedOpeningFromPlusHours(t *testing.T) {
+	minutes, _, _, ok := datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
+		BalanceMinutes:      180,
+		OpeningMinutes:      0,
+		OpeningCarryMinutes: 120,
+	})
+
+	assert.True(t, ok)
+	assert.Equal(t, 60, minutes)
+}
 
 // The DATEV files carry no free text today (personnel numbers, Lohnarten,
 // dates), but the encoder must still be ANSI-correct the day a text field is

--- a/backend/services/active/staff_time_export_datev_internal_test.go
+++ b/backend/services/active/staff_time_export_datev_internal_test.go
@@ -7,15 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDatevCategoryValue_ExcludesCarriedOpeningFromPlusHours(t *testing.T) {
+func TestDatevCategoryValue_ExcludesCurrentMonthOpeningFromPlusHours(t *testing.T) {
 	minutes, _, _, ok := datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
 		BalanceMinutes:      180,
-		OpeningMinutes:      0,
+		OpeningMinutes:      120,
 		OpeningCarryMinutes: 120,
 	})
 
 	assert.True(t, ok)
 	assert.Equal(t, 60, minutes)
+
+	minutes, _, _, ok = datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
+		BalanceMinutes:      60,
+		OpeningCarryMinutes: 120,
+	})
+	assert.True(t, ok)
+	assert.Equal(t, 60, minutes, "a later month's saldo must not be reduced by an old opening")
 }
 
 // The DATEV files carry no free text today (personnel numbers, Lohnarten,

--- a/backend/services/active/staff_time_export_datev_internal_test.go
+++ b/backend/services/active/staff_time_export_datev_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDatevCategoryValue_ExcludesOpeningCarryFromPlusHours(t *testing.T) {
+func TestDatevCategoryValue_ExcludesCurrentMonthOpeningFromPlusHours(t *testing.T) {
 	minutes, _, _, ok := datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
 		BalanceMinutes:      180,
 		OpeningMinutes:      120,
@@ -22,14 +22,14 @@ func TestDatevCategoryValue_ExcludesOpeningCarryFromPlusHours(t *testing.T) {
 		OpeningCarryMinutes: 120,
 	})
 	assert.True(t, ok)
-	assert.Equal(t, 60, minutes, "a later month's saldo must exclude the carried opening")
+	assert.Equal(t, 180, minutes, "a later month's delta must not subtract the carried opening")
 
 	minutes, _, _, ok = datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
 		BalanceMinutes:      60,
 		OpeningCarryMinutes: 120,
 	})
-	assert.False(t, ok, "a carried opening alone must not be exported as payable work")
-	assert.Zero(t, minutes)
+	assert.True(t, ok)
+	assert.Equal(t, 60, minutes)
 }
 
 // The DATEV files carry no free text today (personnel numbers, Lohnarten,

--- a/backend/services/active/staff_time_export_datev_internal_test.go
+++ b/backend/services/active/staff_time_export_datev_internal_test.go
@@ -9,24 +9,21 @@ import (
 
 func TestDatevCategoryValue_ExcludesCurrentMonthOpeningFromPlusHours(t *testing.T) {
 	minutes, _, _, ok := datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
-		BalanceMinutes:      180,
-		OpeningMinutes:      120,
-		OpeningCarryMinutes: 120,
+		BalanceMinutes: 180,
+		OpeningMinutes: 120,
 	})
 
 	assert.True(t, ok)
 	assert.Equal(t, 60, minutes)
 
 	minutes, _, _, ok = datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
-		BalanceMinutes:      180,
-		OpeningCarryMinutes: 120,
+		BalanceMinutes: 180,
 	})
 	assert.True(t, ok)
 	assert.Equal(t, 180, minutes, "a later month's delta must not subtract the carried opening")
 
 	minutes, _, _, ok = datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
-		BalanceMinutes:      60,
-		OpeningCarryMinutes: 120,
+		BalanceMinutes: 60,
 	})
 	assert.True(t, ok)
 	assert.Equal(t, 60, minutes)

--- a/backend/services/active/staff_time_export_datev_internal_test.go
+++ b/backend/services/active/staff_time_export_datev_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDatevCategoryValue_ExcludesCurrentMonthOpeningFromPlusHours(t *testing.T) {
+func TestDatevCategoryValue_ExcludesOpeningCarryFromPlusHours(t *testing.T) {
 	minutes, _, _, ok := datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
 		BalanceMinutes:      180,
 		OpeningMinutes:      120,
@@ -18,11 +18,18 @@ func TestDatevCategoryValue_ExcludesCurrentMonthOpeningFromPlusHours(t *testing.
 	assert.Equal(t, 60, minutes)
 
 	minutes, _, _, ok = datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
-		BalanceMinutes:      60,
+		BalanceMinutes:      180,
 		OpeningCarryMinutes: 120,
 	})
 	assert.True(t, ok)
-	assert.Equal(t, 60, minutes, "a later month's saldo must not be reduced by an old opening")
+	assert.Equal(t, 60, minutes, "a later month's saldo must exclude the carried opening")
+
+	minutes, _, _, ok = datevCategoryValue(configSvc.PayrollCategoryStatus{ID: "plus_stunden"}, MonthExportRow{
+		BalanceMinutes:      60,
+		OpeningCarryMinutes: 120,
+	})
+	assert.False(t, ok, "a carried opening alone must not be exported as payable work")
+	assert.Zero(t, minutes)
 }
 
 // The DATEV files carry no free text today (personnel numbers, Lohnarten,

--- a/backend/services/active/staff_time_export_rows.go
+++ b/backend/services/active/staff_time_export_rows.go
@@ -113,6 +113,8 @@ func buildMonthExportRow(staff *userModels.Staff, summary *MonthSummary) MonthEx
 			row.CompTimeMinutes += adjustment.MinutesDelta
 		case activeModels.BalanceAdjustmentTypeReset:
 			row.ResetMinutes += adjustment.MinutesDelta
+		case activeModels.BalanceAdjustmentTypeOpening:
+			row.OpeningMinutes += adjustment.MinutesDelta
 		}
 	}
 	if staff.EmploymentType != nil {

--- a/backend/services/active/staff_time_export_rows.go
+++ b/backend/services/active/staff_time_export_rows.go
@@ -49,6 +49,25 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 	if len(staffMembers) == 0 {
 		return []MonthExportRow{}, nil
 	}
+	staffIDs := make([]interface{}, 0, len(staffMembers))
+	for _, staff := range staffMembers {
+		staffIDs = append(staffIDs, staff.ID)
+	}
+	options := modelBase.NewQueryOptions()
+	options.Filter.In("staff_id", staffIDs...).In("type", activeModels.BalanceAdjustmentTypeOpening, activeModels.BalanceAdjustmentTypeReset).LessThanOrEqual("effective_date", lastKey.lastDay())
+	sorting := &modelBase.Sorting{}
+	sorting.AddField("staff_id", modelBase.SortAsc)
+	sorting.AddField("effective_date", modelBase.SortAsc)
+	sorting.AddField("id", modelBase.SortAsc)
+	options.Sorting = sorting
+	rebaselines, err := s.adjustmentRepo.List(ctx, options)
+	if err != nil {
+		return nil, fmt.Errorf("load opening balance components: %w", err)
+	}
+	byStaff := make(map[int64][]*activeModels.StaffBalanceAdjustment)
+	for _, adjustment := range rebaselines {
+		byStaff[adjustment.StaffID] = append(byStaff[adjustment.StaffID], adjustment)
+	}
 	// One prefetch for the whole request. `lower` widens the window to the
 	// first requested month: for a year export the early months may lie before
 	// the account anchor and are then computed as standalone months — exactly
@@ -62,12 +81,23 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 
 	rows := make([]MonthExportRow, 0, len(staffMembers))
 	for _, staff := range staffMembers {
+		carry, index := 0, 0
+		events := byStaff[staff.ID]
 		for key := firstKey; !lastKey.before(key); key = key.next() {
 			summary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staff.ID, err)
 			}
+			for index < len(events) && !key.lastDay().Before(events[index].EffectiveDate) {
+				if events[index].Type == activeModels.BalanceAdjustmentTypeOpening {
+					carry += events[index].MinutesDelta
+				} else {
+					carry = 0
+				}
+				index++
+			}
 			row := buildMonthExportRow(staff, summary)
+			row.OpeningCarryMinutes = carry
 			rows = append(rows, row)
 		}
 	}

--- a/backend/services/active/staff_time_export_rows.go
+++ b/backend/services/active/staff_time_export_rows.go
@@ -49,25 +49,6 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 	if len(staffMembers) == 0 {
 		return []MonthExportRow{}, nil
 	}
-	staffIDs := make([]interface{}, 0, len(staffMembers))
-	for _, staff := range staffMembers {
-		staffIDs = append(staffIDs, staff.ID)
-	}
-	options := modelBase.NewQueryOptions()
-	options.Filter.In("staff_id", staffIDs...).In("type", activeModels.BalanceAdjustmentTypeOpening, activeModels.BalanceAdjustmentTypeReset).LessThanOrEqual("effective_date", lastKey.lastDay())
-	sorting := &modelBase.Sorting{}
-	sorting.AddField("staff_id", modelBase.SortAsc)
-	sorting.AddField("effective_date", modelBase.SortAsc)
-	sorting.AddField("id", modelBase.SortAsc)
-	options.Sorting = sorting
-	rebaselines, err := s.adjustmentRepo.List(ctx, options)
-	if err != nil {
-		return nil, fmt.Errorf("load opening balance components: %w", err)
-	}
-	byStaff := make(map[int64][]*activeModels.StaffBalanceAdjustment)
-	for _, adjustment := range rebaselines {
-		byStaff[adjustment.StaffID] = append(byStaff[adjustment.StaffID], adjustment)
-	}
 	// One prefetch for the whole request. `lower` widens the window to the
 	// first requested month: for a year export the early months may lie before
 	// the account anchor and are then computed as standalone months — exactly
@@ -81,23 +62,12 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 
 	rows := make([]MonthExportRow, 0, len(staffMembers))
 	for _, staff := range staffMembers {
-		carry, index := 0, 0
-		events := byStaff[staff.ID]
 		for key := firstKey; !lastKey.before(key); key = key.next() {
 			summary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staff.ID, err)
 			}
-			for index < len(events) && !key.lastDay().Before(events[index].EffectiveDate) {
-				if events[index].Type == activeModels.BalanceAdjustmentTypeOpening {
-					carry += events[index].MinutesDelta
-				} else {
-					carry = 0
-				}
-				index++
-			}
 			row := buildMonthExportRow(staff, summary)
-			row.OpeningCarryMinutes = carry
 			rows = append(rows, row)
 		}
 	}

--- a/backend/services/active/staff_time_export_rows.go
+++ b/backend/services/active/staff_time_export_rows.go
@@ -49,21 +49,6 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 	if len(staffMembers) == 0 {
 		return []MonthExportRow{}, nil
 	}
-	staffIDs := make([]interface{}, 0, len(staffMembers))
-	for _, staff := range staffMembers {
-		staffIDs = append(staffIDs, staff.ID)
-	}
-	adjustmentOptions := modelBase.NewQueryOptions()
-	adjustmentOptions.Filter.In("staff_id", staffIDs...).In("type", activeModels.BalanceAdjustmentTypeOpening, activeModels.BalanceAdjustmentTypeReset).LessThanOrEqual("effective_date", lastKey.lastDay())
-	rebaselines, err := s.adjustmentRepo.List(ctx, adjustmentOptions)
-	if err != nil {
-		return nil, fmt.Errorf("load opening balance components: %w", err)
-	}
-	rebaselinesByStaff := make(map[int64][]*activeModels.StaffBalanceAdjustment)
-	for _, adjustment := range rebaselines {
-		rebaselinesByStaff[adjustment.StaffID] = append(rebaselinesByStaff[adjustment.StaffID], adjustment)
-	}
-
 	// One prefetch for the whole request. `lower` widens the window to the
 	// first requested month: for a year export the early months may lie before
 	// the account anchor and are then computed as standalone months — exactly
@@ -77,24 +62,12 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 
 	rows := make([]MonthExportRow, 0, len(staffMembers))
 	for _, staff := range staffMembers {
-		openingCarry, rebaselineIndex := 0, 0
-		staffRebaselines := rebaselinesByStaff[staff.ID]
 		for key := firstKey; !lastKey.before(key); key = key.next() {
 			summary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staff.ID, err)
 			}
-			for rebaselineIndex < len(staffRebaselines) && !key.lastDay().Before(staffRebaselines[rebaselineIndex].EffectiveDate) {
-				adjustment := staffRebaselines[rebaselineIndex]
-				if adjustment.Type == activeModels.BalanceAdjustmentTypeOpening {
-					openingCarry += adjustment.MinutesDelta
-				} else {
-					openingCarry = 0
-				}
-				rebaselineIndex++
-			}
 			row := buildMonthExportRow(staff, summary)
-			row.OpeningCarryMinutes = openingCarry
 			rows = append(rows, row)
 		}
 	}

--- a/backend/services/active/staff_time_export_rows.go
+++ b/backend/services/active/staff_time_export_rows.go
@@ -49,6 +49,20 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 	if len(staffMembers) == 0 {
 		return []MonthExportRow{}, nil
 	}
+	staffIDs := make([]interface{}, 0, len(staffMembers))
+	for _, staff := range staffMembers {
+		staffIDs = append(staffIDs, staff.ID)
+	}
+	adjustmentOptions := modelBase.NewQueryOptions()
+	adjustmentOptions.Filter.In("staff_id", staffIDs...).In("type", activeModels.BalanceAdjustmentTypeOpening, activeModels.BalanceAdjustmentTypeReset).LessThanOrEqual("effective_date", lastKey.lastDay())
+	rebaselines, err := s.adjustmentRepo.List(ctx, adjustmentOptions)
+	if err != nil {
+		return nil, fmt.Errorf("load opening balance components: %w", err)
+	}
+	rebaselinesByStaff := make(map[int64][]*activeModels.StaffBalanceAdjustment)
+	for _, adjustment := range rebaselines {
+		rebaselinesByStaff[adjustment.StaffID] = append(rebaselinesByStaff[adjustment.StaffID], adjustment)
+	}
 
 	// One prefetch for the whole request. `lower` widens the window to the
 	// first requested month: for a year export the early months may lie before
@@ -63,12 +77,25 @@ func (s *staffOverviewService) GetMonthExportRows(ctx context.Context, year, mon
 
 	rows := make([]MonthExportRow, 0, len(staffMembers))
 	for _, staff := range staffMembers {
+		openingCarry, rebaselineIndex := 0, 0
+		staffRebaselines := rebaselinesByStaff[staff.ID]
 		for key := firstKey; !lastKey.before(key); key = key.next() {
 			summary, err := monthSvc.GetMonthSummary(ctx, staff.ID, key.Year, key.Month)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compute month summary for staff %d: %w", staff.ID, err)
 			}
-			rows = append(rows, buildMonthExportRow(staff, summary))
+			for rebaselineIndex < len(staffRebaselines) && !key.lastDay().Before(staffRebaselines[rebaselineIndex].EffectiveDate) {
+				adjustment := staffRebaselines[rebaselineIndex]
+				if adjustment.Type == activeModels.BalanceAdjustmentTypeOpening {
+					openingCarry += adjustment.MinutesDelta
+				} else {
+					openingCarry = 0
+				}
+				rebaselineIndex++
+			}
+			row := buildMonthExportRow(staff, summary)
+			row.OpeningCarryMinutes = openingCarry
+			rows = append(rows, row)
 		}
 	}
 	return rows, nil

--- a/backend/services/active/staff_time_export_writers.go
+++ b/backend/services/active/staff_time_export_writers.go
@@ -35,7 +35,7 @@ var monthExportHeaders = []string{
 	"Übertrag Vormonat", "Soll", "Ist",
 	"Gutschrift Krank", "Gutschrift Urlaub", "Gutschrift Fortbildung", "Gutschrift Sonstige",
 	"Krank (Tage)", "Urlaub (Tage)", "Fortbildung (Tage)",
-	"Auszahlung", "Freizeitausgleich", "Saldo-Reset",
+	"Auszahlung", "Freizeitausgleich", "Saldo-Reset", "Eröffnungssaldo",
 	"Saldo Monat", "Übertrag Monatsende", "Abweichung seit Abschluss", "Status",
 }
 
@@ -93,6 +93,7 @@ func monthExportCells(row MonthExportRow, timeFormat string) []string {
 		formatExportMinutes(row.PayoutMinutes, timeFormat),
 		formatExportMinutes(row.CompTimeMinutes, timeFormat),
 		formatExportMinutes(row.ResetMinutes, timeFormat),
+		formatExportMinutes(row.OpeningMinutes, timeFormat),
 		formatExportMinutes(row.BalanceMinutes, timeFormat),
 		formatExportMinutes(row.ClosingBalanceMinutes, timeFormat),
 		formatExportMinutes(row.DriftMinutes, timeFormat),
@@ -128,15 +129,16 @@ func writeMonthXLSX(rows []MonthExportRow, timeFormat string) ([]byte, error) {
 			values[15] = float64(row.PayoutMinutes) / 60
 			values[16] = float64(row.CompTimeMinutes) / 60
 			values[17] = float64(row.ResetMinutes) / 60
-			values[18] = float64(row.BalanceMinutes) / 60
-			values[19] = float64(row.ClosingBalanceMinutes) / 60
-			values[20] = float64(row.DriftMinutes) / 60
+			values[18] = float64(row.OpeningMinutes) / 60
+			values[19] = float64(row.BalanceMinutes) / 60
+			values[20] = float64(row.ClosingBalanceMinutes) / 60
+			values[21] = float64(row.DriftMinutes) / 60
 		}
 		cells = append(cells, values)
 	}
 	var decimalColumns []int
 	if timeFormat == ExportTimeDecimal {
-		decimalColumns = []int{6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21}
+		decimalColumns = []int{6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22}
 	}
 	return writeExportXLSX("Zeiterfassung", monthExportHeaders, cells, decimalColumns)
 }

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -1,0 +1,209 @@
+package active
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// Sentinel errors for handler mapping (#2132).
+var (
+	// ErrVacationOpeningInvalid marks a caller mistake in a vacation opening
+	// request — HTTP 400.
+	ErrVacationOpeningInvalid = errors.New("invalid vacation opening")
+	// ErrVacationOpeningNotFound marks a delete for a staff/year without an
+	// opening row — HTTP 404.
+	ErrVacationOpeningNotFound = errors.New("vacation opening not found")
+	// ErrVacationOpeningExists marks a second takeover for the same staff
+	// member and year — HTTP 409. Corrections are delete + re-create so the
+	// deletion tombstone keeps the history.
+	ErrVacationOpeningExists = errors.New("vacation opening already exists for this year")
+	// ErrVacationOpeningAbsencesBeforeCutoff rejects a takeover when vacation
+	// absences already exist before the Stichtag: their days are part of the
+	// old system's Resturlaub figure AND would be subtracted again by the
+	// in-app arithmetic — a silent double count — HTTP 409.
+	ErrVacationOpeningAbsencesBeforeCutoff = errors.New("vacation absences exist before the opening date")
+)
+
+// vacationOpeningUniqueConstraintName guards one opening per staff and year
+// (migration 1.15.257).
+const vacationOpeningUniqueConstraintName = "uq_svo_staff_year"
+
+// SetVacationOpeningRequest carries the vacation takeover (#2132). The admin
+// enters the Resturlaub as of the Stichtag; the service derives the days
+// taken before the introduction from entitled + carryover − remaining, so the
+// Jahresanspruch stays authoritative and later entitlement corrections shift
+// the Resturlaub coherently.
+type SetVacationOpeningRequest struct {
+	EffectiveDate timezone.Date
+	RemainingDays float64
+	Note          string
+}
+
+// SetVacationOpeningRepository wires the vacation opening repository (#2132).
+// Setter injection like SetDeletionAudit so existing constructor call sites
+// and unit fixtures stay unchanged; nil means summaries carry no takeover and
+// the write paths fail loudly.
+func (s *staffAbsenceService) SetVacationOpeningRepository(repo activeModels.StaffVacationOpeningRepository) {
+	s.openingRepo = repo
+}
+
+// GetVacationOpening returns the takeover row for a staff/year, or nil.
+func (s *staffAbsenceService) GetVacationOpening(ctx context.Context, staffID int64, year int) (*activeModels.StaffVacationOpening, error) {
+	if staffID <= 0 {
+		return nil, fmt.Errorf("%w: staff id is required", ErrVacationOpeningInvalid)
+	}
+	if s.openingRepo == nil {
+		return nil, nil
+	}
+	return s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
+}
+
+// SetVacationOpening books the vacation takeover for the Stichtag's year.
+func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, decidedBy int64, req SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error) {
+	if s.openingRepo == nil {
+		return nil, fmt.Errorf("vacation opening repository is not configured")
+	}
+	if staffID <= 0 {
+		return nil, fmt.Errorf("%w: staff id is required", ErrVacationOpeningInvalid)
+	}
+	if decidedBy <= 0 {
+		return nil, fmt.Errorf("%w: decided_by is required", ErrVacationOpeningInvalid)
+	}
+	if req.EffectiveDate.IsZero() {
+		return nil, fmt.Errorf("%w: effective_date is required", ErrVacationOpeningInvalid)
+	}
+	if strings.TrimSpace(req.Note) == "" {
+		return nil, fmt.Errorf("%w: note is required", ErrVacationOpeningInvalid)
+	}
+	// Same reasoning as the Stundenkonto opening: the Stichtag needs a closed
+	// cutoff, and the bulk import applies ONE Stichtag to both sides.
+	if !req.EffectiveDate.Before(timezone.TodayDate()) {
+		return nil, fmt.Errorf("%w: effective_date must be before today", ErrVacationOpeningInvalid)
+	}
+
+	year := req.EffectiveDate.Year
+	existing, err := s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing vacation opening: %w", err)
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("%w: booked %s", ErrVacationOpeningExists, existing.EffectiveDate.String())
+	}
+	if err := s.rejectVacationAbsencesBefore(ctx, staffID, req.EffectiveDate); err != nil {
+		return nil, err
+	}
+
+	quota, err := s.quotaRepo.GetByStaffAndYear(ctx, staffID, year)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch quota for vacation opening: %w", err)
+	}
+	entitled, carryover := defaultEntitledDays, 0.0
+	if quota != nil {
+		entitled, carryover = quota.EntitledDays, quota.CarryoverDays
+	}
+	takenBefore := entitled + carryover - req.RemainingDays
+
+	now := time.Now()
+	opening := &activeModels.StaffVacationOpening{
+		StaffID:              staffID,
+		Year:                 year,
+		EffectiveDate:        req.EffectiveDate,
+		TakenBeforeDays:      takenBefore,
+		EnteredRemainingDays: req.RemainingDays,
+		Note:                 req.Note,
+		DecidedBy:            decidedBy,
+		DecidedAt:            now,
+	}
+	opening.CreatedAt = now
+	opening.UpdatedAt = now
+	opening.SetTenantID(tenant.FromContext(ctx))
+	if err := opening.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrVacationOpeningInvalid, err.Error())
+	}
+	if err := s.openingRepo.Create(ctx, opening); err != nil {
+		if modelBase.IsUniqueViolationOn(err, vacationOpeningUniqueConstraintName) {
+			return nil, fmt.Errorf("%w: %d", ErrVacationOpeningExists, year)
+		}
+		return nil, fmt.Errorf("failed to create vacation opening: %w", err)
+	}
+	s.broadcastTimeTrackingChanged(ctx)
+	return opening, nil
+}
+
+// DeleteVacationOpening removes a takeover row and writes an append-only
+// tombstone (audit.time_tracking_deletions) in the same tenant transaction.
+func (s *staffAbsenceService) DeleteVacationOpening(ctx context.Context, staffID, deletedBy int64, year int) error {
+	if s.openingRepo == nil {
+		return fmt.Errorf("vacation opening repository is not configured")
+	}
+	if staffID <= 0 || deletedBy <= 0 {
+		return fmt.Errorf("%w: staff id and deleting staff id are required", ErrVacationOpeningInvalid)
+	}
+	opening, err := s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
+	if err != nil {
+		return fmt.Errorf("failed to load vacation opening: %w", err)
+	}
+	if opening == nil {
+		return fmt.Errorf("%w: staff %d year %d", ErrVacationOpeningNotFound, staffID, year)
+	}
+	if s.deletionRepo == nil {
+		return fmt.Errorf("time tracking deletion audit repository is not configured")
+	}
+	payload, err := json.Marshal(opening)
+	if err != nil {
+		return fmt.Errorf("failed to snapshot vacation opening for deletion audit: %w", err)
+	}
+	if err := s.deletionRepo.Create(ctx, &auditModels.TimeTrackingDeletion{
+		StaffID:   staffID,
+		Source:    auditModels.TimeTrackingDeletionSourceVacationOpening,
+		SourceID:  opening.ID,
+		DeletedBy: deletedBy,
+		Payload:   payload,
+		Note:      opening.Note,
+	}); err != nil {
+		return fmt.Errorf("failed to write deletion audit: %w", err)
+	}
+	if err := s.openingRepo.Delete(ctx, opening.ID); err != nil {
+		return fmt.Errorf("failed to delete vacation opening: %w", err)
+	}
+	s.broadcastTimeTrackingChanged(ctx)
+	return nil
+}
+
+// rejectVacationAbsencesBefore blocks a takeover when vacation absences that
+// count against the quota already exist before the Stichtag in its year.
+func (s *staffAbsenceService) rejectVacationAbsencesBefore(ctx context.Context, staffID int64, effectiveDate timezone.Date) error {
+	yearStart := timezone.NewDate(effectiveDate.Year, time.January, 1)
+	yearEnd := timezone.NewDate(effectiveDate.Year, time.December, 31)
+	absences, err := s.absenceRepo.GetByStaffAndDateRange(ctx, staffID, yearStart, yearEnd)
+	if err != nil {
+		return fmt.Errorf("failed to check absences for vacation opening: %w", err)
+	}
+	for _, a := range absences {
+		if a.AbsenceType != activeModels.AbsenceTypeVacation {
+			continue
+		}
+		switch a.Status {
+		case activeModels.AbsenceStatusDeclined, activeModels.AbsenceStatusCanceled:
+			continue
+		}
+		if a.DateStart.Before(effectiveDate) {
+			return fmt.Errorf(
+				"%w: absence %s-%s starts before %s",
+				ErrVacationOpeningAbsencesBeforeCutoff,
+				a.DateStart.String(), a.DateEnd.String(), effectiveDate.String(),
+			)
+		}
+	}
+	return nil
+}

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -35,7 +35,7 @@ var (
 )
 
 // vacationOpeningUniqueConstraintName guards one opening per staff and year
-// (migration 1.15.257).
+// (migration 1.15.261).
 const vacationOpeningUniqueConstraintName = "uq_svo_staff_year"
 
 // SetVacationOpeningRequest carries the vacation takeover (#2132). The admin
@@ -89,6 +89,14 @@ func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, d
 	// cutoff, and the bulk import applies ONE Stichtag to both sides.
 	if !req.EffectiveDate.Before(timezone.TodayDate()) {
 		return nil, fmt.Errorf("%w: effective_date must be before today", ErrVacationOpeningInvalid)
+	}
+	// The takeover rebaselines the vacation account of the Stichtag's year, and
+	// only the running year still has a live account to rebaseline. A Stichtag
+	// in a closed year would silently rewrite a historical account whose days
+	// are already spent. The import handler bounds its Stichtag the same way;
+	// the check belongs here too so the per-staff route cannot bypass it.
+	if req.EffectiveDate.Year != timezone.TodayDate().Year {
+		return nil, fmt.Errorf("%w: effective_date must be in the current vacation year", ErrVacationOpeningInvalid)
 	}
 	// Vacation absences use the same per-staff advisory lock. Holding it from
 	// the pre-cutoff check through the insert makes the double-count guard

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -170,12 +170,9 @@ func (s *staffAbsenceService) rejectVacationBeforeOpening(ctx context.Context, a
 		if opening == nil {
 			continue
 		}
-		firstDayInYear := absence.DateStart
-		if year != absence.DateStart.Year {
-			firstDayInYear = timezone.NewDate(year, time.January, 1)
-		}
-		if firstDayInYear.Before(opening.EffectiveDate) {
-			return fmt.Errorf("%w: vacation absence begins before opening date %s", ErrVacationOpeningAbsencesBeforeCutoff, opening.EffectiveDate.String())
+		yearStart := timezone.NewDate(year, time.January, 1)
+		if vacationAbsenceHasWorkingDayBefore(absence, yearStart, opening.EffectiveDate) {
+			return fmt.Errorf("%w: vacation absence contains a working day before opening date %s", ErrVacationOpeningAbsencesBeforeCutoff, opening.EffectiveDate.String())
 		}
 	}
 	return nil
@@ -238,13 +235,40 @@ func (s *staffAbsenceService) rejectVacationAbsencesBefore(ctx context.Context, 
 		case activeModels.AbsenceStatusDeclined, activeModels.AbsenceStatusCanceled:
 			continue
 		}
-		if a.DateStart.Before(effectiveDate) {
+		if vacationAbsenceHasWorkingDayBefore(a, yearStart, effectiveDate) {
 			return fmt.Errorf(
-				"%w: absence %s-%s starts before %s",
+				"%w: absence %s-%s contains a working day before %s",
 				ErrVacationOpeningAbsencesBeforeCutoff,
 				a.DateStart.String(), a.DateEnd.String(), effectiveDate.String(),
 			)
 		}
 	}
 	return nil
+}
+
+// vacationAbsenceHasWorkingDayBefore reports whether the absence spends any
+// vacation quota before cutoff within the requested calendar year. Vacation
+// quota currently counts Monday through Friday only; holidays are deliberately
+// not excluded by countWorkingDays yet.
+func vacationAbsenceHasWorkingDayBefore(absence *activeModels.StaffAbsence, yearStart, cutoff timezone.Date) bool {
+	from := absence.DateStart
+	if from.Before(yearStart) {
+		from = yearStart
+	}
+	to := absence.DateEnd
+	cutoffPreviousDay := cutoff.AddDays(-1)
+	if cutoffPreviousDay.Before(to) {
+		to = cutoffPreviousDay
+	}
+	if to.Before(from) {
+		return false
+	}
+	startHalf, endHalf := effectiveBoundaryHalfDays(absence)
+	if from != absence.DateStart {
+		startHalf = false
+	}
+	if to != absence.DateEnd {
+		endHalf = false
+	}
+	return countWorkingDays(from, to, startHalf, endHalf) > 0
 }

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -68,35 +68,42 @@ func (s *staffAbsenceService) GetVacationOpening(ctx context.Context, staffID in
 	return s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
 }
 
-// SetVacationOpening books the vacation takeover for the Stichtag's year.
-func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, decidedBy int64, req SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error) {
-	if s.openingRepo == nil {
-		return nil, fmt.Errorf("vacation opening repository is not configured")
-	}
-	if staffID <= 0 {
-		return nil, fmt.Errorf("%w: staff id is required", ErrVacationOpeningInvalid)
-	}
-	if decidedBy <= 0 {
-		return nil, fmt.Errorf("%w: decided_by is required", ErrVacationOpeningInvalid)
-	}
-	if req.EffectiveDate.IsZero() {
-		return nil, fmt.Errorf("%w: effective_date is required", ErrVacationOpeningInvalid)
-	}
-	if strings.TrimSpace(req.Note) == "" {
-		return nil, fmt.Errorf("%w: note is required", ErrVacationOpeningInvalid)
-	}
+// validateSetVacationOpening runs the pure request guards. Split out so the
+// booking path itself stays readable — the checks are a flat list with no
+// interaction between them.
+func validateSetVacationOpening(staffID, decidedBy int64, req SetVacationOpeningRequest) error {
+	switch {
+	case staffID <= 0:
+		return fmt.Errorf("%w: staff id is required", ErrVacationOpeningInvalid)
+	case decidedBy <= 0:
+		return fmt.Errorf("%w: decided_by is required", ErrVacationOpeningInvalid)
+	case req.EffectiveDate.IsZero():
+		return fmt.Errorf("%w: effective_date is required", ErrVacationOpeningInvalid)
+	case strings.TrimSpace(req.Note) == "":
+		return fmt.Errorf("%w: note is required", ErrVacationOpeningInvalid)
 	// Same reasoning as the Stundenkonto opening: the Stichtag needs a closed
 	// cutoff, and the bulk import applies ONE Stichtag to both sides.
-	if !req.EffectiveDate.Before(timezone.TodayDate()) {
-		return nil, fmt.Errorf("%w: effective_date must be before today", ErrVacationOpeningInvalid)
-	}
+	case !req.EffectiveDate.Before(timezone.TodayDate()):
+		return fmt.Errorf("%w: effective_date must be before today", ErrVacationOpeningInvalid)
 	// The takeover rebaselines the vacation account of the Stichtag's year, and
 	// only the running year still has a live account to rebaseline. A Stichtag
 	// in a closed year would silently rewrite a historical account whose days
 	// are already spent. The import handler bounds its Stichtag the same way;
 	// the check belongs here too so the per-staff route cannot bypass it.
-	if req.EffectiveDate.Year != timezone.TodayDate().Year {
-		return nil, fmt.Errorf("%w: effective_date must be in the current vacation year", ErrVacationOpeningInvalid)
+	case req.EffectiveDate.Year != timezone.TodayDate().Year:
+		return fmt.Errorf("%w: effective_date must be in the current vacation year", ErrVacationOpeningInvalid)
+	default:
+		return nil
+	}
+}
+
+// SetVacationOpening books the vacation takeover for the Stichtag's year.
+func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, decidedBy int64, req SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error) {
+	if s.openingRepo == nil {
+		return nil, fmt.Errorf("vacation opening repository is not configured")
+	}
+	if err := validateSetVacationOpening(staffID, decidedBy, req); err != nil {
+		return nil, err
 	}
 	// Vacation absences use the same per-staff advisory lock. Holding it from
 	// the pre-cutoff check through the insert makes the double-count guard

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -155,6 +155,23 @@ func (s *staffAbsenceService) ValidateVacationOpeningAbsencesBefore(ctx context.
 	return s.rejectVacationAbsencesBefore(ctx, staffID, effectiveDate)
 }
 
+// rejectVacationBeforeOpening keeps later vacation mutations from invalidating
+// an already-booked takeover. Callers hold LockStaffAbsenceWrites, the same
+// lock SetVacationOpening holds while checking and inserting its row.
+func (s *staffAbsenceService) rejectVacationBeforeOpening(ctx context.Context, absence *activeModels.StaffAbsence) error {
+	if absence.AbsenceType != activeModels.AbsenceTypeVacation || s.openingRepo == nil {
+		return nil
+	}
+	opening, err := s.openingRepo.GetByStaffAndYear(ctx, absence.StaffID, absence.DateStart.Year)
+	if err != nil {
+		return fmt.Errorf("failed to check vacation opening: %w", err)
+	}
+	if opening != nil && absence.DateStart.Before(opening.EffectiveDate) {
+		return fmt.Errorf("%w: vacation absence begins before opening date %s", ErrVacationOpeningAbsencesBeforeCutoff, opening.EffectiveDate.String())
+	}
+	return nil
+}
+
 // DeleteVacationOpening removes a takeover row and writes an append-only
 // tombstone (audit.time_tracking_deletions) in the same tenant transaction.
 func (s *staffAbsenceService) DeleteVacationOpening(ctx context.Context, staffID, deletedBy int64, year int) error {

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -162,12 +162,21 @@ func (s *staffAbsenceService) rejectVacationBeforeOpening(ctx context.Context, a
 	if absence.AbsenceType != activeModels.AbsenceTypeVacation || s.openingRepo == nil {
 		return nil
 	}
-	opening, err := s.openingRepo.GetByStaffAndYear(ctx, absence.StaffID, absence.DateStart.Year)
-	if err != nil {
-		return fmt.Errorf("failed to check vacation opening: %w", err)
-	}
-	if opening != nil && absence.DateStart.Before(opening.EffectiveDate) {
-		return fmt.Errorf("%w: vacation absence begins before opening date %s", ErrVacationOpeningAbsencesBeforeCutoff, opening.EffectiveDate.String())
+	for year := absence.DateStart.Year; year <= absence.DateEnd.Year; year++ {
+		opening, err := s.openingRepo.GetByStaffAndYear(ctx, absence.StaffID, year)
+		if err != nil {
+			return fmt.Errorf("failed to check vacation opening: %w", err)
+		}
+		if opening == nil {
+			continue
+		}
+		firstDayInYear := absence.DateStart
+		if year != absence.DateStart.Year {
+			firstDayInYear = timezone.NewDate(year, time.January, 1)
+		}
+		if firstDayInYear.Before(opening.EffectiveDate) {
+			return fmt.Errorf("%w: vacation absence begins before opening date %s", ErrVacationOpeningAbsencesBeforeCutoff, opening.EffectiveDate.String())
+		}
 	}
 	return nil
 }

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -147,11 +147,11 @@ func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, d
 }
 
 // ValidateVacationOpeningAbsencesBefore exposes the read-only half of the
-// opening guard for import previews.
+// opening guard for import previews. It deliberately takes no lock: imports
+// validate rows in file order before their sorted creation pass, and retaining
+// per-staff locks here could deadlock concurrent previews or imports. The
+// actual SetVacationOpening path still locks through insertion.
 func (s *staffAbsenceService) ValidateVacationOpeningAbsencesBefore(ctx context.Context, staffID int64, effectiveDate timezone.Date) error {
-	if err := s.absenceRepo.LockStaffAbsenceWrites(ctx, staffID); err != nil {
-		return fmt.Errorf("failed to lock staff absence writes: %w", err)
-	}
 	return s.rejectVacationAbsencesBefore(ctx, staffID, effectiveDate)
 }
 

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -90,6 +90,12 @@ func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, d
 	if !req.EffectiveDate.Before(timezone.TodayDate()) {
 		return nil, fmt.Errorf("%w: effective_date must be before today", ErrVacationOpeningInvalid)
 	}
+	// Vacation absences use the same per-staff advisory lock. Holding it from
+	// the pre-cutoff check through the insert makes the double-count guard
+	// serializable with concurrent absence writes.
+	if err := s.absenceRepo.LockStaffAbsenceWrites(ctx, staffID); err != nil {
+		return nil, fmt.Errorf("failed to lock staff absence writes: %w", err)
+	}
 
 	year := req.EffectiveDate.Year
 	existing, err := s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
@@ -138,6 +144,15 @@ func (s *staffAbsenceService) SetVacationOpening(ctx context.Context, staffID, d
 	}
 	s.broadcastTimeTrackingChanged(ctx)
 	return opening, nil
+}
+
+// ValidateVacationOpeningAbsencesBefore exposes the read-only half of the
+// opening guard for import previews.
+func (s *staffAbsenceService) ValidateVacationOpeningAbsencesBefore(ctx context.Context, staffID int64, effectiveDate timezone.Date) error {
+	if err := s.absenceRepo.LockStaffAbsenceWrites(ctx, staffID); err != nil {
+		return fmt.Errorf("failed to lock staff absence writes: %w", err)
+	}
+	return s.rejectVacationAbsencesBefore(ctx, staffID, effectiveDate)
 }
 
 // DeleteVacationOpening removes a takeover row and writes an append-only

--- a/backend/services/active/staff_vacation_opening.go
+++ b/backend/services/active/staff_vacation_opening.go
@@ -187,6 +187,12 @@ func (s *staffAbsenceService) DeleteVacationOpening(ctx context.Context, staffID
 	if staffID <= 0 || deletedBy <= 0 {
 		return fmt.Errorf("%w: staff id and deleting staff id are required", ErrVacationOpeningInvalid)
 	}
+	// Serialize the load, tombstone, and delete with SetVacationOpening and
+	// other absence writes. Without this lock, concurrent deletes can both
+	// snapshot the opening and write duplicate tombstones before one removes it.
+	if err := s.absenceRepo.LockStaffAbsenceWrites(ctx, staffID); err != nil {
+		return fmt.Errorf("failed to lock staff absence writes: %w", err)
+	}
 	opening, err := s.openingRepo.GetByStaffAndYear(ctx, staffID, year)
 	if err != nil {
 		return fmt.Errorf("failed to load vacation opening: %w", err)

--- a/backend/services/active/staff_vacation_opening_db_test.go
+++ b/backend/services/active/staff_vacation_opening_db_test.go
@@ -1,0 +1,360 @@
+package active_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	activeRepos "github.com/moto-nrw/project-phoenix/database/repositories/active"
+	auditRepos "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	active "github.com/moto-nrw/project-phoenix/services/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// Vacation takeover (#2132) against the real database: the takeover row, its
+// effect on the Resturlaub arithmetic, the guards that keep it a one-shot
+// booking, and the deletion tombstone.
+
+// vacationOpeningFixture is one tenant with a staff member whose vacation is
+// taken over and an admin who books it. No quota row is created on purpose —
+// the takeover must fall back to the registry default of 30/0.
+type vacationOpeningFixture struct {
+	tenantID int64
+	db       *bun.DB
+	repos    *repositories.Factory
+	ctx      context.Context
+	staff    *userModels.Staff
+	admin    *userModels.Staff
+	svc      active.StaffAbsenceService
+	// cutoff is the Stichtag every test books against; year is derived from
+	// it, exactly as the service does.
+	cutoff timezone.Date
+}
+
+func newVacationOpeningFixture(t *testing.T) *vacationOpeningFixture {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tenantID := testpkg.UniqueTestTenantID(t)
+	testpkg.EnsureTestTenant(t, db, tenantID)
+	staff := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Urlaub", "Uebernahme")
+	admin := testpkg.CreateTestStaffForTenant(t, db, tenantID, "Urlaub", "Leitung")
+	repos := repositories.NewFactory(db)
+	ctx := testpkg.TenantContext(tenantID)
+
+	t.Cleanup(func() {
+		for _, table := range []string{
+			"audit.time_tracking_deletions",
+			"active.staff_vacation_openings",
+			"active.staff_vacation_quotas",
+			"active.staff_absences",
+		} {
+			_, _ = db.NewDelete().ModelTableExpr(table+" AS t").Where("t.tenant_id = ?", tenantID).Exec(context.Background())
+		}
+		testpkg.CleanupStaffFixtures(t, db, staff.ID, admin.ID)
+		testpkg.CleanupTenantTestData(t, db, tenantID)
+	})
+
+	svc := active.NewStaffAbsenceService(
+		repos.StaffAbsence, repos.WorkSession, repos.StaffVacationQuota,
+		repos.StaffAbsenceAudit, wtmIntSettings{}, nil,
+	)
+	// Setter injection, wired exactly like services/factory.go does.
+	openingAware, ok := svc.(interface {
+		SetVacationOpeningRepository(activeModels.StaffVacationOpeningRepository)
+	})
+	require.True(t, ok, "staff absence service must accept the vacation opening repository")
+	openingAware.SetVacationOpeningRepository(activeRepos.NewStaffVacationOpeningRepository(db))
+
+	deletionAware, ok := svc.(interface {
+		SetDeletionAudit(auditModels.TimeTrackingDeletionRepository)
+	})
+	require.True(t, ok, "staff absence service must accept the deletion audit repository")
+	deletionAware.SetDeletionAudit(auditRepos.NewTimeTrackingDeletionRepository(db))
+
+	return &vacationOpeningFixture{
+		tenantID: tenantID,
+		db:       db,
+		repos:    repos,
+		ctx:      ctx,
+		staff:    staff,
+		admin:    admin,
+		svc:      svc,
+		cutoff:   openingCutoffDate(),
+	}
+}
+
+// openingCutoffDate returns a Stichtag in the past that still leaves room for
+// vacation absences EARLIER in the same calendar year. Yesterday satisfies
+// both for all but the first days of January; there the fixture falls back to
+// the previous year, which is equally valid — the service derives the opening
+// year from the Stichtag, not from today.
+func openingCutoffDate() timezone.Date {
+	today := timezone.TodayDate()
+	cutoff := today.AddDays(-1)
+	if cutoff.Year != today.Year || timezone.NewDate(today.Year, time.January, 1).DaysUntil(cutoff) < 5 {
+		return timezone.NewDate(today.Year-1, time.July, 1)
+	}
+	return cutoff
+}
+
+// addVacationAbsence writes an absence row directly, mirroring the overview
+// fixture — the vacation request flow is not under test here.
+func (f *vacationOpeningFixture) addVacationAbsence(t *testing.T, status string, start, end timezone.Date) {
+	t.Helper()
+	absence := &activeModels.StaffAbsence{
+		StaffID:     f.staff.ID,
+		AbsenceType: activeModels.AbsenceTypeVacation,
+		Status:      status,
+		DateStart:   start,
+		DateEnd:     end,
+		CreatedBy:   f.staff.ID,
+	}
+	absence.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.StaffAbsence.Create(f.ctx, absence))
+}
+
+func (f *vacationOpeningFixture) set(remainingDays float64) (*activeModels.StaffVacationOpening, error) {
+	return f.svc.SetVacationOpening(f.ctx, f.staff.ID, f.admin.ID, active.SetVacationOpeningRequest{
+		EffectiveDate: f.cutoff,
+		RemainingDays: remainingDays,
+		Note:          "Übernahme aus Altsystem",
+	})
+}
+
+// TestSetVacationOpening_DerivesTakenBeforeFromQuota is the core arithmetic:
+// the admin enters the Resturlaub, the service stores the days taken before
+// the introduction, and the summary reproduces the entered Resturlaub.
+func TestSetVacationOpening_DerivesTakenBeforeFromQuota(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	opening, err := f.set(12.5)
+	require.NoError(t, err)
+	require.NotNil(t, opening)
+
+	// Quota default 30/0: 30 + 0 − 12,5 already taken before the Stichtag.
+	assert.InDelta(t, 17.5, opening.TakenBeforeDays, 0.001)
+	assert.InDelta(t, 12.5, opening.EnteredRemainingDays, 0.001)
+	assert.Equal(t, f.cutoff, opening.EffectiveDate)
+	assert.Equal(t, f.cutoff.Year, opening.Year)
+	assert.Equal(t, f.admin.ID, opening.DecidedBy)
+	assert.Equal(t, f.tenantID, opening.TenantID)
+
+	summary, err := f.svc.GetVacationQuotaSummary(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	assert.InDelta(t, 17.5, summary.TakenBeforeDays, 0.001)
+	assert.InDelta(t, 12.5, summary.RemainingDays, 0.001,
+		"the entered Resturlaub must survive the round trip through the summary")
+	assert.InDelta(t, 30, summary.EntitledDays, 0.001, "the Jahresanspruch stays untouched")
+	require.NotNil(t, summary.Opening, "the summary carries the takeover row for the admin UI")
+	assert.Equal(t, opening.ID, summary.Opening.ID)
+
+	// The takeover belongs to its own year only.
+	nextYear, err := f.svc.GetVacationQuotaSummary(f.ctx, f.staff.ID, f.cutoff.Year+1)
+	require.NoError(t, err)
+	assert.Zero(t, nextYear.TakenBeforeDays)
+	assert.Nil(t, nextYear.Opening)
+
+	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, opening.ID, stored.ID)
+}
+
+// TestSetVacationOpening_NegativeRemainingAllowsOverdrawnAccount: a staff
+// member who already overdrew their vacation in the old system must be
+// representable — the takeover is signed on both ends.
+func TestSetVacationOpening_NegativeRemainingAllowsOverdrawnAccount(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	opening, err := f.set(-2)
+	require.NoError(t, err)
+	require.NotNil(t, opening)
+	assert.InDelta(t, 32, opening.TakenBeforeDays, 0.001)
+
+	summary, err := f.svc.GetVacationQuotaSummary(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	assert.InDelta(t, -2, summary.RemainingDays, 0.001,
+		"an overdrawn vacation account must stay negative instead of being clamped to zero")
+}
+
+// TestSetVacationOpening_RejectsSecondOpeningForSameYear pins the one-shot
+// rule: corrections are delete + re-create so the tombstone keeps the history.
+func TestSetVacationOpening_RejectsSecondOpeningForSameYear(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	_, err := f.set(10)
+	require.NoError(t, err)
+
+	_, err = f.set(8)
+	require.ErrorIs(t, err, active.ErrVacationOpeningExists)
+
+	// The first booking is untouched.
+	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.InDelta(t, 10, stored.EnteredRemainingDays, 0.001)
+}
+
+// TestSetVacationOpening_RejectsVacationAbsencesBeforeCutoff guards the double
+// count: days already booked in-app before the Stichtag are also part of the
+// old system's Resturlaub figure.
+func TestSetVacationOpening_RejectsVacationAbsencesBeforeCutoff(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	before := f.cutoff.AddDays(-1)
+	f.addVacationAbsence(t, activeModels.AbsenceStatusApproved, before, before)
+
+	_, err := f.set(12)
+	require.ErrorIs(t, err, active.ErrVacationOpeningAbsencesBeforeCutoff)
+
+	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	assert.Nil(t, stored, "nothing may be booked when the guard trips")
+}
+
+// TestSetVacationOpening_IgnoresDeclinedAndLaterAbsences: only absences that
+// actually spend quota before the Stichtag block the takeover.
+func TestSetVacationOpening_IgnoresDeclinedAndLaterAbsences(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	before := f.cutoff.AddDays(-1)
+	f.addVacationAbsence(t, activeModels.AbsenceStatusDeclined, before, before)
+	f.addVacationAbsence(t, activeModels.AbsenceStatusCanceled, before, before)
+	// Starting ON the Stichtag is already inside the moto era.
+	f.addVacationAbsence(t, activeModels.AbsenceStatusApproved, f.cutoff, f.cutoff)
+	// A sick day before the Stichtag never touches the vacation quota.
+	sick := &activeModels.StaffAbsence{
+		StaffID:     f.staff.ID,
+		AbsenceType: activeModels.AbsenceTypeSick,
+		Status:      activeModels.AbsenceStatusApproved,
+		DateStart:   before,
+		DateEnd:     before,
+		CreatedBy:   f.staff.ID,
+	}
+	sick.SetTenantID(f.tenantID)
+	require.NoError(t, f.repos.StaffAbsence.Create(f.ctx, sick))
+
+	opening, err := f.set(12)
+	require.NoError(t, err)
+	require.NotNil(t, opening)
+	assert.InDelta(t, 18, opening.TakenBeforeDays, 0.001)
+}
+
+// TestSetVacationOpening_RejectsOpenCutoff: the Stichtag needs a closed day,
+// otherwise today's bookings would be counted on both sides.
+func TestSetVacationOpening_RejectsOpenCutoff(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	for _, effectiveDate := range []timezone.Date{
+		timezone.TodayDate(),
+		timezone.TodayDate().AddDays(1),
+	} {
+		_, err := f.svc.SetVacationOpening(f.ctx, f.staff.ID, f.admin.ID, active.SetVacationOpeningRequest{
+			EffectiveDate: effectiveDate,
+			RemainingDays: 12,
+			Note:          "Übernahme aus Altsystem",
+		})
+		require.ErrorIs(t, err, active.ErrVacationOpeningInvalid)
+		assert.Contains(t, err.Error(), "effective_date must be before today")
+	}
+
+	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, timezone.TodayDate().Year)
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+// TestSetVacationOpening_RequiresNote: the takeover row IS the audit record,
+// so it may not be booked anonymously.
+func TestSetVacationOpening_RequiresNote(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	_, err := f.svc.SetVacationOpening(f.ctx, f.staff.ID, f.admin.ID, active.SetVacationOpeningRequest{
+		EffectiveDate: f.cutoff,
+		RemainingDays: 12,
+		Note:          "   ",
+	})
+	require.ErrorIs(t, err, active.ErrVacationOpeningInvalid)
+}
+
+// TestDeleteVacationOpening_WritesTombstoneAndRestoresSummary: the delete
+// removes the arithmetic but not the history.
+func TestDeleteVacationOpening_WritesTombstoneAndRestoresSummary(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	opening, err := f.set(12.5)
+	require.NoError(t, err)
+
+	require.NoError(t, f.svc.DeleteVacationOpening(f.ctx, f.staff.ID, f.admin.ID, f.cutoff.Year))
+
+	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+
+	summary, err := f.svc.GetVacationQuotaSummary(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	assert.Zero(t, summary.TakenBeforeDays)
+	assert.Nil(t, summary.Opening)
+	assert.InDelta(t, 30, summary.RemainingDays, 0.001,
+		"without a takeover the Resturlaub is the plain Jahresanspruch again")
+
+	var tombstones []auditModels.TimeTrackingDeletion
+	require.NoError(t, f.db.NewSelect().
+		Model(&tombstones).
+		ModelTableExpr(`audit.time_tracking_deletions AS "time_tracking_deletion"`).
+		Where(`"time_tracking_deletion".staff_id = ?`, f.staff.ID).
+		Where(`"time_tracking_deletion".source = ?`, auditModels.TimeTrackingDeletionSourceVacationOpening).
+		Scan(f.ctx))
+	require.Len(t, tombstones, 1, "the delete must leave exactly one tombstone")
+	assert.Equal(t, opening.ID, tombstones[0].SourceID)
+	assert.Equal(t, f.admin.ID, tombstones[0].DeletedBy)
+	assert.Equal(t, f.tenantID, tombstones[0].TenantID)
+
+	var payload activeModels.StaffVacationOpening
+	require.NoError(t, json.Unmarshal(tombstones[0].Payload, &payload),
+		"the tombstone payload must be the deleted row verbatim")
+	assert.InDelta(t, 17.5, payload.TakenBeforeDays, 0.001)
+	assert.InDelta(t, 12.5, payload.EnteredRemainingDays, 0.001)
+
+	// Delete + re-create is the sanctioned correction path.
+	corrected, err := f.set(9)
+	require.NoError(t, err)
+	assert.InDelta(t, 21, corrected.TakenBeforeDays, 0.001)
+}
+
+// TestDeleteVacationOpening_MissingRowIsNotFound keeps the handler's 404
+// mapping honest.
+func TestDeleteVacationOpening_MissingRowIsNotFound(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	err := f.svc.DeleteVacationOpening(f.ctx, f.staff.ID, f.admin.ID, f.cutoff.Year)
+	require.ErrorIs(t, err, active.ErrVacationOpeningNotFound)
+}
+
+// TestSetVacationOpening_RespectsCustomQuota: the takeover derives from the
+// stored Jahresanspruch, not from the 30/0 default.
+func TestSetVacationOpening_RespectsCustomQuota(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	require.NoError(t, f.svc.UpsertVacationQuota(f.ctx, f.staff.ID, f.cutoff.Year, 26, 4))
+
+	opening, err := f.set(12.5)
+	require.NoError(t, err)
+	// 26 + 4 − 12,5
+	assert.InDelta(t, 17.5, opening.TakenBeforeDays, 0.001)
+
+	summary, err := f.svc.GetVacationQuotaSummary(f.ctx, f.staff.ID, f.cutoff.Year)
+	require.NoError(t, err)
+	assert.InDelta(t, 12.5, summary.RemainingDays, 0.001)
+}

--- a/backend/services/active/staff_vacation_opening_db_test.go
+++ b/backend/services/active/staff_vacation_opening_db_test.go
@@ -224,6 +224,21 @@ func TestSetVacationOpening_RejectsVacationAbsencesBeforeCutoff(t *testing.T) {
 	assert.Nil(t, stored, "nothing may be booked when the guard trips")
 }
 
+func TestSetVacationOpening_AllowsVacationBeginningOnWeekendBeforeCutoff(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+	for f.cutoff.Weekday() != time.Monday {
+		f.cutoff = f.cutoff.AddDays(-1)
+	}
+
+	// The absence begins on Saturday but only consumes quota on the Monday
+	// Stichtag, which belongs to the moto-era calculation.
+	f.addVacationAbsence(t, activeModels.AbsenceStatusApproved, f.cutoff.AddDays(-2), f.cutoff)
+
+	opening, err := f.set(12)
+	require.NoError(t, err)
+	require.NotNil(t, opening)
+}
+
 // TestSetVacationOpening_IgnoresDeclinedAndLaterAbsences: only absences that
 // actually spend quota before the Stichtag block the takeover.
 func TestSetVacationOpening_IgnoresDeclinedAndLaterAbsences(t *testing.T) {

--- a/backend/services/active/staff_vacation_opening_db_test.go
+++ b/backend/services/active/staff_vacation_opening_db_test.go
@@ -91,22 +91,35 @@ func newVacationOpeningFixture(t *testing.T) *vacationOpeningFixture {
 		staff:    staff,
 		admin:    admin,
 		svc:      svc,
-		cutoff:   openingCutoffDate(),
+		cutoff:   openingCutoffDate(t),
 	}
 }
 
 // openingCutoffDate returns a Stichtag in the past that still leaves room for
 // vacation absences EARLIER in the same calendar year. Yesterday satisfies
-// both for all but the first days of January; there the fixture falls back to
-// the previous year, which is equally valid — the service derives the opening
-// year from the Stichtag, not from today.
-func openingCutoffDate() timezone.Date {
+// both for all but the first days of January. There is deliberately no
+// previous-year fallback: the service only books takeovers into the running
+// vacation year, so in early January no usable Stichtag exists and the fixture
+// skips instead of exercising a case the service rejects by design.
+func openingCutoffDate(t *testing.T) timezone.Date {
+	t.Helper()
 	today := timezone.TodayDate()
 	cutoff := today.AddDays(-1)
 	if cutoff.Year != today.Year || timezone.NewDate(today.Year, time.January, 1).DaysUntil(cutoff) < 5 {
-		return timezone.NewDate(today.Year-1, time.July, 1)
+		t.Skip("no closed Stichtag with room for earlier absences in the current vacation year yet")
 	}
 	return cutoff
+}
+
+// previousWorkingDay walks back to the nearest Monday-Friday day. Vacation
+// quota only counts working days, so an absence fixture that must consume
+// quota may not land on a weekend — otherwise the guard under test never
+// trips and the case passes vacuously on some weekdays.
+func previousWorkingDay(d timezone.Date) timezone.Date {
+	for d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
+		d = d.AddDays(-1)
+	}
+	return d
 }
 
 // addVacationAbsence writes an absence row directly, mirroring the overview
@@ -213,7 +226,9 @@ func TestSetVacationOpening_RejectsSecondOpeningForSameYear(t *testing.T) {
 func TestSetVacationOpening_RejectsVacationAbsencesBeforeCutoff(t *testing.T) {
 	f := newVacationOpeningFixture(t)
 
-	before := f.cutoff.AddDays(-1)
+	// Must be a working day: a Saturday absence spends no quota and the guard
+	// would not trip, letting the case pass vacuously on some weekdays.
+	before := previousWorkingDay(f.cutoff.AddDays(-1))
 	f.addVacationAbsence(t, activeModels.AbsenceStatusApproved, before, before)
 
 	_, err := f.set(12)
@@ -286,6 +301,27 @@ func TestSetVacationOpening_RejectsOpenCutoff(t *testing.T) {
 	}
 
 	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, timezone.TodayDate().Year)
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+// TestSetVacationOpening_RejectsPastVacationYear: a Stichtag in a closed year
+// would rebaseline a historical vacation account. The import handler bounds
+// this already; the service must bound it too so the per-staff route cannot
+// bypass the restriction.
+func TestSetVacationOpening_RejectsPastVacationYear(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+
+	lastYear := timezone.NewDate(timezone.TodayDate().Year-1, time.June, 10)
+	_, err := f.svc.SetVacationOpening(f.ctx, f.staff.ID, f.admin.ID, active.SetVacationOpeningRequest{
+		EffectiveDate: lastYear,
+		RemainingDays: 12,
+		Note:          "Übernahme aus Altsystem",
+	})
+	require.ErrorIs(t, err, active.ErrVacationOpeningInvalid)
+	assert.Contains(t, err.Error(), "effective_date must be in the current vacation year")
+
+	stored, err := f.svc.GetVacationOpening(f.ctx, f.staff.ID, lastYear.Year)
 	require.NoError(t, err)
 	assert.Nil(t, stored)
 }

--- a/backend/services/active/staff_vacation_opening_db_test.go
+++ b/backend/services/active/staff_vacation_opening_db_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	active "github.com/moto-nrw/project-phoenix/services/active"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -408,4 +409,56 @@ func TestSetVacationOpening_RespectsCustomQuota(t *testing.T) {
 	summary, err := f.svc.GetVacationQuotaSummary(f.ctx, f.staff.ID, f.cutoff.Year)
 	require.NoError(t, err)
 	assert.InDelta(t, 12.5, summary.RemainingDays, 0.001)
+}
+
+// TestVacationOpeningRepository_BatchAndListReads covers the repository read
+// helpers the summary/overview paths use: the batched per-staff lookup and
+// the options-based List (whose aliased table expression is load-bearing —
+// bun qualifies model columns with the singular struct alias, which the
+// plural table name does not match).
+func TestVacationOpeningRepository_BatchAndListReads(t *testing.T) {
+	f := newVacationOpeningFixture(t)
+	repo := activeRepos.NewStaffVacationOpeningRepository(f.db)
+
+	_, err := f.svc.SetVacationOpening(f.ctx, f.staff.ID, f.admin.ID, active.SetVacationOpeningRequest{
+		EffectiveDate: f.cutoff,
+		RemainingDays: 17.5,
+		Note:          "Übernahme aus Altsystem",
+	})
+	require.NoError(t, err)
+
+	t.Run("batched lookup keyed by staff", func(t *testing.T) {
+		byStaff, err := repo.GetByStaffIDsAndYear(f.ctx, []int64{f.staff.ID, f.admin.ID}, f.cutoff.Year)
+		require.NoError(t, err)
+		require.Contains(t, byStaff, f.staff.ID)
+		assert.NotContains(t, byStaff, f.admin.ID, "staff without a takeover stay absent from the map")
+		assert.InDelta(t, 17.5, byStaff[f.staff.ID].EnteredRemainingDays, 0.0001)
+	})
+
+	t.Run("empty batch short-circuits", func(t *testing.T) {
+		byStaff, err := repo.GetByStaffIDsAndYear(f.ctx, nil, f.cutoff.Year)
+		require.NoError(t, err)
+		assert.Empty(t, byStaff)
+	})
+
+	t.Run("list by year", func(t *testing.T) {
+		options := modelBase.NewQueryOptions()
+		options.Filter.Equal("year", f.cutoff.Year)
+
+		openings, err := repo.List(f.ctx, options)
+
+		require.NoError(t, err)
+		require.Len(t, openings, 1)
+		assert.Equal(t, f.staff.ID, openings[0].StaffID)
+	})
+
+	t.Run("list of another year is empty", func(t *testing.T) {
+		options := modelBase.NewQueryOptions()
+		options.Filter.Equal("year", f.cutoff.Year-1)
+
+		openings, err := repo.List(f.ctx, options)
+
+		require.NoError(t, err)
+		assert.Empty(t, openings)
+	})
 }

--- a/backend/services/active/staff_vacation_opening_internal_test.go
+++ b/backend/services/active/staff_vacation_opening_internal_test.go
@@ -1,0 +1,24 @@
+package active
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVacationAbsenceHasWorkingDayBefore(t *testing.T) {
+	cutoff := timezone.NewDate(2026, time.June, 8) // Monday
+	yearStart := timezone.NewDate(2026, time.January, 1)
+
+	assert.False(t, vacationAbsenceHasWorkingDayBefore(&activeModels.StaffAbsence{
+		DateStart: cutoff.AddDays(-2), // Saturday
+		DateEnd:   cutoff,
+	}, yearStart, cutoff))
+	assert.True(t, vacationAbsenceHasWorkingDayBefore(&activeModels.StaffAbsence{
+		DateStart: cutoff.AddDays(-3), // Friday
+		DateEnd:   cutoff,
+	}, yearStart, cutoff))
+}

--- a/backend/services/active/staff_vacation_opening_mock_test.go
+++ b/backend/services/active/staff_vacation_opening_mock_test.go
@@ -1,0 +1,622 @@
+package active
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Vacation takeover (#2132) guard branches. The happy paths run against the
+// real database in staff_vacation_opening_db_test.go; what is exercised here
+// are the rejections and the repository-failure paths, which need injected
+// errors rather than a DB.
+
+// ============================================================================
+// Mocks (prefixed vo)
+// ============================================================================
+
+type voOpeningRepoMock struct {
+	getByStaffAndYearFunc func(ctx context.Context, staffID int64, year int) (*activeModels.StaffVacationOpening, error)
+	createFunc            func(ctx context.Context, opening *activeModels.StaffVacationOpening) error
+	deleteFunc            func(ctx context.Context, id any) error
+}
+
+func (m *voOpeningRepoMock) Create(ctx context.Context, opening *activeModels.StaffVacationOpening) error {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, opening)
+	}
+	return nil
+}
+
+func (m *voOpeningRepoMock) FindByID(context.Context, any) (*activeModels.StaffVacationOpening, error) {
+	return nil, errors.New("not found")
+}
+
+func (m *voOpeningRepoMock) Update(context.Context, *activeModels.StaffVacationOpening) error {
+	return nil
+}
+
+func (m *voOpeningRepoMock) Delete(ctx context.Context, id any) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *voOpeningRepoMock) List(context.Context, *base.QueryOptions) ([]*activeModels.StaffVacationOpening, error) {
+	return nil, nil
+}
+
+func (m *voOpeningRepoMock) GetByStaffAndYear(ctx context.Context, staffID int64, year int) (*activeModels.StaffVacationOpening, error) {
+	if m.getByStaffAndYearFunc != nil {
+		return m.getByStaffAndYearFunc(ctx, staffID, year)
+	}
+	return nil, nil
+}
+
+func (m *voOpeningRepoMock) GetByStaffIDsAndYear(context.Context, []int64, int) (map[int64]*activeModels.StaffVacationOpening, error) {
+	return nil, nil
+}
+
+type voDeletionRepoMock struct {
+	createFunc func(ctx context.Context, event *auditModels.TimeTrackingDeletion) error
+	created    []*auditModels.TimeTrackingDeletion
+}
+
+func (m *voDeletionRepoMock) Create(ctx context.Context, event *auditModels.TimeTrackingDeletion) error {
+	m.created = append(m.created, event)
+	if m.createFunc != nil {
+		return m.createFunc(ctx, event)
+	}
+	return nil
+}
+
+// voService builds a bare service with the takeover repositories wired.
+func voService(openingRepo *voOpeningRepoMock) (*staffAbsenceService, *absStaffAbsenceRepoMock, *voDeletionRepoMock) {
+	absenceRepo := &absStaffAbsenceRepoMock{}
+	deletionRepo := &voDeletionRepoMock{}
+	svc := &staffAbsenceService{
+		absenceRepo:  absenceRepo,
+		quotaRepo:    &absVacationQuotaRepoMock{},
+		openingRepo:  openingRepo,
+		deletionRepo: deletionRepo,
+	}
+	return svc, absenceRepo, deletionRepo
+}
+
+func voRequest() SetVacationOpeningRequest {
+	return SetVacationOpeningRequest{
+		EffectiveDate: timezone.TodayDate().AddDays(-1),
+		RemainingDays: 17.5,
+		Note:          "Übernahme aus Altsystem",
+	}
+}
+
+// ============================================================================
+// Request validation
+// ============================================================================
+
+func TestValidateSetVacationOpening(t *testing.T) {
+	const (
+		staffID   = int64(41)
+		decidedBy = int64(42)
+	)
+
+	tests := []struct {
+		name    string
+		staffID int64
+		decided int64
+		mutate  func(*SetVacationOpeningRequest)
+		wantMsg string
+	}{
+		{name: "valid"},
+		{name: "missing staff", staffID: -1, wantMsg: "staff id is required"},
+		{name: "missing actor", decided: -1, wantMsg: "decided_by is required"},
+		{
+			name:    "missing Stichtag",
+			mutate:  func(r *SetVacationOpeningRequest) { r.EffectiveDate = timezone.Date{} },
+			wantMsg: "effective_date is required",
+		},
+		{
+			name:    "missing Begründung",
+			mutate:  func(r *SetVacationOpeningRequest) { r.Note = "   " },
+			wantMsg: "note is required",
+		},
+		{
+			name:    "Stichtag today",
+			mutate:  func(r *SetVacationOpeningRequest) { r.EffectiveDate = timezone.TodayDate() },
+			wantMsg: "must be before today",
+		},
+		{
+			name:    "Stichtag in the future",
+			mutate:  func(r *SetVacationOpeningRequest) { r.EffectiveDate = timezone.TodayDate().AddDays(1) },
+			wantMsg: "must be before today",
+		},
+		{
+			// A closed vacation year has no live account left to rebaseline —
+			// the same bound the bulk import applies (#2132 review).
+			name: "Stichtag in a closed vacation year",
+			mutate: func(r *SetVacationOpeningRequest) {
+				r.EffectiveDate = timezone.NewDate(timezone.TodayDate().Year-1, time.June, 1)
+			},
+			wantMsg: "must be in the current vacation year",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := voRequest()
+			if tc.mutate != nil {
+				tc.mutate(&req)
+			}
+			actualStaff, actualDecided := staffID, decidedBy
+			if tc.staffID < 0 {
+				actualStaff = 0
+			}
+			if tc.decided < 0 {
+				actualDecided = 0
+			}
+
+			err := validateSetVacationOpening(actualStaff, actualDecided, req)
+
+			if tc.wantMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrVacationOpeningInvalid)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+// TestSetVacationOpening_CurrentYearGuardAlsoAppliesPerStaff pins the guard on
+// the route the per-person modal uses, not just on the pure validator.
+func TestSetVacationOpening_CurrentYearGuardAlsoAppliesPerStaff(t *testing.T) {
+	svc, _, _ := voService(&voOpeningRepoMock{})
+	req := voRequest()
+	req.EffectiveDate = timezone.NewDate(timezone.TodayDate().Year-1, time.June, 1)
+
+	_, err := svc.SetVacationOpening(context.Background(), 41, 42, req)
+
+	require.ErrorIs(t, err, ErrVacationOpeningInvalid)
+	assert.Contains(t, err.Error(), "current vacation year")
+}
+
+// ============================================================================
+// Booking guards
+// ============================================================================
+
+func TestSetVacationOpening_WithoutRepositoryFailsLoudly(t *testing.T) {
+	svc := &staffAbsenceService{absenceRepo: &absStaffAbsenceRepoMock{}}
+
+	_, err := svc.SetVacationOpening(context.Background(), 41, 42, voRequest())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository is not configured")
+}
+
+func TestSetVacationOpening_RejectsSecondTakeoverForTheSameYear(t *testing.T) {
+	existing := &activeModels.StaffVacationOpening{EffectiveDate: timezone.TodayDate().AddDays(-30)}
+	svc, _, _ := voService(&voOpeningRepoMock{
+		getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+			return existing, nil
+		},
+	})
+
+	_, err := svc.SetVacationOpening(context.Background(), 41, 42, voRequest())
+
+	require.ErrorIs(t, err, ErrVacationOpeningExists)
+	assert.Contains(t, err.Error(), existing.EffectiveDate.String())
+}
+
+func TestSetVacationOpening_PropagatesRepositoryFailures(t *testing.T) {
+	boom := errors.New("db down")
+
+	t.Run("lock", func(t *testing.T) {
+		svc, absenceRepo, _ := voService(&voOpeningRepoMock{})
+		absenceRepo.lockStaffAbsenceWritesFunc = func(context.Context, int64) error { return boom }
+
+		_, err := svc.SetVacationOpening(context.Background(), 41, 42, voRequest())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to lock staff absence writes")
+	})
+
+	t.Run("existing lookup", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return nil, boom
+			},
+		})
+
+		_, err := svc.SetVacationOpening(context.Background(), 41, 42, voRequest())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check existing vacation opening")
+	})
+
+	t.Run("insert", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			createFunc: func(context.Context, *activeModels.StaffVacationOpening) error { return boom },
+		})
+
+		_, err := svc.SetVacationOpening(context.Background(), 41, 42, voRequest())
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create vacation opening")
+	})
+}
+
+// TestSetVacationOpening_DerivesTakenBeforeFromTheQuota is the arithmetic the
+// whole takeover rests on: the Jahresanspruch stays authoritative and the days
+// taken before the Stichtag are derived from it.
+func TestSetVacationOpening_DerivesTakenBeforeFromTheQuota(t *testing.T) {
+	var created *activeModels.StaffVacationOpening
+	svc, _, _ := voService(&voOpeningRepoMock{
+		createFunc: func(_ context.Context, opening *activeModels.StaffVacationOpening) error {
+			created = opening
+			return nil
+		},
+	})
+	svc.quotaRepo = &absVacationQuotaRepoMock{
+		getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationQuota, error) {
+			return &activeModels.StaffVacationQuota{EntitledDays: 28, CarryoverDays: 4}, nil
+		},
+	}
+
+	opening, err := svc.SetVacationOpening(context.Background(), 41, 42, voRequest())
+
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	// 28 + 4 − 17,5 entered rest = 14,5 days spent before the Stichtag.
+	assert.InDelta(t, 14.5, opening.TakenBeforeDays, 0.0001)
+	assert.InDelta(t, 17.5, opening.EnteredRemainingDays, 0.0001)
+}
+
+// TestSetVacationOpening_RejectsADerivedValueTheModelWouldRefuse guards the
+// path where the entered rest is arithmetically impossible for the quota.
+func TestSetVacationOpening_RejectsADerivedValueTheModelWouldRefuse(t *testing.T) {
+	svc, _, _ := voService(&voOpeningRepoMock{})
+	req := voRequest()
+	req.RemainingDays = -990
+
+	_, err := svc.SetVacationOpening(context.Background(), 41, 42, req)
+
+	require.ErrorIs(t, err, ErrVacationOpeningInvalid)
+}
+
+// ============================================================================
+// Deletion
+// ============================================================================
+
+func TestDeleteVacationOpening_WritesTombstoneBeforeDeleting(t *testing.T) {
+	opening := &activeModels.StaffVacationOpening{
+		StaffID:         41,
+		Year:            timezone.TodayDate().Year,
+		EffectiveDate:   timezone.TodayDate().AddDays(-10),
+		TakenBeforeDays: 5,
+		Note:            "Übernahme aus Altsystem",
+	}
+	opening.ID = 77
+	deleted := []any{}
+	svc, _, deletionRepo := voService(&voOpeningRepoMock{
+		getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+			return opening, nil
+		},
+		deleteFunc: func(_ context.Context, id any) error {
+			deleted = append(deleted, id)
+			return nil
+		},
+	})
+
+	require.NoError(t, svc.DeleteVacationOpening(context.Background(), 41, 42, opening.Year))
+
+	require.Len(t, deletionRepo.created, 1)
+	tombstone := deletionRepo.created[0]
+	assert.Equal(t, auditModels.TimeTrackingDeletionSourceVacationOpening, tombstone.Source)
+	assert.Equal(t, opening.ID, tombstone.SourceID)
+	assert.Equal(t, int64(42), tombstone.DeletedBy)
+	assert.Equal(t, opening.Note, tombstone.Note)
+	assert.NotEmpty(t, tombstone.Payload, "the tombstone keeps the deleted row's snapshot")
+	assert.Equal(t, []any{opening.ID}, deleted)
+}
+
+func TestDeleteVacationOpening_Rejects(t *testing.T) {
+	boom := errors.New("db down")
+	year := timezone.TodayDate().Year
+
+	t.Run("without repository", func(t *testing.T) {
+		svc := &staffAbsenceService{absenceRepo: &absStaffAbsenceRepoMock{}}
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "repository is not configured")
+	})
+
+	t.Run("without actor", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{})
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 0, year)
+
+		require.ErrorIs(t, err, ErrVacationOpeningInvalid)
+	})
+
+	t.Run("missing row", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{})
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.ErrorIs(t, err, ErrVacationOpeningNotFound)
+	})
+
+	t.Run("lock failure", func(t *testing.T) {
+		svc, absenceRepo, _ := voService(&voOpeningRepoMock{})
+		absenceRepo.lockStaffAbsenceWritesFunc = func(context.Context, int64) error { return boom }
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to lock staff absence writes")
+	})
+
+	t.Run("load failure", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return nil, boom
+			},
+		})
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load vacation opening")
+	})
+
+	t.Run("audit write failure keeps the row", func(t *testing.T) {
+		deletes := 0
+		svc, _, deletionRepo := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return &activeModels.StaffVacationOpening{StaffID: 41, Year: year}, nil
+			},
+			deleteFunc: func(context.Context, any) error { deletes++; return nil },
+		})
+		deletionRepo.createFunc = func(context.Context, *auditModels.TimeTrackingDeletion) error { return boom }
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to write deletion audit")
+		assert.Zero(t, deletes, "no tombstone, no delete")
+	})
+
+	t.Run("delete failure", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return &activeModels.StaffVacationOpening{StaffID: 41, Year: year}, nil
+			},
+			deleteFunc: func(context.Context, any) error { return boom },
+		})
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete vacation opening")
+	})
+
+	t.Run("without deletion audit repository", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return &activeModels.StaffVacationOpening{StaffID: 41, Year: year}, nil
+			},
+		})
+		svc.deletionRepo = nil
+
+		err := svc.DeleteVacationOpening(context.Background(), 41, 42, year)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deletion audit repository is not configured")
+	})
+}
+
+// ============================================================================
+// Reads and the reverse guard
+// ============================================================================
+
+func TestGetVacationOpening(t *testing.T) {
+	t.Run("requires a staff id", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{})
+
+		_, err := svc.GetVacationOpening(context.Background(), 0, 2026)
+
+		require.ErrorIs(t, err, ErrVacationOpeningInvalid)
+	})
+
+	t.Run("without repository there is no takeover", func(t *testing.T) {
+		svc := &staffAbsenceService{absenceRepo: &absStaffAbsenceRepoMock{}}
+
+		opening, err := svc.GetVacationOpening(context.Background(), 41, 2026)
+
+		require.NoError(t, err)
+		assert.Nil(t, opening)
+	})
+}
+
+// TestRejectVacationBeforeOpening covers the reverse direction: an already
+// booked takeover must block a later vacation absence that would land before
+// its Stichtag (those days are part of the entered Resturlaub already).
+func TestRejectVacationBeforeOpening(t *testing.T) {
+	year := timezone.TodayDate().Year
+	cutoff := timezone.NewDate(year, time.June, 8) // Monday
+
+	t.Run("ignores non-vacation absences", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return &activeModels.StaffVacationOpening{EffectiveDate: cutoff}, nil
+			},
+		})
+
+		err := svc.rejectVacationBeforeOpening(context.Background(), &activeModels.StaffAbsence{
+			AbsenceType: activeModels.AbsenceTypeSick,
+			DateStart:   cutoff.AddDays(-3),
+			DateEnd:     cutoff.AddDays(-3),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("passes without a takeover", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{})
+
+		err := svc.rejectVacationBeforeOpening(context.Background(), &activeModels.StaffAbsence{
+			AbsenceType: activeModels.AbsenceTypeVacation,
+			DateStart:   cutoff.AddDays(-3),
+			DateEnd:     cutoff.AddDays(-3),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("blocks a working day before the Stichtag", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return &activeModels.StaffVacationOpening{EffectiveDate: cutoff}, nil
+			},
+		})
+
+		err := svc.rejectVacationBeforeOpening(context.Background(), &activeModels.StaffAbsence{
+			AbsenceType: activeModels.AbsenceTypeVacation,
+			DateStart:   cutoff.AddDays(-3), // Friday
+			DateEnd:     cutoff.AddDays(-3),
+		})
+
+		require.ErrorIs(t, err, ErrVacationOpeningAbsencesBeforeCutoff)
+	})
+
+	t.Run("allows an absence that starts on the Stichtag", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return &activeModels.StaffVacationOpening{EffectiveDate: cutoff}, nil
+			},
+		})
+
+		err := svc.rejectVacationBeforeOpening(context.Background(), &activeModels.StaffAbsence{
+			AbsenceType: activeModels.AbsenceTypeVacation,
+			DateStart:   cutoff,
+			DateEnd:     cutoff.AddDays(2),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("propagates lookup failures", func(t *testing.T) {
+		svc, _, _ := voService(&voOpeningRepoMock{
+			getByStaffAndYearFunc: func(context.Context, int64, int) (*activeModels.StaffVacationOpening, error) {
+				return nil, errors.New("db down")
+			},
+		})
+
+		err := svc.rejectVacationBeforeOpening(context.Background(), &activeModels.StaffAbsence{
+			AbsenceType: activeModels.AbsenceTypeVacation,
+			DateStart:   cutoff.AddDays(-3),
+			DateEnd:     cutoff.AddDays(-3),
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check vacation opening")
+	})
+}
+
+// TestRejectVacationAbsencesBefore covers the forward guard: declined and
+// canceled absences do not count, an approved one before the Stichtag does.
+func TestRejectVacationAbsencesBefore(t *testing.T) {
+	year := timezone.TodayDate().Year
+	cutoff := timezone.NewDate(year, time.June, 8) // Monday
+	friday := cutoff.AddDays(-3)
+
+	tests := []struct {
+		name      string
+		absences  []*activeModels.StaffAbsence
+		wantBlock bool
+	}{
+		{
+			name: "approved vacation before the Stichtag blocks",
+			absences: []*activeModels.StaffAbsence{{
+				AbsenceType: activeModels.AbsenceTypeVacation,
+				Status:      activeModels.AbsenceStatusApproved,
+				DateStart:   friday, DateEnd: friday,
+			}},
+			wantBlock: true,
+		},
+		{
+			name: "declined vacation does not count",
+			absences: []*activeModels.StaffAbsence{{
+				AbsenceType: activeModels.AbsenceTypeVacation,
+				Status:      activeModels.AbsenceStatusDeclined,
+				DateStart:   friday, DateEnd: friday,
+			}},
+		},
+		{
+			name: "canceled vacation does not count",
+			absences: []*activeModels.StaffAbsence{{
+				AbsenceType: activeModels.AbsenceTypeVacation,
+				Status:      activeModels.AbsenceStatusCanceled,
+				DateStart:   friday, DateEnd: friday,
+			}},
+		},
+		{
+			name: "sick leave does not count against the vacation quota",
+			absences: []*activeModels.StaffAbsence{{
+				AbsenceType: activeModels.AbsenceTypeSick,
+				Status:      activeModels.AbsenceStatusApproved,
+				DateStart:   friday, DateEnd: friday,
+			}},
+		},
+		{
+			name: "vacation on or after the Stichtag is fine",
+			absences: []*activeModels.StaffAbsence{{
+				AbsenceType: activeModels.AbsenceTypeVacation,
+				Status:      activeModels.AbsenceStatusApproved,
+				DateStart:   cutoff, DateEnd: cutoff.AddDays(4),
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, absenceRepo, _ := voService(&voOpeningRepoMock{})
+			absenceRepo.getByStaffAndDateRangeFunc = func(context.Context, int64, timezone.Date, timezone.Date) ([]*activeModels.StaffAbsence, error) {
+				return tc.absences, nil
+			}
+
+			err := svc.ValidateVacationOpeningAbsencesBefore(context.Background(), 41, cutoff)
+
+			if tc.wantBlock {
+				require.ErrorIs(t, err, ErrVacationOpeningAbsencesBeforeCutoff)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRejectVacationAbsencesBefore_PropagatesLookupFailures(t *testing.T) {
+	svc, absenceRepo, _ := voService(&voOpeningRepoMock{})
+	absenceRepo.getByStaffAndDateRangeFunc = func(context.Context, int64, timezone.Date, timezone.Date) ([]*activeModels.StaffAbsence, error) {
+		return nil, errors.New("db down")
+	}
+
+	err := svc.ValidateVacationOpeningAbsencesBefore(context.Background(), 41, timezone.TodayDate())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check absences for vacation opening")
+}

--- a/backend/services/active/work_session_export_test.go
+++ b/backend/services/active/work_session_export_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -463,7 +464,12 @@ func TestCrossStaffCSV_SanitizesUntrustedTextOnly(t *testing.T) {
 	assert.Equal(t, "'=1+1", records[1][0])
 	assert.Equal(t, "'+SUM(A1:A2)", records[1][1])
 	assert.Equal(t, "'@legacy", records[1][2])
-	assert.Equal(t, "-1,50", records[1][18], "trusted negative durations must remain numeric CSV values")
+	// Located by header, not by a fixed index: the column set grows (#2132
+	// inserted "Eröffnungssaldo" ahead of it) and a hardcoded offset turns a
+	// column addition into an unrelated sanitizer failure.
+	balanceColumn := slices.Index(records[0], "Saldo Monat")
+	require.GreaterOrEqual(t, balanceColumn, 0, "month export must carry a Saldo Monat column")
+	assert.Equal(t, "-1,50", records[1][balanceColumn], "trusted negative durations must remain numeric CSV values")
 
 	dayData, err := writeDayCSV([]dayExportBlockRow{{
 		LastName:  "-danger",

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -16,6 +16,8 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	activeRepo "github.com/moto-nrw/project-phoenix/database/repositories/active"
 	"github.com/moto-nrw/project-phoenix/email"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
@@ -121,6 +123,7 @@ type Factory struct {
 	Database                 database.DatabaseService
 	Import                   *importService.ImportService[importModels.StudentImportRow] // Student import service
 	StaffImport              *importService.ImportService[importModels.StaffImportRow]   // Staff (Mitarbeiter) import service
+	OpeningBalanceImport     importService.OpeningBalanceImportFactory                   // Opening balance import (#2132), request-scoped
 	ListExport               *listexport.RendererService
 	Emergency                *emergency.Service
 	SlotLists                slotlists.Service
@@ -500,6 +503,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	}); ok {
 		deletionAware.SetDeletionAudit(repos.TimeTrackingDeletion)
 	}
+	// Vacation takeover at the moto introduction (#2132): the summary
+	// subtracts pre-introduction days, the write paths book/delete them.
+	if openingAware, ok := staffAbsenceService.(interface {
+		SetVacationOpeningRepository(activeModels.StaffVacationOpeningRepository)
+	}); ok {
+		openingAware.SetVacationOpeningRepository(repos.StaffVacationOpening)
+	}
 
 	// Monatsabschluss (#1417): freezes a month's closing balance so a
 	// retroactive correction can no longer rewrite every later Übertrag.
@@ -534,6 +544,9 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		activeLogger,
 	)
 	staffOverviewService.SetHolidayReader(nonWorkingDayService)
+	// Vacation takeover (#2132): the Resturlaub column subtracts
+	// pre-introduction days exactly like the /staff/{id} detail view.
+	staffOverviewService.SetVacationOpeningReader(repos.StaffVacationOpening)
 
 	// Cross-staff payroll/evidence export (#1417 2b): rows via the overview's
 	// prefetch (month) and the single-staff export cells (day); every download
@@ -1297,6 +1310,24 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	staffImportService := importService.NewImportService(staffImportConfig)
 	staffImportService.SetAuditRepository(repos.DataImport)
 
+	// Opening balance import (#2132): the config is request-scoped (Stichtag,
+	// Begründung, and acting staff member come from the upload form), so the
+	// factory closes over the request-independent deps and builds a fresh
+	// service per request.
+	openingBalanceImportFactory := importService.OpeningBalanceImportFactory(
+		func(effectiveDate timezone.Date, note string, decidedByStaffID int64) *importService.ImportService[importModels.OpeningBalanceImportRow] {
+			config := importService.NewOpeningBalanceImportConfig(importService.OpeningBalanceImportDeps{
+				StaffRepo:            repos.Staff,
+				AdjustmentRepo:       repos.StaffBalanceAdjust,
+				VacationOpeningRepo:  repos.StaffVacationOpening,
+				BalanceAdjustService: staffBalanceAdjustService,
+				StaffAbsenceService:  staffAbsenceService,
+			}, effectiveDate, note, decidedByStaffID)
+			svc := importService.NewImportService(config)
+			svc.SetAuditRepository(repos.DataImport)
+			return svc
+		})
+
 	// Email change tokens deliberately reuse PASSWORD_RESET_TOKEN_EXPIRY_MINUTES
 	// because both serve the same purpose (one-time verification links with the same
 	// delivery constraints and security profile). If the two ever need to diverge,
@@ -1979,8 +2010,9 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		GuardianProfileLoader:    guardianProfileLoader,
 		UserContext:              userContextService,
 		Database:                 databaseService,
-		Import:                   studentImportService, // Student import service
-		StaffImport:              staffImportService,   // Staff (Mitarbeiter) import service
+		Import:                   studentImportService,        // Student import service
+		StaffImport:              staffImportService,          // Staff (Mitarbeiter) import service
+		OpeningBalanceImport:     openingBalanceImportFactory, // Opening balance import (#2132)
 		ListExport:               listExportService,
 		PlanExport:               planExportService,
 		Emergency:                emergencyService,

--- a/backend/services/import/import_service.go
+++ b/backend/services/import/import_service.go
@@ -103,6 +103,36 @@ func (s *ImportService[T]) RecordAudit(entityType, filename string, result *impo
 	}()
 }
 
+// RecordAuditInTransaction writes a GDPR import audit record using the caller's
+// tenant-scoped transaction. Use this when completing the import must not be
+// acknowledged unless its required audit record has been persisted.
+func (s *ImportService[T]) RecordAuditInTransaction(ctx context.Context, entityType, filename string, result *importModels.ImportResult[T], userID int64, dryRun bool, tenantID int64) error {
+	if s.auditRepo == nil {
+		return fmt.Errorf("import audit repository not wired")
+	}
+
+	auditRecord := &audit.DataImport{
+		EntityType:   entityType,
+		Filename:     filename,
+		TotalRows:    result.TotalRows,
+		CreatedCount: result.CreatedCount,
+		UpdatedCount: result.UpdatedCount,
+		SkippedCount: 0, // Not tracked separately
+		ErrorCount:   result.ErrorCount,
+		WarningCount: result.WarningCount,
+		DryRun:       dryRun,
+		ImportedBy:   userID,
+		StartedAt:    result.StartedAt,
+		CompletedAt:  &result.CompletedAt,
+		Metadata:     audit.JSONBMap{},
+	}
+	auditRecord.SetTenantID(tenantID)
+	if err := s.auditRepo.Create(ctx, auditRecord); err != nil {
+		return fmt.Errorf("create import audit record: %w", err)
+	}
+	return nil
+}
+
 // Import executes the import operation
 func (s *ImportService[T]) Import(ctx context.Context, request importModels.ImportRequest[T]) (*importModels.ImportResult[T], error) {
 	result := &importModels.ImportResult[T]{

--- a/backend/services/import/import_service.go
+++ b/backend/services/import/import_service.go
@@ -169,7 +169,19 @@ func (s *ImportService[T]) validateBatch(ctx context.Context, rows []T) map[int]
 
 // processAllRows processes all rows in the import request
 func (s *ImportService[T]) processAllRows(ctx context.Context, request importModels.ImportRequest[T], result *importModels.ImportResult[T], batchErrors map[int][]importModels.ValidationError) bool {
+	order := make([]int, len(request.Rows))
 	for i := range request.Rows {
+		order[i] = i
+	}
+	if !request.DryRun {
+		if orderer, ok := s.config.(importModels.ProcessingOrderer[T]); ok {
+			if configuredOrder := orderer.ProcessingOrder(request.Rows); validProcessingOrder(configuredOrder, len(request.Rows)) {
+				order = configuredOrder
+			}
+		}
+	}
+
+	for _, i := range order {
 		row := &request.Rows[i]
 		rowNum := i + 2
 
@@ -178,6 +190,22 @@ func (s *ImportService[T]) processAllRows(ctx context.Context, request importMod
 		}
 	}
 	return false
+}
+
+// validProcessingOrder verifies an optional config's order before using it so
+// a malformed implementation cannot skip a row or panic the generic importer.
+func validProcessingOrder(order []int, rowCount int) bool {
+	if len(order) != rowCount {
+		return false
+	}
+	seen := make([]bool, rowCount)
+	for _, index := range order {
+		if index < 0 || index >= rowCount || seen[index] {
+			return false
+		}
+		seen[index] = true
+	}
+	return true
 }
 
 // processImportRow processes a single row

--- a/backend/services/import/import_service_test.go
+++ b/backend/services/import/import_service_test.go
@@ -27,6 +27,9 @@ type mockImportConfig struct {
 	createErr       error
 	updateErr       error
 	entityName      string
+	processingOrder []int
+	createdRows     []string
+	createErrByName map[string]error
 }
 
 type mockDataImportRepository struct {
@@ -61,7 +64,11 @@ func (m *mockImportConfig) FindExisting(_ context.Context, _ testRow) (*int64, e
 	return m.findExistingID, m.findExistingErr
 }
 
-func (m *mockImportConfig) Create(_ context.Context, _ testRow) (int64, error) {
+func (m *mockImportConfig) Create(_ context.Context, row testRow) (int64, error) {
+	m.createdRows = append(m.createdRows, row.Name)
+	if err := m.createErrByName[row.Name]; err != nil {
+		return 0, err
+	}
 	return m.createID, m.createErr
 }
 
@@ -74,6 +81,10 @@ func (m *mockImportConfig) EntityName() string {
 		return "TestEntity"
 	}
 	return m.entityName
+}
+
+func (m *mockImportConfig) ProcessingOrder(_ []testRow) []int {
+	return m.processingOrder
 }
 
 // ============================================================================
@@ -463,6 +474,38 @@ func TestImportService_Import(t *testing.T) {
 		assert.False(t, result.CompletedAt.IsZero())
 		assert.True(t, result.CompletedAt.After(result.StartedAt) || result.CompletedAt.Equal(result.StartedAt))
 	})
+}
+
+func TestImportService_ImportUsesConfiguredProcessingOrder(t *testing.T) {
+	config := &mockImportConfig{processingOrder: []int{1, 0}}
+	service := NewImportService[testRow](config)
+
+	result, err := service.Import(context.Background(), importModels.ImportRequest[testRow]{
+		Rows: []testRow{{Name: "first"}, {Name: "second"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.CreatedCount)
+	assert.Equal(t, []string{"second", "first"}, config.createdRows)
+}
+
+func TestImportService_ImportKeepsOriginalRowNumbersWhenReordered(t *testing.T) {
+	config := &mockImportConfig{
+		processingOrder: []int{1, 0},
+		createErrByName: map[string]error{
+			"second": errors.New("cannot create second"),
+		},
+	}
+	service := NewImportService[testRow](config)
+
+	result, err := service.Import(context.Background(), importModels.ImportRequest[testRow]{
+		Rows: []testRow{{Name: "first"}, {Name: "second"}},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, 3, result.Errors[0].RowNumber)
+	assert.Equal(t, "second", result.Errors[0].Data.Name)
 }
 
 // ============================================================================

--- a/backend/services/import/import_service_test.go
+++ b/backend/services/import/import_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,26 @@ type mockImportConfig struct {
 	createErr       error
 	updateErr       error
 	entityName      string
+}
+
+type mockDataImportRepository struct {
+	created *auditModels.DataImport
+	ctx     context.Context
+	err     error
+}
+
+func (m *mockDataImportRepository) Create(ctx context.Context, record *auditModels.DataImport) error {
+	m.ctx = ctx
+	m.created = record
+	return m.err
+}
+
+func (m *mockDataImportRepository) FindByID(context.Context, int64) (*auditModels.DataImport, error) {
+	return nil, nil
+}
+
+func (m *mockDataImportRepository) List(context.Context, map[string]interface{}) ([]*auditModels.DataImport, error) {
+	return nil, nil
 }
 
 func (m *mockImportConfig) PreloadReferenceData(_ context.Context) error {
@@ -71,6 +92,31 @@ func TestNewImportService(t *testing.T) {
 		require.NotNil(t, service)
 		assert.Equal(t, 100, service.batchSize)
 	})
+}
+
+func TestImportService_RecordAuditInTransaction(t *testing.T) {
+	service := NewImportService[testRow](&mockImportConfig{})
+	repo := &mockDataImportRepository{}
+	service.SetAuditRepository(repo)
+	result := &importModels.ImportResult[testRow]{
+		TotalRows:    4,
+		CreatedCount: 3,
+		ErrorCount:   1,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := service.RecordAuditInTransaction(ctx, "opening_balance", "opening.csv", result, 42, false, 7)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo.created)
+	assert.Same(t, ctx, repo.ctx)
+	assert.Equal(t, int64(7), repo.created.TenantID)
+	assert.Equal(t, "opening_balance", repo.created.EntityType)
+	assert.Equal(t, "opening.csv", repo.created.Filename)
+	assert.Equal(t, 3, repo.created.CreatedCount)
+	assert.Equal(t, 1, repo.created.ErrorCount)
+	assert.False(t, repo.created.DryRun)
 }
 
 // ============================================================================

--- a/backend/services/import/import_service_test.go
+++ b/backend/services/import/import_service_test.go
@@ -117,12 +117,16 @@ func TestImportService_RecordAuditInTransaction(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := service.RecordAuditInTransaction(ctx, "opening_balance", "opening.csv", result, 42, false, 7)
+	// Sentinel values for the in-memory repository stub — no DB rows involved.
+	const wantTenantID int64 = 7
+	const accountID int64 = 42
+
+	err := service.RecordAuditInTransaction(ctx, "opening_balance", "opening.csv", result, accountID, false, wantTenantID)
 
 	require.NoError(t, err)
 	require.NotNil(t, repo.created)
 	assert.Same(t, ctx, repo.ctx)
-	assert.Equal(t, int64(7), repo.created.TenantID)
+	assert.Equal(t, wantTenantID, repo.created.TenantID)
 	assert.Equal(t, "opening_balance", repo.created.EntityType)
 	assert.Equal(t, "opening.csv", repo.created.Filename)
 	assert.Equal(t, 3, repo.created.CreatedCount)

--- a/backend/services/import/opening_balance_booking_mock_test.go
+++ b/backend/services/import/opening_balance_booking_mock_test.go
@@ -1,0 +1,543 @@
+package importpkg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Booking side of the opening balance import (#2132). The ledger writes go
+// through narrow service interfaces, so these tests drive the config against
+// recording doubles: what matters is WHICH sides of a row get booked, in which
+// order, and how a ledger rejection is reported back to the uploader.
+
+// --- doubles ---------------------------------------------------------------
+
+type recordingOpeningBooker struct {
+	events      *[]string
+	validateErr error
+	createErr   error
+
+	lastMinutes int
+	lastNote    string
+	lastDate    timezone.Date
+}
+
+func (b *recordingOpeningBooker) ValidateOpeningBalance(_ context.Context, _, _ int64, _ timezone.Date, _ int, _ string) error {
+	*b.events = append(*b.events, "validate_hours")
+	return b.validateErr
+}
+
+func (b *recordingOpeningBooker) CreateOpeningBalance(_ context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error) {
+	*b.events = append(*b.events, "create_hours")
+	b.lastMinutes = balanceMinutes
+	b.lastNote = note
+	b.lastDate = effectiveDate
+	if b.createErr != nil {
+		return nil, b.createErr
+	}
+	return &activeModels.StaffBalanceAdjustment{
+		StaffID:       staffID,
+		Type:          activeModels.BalanceAdjustmentTypeOpening,
+		MinutesDelta:  balanceMinutes,
+		EffectiveDate: effectiveDate,
+		DecidedBy:     decidedBy,
+		Note:          note,
+	}, nil
+}
+
+type recordingVacationBooker struct {
+	events *[]string
+
+	summary       *activeSvc.VacationQuotaSummary
+	summaryErr    error
+	upsertErr     error
+	openingErr    error
+	preflightErr  error
+	lastEntitled  float64
+	lastCarryover float64
+	lastRemaining float64
+	lastNote      string
+}
+
+func (b *recordingVacationBooker) GetVacationQuotaSummary(_ context.Context, staffID int64, year int) (*activeSvc.VacationQuotaSummary, error) {
+	*b.events = append(*b.events, "read_quota")
+	if b.summaryErr != nil {
+		return nil, b.summaryErr
+	}
+	if b.summary != nil {
+		return b.summary, nil
+	}
+	return &activeSvc.VacationQuotaSummary{StaffID: staffID, Year: year, EntitledDays: 30, CarryoverDays: 0}, nil
+}
+
+func (b *recordingVacationBooker) UpsertVacationQuota(_ context.Context, _ int64, _ int, entitled, carryover float64) error {
+	*b.events = append(*b.events, "write_quota")
+	b.lastEntitled = entitled
+	b.lastCarryover = carryover
+	return b.upsertErr
+}
+
+func (b *recordingVacationBooker) SetVacationOpening(_ context.Context, staffID, decidedBy int64, req activeSvc.SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error) {
+	*b.events = append(*b.events, "create_vacation_opening")
+	b.lastRemaining = req.RemainingDays
+	b.lastNote = req.Note
+	if b.openingErr != nil {
+		return nil, b.openingErr
+	}
+	return &activeModels.StaffVacationOpening{
+		StaffID:              staffID,
+		Year:                 req.EffectiveDate.Year,
+		EffectiveDate:        req.EffectiveDate,
+		EnteredRemainingDays: req.RemainingDays,
+		DecidedBy:            decidedBy,
+	}, nil
+}
+
+func (b *recordingVacationBooker) ValidateVacationOpeningAbsencesBefore(_ context.Context, _ int64, _ timezone.Date) error {
+	*b.events = append(*b.events, "validate_vacation")
+	return b.preflightErr
+}
+
+// listerFunc adapts a closure to the repository read side used by the preload.
+type listerFunc[T any] func(ctx context.Context, options *modelBase.QueryOptions) ([]T, error)
+
+func (f listerFunc[T]) List(ctx context.Context, options *modelBase.QueryOptions) ([]T, error) {
+	return f(ctx, options)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func intPtr(v int) *int { return &v }
+
+// newBookingConfig wires the preloaded caches from newOpeningConfig with
+// recording booking doubles.
+func newBookingConfig(events *[]string) (*OpeningBalanceImportConfig, *recordingOpeningBooker, *recordingVacationBooker) {
+	hours := &recordingOpeningBooker{events: events}
+	vacation := &recordingVacationBooker{events: events}
+	c := newOpeningConfig()
+	c.BalanceAdjustService = hours
+	c.StaffAbsenceService = vacation
+	return c, hours, vacation
+}
+
+// --- construction & preload ------------------------------------------------
+
+func TestNewOpeningBalanceImportConfig_CarriesRequestScopedValues(t *testing.T) {
+	effectiveDate := timezone.NewDate(2026, time.March, 1)
+
+	c := NewOpeningBalanceImportConfig(OpeningBalanceImportDeps{}, effectiveDate, "Übernahme", openingDecidedByID)
+
+	assert.Equal(t, effectiveDate, c.EffectiveDate)
+	assert.Equal(t, "Übernahme", c.Note)
+	assert.Equal(t, openingDecidedByID, c.DecidedByStaffID)
+	assert.Equal(t, "Eröffnungssaldo", c.EntityName())
+	// The import is create-only; corrections run through the per-person UI.
+	require.NoError(t, c.Update(t.Context(), 1, importModels.OpeningBalanceImportRow{}))
+	existing, err := c.FindExisting(t.Context(), importModels.OpeningBalanceImportRow{})
+	require.NoError(t, err)
+	assert.Nil(t, existing)
+}
+
+func TestPreloadReferenceData_BuildsMatchAndDuplicateCaches(t *testing.T) {
+	blankPersonnelNumber := "   "
+	staffWithBlankNumber := openingStaff(openingStaffBerndID, "", "Bernd", "Schulz")
+	staffWithBlankNumber.PersonnelNumber = &blankPersonnelNumber
+
+	c := NewOpeningBalanceImportConfig(OpeningBalanceImportDeps{
+		StaffRepo: &testpkg.StaffRepoMock{
+			ListAllWithPersonFn: func(_ context.Context) ([]*userModels.Staff, error) {
+				return []*userModels.Staff{
+					openingStaff(openingStaffAnnaID, "P-100", "Anna", "Lehmann"),
+					staffWithBlankNumber,
+					// No person relation: nothing to key a name match on.
+					{},
+				}, nil
+			},
+		},
+		AdjustmentRepo: listerFunc[*activeModels.StaffBalanceAdjustment](
+			func(_ context.Context, _ *modelBase.QueryOptions) ([]*activeModels.StaffBalanceAdjustment, error) {
+				return []*activeModels.StaffBalanceAdjustment{{StaffID: openingStaffAnnaID}}, nil
+			}),
+		VacationOpeningRepo: listerFunc[*activeModels.StaffVacationOpening](
+			func(_ context.Context, _ *modelBase.QueryOptions) ([]*activeModels.StaffVacationOpening, error) {
+				return []*activeModels.StaffVacationOpening{{StaffID: openingStaffBerndID}}, nil
+			}),
+	}, timezone.NewDate(openingEffectiveYear, openingEffectiveMonth, openingEffectiveDay), "Übernahme", openingDecidedByID)
+
+	require.NoError(t, c.PreloadReferenceData(t.Context()))
+
+	assert.Equal(t, openingStaffAnnaID, c.staffByPersonnelNumber["p-100"].ID)
+	assert.NotContains(t, c.staffByPersonnelNumber, "", "a blank Personalnummer must not become a match key")
+	assert.Len(t, c.staffByName[staffNameKey("Anna", "Lehmann")], 1)
+	assert.True(t, c.staffWithHoursOpening[openingStaffAnnaID])
+	assert.True(t, c.staffWithVacOpening[openingStaffBerndID])
+}
+
+func TestPreloadReferenceData_PropagatesRepositoryErrors(t *testing.T) {
+	boom := errors.New("db down")
+	okStaff := &testpkg.StaffRepoMock{
+		ListAllWithPersonFn: func(_ context.Context) ([]*userModels.Staff, error) { return nil, nil },
+	}
+	okAdjustments := listerFunc[*activeModels.StaffBalanceAdjustment](
+		func(_ context.Context, _ *modelBase.QueryOptions) ([]*activeModels.StaffBalanceAdjustment, error) {
+			return nil, nil
+		})
+
+	tests := []struct {
+		name    string
+		deps    OpeningBalanceImportDeps
+		wantMsg string
+	}{
+		{
+			name: "staff",
+			deps: OpeningBalanceImportDeps{StaffRepo: &testpkg.StaffRepoMock{
+				ListAllWithPersonFn: func(_ context.Context) ([]*userModels.Staff, error) { return nil, boom },
+			}},
+			wantMsg: "preload staff",
+		},
+		{
+			name: "hours openings",
+			deps: OpeningBalanceImportDeps{
+				StaffRepo: okStaff,
+				AdjustmentRepo: listerFunc[*activeModels.StaffBalanceAdjustment](
+					func(_ context.Context, _ *modelBase.QueryOptions) ([]*activeModels.StaffBalanceAdjustment, error) {
+						return nil, boom
+					}),
+			},
+			wantMsg: "preload hours openings",
+		},
+		{
+			name: "vacation openings",
+			deps: OpeningBalanceImportDeps{
+				StaffRepo:      okStaff,
+				AdjustmentRepo: okAdjustments,
+				VacationOpeningRepo: listerFunc[*activeModels.StaffVacationOpening](
+					func(_ context.Context, _ *modelBase.QueryOptions) ([]*activeModels.StaffVacationOpening, error) {
+						return nil, boom
+					}),
+			},
+			wantMsg: "preload vacation openings",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewOpeningBalanceImportConfig(tc.deps, timezone.TodayDate(), "Übernahme", openingDecidedByID)
+
+			err := c.PreloadReferenceData(t.Context())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+// --- booking ---------------------------------------------------------------
+
+func TestOpeningBalanceCreate_BooksOnlyTheSidesTheRowCarries(t *testing.T) {
+	t.Run("hours only", func(t *testing.T) {
+		events := []string{}
+		c, hours, _ := newBookingConfig(&events)
+
+		id, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+			StaffID:             openingStaffAnnaID,
+			HoursBalanceMinutes: intPtr(-330),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, openingStaffAnnaID, id)
+		assert.Equal(t, []string{"create_hours"}, events)
+		assert.Equal(t, -330, hours.lastMinutes, "a migrated account may start negative")
+		assert.Equal(t, c.Note, hours.lastNote, "the file-wide Begründung lands on the booking")
+		assert.Equal(t, c.EffectiveDate, hours.lastDate)
+	})
+
+	t.Run("vacation only", func(t *testing.T) {
+		events := []string{}
+		c, _, vacation := newBookingConfig(&events)
+
+		_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+			StaffID:               openingStaffAnnaID,
+			VacationRemainingDays: float64Ptr(17.5),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"create_vacation_opening"}, events)
+		assert.InDelta(t, 17.5, vacation.lastRemaining, 0.0001)
+		assert.Equal(t, c.Note, vacation.lastNote)
+	})
+
+	t.Run("both sides in quota-then-takeover order", func(t *testing.T) {
+		events := []string{}
+		c, _, vacation := newBookingConfig(&events)
+
+		_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+			StaffID:               openingStaffAnnaID,
+			HoursBalanceMinutes:   intPtr(750),
+			VacationEntitledDays:  float64Ptr(28),
+			VacationCarryoverDays: float64Ptr(3),
+			VacationRemainingDays: float64Ptr(20),
+		})
+
+		require.NoError(t, err)
+		// The takeover derives taken_before from the quota, so the quota must
+		// be written first.
+		assert.Equal(t, []string{"create_hours", "read_quota", "write_quota", "create_vacation_opening"}, events)
+		assert.InDelta(t, 28, vacation.lastEntitled, 0.0001)
+		assert.InDelta(t, 3, vacation.lastCarryover, 0.0001)
+	})
+
+	t.Run("empty row books nothing", func(t *testing.T) {
+		events := []string{}
+		c, _, _ := newBookingConfig(&events)
+
+		_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{StaffID: openingStaffAnnaID})
+
+		require.NoError(t, err)
+		assert.Empty(t, events)
+	})
+}
+
+func TestOpeningBalanceCreate_QuotaKeepsUnsuppliedComponent(t *testing.T) {
+	events := []string{}
+	c, _, vacation := newBookingConfig(&events)
+	vacation.summary = &activeSvc.VacationQuotaSummary{EntitledDays: 30, CarryoverDays: 4}
+
+	// Only the Übertrag column is filled: the persisted Jahresanspruch must
+	// survive untouched.
+	_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+		StaffID:               openingStaffAnnaID,
+		VacationCarryoverDays: float64Ptr(1.5),
+	})
+
+	require.NoError(t, err)
+	assert.InDelta(t, 30, vacation.lastEntitled, 0.0001)
+	assert.InDelta(t, 1.5, vacation.lastCarryover, 0.0001)
+}
+
+func TestOpeningBalanceCreate_RejectsRowWithoutResolvedStaff(t *testing.T) {
+	events := []string{}
+	c, _, _ := newBookingConfig(&events)
+
+	_, err := c.Create(t.Context(), importModels.OpeningBalanceImportRow{HoursBalanceMinutes: intPtr(60)})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ohne aufgelöste Person")
+	assert.Empty(t, events)
+}
+
+func TestOpeningBalanceCreate_RequiresATransactionForItsSavepoint(t *testing.T) {
+	// A failed row must roll back its own writes without losing the rest of
+	// the file, which is what the savepoint is for — no transaction, no row.
+	events := []string{}
+	c, _, _ := newBookingConfig(&events)
+
+	_, err := c.Create(t.Context(), importModels.OpeningBalanceImportRow{
+		StaffID:             openingStaffAnnaID,
+		HoursBalanceMinutes: intPtr(60),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transaction is required")
+}
+
+func TestOpeningBalanceCreate_TranslatesLedgerRejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantMsg string
+	}{
+		{
+			name:    "second hours opening",
+			err:     activeSvc.ErrOpeningAlreadyExists,
+			wantMsg: "bereits ein Stundenkonto-Eröffnungssaldo",
+		},
+		{
+			name:    "closed month",
+			err:     activeSvc.ErrAdjustmentInClosedMonth,
+			wantMsg: "bereits abgeschlossen",
+		},
+		{
+			name:    "dependent reset",
+			err:     activeSvc.ErrAdjustmentHasDependentReset,
+			wantMsg: "spätere Stundenkonto-Buchungen",
+		},
+		{
+			name:    "unmapped error passes through",
+			err:     errors.New("connection reset"),
+			wantMsg: "connection reset",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []string{}
+			c, hours, _ := newBookingConfig(&events)
+			hours.createErr = tc.err
+
+			_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+				StaffID:             openingStaffAnnaID,
+				HoursBalanceMinutes: intPtr(60),
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+func TestOpeningBalanceCreate_TranslatesVacationRejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantMsg string
+	}{
+		{
+			name:    "second takeover",
+			err:     activeSvc.ErrVacationOpeningExists,
+			wantMsg: "bereits eine Urlaubs-Übernahme",
+		},
+		{
+			name:    "absences before the Stichtag",
+			err:     activeSvc.ErrVacationOpeningAbsencesBeforeCutoff,
+			wantMsg: "doppelt zählen",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []string{}
+			c, _, vacation := newBookingConfig(&events)
+			vacation.openingErr = tc.err
+
+			_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+				StaffID:               openingStaffAnnaID,
+				VacationRemainingDays: float64Ptr(10),
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+func TestOpeningBalanceCreate_ReportsQuotaFailures(t *testing.T) {
+	t.Run("read", func(t *testing.T) {
+		events := []string{}
+		c, _, vacation := newBookingConfig(&events)
+		vacation.summaryErr = errors.New("db down")
+
+		_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+			StaffID:              openingStaffAnnaID,
+			VacationEntitledDays: float64Ptr(30),
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "urlaubskonto konnte nicht gelesen werden")
+	})
+
+	t.Run("write", func(t *testing.T) {
+		events := []string{}
+		c, _, vacation := newBookingConfig(&events)
+		vacation.upsertErr = errors.New("db down")
+
+		_, err := c.create(t.Context(), importModels.OpeningBalanceImportRow{
+			StaffID:              openingStaffAnnaID,
+			VacationEntitledDays: float64Ptr(30),
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "urlaubsanspruch konnte nicht gespeichert werden")
+	})
+}
+
+// --- preview guards --------------------------------------------------------
+
+func TestOpeningBalanceValidate_ReportsLedgerPreflightRejection(t *testing.T) {
+	events := []string{}
+	c, hours, _ := newBookingConfig(&events)
+	hours.validateErr = activeSvc.ErrAdjustmentInClosedMonth
+
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName: "Anna", LastName: "Lehmann", HoursBalance: "12,5",
+	}
+	errs := c.Validate(t.Context(), row)
+
+	require.Contains(t, errorCodes(errs), "opening_preflight_failed")
+	assert.Contains(t, errs[0].Message, "bereits abgeschlossen")
+}
+
+func TestOpeningBalanceValidate_ReportsVacationPreflightRejection(t *testing.T) {
+	events := []string{}
+	c, _, vacation := newBookingConfig(&events)
+	vacation.preflightErr = activeSvc.ErrVacationOpeningAbsencesBeforeCutoff
+
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName: "Anna", LastName: "Lehmann", VacationRemaining: "17,5",
+	}
+	errs := c.Validate(t.Context(), row)
+
+	require.Contains(t, errorCodes(errs), "vacation_opening_preflight_failed")
+}
+
+func TestOpeningBalanceValidate_ReportsQuotaLookupFailure(t *testing.T) {
+	events := []string{}
+	c, _, vacation := newBookingConfig(&events)
+	vacation.summaryErr = errors.New("db down")
+
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName: "Anna", LastName: "Lehmann", VacationRemaining: "17,5",
+	}
+	errs := c.Validate(t.Context(), row)
+
+	assert.Contains(t, errorCodes(errs), "vacation_quota_lookup_failed")
+}
+
+func TestOpeningBalanceValidate_RejectsDerivedTakeoverOutsideTheModelRange(t *testing.T) {
+	events := []string{}
+	c, _, vacation := newBookingConfig(&events)
+	// Entitled + carryover − Resturlaub must stay inside NUMERIC(5,1).
+	vacation.summary = &activeSvc.VacationQuotaSummary{EntitledDays: 30, CarryoverDays: 0}
+
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName: "Anna", LastName: "Lehmann", VacationRemaining: "-990",
+	}
+	errs := c.Validate(t.Context(), row)
+
+	require.Contains(t, errorCodes(errs), "invalid_vacation_opening")
+}
+
+func TestOpeningBalanceValidate_DerivesTakeoverFromTheRowsOwnQuotaColumns(t *testing.T) {
+	events := []string{}
+	c, _, vacation := newBookingConfig(&events)
+	// Persisted quota is 30 + 0, but the same row raises it to 28 + 4. The
+	// derived takeover must use the uploaded values, not the stored ones.
+	vacation.summary = &activeSvc.VacationQuotaSummary{EntitledDays: 30, CarryoverDays: 0}
+
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:         "Anna",
+		LastName:          "Lehmann",
+		VacationEntitled:  "28",
+		VacationCarryover: "4",
+		VacationRemaining: "12",
+	}
+	errs := c.Validate(t.Context(), row)
+
+	require.Empty(t, errs)
+	require.NotNil(t, row.VacationEntitledDays)
+	assert.InDelta(t, 28, *row.VacationEntitledDays, 0.0001)
+}

--- a/backend/services/import/opening_balance_import_config.go
+++ b/backend/services/import/opening_balance_import_config.go
@@ -14,6 +14,7 @@ import (
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // maxOpeningHours mirrors the ledger's carryover bound (10.000 h).
@@ -290,14 +291,28 @@ func rangeError(field, message, actual string) importModels.ValidationError {
 // parseGermanDecimal parses "12,5", "-3,25", or "7.5" into a float64.
 func parseGermanDecimal(raw string) (float64, error) {
 	normalized := strings.ReplaceAll(strings.TrimSpace(raw), ",", ".")
-	return strconv.ParseFloat(normalized, 64)
+	value, err := strconv.ParseFloat(normalized, 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, errors.New("value must be finite")
+	}
+	return value, nil
 }
 
-// ValidateBatch reports staff members appearing on more than one row.
+// ValidateBatch reports staff members appearing on more than one row. Batch
+// validation runs before per-row validation, so it resolves a sanitized copy
+// of each row rather than relying on the later Validate call to set StaffID.
 func (c *OpeningBalanceImportConfig) ValidateBatch(_ context.Context, rows []importModels.OpeningBalanceImportRow) map[int][]importModels.ValidationError {
 	seen := make(map[int64]int, len(rows))
 	errs := make(map[int][]importModels.ValidationError)
-	for i, row := range rows {
+	for i := range rows {
+		row := rows[i]
+		row.PersonnelNumber = strings.TrimSpace(row.PersonnelNumber)
+		row.FirstName = strings.TrimSpace(row.FirstName)
+		row.LastName = strings.TrimSpace(row.LastName)
+		_ = c.resolveStaff(&row)
 		if row.StaffID <= 0 {
 			continue
 		}
@@ -323,13 +338,29 @@ func (c *OpeningBalanceImportConfig) FindExisting(_ context.Context, _ importMod
 	return nil, nil
 }
 
-// Create books the sides the row carries: the Stundenkonto opening, the
-// vacation quota (Jahresanspruch/Übertrag), and the vacation takeover — in
-// that order, because the takeover derives taken_before from the quota.
+// Create books the sides the row carries atomically: the Stundenkonto opening,
+// the vacation quota (Jahresanspruch/Übertrag), and the vacation takeover —
+// in that order, because the takeover derives taken_before from the quota.
+// A failed row is reported and skipped, so its writes must be rolled back
+// without losing other valid rows from the surrounding import transaction.
 func (c *OpeningBalanceImportConfig) Create(ctx context.Context, row importModels.OpeningBalanceImportRow) (int64, error) {
 	if row.StaffID <= 0 {
 		return 0, errors.New("interner Fehler: Zeile ohne aufgelöste Person")
 	}
+
+	var createdID int64
+	err := tenant.WithSavepoint(ctx, func(ctx context.Context) error {
+		var err error
+		createdID, err = c.create(ctx, row)
+		return err
+	})
+	if err != nil {
+		return 0, err
+	}
+	return createdID, nil
+}
+
+func (c *OpeningBalanceImportConfig) create(ctx context.Context, row importModels.OpeningBalanceImportRow) (int64, error) {
 	if row.HoursBalanceMinutes != nil {
 		if _, err := c.BalanceAdjustService.CreateOpeningBalance(ctx, row.StaffID, c.DecidedByStaffID, c.EffectiveDate, *row.HoursBalanceMinutes, c.Note); err != nil {
 			return 0, translateOpeningBookingError(err)

--- a/backend/services/import/opening_balance_import_config.go
+++ b/backend/services/import/opening_balance_import_config.go
@@ -1,0 +1,395 @@
+package importpkg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	activeSvc "github.com/moto-nrw/project-phoenix/services/active"
+)
+
+// maxOpeningHours mirrors the ledger's carryover bound (10.000 h).
+const maxOpeningHours = 10_000.0
+
+// OpeningBalanceImportDeps contains the request-independent dependencies for
+// the opening balance import (#2132).
+type OpeningBalanceImportDeps struct {
+	StaffRepo            userModels.StaffRepository
+	AdjustmentRepo       activeModels.StaffBalanceAdjustmentRepository
+	VacationOpeningRepo  activeModels.StaffVacationOpeningRepository
+	BalanceAdjustService activeSvc.StaffBalanceAdjustmentService
+	StaffAbsenceService  activeSvc.StaffAbsenceService
+}
+
+// OpeningBalanceImportConfig implements ImportConfig for go-live opening
+// balances (#2132). One instance is built PER REQUEST: EffectiveDate, Note,
+// and DecidedByStaffID come from the upload form, not from the file, and the
+// preload caches are request-scoped.
+//
+// Duplicate detection happens in Validate (per side, with existing openings
+// preloaded) so the dry-run preview reports it; FindExisting always answers
+// "new" and Create books only the sides the row carries.
+type OpeningBalanceImportConfig struct {
+	OpeningBalanceImportDeps
+
+	EffectiveDate    timezone.Date
+	Note             string
+	DecidedByStaffID int64
+
+	staffByPersonnelNumber map[string]*userModels.Staff
+	staffByName            map[string][]*userModels.Staff
+	staffWithHoursOpening  map[int64]bool
+	staffWithVacOpening    map[int64]bool
+}
+
+// OpeningBalanceImportFactory builds a request-scoped import service: the
+// Stichtag, note, and acting staff member come from the upload form, so the
+// config cannot be a shared singleton like the student/staff ones.
+type OpeningBalanceImportFactory func(effectiveDate timezone.Date, note string, decidedByStaffID int64) *ImportService[importModels.OpeningBalanceImportRow]
+
+// NewOpeningBalanceImportConfig creates a request-scoped import configuration.
+func NewOpeningBalanceImportConfig(deps OpeningBalanceImportDeps, effectiveDate timezone.Date, note string, decidedByStaffID int64) *OpeningBalanceImportConfig {
+	return &OpeningBalanceImportConfig{
+		OpeningBalanceImportDeps: deps,
+		EffectiveDate:            effectiveDate,
+		Note:                     note,
+		DecidedByStaffID:         decidedByStaffID,
+	}
+}
+
+// PreloadReferenceData loads the tenant's staff (for row matching) and the
+// already-booked openings on both sides (for duplicate errors in the preview).
+func (c *OpeningBalanceImportConfig) PreloadReferenceData(ctx context.Context) error {
+	staffMembers, err := c.StaffRepo.ListAllWithPerson(ctx)
+	if err != nil {
+		return fmt.Errorf("preload staff: %w", err)
+	}
+	c.staffByPersonnelNumber = make(map[string]*userModels.Staff)
+	c.staffByName = make(map[string][]*userModels.Staff)
+	for _, staff := range staffMembers {
+		if staff.PersonnelNumber != nil {
+			if pn := strings.TrimSpace(*staff.PersonnelNumber); pn != "" {
+				c.staffByPersonnelNumber[strings.ToLower(pn)] = staff
+			}
+		}
+		if staff.Person != nil {
+			key := staffNameKey(staff.Person.FirstName, staff.Person.LastName)
+			c.staffByName[key] = append(c.staffByName[key], staff)
+		}
+	}
+
+	options := modelBase.NewQueryOptions()
+	options.Filter.Equal("type", activeModels.BalanceAdjustmentTypeOpening)
+	hoursOpenings, err := c.AdjustmentRepo.List(ctx, options)
+	if err != nil {
+		return fmt.Errorf("preload hours openings: %w", err)
+	}
+	c.staffWithHoursOpening = make(map[int64]bool, len(hoursOpenings))
+	for _, opening := range hoursOpenings {
+		c.staffWithHoursOpening[opening.StaffID] = true
+	}
+
+	vacOptions := modelBase.NewQueryOptions()
+	vacOptions.Filter.Equal("year", c.EffectiveDate.Year)
+	vacOpenings, err := c.VacationOpeningRepo.List(ctx, vacOptions)
+	if err != nil {
+		return fmt.Errorf("preload vacation openings: %w", err)
+	}
+	c.staffWithVacOpening = make(map[int64]bool, len(vacOpenings))
+	for _, opening := range vacOpenings {
+		c.staffWithVacOpening[opening.StaffID] = true
+	}
+	return nil
+}
+
+func staffNameKey(firstName, lastName string) string {
+	return strings.ToLower(strings.TrimSpace(firstName)) + "|" + strings.ToLower(strings.TrimSpace(lastName))
+}
+
+// Validate resolves the row's staff member, parses the German decimal values,
+// and reports duplicate takeovers per side.
+func (c *OpeningBalanceImportConfig) Validate(_ context.Context, row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
+	var errs []importModels.ValidationError
+
+	row.PersonnelNumber = strings.TrimSpace(row.PersonnelNumber)
+	row.FirstName = strings.TrimSpace(row.FirstName)
+	row.LastName = strings.TrimSpace(row.LastName)
+	row.HoursBalance = strings.TrimSpace(row.HoursBalance)
+	row.VacationEntitled = strings.TrimSpace(row.VacationEntitled)
+	row.VacationCarryover = strings.TrimSpace(row.VacationCarryover)
+	row.VacationRemaining = strings.TrimSpace(row.VacationRemaining)
+
+	errs = append(errs, c.resolveStaff(row)...)
+	errs = append(errs, c.parseValues(row)...)
+
+	if row.HoursBalance == "" && row.VacationEntitled == "" && row.VacationCarryover == "" && row.VacationRemaining == "" {
+		errs = append(errs, importModels.ValidationError{
+			Field:    "values",
+			Message:  "Die Zeile enthält keine Werte (Stundensaldo und Urlaubsspalten sind leer).",
+			Code:     "no_values",
+			Severity: importModels.ErrorSeverityError,
+		})
+	}
+
+	if row.StaffID > 0 {
+		if row.HoursBalanceMinutes != nil && c.staffWithHoursOpening[row.StaffID] {
+			errs = append(errs, importModels.ValidationError{
+				Field:    "hours_balance",
+				Message:  "Für diese Person existiert bereits ein Stundenkonto-Eröffnungssaldo. Zuerst die bestehende Buchung im Stundenkonto löschen.",
+				Code:     "hours_opening_exists",
+				Severity: importModels.ErrorSeverityError,
+			})
+		}
+		if row.VacationRemainingDays != nil && c.staffWithVacOpening[row.StaffID] {
+			errs = append(errs, importModels.ValidationError{
+				Field:    "vacation_remaining",
+				Message:  fmt.Sprintf("Für diese Person existiert bereits eine Urlaubs-Übernahme für %d. Zuerst die bestehende Übernahme löschen.", c.EffectiveDate.Year),
+				Code:     "vacation_opening_exists",
+				Severity: importModels.ErrorSeverityError,
+			})
+		}
+	}
+
+	return errs
+}
+
+// resolveStaff matches the row to a staff member: exact Personalnummer first,
+// then a unique first + last name match.
+func (c *OpeningBalanceImportConfig) resolveStaff(row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
+	if row.PersonnelNumber != "" {
+		staff, ok := c.staffByPersonnelNumber[strings.ToLower(row.PersonnelNumber)]
+		if !ok {
+			return []importModels.ValidationError{{
+				Field:       "personnel_number",
+				Message:     fmt.Sprintf("Personalnummer '%s' wurde keiner Person zugeordnet.", row.PersonnelNumber),
+				Code:        "personnel_number_not_found",
+				Severity:    importModels.ErrorSeverityError,
+				ActualValue: row.PersonnelNumber,
+			}}
+		}
+		row.StaffID = staff.ID
+		return nil
+	}
+
+	if row.FirstName == "" || row.LastName == "" {
+		return []importModels.ValidationError{{
+			Field:    "name",
+			Message:  "Vorname und Nachname sind erforderlich (oder eine Personalnummer).",
+			Code:     "required",
+			Severity: importModels.ErrorSeverityError,
+		}}
+	}
+	matches := c.staffByName[staffNameKey(row.FirstName, row.LastName)]
+	switch len(matches) {
+	case 0:
+		return []importModels.ValidationError{{
+			Field:       "name",
+			Message:     fmt.Sprintf("'%s %s' wurde nicht gefunden. Die Person muss vor dem Import angelegt sein.", row.FirstName, row.LastName),
+			Code:        "staff_not_found",
+			Severity:    importModels.ErrorSeverityError,
+			ActualValue: row.FirstName + " " + row.LastName,
+		}}
+	case 1:
+		row.StaffID = matches[0].ID
+		return nil
+	default:
+		return []importModels.ValidationError{{
+			Field:    "name",
+			Message:  fmt.Sprintf("'%s %s' ist mehrdeutig (%d Treffer). Bitte die Personalnummer angeben.", row.FirstName, row.LastName, len(matches)),
+			Code:     "staff_ambiguous",
+			Severity: importModels.ErrorSeverityError,
+		}}
+	}
+}
+
+// parseValues parses the value columns (German decimals, signed where the
+// business allows it) into the typed row fields.
+func (c *OpeningBalanceImportConfig) parseValues(row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
+	var errs []importModels.ValidationError
+
+	if row.HoursBalance != "" {
+		hours, err := parseGermanDecimal(row.HoursBalance)
+		switch {
+		case err != nil:
+			errs = append(errs, decimalError("hours_balance", "Stundensaldo", row.HoursBalance))
+		case math.Abs(hours) > maxOpeningHours:
+			errs = append(errs, rangeError("hours_balance", fmt.Sprintf("Stundensaldo muss zwischen -%.0f und %.0f Stunden liegen.", maxOpeningHours, maxOpeningHours), row.HoursBalance))
+		default:
+			minutes := int(math.Round(hours * 60))
+			row.HoursBalanceMinutes = &minutes
+		}
+	}
+
+	if row.VacationEntitled != "" {
+		entitled, err := parseGermanDecimal(row.VacationEntitled)
+		switch {
+		case err != nil:
+			errs = append(errs, decimalError("vacation_entitled", "Jahresanspruch", row.VacationEntitled))
+		case entitled < 0 || entitled > 366:
+			errs = append(errs, rangeError("vacation_entitled", "Jahresanspruch muss zwischen 0 und 366 Tagen liegen.", row.VacationEntitled))
+		default:
+			row.VacationEntitledDays = &entitled
+		}
+	}
+
+	if row.VacationCarryover != "" {
+		carryover, err := parseGermanDecimal(row.VacationCarryover)
+		switch {
+		case err != nil:
+			errs = append(errs, decimalError("vacation_carryover", "Vorjahresübertrag", row.VacationCarryover))
+		case carryover < 0 || carryover > 366:
+			errs = append(errs, rangeError("vacation_carryover", "Vorjahresübertrag muss zwischen 0 und 366 Tagen liegen.", row.VacationCarryover))
+		default:
+			row.VacationCarryoverDays = &carryover
+		}
+	}
+
+	if row.VacationRemaining != "" {
+		remaining, err := parseGermanDecimal(row.VacationRemaining)
+		switch {
+		case err != nil:
+			errs = append(errs, decimalError("vacation_remaining", "Resturlaub", row.VacationRemaining))
+		case math.Abs(remaining) > 999:
+			errs = append(errs, rangeError("vacation_remaining", "Resturlaub muss zwischen -999 und 999 Tagen liegen.", row.VacationRemaining))
+		default:
+			row.VacationRemainingDays = &remaining
+		}
+	}
+
+	return errs
+}
+
+func decimalError(field, label, actual string) importModels.ValidationError {
+	return importModels.ValidationError{
+		Field:       field,
+		Message:     fmt.Sprintf("%s '%s' ist keine gültige Zahl (z. B. 12,5 oder -3,25).", label, actual),
+		Code:        "invalid_number",
+		Severity:    importModels.ErrorSeverityError,
+		ActualValue: actual,
+	}
+}
+
+func rangeError(field, message, actual string) importModels.ValidationError {
+	return importModels.ValidationError{
+		Field:       field,
+		Message:     message,
+		Code:        "out_of_range",
+		Severity:    importModels.ErrorSeverityError,
+		ActualValue: actual,
+	}
+}
+
+// parseGermanDecimal parses "12,5", "-3,25", or "7.5" into a float64.
+func parseGermanDecimal(raw string) (float64, error) {
+	normalized := strings.ReplaceAll(strings.TrimSpace(raw), ",", ".")
+	return strconv.ParseFloat(normalized, 64)
+}
+
+// ValidateBatch reports staff members appearing on more than one row.
+func (c *OpeningBalanceImportConfig) ValidateBatch(_ context.Context, rows []importModels.OpeningBalanceImportRow) map[int][]importModels.ValidationError {
+	seen := make(map[int64]int, len(rows))
+	errs := make(map[int][]importModels.ValidationError)
+	for i, row := range rows {
+		if row.StaffID <= 0 {
+			continue
+		}
+		if firstRow, ok := seen[row.StaffID]; ok {
+			errs[i] = append(errs[i], importModels.ValidationError{
+				Field:    "name",
+				Message:  fmt.Sprintf("'%s %s' ist doppelt in der Importdatei vorhanden (erste Zeile: %d).", row.FirstName, row.LastName, firstRow+2),
+				Code:     "duplicate_in_file",
+				Severity: importModels.ErrorSeverityError,
+			})
+			continue
+		}
+		seen[row.StaffID] = i
+	}
+	return errs
+}
+
+// FindExisting always answers "new": duplicate takeovers are reported per
+// side in Validate so the preview shows them, and re-imports for the SAME
+// person with a different side (hours booked earlier, vacation now) must not
+// be blocked wholesale.
+func (c *OpeningBalanceImportConfig) FindExisting(_ context.Context, _ importModels.OpeningBalanceImportRow) (*int64, error) {
+	return nil, nil
+}
+
+// Create books the sides the row carries: the Stundenkonto opening, the
+// vacation quota (Jahresanspruch/Übertrag), and the vacation takeover — in
+// that order, because the takeover derives taken_before from the quota.
+func (c *OpeningBalanceImportConfig) Create(ctx context.Context, row importModels.OpeningBalanceImportRow) (int64, error) {
+	if row.StaffID <= 0 {
+		return 0, errors.New("interner Fehler: Zeile ohne aufgelöste Person")
+	}
+	if row.HoursBalanceMinutes != nil {
+		if _, err := c.BalanceAdjustService.CreateOpeningBalance(ctx, row.StaffID, c.DecidedByStaffID, c.EffectiveDate, *row.HoursBalanceMinutes, c.Note); err != nil {
+			return 0, translateOpeningBookingError(err)
+		}
+	}
+	if row.VacationEntitledDays != nil || row.VacationCarryoverDays != nil {
+		summary, err := c.StaffAbsenceService.GetVacationQuotaSummary(ctx, row.StaffID, c.EffectiveDate.Year)
+		if err != nil {
+			return 0, fmt.Errorf("urlaubskonto konnte nicht gelesen werden: %w", err)
+		}
+		entitled, carryover := summary.EntitledDays, summary.CarryoverDays
+		if row.VacationEntitledDays != nil {
+			entitled = *row.VacationEntitledDays
+		}
+		if row.VacationCarryoverDays != nil {
+			carryover = *row.VacationCarryoverDays
+		}
+		if err := c.StaffAbsenceService.UpsertVacationQuota(ctx, row.StaffID, c.EffectiveDate.Year, entitled, carryover); err != nil {
+			return 0, fmt.Errorf("urlaubsanspruch konnte nicht gespeichert werden: %w", err)
+		}
+	}
+	if row.VacationRemainingDays != nil {
+		if _, err := c.StaffAbsenceService.SetVacationOpening(ctx, row.StaffID, c.DecidedByStaffID, activeSvc.SetVacationOpeningRequest{
+			EffectiveDate: c.EffectiveDate,
+			RemainingDays: *row.VacationRemainingDays,
+			Note:          c.Note,
+		}); err != nil {
+			return 0, translateOpeningBookingError(err)
+		}
+	}
+	return row.StaffID, nil
+}
+
+// translateOpeningBookingError maps the booking sentinels to German messages
+// — the generic import service embeds the error text verbatim in the
+// per-row "Fehler beim Erstellen" message.
+func translateOpeningBookingError(err error) error {
+	switch {
+	case errors.Is(err, activeSvc.ErrOpeningAlreadyExists):
+		return errors.New("für diese Person existiert bereits ein Stundenkonto-Eröffnungssaldo")
+	case errors.Is(err, activeSvc.ErrVacationOpeningExists):
+		return errors.New("für diese Person existiert bereits eine Urlaubs-Übernahme in diesem Jahr")
+	case errors.Is(err, activeSvc.ErrVacationOpeningAbsencesBeforeCutoff):
+		return errors.New("es existieren bereits Urlaubs-Abwesenheiten vor dem Stichtag — Übernahme würde doppelt zählen")
+	case errors.Is(err, activeSvc.ErrAdjustmentInClosedMonth):
+		return errors.New("der Monat des Stichtags ist bereits abgeschlossen")
+	case errors.Is(err, activeSvc.ErrAdjustmentHasDependentReset):
+		return errors.New("es existieren bereits spätere Stundenkonto-Buchungen (Reset), die vom Stichtag abhängen")
+	default:
+		return err
+	}
+}
+
+// Update is a no-op: the import is create-only; corrections go through the
+// per-person UI (delete + re-create with tombstone).
+func (c *OpeningBalanceImportConfig) Update(_ context.Context, _ int64, _ importModels.OpeningBalanceImportRow) error {
+	return nil
+}
+
+// EntityName returns the entity type name for logging and error messages.
+func (c *OpeningBalanceImportConfig) EntityName() string {
+	return "Eröffnungssaldo"
+}

--- a/backend/services/import/opening_balance_import_config.go
+++ b/backend/services/import/opening_balance_import_config.go
@@ -117,7 +117,7 @@ func staffNameKey(firstName, lastName string) string {
 
 // Validate resolves the row's staff member, parses the German decimal values,
 // and reports duplicate takeovers per side.
-func (c *OpeningBalanceImportConfig) Validate(_ context.Context, row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
+func (c *OpeningBalanceImportConfig) Validate(ctx context.Context, row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
 	var errs []importModels.ValidationError
 
 	row.PersonnelNumber = strings.TrimSpace(row.PersonnelNumber)
@@ -130,6 +130,8 @@ func (c *OpeningBalanceImportConfig) Validate(_ context.Context, row *importMode
 
 	errs = append(errs, c.resolveStaff(row)...)
 	errs = append(errs, c.parseValues(row)...)
+	errs = append(errs, c.validateOpeningBalancePreflight(ctx, row)...)
+	errs = append(errs, c.validateDerivedVacationOpening(ctx, row)...)
 
 	if row.HoursBalance == "" && row.VacationEntitled == "" && row.VacationCarryover == "" && row.VacationRemaining == "" {
 		errs = append(errs, importModels.ValidationError{
@@ -160,6 +162,73 @@ func (c *OpeningBalanceImportConfig) Validate(_ context.Context, row *importMode
 	}
 
 	return errs
+}
+
+type openingBalancePreflightValidator interface {
+	ValidateOpeningBalance(context.Context, int64, int64, timezone.Date, int, string) error
+}
+
+func (c *OpeningBalanceImportConfig) validateOpeningBalancePreflight(ctx context.Context, row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
+	if row.StaffID <= 0 || row.HoursBalanceMinutes == nil {
+		return nil
+	}
+	validator, ok := c.BalanceAdjustService.(openingBalancePreflightValidator)
+	if !ok {
+		return nil
+	}
+	if err := validator.ValidateOpeningBalance(ctx, row.StaffID, c.DecidedByStaffID, c.EffectiveDate, *row.HoursBalanceMinutes, c.Note); err != nil {
+		return []importModels.ValidationError{{
+			Field:    "hours_balance",
+			Message:  fmt.Sprintf("Stundenkonto-Eröffnungssaldo kann nicht gebucht werden: %s", translateOpeningBookingError(err)),
+			Code:     "opening_preflight_failed",
+			Severity: importModels.ErrorSeverityError,
+		}}
+	}
+	return nil
+}
+
+// validateDerivedVacationOpening mirrors the model check that SetVacationOpening
+// performs after deriving taken_before_days. The import may replace either
+// quota component in the same row, so validation must use those supplied
+// values rather than only the currently persisted quota.
+func (c *OpeningBalanceImportConfig) validateDerivedVacationOpening(ctx context.Context, row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
+	if row.StaffID <= 0 || row.VacationRemainingDays == nil || c.StaffAbsenceService == nil {
+		return nil
+	}
+	summary, err := c.StaffAbsenceService.GetVacationQuotaSummary(ctx, row.StaffID, c.EffectiveDate.Year)
+	if err != nil {
+		return []importModels.ValidationError{{
+			Field:    "vacation_remaining",
+			Message:  "Urlaubskonto konnte nicht für die Übernahme geprüft werden.",
+			Code:     "vacation_quota_lookup_failed",
+			Severity: importModels.ErrorSeverityError,
+		}}
+	}
+	entitled, carryover := summary.EntitledDays, summary.CarryoverDays
+	if row.VacationEntitledDays != nil {
+		entitled = *row.VacationEntitledDays
+	}
+	if row.VacationCarryoverDays != nil {
+		carryover = *row.VacationCarryoverDays
+	}
+	opening := &activeModels.StaffVacationOpening{
+		StaffID:              row.StaffID,
+		Year:                 c.EffectiveDate.Year,
+		EffectiveDate:        c.EffectiveDate,
+		TakenBeforeDays:      entitled + carryover - *row.VacationRemainingDays,
+		EnteredRemainingDays: *row.VacationRemainingDays,
+		DecidedBy:            c.DecidedByStaffID,
+	}
+	if err := opening.Validate(); err != nil {
+		return []importModels.ValidationError{{
+			Field:       "vacation_remaining",
+			Message:     fmt.Sprintf("Resturlaub ist mit Jahresanspruch und Übertrag nicht gültig: %s.", err.Error()),
+			Code:        "invalid_vacation_opening",
+			Severity:    importModels.ErrorSeverityError,
+			ActualValue: row.VacationRemaining,
+		}}
+	}
+	return nil
 }
 
 // resolveStaff matches the row to a staff member: exact Personalnummer first,
@@ -234,6 +303,8 @@ func (c *OpeningBalanceImportConfig) parseValues(row *importModels.OpeningBalanc
 		switch {
 		case err != nil:
 			errs = append(errs, decimalError("vacation_entitled", "Jahresanspruch", row.VacationEntitled))
+		case !hasOneDecimalPlace(entitled):
+			errs = append(errs, precisionError("vacation_entitled", "Jahresanspruch", row.VacationEntitled))
 		case entitled < 0 || entitled > 366:
 			errs = append(errs, rangeError("vacation_entitled", "Jahresanspruch muss zwischen 0 und 366 Tagen liegen.", row.VacationEntitled))
 		default:
@@ -246,6 +317,8 @@ func (c *OpeningBalanceImportConfig) parseValues(row *importModels.OpeningBalanc
 		switch {
 		case err != nil:
 			errs = append(errs, decimalError("vacation_carryover", "Vorjahresübertrag", row.VacationCarryover))
+		case !hasOneDecimalPlace(carryover):
+			errs = append(errs, precisionError("vacation_carryover", "Vorjahresübertrag", row.VacationCarryover))
 		case carryover < 0 || carryover > 366:
 			errs = append(errs, rangeError("vacation_carryover", "Vorjahresübertrag muss zwischen 0 und 366 Tagen liegen.", row.VacationCarryover))
 		default:
@@ -258,6 +331,8 @@ func (c *OpeningBalanceImportConfig) parseValues(row *importModels.OpeningBalanc
 		switch {
 		case err != nil:
 			errs = append(errs, decimalError("vacation_remaining", "Resturlaub", row.VacationRemaining))
+		case !hasOneDecimalPlace(remaining):
+			errs = append(errs, precisionError("vacation_remaining", "Resturlaub", row.VacationRemaining))
 		case math.Abs(remaining) > 999:
 			errs = append(errs, rangeError("vacation_remaining", "Resturlaub muss zwischen -999 und 999 Tagen liegen.", row.VacationRemaining))
 		default:
@@ -268,11 +343,25 @@ func (c *OpeningBalanceImportConfig) parseValues(row *importModels.OpeningBalanc
 	return errs
 }
 
+func hasOneDecimalPlace(value float64) bool {
+	return math.Abs(value*10-math.Round(value*10)) < 1e-9
+}
+
 func decimalError(field, label, actual string) importModels.ValidationError {
 	return importModels.ValidationError{
 		Field:       field,
 		Message:     fmt.Sprintf("%s '%s' ist keine gültige Zahl (z. B. 12,5 oder -3,25).", label, actual),
 		Code:        "invalid_number",
+		Severity:    importModels.ErrorSeverityError,
+		ActualValue: actual,
+	}
+}
+
+func precisionError(field, label, actual string) importModels.ValidationError {
+	return importModels.ValidationError{
+		Field:       field,
+		Message:     fmt.Sprintf("%s '%s' darf höchstens eine Nachkommastelle haben.", label, actual),
+		Code:        "invalid_precision",
 		Severity:    importModels.ErrorSeverityError,
 		ActualValue: actual,
 	}

--- a/backend/services/import/opening_balance_import_config.go
+++ b/backend/services/import/opening_balance_import_config.go
@@ -21,14 +21,39 @@ import (
 // maxOpeningHours mirrors the ledger's carryover bound (10.000 h).
 const maxOpeningHours = 10_000.0
 
+// OpeningBalanceBooker is the slice of the Stundenkonto ledger the import
+// needs: validate a row for the preview, book it on apply.
+type OpeningBalanceBooker interface {
+	ValidateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) error
+	CreateOpeningBalance(ctx context.Context, staffID, decidedBy int64, effectiveDate timezone.Date, balanceMinutes int, note string) (*activeModels.StaffBalanceAdjustment, error)
+}
+
+// VacationTakeoverBooker is the slice of the absence service the import needs:
+// read and write the quota the takeover derives from, plus the takeover row
+// itself and its read-only preview guard.
+type VacationTakeoverBooker interface {
+	GetVacationQuotaSummary(ctx context.Context, staffID int64, year int) (*activeSvc.VacationQuotaSummary, error)
+	UpsertVacationQuota(ctx context.Context, staffID int64, year int, entitled, carryover float64) error
+	SetVacationOpening(ctx context.Context, staffID, decidedBy int64, req activeSvc.SetVacationOpeningRequest) (*activeModels.StaffVacationOpening, error)
+	ValidateVacationOpeningAbsencesBefore(ctx context.Context, staffID int64, effectiveDate timezone.Date) error
+}
+
+// openingRowLister is the read side of a ledger repository: the preload only
+// lists already-booked openings so the preview can report duplicates.
+type openingRowLister[T any] interface {
+	List(ctx context.Context, options *modelBase.QueryOptions) ([]T, error)
+}
+
 // OpeningBalanceImportDeps contains the request-independent dependencies for
-// the opening balance import (#2132).
+// the opening balance import (#2132). The service dependencies are declared as
+// the narrow slices used here rather than the full service interfaces — the
+// import consumes four ledger operations, not the absence workflow.
 type OpeningBalanceImportDeps struct {
 	StaffRepo            userModels.StaffRepository
-	AdjustmentRepo       activeModels.StaffBalanceAdjustmentRepository
-	VacationOpeningRepo  activeModels.StaffVacationOpeningRepository
-	BalanceAdjustService activeSvc.StaffBalanceAdjustmentService
-	StaffAbsenceService  activeSvc.StaffAbsenceService
+	AdjustmentRepo       openingRowLister[*activeModels.StaffBalanceAdjustment]
+	VacationOpeningRepo  openingRowLister[*activeModels.StaffVacationOpening]
+	BalanceAdjustService OpeningBalanceBooker
+	StaffAbsenceService  VacationTakeoverBooker
 }
 
 // OpeningBalanceImportConfig implements ImportConfig for go-live opening
@@ -165,19 +190,11 @@ func (c *OpeningBalanceImportConfig) Validate(ctx context.Context, row *importMo
 	return errs
 }
 
-type openingBalancePreflightValidator interface {
-	ValidateOpeningBalance(context.Context, int64, int64, timezone.Date, int, string) error
-}
-
 func (c *OpeningBalanceImportConfig) validateOpeningBalancePreflight(ctx context.Context, row *importModels.OpeningBalanceImportRow) []importModels.ValidationError {
-	if row.StaffID <= 0 || row.HoursBalanceMinutes == nil {
+	if row.StaffID <= 0 || row.HoursBalanceMinutes == nil || c.BalanceAdjustService == nil {
 		return nil
 	}
-	validator, ok := c.BalanceAdjustService.(openingBalancePreflightValidator)
-	if !ok {
-		return nil
-	}
-	if err := validator.ValidateOpeningBalance(ctx, row.StaffID, c.DecidedByStaffID, c.EffectiveDate, *row.HoursBalanceMinutes, c.Note); err != nil {
+	if err := c.BalanceAdjustService.ValidateOpeningBalance(ctx, row.StaffID, c.DecidedByStaffID, c.EffectiveDate, *row.HoursBalanceMinutes, c.Note); err != nil {
 		return []importModels.ValidationError{{
 			Field:    "hours_balance",
 			Message:  fmt.Sprintf("Stundenkonto-Eröffnungssaldo kann nicht gebucht werden: %s", translateOpeningBookingError(err)),
@@ -229,17 +246,13 @@ func (c *OpeningBalanceImportConfig) validateDerivedVacationOpening(ctx context.
 			ActualValue: row.VacationRemaining,
 		}}
 	}
-	if validator, ok := c.StaffAbsenceService.(interface {
-		ValidateVacationOpeningAbsencesBefore(context.Context, int64, timezone.Date) error
-	}); ok {
-		if err := validator.ValidateVacationOpeningAbsencesBefore(ctx, row.StaffID, c.EffectiveDate); err != nil {
-			return []importModels.ValidationError{{
-				Field:    "vacation_remaining",
-				Message:  fmt.Sprintf("Urlaubs-Übernahme kann nicht gebucht werden: %s", translateOpeningBookingError(err)),
-				Code:     "vacation_opening_preflight_failed",
-				Severity: importModels.ErrorSeverityError,
-			}}
-		}
+	if err := c.StaffAbsenceService.ValidateVacationOpeningAbsencesBefore(ctx, row.StaffID, c.EffectiveDate); err != nil {
+		return []importModels.ValidationError{{
+			Field:    "vacation_remaining",
+			Message:  fmt.Sprintf("Urlaubs-Übernahme kann nicht gebucht werden: %s", translateOpeningBookingError(err)),
+			Code:     "vacation_opening_preflight_failed",
+			Severity: importModels.ErrorSeverityError,
+		}}
 	}
 	return nil
 }
@@ -490,21 +503,8 @@ func (c *OpeningBalanceImportConfig) create(ctx context.Context, row importModel
 			return 0, translateOpeningBookingError(err)
 		}
 	}
-	if row.VacationEntitledDays != nil || row.VacationCarryoverDays != nil {
-		summary, err := c.StaffAbsenceService.GetVacationQuotaSummary(ctx, row.StaffID, c.EffectiveDate.Year)
-		if err != nil {
-			return 0, fmt.Errorf("urlaubskonto konnte nicht gelesen werden: %w", err)
-		}
-		entitled, carryover := summary.EntitledDays, summary.CarryoverDays
-		if row.VacationEntitledDays != nil {
-			entitled = *row.VacationEntitledDays
-		}
-		if row.VacationCarryoverDays != nil {
-			carryover = *row.VacationCarryoverDays
-		}
-		if err := c.StaffAbsenceService.UpsertVacationQuota(ctx, row.StaffID, c.EffectiveDate.Year, entitled, carryover); err != nil {
-			return 0, fmt.Errorf("urlaubsanspruch konnte nicht gespeichert werden: %w", err)
-		}
+	if err := c.applyVacationQuota(ctx, row); err != nil {
+		return 0, err
 	}
 	if row.VacationRemainingDays != nil {
 		if _, err := c.StaffAbsenceService.SetVacationOpening(ctx, row.StaffID, c.DecidedByStaffID, activeSvc.SetVacationOpeningRequest{
@@ -516,6 +516,30 @@ func (c *OpeningBalanceImportConfig) create(ctx context.Context, row importModel
 		}
 	}
 	return row.StaffID, nil
+}
+
+// applyVacationQuota writes the Jahresanspruch/Übertrag columns. An empty
+// cell leaves that side of the quota untouched, so the current value is read
+// first and only the supplied columns are overwritten.
+func (c *OpeningBalanceImportConfig) applyVacationQuota(ctx context.Context, row importModels.OpeningBalanceImportRow) error {
+	if row.VacationEntitledDays == nil && row.VacationCarryoverDays == nil {
+		return nil
+	}
+	summary, err := c.StaffAbsenceService.GetVacationQuotaSummary(ctx, row.StaffID, c.EffectiveDate.Year)
+	if err != nil {
+		return fmt.Errorf("urlaubskonto konnte nicht gelesen werden: %w", err)
+	}
+	entitled, carryover := summary.EntitledDays, summary.CarryoverDays
+	if row.VacationEntitledDays != nil {
+		entitled = *row.VacationEntitledDays
+	}
+	if row.VacationCarryoverDays != nil {
+		carryover = *row.VacationCarryoverDays
+	}
+	if err := c.StaffAbsenceService.UpsertVacationQuota(ctx, row.StaffID, c.EffectiveDate.Year, entitled, carryover); err != nil {
+		return fmt.Errorf("urlaubsanspruch konnte nicht gespeichert werden: %w", err)
+	}
+	return nil
 }
 
 // translateOpeningBookingError maps the booking sentinels to German messages

--- a/backend/services/import/opening_balance_import_config.go
+++ b/backend/services/import/opening_balance_import_config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -429,6 +430,28 @@ func (c *OpeningBalanceImportConfig) ValidateBatch(_ context.Context, rows []imp
 		seen[row.StaffID] = i
 	}
 	return errs
+}
+
+// ProcessingOrder acquires the transaction-scoped per-staff locks in a stable
+// order. Concurrent uploads containing the same staff in different file
+// orders therefore cannot deadlock. Resolution uses copies, leaving normal
+// validation to report errors against the original upload rows.
+func (c *OpeningBalanceImportConfig) ProcessingOrder(rows []importModels.OpeningBalanceImportRow) []int {
+	order := make([]int, len(rows))
+	staffIDs := make([]int64, len(rows))
+	for i := range rows {
+		order[i] = i
+		row := rows[i]
+		row.PersonnelNumber = strings.TrimSpace(row.PersonnelNumber)
+		row.FirstName = strings.TrimSpace(row.FirstName)
+		row.LastName = strings.TrimSpace(row.LastName)
+		_ = c.resolveStaff(&row)
+		staffIDs[i] = row.StaffID
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		return staffIDs[order[i]] < staffIDs[order[j]]
+	})
+	return order
 }
 
 // FindExisting always answers "new": duplicate takeovers are reported per

--- a/backend/services/import/opening_balance_import_config.go
+++ b/backend/services/import/opening_balance_import_config.go
@@ -228,6 +228,18 @@ func (c *OpeningBalanceImportConfig) validateDerivedVacationOpening(ctx context.
 			ActualValue: row.VacationRemaining,
 		}}
 	}
+	if validator, ok := c.StaffAbsenceService.(interface {
+		ValidateVacationOpeningAbsencesBefore(context.Context, int64, timezone.Date) error
+	}); ok {
+		if err := validator.ValidateVacationOpeningAbsencesBefore(ctx, row.StaffID, c.EffectiveDate); err != nil {
+			return []importModels.ValidationError{{
+				Field:    "vacation_remaining",
+				Message:  fmt.Sprintf("Urlaubs-Übernahme kann nicht gebucht werden: %s", translateOpeningBookingError(err)),
+				Code:     "vacation_opening_preflight_failed",
+				Severity: importModels.ErrorSeverityError,
+			}}
+		}
+	}
 	return nil
 }
 

--- a/backend/services/import/opening_balance_import_config_test.go
+++ b/backend/services/import/opening_balance_import_config_test.go
@@ -91,6 +91,9 @@ func TestParseGermanDecimal(t *testing.T) {
 		{raw: " 12,5 ", want: 12.5},
 		{raw: "abc", wantErr: true},
 		{raw: "", wantErr: true},
+		{raw: "NaN", wantErr: true},
+		{raw: "+Inf", wantErr: true},
+		{raw: "-Inf", wantErr: true},
 		// The German thousands separator is NOT supported — "1.234,5" would
 		// silently become an invalid float rather than 1234,5.
 		{raw: "1.234,5", wantErr: true},
@@ -368,9 +371,9 @@ func TestOpeningBalanceValidate_AcceptsCompleteRow(t *testing.T) {
 func TestOpeningBalanceValidateBatch_DuplicateStaffInFile(t *testing.T) {
 	c := newOpeningConfig()
 	rows := []importModels.OpeningBalanceImportRow{
-		{FirstName: "Anna", LastName: "Lehmann", StaffID: openingStaffAnnaID},
-		{FirstName: "Bernd", LastName: "Schulz", StaffID: openingStaffBerndID},
-		{FirstName: "Anna", LastName: "Lehmann", StaffID: openingStaffAnnaID},
+		{FirstName: "Anna", LastName: "Lehmann"},
+		{FirstName: "Bernd", LastName: "Schulz"},
+		{FirstName: " Anna ", LastName: " Lehmann "},
 	}
 
 	errs := c.ValidateBatch(context.Background(), rows)

--- a/backend/services/import/opening_balance_import_config_test.go
+++ b/backend/services/import/opening_balance_import_config_test.go
@@ -237,31 +237,43 @@ func TestOpeningBalanceValidate_OutOfRangeValues(t *testing.T) {
 		name  string
 		row   importModels.OpeningBalanceImportRow
 		field string
+		code  string
 	}{
 		{
 			name:  "Jahresanspruch über 366 Tagen",
 			row:   importModels.OpeningBalanceImportRow{VacationEntitled: "400"},
 			field: "vacation_entitled",
+			code:  "out_of_range",
 		},
 		{
 			name:  "negativer Jahresanspruch",
 			row:   importModels.OpeningBalanceImportRow{VacationEntitled: "-1"},
 			field: "vacation_entitled",
+			code:  "out_of_range",
 		},
 		{
 			name:  "negativer Vorjahresübertrag",
 			row:   importModels.OpeningBalanceImportRow{VacationCarryover: "-1"},
 			field: "vacation_carryover",
+			code:  "out_of_range",
 		},
 		{
 			name:  "Stundensaldo über der Ledger-Grenze",
 			row:   importModels.OpeningBalanceImportRow{HoursBalance: "10001"},
 			field: "hours_balance",
+			code:  "out_of_range",
 		},
 		{
 			name:  "Resturlaub außerhalb ±999",
 			row:   importModels.OpeningBalanceImportRow{VacationRemaining: "1000"},
 			field: "vacation_remaining",
+			code:  "out_of_range",
+		},
+		{
+			name:  "Resturlaub mit mehr als einer Nachkommastelle",
+			row:   importModels.OpeningBalanceImportRow{VacationRemaining: "12,25"},
+			field: "vacation_remaining",
+			code:  "invalid_precision",
 		},
 	}
 
@@ -275,7 +287,7 @@ func TestOpeningBalanceValidate_OutOfRangeValues(t *testing.T) {
 			errs := c.Validate(context.Background(), &row)
 
 			require.Len(t, errs, 1)
-			assert.Equal(t, "out_of_range", errs[0].Code)
+			assert.Equal(t, tc.code, errs[0].Code)
 			assert.Equal(t, tc.field, errs[0].Field)
 		})
 	}

--- a/backend/services/import/opening_balance_import_config_test.go
+++ b/backend/services/import/opening_balance_import_config_test.go
@@ -120,6 +120,17 @@ func TestOpeningBalanceValidate_RowWithoutValues(t *testing.T) {
 	assert.Equal(t, openingStaffAnnaID, row.StaffID, "the person still resolves")
 }
 
+func TestOpeningBalanceProcessingOrder_SortsResolvedStaffIDs(t *testing.T) {
+	c := newOpeningConfig()
+	rows := []importModels.OpeningBalanceImportRow{
+		{PersonnelNumber: "P-100", HoursBalance: "1"},
+		{FirstName: "Bernd", LastName: "Schulz", HoursBalance: "1"},
+		{PersonnelNumber: "unknown", HoursBalance: "1"},
+	}
+
+	assert.Equal(t, []int{2, 0, 1}, c.ProcessingOrder(rows))
+}
+
 func TestOpeningBalanceValidate_UnknownPersonnelNumber(t *testing.T) {
 	c := newOpeningConfig()
 	row := &importModels.OpeningBalanceImportRow{

--- a/backend/services/import/opening_balance_import_config_test.go
+++ b/backend/services/import/opening_balance_import_config_test.go
@@ -1,0 +1,420 @@
+package importpkg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Opening balance import validation (#2132). These are pure unit tests: the
+// preload caches are the only state Validate/ValidateBatch read, so the test
+// sets them directly instead of going through PreloadReferenceData and a
+// database.
+
+// Fake staff IDs — in-memory map keys, never DB rows.
+const (
+	openingStaffAnnaID    = int64(9101)
+	openingStaffBerndID   = int64(9102)
+	openingStaffTwinAID   = int64(9103)
+	openingStaffTwinBID   = int64(9104)
+	openingDecidedByID    = int64(9105)
+	openingEffectiveYear  = 2026
+	openingEffectiveMonth = time.March
+	openingEffectiveDay   = 1
+)
+
+func openingStaff(id int64, personnelNumber, firstName, lastName string) *userModels.Staff {
+	staff := &userModels.Staff{
+		Person: &userModels.Person{FirstName: firstName, LastName: lastName},
+	}
+	staff.ID = id
+	if personnelNumber != "" {
+		pn := personnelNumber
+		staff.PersonnelNumber = &pn
+	}
+	return staff
+}
+
+// newOpeningConfig builds a config with the preload caches already populated:
+// Anna (with Personalnummer), Bernd (name only), and two staff members sharing
+// one name to exercise the ambiguity branch.
+func newOpeningConfig() *OpeningBalanceImportConfig {
+	anna := openingStaff(openingStaffAnnaID, "P-100", "Anna", "Lehmann")
+	bernd := openingStaff(openingStaffBerndID, "", "Bernd", "Schulz")
+	twinA := openingStaff(openingStaffTwinAID, "P-200", "Maria", "Müller")
+	twinB := openingStaff(openingStaffTwinBID, "P-201", "Maria", "Müller")
+
+	return &OpeningBalanceImportConfig{
+		EffectiveDate:    timezone.NewDate(openingEffectiveYear, openingEffectiveMonth, openingEffectiveDay),
+		Note:             "Übernahme aus Altsystem",
+		DecidedByStaffID: openingDecidedByID,
+		staffByPersonnelNumber: map[string]*userModels.Staff{
+			"p-100": anna,
+			"p-200": twinA,
+			"p-201": twinB,
+		},
+		staffByName: map[string][]*userModels.Staff{
+			staffNameKey("Anna", "Lehmann"): {anna},
+			staffNameKey("Bernd", "Schulz"): {bernd},
+			staffNameKey("Maria", "Müller"): {twinA, twinB},
+		},
+		staffWithHoursOpening: map[int64]bool{},
+		staffWithVacOpening:   map[int64]bool{},
+	}
+}
+
+// errorCodes reduces a validation result to its codes for readable assertions.
+func errorCodes(errs []importModels.ValidationError) []string {
+	codes := make([]string, 0, len(errs))
+	for _, e := range errs {
+		codes = append(codes, e.Code)
+	}
+	return codes
+}
+
+func TestParseGermanDecimal(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    float64
+		wantErr bool
+	}{
+		{raw: "12,5", want: 12.5},
+		{raw: "-3,25", want: -3.25},
+		{raw: "7.5", want: 7.5},
+		{raw: "0", want: 0},
+		{raw: " 12,5 ", want: 12.5},
+		{raw: "abc", wantErr: true},
+		{raw: "", wantErr: true},
+		// The German thousands separator is NOT supported — "1.234,5" would
+		// silently become an invalid float rather than 1234,5.
+		{raw: "1.234,5", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		got, err := parseGermanDecimal(tc.raw)
+		if tc.wantErr {
+			assert.Error(t, err, "raw %q must not parse", tc.raw)
+			continue
+		}
+		require.NoError(t, err, "raw %q", tc.raw)
+		assert.InDelta(t, tc.want, got, 0.0001, "raw %q", tc.raw)
+	}
+}
+
+func TestOpeningBalanceValidate_RowWithoutValues(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{FirstName: "Anna", LastName: "Lehmann"}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Contains(t, errorCodes(errs), "no_values")
+	assert.Equal(t, openingStaffAnnaID, row.StaffID, "the person still resolves")
+}
+
+func TestOpeningBalanceValidate_UnknownPersonnelNumber(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		PersonnelNumber: "P-999",
+		FirstName:       "Anna",
+		LastName:        "Lehmann",
+		HoursBalance:    "5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Contains(t, errorCodes(errs), "personnel_number_not_found")
+	assert.Zero(t, row.StaffID,
+		"an unknown Personalnummer must not fall back to the name match")
+}
+
+func TestOpeningBalanceValidate_UnknownName(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:    "Klaus",
+		LastName:     "Unbekannt",
+		HoursBalance: "5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Contains(t, errorCodes(errs), "staff_not_found")
+	assert.Zero(t, row.StaffID)
+}
+
+func TestOpeningBalanceValidate_AmbiguousName(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:    "Maria",
+		LastName:     "Müller",
+		HoursBalance: "5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Contains(t, errorCodes(errs), "staff_ambiguous")
+	assert.Zero(t, row.StaffID, "an ambiguous match must not pick a winner")
+}
+
+func TestOpeningBalanceValidate_MissingNameWithoutPersonnelNumber(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{LastName: "Lehmann", HoursBalance: "5"}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Contains(t, errorCodes(errs), "required")
+}
+
+func TestOpeningBalanceValidate_PersonnelNumberMatchIsCaseInsensitive(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{PersonnelNumber: " p-100 ", HoursBalance: "1"}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Empty(t, errs)
+	assert.Equal(t, openingStaffAnnaID, row.StaffID)
+}
+
+func TestOpeningBalanceValidate_NegativeHoursBalanceBecomesMinutes(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:    "Anna",
+		LastName:     "Lehmann",
+		HoursBalance: "-3,25",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	require.Empty(t, errs)
+	require.NotNil(t, row.HoursBalanceMinutes)
+	// −3,25 h = −195 min. A negative opening balance is the whole point of
+	// the takeover: staff members arrive with a minus on the Stundenkonto.
+	assert.Equal(t, -195, *row.HoursBalanceMinutes)
+}
+
+func TestOpeningBalanceValidate_HoursBalanceRoundsToWholeMinutes(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:    "Anna",
+		LastName:     "Lehmann",
+		HoursBalance: "1,505", // 90,3 min
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	require.Empty(t, errs)
+	require.NotNil(t, row.HoursBalanceMinutes)
+	assert.Equal(t, 90, *row.HoursBalanceMinutes)
+}
+
+func TestOpeningBalanceValidate_InvalidNumber(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:    "Anna",
+		LastName:     "Lehmann",
+		HoursBalance: "acht",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	require.Len(t, errs, 1)
+	assert.Equal(t, "invalid_number", errs[0].Code)
+	assert.Equal(t, "hours_balance", errs[0].Field)
+	assert.Equal(t, "acht", errs[0].ActualValue)
+	assert.Nil(t, row.HoursBalanceMinutes)
+}
+
+func TestOpeningBalanceValidate_OutOfRangeValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		row   importModels.OpeningBalanceImportRow
+		field string
+	}{
+		{
+			name:  "Jahresanspruch über 366 Tagen",
+			row:   importModels.OpeningBalanceImportRow{VacationEntitled: "400"},
+			field: "vacation_entitled",
+		},
+		{
+			name:  "negativer Jahresanspruch",
+			row:   importModels.OpeningBalanceImportRow{VacationEntitled: "-1"},
+			field: "vacation_entitled",
+		},
+		{
+			name:  "negativer Vorjahresübertrag",
+			row:   importModels.OpeningBalanceImportRow{VacationCarryover: "-1"},
+			field: "vacation_carryover",
+		},
+		{
+			name:  "Stundensaldo über der Ledger-Grenze",
+			row:   importModels.OpeningBalanceImportRow{HoursBalance: "10001"},
+			field: "hours_balance",
+		},
+		{
+			name:  "Resturlaub außerhalb ±999",
+			row:   importModels.OpeningBalanceImportRow{VacationRemaining: "1000"},
+			field: "vacation_remaining",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newOpeningConfig()
+			row := tc.row
+			row.FirstName = "Anna"
+			row.LastName = "Lehmann"
+
+			errs := c.Validate(context.Background(), &row)
+
+			require.Len(t, errs, 1)
+			assert.Equal(t, "out_of_range", errs[0].Code)
+			assert.Equal(t, tc.field, errs[0].Field)
+		})
+	}
+}
+
+func TestOpeningBalanceValidate_NegativeRemainingVacationIsAllowed(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:         "Anna",
+		LastName:          "Lehmann",
+		VacationRemaining: "-2",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	require.Empty(t, errs, "an overdrawn vacation account must be importable")
+	require.NotNil(t, row.VacationRemainingDays)
+	assert.InDelta(t, -2, *row.VacationRemainingDays, 0.0001)
+}
+
+func TestOpeningBalanceValidate_ExistingHoursOpening(t *testing.T) {
+	c := newOpeningConfig()
+	c.staffWithHoursOpening[openingStaffAnnaID] = true
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:    "Anna",
+		LastName:     "Lehmann",
+		HoursBalance: "5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Contains(t, errorCodes(errs), "hours_opening_exists")
+}
+
+func TestOpeningBalanceValidate_ExistingHoursOpeningIgnoredWithoutHoursColumn(t *testing.T) {
+	c := newOpeningConfig()
+	c.staffWithHoursOpening[openingStaffAnnaID] = true
+	// Vacation-only row for a person whose Stundenkonto was taken over
+	// earlier: the second side must still be importable.
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:         "Anna",
+		LastName:          "Lehmann",
+		VacationRemaining: "12,5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	assert.Empty(t, errs)
+}
+
+func TestOpeningBalanceValidate_ExistingVacationOpening(t *testing.T) {
+	c := newOpeningConfig()
+	c.staffWithVacOpening[openingStaffAnnaID] = true
+	row := &importModels.OpeningBalanceImportRow{
+		FirstName:         "Anna",
+		LastName:          "Lehmann",
+		VacationRemaining: "12,5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	require.Len(t, errs, 1)
+	assert.Equal(t, "vacation_opening_exists", errs[0].Code)
+	assert.Contains(t, errs[0].Message, "2026", "the message names the affected year")
+}
+
+func TestOpeningBalanceValidate_AcceptsCompleteRow(t *testing.T) {
+	c := newOpeningConfig()
+	row := &importModels.OpeningBalanceImportRow{
+		PersonnelNumber:   "P-100",
+		FirstName:         "Anna",
+		LastName:          "Lehmann",
+		HoursBalance:      "12,5",
+		VacationEntitled:  "30",
+		VacationCarryover: "2",
+		VacationRemaining: "17,5",
+	}
+
+	errs := c.Validate(context.Background(), row)
+
+	require.Empty(t, errs)
+	assert.Equal(t, openingStaffAnnaID, row.StaffID)
+	require.NotNil(t, row.HoursBalanceMinutes)
+	assert.Equal(t, 750, *row.HoursBalanceMinutes)
+	require.NotNil(t, row.VacationEntitledDays)
+	assert.InDelta(t, 30, *row.VacationEntitledDays, 0.0001)
+	require.NotNil(t, row.VacationCarryoverDays)
+	assert.InDelta(t, 2, *row.VacationCarryoverDays, 0.0001)
+	require.NotNil(t, row.VacationRemainingDays)
+	assert.InDelta(t, 17.5, *row.VacationRemainingDays, 0.0001)
+}
+
+func TestOpeningBalanceValidateBatch_DuplicateStaffInFile(t *testing.T) {
+	c := newOpeningConfig()
+	rows := []importModels.OpeningBalanceImportRow{
+		{FirstName: "Anna", LastName: "Lehmann", StaffID: openingStaffAnnaID},
+		{FirstName: "Bernd", LastName: "Schulz", StaffID: openingStaffBerndID},
+		{FirstName: "Anna", LastName: "Lehmann", StaffID: openingStaffAnnaID},
+	}
+
+	errs := c.ValidateBatch(context.Background(), rows)
+
+	require.Len(t, errs, 1, "only the second occurrence is flagged")
+	require.Contains(t, errs, 2)
+	assert.Equal(t, "duplicate_in_file", errs[2][0].Code)
+	// Row index 0 is spreadsheet line 2.
+	assert.Contains(t, errs[2][0].Message, "erste Zeile: 2")
+}
+
+func TestOpeningBalanceValidateBatch_IgnoresUnresolvedRows(t *testing.T) {
+	c := newOpeningConfig()
+	rows := []importModels.OpeningBalanceImportRow{
+		{FirstName: "Klaus", LastName: "Unbekannt"},
+		{FirstName: "Klaus", LastName: "Unbekannt"},
+	}
+
+	errs := c.ValidateBatch(context.Background(), rows)
+
+	assert.Empty(t, errs, "rows without a resolved person already carry their own error")
+}
+
+func TestOpeningBalanceConfig_FindExistingAlwaysNew(t *testing.T) {
+	c := newOpeningConfig()
+
+	existing, err := c.FindExisting(context.Background(), importModels.OpeningBalanceImportRow{StaffID: openingStaffAnnaID})
+
+	require.NoError(t, err)
+	assert.Nil(t, existing, "duplicates are reported per side in Validate, not here")
+}
+
+func TestOpeningBalanceConfig_UpdateIsNoOp(t *testing.T) {
+	c := newOpeningConfig()
+
+	require.NoError(t, c.Update(context.Background(), openingStaffAnnaID, importModels.OpeningBalanceImportRow{}))
+	assert.Equal(t, "Eröffnungssaldo", c.EntityName())
+}
+
+func TestOpeningBalanceConfig_CreateRejectsUnresolvedRow(t *testing.T) {
+	c := newOpeningConfig()
+
+	_, err := c.Create(context.Background(), importModels.OpeningBalanceImportRow{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ohne aufgelöste Person")
+}

--- a/backend/services/import/opening_balance_parser.go
+++ b/backend/services/import/opening_balance_parser.go
@@ -12,10 +12,6 @@ import (
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
 )
 
-// openingBalanceRequiredColumns are the normalized header keys the opening
-// balance import file must contain. The value columns are all optional.
-var openingBalanceRequiredColumns = []string{"vorname", "nachname"}
-
 // MapOpeningBalanceRow maps column values to an OpeningBalanceImportRow.
 // The four value columns use GetRawCol: sanitizeCellValue's CSV-injection
 // guard prefixes leading '-' with a quote, which would break exactly the
@@ -35,8 +31,11 @@ func MapOpeningBalanceRow(mapper *ColumnMapper) importModels.OpeningBalanceImpor
 
 // missingOpeningBalanceColumns returns the required columns absent from the mapping.
 func missingOpeningBalanceColumns(mapping map[string]int) []string {
-	var missing []string
-	for _, col := range openingBalanceRequiredColumns {
+	if _, ok := mapping["personalnummer"]; ok {
+		return nil
+	}
+	missing := make([]string, 0, 2)
+	for _, col := range []string{"vorname", "nachname"} {
 		if _, ok := mapping[col]; !ok {
 			missing = append(missing, col)
 		}

--- a/backend/services/import/opening_balance_parser.go
+++ b/backend/services/import/opening_balance_parser.go
@@ -1,0 +1,146 @@
+package importpkg
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/xuri/excelize/v2"
+
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+)
+
+// openingBalanceRequiredColumns are the normalized header keys the opening
+// balance import file must contain. The value columns are all optional.
+var openingBalanceRequiredColumns = []string{"vorname", "nachname"}
+
+// MapOpeningBalanceRow maps column values to an OpeningBalanceImportRow.
+// The four value columns use GetRawCol: sanitizeCellValue's CSV-injection
+// guard prefixes leading '-' with a quote, which would break exactly the
+// negative balances this import exists for. The raw values go straight into
+// strict float parsing, so there is no injection surface.
+func MapOpeningBalanceRow(mapper *ColumnMapper) importModels.OpeningBalanceImportRow {
+	return importModels.OpeningBalanceImportRow{
+		PersonnelNumber:   mapper.GetCol("personalnummer"),
+		FirstName:         mapper.GetCol("vorname"),
+		LastName:          mapper.GetCol("nachname"),
+		HoursBalance:      mapper.GetRawCol("stundensaldo"),
+		VacationEntitled:  mapper.GetRawCol("jahresanspruch"),
+		VacationCarryover: mapper.GetRawCol("vorjahresübertrag"),
+		VacationRemaining: mapper.GetRawCol("resturlaub"),
+	}
+}
+
+// missingOpeningBalanceColumns returns the required columns absent from the mapping.
+func missingOpeningBalanceColumns(mapping map[string]int) []string {
+	var missing []string
+	for _, col := range openingBalanceRequiredColumns {
+		if _, ok := mapping[col]; !ok {
+			missing = append(missing, col)
+		}
+	}
+	return missing
+}
+
+// ParseOpeningBalanceCSV parses a CSV file into opening balance import rows.
+func ParseOpeningBalanceCSV(reader io.Reader) ([]importModels.OpeningBalanceImportRow, error) {
+	csvReader := csv.NewReader(reader)
+	csvReader.FieldsPerRecord = -1
+	csvReader.TrimLeadingSpace = true
+	csvReader.LazyQuotes = true
+
+	header, err := csvReader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+
+	mapping := make(map[string]int)
+	for i, col := range header {
+		mapping[normalizeHeaderKey(col)] = i
+	}
+	if missing := missingOpeningBalanceColumns(mapping); len(missing) > 0 {
+		return nil, fmt.Errorf("fehlende erforderliche Spalten: %s", strings.Join(missing, ", "))
+	}
+
+	var rows []importModels.OpeningBalanceImportRow
+	rowNum := 2
+	for {
+		values, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("row %d: %w", rowNum, err)
+		}
+
+		if isEmptyRow(values) {
+			rowNum++
+			continue
+		}
+
+		mapper := NewColumnMapper(mapping, values)
+		rows = append(rows, MapOpeningBalanceRow(mapper))
+		rowNum++
+	}
+
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("die CSV-Datei enthält keine Datenzeilen. Möglicherweise haben Sie versehentlich die Vorlage hochgeladen")
+	}
+
+	return rows, nil
+}
+
+// ParseOpeningBalanceXLSX parses an Excel (.xlsx) file into opening balance import rows.
+func ParseOpeningBalanceXLSX(reader io.Reader) ([]importModels.OpeningBalanceImportRow, error) {
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	f, err := excelize.OpenReader(buf)
+	if err != nil {
+		return nil, fmt.Errorf("open excel file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	sheetName := f.GetSheetName(0)
+	if sheetName == "" {
+		return nil, fmt.Errorf("no sheets found in Excel file")
+	}
+
+	sheetRows, err := f.GetRows(sheetName)
+	if err != nil {
+		return nil, fmt.Errorf("read rows: %w", err)
+	}
+	if len(sheetRows) == 0 {
+		return nil, fmt.Errorf("empty Excel file")
+	}
+
+	mapping := make(map[string]int)
+	for i, col := range sheetRows[0] {
+		mapping[normalizeHeaderKey(col)] = i
+	}
+	if missing := missingOpeningBalanceColumns(mapping); len(missing) > 0 {
+		return nil, fmt.Errorf("fehlende erforderliche Spalten: %s", strings.Join(missing, ", "))
+	}
+
+	var rows []importModels.OpeningBalanceImportRow
+	for rowNum := 2; rowNum <= len(sheetRows); rowNum++ {
+		values := sheetRows[rowNum-1]
+		if isEmptyRow(values) {
+			continue
+		}
+		mapper := NewColumnMapper(mapping, values)
+		rows = append(rows, MapOpeningBalanceRow(mapper))
+	}
+
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("die Excel-Datei enthält keine Datenzeilen. Möglicherweise haben Sie versehentlich die Vorlage hochgeladen")
+	}
+
+	return rows, nil
+}

--- a/backend/services/import/opening_balance_parser_test.go
+++ b/backend/services/import/opening_balance_parser_test.go
@@ -1,0 +1,165 @@
+package importpkg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Opening balance file parsing (#2132). The parser uses encoding/csv with the
+// standard comma separator, so German decimals ("12,5") must be quoted in the
+// file; the fixtures below mirror that.
+
+const openingBalanceCSVHeader = "Personalnummer,Vorname,Nachname,Stundensaldo,Jahresanspruch,Vorjahresübertrag,Resturlaub\n"
+
+func TestParseOpeningBalanceCSV_MapsColumns(t *testing.T) {
+	csvData := openingBalanceCSVHeader +
+		"P-100,Anna,Lehmann,\"12,5\",30,\"2\",\"17,5\"\n" +
+		",Bernd,Schulz,,,,\"5\""
+
+	rows, err := ParseOpeningBalanceCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	assert.Equal(t, "P-100", rows[0].PersonnelNumber)
+	assert.Equal(t, "Anna", rows[0].FirstName)
+	assert.Equal(t, "Lehmann", rows[0].LastName)
+	assert.Equal(t, "12,5", rows[0].HoursBalance)
+	assert.Equal(t, "30", rows[0].VacationEntitled)
+	assert.Equal(t, "2", rows[0].VacationCarryover)
+	assert.Equal(t, "17,5", rows[0].VacationRemaining)
+
+	// Every value column is optional — a vacation-only row is legitimate.
+	assert.Empty(t, rows[1].PersonnelNumber)
+	assert.Equal(t, "Bernd", rows[1].FirstName)
+	assert.Empty(t, rows[1].HoursBalance)
+	assert.Equal(t, "5", rows[1].VacationRemaining)
+}
+
+func TestParseOpeningBalanceCSV_HeaderIsCaseInsensitiveAndOptionalAnnotated(t *testing.T) {
+	csvData := "vorname,nachname,stundensaldo (optional),resturlaub (optional)\n" +
+		"Anna,Lehmann,\"12,5\",\"17,5\""
+
+	rows, err := ParseOpeningBalanceCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "12,5", rows[0].HoursBalance)
+	assert.Equal(t, "17,5", rows[0].VacationRemaining)
+}
+
+func TestParseOpeningBalanceCSV_MissingRequiredColumns(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		missing string
+	}{
+		{
+			name:    "ohne Vorname",
+			header:  "Personalnummer,Nachname,Stundensaldo\nP-100,Lehmann,\"12,5\"",
+			missing: "vorname",
+		},
+		{
+			name:    "ohne Nachname",
+			header:  "Personalnummer,Vorname,Stundensaldo\nP-100,Anna,\"12,5\"",
+			missing: "nachname",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := ParseOpeningBalanceCSV(strings.NewReader(tc.header))
+			require.Error(t, err)
+			assert.Nil(t, rows)
+			assert.Contains(t, err.Error(), "fehlende erforderliche Spalten")
+			assert.Contains(t, err.Error(), tc.missing)
+		})
+	}
+}
+
+func TestParseOpeningBalanceCSV_SkipsEmptyRows(t *testing.T) {
+	csvData := openingBalanceCSVHeader +
+		",,,,,,\n" +
+		"P-100,Anna,Lehmann,\"12,5\",,,\n" +
+		"   ,   ,   ,   ,   ,   ,   "
+
+	rows, err := ParseOpeningBalanceCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "Anna", rows[0].FirstName)
+}
+
+func TestParseOpeningBalanceCSV_TemplateWithoutDataRows(t *testing.T) {
+	rows, err := ParseOpeningBalanceCSV(strings.NewReader(openingBalanceCSVHeader))
+
+	require.Error(t, err)
+	assert.Nil(t, rows)
+	assert.Contains(t, err.Error(), "keine Datenzeilen")
+}
+
+func TestParseOpeningBalanceCSV_ShortRowKeepsMappedColumns(t *testing.T) {
+	// Trailing columns omitted entirely (a common spreadsheet export shape).
+	csvData := openingBalanceCSVHeader + "P-100,Anna,Lehmann"
+
+	rows, err := ParseOpeningBalanceCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "Anna", rows[0].FirstName)
+	assert.Empty(t, rows[0].HoursBalance)
+	assert.Empty(t, rows[0].VacationRemaining)
+}
+
+func TestParseOpeningBalanceXLSX_MapsColumns(t *testing.T) {
+	reader := buildStaffXLSX(t, [][]string{
+		{"Personalnummer", "Vorname", "Nachname", "Stundensaldo", "Jahresanspruch", "Vorjahresübertrag", "Resturlaub"},
+		{"P-100", "Anna", "Lehmann", "12,5", "30", "2", "17,5"},
+		{"", "", "", "", "", "", ""},
+		{"", "Bernd", "Schulz", "", "", "", "5"},
+	})
+
+	rows, err := ParseOpeningBalanceXLSX(reader)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "the blank sheet row must be skipped")
+	assert.Equal(t, "12,5", rows[0].HoursBalance)
+	assert.Equal(t, "17,5", rows[0].VacationRemaining)
+	assert.Equal(t, "Bernd", rows[1].FirstName)
+	assert.Equal(t, "5", rows[1].VacationRemaining)
+}
+
+func TestParseOpeningBalanceXLSX_MissingRequiredColumns(t *testing.T) {
+	reader := buildStaffXLSX(t, [][]string{
+		{"Personalnummer", "Nachname", "Stundensaldo"},
+		{"P-100", "Lehmann", "12,5"},
+	})
+
+	rows, err := ParseOpeningBalanceXLSX(reader)
+
+	require.Error(t, err)
+	assert.Nil(t, rows)
+	assert.Contains(t, err.Error(), "vorname")
+}
+
+// TestParseOpeningBalanceCSV_NegativeValuesSurviveTheSanitizer is the
+// end-to-end check for the case the whole takeover exists for: a staff member
+// who arrives with a MINUS on the Stundenkonto (or an overdrawn vacation
+// account). The value must reach Validate parseable.
+func TestParseOpeningBalanceCSV_NegativeValuesSurviveTheSanitizer(t *testing.T) {
+	csvData := openingBalanceCSVHeader + "P-100,Anna,Lehmann,\"-3,25\",30,,\"-2\""
+
+	rows, err := ParseOpeningBalanceCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "-3,25", rows[0].HoursBalance)
+	assert.Equal(t, "-2", rows[0].VacationRemaining)
+
+	c := newOpeningConfig()
+	row := rows[0]
+	errs := c.Validate(t.Context(), &row)
+
+	require.Empty(t, errs, "a negative opening balance must import without a validation error")
+	require.NotNil(t, row.HoursBalanceMinutes)
+	assert.Equal(t, -195, *row.HoursBalanceMinutes)
+	require.NotNil(t, row.VacationRemainingDays)
+	assert.InDelta(t, -2, *row.VacationRemainingDays, 0.0001)
+}

--- a/backend/services/import/opening_balance_parser_test.go
+++ b/backend/services/import/opening_balance_parser_test.go
@@ -159,3 +159,51 @@ func TestParseOpeningBalanceCSV_NegativeValuesSurviveTheSanitizer(t *testing.T) 
 	require.NotNil(t, row.VacationRemainingDays)
 	assert.InDelta(t, -2, *row.VacationRemainingDays, 0.0001)
 }
+
+func TestParseOpeningBalanceCSV_RejectsMissingIdentityColumns(t *testing.T) {
+	// Neither a Personalnummer nor both name columns: nothing can be matched.
+	csvData := "vorname,stundensaldo\nAnna,\"12,5\""
+
+	_, err := ParseOpeningBalanceCSV(strings.NewReader(csvData))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fehlende erforderliche Spalten")
+	assert.Contains(t, err.Error(), "nachname")
+}
+
+func TestParseOpeningBalanceCSV_RejectsEmptyFile(t *testing.T) {
+	_, err := ParseOpeningBalanceCSV(strings.NewReader(""))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read header")
+}
+
+func TestParseOpeningBalanceXLSX_RejectsNonExcelInput(t *testing.T) {
+	_, err := ParseOpeningBalanceXLSX(strings.NewReader("Personalnummer;Vorname\nP-100;Anna"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open excel file")
+}
+
+func TestParseOpeningBalanceXLSX_RejectsMissingIdentityColumns(t *testing.T) {
+	reader := buildStaffXLSX(t, [][]string{
+		{"Vorname", "Stundensaldo"},
+		{"Anna", "12,5"},
+	})
+
+	_, err := ParseOpeningBalanceXLSX(reader)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fehlende erforderliche Spalten")
+}
+
+func TestParseOpeningBalanceXLSX_TemplateWithoutDataRows(t *testing.T) {
+	reader := buildStaffXLSX(t, [][]string{
+		{"Personalnummer", "Vorname", "Nachname", "Stundensaldo"},
+	})
+
+	_, err := ParseOpeningBalanceXLSX(reader)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keine Datenzeilen")
+}

--- a/backend/services/import/opening_balance_parser_test.go
+++ b/backend/services/import/opening_balance_parser_test.go
@@ -49,31 +49,27 @@ func TestParseOpeningBalanceCSV_HeaderIsCaseInsensitiveAndOptionalAnnotated(t *t
 	assert.Equal(t, "17,5", rows[0].VacationRemaining)
 }
 
-func TestParseOpeningBalanceCSV_MissingRequiredColumns(t *testing.T) {
+func TestParseOpeningBalanceCSV_PersonnelNumberDoesNotRequireNames(t *testing.T) {
 	tests := []struct {
-		name    string
-		header  string
-		missing string
+		name   string
+		header string
 	}{
 		{
-			name:    "ohne Vorname",
-			header:  "Personalnummer,Nachname,Stundensaldo\nP-100,Lehmann,\"12,5\"",
-			missing: "vorname",
+			name:   "ohne Vorname",
+			header: "Personalnummer,Nachname,Stundensaldo\nP-100,Lehmann,\"12,5\"",
 		},
 		{
-			name:    "ohne Nachname",
-			header:  "Personalnummer,Vorname,Stundensaldo\nP-100,Anna,\"12,5\"",
-			missing: "nachname",
+			name:   "ohne Nachname",
+			header: "Personalnummer,Vorname,Stundensaldo\nP-100,Anna,\"12,5\"",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			rows, err := ParseOpeningBalanceCSV(strings.NewReader(tc.header))
-			require.Error(t, err)
-			assert.Nil(t, rows)
-			assert.Contains(t, err.Error(), "fehlende erforderliche Spalten")
-			assert.Contains(t, err.Error(), tc.missing)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			assert.Equal(t, "P-100", rows[0].PersonnelNumber)
 		})
 	}
 }
@@ -127,7 +123,7 @@ func TestParseOpeningBalanceXLSX_MapsColumns(t *testing.T) {
 	assert.Equal(t, "5", rows[1].VacationRemaining)
 }
 
-func TestParseOpeningBalanceXLSX_MissingRequiredColumns(t *testing.T) {
+func TestParseOpeningBalanceXLSX_PersonnelNumberDoesNotRequireNames(t *testing.T) {
 	reader := buildStaffXLSX(t, [][]string{
 		{"Personalnummer", "Nachname", "Stundensaldo"},
 		{"P-100", "Lehmann", "12,5"},
@@ -135,9 +131,9 @@ func TestParseOpeningBalanceXLSX_MissingRequiredColumns(t *testing.T) {
 
 	rows, err := ParseOpeningBalanceXLSX(reader)
 
-	require.Error(t, err)
-	assert.Nil(t, rows)
-	assert.Contains(t, err.Error(), "vorname")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "P-100", rows[0].PersonnelNumber)
 }
 
 // TestParseOpeningBalanceCSV_NegativeValuesSurviveTheSanitizer is the

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.test.tsx
@@ -223,6 +223,28 @@ describe("OpeningBalanceImportPage", () => {
     expect(screen.getByText("2 Übernahmen buchen")).toBeInTheDocument();
   });
 
+  it("clears the previous preview while a newly selected file is being previewed", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      previewResponse(),
+    );
+    render(<OpeningBalanceImportPage />);
+    fillParams();
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 Übernahmen buchen")).toBeInTheDocument();
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    expect(
+      screen.queryByRole("button", { name: "2 Übernahmen buchen" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("verwirft die Vorschau, wenn der Stichtag nachträglich geändert wird", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       previewResponse(),

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.test.tsx
@@ -1,0 +1,289 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import OpeningBalanceImportPage from "./page";
+
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(() => ({
+    data: { user: { token: "test-token" } },
+    status: "authenticated",
+  })),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+const mockToast = {
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+};
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => mockToast,
+}));
+
+vi.mock("~/lib/auth-utils", () => ({
+  hasPermission: () => true,
+}));
+
+vi.mock("~/lib/tenant-router", () => ({
+  useTenantRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("~/components/ui/date-picker", async (importOriginal) => {
+  const { isoDatePickerMock } = await import("~/test/mocks/date-picker");
+  return { ...(await importOriginal<object>()), ...isoDatePickerMock() };
+});
+
+vi.mock("~/components/import/upload-section", () => ({
+  UploadSection: ({
+    title,
+    onFileSelect,
+  }: {
+    title?: string;
+    onFileSelect: (file: File) => void;
+  }) => (
+    <div data-testid="upload-section">
+      <span>{title}</span>
+      <button
+        type="button"
+        data-testid="file-select-trigger"
+        onClick={() =>
+          onFileSelect(new File(["x"], "salden.csv", { type: "text/csv" }))
+        }
+      >
+        Datei wählen
+      </button>
+    </div>
+  ),
+}));
+
+function fillParams() {
+  fireEvent.change(screen.getByLabelText("Stichtag"), {
+    target: { value: "2026-08-01" },
+  });
+  fireEvent.change(screen.getByLabelText("Begründung"), {
+    target: { value: "Übernahme aus Altsystem" },
+  });
+}
+
+function previewResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        data: {
+          TotalRows: 3,
+          CreatedCount: 2,
+          UpdatedCount: 0,
+          ErrorCount: 1,
+          WarningCount: 0,
+          DryRun: true,
+          Errors: [
+            {
+              RowNumber: 4,
+              Data: {
+                personnel_number: "1003",
+                first_name: "Clara",
+                last_name: "Weber",
+                hours_balance: "",
+                vacation_entitled: "28",
+                vacation_carryover: "0",
+                vacation_remaining: "28",
+              },
+              Errors: [
+                {
+                  field: "vacation",
+                  message: "Für diese Person besteht bereits eine Übernahme",
+                  code: "already_exists",
+                  severity: "error",
+                },
+              ],
+              Timestamp: "2026-08-03T10:00:00Z",
+            },
+          ],
+          ...overrides,
+        },
+      }),
+  };
+}
+
+describe("OpeningBalanceImportPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("rendert die vier Schritte der Seite", () => {
+    render(<OpeningBalanceImportPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Eröffnungssalden importieren" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Schritt 1: Vorlage herunterladen"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Schritt 2: Stichtag und Begründung"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Schritt 3: Datei hochladen")).toBeInTheDocument();
+  });
+
+  it("lädt die Vorlage über den Eröffnungssalden-Endpoint", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(["x"], { type: "text/csv" })),
+    });
+    global.URL.createObjectURL = vi.fn(() => "blob:test");
+    global.URL.revokeObjectURL = vi.fn();
+
+    render(<OpeningBalanceImportPage />);
+    fireEvent.click(screen.getByText("Vorlage herunterladen"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/import/opening-balances/template?format=xlsx",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer test-token" },
+        }),
+      );
+    });
+  });
+
+  it("verlangt Stichtag und Begründung, bevor die Vorschau läuft", async () => {
+    render(<OpeningBalanceImportPage />);
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Bitte zuerst Stichtag und Begründung angeben, dann wird die Vorschau erstellt.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("schickt Stichtag und Begründung im FormData der Vorschau", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      previewResponse(),
+    );
+
+    render(<OpeningBalanceImportPage />);
+    fillParams();
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/import/opening-balances/preview",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { body: FormData },
+    ];
+    expect(call[1].body.get("effective_date")).toBe("2026-08-01");
+    expect(call[1].body.get("note")).toBe("Übernahme aus Altsystem");
+    expect(call[1].body.get("file")).toBeInstanceOf(File);
+  });
+
+  it("zeigt Fehlerzeile und Sammelzeile für die übrigen Zeilen", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      previewResponse(),
+    );
+
+    render(<OpeningBalanceImportPage />);
+    fillParams();
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Clara Weber")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Für diese Person besteht bereits eine Übernahme"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("2 weitere Zeilen ohne Befund"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2 Übernahmen buchen")).toBeInTheDocument();
+  });
+
+  it("verwirft die Vorschau, wenn der Stichtag nachträglich geändert wird", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      previewResponse(),
+    );
+
+    render(<OpeningBalanceImportPage />);
+    fillParams();
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 Übernahmen buchen")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Stichtag"), {
+      target: { value: "2026-07-31" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("2 Übernahmen buchen")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Vorschau erneut erstellen")).toBeInTheDocument();
+  });
+
+  it("bucht den Import und meldet Teilerfolg als Warnung", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(previewResponse())
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              TotalRows: 3,
+              CreatedCount: 2,
+              UpdatedCount: 0,
+              ErrorCount: 1,
+              WarningCount: 0,
+              DryRun: false,
+              Errors: [],
+            },
+          }),
+      });
+
+    render(<OpeningBalanceImportPage />);
+    fillParams();
+    fireEvent.click(screen.getByTestId("file-select-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 Übernahmen buchen")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("2 Übernahmen buchen"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/import/opening-balances/import",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(mockToast.warning).toHaveBeenCalledWith(
+        "2 übernommen, 1 übersprungen",
+      );
+    });
+    expect(screen.getByText("Import abgeschlossen")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -360,8 +360,8 @@ export default function OpeningBalanceImportPage() {
     (file: File) => {
       previewRequestVersion.current++;
       setUploadedFile(file);
+      resetPreview();
       if (!paramsComplete) {
-        resetPreview();
         setError(
           "Bitte zuerst Stichtag und Begründung angeben, dann wird die Vorschau erstellt.",
         );

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -460,6 +460,9 @@ export default function OpeningBalanceImportPage() {
   const importable = previewResult?.CreatedCount ?? 0;
   const previewErrors = previewResult?.ErrorCount ?? 0;
   const showPreview = previewResult !== null && importResult === null;
+  const importButtonLabel = isImporting
+    ? "Wird übernommen…"
+    : `${importable} ${importable === 1 ? "Übernahme" : "Übernahmen"} buchen`;
 
   return (
     <main className="mx-auto w-full max-w-5xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
@@ -723,9 +726,7 @@ export default function OpeningBalanceImportPage() {
             disabled={importable === 0 || isImporting}
             onClick={() => void handleImport()}
           >
-            {isImporting
-              ? "Wird übernommen…"
-              : `${importable} ${importable === 1 ? "Übernahme" : "Übernahmen"} buchen`}
+            {importButtonLabel}
           </Button>
         </div>
       )}

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -568,6 +568,7 @@ export default function OpeningBalanceImportPage() {
             id="opening-balance-effective-date"
             label="Stichtag"
             value={effectiveDate}
+            min={`${berlinToday.slice(0, 4)}-01-01`}
             max={latestEffectiveDate}
             onChange={(next) => handleParamChange(() => setEffectiveDate(next))}
             placeholder="Datum wählen"

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -374,17 +374,13 @@ export default function OpeningBalanceImportPage() {
 
   // Stichtag und Begründung gehen in jede Buchung ein — eine Vorschau, die
   // mit anderen Werten gerechnet wurde, darf nicht bestätigt werden.
-  const handleParamChange = useCallback(
-    (apply: () => void) => {
-      previewRequestVersion.current++;
-      apply();
-      setPreviewRows([]);
-      setPreviewResult(null);
-      setImportResult(null);
-      setPreviewStale(uploadedFile !== null);
-    },
-    [uploadedFile],
-  );
+  const invalidatePreview = useCallback(() => {
+    previewRequestVersion.current++;
+    setPreviewRows([]);
+    setPreviewResult(null);
+    setImportResult(null);
+    setPreviewStale(uploadedFile !== null);
+  }, [uploadedFile]);
 
   const handleImport = useCallback(async () => {
     if (!uploadedFile) return;
@@ -573,7 +569,10 @@ export default function OpeningBalanceImportPage() {
             value={effectiveDate}
             min={`${berlinToday.slice(0, 4)}-01-01`}
             max={latestEffectiveDate}
-            onChange={(next) => handleParamChange(() => setEffectiveDate(next))}
+            onChange={(next) => {
+              setEffectiveDate(next);
+              invalidatePreview();
+            }}
             placeholder="Datum wählen"
           />
           <Input
@@ -583,7 +582,10 @@ export default function OpeningBalanceImportPage() {
             value={note}
             maxLength={200}
             placeholder={`Übernahme aus Altsystem zum ${formatDate(latestEffectiveDate)}`}
-            onChange={(e) => handleParamChange(() => setNote(e.target.value))}
+            onChange={(e) => {
+              setNote(e.target.value);
+              invalidatePreview();
+            }}
           />
         </div>
       </section>

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 
@@ -238,6 +238,7 @@ export default function OpeningBalanceImportPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const previewRequestVersion = useRef(0);
 
   // Ein Eröffnungssaldo beschreibt einen abgeschlossenen Stand; der heutige
   // Tag läuft noch, deshalb ist gestern der späteste sinnvolle Stichtag.
@@ -310,6 +311,7 @@ export default function OpeningBalanceImportPage() {
 
   const runPreview = useCallback(
     async (file: File) => {
+      const requestVersion = ++previewRequestVersion.current;
       setError(null);
       setIsLoading(true);
       setImportResult(null);
@@ -333,17 +335,21 @@ export default function OpeningBalanceImportPage() {
         }
 
         const result = payload.data as ImportResult;
+        if (requestVersion !== previewRequestVersion.current) return;
         setPreviewResult(result);
         setPreviewRows(buildDisplayRows(result));
       } catch (err) {
         logger.error("opening_balance_preview_failed", {
           error: err instanceof Error ? err.message : String(err),
         });
-        setError(err instanceof Error ? err.message : "Unbekannter Fehler");
-        setPreviewRows([]);
-        setPreviewResult(null);
+        if (requestVersion === previewRequestVersion.current) {
+          setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+          setPreviewRows([]);
+          setPreviewResult(null);
+        }
       } finally {
-        setIsLoading(false);
+        if (requestVersion === previewRequestVersion.current)
+          setIsLoading(false);
       }
     },
     [buildFormData, session],
@@ -351,6 +357,7 @@ export default function OpeningBalanceImportPage() {
 
   const handleFileSelect = useCallback(
     (file: File) => {
+      previewRequestVersion.current++;
       setUploadedFile(file);
       if (!paramsComplete) {
         resetPreview();
@@ -368,6 +375,7 @@ export default function OpeningBalanceImportPage() {
   // mit anderen Werten gerechnet wurde, darf nicht bestätigt werden.
   const handleParamChange = useCallback(
     (apply: () => void) => {
+      previewRequestVersion.current++;
       apply();
       setPreviewRows([]);
       setPreviewResult(null);

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -1,0 +1,719 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+
+import { Alert } from "~/components/ui/alert";
+import { BackButton } from "~/components/ui/back-button";
+import { Button } from "~/components/ui/button";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { ISODatePicker } from "~/components/ui/date-picker";
+import { EmptyState } from "~/components/ui/empty-state";
+import { ForbiddenPage } from "~/components/ui/forbidden-page";
+import { Input } from "~/components/ui/input";
+import { Loading } from "~/components/ui/loading";
+import { StatusBadge } from "~/components/ui/status-badge";
+import { UploadSection } from "~/components/import/upload-section";
+import { useToast } from "~/contexts/ToastContext";
+import { hasPermission } from "~/lib/auth-utils";
+import { formatDate, parseISODate, toISODate } from "~/lib/date-helpers";
+import { useBerlinToday } from "~/lib/hooks/use-berlin-today";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "OpeningBalanceImportPage" });
+
+// Wire-Format des generischen Imports (PascalCase, siehe
+// services/import/import_service.go). Zeilen ohne Befund tauchen NICHT in
+// `Errors` auf — nur fehlerhafte und mit Hinweisen versehene Zeilen.
+interface ImportValidationError {
+  field: string;
+  message: string;
+  code: string;
+  severity: "error" | "warning";
+}
+
+interface OpeningBalanceRowData {
+  personnel_number?: string;
+  first_name?: string;
+  last_name?: string;
+  hours_balance?: string;
+  vacation_entitled?: string;
+  vacation_carryover?: string;
+  vacation_remaining?: string;
+}
+
+interface ImportRowResult {
+  RowNumber: number;
+  Data: OpeningBalanceRowData;
+  Errors: ImportValidationError[];
+  Timestamp: string;
+}
+
+interface ImportResult {
+  TotalRows: number;
+  CreatedCount: number;
+  UpdatedCount: number;
+  ErrorCount: number;
+  WarningCount: number;
+  Errors: ImportRowResult[];
+  DryRun: boolean;
+}
+
+type RowStatus = "ok" | "warning" | "error";
+
+interface DisplayRow {
+  key: string;
+  rowNumber: number;
+  status: RowStatus;
+  name: string;
+  personnelNumber: string;
+  values: readonly { label: string; value: string }[];
+  messages: readonly string[];
+  isSummary: boolean;
+}
+
+const STATUS_TONE = {
+  ok: { tone: "green", label: "Übernehmbar" },
+  warning: { tone: "orange", label: "Hinweis" },
+  error: { tone: "red", label: "Fehler" },
+} as const;
+
+function rowStatusFor(errors: readonly ImportValidationError[]): RowStatus {
+  if (errors.some((e) => e.severity === "error")) return "error";
+  if (errors.length > 0) return "warning";
+  return "ok";
+}
+
+/** Leere Zellen bedeuten „diese Seite überspringen", nicht „Null". */
+function cellValue(raw: string | undefined): string {
+  const trimmed = raw?.trim() ?? "";
+  return trimmed === "" ? "–" : trimmed;
+}
+
+function toDisplayRow(row: ImportRowResult): DisplayRow {
+  const data = row.Data;
+  const name = `${data.first_name ?? ""} ${data.last_name ?? ""}`.trim();
+  return {
+    key: `row-${row.RowNumber}`,
+    rowNumber: row.RowNumber,
+    status: rowStatusFor(row.Errors),
+    name: name === "" ? "Ohne Namen" : name,
+    personnelNumber: data.personnel_number?.trim() ?? "",
+    values: [
+      { label: "Stundensaldo", value: cellValue(data.hours_balance) },
+      { label: "Jahresanspruch", value: cellValue(data.vacation_entitled) },
+      { label: "Übertrag", value: cellValue(data.vacation_carryover) },
+      { label: "Resturlaub", value: cellValue(data.vacation_remaining) },
+    ],
+    messages: row.Errors.map((e) => e.message),
+    isSummary: false,
+  };
+}
+
+/**
+ * Sammelzeile für die Zeilen, die der Import gar nicht erst zurückmeldet:
+ * das Framework listet nur auffällige Zeilen, sonst sähe eine saubere Datei
+ * in der Vorschau leer aus.
+ */
+function summaryRow(count: number): DisplayRow {
+  return {
+    key: "row-summary",
+    rowNumber: 0,
+    status: "ok",
+    name: `${count} weitere ${count === 1 ? "Zeile" : "Zeilen"} ohne Befund`,
+    personnelNumber: "",
+    values: [],
+    messages: [],
+    isSummary: true,
+  };
+}
+
+function buildDisplayRows(result: ImportResult): DisplayRow[] {
+  const listed = (result.Errors ?? []).map(toDisplayRow);
+  const untouched = result.TotalRows - listed.length;
+  return untouched > 0 ? [...listed, summaryRow(untouched)] : listed;
+}
+
+function isSpreadsheet(file: File): boolean {
+  return (
+    file.type === "text/csv" ||
+    file.type ===
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+    file.name.endsWith(".csv") ||
+    file.name.endsWith(".xlsx")
+  );
+}
+
+function PreviewRowCard({ row }: { readonly row: DisplayRow }) {
+  const status = STATUS_TONE[row.status];
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="flex items-start gap-3">
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-semibold text-gray-600">
+          {row.isSummary ? "∑" : row.rowNumber}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="text-sm font-semibold text-gray-900">{row.name}</h4>
+            {!row.isSummary && (
+              <StatusBadge label={status.label} tone={status.tone} />
+            )}
+            {row.personnelNumber !== "" && (
+              <span className="text-xs text-gray-500">
+                Personalnummer {row.personnelNumber}
+              </span>
+            )}
+          </div>
+          {row.values.length > 0 && (
+            <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-4">
+              {row.values.map((value) => (
+                <div key={value.label}>
+                  <dt className="text-[11px] font-medium tracking-wide text-gray-500 uppercase">
+                    {value.label}
+                  </dt>
+                  <dd className="text-sm text-gray-900 tabular-nums">
+                    {value.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+          {row.messages.length > 0 && (
+            <ul className="mt-2 space-y-0.5">
+              {row.messages.map((message) => (
+                <li
+                  key={message}
+                  className={`text-xs ${row.status === "error" ? "text-[#9F1F1E]" : "text-[#8A5600]"}`}
+                >
+                  {message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: number;
+}) {
+  return (
+    <div className="rounded-xl bg-gray-50 px-3 py-2.5">
+      <p className="text-[11px] font-medium tracking-wide text-gray-500 uppercase">
+        {label}
+      </p>
+      <p className="mt-0.5 text-xl font-semibold text-gray-900 tabular-nums">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export default function OpeningBalanceImportPage() {
+  const { data: session, status } = useSession({
+    required: true,
+    onUnauthenticated() {
+      redirect("/");
+    },
+  });
+  const toast = useToast();
+  const berlinToday = useBerlinToday();
+
+  const [templateFormat, setTemplateFormat] = useState<"csv" | "xlsx">("xlsx");
+  const [effectiveDate, setEffectiveDate] = useState("");
+  const [note, setNote] = useState("");
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [previewRows, setPreviewRows] = useState<DisplayRow[]>([]);
+  const [previewResult, setPreviewResult] = useState<ImportResult | null>(null);
+  const [previewStale, setPreviewStale] = useState(false);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Ein Eröffnungssaldo beschreibt einen abgeschlossenen Stand; der heutige
+  // Tag läuft noch, deshalb ist gestern der späteste sinnvolle Stichtag.
+  const latestEffectiveDate = useMemo(
+    () => toISODate(new Date(parseISODate(berlinToday).getTime() - 86_400_000)),
+    [berlinToday],
+  );
+
+  const paramsComplete = effectiveDate !== "" && note.trim() !== "";
+
+  const resetPreview = useCallback(() => {
+    setPreviewRows([]);
+    setPreviewResult(null);
+    setImportResult(null);
+    setPreviewStale(false);
+  }, []);
+
+  const resetAll = useCallback(() => {
+    setUploadedFile(null);
+    resetPreview();
+    setIsDragging(false);
+    setError(null);
+  }, [resetPreview]);
+
+  const buildFormData = useCallback(
+    (file: File) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("effective_date", effectiveDate);
+      formData.append("note", note.trim());
+      return formData;
+    },
+    [effectiveDate, note],
+  );
+
+  const handleDownloadTemplate = useCallback(async () => {
+    try {
+      const token = session?.user?.token;
+      if (!token) throw new Error("Keine Authentifizierung");
+
+      const response = await fetch(
+        `/api/import/opening-balances/template?format=${templateFormat}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (!response.ok) {
+        throw new Error("Fehler beim Herunterladen der Vorlage");
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download =
+        templateFormat === "xlsx"
+          ? "eroeffnungssalden-import-vorlage.xlsx"
+          : "eroeffnungssalden-import-vorlage.csv";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      logger.error("opening_balance_template_download_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        format: templateFormat,
+      });
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+    }
+  }, [session, templateFormat]);
+
+  const runPreview = useCallback(
+    async (file: File) => {
+      setError(null);
+      setIsLoading(true);
+      setImportResult(null);
+      setPreviewStale(false);
+
+      try {
+        const token = session?.user?.token;
+        if (!token) throw new Error("Keine Authentifizierung");
+
+        const response = await fetch("/api/import/opening-balances/preview", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: buildFormData(file),
+        });
+        const payload = (await response.json()) as Record<string, unknown>;
+        if (!response.ok) {
+          throw new Error(
+            (payload.message as string | undefined) ??
+              "Fehler bei der Vorschau",
+          );
+        }
+
+        const result = payload.data as ImportResult;
+        setPreviewResult(result);
+        setPreviewRows(buildDisplayRows(result));
+      } catch (err) {
+        logger.error("opening_balance_preview_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+        setPreviewRows([]);
+        setPreviewResult(null);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [buildFormData, session],
+  );
+
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      setUploadedFile(file);
+      if (!paramsComplete) {
+        resetPreview();
+        setError(
+          "Bitte zuerst Stichtag und Begründung angeben, dann wird die Vorschau erstellt.",
+        );
+        return;
+      }
+      void runPreview(file);
+    },
+    [paramsComplete, resetPreview, runPreview],
+  );
+
+  // Stichtag und Begründung gehen in jede Buchung ein — eine Vorschau, die
+  // mit anderen Werten gerechnet wurde, darf nicht bestätigt werden.
+  const handleParamChange = useCallback(
+    (apply: () => void) => {
+      apply();
+      setPreviewRows([]);
+      setPreviewResult(null);
+      setImportResult(null);
+      setPreviewStale(uploadedFile !== null);
+    },
+    [uploadedFile],
+  );
+
+  const handleImport = useCallback(async () => {
+    if (!uploadedFile) return;
+    setIsImporting(true);
+    setError(null);
+
+    try {
+      const token = session?.user?.token;
+      if (!token) throw new Error("Keine Authentifizierung");
+
+      const response = await fetch("/api/import/opening-balances/import", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: buildFormData(uploadedFile),
+      });
+      const payload = (await response.json()) as Record<string, unknown>;
+      if (!response.ok) {
+        throw new Error(
+          (payload.message as string | undefined) ?? "Fehler beim Import",
+        );
+      }
+
+      const result = payload.data as ImportResult;
+      setImportResult(result);
+      setPreviewResult(null);
+      setPreviewRows((result.Errors ?? []).map(toDisplayRow));
+
+      if (result.ErrorCount > 0) {
+        toast.warning(
+          `${result.CreatedCount} übernommen, ${result.ErrorCount} übersprungen`,
+        );
+      } else {
+        toast.success(
+          `${result.CreatedCount} ${result.CreatedCount === 1 ? "Übernahme" : "Übernahmen"} gebucht`,
+        );
+      }
+    } catch (err) {
+      logger.error("opening_balance_import_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+    } finally {
+      setIsImporting(false);
+    }
+  }, [buildFormData, session, toast, uploadedFile]);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      const file = e.dataTransfer.files[0];
+      if (!file) return;
+      if (!isSpreadsheet(file)) {
+        setError("Bitte nur CSV- oder Excel-Dateien (.csv, .xlsx) hochladen");
+        return;
+      }
+      handleFileSelect(file);
+    },
+    [handleFileSelect],
+  );
+
+  if (status === "loading") {
+    return <Loading fullPage={false} />;
+  }
+
+  // Die Datenverwaltung ist bereits adminOnly (database/layout.tsx); die
+  // Buchungen selbst hängen am Stundenkonto-Recht.
+  if (!hasPermission(session, "time_tracking:manage")) {
+    return (
+      <ForbiddenPage message="Für den Import von Eröffnungssalden wird die Berechtigung zur Verwaltung der Zeiterfassung benötigt." />
+    );
+  }
+
+  const importable = previewResult?.CreatedCount ?? 0;
+  const previewErrors = previewResult?.ErrorCount ?? 0;
+  const showPreview = previewResult !== null && importResult === null;
+
+  return (
+    <main className="mx-auto w-full max-w-5xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
+      <BackButton referrer="/database/personal" />
+
+      <header>
+        <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
+          Datenverwaltung
+        </p>
+        <h1 className="mt-1 text-2xl font-bold text-gray-900 sm:text-3xl">
+          Eröffnungssalden importieren
+        </h1>
+        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-gray-600">
+          Übernimmt die Stände aus dem Altsystem: Stundenkonto-Saldo,
+          Urlaubsanspruch samt Vorjahresübertrag und den Resturlaub zum
+          Stichtag. Aus dem Resturlaub errechnet moto die vor der Einführung
+          genommenen Urlaubstage. Pro Person ist nur eine Übernahme möglich.
+        </p>
+      </header>
+
+      {error && (
+        <div className="relative">
+          <Alert type="error" message={error} />
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            className="absolute top-1/2 right-4 -translate-y-1/2 text-gray-500 hover:text-gray-800"
+            aria-label="Fehler schließen"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {/* Schritt 1 — Vorlage */}
+      <section className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+        <h2 className="text-sm font-semibold text-gray-900">
+          Schritt 1: Vorlage herunterladen
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Spalten: <span className="font-medium">Personalnummer</span>{" "}
+          (optional), <span className="font-medium">Vorname</span>,{" "}
+          <span className="font-medium">Nachname</span>,{" "}
+          <span className="font-medium">Stundensaldo</span>,{" "}
+          <span className="font-medium">Jahresanspruch</span>,{" "}
+          <span className="font-medium">Vorjahresübertrag</span>,{" "}
+          <span className="font-medium">Resturlaub</span>. Eine leere Zelle
+          lässt die jeweilige Seite unangetastet.
+        </p>
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="sm:w-64">
+            <label
+              id="template-format-label"
+              htmlFor="template-format"
+              className="mb-1.5 block text-sm font-medium text-gray-700"
+            >
+              Format wählen
+            </label>
+            <CustomSelect
+              id="template-format"
+              ariaLabelledBy="template-format-label"
+              value={templateFormat}
+              options={[
+                { value: "csv", label: "CSV (Komma-getrennt)" },
+                { value: "xlsx", label: "Excel (.xlsx)" },
+              ]}
+              onChange={(next) => setTemplateFormat(next as "csv" | "xlsx")}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            className="h-9"
+            onClick={() => void handleDownloadTemplate()}
+          >
+            Vorlage herunterladen
+          </Button>
+        </div>
+      </section>
+
+      {/* Schritt 2 — Stichtag und Begründung */}
+      <section className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+        <h2 className="text-sm font-semibold text-gray-900">
+          Schritt 2: Stichtag und Begründung
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Beides gilt für die ganze Datei und wird an jeder Buchung
+          protokolliert.
+        </p>
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+          <ISODatePicker
+            id="opening-balance-effective-date"
+            label="Stichtag"
+            value={effectiveDate}
+            max={latestEffectiveDate}
+            onChange={(next) => handleParamChange(() => setEffectiveDate(next))}
+            placeholder="Datum wählen"
+          />
+          <Input
+            id="opening-balance-note"
+            name="opening-balance-note"
+            label="Begründung"
+            value={note}
+            maxLength={200}
+            placeholder={`Übernahme aus Altsystem zum ${formatDate(latestEffectiveDate)}`}
+            onChange={(e) => handleParamChange(() => setNote(e.target.value))}
+          />
+        </div>
+      </section>
+
+      {/* Schritt 3 — Datei */}
+      <UploadSection
+        title="Schritt 3: Datei hochladen"
+        isDragging={isDragging}
+        isLoading={isLoading}
+        uploadedFile={uploadedFile}
+        onDragEnter={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setIsDragging(true);
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setIsDragging(false);
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        onDrop={handleDrop}
+        onFileSelect={handleFileSelect}
+      />
+
+      {previewStale && uploadedFile !== null && (
+        <section className="moto-content-surface flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+          <p className="text-sm text-gray-600">
+            Stichtag oder Begründung wurden geändert. Die Vorschau muss mit den
+            neuen Angaben neu erstellt werden.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            className="h-9"
+            disabled={!paramsComplete || isLoading}
+            onClick={() => void runPreview(uploadedFile)}
+          >
+            Vorschau erneut erstellen
+          </Button>
+        </section>
+      )}
+
+      {/* Schritt 4 — Vorschau */}
+      {showPreview && previewResult && (
+        <section className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+          <h2 className="text-sm font-semibold text-gray-900">
+            Schritt 4: Vorschau prüfen
+          </h2>
+          <div className="mt-3 grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+            <StatTile label="Zeilen" value={previewResult.TotalRows} />
+            <StatTile label="Übernehmbar" value={importable} />
+            <StatTile label="Hinweise" value={previewResult.WarningCount} />
+            <StatTile label="Fehler" value={previewErrors} />
+          </div>
+          {previewErrors > 0 && importable > 0 && (
+            <p className="mt-3 text-sm text-gray-600">
+              Fehlerhafte Zeilen werden beim Import übersprungen; die übrigen{" "}
+              {importable} werden gebucht.
+            </p>
+          )}
+          <div className="mt-3 space-y-2">
+            {previewRows.length === 0 ? (
+              <EmptyState
+                title="Keine Zeilen gefunden"
+                description="Die Datei enthält keine auswertbaren Datenzeilen."
+              />
+            ) : (
+              previewRows.map((row) => (
+                <PreviewRowCard key={row.key} row={row} />
+              ))
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Ergebnis */}
+      {importResult && (
+        <section className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+          <h2 className="text-sm font-semibold text-gray-900">
+            Import abgeschlossen
+          </h2>
+          <div className="mt-3 grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+            <StatTile label="Zeilen" value={importResult.TotalRows} />
+            <StatTile label="Übernommen" value={importResult.CreatedCount} />
+            <StatTile label="Hinweise" value={importResult.WarningCount} />
+            <StatTile label="Fehler" value={importResult.ErrorCount} />
+          </div>
+          {previewRows.length > 0 && (
+            <>
+              <p className="mt-3 text-sm text-gray-600">
+                Diese Zeilen wurden übersprungen oder tragen Hinweise:
+              </p>
+              <div className="mt-2 space-y-2">
+                {previewRows.map((row) => (
+                  <PreviewRowCard key={row.key} row={row} />
+                ))}
+              </div>
+            </>
+          )}
+          <div className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              className="h-9"
+              onClick={resetAll}
+            >
+              Weitere Datei importieren
+            </Button>
+          </div>
+        </section>
+      )}
+
+      {showPreview && previewRows.length > 0 && (
+        <div className="sticky bottom-4 z-10 flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur-sm sm:flex-row">
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            className="h-9 flex-1"
+            onClick={resetAll}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            variant="success"
+            size="md"
+            className="h-9 flex-1"
+            disabled={importable === 0 || isImporting}
+            onClick={() => void handleImport()}
+          >
+            {isImporting
+              ? "Wird übernommen…"
+              : `${importable} ${importable === 1 ? "Übernahme" : "Übernahmen"} buchen`}
+          </Button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -241,10 +241,11 @@ export default function OpeningBalanceImportPage() {
 
   // Ein Eröffnungssaldo beschreibt einen abgeschlossenen Stand; der heutige
   // Tag läuft noch, deshalb ist gestern der späteste sinnvolle Stichtag.
-  const latestEffectiveDate = useMemo(
-    () => toISODate(new Date(parseISODate(berlinToday).getTime() - 86_400_000)),
-    [berlinToday],
-  );
+  const latestEffectiveDate = useMemo(() => {
+    const latest = parseISODate(berlinToday);
+    latest.setDate(latest.getDate() - 1);
+    return toISODate(latest);
+  }, [berlinToday]);
 
   const paramsComplete = effectiveDate !== "" && note.trim() !== "";
 

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -329,7 +329,8 @@ export default function OpeningBalanceImportPage() {
         const payload = (await response.json()) as Record<string, unknown>;
         if (!response.ok) {
           throw new Error(
-            (payload.message as string | undefined) ??
+            (payload.error as string | undefined) ??
+              (payload.message as string | undefined) ??
               "Fehler bei der Vorschau",
           );
         }
@@ -402,7 +403,9 @@ export default function OpeningBalanceImportPage() {
       const payload = (await response.json()) as Record<string, unknown>;
       if (!response.ok) {
         throw new Error(
-          (payload.message as string | undefined) ?? "Fehler beim Import",
+          (payload.error as string | undefined) ??
+            (payload.message as string | undefined) ??
+            "Fehler beim Import",
         );
       }
 

--- a/frontend/src/app/[tenant]/(protected)/database/personal/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/page.tsx
@@ -13,6 +13,7 @@ import {
   type Grouper,
 } from "~/components/database/use-grouped-items";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import type { ActiveFilter } from "~/components/ui/page-header/types";
 import { useToast } from "~/contexts/ToastContext";
 import { useIsMobile } from "~/components/ui/hooks/useIsMobile";
@@ -346,6 +347,18 @@ function TeachersPageContent() {
                   </Link>
                 </>
               ) : null}
+              {/* Zweiter Import-Weg (#2132): eigener Flow mit Stichtag und
+                  Begründung, deshalb im Menü statt als weiterer Button. */}
+              <OverflowMenu
+                ariaLabel="Weitere Import-Aktionen"
+                items={[
+                  {
+                    label: "Eröffnungssalden importieren",
+                    href: "/database/personal/opening-balances",
+                    onClick: () => undefined,
+                  },
+                ]}
+              />
               {canManageUsers ? (
                 <DatabaseCreateAction
                   label="Personal"

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -559,6 +559,11 @@ function StaffPageContent() {
           monthIsOver={!isCurrentOrFutureMonth}
           onCloseMonth={() => setShowCloseModal(true)}
           onExport={() => setShowExportModal(true)}
+          onOpeningBalances={
+            userIsAdmin
+              ? () => router.push("/database/personal/opening-balances")
+              : undefined
+          }
           isLoading={accountsLoading && !accounts}
           error={
             accountsError ? "Zeitkonten konnten nicht geladen werden." : null

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -560,7 +560,7 @@ function StaffPageContent() {
           onCloseMonth={() => setShowCloseModal(true)}
           onExport={() => setShowExportModal(true)}
           onOpeningBalances={
-            canManageTimeTracking
+            userIsAdmin
               ? () => router.push("/database/personal/opening-balances")
               : undefined
           }

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -560,7 +560,7 @@ function StaffPageContent() {
           onCloseMonth={() => setShowCloseModal(true)}
           onExport={() => setShowExportModal(true)}
           onOpeningBalances={
-            userIsAdmin
+            canManageTimeTracking
               ? () => router.push("/database/personal/opening-balances")
               : undefined
           }

--- a/frontend/src/app/api/import/opening-balances/import/route.ts
+++ b/frontend/src/app/api/import/opening-balances/import/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "OpeningBalanceImportRoute" });
+
+async function POSTHandler(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await request.formData();
+
+    const response = await fetch(
+      `${getServerApiUrl()}/api/import/opening-balances/import`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.user.token}`,
+        },
+        body: formData,
+      },
+    );
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    logger.error("opening_balance_import_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const POST = withTenantAuth(POSTHandler);

--- a/frontend/src/app/api/import/opening-balances/preview/route.ts
+++ b/frontend/src/app/api/import/opening-balances/preview/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "OpeningBalancePreviewRoute" });
+
+async function POSTHandler(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await request.formData();
+
+    const response = await fetch(
+      `${getServerApiUrl()}/api/import/opening-balances/preview`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.user.token}`,
+        },
+        body: formData,
+      },
+    );
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    logger.error("opening_balance_preview_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const POST = withTenantAuth(POSTHandler);

--- a/frontend/src/app/api/import/opening-balances/template/route.ts
+++ b/frontend/src/app/api/import/opening-balances/template/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { auth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "OpeningBalanceTemplateRoute" });
+
+async function GETHandler(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const format = searchParams.get("format") ?? "csv";
+
+    const response = await fetch(
+      `${getServerApiUrl()}/api/import/opening-balances/template?format=${format}`,
+      {
+        headers: {
+          Authorization: `Bearer ${session.user.token}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      return NextResponse.json(
+        { error: error || "Failed to download template" },
+        { status: response.status },
+      );
+    }
+
+    const contentType =
+      response.headers.get("Content-Type") ?? "text/csv; charset=utf-8";
+    const contentDisposition =
+      response.headers.get("Content-Disposition") ??
+      'attachment; filename="eroeffnungssalden-import-vorlage.csv"';
+
+    const blob = await response.blob();
+    return new NextResponse(blob, {
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": contentDisposition,
+      },
+    });
+  } catch (error) {
+    logger.error("template_download_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = withTenantAuth(GETHandler);

--- a/frontend/src/app/api/staff/[id]/time-tracking/opening/route.ts
+++ b/frontend/src/app/api/staff/[id]/time-tracking/opening/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from "next/server";
+import { apiPost } from "~/lib/api-helpers.server";
+import { createPostHandler } from "~/lib/route-wrapper.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+// Explicit allowlist: only these fields reach the backend.
+interface OpeningBalanceBody {
+  effective_date?: string;
+  balance_minutes?: number;
+  note?: string;
+}
+
+/**
+ * POST /api/staff/[id]/time-tracking/opening
+ * Go-live Eröffnungssaldo (#2132): the backend computes the delta that turns
+ * the closing balance as of effective_date into the SIGNED target value.
+ */
+export const POST = createPostHandler<unknown, OpeningBalanceBody>(
+  async (
+    _request: NextRequest,
+    body: OpeningBalanceBody,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const staffId = requirePathSegmentParam(params);
+    const response = await apiPost<{ data: unknown }>(
+      `/api/staff/${staffId}/time-tracking/opening`,
+      token,
+      {
+        effective_date: body.effective_date,
+        balance_minutes: body.balance_minutes,
+        note: body.note,
+      },
+    );
+    return response.data;
+  },
+);

--- a/frontend/src/app/api/staff/[id]/vacation/opening/route.ts
+++ b/frontend/src/app/api/staff/[id]/vacation/opening/route.ts
@@ -1,0 +1,61 @@
+import type { NextRequest } from "next/server";
+import { apiDelete, apiPost } from "~/lib/api-helpers.server";
+import {
+  createDeleteHandler,
+  createPostHandler,
+} from "~/lib/route-wrapper.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+// Explicit allowlist: only these fields reach the backend.
+interface VacationOpeningBody {
+  effective_date?: string;
+  remaining_days?: number;
+  note?: string;
+}
+
+/**
+ * POST /api/staff/[id]/vacation/opening
+ * Vacation takeover (#2132): the admin enters the Resturlaub as of the
+ * Stichtag; the backend derives the pre-introduction days from the quota.
+ */
+export const POST = createPostHandler<unknown, VacationOpeningBody>(
+  async (
+    _request: NextRequest,
+    body: VacationOpeningBody,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const staffId = requirePathSegmentParam(params);
+    const response = await apiPost<{ data: unknown }>(
+      `/api/staff/${staffId}/vacation/opening`,
+      token,
+      {
+        effective_date: body.effective_date,
+        remaining_days: body.remaining_days,
+        note: body.note,
+      },
+    );
+    return response.data;
+  },
+);
+
+/**
+ * DELETE /api/staff/[id]/vacation/opening?year=YYYY
+ * Removes the takeover (with an append-only deletion tombstone backend-side).
+ */
+export const DELETE = createDeleteHandler(
+  async (
+    request: NextRequest,
+    token: string,
+    params: Record<string, unknown>,
+  ) => {
+    const staffId = requirePathSegmentParam(params);
+    const year = request.nextUrl.searchParams.get("year") ?? "";
+    if (year && !/^\d{4}$/.test(year)) {
+      throw new Error("Invalid year");
+    }
+    const qs = year ? `?year=${year}` : "";
+    await apiDelete(`/api/staff/${staffId}/vacation/opening${qs}`, token);
+    return null;
+  },
+);

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.ts
@@ -95,6 +95,7 @@ const subPageLabels: Record<string, string> = {
   edit: "Bearbeiten",
   details: "Details",
   permissions: "Berechtigungen",
+  "opening-balances": "Eröffnungssalden",
 };
 
 /**

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -822,13 +822,15 @@ export const appChapters: readonly GuideChapter[] = [
           "Im Reiter `Stammdaten` die Sektionen `Person`, `Kontakt`, `Arbeitsvertrag` und `Qualifikationen` (mit Ablaufdatum, z. B. Erste-Hilfe-Kurs) pflegen. Sichtbar sind diese Sektionen nur mit `Benutzer bearbeiten` oder `time_tracking:manage` — nicht für alle, die die Mitarbeiterliste sehen dürfen; `Bearbeiten` erfordert `Benutzer bearbeiten`, jede Änderung landet mit optionaler Begründung im Audit-Log. In der Sektion `Abrechnung` liegt die Personalnummer für die Abrechnung. Bank- und Steuerdaten (IBAN, Steuer-ID, SV-Nummer) sehen nur Rollen mit der Berechtigung `Bank- & Steuerdaten`: Die Werte sind maskiert, `Anzeigen` blendet sie ein, und jeder Abruf wird protokolliert.",
           "Im Reiter `Übersicht` Stundenkonto, Urlaubstage und Krankheitstage prüfen. Die Diagramme lassen sich einzeln nach Zeitraum filtern.",
           "Im Bereich `Stundenkonto-Verwaltung` Plus-Stunden auszahlen (`Auszahlung`), pauschal als `Freizeitausgleich` verrechnen oder das Konto mit `Zurücksetzen` zum Stichtag (Schuljahresende 31.07.) auf null bzw. einen Rest-Übertrag setzen. Für einen Reset lässt sich nur ein bereits abgeschlossener Tag wählen, nicht der heutige Tag. Jede Buchung braucht eine Begründung und erscheint in der Historie darunter; eine Fehlbuchung lässt sich dort wieder löschen.",
+          "Beim Umstieg auf moto den Stand aus dem Altsystem über `Eröffnungssaldo` übernehmen: Stichtag wählen, den Saldo in Stunden eintragen (auch negativ, z. B. -3,25) und begründen. Ab dem Stichtag zählt moto auf diesem Stand weiter. Pro Person ist nur ein Eröffnungssaldo möglich; eine Korrektur läuft über Löschen der Buchung und Neuanlegen.",
           "Im Reiter `Zeiterfassung` zwischen Woche und Monat wechseln und Plan (geplante Schicht aus dem Dienstplan), Check-in, Check-out, Pause, Soll, Ist, Saldo, Quelle und Hinweise kontrollieren. So stehen geplante Schicht und tatsächliche Zeit nebeneinander.",
-          "In der Monatsansicht zeigt die `Monatskarte` Übertrag aus dem Vormonat, Summe Soll, Summe Ist, Gutschriften für Krankheit und Urlaub (mit Tagen), Stundenkonto-Buchungen des Monats (Auszahlung, Freizeitausgleich, Reset), die im Dienstplan verplanten Stunden und den Monatssaldo. Krankheit und Urlaub erzeugen keine Minusstunden — der Tag wird mit dem Tagessoll gutgeschrieben. Alle Werte werden live berechnet: Eine Korrektur in einem früheren Monat aktualisiert den Übertrag automatisch.",
+          "In der Monatsansicht zeigt die `Monatskarte` Übertrag aus dem Vormonat, Summe Soll, Summe Ist, Gutschriften für Krankheit und Urlaub (mit Tagen), Stundenkonto-Buchungen des Monats (Auszahlung, Freizeitausgleich, Reset, Eröffnungssaldo), die im Dienstplan verplanten Stunden und den Monatssaldo. Krankheit und Urlaub erzeugen keine Minusstunden — der Tag wird mit dem Tagessoll gutgeschrieben. Alle Werte werden live berechnet: Eine Korrektur in einem früheren Monat aktualisiert den Übertrag automatisch.",
           "Bei einem abgeschlossenen Monat trägt die Monatskarte das Schloss-Symbol `Abgeschlossen am ...` und zeigt als verbindlichen Wert den `Übertrag Monatsende (eingefroren)`. Werden danach noch Zeiten in diesem Monat geändert, bleibt der Übertrag in den Folgemonat stehen; ein gelber Hinweis zeigt die Abweichung zum abgeschlossenen Stand. Für die Korrektur gibt es zwei Wege: die Differenz als Buchung im offenen Monat erfassen (Stundenkonto-Verwaltung im Reiter `Übersicht`, empfohlen), oder über `Monat wieder öffnen` den Abschluss dieser Person mit Begründung aufheben, wenn der Abschluss selbst falsch war. Buchungen mit Datum in einem abgeschlossenen Monat lehnt das System ab.",
           "Eine Zeile mit Änderungshistorie aufklappen, um geplante gegen tatsächliche Zeit zu sehen. Wurde beim Stempeln eine Abweichung begründet, erscheint sie dort als `Abweichung` mit geplanter Zeit, Ist-Zeit und Grund.",
           "Bei einem Arbeitstag das Stift-Symbol nutzen, um Zeiten nachzutragen oder zu korrigieren. Eine Begründung ist erforderlich und landet im Audit-Log.",
           "Im Reiter `Arbeitszeitmodell` eine Vorlage zuweisen oder ein eigenes Modell mit 1 bis 4 Wochen Rotation pflegen. Pro Arbeitstag kann optional eine Startzeit hinterlegt werden.",
           "Im Reiter `Abwesenheiten` Urlaubsanspruch und offene Anträge prüfen, genehmigen, mit Begründung ablehnen oder eine `Rückfrage` mit Notiz stellen. Die Person sieht die Rückfrage in ihrer Zeiterfassung, kann ihre Antwort ergänzen und den Antrag erneut einreichen.",
+          "Beim Umstieg auf moto den Resturlaub über die `Urlaubs-Übernahme` erfassen: Stichtag und Resturlaub zum Stichtag eintragen; moto errechnet daraus die vor der Einführung bereits genommenen Tage. Der Jahresanspruch bleibt unverändert, spätere Anspruchskorrekturen wirken sich weiterhin korrekt auf den Rest aus. Auch ein überzogenes Konto (negativer Rest) lässt sich abbilden.",
           "Über `Freizeitausgleich eintragen` im Reiter `Abwesenheiten` einen ganzen freien Zeitraum oder einen halben einzelnen Tag direkt für die Person erfassen. Das Stundenkonto sinkt um die ausfallende Sollzeit. Bei einem halben Tag muss die gearbeitete Hälfte als Arbeitszeit erfasst sein; nicht erfasste Zeit bleibt als Minus bestehen. Mitarbeitende können diesen Eintrag nur ansehen, nicht selbst anlegen, ändern oder löschen.",
           "Über `Krank melden` im Reiter `Abwesenheiten` eine Krankmeldung für die Person eintragen; sie storniert reguläre Schichten und markiert Betreuungsblöcke als abwesend. Bereits eingetragene Vertretungsschichten bleiben bestehen und müssen manuell geprüft werden. Ein halber Krankheitstag gilt immer für ein einzelnes Datum und ändert Dienst- und Betreuungsplan nicht automatisch. Beim Löschen der Krankmeldung werden nur Schichten und Blöcke ohne eingetragenen Ersatz automatisch wiederhergestellt.",
         ],
@@ -839,6 +841,28 @@ export const appChapters: readonly GuideChapter[] = [
         },
         screenshot:
           "Mitarbeiterprofil mit Tabs für Übersicht, Zeiterfassung, Arbeitszeitmodell und Abwesenheiten.",
+        printCompact: true,
+      },
+      {
+        id: "eroeffnungssalden-import",
+        title: "Eröffnungssalden gesammelt importieren",
+        icon: Download,
+        summary:
+          "Übernimmt beim Umstieg auf moto Stundenkonto-Stände und Resturlaub für das ganze Team aus einer Excel- oder CSV-Liste.",
+        steps: [
+          "In der Datenverwaltung unter `Personal` den Punkt `Eröffnungssalden importieren` öffnen.",
+          "Die Vorlage herunterladen und pro Person ausfüllen: `Stundensaldo` in Stunden (auch negativ, z. B. -3,25), `Jahresanspruch`, `Vorjahresübertrag` und `Resturlaub` in Tagen. Leere Zellen überspringen die jeweilige Übernahme. Die `Personalnummer` sorgt bei Namensgleichheit für eine eindeutige Zuordnung.",
+          "Stichtag (z. B. der Tag vor dem Go-live) und eine Begründung eintragen; beides gilt für die ganze Datei und wird an jeder Buchung gespeichert.",
+          "Die Vorschau prüfen: Zeilen mit Fehlern (unbekannte Person, ungültige Zahl, bereits vorhandene Übernahme) werden einzeln erklärt und beim Import übersprungen.",
+          "Mit `Importieren` bestätigen. Jede Übernahme erscheint anschließend im Änderungsprotokoll der Zeiterfassung und in der Stundenkonto-Historie der Person.",
+        ],
+        callout: {
+          title: "Nur einmal pro Person",
+          body: "Pro Person ist eine Übernahme je Konto möglich. Eine fehlerhafte Übernahme lässt sich im Mitarbeiterprofil löschen und danach neu erfassen oder erneut importieren.",
+          tone: "blue",
+        },
+        screenshot:
+          "Import-Seite für Eröffnungssalden mit Vorlage, Stichtag, Begründung und Vorschau.",
         printCompact: true,
       },
       {

--- a/frontend/src/components/import/upload-section.tsx
+++ b/frontend/src/components/import/upload-section.tsx
@@ -68,6 +68,10 @@ export function UploadSection({
         onChange={(e) => {
           const file = e.target.files?.[0];
           if (file) onFileSelect(file);
+          // Clear the input so re-selecting the SAME filename fires change
+          // again — the common "Datei korrigieren und erneut hochladen" case
+          // would otherwise silently do nothing.
+          e.target.value = "";
         }}
         className="sr-only"
         aria-label="Datei auswählen"

--- a/frontend/src/components/import/upload-section.tsx
+++ b/frontend/src/components/import/upload-section.tsx
@@ -4,6 +4,12 @@ interface UploadSectionProps {
   readonly isDragging: boolean;
   readonly isLoading: boolean;
   readonly uploadedFile: File | null;
+  /**
+   * Überschrift der Karte. Der Eröffnungssalden-Import (#2132) hat einen
+   * Schritt mehr (Stichtag und Begründung), deshalb ist die Schrittnummer
+   * überschreibbar. Ohne Angabe bleibt der bisherige Text stehen.
+   */
+  readonly title?: string;
   readonly onDragEnter: (e: React.DragEvent) => void;
   readonly onDragLeave: (e: React.DragEvent) => void;
   readonly onDragOver: (e: React.DragEvent) => void;
@@ -15,6 +21,7 @@ export function UploadSection({
   isDragging,
   isLoading,
   uploadedFile,
+  title = "Schritt 2: Datei hochladen",
   onDragEnter,
   onDragLeave,
   onDragOver,
@@ -49,7 +56,7 @@ export function UploadSection({
             d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
           />
         </svg>
-        Schritt 2: Datei hochladen
+        {title}
       </h3>
 
       {/* Hidden file input */}

--- a/frontend/src/components/staff/abwesenheiten-tab.opening.test.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.opening.test.tsx
@@ -115,14 +115,14 @@ function quota(
 }
 
 const existingOpening = {
-  id: 7,
-  staff_id: 4,
+  id: "7",
+  staff_id: "4",
   year,
   effective_date: `${year}-02-28`,
   taken_before_days: 6,
   entered_remaining_days: 26,
   note: "Übernahme aus Urlaubsliste",
-  decided_by: 9,
+  decided_by: "9",
   decided_at: `${year}-03-01T08:00:00Z`,
 };
 
@@ -164,6 +164,38 @@ describe("AbwesenheitenTab vacation takeover", () => {
         note: "Übernahme aus Urlaubsliste",
       });
     });
+  });
+
+  it("rejects malformed and over-precise vacation opening values", async () => {
+    mocks.getVacationQuota.mockResolvedValue(quota());
+    mocks.getAbsences.mockResolvedValue([]);
+    renderTab();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Urlaubs-Übernahme" }),
+    );
+    fireEvent.change(screen.getByLabelText("Stichtag"), {
+      target: { value: `${year}-02-28` },
+    });
+    fireEvent.change(screen.getByLabelText("Begründung (Pflicht)"), {
+      target: { value: "Übernahme aus Urlaubsliste" },
+    });
+
+    const remainingInput = screen.getByLabelText(
+      "Resturlaub zum Stichtag (Tage)",
+    );
+    for (const value of ["14,5 Tage", "12abc", "12,25"]) {
+      fireEvent.change(remainingInput, { target: { value } });
+
+      expect(
+        screen.getByRole("button", { name: "Übernahme buchen" }),
+      ).toBeDisabled();
+      expect(
+        screen.getByText(
+          "Bitte eine Zahl zwischen -999 und 999 mit höchstens einer Nachkommastelle eingeben.",
+        ),
+      ).toBeInTheDocument();
+    }
   });
 
   it("shows the booked takeover and deletes it instead of editing", async () => {

--- a/frontend/src/components/staff/abwesenheiten-tab.opening.test.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.opening.test.tsx
@@ -1,0 +1,216 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { StaffVacationQuotaSummary } from "~/lib/staff-api";
+
+// Same stub as stundenkonto-panel.test.tsx: the kit picker opens a calendar
+// overlay, the native input keeps the Stichtag settable via fireEvent.change
+// and forwards min/max so the computed bounds stay assertable.
+vi.mock("~/components/ui/date-picker", async (importOriginal) => {
+  const { isoDatePickerMock } = await import("~/test/mocks/date-picker");
+  return { ...(await importOriginal<object>()), ...isoDatePickerMock() };
+});
+
+vi.mock("~/components/ui/modal", () => ({
+  Modal: ({
+    isOpen,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+// Reduced to the confirm path: the two-step gate is the shared component's own
+// concern and is covered where that component lives.
+vi.mock("~/components/ui/confirm-delete-modal", () => ({
+  ConfirmDeleteModal: ({
+    isOpen,
+    title,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    title: string;
+    onConfirm: () => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        <button type="button" onClick={onConfirm}>
+          Bestätigen
+        </button>
+      </div>
+    ) : null,
+}));
+
+// Both hooks return stable identities on purpose: the tab's reload callback
+// depends on the toast object, so a fresh object per render would re-run the
+// load effect forever and keep the tab in its loading state.
+const stable = vi.hoisted(() => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  mutateMatching: vi.fn().mockResolvedValue(undefined),
+  swrMutate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => stable.toast,
+}));
+
+// Without an SWRConfig provider `useSWRConfig()` hands back a fresh `mutate`
+// on every render, which would re-run the tab's load effect endlessly.
+vi.mock("swr", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useSWRConfig: () => ({ mutate: stable.swrMutate }),
+}));
+
+vi.mock("~/lib/swr", () => ({
+  useTenantMutateMatching: () => stable.mutateMatching,
+}));
+
+const mocks = vi.hoisted(() => ({
+  getVacationQuota: vi.fn(),
+  getAbsences: vi.fn(),
+  setVacationOpening: vi.fn(),
+  deleteVacationOpening: vi.fn(),
+}));
+
+vi.mock("~/lib/staff-api", () => ({
+  staffAbsenceService: {
+    getVacationQuota: mocks.getVacationQuota,
+    getAbsences: mocks.getAbsences,
+    setVacationOpening: mocks.setVacationOpening,
+    deleteVacationOpening: mocks.deleteVacationOpening,
+    approve: vi.fn(),
+    deleteAbsence: vi.fn(),
+  },
+}));
+
+import { AbwesenheitenTab } from "./abwesenheiten-tab";
+
+const year = new Date().getFullYear();
+
+function quota(
+  overrides: Partial<StaffVacationQuotaSummary> = {},
+): StaffVacationQuotaSummary {
+  return {
+    staff_id: 4,
+    year,
+    entitled_days: 30,
+    carryover_days: 2,
+    taken_before_days: 0,
+    taken_days: 0,
+    reserved_days: 0,
+    remaining_days: 32,
+    ...overrides,
+  };
+}
+
+const existingOpening = {
+  id: 7,
+  staff_id: 4,
+  year,
+  effective_date: `${year}-02-28`,
+  taken_before_days: 6,
+  entered_remaining_days: 26,
+  note: "Übernahme aus Urlaubsliste",
+  decided_by: 9,
+  decided_at: `${year}-03-01T08:00:00Z`,
+};
+
+function renderTab() {
+  return render(
+    <AbwesenheitenTab staffId="4" canEdit canManageSickReports={false} />,
+  );
+}
+
+describe("AbwesenheitenTab vacation takeover", () => {
+  it("books a takeover from the entered Resturlaub", async () => {
+    mocks.getVacationQuota.mockResolvedValue(quota());
+    mocks.getAbsences.mockResolvedValue([]);
+    mocks.setVacationOpening.mockResolvedValue(existingOpening);
+    renderTab();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Urlaubs-Übernahme" }),
+    );
+
+    const date = screen.getByLabelText("Stichtag");
+    fireEvent.change(date, { target: { value: `${year}-02-28` } });
+    fireEvent.change(screen.getByLabelText("Resturlaub zum Stichtag (Tage)"), {
+      target: { value: "26" },
+    });
+    fireEvent.change(screen.getByLabelText("Begründung (Pflicht)"), {
+      target: { value: "Übernahme aus Urlaubsliste" },
+    });
+
+    // Anspruch 30 + Übertrag 2 − Rest 26 = 6, wie der Server rechnet.
+    expect(screen.getByText("6 Tage")).toBeInTheDocument();
+    // Der Stichtag bleibt im angezeigten Jahr.
+    expect(date).toHaveAttribute("min", `${year}-01-01`);
+
+    fireEvent.click(screen.getByRole("button", { name: "Übernahme buchen" }));
+
+    await waitFor(() => {
+      expect(mocks.setVacationOpening).toHaveBeenCalledWith("4", {
+        effectiveDate: `${year}-02-28`,
+        remainingDays: 26,
+        note: "Übernahme aus Urlaubsliste",
+      });
+    });
+  });
+
+  it("shows the booked takeover and deletes it instead of editing", async () => {
+    mocks.getVacationQuota.mockResolvedValue(
+      quota({
+        taken_before_days: 6,
+        remaining_days: 26,
+        opening: existingOpening,
+      }),
+    );
+    mocks.getAbsences.mockResolvedValue([]);
+    mocks.deleteVacationOpening.mockResolvedValue(undefined);
+    renderTab();
+
+    expect(
+      await screen.findByText("6 Tage vor Einführung genommen"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Urlaubs-Übernahme" }));
+    expect(
+      screen.queryByLabelText("Resturlaub zum Stichtag (Tage)"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Übernahme löschen" }));
+    fireEvent.click(screen.getByRole("button", { name: "Bestätigen" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteVacationOpening).toHaveBeenCalledWith("4", year);
+    });
+  });
+
+  it("hides the takeover entry point without edit permission", async () => {
+    mocks.getVacationQuota.mockResolvedValue(quota());
+    mocks.getAbsences.mockResolvedValue([]);
+    render(
+      <AbwesenheitenTab
+        staffId="4"
+        canEdit={false}
+        canManageSickReports={false}
+      />,
+    );
+
+    expect(await screen.findByText("Historie " + year)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Urlaubs-Übernahme" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/staff/abwesenheiten-tab.opening.test.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.opening.test.tsx
@@ -127,9 +127,7 @@ const existingOpening = {
 };
 
 function renderTab() {
-  return render(
-    <AbwesenheitenTab staffId="4" canEdit canManageSickReports={false} />,
-  );
+  return render(<AbwesenheitenTab staffId="4" canEdit canManageSickReports />);
 }
 
 describe("AbwesenheitenTab vacation takeover", () => {
@@ -146,14 +144,14 @@ describe("AbwesenheitenTab vacation takeover", () => {
     const date = screen.getByLabelText("Stichtag");
     fireEvent.change(date, { target: { value: `${year}-02-28` } });
     fireEvent.change(screen.getByLabelText("Resturlaub zum Stichtag (Tage)"), {
-      target: { value: "26" },
+      target: { value: "26,5" },
     });
     fireEvent.change(screen.getByLabelText("Begründung (Pflicht)"), {
       target: { value: "Übernahme aus Urlaubsliste" },
     });
 
-    // Anspruch 30 + Übertrag 2 − Rest 26 = 6, wie der Server rechnet.
-    expect(screen.getByText("6 Tage")).toBeInTheDocument();
+    // Anspruch 30 + Übertrag 2 − Rest 26,5 = 5,5, wie der Server rechnet.
+    expect(screen.getByText("5,5 Tage")).toBeInTheDocument();
     // Der Stichtag bleibt im angezeigten Jahr.
     expect(date).toHaveAttribute("min", `${year}-01-01`);
 
@@ -162,7 +160,7 @@ describe("AbwesenheitenTab vacation takeover", () => {
     await waitFor(() => {
       expect(mocks.setVacationOpening).toHaveBeenCalledWith("4", {
         effectiveDate: `${year}-02-28`,
-        remainingDays: 26,
+        remainingDays: 26.5,
         note: "Übernahme aus Urlaubsliste",
       });
     });

--- a/frontend/src/components/staff/abwesenheiten-tab.stories.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.stories.tsx
@@ -11,9 +11,28 @@ const quota: StaffVacationQuotaSummary = {
   year: new Date().getFullYear(),
   entitled_days: 30,
   carryover_days: 2,
+  taken_before_days: 0,
   taken_days: 8,
   reserved_days: 3,
   remaining_days: 21,
+};
+
+// Urlaubs-Übernahme zum Go-live-Stichtag (#2132).
+const quotaWithOpening: StaffVacationQuotaSummary = {
+  ...quota,
+  taken_before_days: 6,
+  remaining_days: 15,
+  opening: {
+    id: 7,
+    staff_id: 1,
+    year: quota.year,
+    effective_date: `${quota.year}-02-28`,
+    taken_before_days: 6,
+    entered_remaining_days: 26,
+    note: "Übernahme aus Urlaubsliste, Stand 28.02.",
+    decided_by: 4,
+    decided_at: `${quota.year}-03-01T08:00:00Z`,
+  },
 };
 
 const pendingAbsence: StaffAbsenceRow = {
@@ -101,6 +120,16 @@ export const ReadOnly: Story = {
   },
   beforeEach: () =>
     withMockedAbsences([pendingAbsence, upcomingAbsence, historyAbsence]),
+};
+
+export const WithVacationOpening: Story = {
+  args: {
+    staffId: "1",
+    canEdit: true,
+    canManageSickReports: true,
+  },
+  beforeEach: () =>
+    withMockedAbsences([upcomingAbsence, historyAbsence], quotaWithOpening),
 };
 
 export const Empty: Story = {

--- a/frontend/src/components/staff/abwesenheiten-tab.stories.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.stories.tsx
@@ -23,14 +23,14 @@ const quotaWithOpening: StaffVacationQuotaSummary = {
   taken_before_days: 6,
   remaining_days: 15,
   opening: {
-    id: 7,
-    staff_id: 1,
+    id: "7",
+    staff_id: "1",
     year: quota.year,
     effective_date: `${quota.year}-02-28`,
     taken_before_days: 6,
     entered_remaining_days: 26,
     note: "Übernahme aus Urlaubsliste, Stand 28.02.",
-    decided_by: 4,
+    decided_by: "4",
     decided_at: `${quota.year}-03-01T08:00:00Z`,
   },
 };

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -175,8 +175,6 @@ export function AbwesenheitenTab({
   // takeover modal.
   const [openingDeleteTarget, setOpeningDeleteTarget] =
     useState<StaffVacationOpening | null>(null);
-  const [openingDeleteLoading, setOpeningDeleteLoading] = useState(false);
-  const [openingDeleteError, setOpeningDeleteError] = useState("");
   // Snapshot of the staff identity taken when the modal opens: the live
   // `staff` prop can flip to undefined while onCreated's cache invalidation
   // refetches the page data, and a conditional `{staff && <Modal/>}` render
@@ -264,27 +262,6 @@ export function AbwesenheitenTab({
       );
     } finally {
       setPendingActionId(null);
-    }
-  };
-
-  const handleDeleteOpening = async () => {
-    if (!openingDeleteTarget) return;
-    setOpeningDeleteLoading(true);
-    setOpeningDeleteError("");
-    try {
-      await staffAbsenceService.deleteVacationOpening(
-        staffId,
-        openingDeleteTarget.year,
-      );
-      toast.success("Urlaubs-Übernahme gelöscht.");
-      setOpeningDeleteTarget(null);
-      await reload();
-    } catch (err) {
-      setOpeningDeleteError(
-        err instanceof Error ? err.message : "Löschen fehlgeschlagen.",
-      );
-    } finally {
-      setOpeningDeleteLoading(false);
     }
   };
 
@@ -520,32 +497,17 @@ export function AbwesenheitenTab({
           }}
         />
       )}
-      <ConfirmDeleteModal
-        isOpen={openingDeleteTarget !== null}
-        title="Urlaubs-Übernahme löschen"
-        description={
-          <>
-            Die Übernahme zum Stichtag{" "}
-            <strong>
-              {openingDeleteTarget
-                ? formatDate(openingDeleteTarget.effective_date)
-                : ""}
-            </strong>{" "}
-            wird gelöscht. Der Resturlaub steigt dadurch wieder um{" "}
-            {openingDeleteTarget
-              ? formatDayCount(openingDeleteTarget.taken_before_days)
-              : ""}
-            .
-          </>
-        }
-        gate={{ mode: "twoStep" }}
-        loading={openingDeleteLoading}
-        error={openingDeleteError}
-        confirmLabel="Löschen"
-        loadingLabel="Wird gelöscht…"
-        onConfirm={handleDeleteOpening}
-        onClose={() => setOpeningDeleteTarget(null)}
-      />
+      {openingDeleteTarget && (
+        <VacationOpeningDeleteModal
+          staffId={staffId}
+          opening={openingDeleteTarget}
+          onClose={() => setOpeningDeleteTarget(null)}
+          onDeleted={async () => {
+            setOpeningDeleteTarget(null);
+            await reload();
+          }}
+        />
+      )}
       {openingModal && quota && (
         <VacationOpeningModal
           staffId={staffId}
@@ -554,7 +516,6 @@ export function AbwesenheitenTab({
           onClose={() => setOpeningModal(false)}
           onDelete={(opening) => {
             setOpeningModal(false);
-            setOpeningDeleteError("");
             setOpeningDeleteTarget(opening);
           }}
           onSaved={async () => {
@@ -579,6 +540,61 @@ export function AbwesenheitenTab({
   );
 
   return <TabLoadingBoundary loading={loading}>{content}</TabLoadingBoundary>;
+}
+
+// Deletion of a vacation takeover (#2132). Own component so the tab renders
+// it as a plain `{target && <Modal/>}` branch: target, loading and error state
+// belong to the dialog, not to the tab.
+function VacationOpeningDeleteModal({
+  staffId,
+  opening,
+  onClose,
+  onDeleted,
+}: {
+  readonly staffId: string;
+  readonly opening: StaffVacationOpening;
+  readonly onClose: () => void;
+  readonly onDeleted: () => Promise<void>;
+}) {
+  const toast = useToast();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      await staffAbsenceService.deleteVacationOpening(staffId, opening.year);
+      toast.success("Urlaubs-Übernahme gelöscht.");
+      await onDeleted();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Löschen fehlgeschlagen.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ConfirmDeleteModal
+      isOpen
+      title="Urlaubs-Übernahme löschen"
+      description={
+        <>
+          Die Übernahme zum Stichtag{" "}
+          <strong>{formatDate(opening.effective_date)}</strong> wird gelöscht.
+          Der Resturlaub steigt dadurch wieder um{" "}
+          {formatDayCount(opening.taken_before_days)}.
+        </>
+      }
+      gate={{ mode: "twoStep" }}
+      loading={loading}
+      error={error}
+      confirmLabel="Löschen"
+      loadingLabel="Wird gelöscht…"
+      onConfirm={handleConfirm}
+      onClose={onClose}
+    />
+  );
 }
 
 function PendingAbsences({

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -997,10 +997,8 @@ function VacationOpeningModal({
           </label>
           <input
             id="vacation-opening-remaining"
-            type="number"
-            min="-999"
-            max="999"
-            step="0.5"
+            type="text"
+            inputMode="decimal"
             value={remainingDays}
             onChange={(e) => setRemainingDays(e.target.value)}
             placeholder="z. B. 12,5"

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -150,7 +150,7 @@ export function AbwesenheitenTab({
   readonly staff?: SickReportStaff;
 }) {
   const toast = useToast();
-  const year = useMemo(() => new Date().getFullYear(), []);
+  const year = Number.parseInt(berlinTodayISO().slice(0, 4), 10);
   const [quota, setQuota] = useState<StaffVacationQuotaSummary | null>(null);
   const [absences, setAbsences] = useState<StaffAbsenceRow[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -364,7 +364,7 @@ export function AbwesenheitenTab({
               </Button>
             </>
           )}
-          {canEdit && (
+          {canManageSickReports && (
             <Button
               type="button"
               variant="outline"

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -40,9 +40,10 @@ import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
 import {
   formatDate,
+  berlinTodayISO,
   parseISODate,
-  toISODate,
   todayISO,
+  toISODate,
 } from "~/lib/date-helpers";
 import {
   staffAbsenceService,
@@ -828,7 +829,7 @@ function VacationOpeningModal({
   const toast = useToast();
 
   const yearEndKey = `${year}-12-31`;
-  const yesterdayKey = previousDayISO(todayISO());
+  const yesterdayKey = previousDayISO(berlinTodayISO());
   const maxEffectiveDateKey =
     yesterdayKey < yearEndKey ? yesterdayKey : yearEndKey;
 

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 import { useSWRConfig } from "swr";
-import { Clock3, Thermometer, Trash2 } from "lucide-react";
+import { CalendarClock, Clock3, Thermometer, Trash2 } from "lucide-react";
 
 import {
   DenyAbsenceModal,
@@ -32,15 +32,22 @@ import {
 import { LOCATION_COLORS } from "~/lib/location-helper";
 import { Button } from "~/components/ui/button";
 import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
+import { ISODatePicker } from "~/components/ui/date-picker";
 import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
 import { StatusDotBadge } from "~/components/ui/status-dot-badge";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
-import { todayISO } from "~/lib/date-helpers";
+import {
+  formatDate,
+  parseISODate,
+  toISODate,
+  todayISO,
+} from "~/lib/date-helpers";
 import {
   staffAbsenceService,
   type StaffAbsenceRow,
+  type StaffVacationOpening,
   type StaffVacationQuotaSummary,
 } from "~/lib/staff-api";
 import { useTenantMutateMatching } from "~/lib/swr";
@@ -152,6 +159,14 @@ export function AbwesenheitenTab({
     null,
   );
   const [quotaModal, setQuotaModal] = useState(false);
+  const [openingModal, setOpeningModal] = useState(false);
+  // Vacation takeover deletion (#2132) runs through the shared
+  // ConfirmDeleteModal at tab level instead of nesting a dialog inside the
+  // takeover modal.
+  const [openingDeleteTarget, setOpeningDeleteTarget] =
+    useState<StaffVacationOpening | null>(null);
+  const [openingDeleteLoading, setOpeningDeleteLoading] = useState(false);
+  const [openingDeleteError, setOpeningDeleteError] = useState("");
   // Snapshot of the staff identity taken when the modal opens: the live
   // `staff` prop can flip to undefined while onCreated's cache invalidation
   // refetches the page data, and a conditional `{staff && <Modal/>}` render
@@ -242,6 +257,27 @@ export function AbwesenheitenTab({
     }
   };
 
+  const handleDeleteOpening = async () => {
+    if (!openingDeleteTarget) return;
+    setOpeningDeleteLoading(true);
+    setOpeningDeleteError("");
+    try {
+      await staffAbsenceService.deleteVacationOpening(
+        staffId,
+        openingDeleteTarget.year,
+      );
+      toast.success("Urlaubs-Übernahme gelöscht.");
+      setOpeningDeleteTarget(null);
+      await reload();
+    } catch (err) {
+      setOpeningDeleteError(
+        err instanceof Error ? err.message : "Löschen fehlgeschlagen.",
+      );
+    } finally {
+      setOpeningDeleteLoading(false);
+    }
+  };
+
   const handleDelete = async () => {
     if (!deleteTarget) return;
     setDeleteLoading(true);
@@ -295,37 +331,50 @@ export function AbwesenheitenTab({
         />
       </div>
 
-      <div className="flex items-center justify-between gap-3">
-        {canManageSickReports && staff ? (
-          <div className="flex flex-wrap gap-2">
+      {quota?.opening && <VacationOpeningSummary opening={quota.opening} />}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          {canManageSickReports && staff && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                onClick={() => {
+                  setManagedAbsenceType("sick");
+                  setSickStaff(staff);
+                }}
+              >
+                <Thermometer className="mr-1.5 h-4 w-4" aria-hidden />
+                Krank melden
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                onClick={() => {
+                  setManagedAbsenceType("comp_time");
+                  setSickStaff(staff);
+                }}
+              >
+                <Clock3 className="mr-1.5 h-4 w-4" aria-hidden />
+                Freizeitausgleich eintragen
+              </Button>
+            </>
+          )}
+          {canEdit && (
             <Button
               type="button"
               variant="outline"
               size="md"
-              onClick={() => {
-                setManagedAbsenceType("sick");
-                setSickStaff(staff);
-              }}
+              onClick={() => setOpeningModal(true)}
             >
-              <Thermometer className="mr-1.5 h-4 w-4" aria-hidden />
-              Krank melden
+              <CalendarClock className="mr-1.5 h-4 w-4" aria-hidden />
+              Urlaubs-Übernahme
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="md"
-              onClick={() => {
-                setManagedAbsenceType("comp_time");
-                setSickStaff(staff);
-              }}
-            >
-              <Clock3 className="mr-1.5 h-4 w-4" aria-hidden />
-              Freizeitausgleich eintragen
-            </Button>
-          </div>
-        ) : (
-          <span />
-        )}
+          )}
+        </div>
         <span className="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600">
           Jahr {year}
         </span>
@@ -457,6 +506,49 @@ export function AbwesenheitenTab({
           onClose={() => setQuestionModal(null)}
           onQuestioned={async () => {
             setQuestionModal(null);
+            await reload();
+          }}
+        />
+      )}
+      <ConfirmDeleteModal
+        isOpen={openingDeleteTarget !== null}
+        title="Urlaubs-Übernahme löschen"
+        description={
+          <>
+            Die Übernahme zum Stichtag{" "}
+            <strong>
+              {openingDeleteTarget
+                ? formatDate(openingDeleteTarget.effective_date)
+                : ""}
+            </strong>{" "}
+            wird gelöscht. Der Resturlaub steigt dadurch wieder um{" "}
+            {openingDeleteTarget
+              ? formatDayCount(openingDeleteTarget.taken_before_days)
+              : ""}
+            .
+          </>
+        }
+        gate={{ mode: "twoStep" }}
+        loading={openingDeleteLoading}
+        error={openingDeleteError}
+        confirmLabel="Löschen"
+        loadingLabel="Wird gelöscht…"
+        onConfirm={handleDeleteOpening}
+        onClose={() => setOpeningDeleteTarget(null)}
+      />
+      {openingModal && quota && (
+        <VacationOpeningModal
+          staffId={staffId}
+          year={year}
+          quota={quota}
+          onClose={() => setOpeningModal(false)}
+          onDelete={(opening) => {
+            setOpeningModal(false);
+            setOpeningDeleteError("");
+            setOpeningDeleteTarget(opening);
+          }}
+          onSaved={async () => {
+            setOpeningModal(false);
             await reload();
           }}
         />
@@ -678,6 +770,284 @@ function AbsenceRow({
         )}
       </div>
     </li>
+  );
+}
+
+// Dezente Zeile unter den Quota-Kacheln: macht sichtbar, dass ein Teil des
+// Jahresanspruchs bereits vor der moto-Einführung verbraucht war (#2132).
+function VacationOpeningSummary({
+  opening,
+}: {
+  readonly opening: StaffVacationOpening;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-2.5 text-xs text-gray-600">
+      <span className="font-semibold tracking-wider text-gray-500 uppercase">
+        Übernahme
+      </span>
+      <span className="tabular-nums">
+        {formatDayCount(opening.taken_before_days)} vor Einführung genommen
+      </span>
+      <span className="text-gray-300">·</span>
+      <span>Stichtag {formatDate(opening.effective_date)}</span>
+    </div>
+  );
+}
+
+function previousDayISO(dateKey: string): string {
+  const date = parseISODate(dateKey);
+  date.setDate(date.getDate() - 1);
+  return toISODate(date);
+}
+
+// Urlaubs-Übernahme zum Go-live-Stichtag (#2132). Der Admin trägt den
+// Resturlaub zum Stichtag ein, der Server leitet daraus die vorher genommenen
+// Tage ab (Anspruch + Übertrag − Rest). Existiert die Übernahme bereits, zeigt
+// das Modal nur noch den gebuchten Stand: Korrekturen laufen über Löschen und
+// neu anlegen, damit die Historie erhalten bleibt.
+function VacationOpeningModal({
+  staffId,
+  year,
+  quota,
+  onClose,
+  onDelete,
+  onSaved,
+}: {
+  readonly staffId: string;
+  readonly year: number;
+  readonly quota: StaffVacationQuotaSummary;
+  readonly onClose: () => void;
+  readonly onDelete: (opening: StaffVacationOpening) => void;
+  readonly onSaved: () => void | Promise<void>;
+}) {
+  const existing = quota.opening ?? null;
+  const [effectiveDate, setEffectiveDate] = useState("");
+  const [remainingDays, setRemainingDays] = useState("");
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const toast = useToast();
+
+  const yearEndKey = `${year}-12-31`;
+  const yesterdayKey = previousDayISO(todayISO());
+  const maxEffectiveDateKey =
+    yesterdayKey < yearEndKey ? yesterdayKey : yearEndKey;
+
+  const remaining = Number.parseFloat(remainingDays.replace(",", "."));
+  const remainingValid =
+    !Number.isNaN(remaining) && remaining >= -999 && remaining <= 999;
+  const entitledTotal = quota.entitled_days + quota.carryover_days;
+  const computedTakenBefore = entitledTotal - remaining;
+
+  const handleSubmit = async () => {
+    if (!effectiveDate) {
+      toast.error("Stichtag fehlt.");
+      return;
+    }
+    if (!remainingValid) {
+      toast.error("Resturlaub ungültig (-999 bis 999).");
+      return;
+    }
+    if (note.trim() === "") {
+      toast.error("Begründung fehlt.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await staffAbsenceService.setVacationOpening(staffId, {
+        effectiveDate,
+        remainingDays: remaining,
+        note: note.trim(),
+      });
+      toast.success("Urlaubs-Übernahme gespeichert.");
+      await onSaved();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Übernahme fehlgeschlagen.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (existing) {
+    return (
+      <Modal
+        isOpen
+        onClose={onClose}
+        title={`Urlaubs-Übernahme ${year}`}
+        footer={
+          <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" size="md" onClick={onClose}>
+              Schließen
+            </Button>
+            <Button
+              type="button"
+              variant="outline_danger"
+              size="md"
+              onClick={() => onDelete(existing)}
+            >
+              <Trash2 className="mr-1.5 h-4 w-4" aria-hidden />
+              Übernahme löschen
+            </Button>
+          </div>
+        }
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-500">
+            Für dieses Jahr ist bereits eine Übernahme gebucht. Eine Korrektur
+            läuft über Löschen und neues Anlegen, damit die Historie
+            nachvollziehbar bleibt.
+          </p>
+          <dl className="space-y-2 rounded-xl bg-gray-50 px-3 py-2 text-sm text-gray-700">
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Stichtag</dt>
+              <dd className="font-medium">
+                {formatDate(existing.effective_date)}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Resturlaub zum Stichtag</dt>
+              <dd className="font-medium tabular-nums">
+                {formatDayCount(existing.entered_remaining_days)}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Vor Einführung genommen</dt>
+              <dd className="font-medium tabular-nums">
+                {formatDayCount(existing.taken_before_days)}
+              </dd>
+            </div>
+          </dl>
+          {existing.note && (
+            <div>
+              <p className="mb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                Begründung
+              </p>
+              <p className="text-sm text-gray-700">{existing.note}</p>
+            </div>
+          )}
+        </div>
+      </Modal>
+    );
+  }
+
+  const canSubmit =
+    !submitting && effectiveDate !== "" && remainingValid && note.trim() !== "";
+
+  return (
+    <Modal
+      isOpen
+      onClose={() => !submitting && onClose()}
+      title={`Urlaubs-Übernahme ${year}`}
+      footer={
+        <div className="flex w-full flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {submitting ? "…" : "Übernahme buchen"}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-gray-500">
+          moto errechnet daraus die vor der Einführung bereits genommenen Tage.
+          Der Jahresanspruch bleibt unverändert.
+        </p>
+        <div>
+          <label
+            htmlFor="vacation-opening-date"
+            className="mb-1 block text-xs font-semibold tracking-wider text-gray-500 uppercase"
+          >
+            Stichtag
+          </label>
+          <ISODatePicker
+            id="vacation-opening-date"
+            min={`${year}-01-01`}
+            max={maxEffectiveDateKey}
+            value={effectiveDate}
+            onChange={setEffectiveDate}
+            calendarLayout="popover"
+            hideClearButton
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            Der Stichtag muss im Jahr {year} und vor dem heutigen Tag liegen.
+          </p>
+        </div>
+        <div>
+          <label
+            htmlFor="vacation-opening-remaining"
+            className="mb-1 block text-xs font-semibold tracking-wider text-gray-500 uppercase"
+          >
+            Resturlaub zum Stichtag (Tage)
+          </label>
+          <input
+            id="vacation-opening-remaining"
+            type="number"
+            min="-999"
+            max="999"
+            step="0.5"
+            value={remainingDays}
+            onChange={(e) => setRemainingDays(e.target.value)}
+            placeholder="z. B. 12,5"
+            className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
+          />
+        </div>
+        <div className="space-y-1 rounded-xl bg-gray-50 px-3 py-2 text-sm text-gray-700">
+          <p>
+            Jahresanspruch inklusive Übertrag:{" "}
+            <span className="font-medium tabular-nums">
+              {formatDayCount(entitledTotal)}
+            </span>
+          </p>
+          {remainingValid && (
+            <p>
+              Errechnet vor Einführung genommen:{" "}
+              <span className="font-medium tabular-nums">
+                {formatDayCount(computedTakenBefore)}
+              </span>
+            </p>
+          )}
+          {/* Brand orange (LOCATION_COLORS.SCHOOLYARD) statt einer generischen
+              Tailwind-Warnfarbe. */}
+          {remainingValid && computedTakenBefore < 0 && (
+            <p className="text-xs text-[#F78C10]">
+              Der eingegebene Resturlaub liegt über dem Jahresanspruch. moto
+              schreibt die Differenz zusätzlich gut.
+            </p>
+          )}
+        </div>
+        <div>
+          <label
+            htmlFor="vacation-opening-note"
+            className="mb-1 block text-xs font-semibold tracking-wider text-gray-500 uppercase"
+          >
+            Begründung (Pflicht)
+          </label>
+          <textarea
+            id="vacation-opening-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={2}
+            placeholder="z. B. Übernahme aus Urlaubsliste, Stand 31.07."
+            className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
+          />
+        </div>
+      </div>
+    </Modal>
   );
 }
 

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -67,6 +67,15 @@ const VACATION_WORKFLOW_STATUSES = new Set([
   "canceled",
 ]);
 
+const ONE_DECIMAL_INPUT_PATTERN = /^[+-]?(?:\d+(?:[,.]\d)?|[,.]\d)$/;
+
+function parseOneDecimalInput(value: string): number | null {
+  const normalized = value.trim();
+  if (!ONE_DECIMAL_INPUT_PATTERN.test(normalized)) return null;
+  const parsed = Number(normalized.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function formatRange(start: string, end: string): string {
   return formatAbsenceRange(start, end);
 }
@@ -833,18 +842,19 @@ function VacationOpeningModal({
   const maxEffectiveDateKey =
     yesterdayKey < yearEndKey ? yesterdayKey : yearEndKey;
 
-  const remaining = Number.parseFloat(remainingDays.replace(",", "."));
+  const remaining = parseOneDecimalInput(remainingDays);
   const remainingValid =
-    !Number.isNaN(remaining) && remaining >= -999 && remaining <= 999;
+    remaining !== null && remaining >= -999 && remaining <= 999;
   const entitledTotal = quota.entitled_days + quota.carryover_days;
-  const computedTakenBefore = entitledTotal - remaining;
+  const computedTakenBefore =
+    remaining === null ? null : entitledTotal - remaining;
 
   const handleSubmit = async () => {
     if (!effectiveDate) {
       toast.error("Stichtag fehlt.");
       return;
     }
-    if (!remainingValid) {
+    if (remaining === null || remaining < -999 || remaining > 999) {
       toast.error("Resturlaub ungültig (-999 bis 999).");
       return;
     }
@@ -1004,6 +1014,12 @@ function VacationOpeningModal({
             placeholder="z. B. 12,5"
             className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
           />
+          {remainingDays.trim() !== "" && !remainingValid && (
+            <p className="mt-1 text-xs text-[#FF3130]" role="alert">
+              Bitte eine Zahl zwischen -999 und 999 mit höchstens einer
+              Nachkommastelle eingeben.
+            </p>
+          )}
         </div>
         <div className="space-y-1 rounded-xl bg-gray-50 px-3 py-2 text-sm text-gray-700">
           <p>
@@ -1012,7 +1028,7 @@ function VacationOpeningModal({
               {formatDayCount(entitledTotal)}
             </span>
           </p>
-          {remainingValid && (
+          {remainingValid && computedTakenBefore !== null && (
             <p>
               Errechnet vor Einführung genommen:{" "}
               <span className="font-medium tabular-nums">
@@ -1022,7 +1038,7 @@ function VacationOpeningModal({
           )}
           {/* Brand orange (LOCATION_COLORS.SCHOOLYARD) statt einer generischen
               Tailwind-Warnfarbe. */}
-          {remainingValid && computedTakenBefore < 0 && (
+          {computedTakenBefore !== null && computedTakenBefore < 0 && (
             <p className="text-xs text-[#F78C10]">
               Der eingegebene Resturlaub liegt über dem Jahresanspruch. moto
               schreibt die Differenz zusätzlich gut.

--- a/frontend/src/components/staff/staff-audit-log.test.tsx
+++ b/frontend/src/components/staff/staff-audit-log.test.tsx
@@ -128,6 +128,43 @@ describe("StaffAuditLog", () => {
     });
   });
 
+  it("beschreibt Urlaubs-Übernahmen und deren Löschung", async () => {
+    const opening: AuditLogEvent = {
+      ...event(8),
+      source: "vacation_opening",
+      entryId: "opening-1",
+      detail: {
+        opening_id: 3,
+        year: 2026,
+        effective_date: "2026-08-01",
+        taken_before_days: 4,
+        entered_remaining_days: 12.5,
+      },
+    };
+    const deleted: AuditLogEvent = {
+      ...event(9),
+      source: "deletion",
+      entryId: "deletion-1",
+      detail: {
+        deleted_source: "vacation_opening",
+        source_id: 3,
+        payload: { year: 2026, entered_remaining_days: 12.5 },
+      },
+    };
+    getAuditLog.mockResolvedValueOnce(page([opening, deleted], null));
+
+    render(<StaffAuditLog staffOptions={[]} />);
+
+    expect(
+      await screen.findByText(
+        "Urlaubs-Übernahme 2026: 12,5 Tage Rest zum 01.08.2026",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Urlaubs-Übernahme gelöscht: 2026 (12,5 Tage Rest)"),
+    ).toBeInTheDocument();
+  });
+
   it("rendert Ereignisse mit gleichem Umschlag über eindeutige Entry-IDs", async () => {
     const first = event(6);
     const second = { ...event(6), entryId: "different-entry" };

--- a/frontend/src/components/staff/staff-audit-log.tsx
+++ b/frontend/src/components/staff/staff-audit-log.tsx
@@ -60,6 +60,13 @@ const absenceStatusLabels: Record<string, string> = {
   canceled: "storniert",
 };
 
+// Vacation takeover values are half-day granular and signed (#2132).
+function formatOpeningDays(value: unknown): string {
+  const days = typeof value === "number" ? value : 0;
+  const formatted = days.toLocaleString("de-DE", { maximumFractionDigits: 1 });
+  return `${formatted} ${days === 1 ? "Tag" : "Tage"}`;
+}
+
 // One German sentence per event; the typed detail payloads stay readable
 // instead of being squeezed into a shared column schema.
 function describeEvent(event: AuditLogEvent): string {
@@ -97,6 +104,14 @@ function describeEvent(event: AuditLogEvent): string {
           : "";
       return `${type} ${formatSignedDuration(minutes)} zum ${day}`;
     }
+    case "vacation_opening": {
+      const year = typeof d.year === "number" ? d.year : "";
+      const day =
+        typeof d.effective_date === "string"
+          ? formatDate(d.effective_date)
+          : "";
+      return `Urlaubs-Übernahme ${year}: ${formatOpeningDays(d.entered_remaining_days)} Rest zum ${day}`;
+    }
     case "month_close": {
       const count = typeof d.account_count === "number" ? d.account_count : 0;
       return `Monat ${String(d.month).padStart(2, "0")}/${String(d.year)} abgeschlossen (${count} ${count === 1 ? "Konto" : "Konten"})`;
@@ -113,6 +128,10 @@ function describeEvent(event: AuditLogEvent): string {
         const minutes =
           typeof payload.minutes_delta === "number" ? payload.minutes_delta : 0;
         return `Buchung gelöscht: ${type} ${formatSignedDuration(minutes)}`;
+      }
+      if (d.deleted_source === "vacation_opening") {
+        const year = typeof payload.year === "number" ? payload.year : "";
+        return `Urlaubs-Übernahme gelöscht: ${year} (${formatOpeningDays(payload.entered_remaining_days)} Rest)`;
       }
       const type =
         absenceTypeLabels[payload.absence_type as AbsenceType] ??

--- a/frontend/src/components/staff/staff-time-accounts-table.tsx
+++ b/frontend/src/components/staff/staff-time-accounts-table.tsx
@@ -91,6 +91,9 @@ interface Props {
   /** Öffnet den Cross-MA-Export-Dialog (#1417 2b). Optional, damit rein
    *  lesende Einbettungen keinen toten Button zeigen. */
   readonly onExport?: () => void;
+  /** Führt zum Eröffnungssalden-Import (#2132). Optional, weil der Import in
+   *  der Datenverwaltung liegt und damit nur Admins offensteht. */
+  readonly onOpeningBalances?: () => void;
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly onRowClick: (row: TimeAccountRow) => void;
@@ -117,6 +120,7 @@ export function StaffTimeAccountsTable({
   monthIsOver,
   onCloseMonth,
   onExport,
+  onOpeningBalances,
   isLoading,
   error,
   onRowClick,
@@ -290,6 +294,17 @@ export function StaffTimeAccountsTable({
             >
               <Download className="mr-1 h-3 w-3" />
               Exportieren
+            </Button>
+          )}
+          {onOpeningBalances && (
+            <Button
+              type="button"
+              size="compact"
+              variant="ghost"
+              onClick={onOpeningBalances}
+              title="Stundenkonto- und Urlaubsstände aus dem Altsystem übernehmen"
+            >
+              Eröffnungssalden importieren
             </Button>
           )}
           {monthClose !== null && !monthClose.closed && (

--- a/frontend/src/components/staff/stundenkonto-panel.test.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.test.tsx
@@ -164,6 +164,10 @@ describe("StundenkontoPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Eröffnungssaldo" }));
 
+    expect(
+      screen.getByLabelText("Übernommener Saldo (Stunden)"),
+    ).toHaveAttribute("type", "text");
+
     const openingDate = screen.getByLabelText("Stichtag");
     expect(openingDate).toHaveAttribute("min", "2026-01-01");
     expect(openingDate).toHaveAttribute("max", "2026-07-23");

--- a/frontend/src/components/staff/stundenkonto-panel.test.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 // The date fields moved from native inputs to the kit picker; this stub keeps
@@ -47,9 +47,11 @@ vi.mock("~/lib/staff-api", () => ({
     create: vi.fn(),
     delete: vi.fn(),
     reset: vi.fn(),
+    createOpening: vi.fn(),
   },
 }));
 
+import { staffBalanceAdjustmentService } from "~/lib/staff-api";
 import { StundenkontoPanel } from "./stundenkonto-panel";
 
 describe("StundenkontoPanel", () => {
@@ -137,5 +139,78 @@ describe("StundenkontoPanel", () => {
     );
 
     expect(screen.getByRole("button", { name: "Zurücksetzen" })).toBeDisabled();
+  });
+
+  it("bucht einen negativen Eröffnungssaldo in Minuten zum Stichtag", async () => {
+    const createOpening = vi.mocked(
+      staffBalanceAdjustmentService.createOpening,
+    );
+    createOpening.mockResolvedValue(
+      {} as Awaited<
+        ReturnType<typeof staffBalanceAdjustmentService.createOpening>
+      >,
+    );
+
+    render(
+      <StundenkontoPanel
+        staffId="4"
+        balanceMinutes={0}
+        accountStartKey="2026-01-01"
+        todayKey="2026-07-24"
+        adjustments={[]}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Eröffnungssaldo" }));
+
+    const openingDate = screen.getByLabelText("Stichtag");
+    expect(openingDate).toHaveAttribute("min", "2026-01-01");
+    expect(openingDate).toHaveAttribute("max", "2026-07-23");
+    expect(openingDate).toHaveValue("2026-01-01");
+
+    fireEvent.change(screen.getByLabelText("Übernommener Saldo (Stunden)"), {
+      target: { value: "-2,5" },
+    });
+    fireEvent.change(screen.getByLabelText("Begründung (Pflicht)"), {
+      target: { value: "Übernahme Altsystem" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Buchen" }));
+
+    await waitFor(() => {
+      expect(createOpening).toHaveBeenCalledWith("4", {
+        effectiveDate: "2026-01-01",
+        balanceMinutes: -150,
+        note: "Übernahme Altsystem",
+      });
+    });
+  });
+
+  it("sperrt einen zweiten Eröffnungssaldo", () => {
+    render(
+      <StundenkontoPanel
+        staffId="4"
+        balanceMinutes={180}
+        accountStartKey="2026-01-01"
+        todayKey="2026-07-24"
+        adjustments={[
+          {
+            id: "21",
+            type: "opening",
+            minutesDelta: 180,
+            effectiveDate: "2026-01-01",
+            note: "Übernahme Altsystem",
+            decidedBy: "9",
+            decidedAt: "2026-01-02T08:00:00Z",
+          },
+        ]}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Eröffnungssaldo" }),
+    ).toBeDisabled();
+    expect(screen.getAllByText("Eröffnungssaldo")).toHaveLength(2);
   });
 });

--- a/frontend/src/components/staff/stundenkonto-panel.test.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.test.tsx
@@ -190,6 +190,29 @@ describe("StundenkontoPanel", () => {
     });
   });
 
+  it("rejects opening balances with trailing text", () => {
+    render(
+      <StundenkontoPanel
+        staffId="4"
+        balanceMinutes={0}
+        accountStartKey="2026-01-01"
+        todayKey="2026-07-24"
+        adjustments={[]}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Eröffnungssaldo" }));
+    fireEvent.change(screen.getByLabelText("Übernommener Saldo (Stunden)"), {
+      target: { value: "-3,25x" },
+    });
+    fireEvent.change(screen.getByLabelText("Begründung (Pflicht)"), {
+      target: { value: "Übernahme Altsystem" },
+    });
+
+    expect(screen.getByRole("button", { name: "Buchen" })).toBeDisabled();
+  });
+
   it("sperrt einen zweiten Eröffnungssaldo", () => {
     render(
       <StundenkontoPanel

--- a/frontend/src/components/staff/stundenkonto-panel.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.tsx
@@ -68,6 +68,15 @@ export function StundenkontoPanel({
   const hasOpening = adjustments.some(
     (adjustment) => adjustment.type === "opening",
   );
+  const openingDisabledHint = () => {
+    if (hasOpening) {
+      return "Es existiert bereits ein Eröffnungssaldo. Lösche zuerst die bestehende Buchung.";
+    }
+    if (!canResetClosedPeriod) {
+      return "Ein Eröffnungssaldo ist erst nach dem ersten abgeschlossenen Kontotag möglich.";
+    }
+    return undefined;
+  };
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -133,13 +142,7 @@ export function StundenkontoPanel({
             size="compact"
             onClick={() => setActiveModal("opening")}
             disabled={!canResetClosedPeriod || hasOpening}
-            title={
-              hasOpening
-                ? "Es existiert bereits ein Eröffnungssaldo. Lösche zuerst die bestehende Buchung."
-                : canResetClosedPeriod
-                  ? undefined
-                  : "Ein Eröffnungssaldo ist erst nach dem ersten abgeschlossenen Kontotag möglich."
-            }
+            title={openingDisabledHint()}
           >
             <Flag className="h-3.5 w-3.5" aria-hidden />
             Eröffnungssaldo

--- a/frontend/src/components/staff/stundenkonto-panel.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.tsx
@@ -672,7 +672,11 @@ function OpeningModal({
             className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
           />
         </div>
-        <NoteField note={note} onChange={setNote} />
+        <NoteField
+          note={note}
+          onChange={setNote}
+          placeholder="z. B. Übernahme aus Altsystem, Stand 31.07."
+        />
       </div>
     </Modal>
   );
@@ -718,9 +722,12 @@ function AdjustmentModalFooter({
 function NoteField({
   note,
   onChange,
+  placeholder = "z. B. Auszahlung mit Juligehalt",
 }: {
   readonly note: string;
   readonly onChange: (value: string) => void;
+  /** Beispieltext passend zur Buchungsart; Standard ist die Auszahlung. */
+  readonly placeholder?: string;
 }) {
   return (
     <div>
@@ -735,7 +742,7 @@ function NoteField({
         value={note}
         onChange={(e) => onChange(e.target.value)}
         rows={2}
-        placeholder="z. B. Auszahlung mit Juligehalt"
+        placeholder={placeholder}
         className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
       />
     </div>

--- a/frontend/src/components/staff/stundenkonto-panel.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.tsx
@@ -22,6 +22,15 @@ import {
   type BalanceAdjustment,
 } from "~/lib/time-tracking-helpers";
 
+const DECIMAL_INPUT_PATTERN = /^[+-]?(?:\d+(?:[,.]\d+)?|[,.]\d+)$/;
+
+function parseDecimalInput(value: string): number | null {
+  const normalized = value.trim();
+  if (!DECIMAL_INPUT_PATTERN.test(normalized)) return null;
+  const parsed = Number(normalized.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 import { formatSignedDuration } from "./staff-time-views";
 
 interface StundenkontoPanelProps {
@@ -552,12 +561,12 @@ function OpeningModal({
   const [submitting, setSubmitting] = useState(false);
   const toast = useToast();
 
-  const opening = Number.parseFloat(openingHours.replace(",", "."));
+  const opening = parseDecimalInput(openingHours);
   const openingValid =
-    !Number.isNaN(opening) && opening >= -10_000 && opening <= 10_000;
+    opening !== null && opening >= -10_000 && opening <= 10_000;
 
   const handleSubmit = async () => {
-    if (!openingValid) {
+    if (opening === null || opening < -10_000 || opening > 10_000) {
       toast.error("Eröffnungssaldo ungültig.");
       return;
     }
@@ -616,7 +625,7 @@ function OpeningModal({
                 {formatSignedDuration(balanceMinutes)}
               </span>
             </p>
-            {openingValid && (
+            {opening !== null && openingValid && (
               <p>
                 Gewünschter Stand am Stichtag:{" "}
                 <span className="font-medium tabular-nums">

--- a/frontend/src/components/staff/stundenkonto-panel.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.tsx
@@ -4,10 +4,11 @@
 // Schuljahres-Reset als Admin-Aktionen auf dem Übersicht-Tab, plus die
 // Historie aller Buchungen. Jede Buchung ist eine eigene Transaktion im
 // Stundenkonto, kein Zeiteintrag — der Server rechnet sie live in die
-// Monatskarten-Kette ein.
+// Monatskarten-Kette ein. Dazu der einmalige Eröffnungssaldo (#2132), der den
+// Übernahme-Stand aus dem Altsystem setzt.
 
 import { useState } from "react";
-import { Banknote, Clock4, RotateCcw, Trash2 } from "lucide-react";
+import { Banknote, Clock4, Flag, RotateCcw, Trash2 } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
@@ -44,7 +45,7 @@ export function StundenkontoPanel({
   onChanged,
 }: StundenkontoPanelProps) {
   const [activeModal, setActiveModal] = useState<
-    "payout" | "comp_time" | "reset" | null
+    "payout" | "comp_time" | "reset" | "opening" | null
   >(null);
   const [deleteTarget, setDeleteTarget] = useState<BalanceAdjustment | null>(
     null,
@@ -52,7 +53,12 @@ export function StundenkontoPanel({
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
   const toast = useToast();
+  // Reset und Eröffnungssaldo brauchen beide einen abgeschlossenen Kontotag:
+  // der Stichtag muss vor heute liegen.
   const canResetClosedPeriod = accountStartKey < todayKey;
+  const hasOpening = adjustments.some(
+    (adjustment) => adjustment.type === "opening",
+  );
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -112,13 +118,30 @@ export function StundenkontoPanel({
             <RotateCcw className="h-3.5 w-3.5" aria-hidden />
             Zurücksetzen
           </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            onClick={() => setActiveModal("opening")}
+            disabled={!canResetClosedPeriod || hasOpening}
+            title={
+              hasOpening
+                ? "Es existiert bereits ein Eröffnungssaldo. Lösche zuerst die bestehende Buchung."
+                : canResetClosedPeriod
+                  ? undefined
+                  : "Ein Eröffnungssaldo ist erst nach dem ersten abgeschlossenen Kontotag möglich."
+            }
+          >
+            <Flag className="h-3.5 w-3.5" aria-hidden />
+            Eröffnungssaldo
+          </Button>
         </div>
       </div>
 
       {adjustments.length === 0 ? (
         <p className="py-6 text-center text-sm text-gray-400">
-          Noch keine Buchungen — Auszahlungen, Freizeitausgleich und Resets
-          erscheinen hier.
+          Noch keine Buchungen — Auszahlungen, Freizeitausgleich, Resets und
+          Eröffnungssalden erscheinen hier.
         </p>
       ) : (
         <ul className="divide-y divide-gray-100">
@@ -176,6 +199,19 @@ export function StundenkontoPanel({
       )}
       {activeModal === "reset" && (
         <ResetModal
+          staffId={staffId}
+          accountStartKey={accountStartKey}
+          todayKey={todayKey}
+          balanceMinutes={balanceMinutes}
+          onClose={() => setActiveModal(null)}
+          onSaved={async () => {
+            setActiveModal(null);
+            await onChanged();
+          }}
+        />
+      )}
+      {activeModal === "opening" && (
+        <OpeningModal
           staffId={staffId}
           accountStartKey={accountStartKey}
           todayKey={todayKey}
@@ -481,6 +517,151 @@ function ResetModal({
             step="0.25"
             value={carryoverHours}
             onChange={(e) => setCarryoverHours(e.target.value)}
+            className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
+          />
+        </div>
+        <NoteField note={note} onChange={setNote} />
+      </div>
+    </Modal>
+  );
+}
+
+// Eröffnungssaldo (#2132): einmalige Übernahme aus dem Altsystem. Gleiche
+// Stichtags-Grenzen wie der Reset, aber der Zielwert darf negativ sein.
+function OpeningModal({
+  staffId,
+  accountStartKey,
+  todayKey,
+  balanceMinutes,
+  onClose,
+  onSaved,
+}: {
+  readonly staffId: string;
+  readonly accountStartKey: string;
+  readonly todayKey: string;
+  readonly balanceMinutes: number | null;
+  readonly onClose: () => void;
+  readonly onSaved: () => void | Promise<void>;
+}) {
+  const lastClosedDateKey = previousDateISO(todayKey);
+  const [effectiveDate, setEffectiveDate] = useState(
+    accountStartKey <= lastClosedDateKey ? accountStartKey : lastClosedDateKey,
+  );
+  const [openingHours, setOpeningHours] = useState("0");
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const toast = useToast();
+
+  const opening = Number.parseFloat(openingHours.replace(",", "."));
+  const openingValid =
+    !Number.isNaN(opening) && opening >= -10_000 && opening <= 10_000;
+
+  const handleSubmit = async () => {
+    if (!openingValid) {
+      toast.error("Eröffnungssaldo ungültig.");
+      return;
+    }
+    if (!effectiveDate) {
+      toast.error("Datum fehlt.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await staffBalanceAdjustmentService.createOpening(staffId, {
+        effectiveDate,
+        balanceMinutes: Math.round(opening * 60),
+        note: note.trim(),
+      });
+      toast.success("Eröffnungssaldo gebucht.");
+      await onSaved();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Buchung fehlgeschlagen.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSubmit = !submitting && openingValid && note.trim() !== "";
+
+  return (
+    <Modal
+      isOpen
+      onClose={() => !submitting && onClose()}
+      title="Eröffnungssaldo buchen"
+      footer={
+        <AdjustmentModalFooter
+          submitting={submitting}
+          canSubmit={canSubmit}
+          submitLabel="Buchen"
+          onCancel={onClose}
+          onSubmit={handleSubmit}
+        />
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-gray-500">
+          Der Eröffnungssaldo setzt den Übernahme-Stand aus dem Altsystem. Das
+          Stundenkonto steht zum Stichtag danach exakt auf dem eingetragenen
+          Wert. Negative Werte sind zulässig, wenn im Altsystem Minusstunden
+          bestanden. Pro Person ist genau ein Eröffnungssaldo möglich. Für eine
+          Korrektur die bestehende Buchung löschen und neu anlegen.
+        </p>
+        {balanceMinutes !== null && (
+          <div className="space-y-1 rounded-xl bg-gray-50 px-3 py-2 text-sm text-gray-700">
+            <p>
+              Aktueller Stand:{" "}
+              <span className="font-medium tabular-nums">
+                {formatSignedDuration(balanceMinutes)}
+              </span>
+            </p>
+            {openingValid && (
+              <p>
+                Gewünschter Stand am Stichtag:{" "}
+                <span className="font-medium tabular-nums">
+                  {formatSignedDuration(Math.round(opening * 60))}
+                </span>
+              </p>
+            )}
+          </div>
+        )}
+        <div>
+          <label
+            htmlFor="opening-date"
+            className="mb-1 block text-xs font-semibold tracking-wider text-gray-500 uppercase"
+          >
+            Stichtag
+          </label>
+          <ISODatePicker
+            id="opening-date"
+            min={accountStartKey}
+            max={lastClosedDateKey}
+            value={effectiveDate}
+            onChange={setEffectiveDate}
+            calendarLayout="popover"
+            hideClearButton
+          />
+          <p className="mt-1 text-xs text-gray-400">
+            Der Stichtag muss vor dem heutigen Tag liegen.
+          </p>
+        </div>
+        <div>
+          <label
+            htmlFor="opening-balance"
+            className="mb-1 block text-xs font-semibold tracking-wider text-gray-500 uppercase"
+          >
+            Übernommener Saldo (Stunden)
+          </label>
+          <input
+            id="opening-balance"
+            type="number"
+            min="-10000"
+            max="10000"
+            step="0.25"
+            value={openingHours}
+            onChange={(e) => setOpeningHours(e.target.value)}
+            placeholder="z. B. 12,5 oder -3"
             className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 focus:border-[#83CD2D] focus:outline-none"
           />
         </div>

--- a/frontend/src/components/staff/stundenkonto-panel.tsx
+++ b/frontend/src/components/staff/stundenkonto-panel.tsx
@@ -655,10 +655,8 @@ function OpeningModal({
           </label>
           <input
             id="opening-balance"
-            type="number"
-            min="-10000"
-            max="10000"
-            step="0.25"
+            type="text"
+            inputMode="decimal"
             value={openingHours}
             onChange={(e) => setOpeningHours(e.target.value)}
             placeholder="z. B. 12,5 oder -3"

--- a/frontend/src/lib/analytics-routes.ts
+++ b/frontend/src/lib/analytics-routes.ts
@@ -27,6 +27,7 @@ export const TRACKED_TENANT_ROUTE_TEMPLATES = [
   "/database/permissions",
   "/database/personal",
   "/database/personal/import",
+  "/database/personal/opening-balances",
   "/database/roles",
   "/database/rooms",
   "/database/students",

--- a/frontend/src/lib/staff-api.test.ts
+++ b/frontend/src/lib/staff-api.test.ts
@@ -1774,6 +1774,61 @@ describe("staff-api", () => {
       });
     });
 
+    it.each([
+      [
+        "vacation_opening_already_exists",
+        "Für dieses Jahr existiert bereits eine Urlaubs-Übernahme. Lösche zuerst die bestehende Übernahme.",
+      ],
+      [
+        "vacation_opening_absences_before_cutoff",
+        "Es existieren bereits Urlaubs-Abwesenheiten vor dem Stichtag. Die Übernahme würde diese Tage doppelt zählen.",
+      ],
+    ])("explains the takeover rejection %s", async (code, message) => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        text: () =>
+          Promise.resolve(JSON.stringify({ error: "rejected", code })),
+      } as Response);
+
+      await expect(
+        staffAbsenceService.setVacationOpening("4", {
+          effectiveDate: "2026-02-28",
+          remainingDays: 26.5,
+          note: "Übernahme aus Urlaubsliste",
+        }),
+      ).rejects.toThrow(message);
+    });
+
+    it("reports a failed takeover deletion", async () => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ error: "Keine Übernahme für dieses Jahr" }),
+          ),
+      } as Response);
+
+      await expect(
+        staffAbsenceService.deleteVacationOpening("4", 2026),
+      ).rejects.toThrow("Keine Übernahme für dieses Jahr");
+    });
+
+    it("deletes a takeover for the given year", async () => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+      await staffAbsenceService.deleteVacationOpening("4", 2026);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/staff/4/vacation/opening?year=2026",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+
     it("throws when saving vacation quota fails", async () => {
       const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
       mockFetch.mockResolvedValueOnce({
@@ -2409,6 +2464,91 @@ describe("staff-api", () => {
           note: "x",
         }),
       ).rejects.toThrow("Ungültiger Reset");
+    });
+
+    // Eröffnungssaldo (#2132). The backend's stable error codes carry no German
+    // text; the copy the admin reads lives here, so it is pinned here too.
+    it("maps the opening balance response", async () => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              id: 21,
+              staff_id: 4,
+              type: "opening",
+              minutes_delta: -330,
+              effective_date: "2026-07-31",
+              note: "Übernahme aus Altsystem",
+              decided_by: 9,
+              decided_at: "2026-08-01T08:00:00Z",
+            },
+          }),
+      } as Response);
+
+      const opening = await staffBalanceAdjustmentService.createOpening("4", {
+        effectiveDate: "2026-07-31",
+        balanceMinutes: -330,
+        note: "Übernahme aus Altsystem",
+      });
+
+      expect(opening).toMatchObject({
+        id: "21",
+        type: "opening",
+        minutesDelta: -330,
+      });
+    });
+
+    it.each([
+      [
+        "opening_balance_already_exists",
+        "Für diese Person existiert bereits ein Eröffnungssaldo. Lösche zuerst die bestehende Buchung.",
+      ],
+      [
+        "dependent_balance_reset",
+        "Es existieren bereits spätere Buchungen (Reset), die vom Stichtag abhängen.",
+      ],
+      [
+        "adjustment_in_closed_month",
+        "Der gewählte Monat ist abgeschlossen. Wähle ein Datum im offenen Monat oder öffne den Monatsabschluss wieder.",
+      ],
+    ])("explains the opening rejection %s", async (code, message) => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        text: () =>
+          Promise.resolve(JSON.stringify({ error: "rejected", code })),
+      } as Response);
+
+      await expect(
+        staffBalanceAdjustmentService.createOpening("4", {
+          effectiveDate: "2026-07-31",
+          balanceMinutes: 600,
+          note: "Übernahme",
+        }),
+      ).rejects.toThrow(message);
+    });
+
+    it("passes an unmapped opening rejection through verbatim", async () => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ error: "Stichtag liegt in der Zukunft" }),
+          ),
+      } as Response);
+
+      await expect(
+        staffBalanceAdjustmentService.createOpening("4", {
+          effectiveDate: "2099-01-01",
+          balanceMinutes: 600,
+          note: "Übernahme",
+        }),
+      ).rejects.toThrow("Stichtag liegt in der Zukunft");
     });
   });
 

--- a/frontend/src/lib/staff-api.test.ts
+++ b/frontend/src/lib/staff-api.test.ts
@@ -1741,6 +1741,39 @@ describe("staff-api", () => {
       expect(result.entitled_days).toBe(30);
     });
 
+    it("maps vacation opening identifiers to strings", async () => {
+      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              id: 7,
+              staff_id: 4,
+              year: 2026,
+              effective_date: "2026-02-28",
+              taken_before_days: 5.5,
+              entered_remaining_days: 26.5,
+              note: "Übernahme aus Urlaubsliste",
+              decided_by: 9,
+              decided_at: "2026-03-01T08:00:00Z",
+            },
+          }),
+      } as Response);
+
+      await expect(
+        staffAbsenceService.setVacationOpening("4", {
+          effectiveDate: "2026-02-28",
+          remainingDays: 26.5,
+          note: "Übernahme aus Urlaubsliste",
+        }),
+      ).resolves.toMatchObject({
+        id: "7",
+        staff_id: "4",
+        decided_by: "9",
+      });
+    });
+
     it("throws when saving vacation quota fails", async () => {
       const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
       mockFetch.mockResolvedValueOnce({

--- a/frontend/src/lib/staff-api.ts
+++ b/frontend/src/lib/staff-api.ts
@@ -378,8 +378,7 @@ class StaffService {
     }
 
     const staffData = (await staffResponse.json()) as
-      | BackendStaffResponse[]
-      | { data: BackendStaffResponse[] };
+      BackendStaffResponse[] | { data: BackendStaffResponse[] };
     const staffList = extractStaffList(staffData);
     const staffGroupsMap = buildStaffGroupsMap(activeGroups);
 
@@ -472,8 +471,7 @@ class StaffService {
       }
 
       const data = (await response.json()) as
-        | ActiveSupervisionResponse[]
-        | { data: ActiveSupervisionResponse[] };
+        ActiveSupervisionResponse[] | { data: ActiveSupervisionResponse[] };
 
       if (Array.isArray(data)) {
         return data;
@@ -591,8 +589,7 @@ interface UpdateScheduleTemplateRequest {
 }
 
 export type UpdateScheduleRequest =
-  | UpdateScheduleCustomRequest
-  | UpdateScheduleTemplateRequest;
+  UpdateScheduleCustomRequest | UpdateScheduleTemplateRequest;
 
 class StaffScheduleService {
   async getSchedule(staffId: string): Promise<StaffSchedule> {
@@ -758,15 +755,35 @@ export interface StaffAbsenceRow {
 // before the Stichtag in the previous system. The row is its own audit
 // record (Stichtag, entered Resturlaub, note, actor).
 export interface StaffVacationOpening {
-  id: number;
-  staff_id: number;
+  id: string;
+  staff_id: string;
   year: number;
   effective_date: string;
   taken_before_days: number;
   entered_remaining_days: number;
   note: string;
-  decided_by: number;
+  decided_by: string;
   decided_at: string;
+}
+
+interface BackendStaffVacationOpening extends Omit<
+  StaffVacationOpening,
+  "id" | "staff_id" | "decided_by"
+> {
+  id: number;
+  staff_id: number;
+  decided_by: number;
+}
+
+function mapStaffVacationOpening(
+  data: BackendStaffVacationOpening,
+): StaffVacationOpening {
+  return {
+    ...data,
+    id: data.id.toString(),
+    staff_id: data.staff_id.toString(),
+    decided_by: data.decided_by.toString(),
+  };
 }
 
 export interface StaffVacationQuotaSummary {
@@ -779,6 +796,24 @@ export interface StaffVacationQuotaSummary {
   reserved_days: number;
   remaining_days: number;
   opening?: StaffVacationOpening | null;
+}
+
+interface BackendStaffVacationQuotaSummary extends Omit<
+  StaffVacationQuotaSummary,
+  "opening"
+> {
+  opening?: BackendStaffVacationOpening | null;
+}
+
+function mapStaffVacationQuotaSummary(
+  data: BackendStaffVacationQuotaSummary,
+): StaffVacationQuotaSummary {
+  return {
+    ...data,
+    opening: data.opening
+      ? mapStaffVacationOpening(data.opening)
+      : data.opening,
+  };
 }
 
 // Body for the admin "Abwesenheit anlegen" endpoint (POST
@@ -826,9 +861,9 @@ class StaffAbsenceService {
       throw new Error(`Failed to fetch quota: ${response.statusText}`);
     }
     const json = (await response.json()) as {
-      data: StaffVacationQuotaSummary;
+      data: BackendStaffVacationQuotaSummary;
     };
-    return json.data;
+    return mapStaffVacationQuotaSummary(json.data);
   }
 
   async setVacationQuota(
@@ -851,9 +886,9 @@ class StaffAbsenceService {
       throw new Error(`Failed to save quota: ${response.statusText}`);
     }
     const json = (await response.json()) as {
-      data: StaffVacationQuotaSummary;
+      data: BackendStaffVacationQuotaSummary;
     };
-    return json.data;
+    return mapStaffVacationQuotaSummary(json.data);
   }
 
   // Vacation takeover (#2132): the admin enters the Resturlaub as of the
@@ -895,8 +930,10 @@ class StaffAbsenceService {
       }
       throw new Error(error.message);
     }
-    const json = (await response.json()) as { data: StaffVacationOpening };
-    return json.data;
+    const json = (await response.json()) as {
+      data: BackendStaffVacationOpening;
+    };
+    return mapStaffVacationOpening(json.data);
   }
 
   async deleteVacationOpening(staffId: string, year: number): Promise<void> {

--- a/frontend/src/lib/staff-api.ts
+++ b/frontend/src/lib/staff-api.ts
@@ -378,7 +378,8 @@ class StaffService {
     }
 
     const staffData = (await staffResponse.json()) as
-      BackendStaffResponse[] | { data: BackendStaffResponse[] };
+      | BackendStaffResponse[]
+      | { data: BackendStaffResponse[] };
     const staffList = extractStaffList(staffData);
     const staffGroupsMap = buildStaffGroupsMap(activeGroups);
 
@@ -471,7 +472,8 @@ class StaffService {
       }
 
       const data = (await response.json()) as
-        ActiveSupervisionResponse[] | { data: ActiveSupervisionResponse[] };
+        | ActiveSupervisionResponse[]
+        | { data: ActiveSupervisionResponse[] };
 
       if (Array.isArray(data)) {
         return data;
@@ -589,7 +591,8 @@ interface UpdateScheduleTemplateRequest {
 }
 
 export type UpdateScheduleRequest =
-  UpdateScheduleCustomRequest | UpdateScheduleTemplateRequest;
+  | UpdateScheduleCustomRequest
+  | UpdateScheduleTemplateRequest;
 
 class StaffScheduleService {
   async getSchedule(staffId: string): Promise<StaffSchedule> {
@@ -751,14 +754,31 @@ export interface StaffAbsenceRow {
   duration_days?: number;
 }
 
+// Vacation takeover at the moto introduction (#2132): days already taken
+// before the Stichtag in the previous system. The row is its own audit
+// record (Stichtag, entered Resturlaub, note, actor).
+export interface StaffVacationOpening {
+  id: number;
+  staff_id: number;
+  year: number;
+  effective_date: string;
+  taken_before_days: number;
+  entered_remaining_days: number;
+  note: string;
+  decided_by: number;
+  decided_at: string;
+}
+
 export interface StaffVacationQuotaSummary {
   staff_id: number;
   year: number;
   entitled_days: number;
   carryover_days: number;
+  taken_before_days: number;
   taken_days: number;
   reserved_days: number;
   remaining_days: number;
+  opening?: StaffVacationOpening | null;
 }
 
 // Body for the admin "Abwesenheit anlegen" endpoint (POST
@@ -834,6 +854,60 @@ class StaffAbsenceService {
       data: StaffVacationQuotaSummary;
     };
     return json.data;
+  }
+
+  // Vacation takeover (#2132): the admin enters the Resturlaub as of the
+  // Stichtag; the backend derives the pre-introduction days from the quota.
+  async setVacationOpening(
+    staffId: string,
+    payload: {
+      effectiveDate: string;
+      remainingDays: number;
+      note: string;
+    },
+  ): Promise<StaffVacationOpening> {
+    const response = await sessionFetch(
+      `/api/staff/${staffId}/vacation/opening`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          effective_date: payload.effectiveDate,
+          remaining_days: payload.remainingDays,
+          note: payload.note,
+        }),
+      },
+    );
+    if (!response.ok) {
+      const error = await readStaffAPIError(
+        response,
+        "Übernahme fehlgeschlagen",
+      );
+      if (error.code === "vacation_opening_already_exists") {
+        throw new Error(
+          "Für dieses Jahr existiert bereits eine Urlaubs-Übernahme. Lösche zuerst die bestehende Übernahme.",
+        );
+      }
+      if (error.code === "vacation_opening_absences_before_cutoff") {
+        throw new Error(
+          "Es existieren bereits Urlaubs-Abwesenheiten vor dem Stichtag. Die Übernahme würde diese Tage doppelt zählen.",
+        );
+      }
+      throw new Error(error.message);
+    }
+    const json = (await response.json()) as { data: StaffVacationOpening };
+    return json.data;
+  }
+
+  async deleteVacationOpening(staffId: string, year: number): Promise<void> {
+    const response = await sessionFetch(
+      `/api/staff/${staffId}/vacation/opening?year=${year}`,
+      { method: "DELETE" },
+    );
+    if (!response.ok) {
+      const error = await readStaffAPIError(response, "Löschen fehlgeschlagen");
+      throw new Error(error.message);
+    }
   }
 
   async approve(absenceId: number, decisionNote?: string): Promise<void> {
@@ -1340,6 +1414,55 @@ class StaffBalanceAdjustmentService {
       if (error.code === "balance_adjustment_exceeds_balance") {
         throw new Error(
           "Der Reset kann nicht durchgeführt werden, weil spätere Buchungen oder Freizeitausgleichstage vom aktuellen Guthaben abhängen.",
+        );
+      }
+      if (error.code === "adjustment_in_closed_month") {
+        throw new Error(
+          "Der gewählte Monat ist abgeschlossen. Wähle ein Datum im offenen Monat oder öffne den Monatsabschluss wieder.",
+        );
+      }
+      throw new Error(error.message);
+    }
+    const json = (await response.json()) as { data: BackendBalanceAdjustment };
+    return mapBalanceAdjustmentResponse(json.data);
+  }
+
+  // Eröffnungssaldo (#2132): sets the Stundenkonto to a SIGNED target value
+  // as of the Stichtag — the only booking that may take the account negative
+  // (takeover from the previous system). One opening per person, ever.
+  async createOpening(
+    staffId: string,
+    payload: {
+      effectiveDate: string;
+      balanceMinutes: number;
+      note: string;
+    },
+  ): Promise<BalanceAdjustment> {
+    const response = await sessionFetch(
+      `/api/staff/${staffId}/time-tracking/opening`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          effective_date: payload.effectiveDate,
+          balance_minutes: payload.balanceMinutes,
+          note: payload.note,
+        }),
+      },
+    );
+    if (!response.ok) {
+      const error = await readStaffAPIError(
+        response,
+        "Eröffnungssaldo fehlgeschlagen",
+      );
+      if (error.code === "opening_balance_already_exists") {
+        throw new Error(
+          "Für diese Person existiert bereits ein Eröffnungssaldo. Lösche zuerst die bestehende Buchung.",
+        );
+      }
+      if (error.code === "dependent_balance_reset") {
+        throw new Error(
+          "Es existieren bereits spätere Buchungen (Reset), die vom Stichtag abhängen.",
         );
       }
       if (error.code === "adjustment_in_closed_month") {

--- a/frontend/src/lib/staff-audit-log-api.ts
+++ b/frontend/src/lib/staff-audit-log-api.ts
@@ -12,6 +12,7 @@ export type AuditLogSource =
   | "session_edit"
   | "absence"
   | "adjustment"
+  | "vacation_opening"
   | "month_close"
   | "month_reopen"
   | "deletion"
@@ -66,6 +67,7 @@ export const auditLogSourceLabels: Record<AuditLogSource, string> = {
   session_edit: "Zeiterfassung",
   absence: "Abwesenheit",
   adjustment: "Stundenkonto",
+  vacation_opening: "Urlaubs-Übernahme",
   month_close: "Monatsabschluss",
   month_reopen: "Monat geöffnet",
   deletion: "Löschung",

--- a/frontend/src/lib/time-tracking-helpers.ts
+++ b/frontend/src/lib/time-tracking-helpers.ts
@@ -101,7 +101,11 @@ export interface BackendStaffAbsence {
 
 // Frontend absence type
 export type AbsenceType =
-  "sick" | "vacation" | "training" | "other" | "comp_time";
+  | "sick"
+  | "vacation"
+  | "training"
+  | "other"
+  | "comp_time";
 
 export interface StaffAbsence {
   id: string;
@@ -618,7 +622,11 @@ export interface BackendBalanceAdjustment {
   decided_at: string;
 }
 
-export type BalanceAdjustmentType = "payout" | "comp_time" | "reset";
+export type BalanceAdjustmentType =
+  | "payout"
+  | "comp_time"
+  | "reset"
+  | "opening";
 
 export interface BalanceAdjustment {
   id: string;
@@ -634,6 +642,7 @@ const balanceAdjustmentTypeLabels: Record<BalanceAdjustmentType, string> = {
   payout: "Auszahlung",
   comp_time: "Freizeitausgleich",
   reset: "Reset",
+  opening: "Eröffnungssaldo",
 };
 
 // Defensive lookup: mapBalanceAdjustmentResponse casts the wire type without


### PR DESCRIPTION
Closes #2132

## Worum es geht

Beim Umstieg auf moto bringt jede Schule bestehende Konten mit: Überstunden, Minusstunden, Resturlaub. Bisher ließ sich davon nur ein positiver Stundenübertrag über "Zurücksetzen" abbilden. Diese PR macht die vollständige Übernahme zum Go-live-Stichtag möglich, pro Person und als Sammelimport für das ganze Team.

## Drei Bausteine

**Stundenkonto** bekommt einen vierten Buchungstyp `opening`. Der Admin trägt den Zielsaldo zum Stichtag ein, das Backend bucht die Differenz zum Live-Stand. Anders als beim Reset gibt es keine Untergrenze und keine Deckelung durch verfügbare Plus-Stunden, denn ein übernommenes Konto darf negativ starten. Genau ein Eröffnungssaldo pro Person, abgesichert über einen partiellen Unique-Index; eine Korrektur läuft über Löschen und neu anlegen, damit der Tombstone die Historie behält.

**Urlaub** bekommt eine eigene Tabelle `active.staff_vacation_openings` für die vor der Einführung genommenen Tage. Eingegeben wird der Resturlaub zum Stichtag, das Backend leitet daraus die genommenen Tage ab. Damit bleibt der Jahresanspruch die führende Größe: Wird er später korrigiert, verschiebt sich der Rest korrekt mit. Urlaubs-Abwesenheiten, die vor dem Stichtag bereits in moto stehen, werden abgewiesen, weil sie sonst doppelt zählen würden.

**Sammelimport** unter Datenverwaltung, Personal. Eine Datei für beide Seiten, Vorlage als CSV und Excel inklusive Hinweise-Blatt. Stichtag und Begründung gelten für die ganze Datei und landen an jeder Buchung. Leere Zelle heißt: diese Seite unangetastet lassen. Zuordnung über die Personalnummer, sonst über einen eindeutigen Namen. Die Wertspalten umgehen bewusst den CSV-Injection-Schutz, weil dessen Hochkomma vor führenden Minuszeichen genau die negativen Salden zerstört hätte, um die es hier geht.

Jede Buchung erscheint im Änderungsprotokoll der Zeiterfassung mit Stichtag, Begründung, betroffener und handelnder Person.

## Migration

`1.15.257`. Erweitert den Typ-Check der Buchungstabelle, legt die Urlaubs-Übernahme-Tabelle mit RLS an und ergänzt die Tombstone-Quelle. Die Präfixe 253 bis 256 waren durch parallele Branches belegt.

## Screenshots

<details>
<summary>Eröffnungssalden im Alltag</summary>
<img width="1440" height="900" alt="01-stundenkonto-eroeffnungssaldo-desktop" src="https://github.com/user-attachments/assets/489dcf8b-1d97-4039-808e-a85c817c5148" />
<img width="1440" height="900" alt="02-urlaubs-uebernahme-anzeige-desktop" src="https://github.com/user-attachments/assets/a1866493-96d9-4214-ac18-eddec8b6b5f0" />
<img width="1440" height="900" alt="03-urlaubs-uebernahme-modal-vorhanden-desktop" src="https://github.com/user-attachments/assets/9c66c661-0bc8-4c77-ada1-9154bbfbf5ff" />
<img width="1440" height="900" alt="04-eroeffnungssaldo-modal-desktop" src="https://github.com/user-attachments/assets/a7521814-9265-4146-bf4c-bf0a63768701" />
<img width="1440" height="900" alt="05-negativer-eroeffnungssaldo-desktop" src="https://github.com/user-attachments/assets/4048af64-9d47-475a-823d-92f65a725c5e" />
<img width="1432" height="1115" alt="06-import-seite-desktop" src="https://github.com/user-attachments/assets/e3f55874-fce4-4a93-b802-8ee2c9898d12" />
<img width="382" height="1655" alt="07-import-seite-mobil" src="https://github.com/user-attachments/assets/559c6a72-4f02-4fde-9b8b-f2182cb35eaf" />
<img width="390" height="844" alt="08-stundenkonto-mobil" src="https://github.com/user-attachments/assets/25d6f1e9-1a46-4936-9823-d858f8068ca8" />
<img width="390" height="844" alt="09-urlaubs-uebernahme-mobil" src="https://github.com/user-attachments/assets/b1fc1da6-4fa1-440f-8f81-1162c9276639" />
<img width="1432" height="1813" alt="10-import-duplikatsperre-desktop" src="https://github.com/user-attachments/assets/e38e157e-f7a0-4990-914d-f0f78144e22e" />
<img width="1440" height="900" alt="11-aenderungsprotokoll-desktop" src="https://github.com/user-attachments/assets/0e758450-86df-44dd-a464-78d34ec254d1" />
<img width="1440" height="900" alt="12-urlaubs-uebernahme-modal-anlegen-desktop" src="https://github.com/user-attachments/assets/f03d6c14-8105-45ce-bf47-642a1aa25760" />
<img width="1440" height="900" alt="13-urlaubs-uebernahme-validierung-desktop" src="https://github.com/user-attachments/assets/055c187c-57b3-46db-a6d6-4b3adb86f7cb" />

</details>

## Testabdeckung

40 neue Backend-Tests: hermetische DB-Tests für die Urlaubs-Übernahme (Ableitung aus dem Anspruch, negativer Rest, Duplikat, Abwesenheiten vor dem Stichtag, Tombstone), Unit-Tests für den Eröffnungssaldo (negatives Ziel ohne Kapazitätsprüfung, Delta gegen den Live-Stand, offener Stichtag, Wertebereich) sowie 30 Tests für Parser und Validierung des Imports. Dazu Frontend-Tests für beide Modals, die Import-Seite und das Änderungsprotokoll.

Manuell im Browser durchgespielt: Vorlagen-Download in beiden Formaten, Import einer ausgefüllten Excel- und einer CSV-Datei mit absichtlich fehlerhaften Zeilen, erneuter Import derselben Datei gegen die Duplikatsperre, beide Löschwege und das Änderungsprotokoll.

## Nebenbefund

Beim Testen ist aufgefallen, dass die GDPR-Protokollierung von Importen generell nichts schreibt: `audit.data_imports` bleibt leer, betroffen sind auch Kinder- und Personal-Import. Das ist älter als diese PR und in #2141 zur Untersuchung festgehalten.

## Offen

Der Fall "Buchung in einen abgeschlossenen Monat" ist durch Unit-Tests abgedeckt, aber nicht mit einem echt abgeschlossenen Monat im Browser durchgespielt. Das Guide-Kapitel zum Import hat noch kein Screenshot-Bild, nur die Bildunterschrift.
