### PR TITLE
chore(review): Reviewer nach quorum-Fixes per Stop-Hook zwingend re-requesten

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -15,6 +15,8 @@ Shared [Claude Code](https://claude.ai/code) configuration for this repo. Everyt
 │   ├── check-env-files.sh      #   env file security check on session start
 │   ├── skill-reminder.sh       #   nudges active skill usage, area-aware
 │   └── subagent-reminder.sh
+│                               # (the Stop hook lives outside: it runs
+│                               #  ../scripts/quorum-rerequest.sh --stop-hook)
 ├── scripts/                    # Helper scripts (context-monitor.py)
 ├── skills/                     # Project skills: settings, help-guide-sync,
 │   │                           #   env-docker-sync, creating-team-skills, find-skills
@@ -53,6 +55,7 @@ Files in `.claude/rules/` without frontmatter are loaded into **every** session;
 | `help-guide-sync.md` | Keeping the in-app manual in sync with features |
 | `env-docker-sync.md` | Env var + docker-compose file sync checklists |
 | `github-labels.md` | Only existing labels; one Type + one Priority |
+| `quorum-review-loop.md` | Re-request the reviewer after fixing quorum findings |
 | `no-test-modifications.md` | Never change existing tests to make new code pass |
 | `no-production-requests.md` | Never hit moto-app.de / moto.nrw domains |
 | `security/hardcoded-credentials.md` | Never hardcode secrets |

--- a/.claude/rules/quorum-review-loop.md
+++ b/.claude/rules/quorum-review-loop.md
@@ -23,9 +23,9 @@ Without it the fixes sit on the PR unreviewed, and nothing tells you: the PR loo
 - The PR has no quorum review yet, or nothing was pushed since the last one → nothing owed; the script exits without acting.
 - The quorum report came from the PR author's own account → GitHub refuses that review request; `quorum babysit` re-triggers itself there, so nothing is owed.
 
-A quorum report is recognised by all five of its headings (`## Summary`, `## Blockers`, `## Critical`, `## Suggestions`, `## Questions`); two of them would also match an ordinary comment. Pin the account explicitly with `git config quorum.reviewer <login>` when in doubt.
+The quorum account is declared, never guessed: `git config quorum.reviewer <login>` per clone, otherwise the tracked `.github/quorum-reviewer`. Without a declared account no review request is touched at all. A quorum report is a comment from that account carrying all five headings (`## Summary`, `## Blockers`, `## Critical`, `## Suggestions`, `## Questions`).
 
-**Only the quorum account is re-requested.** Human reviewers and teams on the PR are never removed and re-added, that would reset a review someone is in the middle of. For the same reason a `review_requested` event only counts as a fresh round when it aimed at the quorum account.
+**Only the quorum account is re-requested.** Human reviewers and teams on the PR are never removed and re-added, that would reset a review someone is in the middle of. For the same reason a `review_requested` event only counts as a fresh round when it aimed at the quorum account **and** came after the last push. Re-requesting and then pushing more commits leaves those commits unreviewed, so the check stays open.
 
 ## Enforcement
 

--- a/.claude/rules/quorum-review-loop.md
+++ b/.claude/rules/quorum-review-loop.md
@@ -1,0 +1,30 @@
+# Fixing Review Findings: Always Re-request the Reviewer
+
+**RULE: After pushing fixes for a `quorum` review, the reviewer MUST be re-requested — removed and added again. A fix round that ends without that re-request is not finished.**
+
+```bash
+scripts/quorum-rerequest.sh        # does the remove/add round trip for this branch's PR
+scripts/quorum-rerequest.sh --check   # exit 1 when a re-request is owed
+```
+
+## Why removing and re-adding, not just adding
+
+`quorum` reviews on the **review request**, not on new code. Its own README:
+
+> "The trigger is the review request, not the code. One request is one review, so pushing more commits does not trigger another one; re-request the review to get a fresh one."
+
+`quorum` posts its report as a plain PR **comment**, not as a formal GitHub review. GitHub therefore never clears the pending request, the reviewer stays in `reviewRequests` — and `gh pr edit --add-reviewer` on someone already listed is a silent no-op that notifies nobody. Only removing and re-adding produces a fresh `review_requested` event, which is what the next review round hangs on.
+
+Without it the fixes sit on the PR unreviewed, and nothing tells you: the PR looks reviewed, the findings look handled, and no one is waiting on anything.
+
+## When it applies
+
+- Findings from a quorum review comment (`## Summary` / `## Blockers` / `## Critical`) were fixed and pushed → re-request.
+- The PR has no quorum review yet, or nothing was pushed since the last one → nothing owed; the script exits without acting.
+- `quorum babysit` runs its own review→fix loop locally and re-triggers itself → no manual re-request needed there.
+
+## Enforcement
+
+The `Stop` hook `scripts/quorum-rerequest.sh --stop-hook` (wired in `.claude/settings.json` and `.codex/hooks.json`) blocks the end of a turn while a re-request is owed. It only fires when the work looks finished (no uncommitted changes, nothing unpushed) and never twice in a row.
+
+If a re-request is deliberately unwanted, say so — do not work around the hook. Per clone it can be switched off with `touch .git/quorum-rerequest-off`.

--- a/.claude/rules/quorum-review-loop.md
+++ b/.claude/rules/quorum-review-loop.md
@@ -19,9 +19,13 @@ Without it the fixes sit on the PR unreviewed, and nothing tells you: the PR loo
 
 ## When it applies
 
-- Findings from a quorum review comment (`## Summary` / `## Blockers` / `## Critical`) were fixed and pushed → re-request.
+- Findings from a quorum report were fixed and pushed → re-request.
 - The PR has no quorum review yet, or nothing was pushed since the last one → nothing owed; the script exits without acting.
-- `quorum babysit` runs its own review→fix loop locally and re-triggers itself → no manual re-request needed there.
+- The quorum report came from the PR author's own account → GitHub refuses that review request; `quorum babysit` re-triggers itself there, so nothing is owed.
+
+A quorum report is recognised by all five of its headings (`## Summary`, `## Blockers`, `## Critical`, `## Suggestions`, `## Questions`); two of them would also match an ordinary comment. Pin the account explicitly with `git config quorum.reviewer <login>` when in doubt.
+
+**Only the quorum account is re-requested.** Human reviewers and teams on the PR are never removed and re-added, that would reset a review someone is in the middle of. For the same reason a `review_requested` event only counts as a fresh round when it aimed at the quorum account.
 
 ## Enforcement
 

--- a/.claude/rules/quorum-review-loop.md
+++ b/.claude/rules/quorum-review-loop.md
@@ -31,4 +31,6 @@ The quorum account is declared, never guessed: `git config quorum.reviewer <logi
 
 The `Stop` hook `scripts/quorum-rerequest.sh --stop-hook` (wired in `.claude/settings.json` and `.codex/hooks.json`) blocks the end of a turn while a re-request is owed. It only fires when the work looks finished (no uncommitted changes, nothing unpushed) and never twice in a row.
 
+Codex loads `.codex/hooks.json` only behind its experimental hooks feature flag. The repo config (`.codex/config.toml`) switches it on (`[features] hooks = true`, plus the pre-rename alias `codex_hooks` for older CLI versions); if the Stop hook still does not fire there, set the same flag in `~/.codex/config.toml`.
+
 If a re-request is deliberately unwanted, say so — do not work around the hook. Per clone it can be switched off with `touch .git/quorum-rerequest-off`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -186,6 +186,16 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'root=\"${CLAUDE_PROJECT_DIR:-}\"; if [[ -z \"$root\" ]]; then root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; fi; bash \"$root/scripts/quorum-rerequest.sh\" --stop-hook'"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,12 @@
+# Codex loads lifecycle hooks (.codex/hooks.json - including the Stop hook
+# that enforces the quorum re-request) only behind this experimental feature
+# flag. "hooks" is the current flag name, "codex_hooks" the pre-rename alias
+# still accepted for older CLI versions. If the Stop hook still does not fire
+# with this repo config, set the flag in ~/.codex/config.toml.
+[features]
+hooks = true
+codex_hooks = true
+
 [shell_environment_policy]
 inherit = "core"
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -37,6 +37,16 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; bash \"$root/scripts/quorum-rerequest.sh\" --stop-hook'"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/.github/quorum-reviewer
+++ b/.github/quorum-reviewer
@@ -1,0 +1,5 @@
+# GitHub login of the account that posts quorum reviews on this repository.
+# scripts/quorum-rerequest.sh re-requests exactly this account after review
+# findings were fixed, and never touches the other reviewers on a PR.
+# Override per clone with: git config quorum.reviewer <login>
+yungweng

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,20 @@ Key rules:
 
 **CRITICAL**: Never include "Co-Authored-By: Claude" in commits.
 
+### After Fixing Review Findings: Re-request the Reviewer
+
+`quorum` reviews trigger on the **review request**, not on new code, and it posts
+its report as a plain PR comment — so GitHub never clears the request and a bare
+`gh pr edit --add-reviewer` is a silent no-op. Once fixes for a quorum review are
+pushed, the reviewer must be removed and added again:
+
+```bash
+scripts/quorum-rerequest.sh   # remove/add round trip for this branch's PR
+```
+
+A `Stop` hook blocks the end of a turn while this is owed. Details:
+`.claude/rules/quorum-review-loop.md`.
+
 ### PR Screenshots and QA Evidence
 
 Never create GitHub Releases, prereleases, tags, Gists, branches, or commits

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -19,9 +19,9 @@
 #   --stop-hook   Stop-hook protocol: exit 2 (with instructions on stderr)
 #                 when a re-request is owed and the work looks finished
 #
-# The quorum account is taken from the author of the quorum report on the PR.
-# Pin it explicitly with `git config quorum.reviewer <login>`. Only that account
-# is ever re-requested; other reviewers and teams on the PR are left alone.
+# The quorum account is declared, not guessed: `git config quorum.reviewer
+# <login>` per clone, otherwise the tracked `.github/quorum-reviewer`. Only that
+# account is ever re-requested; other reviewers and teams are left alone.
 #
 # Opt out per clone with `touch .git/quorum-rerequest-off`, per invocation
 # with QUORUM_RERQ_OFF=1.
@@ -94,8 +94,12 @@ if [[ "$mode" == "stop-hook" ]]; then
     fi
 fi
 
+# can_cache drops to 0 as soon as a lookup was inconclusive, so an incomplete
+# answer is never frozen into the per-HEAD cache.
+can_cache=1
+
 mark_clean() {
-    if [[ "$mode" == "stop-hook" ]]; then
+    if [[ "$mode" == "stop-hook" && "$can_cache" == "1" ]]; then
         printf 'clean %s' "$(git rev-parse HEAD 2>/dev/null || echo unknown)" >"$cache_file" 2>/dev/null || true
     fi
 }
@@ -126,13 +130,32 @@ pr_number=$(printf '%s' "$pr_json" | jq -r '.number')
 pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
 pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login // empty')
 
-# A quorum report carries all five of its section headings. Two of them would
-# also match an ordinary human comment; the full set is the stable fingerprint,
-# and it excludes quorum's own "Review fix round N" notes and other bots.
-# `git config quorum.reviewer <login>` pins the account on top of that.
-quorum_reviewer=$(git config --get quorum.reviewer 2>/dev/null || echo "")
+# --- who runs quorum here ---------------------------------------------------
+# The account is declared, never guessed: this script removes and re-adds a
+# review request, and inferring the account from comment shape alone would let a
+# human who writes the same headings have their pending review reset.
+# Per clone `git config quorum.reviewer` wins, otherwise the tracked
+# .github/quorum-reviewer applies.
+target=$(git config --get quorum.reviewer 2>/dev/null || echo "")
+if [[ -z "$target" && -f "$project_root/.github/quorum-reviewer" ]]; then
+    target=$(sed -e 's/#.*//' -e 's/[[:space:]]//g' "$project_root/.github/quorum-reviewer" |
+        sed '/^$/d' | head -n 1)
+fi
 
-last_review=$(printf '%s' "$pr_json" | jq -c --arg qr "$quorum_reviewer" '
+if [[ -z "$target" ]]; then
+    # Without a declared account there is nothing safe to re-request.
+    if [[ "$mode" == "apply" ]]; then
+        echo "No quorum account configured. Set one with:" >&2
+        echo "  git config quorum.reviewer <login>    # or commit .github/quorum-reviewer" >&2
+        exit 1
+    fi
+    mark_clean
+    exit 0
+fi
+
+# A quorum report comes from that account and carries all five of its section
+# headings, which excludes quorum's own "Review fix round N" notes.
+last_review=$(printf '%s' "$pr_json" | jq -c --arg qr "$target" '
     def is_quorum_report:
         (.body | test("(^|\n)## Summary"))
         and (.body | test("(^|\n)## Blockers"))
@@ -140,11 +163,10 @@ last_review=$(printf '%s' "$pr_json" | jq -c --arg qr "$quorum_reviewer" '
         and (.body | test("(^|\n)## Suggestions"))
         and (.body | test("(^|\n)## Questions"));
     .comments
-    | map(select(is_quorum_report and ($qr == "" or .author.login == $qr)))
+    | map(select(.author.login == $qr and is_quorum_report))
     | last // {}
 ')
 last_review_at=$(printf '%s' "$last_review" | jq -r '.createdAt // empty')
-last_review_by=$(printf '%s' "$last_review" | jq -r '.author.login // empty')
 
 # Nothing to re-trigger without a review to answer.
 if [[ -z "$last_review_at" ]]; then
@@ -155,12 +177,7 @@ if [[ -z "$last_review_at" ]]; then
     exit 0
 fi
 
-# --- who to re-request ------------------------------------------------------
-# Exactly the quorum account, never the other reviewers on the PR: re-requesting
-# a human or a team would reset a review they are in the middle of.
-target="${quorum_reviewer:-$last_review_by}"
-
-if [[ -z "$target" || "$target" == "$pr_author" ]]; then
+if [[ "$target" == "$pr_author" ]]; then
     # GitHub refuses a review request from the PR author. quorum reviewing its
     # own operator's PR means `quorum babysit`, which re-triggers itself, so
     # there is nothing to enforce here.
@@ -180,27 +197,46 @@ fi
 last_commit_at=$(printf '%s' "$pr_json" | jq -r '[.commits[].committedDate] | max // empty')
 
 repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')
-timeline=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate --slurp 2>/dev/null |
-    jq -c 'add // []' 2>/dev/null) || timeline="[]"
 
-# A review_requested event only counts when it aimed at the quorum account -
-# requesting some other reviewer must not pass as a fresh quorum round.
-timeline_flags=$(printf '%s' "$timeline" | jq -c --arg rev "$last_review_at" --arg tgt "$target" '
+# A failed timeline call must not read as "nothing changed" and must never be
+# cached as clean, otherwise one flaky request silences the check for this HEAD.
+timeline="[]"
+timeline_ok=1
+if timeline_raw=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate --slurp 2>/dev/null); then
+    timeline=$(printf '%s' "$timeline_raw" | jq -c 'add // []' 2>/dev/null) || timeline_ok=0
+else
+    timeline_ok=0
+fi
+if [[ "$timeline_ok" == "0" ]]; then
+    timeline="[]"
+    can_cache=0
+fi
+
+# A review_requested event only counts when it aimed at the quorum account and
+# came after the last head movement. A re-request followed by further commits
+# leaves those commits unreviewed, so it does not settle the loop.
+timeline_flags=$(printf '%s' "$timeline" | jq -c \
+    --arg rev "$last_review_at" --arg tgt "$target" --arg head "$last_commit_at" '
     def target_of: (.requested_reviewer.login // .requested_team.slug // "");
     def short: ($tgt | split("/") | last);
+    def is_head_move: (.event == "committed" or .event == "head_ref_force_pushed");
     . as $ev
     | ([range(0; length) | select($ev[.].event == "commented" and $ev[.].created_at == $rev)] | last) as $i
+    | ([range(0; length) | select($ev[.] | is_head_move)] | last) as $h
     | {
         head_moved: (
             if $i == null then false
-            else ($ev[($i + 1):] | map(select(.event == "committed" or .event == "head_ref_force_pushed")) | length > 0)
+            else ($ev[($i + 1):] | map(select(is_head_move)) | length > 0)
             end
         ),
         rerequested: (
-            $ev
-            | map(select(.event == "review_requested"
-                and (target_of == $tgt or target_of == short)
-                and (.created_at > $rev)))
+            [range(0; length)
+             | select(
+                 ($ev[.].event == "review_requested")
+                 and ((($ev[.] | target_of) == $tgt) or (($ev[.] | target_of) == short))
+                 and ($ev[.].created_at > $rev)
+                 and ($head == "" or $ev[.].created_at > $head)
+                 and ($h == null or . > $h))]
             | length > 0
         )
     }

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -19,6 +19,10 @@
 #   --stop-hook   Stop-hook protocol: exit 2 (with instructions on stderr)
 #                 when a re-request is owed and the work looks finished
 #
+# The quorum account is taken from the author of the quorum report on the PR.
+# Pin it explicitly with `git config quorum.reviewer <login>`. Only that account
+# is ever re-requested; other reviewers and teams on the PR are left alone.
+#
 # Opt out per clone with `touch .git/quorum-rerequest-off`, per invocation
 # with QUORUM_RERQ_OFF=1.
 #
@@ -122,12 +126,21 @@ pr_number=$(printf '%s' "$pr_json" | jq -r '.number')
 pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
 pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login // empty')
 
-# A quorum report is a comment carrying both the Summary and the Blockers
-# heading. That excludes quorum's own "Review fix round N" progress notes and
-# third-party bot comments.
-last_review=$(printf '%s' "$pr_json" | jq -c '
+# A quorum report carries all five of its section headings. Two of them would
+# also match an ordinary human comment; the full set is the stable fingerprint,
+# and it excludes quorum's own "Review fix round N" notes and other bots.
+# `git config quorum.reviewer <login>` pins the account on top of that.
+quorum_reviewer=$(git config --get quorum.reviewer 2>/dev/null || echo "")
+
+last_review=$(printf '%s' "$pr_json" | jq -c --arg qr "$quorum_reviewer" '
+    def is_quorum_report:
+        (.body | test("(^|\n)## Summary"))
+        and (.body | test("(^|\n)## Blockers"))
+        and (.body | test("(^|\n)## Critical"))
+        and (.body | test("(^|\n)## Suggestions"))
+        and (.body | test("(^|\n)## Questions"));
     .comments
-    | map(select((.body | test("(^|\n)## Summary")) and (.body | test("(^|\n)## Blockers"))))
+    | map(select(is_quorum_report and ($qr == "" or .author.login == $qr)))
     | last // {}
 ')
 last_review_at=$(printf '%s' "$last_review" | jq -r '.createdAt // empty')
@@ -142,101 +155,117 @@ if [[ -z "$last_review_at" ]]; then
     exit 0
 fi
 
-# ISO-8601 Z timestamps compare correctly as strings.
+# --- who to re-request ------------------------------------------------------
+# Exactly the quorum account, never the other reviewers on the PR: re-requesting
+# a human or a team would reset a review they are in the middle of.
+target="${quorum_reviewer:-$last_review_by}"
+
+if [[ -z "$target" || "$target" == "$pr_author" ]]; then
+    # GitHub refuses a review request from the PR author. quorum reviewing its
+    # own operator's PR means `quorum babysit`, which re-triggers itself, so
+    # there is nothing to enforce here.
+    if [[ "$mode" == "apply" ]]; then
+        echo "PR #$pr_number: the quorum review came from the PR author ($pr_author);"
+        echo "GitHub does not accept a review request from the author. Nothing to do."
+    fi
+    mark_clean
+    exit 0
+fi
+
+# --- did anything change since that review ----------------------------------
+# committedDate is when a commit was written, not when it reached the PR, so it
+# alone misses a fix that was committed before the review and pushed after it.
+# The timeline is the second opinion: commit events that sit behind the review
+# comment arrived after it. Either signal is enough.
 last_commit_at=$(printf '%s' "$pr_json" | jq -r '[.commits[].committedDate] | max // empty')
 
-pushed_after_review=1
-if [[ -z "$last_commit_at" ]] || [[ ! "$last_commit_at" > "$last_review_at" ]]; then
-    pushed_after_review=0
+repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')
+timeline=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate --slurp 2>/dev/null |
+    jq -c 'add // []' 2>/dev/null) || timeline="[]"
+
+# A review_requested event only counts when it aimed at the quorum account -
+# requesting some other reviewer must not pass as a fresh quorum round.
+timeline_flags=$(printf '%s' "$timeline" | jq -c --arg rev "$last_review_at" --arg tgt "$target" '
+    def target_of: (.requested_reviewer.login // .requested_team.slug // "");
+    def short: ($tgt | split("/") | last);
+    . as $ev
+    | ([range(0; length) | select($ev[.].event == "commented" and $ev[.].created_at == $rev)] | last) as $i
+    | {
+        head_moved: (
+            if $i == null then false
+            else ($ev[($i + 1):] | map(select(.event == "committed" or .event == "head_ref_force_pushed")) | length > 0)
+            end
+        ),
+        rerequested: (
+            $ev
+            | map(select(.event == "review_requested"
+                and (target_of == $tgt or target_of == short)
+                and (.created_at > $rev)))
+            | length > 0
+        )
+    }
+' 2>/dev/null) || timeline_flags='{"head_moved":false,"rerequested":false}'
+
+head_moved=$(printf '%s' "$timeline_flags" | jq -r '.head_moved // false')
+rerequested=$(printf '%s' "$timeline_flags" | jq -r '.rerequested // false')
+
+pushed_after_review=0
+if [[ -n "$last_commit_at" ]] && [[ "$last_commit_at" > "$last_review_at" ]]; then
+    pushed_after_review=1
+fi
+if [[ "$head_moved" == "true" ]]; then
+    pushed_after_review=1
 fi
 
 if [[ "$force" == "0" && "$pushed_after_review" == "0" ]]; then
     if [[ "$mode" == "apply" ]]; then
-        echo "PR #$pr_number: no commits pushed since the quorum review at $last_review_at."
+        echo "PR #$pr_number: nothing pushed since the quorum review at $last_review_at."
         echo "Nothing to re-review. Use --force to request a fresh round anyway."
     fi
     mark_clean
     exit 0
 fi
 
-# Only now, when a re-request is plausible, pay for the timeline call.
-repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')
-last_request_at=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate \
-    --jq '[.[] | select(.event == "review_requested") | .created_at] | max // empty' 2>/dev/null || echo "")
-
-if [[ "$force" == "0" && -n "$last_request_at" ]] && [[ "$last_request_at" > "$last_review_at" ]]; then
+if [[ "$force" == "0" && "$rerequested" == "true" ]]; then
     if [[ "$mode" == "apply" ]]; then
-        echo "PR #$pr_number was already re-requested at $last_request_at (review: $last_review_at)."
+        echo "PR #$pr_number: $target was already re-requested after the review at $last_review_at."
         echo "Use --force to request another round."
     fi
     mark_clean
     exit 0
 fi
 
-# --- who to re-request ------------------------------------------------------
-# Whoever is on the PR right now, else the account that posted the review.
-# GitHub refuses a review request from the PR author, so that case is reported
-# rather than failed on.
-targets=$(printf '%s' "$pr_json" |
-    jq -r '.reviewRequests[]? | (.login // .slug // empty)' | sed '/^$/d')
-
-if [[ -z "$targets" && -n "$last_review_by" && "$last_review_by" != "$pr_author" ]]; then
-    targets="$last_review_by"
-fi
-
-if [[ -z "$targets" ]]; then
-    no_target_msg="quorum re-request owed on PR #$pr_number, but no reviewer could be determined:
-nobody is requested on the PR, and the review came from the PR author, whom
-GitHub refuses as a reviewer.
-
-Ask the user who should be re-requested, then run:
-  gh pr edit $pr_number --add-reviewer <login-or-org/team>"
-    # Blocking here too: silently dropping this case is the exact failure the
-    # hook exists to prevent.
-    if [[ "$mode" == "stop-hook" ]]; then emit_block "$no_target_msg"; fi
-    printf '%s\n' "$no_target_msg" >&2
-    exit 1
-fi
-
-targets_flat=$(printf '%s' "$targets" | tr '\n' ' ' | sed 's/ *$//')
-
 # --- report / act -----------------------------------------------------------
 if [[ "$mode" == "check" ]]; then
-    echo "quorum re-request owed on PR #$pr_number (review $last_review_at, head $last_commit_at): $targets_flat"
+    echo "quorum re-request owed on PR #$pr_number (review $last_review_at): $target"
     exit 1
 fi
 
 if [[ "$mode" == "stop-hook" ]]; then
     emit_block "BLOCKED: quorum re-request owed on PR #$pr_number.
 
-The quorum review from $last_review_at was answered with commits pushed
-afterwards ($last_commit_at), and no review has been re-requested since. quorum
-triggers on the review request, not on new code, so those fixes sit there
-unreviewed until the reviewer is removed and added again.
+The quorum review from $last_review_at was answered with pushed commits, and
+$target has not been re-requested since. quorum triggers on the review request,
+not on new code, so those fixes sit there unreviewed until the reviewer is
+removed and added again.
 
 Run this, then finish:
   scripts/quorum-rerequest.sh
 
-Reviewers to re-request: $targets_flat
+Reviewer to re-request: $target
 If the user deliberately does not want another review round, say so instead of
 running it - and touch .git/quorum-rerequest-off to stop the check for this
 clone."
 fi
 
 # apply
-exit_code=0
-for target in $targets; do
-    # Removing a reviewer who is not currently requested errors; that is fine.
-    gh pr edit "$pr_number" --remove-reviewer "$target" >/dev/null 2>&1 || true
-    if gh pr edit "$pr_number" --add-reviewer "$target" >/dev/null 2>&1; then
-        echo "Re-requested review from $target on PR #$pr_number."
-    else
-        echo "Failed to re-request review from $target on PR #$pr_number." >&2
-        exit_code=1
-    fi
-done
-
-if [[ "$exit_code" == "0" ]]; then
-    rm -f "$cache_file" 2>/dev/null || true
+# Removing a reviewer who is not currently requested errors; that is fine. The
+# removal is what makes the following add produce a new review_requested event.
+gh pr edit "$pr_number" --remove-reviewer "$target" >/dev/null 2>&1 || true
+if ! gh pr edit "$pr_number" --add-reviewer "$target" >/dev/null 2>&1; then
+    echo "Failed to re-request review from $target on PR #$pr_number." >&2
+    exit 1
 fi
-exit "$exit_code"
+
+echo "Re-requested review from $target on PR #$pr_number."
+rm -f "$cache_file" 2>/dev/null || true

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# quorum-rerequest.sh - re-trigger a quorum review after fixing its findings.
+#
+# quorum reviews on a review REQUEST, not on new code (quorum README: "The
+# trigger is the review request, not the code. One request is one review, so
+# pushing more commits does not trigger another one; re-request the review to
+# get a fresh one."). quorum posts its report as a plain PR comment, so GitHub
+# never clears the pending request - which makes a bare `gh pr edit
+# --add-reviewer` a no-op that fires no notification. The reviewer has to be
+# removed and added again to produce a fresh review_requested event.
+#
+# Usage: quorum-rerequest.sh [--check|--stop-hook] [--force] [pr-number]
+#
+# Modes:
+#   (default)     perform the remove/add round trip; without a PR number the
+#                 open PR of the current branch is used
+#   --force       re-request even when nothing new was pushed
+#   --check       report whether a re-request is owed; exit 1 when it is
+#   --stop-hook   Stop-hook protocol: exit 2 (with instructions on stderr)
+#                 when a re-request is owed and the work looks finished
+#
+# Opt out per clone with `touch .git/quorum-rerequest-off`, per invocation
+# with QUORUM_RERQ_OFF=1.
+#
+# Kept bash-3.2 compatible (macOS /bin/bash).
+
+set -euo pipefail
+
+mode="apply"
+force=0
+pr_arg=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) mode="check" ;;
+        --stop-hook) mode="stop-hook" ;;
+        --force) force=1 ;;
+        -h | --help)
+            sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        [0-9]*) pr_arg="$1" ;;
+        *)
+            echo "unknown option: $1" >&2
+            exit 64
+            ;;
+    esac
+    shift
+done
+
+# A hook must never break the session over a missing tool or a detached repo.
+soft_exit() { exit 0; }
+
+if ! command -v gh >/dev/null 2>&1; then soft_exit; fi
+if ! command -v jq >/dev/null 2>&1; then soft_exit; fi
+if ! project_root=$(git rev-parse --show-toplevel 2>/dev/null); then soft_exit; fi
+cd "$project_root"
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || soft_exit
+
+if [[ -n "${QUORUM_RERQ_OFF:-}" ]]; then soft_exit; fi
+if [[ -f "$git_dir/quorum-rerequest-off" ]]; then soft_exit; fi
+
+cache_file="$git_dir/quorum-rerequest.cache"
+
+# --- stop-hook input --------------------------------------------------------
+# stop_hook_active is true when the agent is already continuing because of a
+# Stop hook. Blocking again there loops forever.
+if [[ "$mode" == "stop-hook" ]]; then
+    hook_input=""
+    if [[ ! -t 0 ]]; then
+        IFS= read -r -d '' -t 1 hook_input || true
+    fi
+    if [[ -n "$hook_input" ]]; then
+        active=$(printf '%s' "$hook_input" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)
+        if [[ "$active" == "true" ]]; then soft_exit; fi
+    fi
+
+    # Only block when the work actually looks finished: uncommitted changes or
+    # unpushed commits mean the fix round is still running, and nagging there
+    # is noise. Untracked files are ignored on purpose - a stray screenshot or
+    # scratch file must not be able to switch the check off by accident.
+    if [[ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]]; then soft_exit; fi
+    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) || soft_exit
+    if [[ -n "$(git log --oneline "$upstream..HEAD" 2>/dev/null)" ]]; then soft_exit; fi
+
+    # Negative results are cached per HEAD sha, so the API round trip only
+    # happens on turns that actually moved the branch.
+    head_sha=$(git rev-parse HEAD 2>/dev/null) || soft_exit
+    if [[ -f "$cache_file" ]] && [[ "$(cat "$cache_file" 2>/dev/null)" == "clean $head_sha" ]]; then
+        soft_exit
+    fi
+fi
+
+mark_clean() {
+    if [[ "$mode" == "stop-hook" ]]; then
+        printf 'clean %s' "$(git rev-parse HEAD 2>/dev/null || echo unknown)" >"$cache_file" 2>/dev/null || true
+    fi
+}
+
+# Both Claude Code and Codex accept a Stop hook blocking either through exit
+# code 2 with the reason on stderr, or through {"decision":"block","reason":…}
+# on stdout. Emitting both makes the block independent of which channel the
+# running tool prefers.
+emit_block() {
+    local reason="$1"
+    jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'
+    printf '%s\n' "$reason" >&2
+    exit 2
+}
+
+# --- PR state ---------------------------------------------------------------
+pr_fields="number,state,url,author,reviewRequests,comments,commits"
+if [[ -n "$pr_arg" ]]; then
+    pr_json=$(gh pr view "$pr_arg" --json "$pr_fields" 2>/dev/null) || soft_exit
+else
+    pr_json=$(gh pr view --json "$pr_fields" 2>/dev/null) || soft_exit
+fi
+if [[ -z "$pr_json" ]]; then soft_exit; fi
+
+if [[ "$(printf '%s' "$pr_json" | jq -r '.state // empty')" != "OPEN" ]]; then soft_exit; fi
+
+pr_number=$(printf '%s' "$pr_json" | jq -r '.number')
+pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
+pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login // empty')
+
+# A quorum report is a comment carrying both the Summary and the Blockers
+# heading. That excludes quorum's own "Review fix round N" progress notes and
+# third-party bot comments.
+last_review=$(printf '%s' "$pr_json" | jq -c '
+    .comments
+    | map(select((.body | test("(^|\n)## Summary")) and (.body | test("(^|\n)## Blockers"))))
+    | last // {}
+')
+last_review_at=$(printf '%s' "$last_review" | jq -r '.createdAt // empty')
+last_review_by=$(printf '%s' "$last_review" | jq -r '.author.login // empty')
+
+# Nothing to re-trigger without a review to answer.
+if [[ -z "$last_review_at" ]]; then
+    if [[ "$mode" == "apply" ]]; then
+        echo "No quorum review found on PR #$pr_number - nothing to re-request."
+    fi
+    mark_clean
+    exit 0
+fi
+
+# ISO-8601 Z timestamps compare correctly as strings.
+last_commit_at=$(printf '%s' "$pr_json" | jq -r '[.commits[].committedDate] | max // empty')
+
+pushed_after_review=1
+if [[ -z "$last_commit_at" ]] || [[ ! "$last_commit_at" > "$last_review_at" ]]; then
+    pushed_after_review=0
+fi
+
+if [[ "$force" == "0" && "$pushed_after_review" == "0" ]]; then
+    if [[ "$mode" == "apply" ]]; then
+        echo "PR #$pr_number: no commits pushed since the quorum review at $last_review_at."
+        echo "Nothing to re-review. Use --force to request a fresh round anyway."
+    fi
+    mark_clean
+    exit 0
+fi
+
+# Only now, when a re-request is plausible, pay for the timeline call.
+repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')
+last_request_at=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate \
+    --jq '[.[] | select(.event == "review_requested") | .created_at] | max // empty' 2>/dev/null || echo "")
+
+if [[ "$force" == "0" && -n "$last_request_at" ]] && [[ "$last_request_at" > "$last_review_at" ]]; then
+    if [[ "$mode" == "apply" ]]; then
+        echo "PR #$pr_number was already re-requested at $last_request_at (review: $last_review_at)."
+        echo "Use --force to request another round."
+    fi
+    mark_clean
+    exit 0
+fi
+
+# --- who to re-request ------------------------------------------------------
+# Whoever is on the PR right now, else the account that posted the review.
+# GitHub refuses a review request from the PR author, so that case is reported
+# rather than failed on.
+targets=$(printf '%s' "$pr_json" |
+    jq -r '.reviewRequests[]? | (.login // .slug // empty)' | sed '/^$/d')
+
+if [[ -z "$targets" && -n "$last_review_by" && "$last_review_by" != "$pr_author" ]]; then
+    targets="$last_review_by"
+fi
+
+if [[ -z "$targets" ]]; then
+    no_target_msg="quorum re-request owed on PR #$pr_number, but no reviewer could be determined:
+nobody is requested on the PR, and the review came from the PR author, whom
+GitHub refuses as a reviewer.
+
+Ask the user who should be re-requested, then run:
+  gh pr edit $pr_number --add-reviewer <login-or-org/team>"
+    # Blocking here too: silently dropping this case is the exact failure the
+    # hook exists to prevent.
+    if [[ "$mode" == "stop-hook" ]]; then emit_block "$no_target_msg"; fi
+    printf '%s\n' "$no_target_msg" >&2
+    exit 1
+fi
+
+targets_flat=$(printf '%s' "$targets" | tr '\n' ' ' | sed 's/ *$//')
+
+# --- report / act -----------------------------------------------------------
+if [[ "$mode" == "check" ]]; then
+    echo "quorum re-request owed on PR #$pr_number (review $last_review_at, head $last_commit_at): $targets_flat"
+    exit 1
+fi
+
+if [[ "$mode" == "stop-hook" ]]; then
+    emit_block "BLOCKED: quorum re-request owed on PR #$pr_number.
+
+The quorum review from $last_review_at was answered with commits pushed
+afterwards ($last_commit_at), and no review has been re-requested since. quorum
+triggers on the review request, not on new code, so those fixes sit there
+unreviewed until the reviewer is removed and added again.
+
+Run this, then finish:
+  scripts/quorum-rerequest.sh
+
+Reviewers to re-request: $targets_flat
+If the user deliberately does not want another review round, say so instead of
+running it - and touch .git/quorum-rerequest-off to stop the check for this
+clone."
+fi
+
+# apply
+exit_code=0
+for target in $targets; do
+    # Removing a reviewer who is not currently requested errors; that is fine.
+    gh pr edit "$pr_number" --remove-reviewer "$target" >/dev/null 2>&1 || true
+    if gh pr edit "$pr_number" --add-reviewer "$target" >/dev/null 2>&1; then
+        echo "Re-requested review from $target on PR #$pr_number."
+    else
+        echo "Failed to re-request review from $target on PR #$pr_number." >&2
+        exit_code=1
+    fi
+done
+
+if [[ "$exit_code" == "0" ]]; then
+    rm -f "$cache_file" 2>/dev/null || true
+fi
+exit "$exit_code"

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -83,6 +83,10 @@ fi
 
 cache_file="$git_dir/quorum-rerequest.cache"
 
+# Set when the local push state cannot be settled from local refs alone; the
+# answer then comes from comparing the PR head with the local HEAD below.
+check_pr_head=0
+
 # --- stop-hook input --------------------------------------------------------
 # stop_hook_active is true when the agent is already continuing because of a
 # Stop hook. Blocking again there loops forever.
@@ -101,8 +105,24 @@ if [[ "$mode" == "stop-hook" ]]; then
     # is noise. Untracked files are ignored on purpose - a stray screenshot or
     # scratch file must not be able to switch the check off by accident.
     if [[ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]]; then soft_exit; fi
-    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) || soft_exit
-    if [[ -n "$(git log --oneline "$upstream..HEAD" 2>/dev/null)" ]]; then soft_exit; fi
+
+    # A branch can be fully pushed without tracking information (git push
+    # origin HEAD without -u), so a missing upstream must not switch the
+    # enforcement off. Fall back to the matching origin ref; when neither
+    # exists, the push state is settled against the PR head further down.
+    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) || upstream=""
+    if [[ -z "$upstream" ]]; then
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch=""
+        if [[ -n "$branch" && "$branch" != "HEAD" ]] &&
+            git rev-parse --verify --quiet "refs/remotes/origin/$branch" >/dev/null 2>&1; then
+            upstream="origin/$branch"
+        fi
+    fi
+    if [[ -n "$upstream" ]]; then
+        if [[ -n "$(git log --oneline "$upstream..HEAD" 2>/dev/null)" ]]; then soft_exit; fi
+    else
+        check_pr_head=1
+    fi
 
     # Negative results are cached per HEAD sha, so the API round trip only
     # happens on turns that actually moved the branch.
@@ -152,16 +172,20 @@ if [[ -z "$target" ]]; then
 fi
 
 # --- PR state ---------------------------------------------------------------
-pr_fields="number,state,url,author,reviewRequests"
+pr_fields="number,state,url,author,reviewRequests,headRefOid"
 if ! pr_json=$(gh pr view ${pr_arg:+"$pr_arg"} --json "$pr_fields" 2>&1); then
     case "$pr_json" in
         *"no pull requests found"* | *"Could not resolve"* | *"no default remote"*)
-            # No PR is genuinely "nothing owed", not an error.
-            if [[ "$mode" == "check" ]]; then
-                echo "No open PR here - nothing owed."
-                exit 0
+            # An explicitly named PR that cannot be resolved is an error; a
+            # branch without an open PR is genuinely "nothing owed" - in every
+            # mode, not just --check.
+            if [[ -n "$pr_arg" ]]; then
+                bail "no open PR found for '$pr_arg'"
             fi
-            bail "no open PR found${pr_arg:+ for '$pr_arg'}"
+            if [[ "$mode" != "stop-hook" ]]; then
+                echo "No open PR here - nothing owed."
+            fi
+            exit 0
             ;;
         *) bail "gh pr view failed: $pr_json" ;;
     esac
@@ -178,6 +202,17 @@ if [[ "$pr_state" != "OPEN" ]]; then
         echo "PR #$pr_number is $pr_state - nothing to re-request."
     fi
     exit 0
+fi
+
+# Without a local tracking ref, "is everything pushed" is answered by the PR
+# itself: a head that does not match the local HEAD (or cannot be read) means
+# the fix round is still in flight - not a finished turn. Never cached: the
+# next push changes the answer.
+if [[ "$mode" == "stop-hook" && "$check_pr_head" == "1" ]]; then
+    pr_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
+    if [[ -z "$pr_head" || "$pr_head" != "$(git rev-parse HEAD 2>/dev/null)" ]]; then
+        soft_exit
+    fi
 fi
 
 repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -222,6 +222,7 @@ last_review=$(printf '%s' "$comments" | jq -c --arg qr "$target" '
     | last // {}
 ')
 last_review_at=$(printf '%s' "$last_review" | jq -r '.created_at // empty')
+last_review_id=$(printf '%s' "$last_review" | jq -r '.id // empty')
 
 # Nothing to re-trigger without a review to answer.
 if [[ -z "$last_review_at" ]]; then
@@ -250,8 +251,10 @@ fi
 # a fix committed before the review and pushed after it carries an old date
 # (missed re-request), a preserved or future-dated commit pushed before the
 # review carries a newer one (false alarm). Only the POSITION of head-movement
-# events relative to the report comment is trustworthy; every issue comment
-# has exactly one timeline "commented" event with an identical created_at.
+# events relative to the report comment is trustworthy. The report is located
+# by its comment ID, which the timeline "commented" event carries verbatim -
+# created_at is NOT unique (two comments can share a second, and `last` would
+# then anchor on the wrong one).
 
 # A failed timeline call must not read as "nothing changed" and must never be
 # cached as clean, otherwise one flaky request silences the check for this HEAD.
@@ -280,12 +283,13 @@ fi
 # sits behind the last head movement: a re-request followed by further commits
 # leaves those commits unreviewed, so it does not settle the loop.
 timeline_flags=$(printf '%s' "$timeline" | jq -c \
-    --arg rev "$last_review_at" --arg tgt "$target" '
+    --arg rid "$last_review_id" --arg tgt "$target" '
     def target_of: (.requested_reviewer.login // .requested_team.slug // "");
     def short: ($tgt | split("/") | last);
     def is_head_move: (.event == "committed" or .event == "head_ref_force_pushed");
     . as $ev
-    | ([range(0; length) | select($ev[.].event == "commented" and $ev[.].created_at == $rev)] | last) as $i
+    | ([range(0; length)
+        | select($ev[.].event == "commented" and (($ev[.].id | tostring) == $rid))] | last) as $i
     | ([range(0; length) | select($ev[.] | is_head_move)] | last) as $h
     | {
         head_moved: (
@@ -299,7 +303,7 @@ timeline_flags=$(printf '%s' "$timeline" | jq -c \
              | select(
                  ($ev[.].event == "review_requested")
                  and ((($ev[.] | target_of) == $tgt) or (($ev[.] | target_of) == short))
-                 and ($ev[.].created_at > $rev)
+                 and ($i != null and . > $i)
                  and ($h == null or . > $h))]
             | length > 0
         )

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -152,7 +152,7 @@ if [[ -z "$target" ]]; then
 fi
 
 # --- PR state ---------------------------------------------------------------
-pr_fields="number,state,url,author,reviewRequests,comments,commits"
+pr_fields="number,state,url,author,reviewRequests"
 if ! pr_json=$(gh pr view ${pr_arg:+"$pr_arg"} --json "$pr_fields" 2>&1); then
     case "$pr_json" in
         *"no pull requests found"* | *"Could not resolve"* | *"no default remote"*)
@@ -180,20 +180,48 @@ if [[ "$pr_state" != "OPEN" ]]; then
     exit 0
 fi
 
+repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')
+
+# Comments come from the REST endpoint with explicit pagination - provably
+# complete on any PR size. An unanswerable lookup is inconclusive, not clean.
+comments="[]"
+comments_ok=0
+for _ in 1 2 3; do
+    if comments_raw=$(gh api "repos/$repo_slug/issues/$pr_number/comments" --paginate --slurp 2>/dev/null) &&
+        comments=$(printf '%s' "$comments_raw" | jq -c 'add // []' 2>/dev/null); then
+        comments_ok=1
+        break
+    fi
+    sleep 1
+done
+if [[ "$comments_ok" == "0" ]]; then
+    can_cache=0
+    if [[ "$mode" == "stop-hook" ]]; then
+        emit_block "BLOCKED: quorum re-request status on PR #$pr_number is INCONCLUSIVE.
+
+The PR's comments could not be fetched, so it is unknown whether a quorum
+review exists that was answered without a re-request. Do not report this work
+as finished. Retry:
+  scripts/quorum-rerequest.sh --check
+If GitHub is unreachable and the user wants to finish anyway, they can opt out
+with QUORUM_RERQ_OFF=1 or: touch .git/quorum-rerequest-off"
+    fi
+    bail "could not fetch comments for PR #$pr_number"
+fi
+
 # A quorum report comes from that account and carries all five of its section
 # headings, which excludes quorum's own "Review fix round N" notes.
-last_review=$(printf '%s' "$pr_json" | jq -c --arg qr "$target" '
+last_review=$(printf '%s' "$comments" | jq -c --arg qr "$target" '
     def is_quorum_report:
         (.body | test("(^|\n)## Summary"))
         and (.body | test("(^|\n)## Blockers"))
         and (.body | test("(^|\n)## Critical"))
         and (.body | test("(^|\n)## Suggestions"))
         and (.body | test("(^|\n)## Questions"));
-    .comments
-    | map(select(.author.login == $qr and is_quorum_report))
+    map(select(.user.login == $qr and is_quorum_report))
     | last // {}
 ')
-last_review_at=$(printf '%s' "$last_review" | jq -r '.createdAt // empty')
+last_review_at=$(printf '%s' "$last_review" | jq -r '.created_at // empty')
 
 # Nothing to re-trigger without a review to answer.
 if [[ -z "$last_review_at" ]]; then
@@ -217,13 +245,13 @@ if [[ "$target" == "$pr_author" ]]; then
 fi
 
 # --- did anything change since that review ----------------------------------
-# committedDate is when a commit was written, not when it reached the PR, so it
-# alone misses a fix that was committed before the review and pushed after it.
-# The timeline is the second opinion: commit events that sit behind the review
-# comment arrived after it. Either signal is enough.
-last_commit_at=$(printf '%s' "$pr_json" | jq -r '[.commits[].committedDate] | max // empty')
-
-repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.*#\1#')
+# The timeline is the only authority on "was something pushed after the
+# review": commit TIMESTAMPS (committedDate) are useless in both directions -
+# a fix committed before the review and pushed after it carries an old date
+# (missed re-request), a preserved or future-dated commit pushed before the
+# review carries a newer one (false alarm). Only the POSITION of head-movement
+# events relative to the report comment is trustworthy; every issue comment
+# has exactly one timeline "commented" event with an identical created_at.
 
 # A failed timeline call must not read as "nothing changed" and must never be
 # cached as clean, otherwise one flaky request silences the check for this HEAD.
@@ -244,13 +272,13 @@ if [[ "$timeline_ok" == "0" ]]; then
     can_cache=0
 fi
 
+# head_moved is three-valued: true / false / unknown. Unknown covers a dead
+# timeline AND a timeline in which the report comment cannot be located - in
+# both cases "nothing changed" would be a guess, and a guess must not end a
+# turn cleanly.
 # A review_requested event only counts when it aimed at the quorum account and
-# sits behind the last head movement in the timeline: a re-request followed by
-# further commits leaves those commits unreviewed, so it does not settle the
-# loop. Ordering is judged by timeline POSITION, not by committedDate - the
-# committer timestamp survives rebases and cherry-picks, so a preserved or
-# future-dated commit would otherwise reject a perfectly valid re-request
-# forever.
+# sits behind the last head movement: a re-request followed by further commits
+# leaves those commits unreviewed, so it does not settle the loop.
 timeline_flags=$(printf '%s' "$timeline" | jq -c \
     --arg rev "$last_review_at" --arg tgt "$target" '
     def target_of: (.requested_reviewer.login // .requested_team.slug // "");
@@ -261,8 +289,9 @@ timeline_flags=$(printf '%s' "$timeline" | jq -c \
     | ([range(0; length) | select($ev[.] | is_head_move)] | last) as $h
     | {
         head_moved: (
-            if $i == null then false
-            else ($ev[($i + 1):] | map(select(is_head_move)) | length > 0)
+            if $i == null then "unknown"
+            elif ($ev[($i + 1):] | map(select(is_head_move)) | length > 0) then "true"
+            else "false"
             end
         ),
         rerequested: (
@@ -275,38 +304,34 @@ timeline_flags=$(printf '%s' "$timeline" | jq -c \
             | length > 0
         )
     }
-' 2>/dev/null) || timeline_flags='{"head_moved":false,"rerequested":false}'
+' 2>/dev/null) || timeline_flags='{"head_moved":"unknown","rerequested":false}'
 
-head_moved=$(printf '%s' "$timeline_flags" | jq -r '.head_moved // false')
+head_moved=$(printf '%s' "$timeline_flags" | jq -r '.head_moved // "unknown"')
 rerequested=$(printf '%s' "$timeline_flags" | jq -r '.rerequested // false')
 
-pushed_after_review=0
-if [[ -n "$last_commit_at" ]] && [[ "$last_commit_at" > "$last_review_at" ]]; then
-    pushed_after_review=1
-fi
-if [[ "$head_moved" == "true" ]]; then
-    pushed_after_review=1
+if [[ "$timeline_ok" == "0" ]]; then
+    head_moved="unknown"
 fi
 
-# With the timeline unavailable, "nothing pushed" cannot be distinguished from
-# "a pre-review commit was pushed after the review": committedDate alone cannot
-# see the latter. Inconclusive is not clean - the Stop hook blocks and says so,
-# the other modes exit 3.
-if [[ "$timeline_ok" == "0" && "$pushed_after_review" == "0" && "$force" == "0" ]]; then
+# Unknown is not clean - the Stop hook blocks and says so, the other modes
+# exit 3. --force skips the question entirely.
+if [[ "$head_moved" == "unknown" && "$force" == "0" ]]; then
+    can_cache=0
     if [[ "$mode" == "stop-hook" ]]; then
         emit_block "BLOCKED: quorum re-request status on PR #$pr_number is INCONCLUSIVE.
 
-A quorum review from $last_review_at exists, but the GitHub timeline could not
-be fetched, so it is unknown whether fixes were pushed since and whether
-$target was re-requested. Do not report this work as finished. Retry:
+A quorum review from $last_review_at exists, but the PR timeline could not be
+read (or the report could not be located in it), so it is unknown whether
+fixes were pushed since and whether $target was re-requested. Do not report
+this work as finished. Retry:
   scripts/quorum-rerequest.sh --check
 If GitHub is unreachable and the user wants to finish anyway, they can opt out
 with QUORUM_RERQ_OFF=1 or: touch .git/quorum-rerequest-off"
     fi
-    bail "timeline lookup for PR #$pr_number failed - cannot tell whether a re-request is owed (retry, or --force to re-request regardless)"
+    bail "cannot tell whether a re-request is owed on PR #$pr_number - timeline unreadable or report not found in it (retry, or --force to re-request regardless)"
 fi
 
-if [[ "$force" == "0" && "$pushed_after_review" == "0" ]]; then
+if [[ "$force" == "0" && "$head_moved" == "false" ]]; then
     if [[ "$mode" == "apply" ]]; then
         echo "PR #$pr_number: nothing pushed since the quorum review at $last_review_at."
         echo "Nothing to re-review. Use --force to request a fresh round anyway."
@@ -349,19 +374,28 @@ fi
 
 # apply
 # The removal is what makes the following add produce a fresh review_requested
-# event. A failed removal may only be ignored while the target is NOT currently
-# requested (removing an absent reviewer errors by design) - swallowing it
-# otherwise would turn the add into a silent no-op that this script would then
-# report as a fresh request.
-requested_now=$(printf '%s' "$pr_json" | jq -r --arg t "$target" '
-    [.reviewRequests[]? | (.login // .slug // "")]
-    | any(. == $t or . == ($t | split("/") | last))')
+# event. Every pending-request check below asks GitHub FRESH - the pr_json
+# snapshot from the top of the script is stale by now and a stale answer here
+# turns the add into a silent no-op that would be reported as success.
+pending_now() {
+    # Prints true / false, or fails (non-zero) when GitHub cannot be asked.
+    gh pr view "$pr_number" --json reviewRequests 2>/dev/null |
+        jq -r --arg t "$target" '
+            [.reviewRequests[]? | (.login // .slug // "")]
+            | any(. == $t or . == ($t | split("/") | last))' 2>/dev/null
+    return "${PIPESTATUS[0]}"
+}
 
 if ! rm_out=$(gh pr edit "$pr_number" --remove-reviewer "$target" 2>&1); then
-    if [[ "$requested_now" == "true" ]]; then
+    # A failed removal is only tolerable when the target is verifiably not
+    # requested (removing an absent reviewer errors by design). Decide on a
+    # fresh lookup; if that lookup fails too, the state is unknown - abort.
+    still_pending=$(pending_now) || still_pending="unknown"
+    if [[ "$still_pending" != "false" ]]; then
         echo "Failed to remove the pending request for $target on PR #$pr_number:" >&2
         echo "  $rm_out" >&2
-        echo "Without the removal the add would be a silent no-op. Nothing was changed." >&2
+        echo "Pending state now: $still_pending. Without a confirmed removal the add" >&2
+        echo "would be a silent no-op. Nothing was changed." >&2
         exit 1
     fi
 fi
@@ -378,22 +412,20 @@ done
 if [[ "$added" == "0" ]]; then
     echo "Failed to re-request review from $target on PR #$pr_number:" >&2
     echo "  $add_out" >&2
-    if [[ "$requested_now" == "true" ]]; then
-        echo "The previous request WAS already removed - the PR currently has no pending" >&2
-        echo "request for $target. Repair it with:" >&2
-        echo "  gh pr edit $pr_number --add-reviewer $target" >&2
-    fi
+    echo "The pending request may already have been removed. Check and repair with:" >&2
+    echo "  gh pr view $pr_number --json reviewRequests" >&2
+    echo "  gh pr edit $pr_number --add-reviewer $target" >&2
     exit 1
 fi
 
-# Trust, but verify: the add must actually have landed as a pending request.
-verify=$(gh pr view "$pr_number" --json reviewRequests 2>/dev/null |
-    jq -r --arg t "$target" '
-        [.reviewRequests[]? | (.login // .slug // "")]
-        | any(. == $t or . == ($t | split("/") | last))' 2>/dev/null || echo "unknown")
-if [[ "$verify" == "false" ]]; then
-    echo "gh reported success, but $target is not in the PR's pending requests." >&2
-    echo "Verify manually: gh pr view $pr_number --json reviewRequests" >&2
+# Trust, but verify: the add must verifiably have landed as a pending request.
+# An unanswerable verification is a failure, not a pass - the cache stays
+# untouched so the next hook run re-checks.
+verify=$(pending_now) || verify="unknown"
+if [[ "$verify" != "true" ]]; then
+    echo "gh reported success, but the pending request for $target could not be" >&2
+    echo "confirmed (state: $verify). Verify manually:" >&2
+    echo "  gh pr view $pr_number --json reviewRequests" >&2
     exit 1
 fi
 

--- a/scripts/quorum-rerequest.sh
+++ b/scripts/quorum-rerequest.sh
@@ -23,8 +23,14 @@
 # <login>` per clone, otherwise the tracked `.github/quorum-reviewer`. Only that
 # account is ever re-requested; other reviewers and teams are left alone.
 #
-# Opt out per clone with `touch .git/quorum-rerequest-off`, per invocation
-# with QUORUM_RERQ_OFF=1.
+# Exit codes: 0 nothing owed / re-request performed, 1 re-request owed
+# (--check) or the remove/add round trip failed, 2 Stop-hook block, 3 unable
+# to determine (missing tool, API failure). --stop-hook never exits 3: it
+# stays silent on environment problems and blocks on an inconclusive check.
+#
+# The opt-outs (`touch .git/quorum-rerequest-off` per clone, QUORUM_RERQ_OFF=1
+# per invocation) silence only the Stop hook; manual and --check runs always
+# answer.
 #
 # Kept bash-3.2 compatible (macOS /bin/bash).
 
@@ -39,7 +45,7 @@ while [[ $# -gt 0 ]]; do
         --stop-hook) mode="stop-hook" ;;
         --force) force=1 ;;
         -h | --help)
-            sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         [0-9]*) pr_arg="$1" ;;
@@ -51,17 +57,29 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-# A hook must never break the session over a missing tool or a detached repo.
+# The Stop hook must never wedge a session over a missing tool or a broken
+# lookup - but a manual or --check run reporting success for a skipped action
+# is exactly the silent failure this script exists to prevent. Environment
+# problems are therefore silent (exit 0) only in stop-hook mode and loud
+# (exit 3) everywhere else.
 soft_exit() { exit 0; }
+bail() {
+    if [[ "$mode" == "stop-hook" ]]; then exit 0; fi
+    echo "quorum-rerequest: $1" >&2
+    exit 3
+}
 
-if ! command -v gh >/dev/null 2>&1; then soft_exit; fi
-if ! command -v jq >/dev/null 2>&1; then soft_exit; fi
-if ! project_root=$(git rev-parse --show-toplevel 2>/dev/null); then soft_exit; fi
+command -v gh >/dev/null 2>&1 || bail "gh is not installed"
+command -v jq >/dev/null 2>&1 || bail "jq is not installed"
+project_root=$(git rev-parse --show-toplevel 2>/dev/null) || bail "not inside a git repository"
 cd "$project_root"
-git_dir=$(git rev-parse --git-dir 2>/dev/null) || soft_exit
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || bail "cannot resolve the git directory"
 
-if [[ -n "${QUORUM_RERQ_OFF:-}" ]]; then soft_exit; fi
-if [[ -f "$git_dir/quorum-rerequest-off" ]]; then soft_exit; fi
+# Deliberate opt-outs silence only the enforcement path.
+if [[ "$mode" == "stop-hook" ]]; then
+    if [[ -n "${QUORUM_RERQ_OFF:-}" ]]; then soft_exit; fi
+    if [[ -f "$git_dir/quorum-rerequest-off" ]]; then soft_exit; fi
+fi
 
 cache_file="$git_dir/quorum-rerequest.cache"
 
@@ -115,27 +133,13 @@ emit_block() {
     exit 2
 }
 
-# --- PR state ---------------------------------------------------------------
-pr_fields="number,state,url,author,reviewRequests,comments,commits"
-if [[ -n "$pr_arg" ]]; then
-    pr_json=$(gh pr view "$pr_arg" --json "$pr_fields" 2>/dev/null) || soft_exit
-else
-    pr_json=$(gh pr view --json "$pr_fields" 2>/dev/null) || soft_exit
-fi
-if [[ -z "$pr_json" ]]; then soft_exit; fi
-
-if [[ "$(printf '%s' "$pr_json" | jq -r '.state // empty')" != "OPEN" ]]; then soft_exit; fi
-
-pr_number=$(printf '%s' "$pr_json" | jq -r '.number')
-pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
-pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login // empty')
-
 # --- who runs quorum here ---------------------------------------------------
 # The account is declared, never guessed: this script removes and re-adds a
 # review request, and inferring the account from comment shape alone would let a
 # human who writes the same headings have their pending review reset.
 # Per clone `git config quorum.reviewer` wins, otherwise the tracked
-# .github/quorum-reviewer applies.
+# .github/quorum-reviewer applies. Resolved before any API call, so repos
+# without quorum pay nothing per turn.
 target=$(git config --get quorum.reviewer 2>/dev/null || echo "")
 if [[ -z "$target" && -f "$project_root/.github/quorum-reviewer" ]]; then
     target=$(sed -e 's/#.*//' -e 's/[[:space:]]//g' "$project_root/.github/quorum-reviewer" |
@@ -144,12 +148,35 @@ fi
 
 if [[ -z "$target" ]]; then
     # Without a declared account there is nothing safe to re-request.
-    if [[ "$mode" == "apply" ]]; then
-        echo "No quorum account configured. Set one with:" >&2
-        echo "  git config quorum.reviewer <login>    # or commit .github/quorum-reviewer" >&2
-        exit 1
+    bail "no quorum account configured - set 'git config quorum.reviewer <login>' or commit .github/quorum-reviewer"
+fi
+
+# --- PR state ---------------------------------------------------------------
+pr_fields="number,state,url,author,reviewRequests,comments,commits"
+if ! pr_json=$(gh pr view ${pr_arg:+"$pr_arg"} --json "$pr_fields" 2>&1); then
+    case "$pr_json" in
+        *"no pull requests found"* | *"Could not resolve"* | *"no default remote"*)
+            # No PR is genuinely "nothing owed", not an error.
+            if [[ "$mode" == "check" ]]; then
+                echo "No open PR here - nothing owed."
+                exit 0
+            fi
+            bail "no open PR found${pr_arg:+ for '$pr_arg'}"
+            ;;
+        *) bail "gh pr view failed: $pr_json" ;;
+    esac
+fi
+[[ -n "$pr_json" ]] || bail "gh pr view returned nothing"
+
+pr_number=$(printf '%s' "$pr_json" | jq -r '.number')
+pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
+pr_author=$(printf '%s' "$pr_json" | jq -r '.author.login // empty')
+pr_state=$(printf '%s' "$pr_json" | jq -r '.state // empty')
+
+if [[ "$pr_state" != "OPEN" ]]; then
+    if [[ "$mode" != "stop-hook" ]]; then
+        echo "PR #$pr_number is $pr_state - nothing to re-request."
     fi
-    mark_clean
     exit 0
 fi
 
@@ -200,23 +227,32 @@ repo_slug=$(printf '%s' "$pr_url" | sed -E 's#https://[^/]+/([^/]+/[^/]+)/pull/.
 
 # A failed timeline call must not read as "nothing changed" and must never be
 # cached as clean, otherwise one flaky request silences the check for this HEAD.
+# Retried, because a transient blip downgrading the whole check to
+# "inconclusive" (below) is worth two seconds.
 timeline="[]"
-timeline_ok=1
-if timeline_raw=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate --slurp 2>/dev/null); then
-    timeline=$(printf '%s' "$timeline_raw" | jq -c 'add // []' 2>/dev/null) || timeline_ok=0
-else
-    timeline_ok=0
-fi
+timeline_ok=0
+for _ in 1 2 3; do
+    if timeline_raw=$(gh api "repos/$repo_slug/issues/$pr_number/timeline" --paginate --slurp 2>/dev/null) &&
+        timeline=$(printf '%s' "$timeline_raw" | jq -c 'add // []' 2>/dev/null); then
+        timeline_ok=1
+        break
+    fi
+    sleep 1
+done
 if [[ "$timeline_ok" == "0" ]]; then
     timeline="[]"
     can_cache=0
 fi
 
 # A review_requested event only counts when it aimed at the quorum account and
-# came after the last head movement. A re-request followed by further commits
-# leaves those commits unreviewed, so it does not settle the loop.
+# sits behind the last head movement in the timeline: a re-request followed by
+# further commits leaves those commits unreviewed, so it does not settle the
+# loop. Ordering is judged by timeline POSITION, not by committedDate - the
+# committer timestamp survives rebases and cherry-picks, so a preserved or
+# future-dated commit would otherwise reject a perfectly valid re-request
+# forever.
 timeline_flags=$(printf '%s' "$timeline" | jq -c \
-    --arg rev "$last_review_at" --arg tgt "$target" --arg head "$last_commit_at" '
+    --arg rev "$last_review_at" --arg tgt "$target" '
     def target_of: (.requested_reviewer.login // .requested_team.slug // "");
     def short: ($tgt | split("/") | last);
     def is_head_move: (.event == "committed" or .event == "head_ref_force_pushed");
@@ -235,7 +271,6 @@ timeline_flags=$(printf '%s' "$timeline" | jq -c \
                  ($ev[.].event == "review_requested")
                  and ((($ev[.] | target_of) == $tgt) or (($ev[.] | target_of) == short))
                  and ($ev[.].created_at > $rev)
-                 and ($head == "" or $ev[.].created_at > $head)
                  and ($h == null or . > $h))]
             | length > 0
         )
@@ -251,6 +286,24 @@ if [[ -n "$last_commit_at" ]] && [[ "$last_commit_at" > "$last_review_at" ]]; th
 fi
 if [[ "$head_moved" == "true" ]]; then
     pushed_after_review=1
+fi
+
+# With the timeline unavailable, "nothing pushed" cannot be distinguished from
+# "a pre-review commit was pushed after the review": committedDate alone cannot
+# see the latter. Inconclusive is not clean - the Stop hook blocks and says so,
+# the other modes exit 3.
+if [[ "$timeline_ok" == "0" && "$pushed_after_review" == "0" && "$force" == "0" ]]; then
+    if [[ "$mode" == "stop-hook" ]]; then
+        emit_block "BLOCKED: quorum re-request status on PR #$pr_number is INCONCLUSIVE.
+
+A quorum review from $last_review_at exists, but the GitHub timeline could not
+be fetched, so it is unknown whether fixes were pushed since and whether
+$target was re-requested. Do not report this work as finished. Retry:
+  scripts/quorum-rerequest.sh --check
+If GitHub is unreachable and the user wants to finish anyway, they can opt out
+with QUORUM_RERQ_OFF=1 or: touch .git/quorum-rerequest-off"
+    fi
+    bail "timeline lookup for PR #$pr_number failed - cannot tell whether a re-request is owed (retry, or --force to re-request regardless)"
 fi
 
 if [[ "$force" == "0" && "$pushed_after_review" == "0" ]]; then
@@ -295,11 +348,52 @@ clone."
 fi
 
 # apply
-# Removing a reviewer who is not currently requested errors; that is fine. The
-# removal is what makes the following add produce a new review_requested event.
-gh pr edit "$pr_number" --remove-reviewer "$target" >/dev/null 2>&1 || true
-if ! gh pr edit "$pr_number" --add-reviewer "$target" >/dev/null 2>&1; then
-    echo "Failed to re-request review from $target on PR #$pr_number." >&2
+# The removal is what makes the following add produce a fresh review_requested
+# event. A failed removal may only be ignored while the target is NOT currently
+# requested (removing an absent reviewer errors by design) - swallowing it
+# otherwise would turn the add into a silent no-op that this script would then
+# report as a fresh request.
+requested_now=$(printf '%s' "$pr_json" | jq -r --arg t "$target" '
+    [.reviewRequests[]? | (.login // .slug // "")]
+    | any(. == $t or . == ($t | split("/") | last))')
+
+if ! rm_out=$(gh pr edit "$pr_number" --remove-reviewer "$target" 2>&1); then
+    if [[ "$requested_now" == "true" ]]; then
+        echo "Failed to remove the pending request for $target on PR #$pr_number:" >&2
+        echo "  $rm_out" >&2
+        echo "Without the removal the add would be a silent no-op. Nothing was changed." >&2
+        exit 1
+    fi
+fi
+
+added=0
+add_out=""
+for _ in 1 2 3; do
+    if add_out=$(gh pr edit "$pr_number" --add-reviewer "$target" 2>&1); then
+        added=1
+        break
+    fi
+    sleep 2
+done
+if [[ "$added" == "0" ]]; then
+    echo "Failed to re-request review from $target on PR #$pr_number:" >&2
+    echo "  $add_out" >&2
+    if [[ "$requested_now" == "true" ]]; then
+        echo "The previous request WAS already removed - the PR currently has no pending" >&2
+        echo "request for $target. Repair it with:" >&2
+        echo "  gh pr edit $pr_number --add-reviewer $target" >&2
+    fi
+    exit 1
+fi
+
+# Trust, but verify: the add must actually have landed as a pending request.
+verify=$(gh pr view "$pr_number" --json reviewRequests 2>/dev/null |
+    jq -r --arg t "$target" '
+        [.reviewRequests[]? | (.login // .slug // "")]
+        | any(. == $t or . == ($t | split("/") | last))' 2>/dev/null || echo "unknown")
+if [[ "$verify" == "false" ]]; then
+    echo "gh reported success, but $target is not in the PR's pending requests." >&2
+    echo "Verify manually: gh pr view $pr_number --json reviewRequests" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Problem

quorum startet einen Review, wenn ein Review-Request reinkommt, nicht wenn neuer Code gepusht wird. Seinen Report postet es als normalen PR-Kommentar, also räumt GitHub den Request nie ab: der Reviewer bleibt dauerhaft in `reviewRequests` stehen, und `gh pr edit --add-reviewer` auf jemanden, der schon drinsteht, ist ein stiller No-op ohne Benachrichtigung.

Folge: wer Findings fixt und pusht, hält sich für fertig, aber niemand schaut nochmal drauf. Nur Reviewer entfernen und neu hinzufügen erzeugt ein frisches `review_requested`-Event. Aus der quorum-README:

> "The trigger is the review request, not the code. One request is one review, so pushing more commits does not trigger another one; re-request the review to get a fresh one."

## Lösung

Das Re-Requesten wird zur Pflicht statt zur Gedächtnisleistung.

`scripts/quorum-rerequest.sh` erledigt den Remove-plus-Add-Durchlauf für den PR des aktuellen Branches. Dasselbe Script erkennt im Prüfmodus, ob das ansteht: offener PR, quorum-Review-Kommentar vorhanden, danach gepusht, seitdem kein `review_requested`.

Als `Stop`-Hook in Claude Code und Codex verdrahtet blockiert es das Ende eines Agenten-Turns, solange das offen ist, und gibt das Kommando zurück. Dazu eine immer geladene Rule plus je ein Absatz in `CLAUDE.md` und `.claude/README.md`, damit der Agent es idealerweise schon vorher von selbst tut.

| Datei | Rolle |
|---|---|
| `scripts/quorum-rerequest.sh` | Logik. Modi: default (Remove+Add), `--check`, `--stop-hook`, `--force`, optional mit PR-Nummer |
| `.claude/settings.json` + `.codex/hooks.json` | `Stop`-Hook, beide Tools, identischer Aufruf |
| `.claude/rules/quorum-review-loop.md` | Immer geladene Rule |
| `CLAUDE.md` + `.claude/README.md` | Einordnung an den Stellen, wo man danach sucht |

## Design-Entscheidungen

- **Fehlalarme.** Der Hook feuert nur bei sauberem Baum und vollständig gepushtem Branch, also nicht mitten in einer laufenden Fix-Runde. Untracked Dateien zählen bewusst nicht mit, sonst deaktiviert ein herumliegender Screenshot den Check versehentlich.
- **Kosten pro Turn.** Negativergebnisse werden pro HEAD-SHA in `.git/` gecacht, Turns ohne neuen Commit machen null API-Calls. Der teure Timeline-Call läuft erst, wenn die beiden billigen Bedingungen schon zutreffen.
- **Kein Deadlock.** `stop_hook_active` verhindert Endlosschleifen, Opt-out per `touch .git/quorum-rerequest-off` oder `QUORUM_RERQ_OFF=1`, jeder Fehlerfall (kein `gh`, kein PR, kein Repo) endet still mit 0.
- **Der eine bewusste Blocker.** Ist kein Reviewer ermittelbar (niemand requested, Review kam vom PR-Autor), blockiert es trotzdem und fordert zur Rückfrage auf, statt still durchzuwinken.
- **Zwei Ausgabekanäle.** Codex nutzt dasselbe Wire-Format wie Claude Code, deshalb gibt das Script beides aus: `{"decision":"block"}` auf stdout und die Meldung auf stderr mit Exit 2. Damit greift es unabhängig davon, welchen Kanal das jeweilige Tool auswertet.

## Testing

Gegen echte PRs: #2146, #2143 und #2147 melden korrekt "nichts offen" (jeweils Review neuer als der letzte Commit); die Timeline-Abfrage liefert auf Live-PRs sowohl User- als auch Team-Requests.

Gegen einen `gh`-Stub: Positivfall blockiert mit Exit 2, Loop-Guard über `stop_hook_active` greift, Opt-out greift, Cache verhindert jeden API-Call, Team-Slug (`org/team`) und Fallback auf den Autor des Review-Kommentars stimmen. Beide Hook-Wrapper laufen auch aus einem Unterverzeichnis.

**Nicht verifiziert:** der echte `gh pr edit --remove-reviewer` plus `--add-reviewer` Durchlauf an einem Live-PR, weil das sofort eine reale quorum-Runde gestartet hätte.

## Related Issues

Kein Issue, direkt aus der Arbeitspraxis mit quorum entstanden.

## Type of Change

- [x] CI/CD improvement (Agent-Tooling und Repo-Konfiguration)

## Checklist

- [x] Keine Produktionslogik berührt, nur `.claude/`, `.codex/` und `scripts/`
- [x] Keine Secrets, keine neuen Env-Vars
- [x] Selbst-Review durchgeführt
- [x] In-App-Hilfe nicht betroffen (kein user-facing Flow)
