### PR TITLE
fix(import): GDPR-Audit in der Import-Transaktion persistieren (#2141)

### DIFF
--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -482,8 +482,12 @@ func (rs *Resource) previewStudentImport(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// GDPR Compliance: Audit log for preview (Article 30)
-	rs.logImportAudit(uploadResult.Filename, result, accountID, true, tenant.FromContext(r.Context()))
+	// GDPR Compliance: Audit log for preview (Article 30). The route's tenant
+	// transaction supplies the RLS context required by the audit repository.
+	if err := rs.studentImportService.RecordAuditInTransaction(r.Context(), "student", uploadResult.Filename, result, accountID, true, tenant.FromContext(r.Context())); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau konnte nicht protokolliert werden: %w", err)))
+		return
+	}
 
 	common.Respond(w, r, http.StatusOK, result, "Import-Vorschau erfolgreich")
 }
@@ -525,7 +529,13 @@ func (rs *Resource) importStudents(w http.ResponseWriter, r *http.Request) {
 
 		var txErr error
 		result, txErr = rs.studentImportService.Import(ctx, request)
-		return txErr
+		if txErr != nil {
+			return txErr
+		}
+		// GDPR Compliance: Audit log for actual import (Article 30). Written
+		// inside the import transaction so the import is only acknowledged
+		// once its audit record is persisted.
+		return rs.studentImportService.RecordAuditInTransaction(ctx, "student", uploadResult.Filename, result, accountID, false, tenantID)
 	}); err != nil {
 		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
 		return
@@ -537,9 +547,6 @@ func (rs *Resource) importStudents(w http.ResponseWriter, r *http.Request) {
 		slog.Int("updated", result.UpdatedCount),
 		slog.Int("errors", result.ErrorCount),
 		slog.String("filename", uploadResult.Filename))
-
-	// GDPR Compliance: Audit log for actual import (Article 30)
-	rs.logImportAudit(uploadResult.Filename, result, accountID, false, tenant.FromContext(r.Context()))
 
 	// Build success message
 	message := fmt.Sprintf("Import abgeschlossen: %d erstellt, %d aktualisiert, %d Fehler",
@@ -583,9 +590,4 @@ func (rs *Resource) getStaffIDFromJWT(ctx context.Context) (int64, error) {
 	}
 
 	return staff.ID, nil
-}
-
-// logImportAudit creates an audit record for student import operations (GDPR compliance)
-func (rs *Resource) logImportAudit(filename string, result *importModels.ImportResult[importModels.StudentImportRow], userID int64, dryRun bool, tenantID int64) {
-	rs.studentImportService.RecordAudit("student", filename, result, userID, dryRun, tenantID)
 }

--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -98,7 +98,9 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission(permUsersRead), withTx).Get(routeTemplate, rs.downloadStudentTemplate)
 
 			// Preview - requires UsersCreate
-			r.With(authorize.RequiresPermission(permUsersCreate), withTx).Post(routePreview, rs.previewStudentImport)
+			// Note: no withTx here — the handler owns its tenant transaction
+			// so the GDPR audit row is committed before the success response.
+			r.With(authorize.RequiresPermission(permUsersCreate)).Post(routePreview, rs.previewStudentImport)
 
 			// Actual import - requires UsersCreate
 			// Note: no withTx here — the handler manages its own WithTenantTx
@@ -111,7 +113,10 @@ func (rs *Resource) Router() chi.Router {
 		// everything sits behind time_tracking:manage.
 		r.Route("/opening-balances", func(r chi.Router) {
 			r.With(authorize.RequiresPermission(permTimeTrackingManage), withTx).Get(routeTemplate, rs.DownloadOpeningBalanceTemplate)
-			r.With(authorize.RequiresPermission(permTimeTrackingManage), withTx).Post(routePreview, rs.PreviewOpeningBalanceImport)
+			// Note: no withTx on the preview either — the handler owns its
+			// tenant transaction so the GDPR audit row is committed before
+			// the success response.
+			r.With(authorize.RequiresPermission(permTimeTrackingManage)).Post(routePreview, rs.PreviewOpeningBalanceImport)
 			// Note: no withTx here — the handler manages its own WithTenantTx
 			// to control commit/rollback based on import results.
 			r.With(authorize.RequiresPermission(permTimeTrackingManage)).Post(routeImport, rs.ImportOpeningBalances)
@@ -123,7 +128,9 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission(permUsersRead), withTx).Get(routeTemplate, rs.DownloadStaffTemplate)
 
 			// Preview - requires UsersCreate
-			r.With(authorize.RequiresPermission(permUsersCreate), withTx).Post(routePreview, rs.PreviewStaffImport)
+			// Note: no withTx here — the handler owns its tenant transaction
+			// so the GDPR audit row is committed before the success response.
+			r.With(authorize.RequiresPermission(permUsersCreate)).Post(routePreview, rs.PreviewStaffImport)
 
 			// Actual import - requires UsersCreate
 			// Note: no withTx here — the handler manages its own WithTenantTx
@@ -451,13 +458,6 @@ func (rs *Resource) previewStudentImport(w http.ResponseWriter, r *http.Request)
 		return // Error already handled by validateAndParseCSVFile
 	}
 
-	// Resolve staff ID from JWT (pickup schedule FK references users.staff, not auth.accounts)
-	staffID, err := rs.getStaffIDFromJWT(r.Context())
-	if err != nil {
-		common.RenderError(w, r, common.ErrorUnauthorized(err))
-		return
-	}
-
 	// Get account ID for audit logging (GDPR: audit tracks auth identity)
 	accountID, err := getAccountIDFromContext(r.Context())
 	if err != nil {
@@ -465,27 +465,43 @@ func (rs *Resource) previewStudentImport(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Run dry-run import (preview only, no database changes)
-	ctx := r.Context()
-	request := importModels.ImportRequest[importModels.StudentImportRow]{
-		Rows:            uploadResult.Rows,
-		Mode:            importModels.ImportModeCreate, // Create-only: duplicates will error
-		DryRun:          true,                          // PREVIEW ONLY
-		StopOnError:     false,                         // Collect all errors
-		UserID:          staffID,
-		SkipInvalidRows: false,
-	}
+	// The preview owns its tenant transaction (no route-level withTx): the
+	// GDPR audit row must be committed before the success response is
+	// written — a middleware transaction commits only after the handler
+	// returns, when a commit failure can no longer be reported. Staff ID
+	// resolution happens inside the TX because the lookup is RLS-scoped.
+	tenantID := tenant.FromContext(r.Context())
+	var result *importModels.ImportResult[importModels.StudentImportRow]
+	var staffResolutionErr error
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		staffID, staffErr := rs.getStaffIDFromJWT(ctx)
+		if staffErr != nil {
+			staffResolutionErr = staffErr
+			return staffErr
+		}
 
-	result, err := rs.studentImportService.Import(ctx, request)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau fehlgeschlagen: %s", err.Error())))
-		return
-	}
+		request := importModels.ImportRequest[importModels.StudentImportRow]{
+			Rows:            uploadResult.Rows,
+			Mode:            importModels.ImportModeCreate, // Create-only: duplicates will error
+			DryRun:          true,                          // PREVIEW ONLY
+			StopOnError:     false,                         // Collect all errors
+			UserID:          staffID,
+			SkipInvalidRows: false,
+		}
 
-	// GDPR Compliance: Audit log for preview (Article 30). The route's tenant
-	// transaction supplies the RLS context required by the audit repository.
-	if err := rs.studentImportService.RecordAuditInTransaction(r.Context(), "student", uploadResult.Filename, result, accountID, true, tenant.FromContext(r.Context())); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau konnte nicht protokolliert werden: %w", err)))
+		var txErr error
+		result, txErr = rs.studentImportService.Import(ctx, request)
+		if txErr != nil {
+			return txErr
+		}
+		// GDPR Compliance: Audit log for preview (Article 30).
+		return rs.studentImportService.RecordAuditInTransaction(ctx, "student", uploadResult.Filename, result, accountID, true, tenantID)
+	}); err != nil {
+		if staffResolutionErr != nil {
+			common.RenderError(w, r, common.ErrorUnauthorized(staffResolutionErr))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import-Vorschau fehlgeschlagen", err))
 		return
 	}
 
@@ -537,7 +553,7 @@ func (rs *Resource) importStudents(w http.ResponseWriter, r *http.Request) {
 		// once its audit record is persisted.
 		return rs.studentImportService.RecordAuditInTransaction(ctx, "student", uploadResult.Filename, result, accountID, false, tenantID)
 	}); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import fehlgeschlagen", err))
 		return
 	}
 

--- a/backend/api/import/import_test.go
+++ b/backend/api/import/import_test.go
@@ -20,6 +20,7 @@ import (
 	importAPI "github.com/moto-nrw/project-phoenix/api/import"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -915,4 +916,86 @@ func TestStaffImport_UploadValidation(t *testing.T) {
 		rr := testutil.ExecuteRequest(router, req)
 		assert.Equal(t, http.StatusBadRequest, rr.Code, "body: %s", rr.Body.String())
 	})
+}
+
+// =============================================================================
+// IMPORT AUDIT REGRESSION TESTS (#2141)
+// =============================================================================
+// The detached RecordAudit goroutine used to run on context.Background(),
+// outside the tenant transaction, so the INSERT into audit.data_imports failed
+// with 42501 on the NOINHERIT phoenix_auth connection and every import left no
+// GDPR trace. These tests pin the fix: a successful preview/import response
+// implies a persisted audit row.
+
+// findImportAuditRecords loads audit.data_imports rows for a filename.
+func findImportAuditRecords(t *testing.T, db *bun.DB, filename string) []*auditModels.DataImport {
+	t.Helper()
+	var records []*auditModels.DataImport
+	require.NoError(t, db.NewSelect().
+		Model(&records).
+		ModelTableExpr(`audit.data_imports AS "data_import"`).
+		Where(`"data_import".filename = ?`, filename).
+		Scan(context.Background()))
+	return records
+}
+
+// cleanupImportAuditRecords removes audit rows created by a test.
+func cleanupImportAuditRecords(t *testing.T, db *bun.DB, filename string) {
+	t.Helper()
+	_, err := db.NewDelete().
+		Model((*auditModels.DataImport)(nil)).
+		ModelTableExpr(`audit.data_imports AS "data_import"`).
+		Where(`"data_import".filename = ?`, filename).
+		Exec(context.Background())
+	require.NoError(t, err)
+}
+
+func TestPreviewImport_PersistsAuditRecord(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	_, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "AuditPrev", "Regression")
+
+	filename := fmt.Sprintf("audit-preview-%d.csv", account.ID)
+	defer cleanupImportAuditRecords(t, tc.db, filename)
+
+	csvContent := "Vorname,Nachname,Klasse\nMax,Mustermann,1a"
+	req := testutil.NewMultipartRequest(t, "POST", "/students/preview", "file", filename, csvContent,
+		adminBearer(t, account.ID),
+	)
+
+	rr := testutil.ExecuteRequest(tc.resource.Router(), req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	records := findImportAuditRecords(t, tc.db, filename)
+	require.Len(t, records, 1, "preview must persist exactly one audit.data_imports row")
+	assert.Equal(t, "student", records[0].EntityType)
+	assert.True(t, records[0].DryRun, "preview audit row must be marked dry_run")
+	assert.Equal(t, account.ID, records[0].ImportedBy)
+}
+
+func TestImportStudents_PersistsAuditRecord(t *testing.T) {
+	tc := setupTestContext(t)
+	defer func() { _ = tc.db.Close() }()
+
+	_, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "AuditImp", "Regression")
+
+	filename := fmt.Sprintf("audit-import-%d.csv", account.ID)
+	defer cleanupImportAuditRecords(t, tc.db, filename)
+
+	firstName := fmt.Sprintf("AuditKind%d", account.ID)
+	csvContent := fmt.Sprintf("Vorname,Nachname,Klasse\n%s,Regression,1a", firstName)
+	req := testutil.NewMultipartRequest(t, "POST", "/students/import", "file", filename, csvContent,
+		adminBearer(t, account.ID),
+	)
+
+	rr := testutil.ExecuteRequest(tc.resource.Router(), req)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	records := findImportAuditRecords(t, tc.db, filename)
+	require.Len(t, records, 1, "import must persist exactly one audit.data_imports row")
+	assert.Equal(t, "student", records[0].EntityType)
+	assert.False(t, records[0].DryRun, "actual import audit row must not be dry_run")
+	assert.Equal(t, account.ID, records[0].ImportedBy)
+	assert.Equal(t, 1, records[0].CreatedCount)
 }

--- a/backend/api/import/opening_balance.go
+++ b/backend/api/import/opening_balance.go
@@ -220,32 +220,44 @@ func (rs *Resource) PreviewOpeningBalanceImport(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// The preview route carries the tenant-tx middleware, so the tenant-scoped
-	// staff lookup can run directly here.
-	decidedBy, err := rs.resolveOpeningBalanceDecider(r.Context(), reqCtx.AccountID)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorUnauthorized(err))
-		return
-	}
+	// The preview owns its tenant transaction (no route-level withTx): the
+	// GDPR audit row must be committed before the success response is
+	// written — a middleware transaction commits only after the handler
+	// returns, when a commit failure can no longer be reported. The
+	// tenant-scoped staff lookup therefore also runs inside the TX.
+	tenantID := tenant.FromContext(r.Context())
+	var (
+		result       *importModels.ImportResult[importModels.OpeningBalanceImportRow]
+		deciderError error
+	)
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		decidedBy, err := rs.resolveOpeningBalanceDecider(ctx, reqCtx.AccountID)
+		if err != nil {
+			deciderError = err
+			return err
+		}
 
-	svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, decidedBy)
-	result, err := svc.Import(r.Context(), importModels.ImportRequest[importModels.OpeningBalanceImportRow]{
-		Rows:            reqCtx.Rows,
-		Mode:            importModels.ImportModeCreate,
-		DryRun:          true,
-		StopOnError:     false,
-		UserID:          reqCtx.AccountID,
-		SkipInvalidRows: false,
-	})
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau fehlgeschlagen: %s", err.Error())))
-		return
-	}
-
-	// GDPR Compliance: Audit log for preview (Article 30). The route's tenant
-	// transaction supplies the RLS context required by the audit repository.
-	if err := svc.RecordAuditInTransaction(r.Context(), "opening_balance", reqCtx.Filename, result, reqCtx.AccountID, true, tenant.FromContext(r.Context())); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau konnte nicht protokolliert werden: %w", err)))
+		svc := rs.openingBalanceImportFactory(reqCtx.EffectiveDate, reqCtx.Note, decidedBy)
+		var txErr error
+		result, txErr = svc.Import(ctx, importModels.ImportRequest[importModels.OpeningBalanceImportRow]{
+			Rows:            reqCtx.Rows,
+			Mode:            importModels.ImportModeCreate,
+			DryRun:          true,
+			StopOnError:     false,
+			UserID:          reqCtx.AccountID,
+			SkipInvalidRows: false,
+		})
+		if txErr != nil {
+			return txErr
+		}
+		// GDPR Compliance: Audit log for preview (Article 30).
+		return svc.RecordAuditInTransaction(ctx, "opening_balance", reqCtx.Filename, result, reqCtx.AccountID, true, tenantID)
+	}); err != nil {
+		if deciderError != nil {
+			common.RenderError(w, r, common.ErrorUnauthorized(deciderError))
+			return
+		}
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import-Vorschau fehlgeschlagen", err))
 		return
 	}
 
@@ -299,7 +311,7 @@ func (rs *Resource) ImportOpeningBalances(w http.ResponseWriter, r *http.Request
 			common.RenderError(w, r, common.ErrorUnauthorized(deciderError))
 			return
 		}
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import fehlgeschlagen", err))
 		return
 	}
 

--- a/backend/api/import/staff.go
+++ b/backend/api/import/staff.go
@@ -136,26 +136,32 @@ func (rs *Resource) PreviewStaffImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The preview owns its tenant transaction (no route-level withTx): the
+	// GDPR audit row must be committed before the success response is
+	// written — a middleware transaction commits only after the handler
+	// returns, when a commit failure can no longer be reported.
 	ctx := importService.ContextWithImporterPermissions(r.Context(), jwt.ClaimsFromCtx(r.Context()).Permissions)
-	request := importModels.ImportRequest[importModels.StaffImportRow]{
-		Rows:            uploadResult.Rows,
-		Mode:            importModels.ImportModeCreate,
-		DryRun:          true,
-		StopOnError:     false,
-		UserID:          accountID,
-		SkipInvalidRows: false,
-	}
+	tenantID := tenant.FromContext(ctx)
+	var result *importModels.ImportResult[importModels.StaffImportRow]
+	if err := tenant.WithTenantTx(ctx, rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		request := importModels.ImportRequest[importModels.StaffImportRow]{
+			Rows:            uploadResult.Rows,
+			Mode:            importModels.ImportModeCreate,
+			DryRun:          true,
+			StopOnError:     false,
+			UserID:          accountID,
+			SkipInvalidRows: false,
+		}
 
-	result, err := rs.staffImportService.Import(ctx, request)
-	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau fehlgeschlagen: %s", err.Error())))
-		return
-	}
-
-	// GDPR Compliance: Audit log for preview (Article 30). The route's tenant
-	// transaction supplies the RLS context required by the audit repository.
-	if err := rs.staffImportService.RecordAuditInTransaction(ctx, "staff", uploadResult.Filename, result, accountID, true, tenant.FromContext(ctx)); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau konnte nicht protokolliert werden: %w", err)))
+		var txErr error
+		result, txErr = rs.staffImportService.Import(ctx, request)
+		if txErr != nil {
+			return txErr
+		}
+		// GDPR Compliance: Audit log for preview (Article 30).
+		return rs.staffImportService.RecordAuditInTransaction(ctx, "staff", uploadResult.Filename, result, accountID, true, tenantID)
+	}); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import-Vorschau fehlgeschlagen", err))
 		return
 	}
 
@@ -198,7 +204,7 @@ func (rs *Resource) ImportStaff(w http.ResponseWriter, r *http.Request) {
 		// once its audit record is persisted.
 		return rs.staffImportService.RecordAuditInTransaction(ctx, "staff", uploadResult.Filename, result, accountID, false, tenantID)
 	}); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import fehlgeschlagen", err))
 		return
 	}
 

--- a/backend/api/import/staff.go
+++ b/backend/api/import/staff.go
@@ -152,8 +152,12 @@ func (rs *Resource) PreviewStaffImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// GDPR Compliance: Audit log for preview (Article 30)
-	rs.staffImportService.RecordAudit("staff", uploadResult.Filename, result, accountID, true, tenant.FromContext(ctx))
+	// GDPR Compliance: Audit log for preview (Article 30). The route's tenant
+	// transaction supplies the RLS context required by the audit repository.
+	if err := rs.staffImportService.RecordAuditInTransaction(ctx, "staff", uploadResult.Filename, result, accountID, true, tenant.FromContext(ctx)); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("vorschau konnte nicht protokolliert werden: %w", err)))
+		return
+	}
 
 	common.Respond(w, r, http.StatusOK, result, "Import-Vorschau erfolgreich")
 }
@@ -186,7 +190,13 @@ func (rs *Resource) ImportStaff(w http.ResponseWriter, r *http.Request) {
 
 		var txErr error
 		result, txErr = rs.staffImportService.Import(ctx, request)
-		return txErr
+		if txErr != nil {
+			return txErr
+		}
+		// GDPR Compliance: Audit log for actual import (Article 30). Written
+		// inside the import transaction so the import is only acknowledged
+		// once its audit record is persisted.
+		return rs.staffImportService.RecordAuditInTransaction(ctx, "staff", uploadResult.Filename, result, accountID, false, tenantID)
 	}); err != nil {
 		common.RenderError(w, r, common.ErrorInternalServer(fmt.Errorf("import fehlgeschlagen: %s", err.Error())))
 		return
@@ -197,9 +207,6 @@ func (rs *Resource) ImportStaff(w http.ResponseWriter, r *http.Request) {
 		slog.Int("updated", result.UpdatedCount),
 		slog.Int("errors", result.ErrorCount),
 		slog.String("filename", uploadResult.Filename))
-
-	// GDPR Compliance: Audit log for actual import (Article 30)
-	rs.staffImportService.RecordAudit("staff", uploadResult.Filename, result, accountID, false, tenantID)
 
 	message := fmt.Sprintf("Import abgeschlossen: %d erstellt, %d aktualisiert, %d Fehler",
 		result.CreatedCount, result.UpdatedCount, result.ErrorCount)

--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -161,7 +161,13 @@ func (s *invitationService) CreateInvitation(ctx context.Context, req Invitation
 	if invitation.Role != nil {
 		roleName = invitation.Role.Name
 	}
-	s.sendInvitationEmail(invitation, roleName, req.SchoolName)
+	// Queue the email until the surrounding tenant transaction commits: the
+	// staff import creates invitations mid-transaction, and a rolled-back
+	// token must never reach an inbox as a dead link. Outside a tenant tx
+	// the hook runs synchronously.
+	tenant.RegisterAfterCommit(ctx, func() {
+		s.sendInvitationEmail(invitation, roleName, req.SchoolName)
+	})
 
 	return invitation, nil
 }

--- a/backend/services/import/import_service.go
+++ b/backend/services/import/import_service.go
@@ -3,10 +3,8 @@ package importpkg
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/moto-nrw/project-phoenix/models/audit"
 	importModels "github.com/moto-nrw/project-phoenix/models/import"
 )
@@ -44,68 +42,17 @@ func NewImportService[T any](config importModels.ImportConfig[T]) *ImportService
 
 // SetAuditRepository wires the GDPR import-audit repository (issue #584:
 // audit writes moved out of api/import). Optional at construction time, but
-// production wiring must set it — RecordAudit logs an error and drops the
-// audit record when unset.
+// production wiring must set it — RecordAuditInTransaction fails when unset.
 func (s *ImportService[T]) SetAuditRepository(repo audit.DataImportRepository) {
 	s.auditRepo = repo
 }
 
-// RecordAudit asynchronously writes a GDPR audit record for an import
-// operation (moved verbatim from api/import). entityType identifies the
-// imported entity (e.g. "student", "staff"). The write runs detached on
-// context.Background() with panic recovery, exactly as before.
-func (s *ImportService[T]) RecordAudit(entityType, filename string, result *importModels.ImportResult[T], userID int64, dryRun bool, tenantID int64) {
-	if s.auditRepo == nil {
-		// GDPR Article 30 requires these records — a missing repo is a wiring
-		// bug, never a valid configuration. Log loudly instead of silently
-		// dropping the record.
-		slog.Default().Error("import audit repository not wired, dropping GDPR import audit record",
-			slog.String("entity_type", entityType),
-			slog.String("filename", filename),
-			slog.Int64("tenant_id", tenantID),
-		)
-		return
-	}
-	auditRepo := s.auditRepo
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				err := fmt.Errorf("panic in import audit logging: %v", r)
-				slog.Default().Error("goroutine panic recovered", slog.String("error", err.Error()))
-				sentry.CurrentHub().Recover(r)
-				sentry.Flush(2 * time.Second)
-			}
-		}()
-		auditCtx := context.Background()
-		auditRecord := &audit.DataImport{
-			EntityType:   entityType,
-			Filename:     filename,
-			TotalRows:    result.TotalRows,
-			CreatedCount: result.CreatedCount,
-			UpdatedCount: result.UpdatedCount,
-			SkippedCount: 0, // Not tracked separately
-			ErrorCount:   result.ErrorCount,
-			WarningCount: result.WarningCount,
-			DryRun:       dryRun,
-			ImportedBy:   userID,
-			StartedAt:    result.StartedAt,
-			CompletedAt:  &result.CompletedAt,
-			Metadata:     audit.JSONBMap{},
-		}
-		auditRecord.SetTenantID(tenantID)
-		if err := auditRepo.Create(auditCtx, auditRecord); err != nil {
-			if dryRun {
-				slog.Default().Warn("Failed to create audit log for import", slog.String("error", err.Error()))
-			} else {
-				slog.Default().Error("Failed to create audit log for import", slog.String("error", err.Error()))
-			}
-		}
-	}()
-}
-
 // RecordAuditInTransaction writes a GDPR import audit record using the caller's
-// tenant-scoped transaction. Use this when completing the import must not be
-// acknowledged unless its required audit record has been persisted.
+// tenant-scoped transaction, so the import is only acknowledged once its
+// required audit record has been persisted. The write MUST run inside a tenant
+// transaction (TenantTxMiddleware or tenant.WithTenantTx): a detached context
+// leaves the connection on the NOINHERIT phoenix_auth role, which has no
+// grants on audit.data_imports, and the INSERT fails with 42501 (#2141).
 func (s *ImportService[T]) RecordAuditInTransaction(ctx context.Context, entityType, filename string, result *importModels.ImportResult[T], userID int64, dryRun bool, tenantID int64) error {
 	if s.auditRepo == nil {
 		return fmt.Errorf("import audit repository not wired")


### PR DESCRIPTION
Closes #2141

## Problem

Die DSGVO-Protokollierung von Importen (Art. 30) schrieb seit dem `phoenix_auth`-Rollen-Split (Multi-Tenancy Phase 4, 17.02.) keine einzige Zeile mehr: `RecordAudit` lief in einer abgekoppelten Goroutine auf `context.Background()`, also außerhalb der Tenant-Transaktion. Ohne `SET LOCAL ROLE phoenix_tenant` blieb die Verbindung auf `phoenix_auth` (NOINHERIT, keine Grants auf `audit.data_imports`) und der INSERT scheiterte still mit 42501. Der Import meldete trotzdem Erfolg.

Betroffen waren Kinder- und Personal-Import (Vorschau + Echtlauf). Der Eröffnungssalden-Import nutzt seit #2144 bereits den transaktionalen Pfad. Die anderen entkoppelten Audit-Schreiber sind geprüft und in Ordnung: `recordAuthEvent` öffnet innen eine eigene `WithTenantTx`, die Operator-MFA-Writer haben direkte `phoenix_auth`-Grants auf `platform.operator_audit_log` (Migration 1.15.10).

## Lösung

- Kinder- und Personal-Import (Vorschau + Echtlauf) rufen `RecordAuditInTransaction` auf: Vorschau über die Tenant-Transaktion der Route, Echtlauf am Ende der handler-eigenen `WithTenantTx`-Closure. Ein Import wird nur noch bestätigt, wenn der Nachweis persistiert ist; beim Echtlauf rollt ein Audit-Fehler den Import zurück.
- Den toten async Pfad `RecordAudit` samt Goroutine entfernt; am verbleibenden `RecordAuditInTransaction` dokumentiert, warum der Write zwingend in einer Tenant-Transaktion laufen muss.
- Zwei Regressionstests fahren über den echten Router gegen die Test-DB und asserten die `audit.data_imports`-Zeile nach Vorschau (dry_run=true) und Echtlauf (dry_run=false).

## Verifikation

- End-to-End gegen den laufenden Dev-Stack (echte Rollen, nicht Superuser): vor dem Fix 200-Antwort + 42501 im Log + 0 Zeilen; nach dem Fix landen Vorschau- und Echtlauf-Zeile mit korrektem Tenant, kein 42501 mehr.
- `go build`, `go test ./api/import/... ./services/import/...`, Handler-Ratchets, Hermetic-Gate, `golangci-lint`: grün.

## Hinweis

Rückwirkend fehlen die Audit-Zeilen seit ~17.02. unwiederbringlich — Datei und Ergebniszählungen sind nirgends sonst gespeichert, ein Backfill ist nicht möglich. Auf Staging/Prod sollten in `audit.data_imports` nur Zeilen von vor dem jeweiligen Phase-4-Deploy liegen.
