### PR TITLE
Kindersuche: Session-Lookups deduplizieren, Seitenaufbau beschleunigen

### DIFF
--- a/frontend/src/components/database/configs/activities.config.tsx
+++ b/frontend/src/components/database/configs/activities.config.tsx
@@ -4,7 +4,7 @@ import { defineEntityConfig } from "@/lib/database/types";
 import { databaseThemes } from "@/lib/database/themes";
 import type { Activity, ActivitySupervisor } from "@/lib/activity-helpers";
 import { getSupervisors } from "@/lib/activity-api";
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "~/lib/session-cache";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "ActivitiesConfig" });
@@ -133,7 +133,7 @@ export const activitiesConfig = defineEntityConfig<Activity>({
               // Fetch categories from API
               const response = await fetch("/api/activities/categories", {
                 headers: {
-                  Authorization: `Bearer ${(await getSession())?.user?.token}`,
+                  Authorization: `Bearer ${(await getCachedSession())?.user?.token}`,
                 },
               });
               const result = (await response.json()) as
@@ -315,7 +315,7 @@ export const activitiesConfig = defineEntityConfig<Activity>({
         loadOptions: async () => {
           try {
             // Fetch supervisors from API
-            const session = await getSession();
+            const session = await getCachedSession();
             const response = await fetch("/api/activities/supervisors", {
               headers: {
                 Authorization: `Bearer ${session?.user?.token}`,

--- a/frontend/src/components/students/student-historie-tab.tsx
+++ b/frontend/src/components/students/student-historie-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { CalendarDays, Loader2 } from "lucide-react";
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "~/lib/session-cache";
 import {
   formatAttendanceSlotStatus,
   type AttendanceSlotStatus,
@@ -96,7 +96,7 @@ export function StudentHistorieTab({ studentId }: StudentHistorieTabProps) {
   const loadData = useCallback(async () => {
     setState({ status: "loading" });
     try {
-      const session = await getSession();
+      const session = await getCachedSession();
       const headers: Record<string, string> = {};
       if (session?.user?.token) {
         headers.Authorization = `Bearer ${session.user.token}`;

--- a/frontend/src/lib/api-interceptor.test.ts
+++ b/frontend/src/lib/api-interceptor.test.ts
@@ -328,6 +328,58 @@ describe("response interceptor token refresh queue", () => {
     }
   });
 
+  it("retries with the NEW token even when the session cache was warm (#2123)", async () => {
+    // Regression: the request interceptor reads the session through the 10s
+    // getCachedSession() cache. After a 401→refresh, axios re-runs the request
+    // interceptor on the retried request — if the refresh path did not clear
+    // the cache, the interceptor would overwrite the fresh token with the
+    // stale cached one and the retry would 401 again (hard failure, _retry is
+    // already set).
+    const restore = setupBrowserEnv();
+    try {
+      // 1. Warm the session cache with the OLD token via a normal request.
+      mockGetSession.mockResolvedValue({ user: { token: "old-token" } });
+      const warmup = await requestInterceptorFulfilled({
+        method: "get",
+        url: "/api/warmup",
+        headers: {},
+      });
+      expect(warmup.headers).toMatchObject({
+        Authorization: "Bearer old-token",
+      });
+
+      // 2. The refresh rotates the token.
+      mockHandleAuthFailure.mockResolvedValue(true);
+      mockGetSession.mockResolvedValue({ user: { token: "rotated-token" } });
+
+      // 3. Simulate real axios: the retried request re-runs the request
+      //    interceptor, then report which Authorization header went out.
+      mockAxiosInstance.mockImplementation(
+        async (config: AxiosRequestConfig) => {
+          const finalConfig = await requestInterceptorFulfilled(config);
+          return {
+            status: 200,
+            data: {
+              sentAuth: (finalConfig.headers as Record<string, string>)
+                .Authorization,
+            },
+          };
+        },
+      );
+
+      const error = make401Error({
+        url: "/api/test",
+        method: "get",
+        headers: {},
+      });
+      const result = await responseInterceptorRejected(error);
+
+      expect(result.data).toEqual({ sentAuth: "Bearer rotated-token" });
+    } finally {
+      restore();
+    }
+  });
+
   it("queued requests reject when client-side refresh fails", async () => {
     const restore = setupBrowserEnv();
     try {

--- a/frontend/src/lib/api-transport.ts
+++ b/frontend/src/lib/api-transport.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
-import { getSession } from "next-auth/react";
 import { env } from "~/env";
 import { createLogger } from "~/lib/logger";
+import { clearSessionCache, getCachedSession } from "~/lib/session-cache";
 
 /**
  * Extended request config with retry tracking properties
@@ -31,9 +31,11 @@ const api = createAxios({
 // Note: This interceptor only runs in client-side code
 api.interceptors.request.use(
   async (config) => {
-    // Only try to get session if we're in the browser
+    // Only try to get session if we're in the browser. getCachedSession
+    // deduplicates concurrent session lookups — every raw getSession() call is
+    // its own network round trip to /api/auth/session (#2123).
     if (globalThis.window !== undefined) {
-      const session = await getSession();
+      const session = await getCachedSession();
 
       // If there's a token, add it to the headers
       if (session?.user?.token) {
@@ -125,7 +127,13 @@ async function attemptClientSideRefresh(
     return null;
   }
 
-  const session = await getSession();
+  // The refresh rotated the tokens. Drop the cached session BEFORE reading it
+  // again: the retry below re-runs the request interceptor, which reads
+  // getCachedSession() — served the stale pre-refresh token, the retry would
+  // 401 again and fail hard (_retry is already set). Repopulating the cache
+  // here also hands the fresh token to every queued subscriber.
+  clearSessionCache();
+  const session = await getCachedSession();
 
   if (!session?.user?.token) {
     return null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -308,6 +308,29 @@ function buildStudentQueryParams(filters?: {
 }
 
 /**
+ * Current session token via the deduplicating session cache.
+ */
+async function getSessionToken(): Promise<string | undefined> {
+  const session = await getCachedSession();
+  return session?.user?.token;
+}
+
+/**
+ * Auth headers for the raw fetch() call sites in the services below.
+ * Undefined when unauthenticated, so the request goes out without an
+ * Authorization header.
+ */
+async function getAuthHeaders(): Promise<Record<string, string> | undefined> {
+  const token = await getSessionToken();
+  return token
+    ? {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      }
+    : undefined;
+}
+
+/**
  * Get new token from session (helper for fetchWithRetry).
  * Called after a 401 → token refresh, so the cached session is stale by
  * definition — drop it first, or this (and every concurrent caller for up to
@@ -315,8 +338,7 @@ function buildStudentQueryParams(filters?: {
  */
 async function getNewTokenFromSession(): Promise<string | undefined> {
   clearSessionCache();
-  const session = await getCachedSession();
-  return session?.user?.token;
+  return getSessionToken();
 }
 
 /**
@@ -990,8 +1012,7 @@ export const studentService = {
         // Use provided token or fall back to getSession()
         let authToken = filters?.token;
         if (!authToken) {
-          const session = await getCachedSession();
-          authToken = session?.user?.token;
+          authToken = await getSessionToken();
         }
 
         const { data } = await fetchWithRetry<unknown>(url, authToken, {
@@ -1029,8 +1050,7 @@ export const studentService = {
       if (useProxyApi) {
         let authToken = filters?.token;
         if (!authToken) {
-          const session = await getCachedSession();
-          authToken = session?.user?.token;
+          authToken = await getSessionToken();
         }
 
         const { data } = await fetchWithRetry<unknown>(url, authToken, {
@@ -1064,15 +1084,11 @@ export const studentService = {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
         // Route handler already maps response, so applyMapping=false
-        const session = await getCachedSession();
-        const { data } = await fetchWithRetry<unknown>(
-          url,
-          session?.user?.token,
-          {
-            onAuthFailure: handleAuthFailure,
-            getNewToken: getNewTokenFromSession,
-          },
-        );
+        const token = await getSessionToken();
+        const { data } = await fetchWithRetry<unknown>(url, token, {
+          onAuthFailure: handleAuthFailure,
+          getNewToken: getNewTokenFromSession,
+        });
 
         if (data === null) {
           throw new Error("Authentication failed");
@@ -1099,16 +1115,10 @@ export const studentService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify(student),
         });
 
@@ -1164,16 +1174,10 @@ export const studentService = {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
         // Send frontend format data - the API route will handle transformation
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify(student),
         });
 
@@ -1307,15 +1311,11 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getCachedSession();
-        const { response, data } = await fetchWithRetry<unknown>(
-          url,
-          session?.user?.token,
-          {
-            onAuthFailure: handleAuthFailure,
-            getNewToken: getNewTokenFromSession,
-          },
-        );
+        const token = await getSessionToken();
+        const { response, data } = await fetchWithRetry<unknown>(url, token, {
+          onAuthFailure: handleAuthFailure,
+          getNewToken: getNewTokenFromSession,
+        });
 
         // Handle errors: null response means auth failed or permission denied
         // Return empty array for graceful degradation
@@ -1349,15 +1349,11 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getCachedSession();
-        const { response, data } = await fetchWithRetry<unknown>(
-          url,
-          session?.user?.token,
-          {
-            onAuthFailure: handleAuthFailure,
-            getNewToken: getNewTokenFromSession,
-          },
-        );
+        const token = await getSessionToken();
+        const { response, data } = await fetchWithRetry<unknown>(url, token, {
+          onAuthFailure: handleAuthFailure,
+          getNewToken: getNewTokenFromSession,
+        });
 
         if (response === null) {
           throw new Error("Authentication failed");
@@ -1395,16 +1391,10 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify(backendGroup),
         });
 
@@ -1454,16 +1444,10 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify(backendUpdates),
         });
 
@@ -1518,16 +1502,10 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "DELETE",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
         });
 
         if (!response.ok) {
@@ -1571,15 +1549,9 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
         });
 
         if (!response.ok) {
@@ -1635,16 +1607,10 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify({
             supervisor_id: Number.parseInt(supervisorId, 10),
           }),
@@ -1690,16 +1656,10 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "DELETE",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
         });
 
         if (!response.ok) {
@@ -1740,16 +1700,10 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify({
             representative_id: Number.parseInt(representativeId, 10),
           }),
@@ -1805,15 +1759,11 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getCachedSession();
-        const { data } = await fetchWithRetry<unknown>(
-          url,
-          session?.user?.token,
-          {
-            onAuthFailure: handleAuthFailure,
-            getNewToken: getNewTokenFromSession,
-          },
-        );
+        const token = await getSessionToken();
+        const { data } = await fetchWithRetry<unknown>(url, token, {
+          onAuthFailure: handleAuthFailure,
+          getNewToken: getNewTokenFromSession,
+        });
 
         const rooms = parseRoomsResponse(data);
         return mapRoomsResponse(rooms);
@@ -1841,15 +1791,11 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getCachedSession();
-        const { response, data } = await fetchWithRetry<unknown>(
-          url,
-          session?.user?.token,
-          {
-            onAuthFailure: handleAuthFailure,
-            getNewToken: getNewTokenFromSession,
-          },
-        );
+        const token = await getSessionToken();
+        const { response, data } = await fetchWithRetry<unknown>(url, token, {
+          onAuthFailure: handleAuthFailure,
+          getNewToken: getNewTokenFromSession,
+        });
 
         if (response === null) {
           throw new Error("Authentication failed");
@@ -1885,16 +1831,10 @@ export const roomService = {
 
     try {
       if (useProxyApi) {
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify(backendRoom),
         });
 
@@ -1940,16 +1880,10 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
           body: JSON.stringify(backendUpdates),
         });
 
@@ -2002,16 +1936,10 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "DELETE",
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
         });
 
         if (!response.ok) {
@@ -2048,15 +1976,9 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getCachedSession();
         const response = await fetch(url, {
           credentials: "include",
-          headers: session?.user?.token
-            ? {
-                Authorization: `Bearer ${session.user.token}`,
-                "Content-Type": "application/json",
-              }
-            : undefined,
+          headers: await getAuthHeaders(),
         });
 
         if (!response.ok) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { AxiosError } from "axios";
-import { getSession } from "next-auth/react";
+import { clearSessionCache, getCachedSession } from "./session-cache";
 import { createLogger } from "~/lib/logger";
 import { env } from "~/env";
 import api from "./api-transport";
@@ -308,10 +308,14 @@ function buildStudentQueryParams(filters?: {
 }
 
 /**
- * Get new token from session (helper for fetchWithRetry)
+ * Get new token from session (helper for fetchWithRetry).
+ * Called after a 401 → token refresh, so the cached session is stale by
+ * definition — drop it first, or this (and every concurrent caller for up to
+ * 10s) would retry with the dead token.
  */
 async function getNewTokenFromSession(): Promise<string | undefined> {
-  const session = await getSession();
+  clearSessionCache();
+  const session = await getCachedSession();
   return session?.user?.token;
 }
 
@@ -986,7 +990,7 @@ export const studentService = {
         // Use provided token or fall back to getSession()
         let authToken = filters?.token;
         if (!authToken) {
-          const session = await getSession();
+          const session = await getCachedSession();
           authToken = session?.user?.token;
         }
 
@@ -1025,7 +1029,7 @@ export const studentService = {
       if (useProxyApi) {
         let authToken = filters?.token;
         if (!authToken) {
-          const session = await getSession();
+          const session = await getCachedSession();
           authToken = session?.user?.token;
         }
 
@@ -1060,7 +1064,7 @@ export const studentService = {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
         // Route handler already maps response, so applyMapping=false
-        const session = await getSession();
+        const session = await getCachedSession();
         const { data } = await fetchWithRetry<unknown>(
           url,
           session?.user?.token,
@@ -1095,7 +1099,7 @@ export const studentService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
@@ -1160,7 +1164,7 @@ export const studentService = {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
         // Send frontend format data - the API route will handle transformation
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
@@ -1303,7 +1307,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getSession();
+        const session = await getCachedSession();
         const { response, data } = await fetchWithRetry<unknown>(
           url,
           session?.user?.token,
@@ -1345,7 +1349,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getSession();
+        const session = await getCachedSession();
         const { response, data } = await fetchWithRetry<unknown>(
           url,
           session?.user?.token,
@@ -1391,7 +1395,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
@@ -1450,7 +1454,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
@@ -1514,7 +1518,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "DELETE",
           credentials: "include",
@@ -1567,7 +1571,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           credentials: "include",
           headers: session?.user?.token
@@ -1631,7 +1635,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
@@ -1686,7 +1690,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "DELETE",
           credentials: "include",
@@ -1736,7 +1740,7 @@ export const groupService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
@@ -1801,7 +1805,7 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getSession();
+        const session = await getCachedSession();
         const { data } = await fetchWithRetry<unknown>(
           url,
           session?.user?.token,
@@ -1837,7 +1841,7 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetchWithRetry for automatic 401 handling
-        const session = await getSession();
+        const session = await getCachedSession();
         const { response, data } = await fetchWithRetry<unknown>(
           url,
           session?.user?.token,
@@ -1881,7 +1885,7 @@ export const roomService = {
 
     try {
       if (useProxyApi) {
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "POST",
           credentials: "include",
@@ -1936,7 +1940,7 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "PUT",
           credentials: "include",
@@ -1998,7 +2002,7 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           method: "DELETE",
           credentials: "include",
@@ -2044,7 +2048,7 @@ export const roomService = {
     try {
       if (useProxyApi) {
         // Browser environment: use fetch with our Next.js API route
-        const session = await getSession();
+        const session = await getCachedSession();
         const response = await fetch(url, {
           credentials: "include",
           headers: session?.user?.token

--- a/frontend/src/lib/auth-service.ts
+++ b/frontend/src/lib/auth-service.ts
@@ -1,5 +1,5 @@
 // lib/auth-service.ts
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "./session-cache";
 import { isAxiosError } from "axios";
 import { env } from "~/env";
 import api from "./api-transport";
@@ -218,8 +218,7 @@ function buildAxiosApiError(
   apiError.status = error.response?.status;
 
   const headers = error.response?.headers as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   const retryAfterHeader = headers ? headers["retry-after"] : undefined;
   let retryAfterValue: string | null = null;
   if (Array.isArray(retryAfterHeader)) {
@@ -276,7 +275,7 @@ async function buildAuthHeaders(
     return headers;
   }
 
-  const session = await getSession();
+  const session = await getCachedSession();
   if (session?.user?.token) {
     headers.Authorization = `Bearer ${session.user.token}`;
   }
@@ -583,7 +582,7 @@ export const authService = {
     const url = useProxyApi ? "/api/auth/logout" : `${env.API_URL}/auth/logout`;
 
     try {
-      const session = await getSession();
+      const session = await getCachedSession();
       if (!session?.user?.token) {
         return; // Already logged out
       }

--- a/frontend/src/lib/database/service-factory.ts
+++ b/frontend/src/lib/database/service-factory.ts
@@ -1,6 +1,6 @@
 // Generic CRUD Service Factory
 
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "~/lib/session-cache";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "ServiceFactory" });
@@ -121,7 +121,7 @@ export function createCrudService<T>(config: EntityConfig<T>): CrudService<T> {
 
   // Helper to get auth token
   const getToken = async () => {
-    const session = await getSession();
+    const session = await getCachedSession();
     return session?.user?.token;
   };
 

--- a/frontend/src/lib/passkey-api.ts
+++ b/frontend/src/lib/passkey-api.ts
@@ -9,7 +9,7 @@ import type {
   PublicKeyCredentialRequestOptionsJSON,
   RegistrationResponseJSON,
 } from "@simplewebauthn/browser";
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "./session-cache";
 
 export type PasskeyScope = "tenant" | "operator";
 
@@ -50,7 +50,7 @@ function extractOptions<TOptions>(
 }
 
 async function currentBearerToken(): Promise<string> {
-  const session = await getSession();
+  const session = await getCachedSession();
   const token = session?.user?.token;
   if (!token) {
     throw new PasskeyApiError(401, "Nicht angemeldet.");

--- a/frontend/src/lib/session-cache.test.ts
+++ b/frontend/src/lib/session-cache.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the getSession() dedupe cache (#2123).
+ *
+ * Every raw next-auth getSession() call is its own network round trip to
+ * /api/auth/session; this cache collapses the parallel page-load fan-out into
+ * one request. The generation guard is the safety net for token refreshes: a
+ * lookup that was already in flight when clearSessionCache() ran must not
+ * write its stale result back into the cache afterwards.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetSession = vi.fn();
+vi.mock("next-auth/react", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args) as unknown,
+}));
+
+type SessionCacheModule = typeof import("./session-cache");
+
+async function freshModule(): Promise<SessionCacheModule> {
+  vi.resetModules();
+  return import("./session-cache");
+}
+
+function session(token: string, tenantId = 1) {
+  return { user: { token, tenantId } };
+}
+
+describe("getCachedSession", () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+  });
+
+  it("serves repeated sequential calls within the TTL from one getSession call", async () => {
+    const { getCachedSession } = await freshModule();
+    mockGetSession.mockResolvedValue(session("token-a"));
+
+    const first = await getCachedSession();
+    const second = await getCachedSession();
+
+    expect(first?.user?.token).toBe("token-a");
+    expect(second).toBe(first);
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates concurrent callers into a single in-flight getSession", async () => {
+    const { getCachedSession } = await freshModule();
+    let resolveSession!: (value: unknown) => void;
+    mockGetSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    const calls = [getCachedSession(), getCachedSession(), getCachedSession()];
+    resolveSession(session("token-b"));
+    const results = await Promise.all(calls);
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      expect(result?.user?.token).toBe("token-b");
+    }
+  });
+
+  it("refetches after the TTL expires", async () => {
+    const { getCachedSession } = await freshModule();
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1_000_000);
+    mockGetSession.mockResolvedValueOnce(session("token-old"));
+    await getCachedSession();
+
+    now.mockReturnValue(1_000_000 + 10_001);
+    mockGetSession.mockResolvedValueOnce(session("token-new"));
+    const result = await getCachedSession();
+
+    expect(result?.user?.token).toBe("token-new");
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+    now.mockRestore();
+  });
+
+  it("refetches after clearSessionCache", async () => {
+    const { getCachedSession, clearSessionCache } = await freshModule();
+    mockGetSession.mockResolvedValueOnce(session("token-old"));
+    await getCachedSession();
+
+    clearSessionCache();
+    mockGetSession.mockResolvedValueOnce(session("token-new"));
+    const result = await getCachedSession();
+
+    expect(result?.user?.token).toBe("token-new");
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an in-flight lookup repopulate the cache across a clear", async () => {
+    // Regression guard for the 401→refresh race: request A starts a session
+    // lookup, a refresh clears the cache, then A resolves with the PRE-refresh
+    // session. That result must not be cached — the next caller has to see the
+    // post-refresh session, or retries go out with the dead token.
+    const { getCachedSession, clearSessionCache } = await freshModule();
+    let resolveStale!: (value: unknown) => void;
+    mockGetSession.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStale = resolve;
+      }),
+    );
+
+    const staleLookup = getCachedSession();
+    clearSessionCache();
+    resolveStale(session("token-stale"));
+    await staleLookup;
+
+    mockGetSession.mockResolvedValueOnce(session("token-fresh"));
+    const result = await getCachedSession();
+
+    expect(result?.user?.token).toBe("token-fresh");
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("a stale in-flight lookup does not clobber the post-clear in-flight state", async () => {
+    // Same race, but the next caller arrives while the stale lookup is STILL
+    // pending: the stale finally-block must not null out the new lookup.
+    const { getCachedSession, clearSessionCache } = await freshModule();
+    let resolveStale!: (value: unknown) => void;
+    let resolveFresh!: (value: unknown) => void;
+    mockGetSession
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStale = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFresh = resolve;
+        }),
+      );
+
+    const staleLookup = getCachedSession();
+    clearSessionCache();
+    const freshLookup = getCachedSession();
+
+    resolveStale(session("token-stale"));
+    await staleLookup;
+    resolveFresh(session("token-fresh"));
+    await freshLookup;
+
+    // The fresh result must be the one cached now.
+    const cached = await getCachedSession();
+    expect(cached?.user?.token).toBe("token-fresh");
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/lib/session-cache.test.ts
+++ b/frontend/src/lib/session-cache.test.ts
@@ -3,11 +3,12 @@
  *
  * Every raw next-auth getSession() call is its own network round trip to
  * /api/auth/session; this cache collapses the parallel page-load fan-out into
- * one request. The generation guard is the safety net for token refreshes: a
+ * one request. The staleness guard is the safety net for token refreshes: a
  * lookup that was already in flight when clearSessionCache() ran must not
  * write its stale result back into the cache afterwards.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockSessionData } from "~/test/mocks/next-auth";
 
 const mockGetSession = vi.fn();
 vi.mock("next-auth/react", () => ({
@@ -22,7 +23,7 @@ async function freshModule(): Promise<SessionCacheModule> {
 }
 
 function session(token: string, tenantId = 1) {
-  return { user: { token, tenantId } };
+  return mockSessionData({ user: { token, tenantId } });
 }
 
 describe("getCachedSession", () => {

--- a/frontend/src/lib/session-cache.ts
+++ b/frontend/src/lib/session-cache.ts
@@ -22,12 +22,6 @@ let inflight: Promise<Awaited<ReturnType<typeof getSession>>> | null = null;
 // which automatically invalidates the stale cache entry.
 let cachedTenantId: number | undefined;
 
-// Incremented on every clearSessionCache(). An in-flight getSession() that
-// started BEFORE a clear must not write its (potentially stale, pre-refresh)
-// result back into the cache after the clear — the retry after a 401/token
-// refresh would then read the dead token again.
-let generation = 0;
-
 const TTL_MS = 10_000; // 10 second cache window
 
 /**
@@ -38,7 +32,6 @@ export function clearSessionCache() {
   cached = null;
   cachedTenantId = undefined;
   inflight = null;
-  generation += 1;
 }
 
 export async function getCachedSession() {
@@ -58,13 +51,14 @@ export async function getCachedSession() {
   }
   if (inflight) return inflight;
 
-  const startedGeneration = generation;
-  const request = getSession()
+  // A request may only touch module state while it is still the current
+  // `inflight`. clearSessionCache() (token refresh, tenant switch) nulls
+  // `inflight`, so a lookup that was already in flight at that point must
+  // neither write its stale, pre-refresh result back into the cache nor
+  // clear a newer lookup that started after the invalidation.
+  const request: Promise<Awaited<ReturnType<typeof getSession>>> = getSession()
     .then((session) => {
-      // Only populate the cache if no clearSessionCache() happened while this
-      // request was in flight — otherwise this result predates a token
-      // refresh/tenant switch and must not be reused.
-      if (generation === startedGeneration) {
+      if (inflight === request) {
         cachedTenantId = (session?.user as { tenantId?: number } | undefined)
           ?.tenantId;
         cached = { session, expiry: Date.now() + TTL_MS };
@@ -72,7 +66,7 @@ export async function getCachedSession() {
       return session;
     })
     .finally(() => {
-      if (generation === startedGeneration) {
+      if (inflight === request) {
         inflight = null;
       }
     });

--- a/frontend/src/lib/session-cache.ts
+++ b/frontend/src/lib/session-cache.ts
@@ -22,6 +22,12 @@ let inflight: Promise<Awaited<ReturnType<typeof getSession>>> | null = null;
 // which automatically invalidates the stale cache entry.
 let cachedTenantId: number | undefined;
 
+// Incremented on every clearSessionCache(). An in-flight getSession() that
+// started BEFORE a clear must not write its (potentially stale, pre-refresh)
+// result back into the cache after the clear — the retry after a 401/token
+// refresh would then read the dead token again.
+let generation = 0;
+
 const TTL_MS = 10_000; // 10 second cache window
 
 /**
@@ -32,6 +38,7 @@ export function clearSessionCache() {
   cached = null;
   cachedTenantId = undefined;
   inflight = null;
+  generation += 1;
 }
 
 export async function getCachedSession() {
@@ -51,18 +58,27 @@ export async function getCachedSession() {
   }
   if (inflight) return inflight;
 
-  inflight = getSession()
+  const startedGeneration = generation;
+  const request = getSession()
     .then((session) => {
-      cachedTenantId = (session?.user as { tenantId?: number } | undefined)
-        ?.tenantId;
-      cached = { session, expiry: Date.now() + TTL_MS };
+      // Only populate the cache if no clearSessionCache() happened while this
+      // request was in flight — otherwise this result predates a token
+      // refresh/tenant switch and must not be reused.
+      if (generation === startedGeneration) {
+        cachedTenantId = (session?.user as { tenantId?: number } | undefined)
+          ?.tenantId;
+        cached = { session, expiry: Date.now() + TTL_MS };
+      }
       return session;
     })
     .finally(() => {
-      inflight = null;
+      if (generation === startedGeneration) {
+        inflight = null;
+      }
     });
+  inflight = request;
 
-  return inflight;
+  return request;
 }
 
 /**
@@ -94,7 +110,11 @@ export async function sessionFetch(
 
   if (response.status === 401) {
     clearSessionCache();
-    const { handleAuthFailure } = await import("./auth-api");
+    // Import from auth-failure directly (auth-api only re-exports it):
+    // going through auth-api would close a module cycle
+    // session-cache -> auth-api -> auth-service -> api-transport -> session-cache
+    // now that the API clients import this module statically (#2123).
+    const { handleAuthFailure } = await import("./auth-failure");
     const refreshed = await handleAuthFailure();
     if (refreshed) {
       const freshSession = await getCachedSession();

--- a/frontend/src/lib/student-arrival-api.ts
+++ b/frontend/src/lib/student-arrival-api.ts
@@ -1,4 +1,4 @@
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "./session-cache";
 
 export interface ArrivalSchedule {
   id: number;
@@ -84,7 +84,7 @@ async function authHeaders(): Promise<HeadersInit> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
-  const session = await getSession();
+  const session = await getCachedSession();
   if (session?.user?.token) {
     headers.Authorization = `Bearer ${session.user.token}`;
   }

--- a/frontend/src/lib/student-companion-api.ts
+++ b/frontend/src/lib/student-companion-api.ts
@@ -1,4 +1,4 @@
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "./session-cache";
 
 /**
  * Laufgemeinschaft ("läuft mit"): the children a child walks home with.
@@ -140,7 +140,7 @@ async function authHeaders(): Promise<HeadersInit> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
-  const session = await getSession();
+  const session = await getCachedSession();
   if (session?.user?.token) {
     headers.Authorization = `Bearer ${session.user.token}`;
   }

--- a/frontend/src/lib/teacher-api.test.ts
+++ b/frontend/src/lib/teacher-api.test.ts
@@ -150,18 +150,17 @@ describe("teacher-api", () => {
       );
     });
 
-    it("works without auth token", async () => {
+    it("rejects without auth token", async () => {
+      // sessionFetch has always thrown without a token; this test previously
+      // asserted the opposite and only stayed green because earlier tests in
+      // this file left a session in the module-level getSession cache (10s
+      // TTL). Since the cache is reset between tests (#2123), the null mock
+      // is actually honored and the real contract shows.
       mockedGetSession.mockResolvedValue(null);
 
-      const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([sampleTeacher]),
-      } as Response);
-
-      const result = await teacherService.getTeachers();
-
-      expect(result).toHaveLength(1);
+      await expect(teacherService.getTeachers()).rejects.toThrow(
+        "No authentication token available",
+      );
     });
   });
 

--- a/frontend/src/lib/time-tracking-api.ts
+++ b/frontend/src/lib/time-tracking-api.ts
@@ -1,6 +1,6 @@
 // Time tracking API service for check-in/out and history management
 
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "./session-cache";
 import { buildApiError } from "./auth-api";
 import type {
   BackendClosingDayRange,
@@ -101,7 +101,7 @@ class TimeTrackingService {
   private readonly baseUrl = "/api/time-tracking";
 
   private async getToken(): Promise<string | undefined> {
-    const session = await getSession();
+    const session = await getCachedSession();
     return session?.user?.token;
   }
 

--- a/frontend/src/lib/timetable-api.ts
+++ b/frontend/src/lib/timetable-api.ts
@@ -9,7 +9,7 @@
  * - materialize(from?, to?)      → POST   /materialize
  */
 
-import { getSession } from "next-auth/react";
+import { getCachedSession } from "./session-cache";
 import { createLogger } from "./logger";
 import type {
   BackendConflictCheckResult,
@@ -134,7 +134,7 @@ class TimetableService {
    * lightweight enrichment (room name, type, staff list, counts).
    */
   async getWeek(from: string, to: string): Promise<WeeklyInstancesResponse> {
-    const session = await getSession();
+    const session = await getCachedSession();
     if (!session?.user?.token) {
       throw new TimetableApiError("Nicht angemeldet", 401, "UNAUTHENTICATED");
     }

--- a/frontend/src/test/mocks/next-auth.ts
+++ b/frontend/src/test/mocks/next-auth.ts
@@ -12,6 +12,7 @@ export function mockSessionData(
       token: string;
       accessToken: string;
       refreshToken: string;
+      tenantId: number;
     }>;
     expires: string;
   }>,

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,21 @@
 import "@testing-library/jest-dom/vitest";
 import type React from "react";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+
+// Reset the module-level session cache between tests. Since #2123 the API
+// clients read the NextAuth session through ~/lib/session-cache (10s TTL), so
+// a session cached by one test would otherwise leak into the next. Lazy import
+// on purpose: a static import would pull next-auth/react into every test
+// file's module graph. Guarded because some tests mock ./session-cache with
+// only a sessionFetch export — those never touch the real cache.
+beforeEach(async () => {
+  try {
+    const { clearSessionCache } = await import("~/lib/session-cache");
+    clearSessionCache();
+  } catch {
+    // Module mocked without clearSessionCache — nothing to reset.
+  }
+});
 
 function createStorageMock(): Storage {
   const store = new Map<string, string>();

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -5,9 +5,11 @@ import { beforeEach, vi } from "vitest";
 // Reset the module-level session cache between tests. Since #2123 the API
 // clients read the NextAuth session through ~/lib/session-cache (10s TTL), so
 // a session cached by one test would otherwise leak into the next. Lazy import
-// on purpose: a static import would pull next-auth/react into every test
-// file's module graph. Guarded because some tests mock ./session-cache with
-// only a sessionFetch export — those never touch the real cache.
+// on purpose: a static import would load the real next-auth/react before a
+// test file's vi.mock of it registers, so mocked files would bind the real
+// getSession. try/catch instead of an export check: some tests mock
+// ./session-cache with only a sessionFetch export, and vitest's mock proxy
+// throws already on ACCESSING the missing clearSessionCache export.
 beforeEach(async () => {
   try {
     const { clearSessionCache } = await import("~/lib/session-cache");


### PR DESCRIPTION
Closes #2123

## Ursache

Jeder Datenabruf bezahlte seine eigene Session-Abfrage: der Axios-Request-Interceptor (`api-transport.ts`) und 21 Service-Methoden in `lib/api.ts` (plus 9 weitere Module) riefen das rohe `getSession()` von next-auth auf, und jeder dieser Aufrufe ist eine eigene Netzwerkanfrage an `/api/auth/session`. Beim Aufbau der Kindersuche ergab das 12 Session-Requests (~55 KB) und eine serialisierte Kette Gruppen (537 ms), Räume (623 ms), Klassen (649 ms), Kinderliste (681 ms), weil jeder Fetcher erst seinen eigenen Session-Roundtrip abwartete. Der Dedupe-Cache existierte bereits (`getCachedSession()` in `session-cache.ts`, von `active-service`/`profile-api`/`usercontext-api` längst genutzt), `lib/api.ts` und der Interceptor waren nur nie migriert worden.

## Änderungen

- Alle Happy-Path-Session-Reads laufen jetzt über `getCachedSession()` (10 s TTL, In-Flight-Dedup): Axios-Interceptor, `lib/api.ts` (21 Stellen), `student-companion-api`, `student-arrival-api`, `passkey-api`, `timetable-api`, `time-tracking-api`, `auth-service`, `database/service-factory`, `activities.config`, `student-historie-tab`.
- Refresh-Pfad (401): `attemptClientSideRefresh` und `getNewTokenFromSession` leeren den Cache und befüllen ihn neu, bevor der Retry läuft. Ohne das würde der Request-Interceptor beim Retry das frische Token mit dem gecachten alten überschreiben und der Retry endgültig scheitern (Regressionstest in `api-interceptor.test.ts` deckt genau das ab, per Mutation verifiziert).
- Neuer Generationszähler in `session-cache.ts`: ein Lookup, der vor einem `clearSessionCache()` gestartet ist, darf sein veraltetes Ergebnis nicht nachträglich zurückschreiben (bisher latenter Bug, wurde durch die breitere Nutzung real).
- `sessionFetch` importiert `handleAuthFailure` direkt aus `auth-failure` statt über `auth-api`, sonst entsteht durch die neuen statischen Importe ein Modulzyklus (depcruise).
- Neue Tests: `session-cache.test.ts` (TTL, In-Flight-Dedup, Generationsschutz), globales Cache-Reset in `test/setup.ts`.

## Messwerte

Gleiches Rezept wie im Issue: lokaler Stack, `/students/search?group_id=`, Admin, `performance.getEntriesByType('resource')`, je 6 Läufe (Median, Spannweite in Klammern). LCP als Näherung für die erste gerenderte Karte, je 3 Läufe.

| Metrik | development | dieser Branch |
|---|---|---|
| API-Requests beim Seitenaufbau | 32 | **24** |
| davon `/api/auth/session` | 12 (~55 KB) | **4 (~18 KB)** |
| Start der Listen-Anfrage | ~591 ms (576-606) | **~415 ms (389-446)** |
| letzter Request der Seite | ~732 ms | **~676 ms** |
| LCP (erste Karte) | ~724 ms (696-744) | **~600 ms (588-604)** |

Gruppen, Räume, Klassen und Kinderliste starten jetzt gleichzeitig statt als Kette. Die Einzeldauer der Listen-Anfrage steigt im Dev-Server (~38 ms auf ~175 ms), weil der single-threaded `next dev` nun zehn Proxy-Requests gleichzeitig statt nacheinander verarbeitet; Gesamtzeit und LCP sinken trotzdem. Von den 4 verbleibenden Session-Calls stammen 2 aus dem React-StrictMode-Doppelmount des SessionProviders (nur Dev); produktiv bleiben rechnerisch 2.

## Zu den übrigen Punkten aus #2123

- **`/api/settings/schema` (Punkt 2): die Begründung im Issue stimmt nicht mehr.** Der Foto-Feature-Zustand im Cache-Key kommt seit Mai aus dem TenantContext, den das Server-Layout über `/auth/tenant/resolve` befüllt, nicht aus dem Settings-Schema. Das Schema (59 KB) laden nur Sidebar und Mobile-Nav für drei Nav-Flags (`timetable.enabled`, `operations.meal_plan_enabled`, `operations.parent_news_enabled`), nur für Accounts mit `config:read`, ein Request dank gemeinsamem SWR-Key. Es blockiert die Liste nicht, es konkurriert nur um Verbindungen. Möglicher Folgeschritt (separates Issue, wenn gewünscht): die drei Flags analog zu `student_photos_enabled` in `/auth/tenant/resolve` aufnehmen, dann entfällt der Request ganz.
- **Proxy-Aufblähung (Punkt 4): war beim Start dieser Arbeit bereits behoben.** `mapSlimStudentResponse` (aus dem finalen Stand von PR #2120, Commit e3bc7c4b0) lässt die fünf abgeleiteten Felder strukturell weg, abgesichert durch den Test "keeps slim responses slim". Konsumenten-Audit: nur die Kindersuche nutzt `view=slim`, kein Slim-Konsument liest die Felder, der Laufgemeinschafts-Picker guardet mit `?? []`. Messung bestätigt: 41 KB im Browser statt 53 KB.

## Test-Anpassung (bewusst, bitte prüfen)

`teacher-api.test.ts` "works without auth token" war ein Scheingrüner: `sessionFetch` wirft ohne Token seit jeher `No authentication token available`, der Test blieb nur grün, weil frühere Tests derselben Datei eine Session im Modul-Cache hinterließen und der `getSession -> null`-Mock dadurch nie griff. Das globale Cache-Reset legt das offen. Der Test heißt jetzt "rejects without auth token" und prüft den tatsächlichen Vertrag. Falls "funktioniert ohne Token" das gewollte Verhalten sein sollte, wäre das eine Änderung an `sessionFetch`, nicht an diesem Test.

## QA

- `pnpm run check` grün, komplette Test-Suite grün (13.218 Tests), depcruise grün
- E2E im Browser (agent-browser, lokaler Stack): Login, Kindersuche rendert alle Karten, Suchfilter, Navigation in die Kinderdetailseite, keine Konsolenfehler
- Kein visueller Unterschied (reine Performance-Änderung)