### PR TITLE
perf(backend): Identitätsauflösung pro Request memoisieren (#2099)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -88,6 +88,10 @@ Every model field mapped to a `DATE` column MUST be `timezone.Date` (or `*timezo
 
 Per-school config resolves tenant DB override → registry default; the service does **not** check env vars. Consumers needing env var backward compatibility must check `HasTenantOverride()` first, then fall back to `os.Getenv()` manually. Use `Resolve*(ctx, key)` inside tenant middleware, `Resolve*ForTenant(ctx, tenantID, key)` outside it (device auth, scheduler loops). Everything else — registry, field types, permissions, add/edit/delete workflows: `.claude/rules/settings-system.md`.
 
+## Request-Scoped Identity Memoization (#2099)
+
+The identity chain (Account → Person → Staff → Teacher → `GetMyGroups`/`GetSubstitutedGroupIDs`) is memoized per request, mirroring the #2065 settings cache: `RequestIdentityCacheMiddleware` (mounted router-wide in `api/base.go` and group-wide in `ProtectedTenantGroup`) attaches an empty cache; `services/usercontext` consults it keyed by `(tenant_id, account_id)`. Only successes and clean not-found outcomes are memoized — never DB errors or partial `GetMyGroups` results. Self-writes (`UpdateCurrentProfile`, `UpdateAvatar`) drop the caller's entry before their trailing re-read; writes to *other* accounts' chains (group transfer, admin substitutions, offboarding) are deliberately exempt. Without the cache in context (scheduler, CLI, device auth, plain tests) behavior is unchanged. Full contract: doc comment in `services/usercontext/identity_request_cache.go`.
+
 ## Domain Knowledge
 
 ### RFID/IoT Integration

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -228,6 +228,10 @@ func setupBasicMiddleware(router chi.Router, logger *slog.Logger, httpMetrics *o
 	// /operator, /parent, public enrollment) dedupe their settings lookups
 	// too. Idempotent with the group-wide attachment in api/common.
 	router.Use(apiCommon.RequestSettingsCacheMiddleware)
+	// Request-scoped identity memo cache (issue #2099). Router-wide so routes
+	// outside ProtectedTenantGroup (notably /api/sse, which builds its own JWT
+	// chain) dedupe their identity-chain lookups too.
+	router.Use(apiCommon.RequestIdentityCacheMiddleware)
 }
 
 func syncClientIPToRemoteAddr(next http.Handler) http.Handler {

--- a/backend/api/common/identity_request_cache_middleware.go
+++ b/backend/api/common/identity_request_cache_middleware.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"net/http"
+
+	"github.com/moto-nrw/project-phoenix/services/usercontext"
+)
+
+// RequestIdentityCacheMiddleware attaches the request-scoped identity memo
+// cache (issue #2099) to every request context. It does no database work —
+// it only seeds an empty per-request map — so it is safe to run before
+// authorization and to stack: WithIdentityRequestCache is idempotent, letting
+// the router-wide attachment in api/base.go and the group-wide attachment in
+// ProtectedTenantGroup share one cache. The consistency contract lives on the
+// cache struct in services/usercontext/identity_request_cache.go.
+func RequestIdentityCacheMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(usercontext.WithIdentityRequestCache(r.Context())))
+	})
+}

--- a/backend/api/common/identity_request_cache_middleware_test.go
+++ b/backend/api/common/identity_request_cache_middleware_test.go
@@ -1,0 +1,30 @@
+package common_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/services/usercontext"
+)
+
+// WithIdentityRequestCache returns its input unchanged when a cache is already
+// attached, so comparing the handler-observed context with a re-wrapped copy
+// proves the middleware attached the cache (#2099).
+func TestRequestIdentityCacheMiddlewareAttachesCache(t *testing.T) {
+	var observed context.Context
+	handler := common.RequestIdentityCacheMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = r.Context()
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+	require.NotNil(t, observed)
+	assert.Equal(t, observed, usercontext.WithIdentityRequestCache(observed),
+		"middleware must have attached the request cache (idempotent re-wrap returns the same context)")
+}

--- a/backend/api/common/router.go
+++ b/backend/api/common/router.go
@@ -28,10 +28,12 @@ func ProtectedTenantGroup(r chi.Router, db *bun.DB, fn func(r chi.Router, withTx
 		gr.Use(tokenAuth.Verifier())
 		gr.Use(jwt.Authenticator)
 		gr.Use(jwt.TenantMiddleware)
-		// Request-scoped settings memo cache (issue #2065). Unlike withTx this
-		// IS applied group-wide: it opens no transaction and does no DB work,
-		// so running it on requests that later 403 costs one map allocation.
+		// Request-scoped settings memo cache (issue #2065) and identity memo
+		// cache (issue #2099). Unlike withTx these ARE applied group-wide:
+		// they open no transaction and do no DB work, so running them on
+		// requests that later 403 costs one map allocation each.
 		gr.Use(RequestSettingsCacheMiddleware)
+		gr.Use(RequestIdentityCacheMiddleware)
 		fn(gr, tenant.TenantTxMiddleware(db))
 	})
 }

--- a/backend/api/students/ogs_group_live_identity_budget_test.go
+++ b/backend/api/students/ogs_group_live_identity_budget_test.go
@@ -1,0 +1,141 @@
+package students_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// identityStageCounter buckets the SELECTs that resolve the identity chain
+// (Account → Person → Staff → Teacher → substitutions). The markers pair the
+// table with the lookup column of the identity resolution so that business
+// queries which merely JOIN the same tables (e.g. substitute names on the
+// transfers projection) do not pollute the buckets.
+type identityStageCounter struct {
+	mu      sync.Mutex
+	queries map[string][]string
+}
+
+// identityStageMatchers maps a stage to a predicate over the lowercased SQL.
+// The substitution stage accepts both SQL shapes: the hand-written finder
+// emits `.substitute_staff_id = ?`, the Filter-based one
+// `"substitute_staff_id" = ?`; substitution reads filtered by group (the
+// transfers projection) don't match either.
+var identityStageMatchers = map[string]func(string) bool{
+	"person": func(q string) bool {
+		return strings.Contains(q, "users.persons") && strings.Contains(q, "account_id = ")
+	},
+	"staff": func(q string) bool {
+		return strings.Contains(q, "users.staff") && strings.Contains(q, "person_id = ")
+	},
+	"teacher": func(q string) bool {
+		return strings.Contains(q, "users.teachers") && strings.Contains(q, "staff_id = ")
+	},
+	"substitutions": func(q string) bool {
+		return strings.Contains(q, "education.group_substitution") &&
+			(strings.Contains(q, "substitute_staff_id = ") || strings.Contains(q, `substitute_staff_id" = `))
+	},
+}
+
+func (c *identityStageCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if !strings.HasPrefix(strings.TrimSpace(query), "select") {
+		return ctx
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for stage, matches := range identityStageMatchers {
+		if matches(query) {
+			c.queries[stage] = append(c.queries[stage], event.Query)
+		}
+	}
+	return ctx
+}
+
+func (*identityStageCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func (c *identityStageCounter) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.queries = make(map[string][]string)
+}
+
+func (c *identityStageCounter) captured(stage string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.queries[stage]...)
+}
+
+// TestOGSGroupLiveIdentityQueryBudget is the endpoint-level #2099 acceptance
+// test: one request through the production Router() (including the
+// RequestIdentityCacheMiddleware mounted by ProtectedTenantGroup) resolves
+// each identity-chain stage at most once, even though the aggregate calls
+// GetMyGroups, GetSubstitutedGroupIDs, and ResolveStudentAccess internally.
+//
+// Before #2099 the same request resolved the person+staff pair ~4 times.
+// The existing TestOGSGroupLive_QueryBudget bounds the total; this test pins
+// the identity share specifically.
+func TestOGSGroupLiveIdentityQueryBudget(t *testing.T) {
+	tc := setupTestContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "IdentityBudget", "Leader")
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "IdentityBudgetGroup")
+	testpkg.CreateTestGroupTeacher(t, tc.db, group.ID, teacher.ID)
+
+	// Substitution with an unassigned regular slot so both substitution
+	// projections (GetMyGroups relations + GetSubstitutedGroupIDs) have a row.
+	today := timezone.TodayDate()
+	subGroup := testpkg.CreateTestEducationGroup(t, tc.db, "IdentityBudgetSubGroup")
+	sub := testpkg.CreateTestGroupSubstitution(t, tc.db, subGroup.ID, nil, teacher.StaffID,
+		today.AddDays(-1), today.AddDays(3))
+
+	var studentIDs []int64
+	for i := range 3 {
+		student := testpkg.CreateTestStudent(t, tc.db, "IdentityBudget", fmt.Sprintf("Kind%d", i), "IB1")
+		testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+		studentIDs = append(studentIDs, student.ID)
+	}
+
+	defer func() {
+		testpkg.CleanupActivityFixtures(t, tc.db, append(studentIDs, sub.ID, subGroup.ID, group.ID, teacher.ID)...)
+	}()
+
+	counter := &identityStageCounter{queries: make(map[string][]string)}
+	tc.db.AddQueryHook(counter)
+	counter.reset()
+
+	req := testutil.NewRequest("GET", fmt.Sprintf("/ogs-group-live?group_id=%d", group.ID), nil)
+	rr := authExec(t, tc, req, testutil.TeacherTestClaims(int(account.ID)), ogsLivePerms)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	for stage, queries := range map[string][]string{
+		"person":        counter.captured("person"),
+		"staff":         counter.captured("staff"),
+		"teacher":       counter.captured("teacher"),
+		"substitutions": counter.captured("substitutions"),
+	} {
+		t.Logf("identity stage %q: %d queries", stage, len(queries))
+		for _, q := range queries {
+			t.Logf("  %s", q)
+		}
+	}
+
+	assert.Len(t, counter.captured("person"), 1, "person stage must be resolved exactly once per request")
+	assert.Len(t, counter.captured("staff"), 1, "staff stage must be resolved exactly once per request")
+	assert.Len(t, counter.captured("teacher"), 1, "teacher stage must be resolved exactly once per request")
+	// Two distinct substitution projections exist (GetMyGroups relations,
+	// GetSubstitutedGroupIDs id-set); each memoizes its own result, so 2 is
+	// the per-request floor.
+	assert.Len(t, counter.captured("substitutions"), 2, "substitution lookups must run once per projection")
+}

--- a/backend/services/usercontext/identity_request_cache.go
+++ b/backend/services/usercontext/identity_request_cache.go
@@ -1,0 +1,241 @@
+package usercontext
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/models/auth"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+type identityRequestCacheContextKey struct{}
+
+type identityCacheKey struct {
+	tenantID  int64
+	accountID int64
+}
+
+// identityRequestCache memoizes the identity chain (account → person → staff
+// → teacher → groups/substitutions) for the lifetime of a single request
+// context (issue #2099, modeled on the settings request cache from #2065).
+// Entries are keyed by (tenant_id, account_id), so a cache attached to a
+// context that touches several tenants can never serve one tenant's identity
+// to another.
+//
+// Consistency contract:
+//   - lifetime is one request; the cache dies with the request context
+//   - only successful outcomes and clean not-found results (account not
+//     linked to a person, person not staff, staff not a teacher) are
+//     memoized; DB/transport errors and GetMyGroups partial failures never are
+//   - UpdateCurrentProfile and UpdateAvatar drop the caller's whole entry
+//     before their trailing GetCurrentProfile re-read, so a same-request read
+//     after a self-write sees committed state
+//   - deliberately exempt from eviction: group transfer/cancel
+//     (api/groups) writes a substitution for a DIFFERENT staff member
+//     (self-transfer is rejected) and renders without re-reading identity;
+//     admin substitution endpoints, staff offboarding, and invitation
+//     acceptance mutate another account's chain or run for an account that is
+//     not authenticated in that request
+//   - writes committed by other transactions become visible at the latest
+//     with the next request
+//   - entries are not date-keyed: timezone.TodayDate() is stable within a
+//     request span, and the only long-lived context (SSE) resolves identity
+//     once at connection setup and never re-reads
+//   - there is deliberately NO process-wide cache and NO TTL
+type identityRequestCache struct {
+	mu      sync.Mutex
+	entries map[identityCacheKey]*identityEntry
+}
+
+// identityEntry holds the memoized stages for one (tenant, account) pair.
+// Each stage has its own loaded flag; a loaded stage with a nil value is a
+// clean "not linked" outcome, not an error.
+type identityEntry struct {
+	accountLoaded bool
+	account       *auth.Account
+	personLoaded  bool
+	person        *users.Person
+	staffLoaded   bool
+	staff         *users.Staff
+	teacherLoaded bool
+	teacher       *users.Teacher
+	groupsLoaded  bool
+	groups        []*education.Group
+	subsLoaded    bool
+	subs          map[int64]bool
+}
+
+// WithIdentityRequestCache attaches a request-scoped identity memo cache to
+// ctx. Idempotent: a context that already carries a cache is returned
+// unchanged, so stacked attachment points (router-wide and group-wide
+// middleware) share one cache instead of shadowing each other.
+func WithIdentityRequestCache(ctx context.Context) context.Context {
+	if identityRequestCacheFromContext(ctx) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, identityRequestCacheContextKey{}, &identityRequestCache{
+		entries: make(map[identityCacheKey]*identityEntry),
+	})
+}
+
+func identityRequestCacheFromContext(ctx context.Context) *identityRequestCache {
+	cache, _ := ctx.Value(identityRequestCacheContextKey{}).(*identityRequestCache)
+	return cache
+}
+
+// identityMemo resolves the request cache and the entry key for the current
+// caller. ok is false when no cache is attached (scheduler, CLI, device auth,
+// tests without the middleware) or when the context carries no authenticated
+// account — both mean "resolve without memoization".
+func identityMemo(ctx context.Context) (*identityRequestCache, identityCacheKey, bool) {
+	cache := identityRequestCacheFromContext(ctx)
+	if cache == nil {
+		return nil, identityCacheKey{}, false
+	}
+	accountID := int64(jwt.ClaimsFromCtx(ctx).ID)
+	if accountID <= 0 {
+		return nil, identityCacheKey{}, false
+	}
+	return cache, identityCacheKey{tenantID: tenant.FromContext(ctx), accountID: accountID}, true
+}
+
+// invalidateIdentity drops every memoized stage for the current caller. The
+// self-mutating profile methods call it before their trailing re-read.
+func invalidateIdentity(ctx context.Context) {
+	cache, key, ok := identityMemo(ctx)
+	if !ok {
+		return
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	delete(cache.entries, key)
+}
+
+// entryLocked returns the entry for key, creating it on demand. Callers must
+// hold c.mu.
+func (c *identityRequestCache) entryLocked(key identityCacheKey) *identityEntry {
+	entry, ok := c.entries[key]
+	if !ok {
+		entry = &identityEntry{}
+		c.entries[key] = entry
+	}
+	return entry
+}
+
+func (c *identityRequestCache) accountFor(key identityCacheKey) (*auth.Account, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.accountLoaded {
+		return nil, false
+	}
+	return entry.account, true
+}
+
+func (c *identityRequestCache) storeAccount(key identityCacheKey, account *auth.Account) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.account = account
+	entry.accountLoaded = true
+}
+
+func (c *identityRequestCache) personFor(key identityCacheKey) (*users.Person, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.personLoaded {
+		return nil, false
+	}
+	return entry.person, true
+}
+
+func (c *identityRequestCache) storePerson(key identityCacheKey, person *users.Person) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.person = person
+	entry.personLoaded = true
+}
+
+func (c *identityRequestCache) staffFor(key identityCacheKey) (*users.Staff, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.staffLoaded {
+		return nil, false
+	}
+	return entry.staff, true
+}
+
+func (c *identityRequestCache) storeStaff(key identityCacheKey, staff *users.Staff) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.staff = staff
+	entry.staffLoaded = true
+}
+
+func (c *identityRequestCache) teacherFor(key identityCacheKey) (*users.Teacher, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.teacherLoaded {
+		return nil, false
+	}
+	return entry.teacher, true
+}
+
+func (c *identityRequestCache) storeTeacher(key identityCacheKey, teacher *users.Teacher) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.teacher = teacher
+	entry.teacherLoaded = true
+}
+
+// groupsFor returns a shallow clone on every hit: ogsgrouplive sorts the
+// returned slice in place, and a caller-visible sort must not reorder the
+// memoized value.
+func (c *identityRequestCache) groupsFor(key identityCacheKey) ([]*education.Group, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.groupsLoaded {
+		return nil, false
+	}
+	return slices.Clone(entry.groups), true
+}
+
+func (c *identityRequestCache) storeGroups(key identityCacheKey, groups []*education.Group) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.groups = slices.Clone(groups)
+	entry.groupsLoaded = true
+}
+
+// substitutedFor clones for the same reason as groupsFor: the returned map
+// must not be a live alias of the memoized one.
+func (c *identityRequestCache) substitutedFor(key identityCacheKey) (map[int64]bool, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.subsLoaded {
+		return nil, false
+	}
+	return maps.Clone(entry.subs), true
+}
+
+func (c *identityRequestCache) storeSubstituted(key identityCacheKey, subs map[int64]bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.subs = maps.Clone(subs)
+	entry.subsLoaded = true
+}

--- a/backend/services/usercontext/identity_request_cache_db_test.go
+++ b/backend/services/usercontext/identity_request_cache_db_test.go
@@ -1,0 +1,259 @@
+package usercontext_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	usercontextSvc "github.com/moto-nrw/project-phoenix/services/usercontext"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// identityQueryCounter buckets SELECT statements against the identity-chain
+// lookups so tests can assert each stage is loaded at most once per request
+// context (#2099). Each matcher pairs the table with the lookup column of the
+// identity resolution, so relation hydration that merely reads the same table
+// by primary-key list (e.g. substitution staff names) stays out of the buckets.
+type identityQueryCounter struct {
+	mu      sync.Mutex
+	buckets map[string]int
+}
+
+// identityStageMatchers maps a stage to a predicate over the lowercased SQL.
+var identityStageMatchers = map[string]func(string) bool{
+	"persons": func(q string) bool {
+		return strings.Contains(q, "users.persons") && strings.Contains(q, "account_id = ")
+	},
+	"staff": func(q string) bool {
+		return strings.Contains(q, "users.staff") && strings.Contains(q, "person_id = ")
+	},
+	"teachers": func(q string) bool {
+		return strings.Contains(q, "users.teachers") && strings.Contains(q, "staff_id = ")
+	},
+	// Two SQL shapes exist: the hand-written finder emits
+	// `.substitute_staff_id = ?`, the Filter-based one `"substitute_staff_id" = ?`.
+	"substitutions": func(q string) bool {
+		return strings.Contains(q, "education.group_substitution") &&
+			(strings.Contains(q, "substitute_staff_id = ") || strings.Contains(q, `substitute_staff_id" = `))
+	},
+}
+
+func (c *identityQueryCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if !strings.HasPrefix(strings.TrimSpace(query), "select") {
+		return ctx
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for bucket, matches := range identityStageMatchers {
+		if matches(query) {
+			c.buckets[bucket]++
+		}
+	}
+	return ctx
+}
+
+func (*identityQueryCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func (c *identityQueryCounter) count(bucket string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buckets[bucket]
+}
+
+func (c *identityQueryCounter) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buckets = make(map[string]int)
+}
+
+func newIdentityQueryCounter(db *bun.DB) *identityQueryCounter {
+	counter := &identityQueryCounter{buckets: make(map[string]int)}
+	db.AddQueryHook(counter)
+	return counter
+}
+
+// resolveFullChain exercises every identity-chain read the way a busy handler
+// does: access check, teacher resolution, groups, substitutions, and the
+// composite ResolveStudentAccess (which itself nests staff + groups).
+func resolveFullChain(t *testing.T, ctx context.Context, service usercontextSvc.UserContextService) {
+	t.Helper()
+
+	_, err := service.GetCurrentStaff(ctx)
+	require.NoError(t, err)
+	_, err = service.GetCurrentTeacher(ctx)
+	require.NoError(t, err)
+	_, err = service.GetMyGroups(ctx)
+	require.NoError(t, err)
+	_, err = service.GetSubstitutedGroupIDs(ctx)
+	require.NoError(t, err)
+
+	access := usercontextSvc.ResolveStudentAccess(ctx, service, &configtest.Mock{}, slog.Default())
+	require.NotNil(t, access)
+}
+
+// TestIdentityRequestCacheDedupesChain is the #2099 acceptance test at service
+// level: with the request cache attached, every stage of the identity chain is
+// loaded from the database at most once, no matter how many chain methods run.
+func TestIdentityRequestCacheDedupesChain(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+	today := timezone.TodayDate()
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "IdentityMemo", "Teacher")
+	group := testpkg.CreateTestEducationGroup(t, db, "IdentityMemoGroup")
+	link := testpkg.CreateTestGroupTeacher(t, db, group.ID, teacher.ID)
+	subGroup := testpkg.CreateTestEducationGroup(t, db, "IdentityMemoSubGroup")
+	sub := testpkg.CreateTestGroupSubstitution(t, db, subGroup.ID, nil, teacher.StaffID,
+		today.AddDays(-1), today.AddDays(3))
+
+	defer testpkg.CleanupActivityFixtures(t, db, sub.ID, subGroup.ID, link.ID, group.ID)
+	defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+	defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	counter := newIdentityQueryCounter(db)
+
+	ctx := usercontextSvc.WithIdentityRequestCache(contextWithClaims(int(account.ID)))
+	resolveFullChain(t, ctx, service)
+
+	assert.Equal(t, 1, counter.count("persons"), "users.persons must be loaded exactly once per request")
+	assert.Equal(t, 1, counter.count("staff"), "users.staff must be loaded exactly once per request")
+	assert.Equal(t, 1, counter.count("teachers"), "users.teachers must be loaded exactly once per request")
+	// Two distinct repo projections read substitutions (GetMyGroups uses
+	// FindActiveBySubstituteWithRelations, GetSubstitutedGroupIDs uses
+	// FindActiveBySubstitute); each is memoized at its result level, so 2 is
+	// the per-request floor. Unifying the two projections is out of scope.
+	assert.Equal(t, 2, counter.count("substitutions"), "substitution lookups must run once per projection")
+
+	// A second full chain on the same context must be entirely memo-served.
+	counter.reset()
+	resolveFullChain(t, ctx, service)
+	for _, bucket := range []string{"persons", "staff", "teachers", "substitutions"} {
+		assert.Zero(t, counter.count(bucket), "repeat resolution of %s must be served from the request cache", bucket)
+	}
+}
+
+// TestIdentityWithoutCacheStillQueries proves there is no hidden global state:
+// on a plain context (scheduler, CLI, tests) every call keeps hitting the
+// database exactly as before #2099.
+func TestIdentityWithoutCacheStillQueries(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, db, "IdentityNoCache", "Teacher")
+
+	defer testpkg.CleanupTeacherFixtures(t, db, teacher.ID)
+	defer testpkg.CleanupStaffFixtures(t, db, teacher.StaffID)
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	counter := newIdentityQueryCounter(db)
+
+	ctx := contextWithClaims(int(account.ID))
+	resolveFullChain(t, ctx, service)
+
+	assert.Greater(t, counter.count("persons"), 1,
+		"without the request cache the person stage is resolved per call — memoization must be opt-in via context")
+}
+
+// TestNonTeacherStaffNotFoundIsMemoized pins the negative-caching behavior:
+// "staff without a teacher role" is a clean outcome and must not re-query
+// users.teachers on every GetMyGroups/GetCurrentTeacher call.
+func TestNonTeacherStaffNotFoundIsMemoized(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+
+	staff, account := testpkg.CreateTestStaffWithAccount(t, db, "IdentityNonTeacher", "Staff")
+
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	counter := newIdentityQueryCounter(db)
+
+	ctx := usercontextSvc.WithIdentityRequestCache(contextWithClaims(int(account.ID)))
+
+	_, err := service.GetMyGroups(ctx)
+	require.NoError(t, err)
+	_, err = service.GetMyGroups(ctx)
+	require.NoError(t, err)
+	_, err = service.GetCurrentTeacher(ctx)
+	require.Error(t, err, "staff without teacher role keeps returning ErrUserNotLinkedToTeacher")
+
+	assert.Equal(t, 1, counter.count("teachers"),
+		"the clean teacher-not-found outcome must be memoized, not re-queried")
+}
+
+// TestUpdateCurrentProfileEvictsIdentity covers the create-person branch: the
+// account has no person, the person stage is memoized as "not linked", then
+// the profile update creates a person. Without eviction the trailing re-read
+// would serve the memoized nil and return an empty name.
+func TestUpdateCurrentProfileEvictsIdentity(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+
+	email := fmt.Sprintf("identity-evict-%d@test.moto-nrw.de", time.Now().UnixNano())
+	account := testpkg.CreateTestAccount(t, db, email)
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	ctx := usercontextSvc.WithIdentityRequestCache(contextWithClaims(int(account.ID)))
+
+	// Prime the memoized "not linked" person stage.
+	_, err := service.GetCurrentPerson(ctx)
+	require.Error(t, err)
+
+	profile, err := service.UpdateCurrentProfile(ctx, map[string]interface{}{
+		"first_name": "Frisch",
+		"last_name":  "Angelegt",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Frisch", profile["first_name"],
+		"the post-write re-read must see the freshly created person, not the memoized 'not linked' outcome")
+
+	// The created person must be cleaned up too; resolve it for the deferred cleanup.
+	person, err := service.GetCurrentPerson(ctx)
+	require.NoError(t, err)
+	defer testpkg.CleanupPerson(t, db, person.ID)
+}
+
+// TestUpdateAvatarEvictsIdentity covers the account stage: UpdateAvatar writes
+// via the repository without mutating the in-memory struct, so a memoized
+// account would ship the old avatar URL in the response.
+func TestUpdateAvatarEvictsIdentity(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+
+	person, account := testpkg.CreateTestPersonWithAccount(t, db, "IdentityAvatar", "Test")
+	defer testpkg.CleanupPerson(t, db, person.ID)
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	ctx := usercontextSvc.WithIdentityRequestCache(contextWithClaims(int(account.ID)))
+
+	// Prime the memoized account stage.
+	_, err := service.GetCurrentUser(ctx)
+	require.NoError(t, err)
+
+	profile, err := service.UpdateAvatar(ctx, "/uploads/avatars/identity-evict-test.png")
+	require.NoError(t, err)
+	assert.Equal(t, "/uploads/avatars/identity-evict-test.png", profile["avatar"],
+		"the post-write re-read must see the new avatar, not the memoized account")
+}

--- a/backend/services/usercontext/identity_request_cache_internal_test.go
+++ b/backend/services/usercontext/identity_request_cache_internal_test.go
@@ -1,0 +1,141 @@
+package usercontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+func cachedCtx(accountID int, tenantID int64) context.Context {
+	ctx := tenant.WithTenantID(context.Background(), tenantID)
+	ctx = context.WithValue(ctx, jwt.CtxClaims, jwt.AppClaims{ID: accountID, TenantID: tenantID})
+	return WithIdentityRequestCache(ctx)
+}
+
+// WithIdentityRequestCache returns its input unchanged when a cache is already
+// attached, so stacked middleware shares one cache (#2099).
+func TestWithIdentityRequestCacheIsIdempotent(t *testing.T) {
+	once := WithIdentityRequestCache(context.Background())
+	assert.Equal(t, once, WithIdentityRequestCache(once))
+	assert.Same(t, identityRequestCacheFromContext(once),
+		identityRequestCacheFromContext(WithIdentityRequestCache(once)))
+}
+
+func TestIdentityMemoRequiresCacheAndClaims(t *testing.T) {
+	_, _, ok := identityMemo(context.Background())
+	assert.False(t, ok, "no cache attached")
+
+	_, _, ok = identityMemo(WithIdentityRequestCache(context.Background()))
+	assert.False(t, ok, "cache attached but no authenticated account")
+
+	cache, key, ok := identityMemo(cachedCtx(42, 7))
+	require.True(t, ok)
+	assert.NotNil(t, cache)
+	assert.Equal(t, identityCacheKey{tenantID: 7, accountID: 42}, key)
+}
+
+func TestIdentityCacheStagesMissStoreHit(t *testing.T) {
+	cache, key, ok := identityMemo(cachedCtx(42, 7))
+	require.True(t, ok)
+
+	_, hit := cache.personFor(key)
+	assert.False(t, hit, "empty cache must miss")
+
+	person := &users.Person{FirstName: "Memo", LastName: "Test"}
+	cache.storePerson(key, person)
+	got, hit := cache.personFor(key)
+	require.True(t, hit)
+	assert.Same(t, person, got)
+
+	// A loaded stage with a nil value is a clean "not linked" outcome — a hit.
+	cache.storeStaff(key, nil)
+	staff, hit := cache.staffFor(key)
+	require.True(t, hit)
+	assert.Nil(t, staff)
+
+	cache.storeTeacher(key, nil)
+	teacher, hit := cache.teacherFor(key)
+	require.True(t, hit)
+	assert.Nil(t, teacher)
+}
+
+func TestIdentityCacheIsolatesTenantsAndAccounts(t *testing.T) {
+	ctx := cachedCtx(42, 7)
+	cache, key, ok := identityMemo(ctx)
+	require.True(t, ok)
+	cache.storePerson(key, &users.Person{FirstName: "Tenant7"})
+
+	// Same cache instance, different tenant on the context: distinct key.
+	_, otherTenantKey, ok := identityMemo(context.WithValue(tenant.WithTenantID(ctx, 8), jwt.CtxClaims, jwt.AppClaims{ID: 42, TenantID: 8}))
+	require.True(t, ok)
+	_, hit := cache.personFor(otherTenantKey)
+	assert.False(t, hit, "another tenant's entry must not be served")
+
+	// Different account, same tenant.
+	_, hit = cache.personFor(identityCacheKey{tenantID: 7, accountID: 43})
+	assert.False(t, hit, "another account's entry must not be served")
+}
+
+func TestInvalidateIdentityDropsAllStages(t *testing.T) {
+	ctx := cachedCtx(42, 7)
+	cache, key, ok := identityMemo(ctx)
+	require.True(t, ok)
+
+	cache.storePerson(key, &users.Person{})
+	cache.storeStaff(key, &users.Staff{})
+	cache.storeGroups(key, []*education.Group{{Name: "1a"}})
+	cache.storeSubstituted(key, map[int64]bool{5: true})
+
+	invalidateIdentity(ctx)
+
+	for name, probe := range map[string]func() bool{
+		"person": func() bool { _, hit := cache.personFor(key); return hit },
+		"staff":  func() bool { _, hit := cache.staffFor(key); return hit },
+		"groups": func() bool { _, hit := cache.groupsFor(key); return hit },
+		"subs":   func() bool { _, hit := cache.substitutedFor(key); return hit },
+	} {
+		assert.False(t, probe(), "stage %s must be dropped after invalidate", name)
+	}
+}
+
+// ogsgrouplive sorts the GetMyGroups result in place — a caller-visible
+// mutation must never reorder or poison the memoized value.
+func TestIdentityCacheGroupsAndSubsAreDefensivelyCopied(t *testing.T) {
+	cache, key, ok := identityMemo(cachedCtx(42, 7))
+	require.True(t, ok)
+
+	stored := []*education.Group{{Name: "b"}, {Name: "a"}}
+	cache.storeGroups(key, stored)
+	// Mutating the slice we stored must not affect the cache either.
+	stored[0], stored[1] = stored[1], stored[0]
+
+	first, hit := cache.groupsFor(key)
+	require.True(t, hit)
+	require.Len(t, first, 2)
+	assert.Equal(t, "b", first[0].Name)
+
+	// Mutate the returned slice; a re-read must be unaffected.
+	first[0], first[1] = first[1], first[0]
+	second, hit := cache.groupsFor(key)
+	require.True(t, hit)
+	assert.Equal(t, "b", second[0].Name)
+
+	subs := map[int64]bool{5: true}
+	cache.storeSubstituted(key, subs)
+	subs[6] = true // mutate the stored-from map
+	got, hit := cache.substitutedFor(key)
+	require.True(t, hit)
+	assert.Equal(t, map[int64]bool{5: true}, got)
+
+	got[7] = true // mutate the returned map
+	again, hit := cache.substitutedFor(key)
+	require.True(t, hit)
+	assert.Equal(t, map[int64]bool{5: true}, again)
+}

--- a/backend/services/usercontext/interface.go
+++ b/backend/services/usercontext/interface.go
@@ -10,7 +10,12 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/users"
 )
 
-// UserContextService defines operations available in the user context service layer
+// UserContextService defines operations available in the user context service layer.
+//
+// Identity reads (account/person/staff/teacher/groups/substitutions) are
+// request-memoized when WithIdentityRequestCache is attached to the context
+// (issue #2099, done by RequestIdentityCacheMiddleware); without the cache
+// behavior is unchanged. Contract: identity_request_cache.go.
 type UserContextService interface {
 	// GetCurrentUser retrieves the currently authenticated user account
 	GetCurrentUser(ctx context.Context) (*auth.Account, error)

--- a/backend/services/usercontext/sse_subscription.go
+++ b/backend/services/usercontext/sse_subscription.go
@@ -80,6 +80,13 @@ func (s *userContextService) resolveSSEStaff(ctx context.Context) (*users.Staff,
 		return nil, "User is not a staff member", http.StatusForbidden
 	}
 
+	// Prime the request memo (#2099) so buildSSESubscription's GetMyGroups
+	// call doesn't resolve person+staff a second time for this connection.
+	if cache, key, ok := identityMemo(ctx); ok {
+		cache.storePerson(key, person)
+		cache.storeStaff(key, staff)
+	}
+
 	return staff, "", 0
 }
 

--- a/backend/services/usercontext/usercontext_service.go
+++ b/backend/services/usercontext/usercontext_service.go
@@ -115,6 +115,13 @@ func (s *userContextService) GetCurrentUser(ctx context.Context) (*auth.Account,
 		return nil, err
 	}
 
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if account, ok := cache.accountFor(key); ok && account != nil {
+			return account, nil
+		}
+	}
+
 	account, err := s.accountRepo.FindByID(ctx, int64(userID))
 	if err != nil {
 		return nil, &UserContextError{Op: "get current user", Err: err}
@@ -123,6 +130,9 @@ func (s *userContextService) GetCurrentUser(ctx context.Context) (*auth.Account,
 		return nil, &UserContextError{Op: "get current user", Err: ErrUserNotFound}
 	}
 
+	if memo {
+		cache.storeAccount(key, account)
+	}
 	return account, nil
 }
 
@@ -133,9 +143,23 @@ func (s *userContextService) GetCurrentPerson(ctx context.Context) (*users.Perso
 		return nil, err
 	}
 
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if person, ok := cache.personFor(key); ok {
+			if person == nil {
+				return nil, &UserContextError{Op: "get current person", Err: ErrUserNotLinkedToPerson}
+			}
+			return person, nil
+		}
+	}
+
 	person, err := s.personRepo.FindByAccountID(ctx, int64(userID))
 	if err != nil {
 		return nil, &UserContextError{Op: "get current person", Err: err}
+	}
+	if memo {
+		// person may be nil here — a clean "not linked" outcome worth memoizing.
+		cache.storePerson(key, person)
 	}
 	if person == nil {
 		return nil, &UserContextError{Op: "get current person", Err: ErrUserNotLinkedToPerson}
@@ -146,6 +170,16 @@ func (s *userContextService) GetCurrentPerson(ctx context.Context) (*users.Perso
 
 // GetCurrentStaff retrieves the staff member linked to the currently authenticated user
 func (s *userContextService) GetCurrentStaff(ctx context.Context) (*users.Staff, error) {
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if staff, ok := cache.staffFor(key); ok {
+			if staff == nil {
+				return nil, &UserContextError{Op: opGetCurrentStaff, Err: ErrUserNotLinkedToStaff}
+			}
+			return staff, nil
+		}
+	}
+
 	person, err := s.GetCurrentPerson(ctx)
 	if err != nil {
 		return nil, err
@@ -155,14 +189,23 @@ func (s *userContextService) GetCurrentStaff(ctx context.Context) (*users.Staff,
 	if err != nil {
 		// Check if it's a "no rows" error
 		if errors.Is(err, sql.ErrNoRows) {
+			if memo {
+				cache.storeStaff(key, nil)
+			}
 			return nil, &UserContextError{Op: opGetCurrentStaff, Err: ErrUserNotLinkedToStaff}
 		}
 		return nil, &UserContextError{Op: opGetCurrentStaff, Err: err}
 	}
 	if staff == nil {
+		if memo {
+			cache.storeStaff(key, nil)
+		}
 		return nil, &UserContextError{Op: opGetCurrentStaff, Err: ErrUserNotLinkedToStaff}
 	}
 
+	if memo {
+		cache.storeStaff(key, staff)
+	}
 	return staff, nil
 }
 
@@ -173,9 +216,33 @@ func (s *userContextService) GetCurrentTeacher(ctx context.Context) (*users.Teac
 		return nil, err
 	}
 
+	return s.resolveTeacherForStaff(ctx, staff)
+}
+
+// resolveTeacherForStaff resolves the teacher linked to an already-resolved
+// staff member. Shared by GetCurrentTeacher and GetMyGroups so both memoize
+// the same teacher stage. The error wrapping is load-bearing:
+// hasValidStaffOrTeacher relies on ErrUserNotLinkedToTeacher for the clean
+// "staff without teacher role" outcome, which is memoized as a nil teacher.
+func (s *userContextService) resolveTeacherForStaff(ctx context.Context, staff *users.Staff) (*users.Teacher, error) {
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if teacher, ok := cache.teacherFor(key); ok {
+			if teacher == nil {
+				return nil, &UserContextError{Op: "get current teacher", Err: ErrUserNotLinkedToTeacher}
+			}
+			return teacher, nil
+		}
+	}
+
 	teacher, err := s.teacherRepo.FindByStaffID(ctx, staff.ID)
 	if err != nil {
 		return nil, &UserContextError{Op: "get current teacher", Err: err}
+	}
+	if memo {
+		// teacher may be nil — staff without a teacher role is a common,
+		// clean outcome (see GetMyGroups) and is memoized as such.
+		cache.storeTeacher(key, teacher)
 	}
 	if teacher == nil {
 		return nil, &UserContextError{Op: "get current teacher", Err: ErrUserNotLinkedToTeacher}
@@ -190,20 +257,23 @@ func (s *userContextService) GetMyGroups(ctx context.Context) ([]*education.Grou
 		return nil, &UserContextError{Op: "get my groups", Err: ErrUserNotAuthenticated}
 	}
 
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if groups, ok := cache.groupsFor(key); ok {
+			return groups, nil
+		}
+	}
+
 	staff, staffErr := s.GetCurrentStaff(ctx)
 
 	// Derive teacher from the already-resolved staff to avoid duplicate identity queries.
 	// GetCurrentTeacher would call GetCurrentStaff again (which calls GetCurrentPerson),
-	// duplicating 2 DB round-trips. Instead, reuse the staff result directly.
+	// duplicating 2 DB round-trips. resolveTeacherForStaff reuses the staff result
+	// directly and shares the memoized teacher stage with GetCurrentTeacher.
 	var teacher *users.Teacher
 	var teacherErr error
 	if staffErr == nil && staff != nil {
-		teacher, teacherErr = s.teacherRepo.FindByStaffID(ctx, staff.ID)
-		if teacher == nil && teacherErr == nil {
-			teacherErr = &UserContextError{Op: "get current teacher", Err: ErrUserNotLinkedToTeacher}
-		} else if teacherErr != nil {
-			teacherErr = &UserContextError{Op: "get current teacher", Err: teacherErr}
-		}
+		teacher, teacherErr = s.resolveTeacherForStaff(ctx, staff)
 	} else {
 		teacherErr = staffErr
 	}
@@ -214,7 +284,11 @@ func (s *userContextService) GetMyGroups(ctx context.Context) ([]*education.Grou
 		return nil, &UserContextError{Op: "get my groups", Err: unexpectedErr}
 	}
 	if !valid {
-		return []*education.Group{}, nil
+		empty := []*education.Group{}
+		if memo {
+			cache.storeGroups(key, empty)
+		}
+		return empty, nil
 	}
 
 	groupMap := make(map[int64]*education.Group)
@@ -232,8 +306,13 @@ func (s *userContextService) GetMyGroups(ctx context.Context) ([]*education.Grou
 		partialErr = s.addSubstitutionGroups(ctx, staff.ID, groupMap)
 	}
 
-	groups := mapToSlice(groupMap)
-	return s.handlePartialError(groups, partialErr)
+	groups, err := s.handlePartialError(mapToSlice(groupMap), partialErr)
+	// Memoize only complete results — a partially loaded group set must not
+	// be pinned for the rest of the request.
+	if err == nil && memo {
+		cache.storeGroups(key, groups)
+	}
+	return groups, err
 }
 
 // isAuthenticated returns true when the context carries JWT claims with a
@@ -317,11 +396,21 @@ func (s *userContextService) addSubstitutionGroups(ctx context.Context, staffID 
 // user is not staff or has no active substitutions; only unexpected errors
 // are propagated.
 func (s *userContextService) GetSubstitutedGroupIDs(ctx context.Context) (map[int64]bool, error) {
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if subs, ok := cache.substitutedFor(key); ok {
+			return subs, nil
+		}
+	}
+
 	result := make(map[int64]bool)
 
 	staff, err := s.GetCurrentStaff(ctx)
 	if err != nil {
 		if isExpectedLinkageError(err) {
+			if memo {
+				cache.storeSubstituted(key, result)
+			}
 			return result, nil
 		}
 		return nil, &UserContextError{Op: "get substituted group IDs", Err: err}
@@ -337,6 +426,9 @@ func (s *userContextService) GetSubstitutedGroupIDs(ctx context.Context) (map[in
 		if sub.RegularStaffID == nil {
 			result[sub.GroupID] = true
 		}
+	}
+	if memo {
+		cache.storeSubstituted(key, result)
 	}
 	return result, nil
 }
@@ -761,6 +853,11 @@ func (s *userContextService) UpdateCurrentProfile(ctx context.Context, updates m
 		return nil, &UserContextError{Op: "update current profile", Err: err}
 	}
 
+	// The writes above may have created a person for an account whose person
+	// stage is memoized as "not linked" (or changed memoized person/account
+	// fields). Drop the entry so the trailing re-read returns committed state.
+	invalidateIdentity(ctx)
+
 	return s.GetCurrentProfile(ctx)
 }
 
@@ -877,6 +974,10 @@ func (s *userContextService) UpdateAvatar(ctx context.Context, avatarURL string)
 	}
 
 	s.cleanupOldAvatar(ctx, oldAvatarPath)
+
+	// accountRepo.UpdateAvatar does not mutate the in-memory account struct —
+	// a memoized account would ship the OLD avatar URL in the response below.
+	invalidateIdentity(ctx)
 
 	return s.GetCurrentProfile(ctx)
 }


### PR DESCRIPTION
Closes #2099. Teil der Performance-Härtung #2063, Nachfolger von #2065 (PR #2082).

## Problem

Die Identitätskette (Account → Person → Staff → Teacher → Gruppen/Vertretungen) löste innerhalb eines HTTP-Requests dieselben Daten mehrfach aus PostgreSQL auf. Das betraf besonders `GET /api/students/ogs-group-live`.

## Lösung

Ein request-gebundener Memo-Cache in `services/usercontext` speichert Identitätsdaten pro `(tenant_id, account_id)`:

- Account, Person, Staff, Teacher, `GetMyGroups` und `GetSubstitutedGroupIDs`
- Router-weit sowie in `ProtectedTenantGroup` eingebunden; das Anhängen ist idempotent und umfasst auch SSE-Verbindungen.
- `GetCurrentTeacher` und `GetMyGroups` teilen dieselbe Teacher-Auflösung.
- SSE primt Person und Staff beim Verbindungsaufbau, damit die anschließende Gruppenauflösung nicht erneut darauf zugreift.
- Gruppen-Slices und Vertretungs-Maps werden beim Speichern und Lesen kopiert, damit Aufrufer den Cache nicht verändern.

Ohne Cache im Context, etwa für Scheduler, CLI, Device-Auth und isolierte Service-Tests, bleibt das bisherige Verhalten bestehen.

## Konsistenz

- Memoisiert werden erfolgreiche Auflösungen und erwartete Nicht-Funde, nicht Datenbankfehler oder teilweise Gruppenergebnisse.
- `UpdateCurrentProfile` und `UpdateAvatar` verwerfen den eigenen Cache-Eintrag vor dem abschließenden Re-Read.
- Der Cache lebt nur für die Request-Spanne; es gibt keinen globalen Cache und keine TTL.

Für `ogs-group-live` sichern Query-Budget-Tests pro Request jeweils eine Auflösung von Person, Staff und Teacher sowie zwei getrennte Vertretungsprojektionen ab.

## Tests

Abgedeckt sind Cache-Isolation, Invalidation, defensive Kopien, erwartete Nicht-Funde, unverändertes Verhalten ohne Cache, Profil-/Avatar-Updates, SSE-Middleware und das Query-Budget des echten Routers.

```bash
docker compose run --rm server go test ./services/usercontext/... ./api/common/... ./api/students/...
```

Backend-only: keine Frontend-, Migrations- oder Settings-Änderungen.
