### PR TITLE
perf(backend): doppelte Arrival-/Pickup-Bulk-Loads pro Listen-Request entfernen

### DIFF
--- a/backend/api/students/day_planning.go
+++ b/backend/api/students/day_planning.go
@@ -163,31 +163,41 @@ func liveFilterError(active []string, date timezone.Date, isToday bool) error {
 	)
 }
 
-func (rs *Resource) enrichWithDayPlanning(ctx context.Context, responses []StudentResponse, planningDate timezone.Date, isToday bool, attendances map[int64]*activeService.AttendanceStatus) error {
+// dayPlanningTimes carries the bulk-loaded effective-time maps out of
+// enrichWithDayPlanning so later pipeline stages reuse them instead of
+// re-running the same three SELECTs per kind (#2098). Maps are keyed by
+// student ID and cover every full-access student of the pre-pagination
+// response set; both may be nil when no full-access student exists.
+type dayPlanningTimes struct {
+	arrivals map[int64]*scheduleService.EffectiveArrivalTime
+	pickups  map[int64]*scheduleService.EffectivePickupTime
+}
+
+func (rs *Resource) enrichWithDayPlanning(ctx context.Context, responses []StudentResponse, planningDate timezone.Date, isToday bool, attendances map[int64]*activeService.AttendanceStatus) (dayPlanningTimes, error) {
 	fullAccessIDs := collectFullAccessStudentIDs(responses)
 	if len(fullAccessIDs) == 0 {
-		return nil
+		return dayPlanningTimes{}, nil
 	}
 
 	arrivals, err := rs.loadDayPlanningArrivals(ctx, fullAccessIDs, planningDate)
 	if err != nil {
-		return err
+		return dayPlanningTimes{}, err
 	}
 	pickups, err := rs.loadDayPlanningPickups(ctx, fullAccessIDs, planningDate)
 	if err != nil {
-		return err
+		return dayPlanningTimes{}, err
 	}
 	timetableIDs, err := rs.loadDayPlanningTimetableIDs(ctx, fullAccessIDs, planningDate)
 	if err != nil {
-		return err
+		return dayPlanningTimes{}, err
 	}
 	pendingExcused, err := rs.loadPendingExcusedForDayPlanning(ctx, planningDate)
 	if err != nil {
-		return err
+		return dayPlanningTimes{}, err
 	}
 
 	applyDayPlanning(responses, arrivals, pickups, attendances, timetableIDs, pendingExcused, isToday)
-	return nil
+	return dayPlanningTimes{arrivals: arrivals, pickups: pickups}, nil
 }
 
 func (rs *Resource) loadDayPlanningArrivals(ctx context.Context, studentIDs []int64, date timezone.Date) (map[int64]*scheduleService.EffectiveArrivalTime, error) {

--- a/backend/api/students/export_handlers.go
+++ b/backend/api/students/export_handlers.go
@@ -225,12 +225,12 @@ func (rs *Resource) prepareDatedExportResponses(r *http.Request, responses []Stu
 	if err := rs.applyStatusDaysForDate(r.Context(), responses, planningDate.BerlinMidnight()); err != nil {
 		return common.ErrorInternalServer(err)
 	}
-	if err := rs.enrichWithDayPlanning(r.Context(), responses, planningDate, isToday, attendanceMapFromSnapshot(dataSnapshot)); err != nil {
+	planningTimes, err := rs.enrichWithDayPlanning(r.Context(), responses, planningDate, isToday, attendanceMapFromSnapshot(dataSnapshot))
+	if err != nil {
 		return common.ErrorInternalServer(err)
 	}
-	fullAccessIDs := collectFullAccessStudentIDs(responses)
-	rs.enrichWithPickupTimes(r.Context(), responses, fullAccessIDs, planningDate.BerlinMidnight())
-	rs.enrichWithArrivalTimes(r.Context(), responses, fullAccessIDs, planningDate.BerlinMidnight())
+	applyPickupTimesFromMap(responses, planningTimes.pickups)
+	applyArrivalTimesFromMap(responses, planningTimes.arrivals)
 	return nil
 }
 

--- a/backend/api/students/list_students_planning_times_budget_test.go
+++ b/backend/api/students/list_students_planning_times_budget_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/uptrace/bun"
 
 	"github.com/moto-nrw/project-phoenix/api/testutil"
-	"github.com/moto-nrw/project-phoenix/internal/timezone"
-	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
 
@@ -74,16 +72,8 @@ func (c *planningTimesCounter) captured(table string) []string {
 // enrichWithDayPlanning had already issued, so every bucket held 2.
 func TestListStudentsPlanningTimesQueryBudget(t *testing.T) {
 	tc := setupTestContext(t)
-
-	// The bulk loaders return early with zero queries on weekends (schedules
-	// only apply Mon-Fri), which would make the ==1 assertions fail vacuously.
-	berlinToday := timezone.DateOf(time.Now())
-	todayWeekday := int(berlinToday.Weekday())
-	if todayWeekday == 0 {
-		todayWeekday = 7 // Sunday
-	}
-	if todayWeekday > scheduleModel.WeekdayFriday {
-		t.Skip("Skipping planning-times budget test on weekend — schedules only apply Mon-Fri")
+	tc.resource.Now = func() time.Time {
+		return time.Date(2026, time.June, 1, 10, 0, 0, 0, time.UTC)
 	}
 
 	studentA := testpkg.CreateTestStudent(t, tc.db, "TimesBudget", "KindA", "TB1")

--- a/backend/api/students/list_students_planning_times_budget_test.go
+++ b/backend/api/students/list_students_planning_times_budget_test.go
@@ -1,0 +1,109 @@
+package students_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// planningTimesTables are the six tables behind the two bulk effective-time
+// loads (GetBulkEffectiveArrivalTimesForDate / GetBulkEffectivePickupTimesForDate,
+// three SELECTs each: exceptions, schedules, notes). Before #2098 a list
+// request with both include flags hit every one of them twice: once in
+// enrichWithDayPlanning and again in the paginated arrival/pickup enrichment.
+var planningTimesTables = []string{
+	"student_arrival_exceptions",
+	"student_arrival_schedules",
+	"student_arrival_notes",
+	"student_pickup_exceptions",
+	"student_pickup_schedules",
+	"student_pickup_notes",
+}
+
+// planningTimesCounter buckets SELECTs by the schedule table they read.
+type planningTimesCounter struct {
+	mu      sync.Mutex
+	queries map[string][]string
+}
+
+func (c *planningTimesCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	query := strings.ToLower(event.Query)
+	if !strings.HasPrefix(strings.TrimSpace(query), "select") {
+		return ctx
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, table := range planningTimesTables {
+		if strings.Contains(query, table) {
+			c.queries[table] = append(c.queries[table], event.Query)
+		}
+	}
+	return ctx
+}
+
+func (*planningTimesCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func (c *planningTimesCounter) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.queries = make(map[string][]string)
+}
+
+func (c *planningTimesCounter) captured(table string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.queries[table]...)
+}
+
+// TestListStudentsPlanningTimesQueryBudget is the #2098 acceptance test: one
+// list request with include_pickup_times and include_arrival_times runs each
+// bulk effective-time SELECT exactly once. Before the fix the paginated
+// enrichment stage re-ran the same three SELECTs per kind that
+// enrichWithDayPlanning had already issued, so every bucket held 2.
+func TestListStudentsPlanningTimesQueryBudget(t *testing.T) {
+	tc := setupTestContext(t)
+
+	// The bulk loaders return early with zero queries on weekends (schedules
+	// only apply Mon-Fri), which would make the ==1 assertions fail vacuously.
+	berlinToday := timezone.DateOf(time.Now())
+	todayWeekday := int(berlinToday.Weekday())
+	if todayWeekday == 0 {
+		todayWeekday = 7 // Sunday
+	}
+	if todayWeekday > scheduleModel.WeekdayFriday {
+		t.Skip("Skipping planning-times budget test on weekend — schedules only apply Mon-Fri")
+	}
+
+	studentA := testpkg.CreateTestStudent(t, tc.db, "TimesBudget", "KindA", "TB1")
+	studentB := testpkg.CreateTestStudent(t, tc.db, "TimesBudget", "KindB", "TB1")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, studentA.ID, studentB.ID)
+
+	counter := &planningTimesCounter{queries: make(map[string][]string)}
+	tc.db.AddQueryHook(counter)
+	counter.reset()
+
+	req := testutil.NewRequest("GET", "/?include_pickup_times=true&include_arrival_times=true&page_size=50", nil)
+	rr := authExec(t, tc, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	for _, table := range planningTimesTables {
+		queries := counter.captured(table)
+		t.Logf("table %q: %d queries", table, len(queries))
+		for _, q := range queries {
+			t.Logf("  %s", q)
+		}
+		assert.Len(t, queries, 1, "bulk load of %s must run exactly once per list request (#2098)", table)
+	}
+}

--- a/backend/api/students/response_helpers.go
+++ b/backend/api/students/response_helpers.go
@@ -476,6 +476,13 @@ func (rs *Resource) enrichWithPickupTimes(ctx context.Context, responses []Stude
 		return
 	}
 
+	applyPickupTimesFromMap(responses, pickupTimes)
+}
+
+// applyPickupTimesFromMap writes already-loaded effective pickup times onto the
+// responses without touching the database, so a pipeline stage that has the
+// bulk map in hand does not re-run the three pickup SELECTs (#2098).
+func applyPickupTimesFromMap(responses []StudentResponse, pickupTimes map[int64]*schedule.EffectivePickupTime) {
 	for i := range responses {
 		if !responses[i].HasFullAccess {
 			continue
@@ -505,6 +512,13 @@ func (rs *Resource) enrichWithArrivalTimes(ctx context.Context, responses []Stud
 		return
 	}
 
+	applyArrivalTimesFromMap(responses, arrivalTimes)
+}
+
+// applyArrivalTimesFromMap writes already-loaded effective arrival times onto
+// the responses without touching the database, so a pipeline stage that has the
+// bulk map in hand does not re-run the three arrival SELECTs (#2098).
+func applyArrivalTimesFromMap(responses []StudentResponse, arrivalTimes map[int64]*schedule.EffectiveArrivalTime) {
 	for i := range responses {
 		if !responses[i].HasFullAccess {
 			continue

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -147,7 +147,8 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
-	if err := rs.enrichWithDayPlanning(r.Context(), responses, planningDate, isToday, attendanceMapFromSnapshot(dataSnapshot)); err != nil {
+	planningTimes, err := rs.enrichWithDayPlanning(r.Context(), responses, planningDate, isToday, attendanceMapFromSnapshot(dataSnapshot))
+	if err != nil {
 		slog.Default().Error("failed to enrich student day planning", slog.String("error", err.Error()))
 		renderError(w, r, common.ErrorInternalServer(err))
 		return
@@ -164,7 +165,7 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 		responses, totalCount = applyInMemoryPagination(responses, params.page, params.pageSize)
 	}
 
-	rs.enrichPaginatedPlanningTimes(r, responses, params, dataSnapshot, planningDate, isToday)
+	enrichPaginatedPlanningTimes(responses, params, dataSnapshot, planningTimes, isToday)
 
 	// Companion ids ("läuft mit") for the day being SHOWN, not for today: the
 	// grouping is per weekday, so a list rendered for another planning date must
@@ -188,9 +189,11 @@ func (rs *Resource) listStudents(w http.ResponseWriter, r *http.Request) {
 // enrichPaginatedPlanningTimes layers the planning-date time data onto the final
 // paginated slice: today's live check-in/out times (kept off any other day so
 // current presence is never read as a plan), and, when requested, the effective
-// pickup/arrival times for the date via a single bulk query per kind. Both skip
-// redacted students — only rows the caller has full access to are enriched.
-func (rs *Resource) enrichPaginatedPlanningTimes(r *http.Request, responses []StudentResponse, params *studentListParams, dataSnapshot *common.StudentDataSnapshot, planningDate timezone.Date, isToday bool) {
+// pickup/arrival times from the maps enrichWithDayPlanning already bulk-loaded
+// for the pre-pagination superset (#2098 — no second round of the same
+// queries). Both skip redacted students — only rows the caller has full access
+// to are enriched.
+func enrichPaginatedPlanningTimes(responses []StudentResponse, params *studentListParams, dataSnapshot *common.StudentDataSnapshot, planningTimes dayPlanningTimes, isToday bool) {
 	if isToday {
 		for i := range responses {
 			if !responses[i].HasFullAccess {
@@ -200,15 +203,11 @@ func (rs *Resource) enrichPaginatedPlanningTimes(r *http.Request, responses []St
 		}
 	}
 
-	if !params.includePickupTimes && !params.includeArrivalTimes {
-		return
-	}
-	fullAccessIDs := collectFullAccessStudentIDs(responses)
 	if params.includePickupTimes {
-		rs.enrichWithPickupTimes(r.Context(), responses, fullAccessIDs, planningDate.BerlinMidnight())
+		applyPickupTimesFromMap(responses, planningTimes.pickups)
 	}
 	if params.includeArrivalTimes {
-		rs.enrichWithArrivalTimes(r.Context(), responses, fullAccessIDs, planningDate.BerlinMidnight())
+		applyArrivalTimesFromMap(responses, planningTimes.arrivals)
 	}
 }
 
@@ -437,7 +436,7 @@ func (rs *Resource) getStudent(w http.ResponseWriter, r *http.Request) {
 		}
 
 		single := []StudentResponse{response.StudentResponse}
-		if err := rs.enrichWithDayPlanning(r.Context(), single, timezone.DateFromTime(now), true, map[int64]*activeService.AttendanceStatus{
+		if _, err := rs.enrichWithDayPlanning(r.Context(), single, timezone.DateFromTime(now), true, map[int64]*activeService.AttendanceStatus{
 			student.ID: attendanceStatus,
 		}); err != nil {
 			renderError(w, r, common.ErrorInternalServer(err))


### PR DESCRIPTION
Schließt #2098.

## Problem

Bei Listen-Requests mit `include_arrival_times=true` und/oder `include_pickup_times=true` wurden die effektiven Arrival-/Pickup-Zeiten zweimal geladen: einmal für die Tagesplanung und erneut nach der Pagination. Auch der datierte Export führte diese doppelten Bulk-Loads aus.

## Lösung

- `enrichWithDayPlanning` gibt die bereits geladenen Arrival-/Pickup-Maps weiter.
- Listen- und Export-Pipeline wenden diese Maps ohne weitere Datenbankabfragen auf die Responses an.
- Die bestehenden `enrichWithArrivalTimes`- und `enrichWithPickupTimes`-Aufrufer bleiben unverändert nutzbar.
- Full-Access-/Redaction-Verhalten und Response-Format bleiben erhalten.

## Tests

- Neuer Query-Budget-Test prüft für einen Listen-Request mit beiden Include-Flags genau einen `SELECT` je Arrival-/Pickup-Exceptions-, Schedules- und Notes-Tabelle.
- Ausführen: `cd backend && go test ./api/students/...`
