### PR TITLE
fix(enrollment): Ladefehler beim Restore nicht als Not-Found maskieren

### DIFF
--- a/backend/database/repositories/enrollment/request_repository.go
+++ b/backend/database/repositories/enrollment/request_repository.go
@@ -82,7 +82,10 @@ func (r *RequestRepository) findByID(ctx context.Context, id int64, lockClause s
 	err := query.Scan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("enrollment request %d not found", id)
+			// Keep sql.ErrNoRows in the chain so services can tell a
+			// missing row from a query failure (same contract as the
+			// form schema repository).
+			return nil, fmt.Errorf("enrollment request %d not found: %w", id, sql.ErrNoRows)
 		}
 		return nil, fmt.Errorf("failed to find enrollment request: %w", err)
 	}

--- a/backend/services/enrollment/restore_service.go
+++ b/backend/services/enrollment/restore_service.go
@@ -2,6 +2,7 @@ package enrollment
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -63,7 +64,13 @@ func (s *decisionService) RestoreWithdrawn(ctx context.Context, requestID, resto
 	// them without lock inversion.
 	request, err := s.RequestRepo.FindByIDForUpdate(ctx, requestID)
 	if err != nil {
-		return nil, ErrDecisionRequestNotFound
+		// Only a genuinely missing row becomes the 404 sentinel;
+		// connection and query failures keep flowing so the handler's
+		// transient-503/default-500 mapping still sees them.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrDecisionRequestNotFound
+		}
+		return nil, fmt.Errorf("restore: load request: %w", err)
 	}
 	children, err := s.RequestChildRepo.ListByRequestIDForUpdate(ctx, requestID)
 	if err != nil {

--- a/backend/services/enrollment/restore_service_test.go
+++ b/backend/services/enrollment/restore_service_test.go
@@ -1,6 +1,7 @@
 package enrollment_test
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
@@ -149,6 +150,23 @@ func TestDecisionService_RestoreWithdrawn_NotFound(t *testing.T) {
 	_, err := env.decision.RestoreWithdrawn(ctx, 99_999_999, env.creatorID)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, enrollmentService.ErrDecisionRequestNotFound))
+}
+
+func TestDecisionService_RestoreWithdrawn_LoadFailurePreservesError(t *testing.T) {
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+
+	// A failed request load (here: canceled context) must keep its cause
+	// instead of collapsing into the 404 sentinel — the handler's
+	// transient-503/default-500 mapping depends on seeing the real error.
+	ctx, cancel := context.WithCancel(testpkg.TenantContext(1))
+	cancel()
+
+	_, err := env.decision.RestoreWithdrawn(ctx, 1, env.creatorID)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, enrollmentService.ErrDecisionRequestNotFound),
+		"a query failure must not surface as request-not-found")
+	assert.True(t, errors.Is(err, context.Canceled))
 }
 
 func TestDecisionService_RestoreWithdrawn_PhaseInactive(t *testing.T) {


### PR DESCRIPTION
Nachzügler zu #2159 (Issue #2157): Der dritte Review-Befund wurde dort kurz vor dem Merge gepostet, der Fix war beim Merge noch nicht gepusht. Dieser PR trägt genau diesen einen Commit nach.

## Problem

`RestoreWithdrawn` machte aus jedem `FindByIDForUpdate`-Fehler pauschal `ErrDecisionRequestNotFound`. Verbindungs- und Query-Fehler wurden damit als 404 gemeldet und liefen am 503/500-Mapping des Handlers (`renderRestoreError`) vorbei.

## Lösung

- Das Request-Repository wrappt `sql.ErrNoRows` jetzt mit `%w` (gleicher Vertrag wie das Formular-Schema-Repository), sodass Services eine fehlende Zeile von einem Query-Fehler unterscheiden können.
- Der Restore mappt nur noch die echte fehlende Zeile auf den 404-Sentinel; alle anderen Fehler fließen unverändert weiter und landen im Transient-503/Default-500-Mapping des Handlers.

## Tests

- Neuer Test `TestDecisionService_RestoreWithdrawn_LoadFailurePreservesError`: ein Ladefehler (abgebrochener Kontext) darf nicht als Not-Found auftauchen.
- Volle Suiten grün: `services/enrollment`, `api/enrollment`, `database/repositories/enrollment`; golangci-lint 0 Issues.