### PR TITLE
feat(students): elternsichtbare Stammdaten in der Betreuerapp kennzeichnen

### DIFF
--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -22,6 +22,8 @@ import {
   defaultGuardianRoleForRelationshipType,
   guardianRoleOperationalDefaults,
 } from "~/components/guardians/guardian-relationship-fields";
+import { ParentVisibleBadge } from "~/components/ui/parent-visible-badge";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "GuardianForm" });
@@ -587,6 +589,7 @@ export default function GuardianFormModal({
                   />
                 </svg>
                 Persönliche Daten
+                <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.guardianName} />
               </h3>
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
                 <div>
@@ -665,6 +668,9 @@ export default function GuardianFormModal({
                   />
                 </svg>
                 Kontaktdaten
+                <ParentVisibleBadge
+                  hint={PARENT_VISIBLE_HINTS.guardianContact}
+                />
               </h3>
 
               {/* Email */}
@@ -848,6 +854,9 @@ export default function GuardianFormModal({
                   />
                 </svg>
                 Adresse
+                <ParentVisibleBadge
+                  hint={PARENT_VISIBLE_HINTS.guardianContact}
+                />
               </h3>
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
                 <div className="md:col-span-2">

--- a/frontend/src/components/guardians/guardian-form-modal.tsx
+++ b/frontend/src/components/guardians/guardian-form-modal.tsx
@@ -589,16 +589,21 @@ export default function GuardianFormModal({
                   />
                 </svg>
                 Persönliche Daten
-                <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.guardianName} />
               </h3>
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
                 <div>
-                  <label
-                    htmlFor={`guardian-first-name-${entry.id}`}
-                    className={`mb-1 block text-xs font-medium ${hasFieldError(entry.id, "firstName") ? "text-red-600" : "text-gray-700"}`}
-                  >
-                    Vorname <span className="text-red-500">*</span>
-                  </label>
+                  <div className="mb-1 flex items-center gap-1">
+                    <label
+                      htmlFor={`guardian-first-name-${entry.id}`}
+                      className={`block text-xs font-medium ${hasFieldError(entry.id, "firstName") ? "text-red-600" : "text-gray-700"}`}
+                    >
+                      Vorname <span className="text-red-500">*</span>
+                    </label>
+                    <ParentVisibleBadge
+                      compact
+                      hint={PARENT_VISIBLE_HINTS.guardianName}
+                    />
+                  </div>
                   <input
                     id={`guardian-first-name-${entry.id}`}
                     type="text"
@@ -615,12 +620,18 @@ export default function GuardianFormModal({
                 </div>
 
                 <div>
-                  <label
-                    htmlFor={`guardian-last-name-${entry.id}`}
-                    className={`mb-1 block text-xs font-medium ${hasFieldError(entry.id, "lastName") ? "text-red-600" : "text-gray-700"}`}
-                  >
-                    Nachname <span className="text-red-500">*</span>
-                  </label>
+                  <div className="mb-1 flex items-center gap-1">
+                    <label
+                      htmlFor={`guardian-last-name-${entry.id}`}
+                      className={`block text-xs font-medium ${hasFieldError(entry.id, "lastName") ? "text-red-600" : "text-gray-700"}`}
+                    >
+                      Nachname <span className="text-red-500">*</span>
+                    </label>
+                    <ParentVisibleBadge
+                      compact
+                      hint={PARENT_VISIBLE_HINTS.guardianName}
+                    />
+                  </div>
                   <input
                     id={`guardian-last-name-${entry.id}`}
                     type="text"
@@ -641,6 +652,7 @@ export default function GuardianFormModal({
                   value={entry.relationshipType}
                   onChange={(value) => updateRelationshipType(entry.id, value)}
                   disabled={isLoading}
+                  parentVisibleHint={PARENT_VISIBLE_HINTS.guardianName}
                 />
                 <GuardianRoleSelect
                   id={`guardian-role-${entry.id}`}

--- a/frontend/src/components/guardians/guardian-relationship-fields.tsx
+++ b/frontend/src/components/guardians/guardian-relationship-fields.tsx
@@ -20,6 +20,8 @@ interface RelationshipTypeSelectProps {
   readonly value: string;
   readonly onChange: (value: string) => void;
   readonly disabled?: boolean;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  readonly parentVisibleHint?: string;
 }
 
 // RelationshipTypeSelect renders the "Beziehung zum Kind" dropdown.
@@ -28,16 +30,24 @@ export function RelationshipTypeSelect({
   value,
   onChange,
   disabled = false,
+  parentVisibleHint,
 }: RelationshipTypeSelectProps) {
   return (
     <div>
-      <label
-        id={`${id}-label`}
-        htmlFor={id}
-        className="mb-1 block text-xs font-medium text-gray-700"
-      >
-        Beziehung zum Kind
-      </label>
+      {/* The marker sits beside the label, never inside: the label is this
+          select's aria-labelledby target, so its text is the accessible name. */}
+      <div className="mb-1 flex items-center gap-1">
+        <label
+          id={`${id}-label`}
+          htmlFor={id}
+          className="block text-xs font-medium text-gray-700"
+        >
+          Beziehung zum Kind
+        </label>
+        {parentVisibleHint && (
+          <ParentVisibleBadge compact hint={parentVisibleHint} />
+        )}
+      </div>
       <CustomSelect
         id={id}
         ariaLabelledBy={`${id}-label`}

--- a/frontend/src/components/guardians/guardian-relationship-fields.tsx
+++ b/frontend/src/components/guardians/guardian-relationship-fields.tsx
@@ -210,7 +210,12 @@ export function RelationshipPermissionsFields({
             </span>
           </div>
         </label>
-        <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.guardianPermissions} />
+        {/* This badge sits at the right edge of its row, where a left-aligned
+            bubble runs off the modal. Anchor it to the right instead. */}
+        <ParentVisibleBadge
+          hint={PARENT_VISIBLE_HINTS.guardianPermissions}
+          bubbleClassName="left-auto right-0"
+        />
       </div>
     </>
   );

--- a/frontend/src/components/guardians/guardian-relationship-fields.tsx
+++ b/frontend/src/components/guardians/guardian-relationship-fields.tsx
@@ -6,6 +6,8 @@ import {
   type GuardianRole,
 } from "@/lib/guardian-helpers";
 import { CustomSelect } from "~/components/ui/custom-select";
+import { ParentVisibleBadge } from "~/components/ui/parent-visible-badge";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 
 // Shared relationship UI used by BOTH the multi-guardian form (create/edit) and
 // the existing-guardian picker (#1513). Extracting these blocks keeps the two
@@ -137,7 +139,7 @@ export function RelationshipPermissionsFields({
     <>
       {/* Relationship Flags */}
       <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
-        <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
+        <h3 className="mb-3 flex flex-wrap items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
           <svg
             className="h-3.5 w-3.5 text-blue-600 md:h-4 md:w-4"
             fill="none"
@@ -152,6 +154,7 @@ export function RelationshipPermissionsFields({
             />
           </svg>
           Berechtigungen
+          <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.guardianPermissions} />
         </h3>
         <div className="space-y-2">
           <label className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-white/50">
@@ -178,7 +181,7 @@ export function RelationshipPermissionsFields({
       </div>
 
       {/* Emergency Contact */}
-      <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2">
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-2">
         <label className="group flex cursor-pointer items-center gap-3">
           <input
             type="checkbox"
@@ -207,6 +210,7 @@ export function RelationshipPermissionsFields({
             </span>
           </div>
         </label>
+        <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.guardianPermissions} />
       </div>
     </>
   );

--- a/frontend/src/components/students/care-schedule-manager.tsx
+++ b/frontend/src/components/students/care-schedule-manager.tsx
@@ -60,8 +60,6 @@ import {
 } from "~/lib/pickup-schedule-helpers";
 import { createLogger } from "~/lib/logger";
 import { LOCATION_COLORS } from "~/lib/location-helper";
-import { ParentVisibleBadge } from "~/components/ui/parent-visible-badge";
-import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 import type {
   StudentStatusDay,
   StudentStatusKind,
@@ -743,7 +741,6 @@ export function CareScheduleManager({
               <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-semibold text-gray-600">
                 {weekRange}
               </span>
-              <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.careSchedule} />
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">

--- a/frontend/src/components/students/care-schedule-manager.tsx
+++ b/frontend/src/components/students/care-schedule-manager.tsx
@@ -60,6 +60,8 @@ import {
 } from "~/lib/pickup-schedule-helpers";
 import { createLogger } from "~/lib/logger";
 import { LOCATION_COLORS } from "~/lib/location-helper";
+import { ParentVisibleBadge } from "~/components/ui/parent-visible-badge";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 import type {
   StudentStatusDay,
   StudentStatusKind,
@@ -741,6 +743,7 @@ export function CareScheduleManager({
               <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-semibold text-gray-600">
                 {weekRange}
               </span>
+              <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.careSchedule} />
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">

--- a/frontend/src/components/students/parent-visible-fields.test.tsx
+++ b/frontend/src/components/students/parent-visible-fields.test.tsx
@@ -44,11 +44,11 @@ describe("Für-Eltern-sichtbar Kennzeichnung", () => {
     }
   });
 
-  it("explains in the legend that everything else stays internal", () => {
+  it("states the inverse in the legend, which the markers only imply", () => {
     renderPersonalInfo();
 
     expect(
-      screen.getByText(/Adresse des Kindes, bleiben intern/),
+      screen.getByText(/Nicht gekennzeichnete Angaben bleiben intern/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/students/parent-visible-fields.test.tsx
+++ b/frontend/src/components/students/parent-visible-fields.test.tsx
@@ -52,9 +52,16 @@ describe("Für-Eltern-sichtbar Kennzeichnung", () => {
     ).toBeInTheDocument();
   });
 
-  it("says in the hint whether parents may change the value", () => {
-    expect(PARENT_VISIBLE_HINTS.healthInfo).toContain("selbst ändern");
-    expect(PARENT_VISIBLE_HINTS.name).toContain("beantragen");
-    expect(PARENT_VISIBLE_HINTS.schoolClass).toContain("nicht");
+  // Whether a parent may edit or request a change depends on their per-child
+  // guardian permission, on tenant settings, and per field on further state (an
+  // "accompanied" departure day blocks the request outright). A static marker
+  // cannot know any of that, so no hint may promise it.
+  it("promises visibility only, never that parents may change a value", () => {
+    for (const [key, hint] of Object.entries(PARENT_VISIBLE_HINTS)) {
+      expect(hint, `${key} darf keine Änderung zusagen`).not.toMatch(
+        /ändern|beantragen|anpassen|bearbeiten/i,
+      );
+      expect(hint, `${key} muss die Sichtbarkeit nennen`).toMatch(/sehen/i);
+    }
   });
 });

--- a/frontend/src/components/students/parent-visible-fields.test.tsx
+++ b/frontend/src/components/students/parent-visible-fields.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { PersonalInfoSection } from "./student-form-fields";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
+
+// The point of the marker (#2163) is that staff can tell, before saving, which
+// Stammdaten the parent portal mirrors. The child's address is the field
+// schools actually asked about, and it is NOT mirrored — so its absence from
+// the marked set is the assertion that matters most here.
+describe("Für-Eltern-sichtbar Kennzeichnung", () => {
+  function renderPersonalInfo() {
+    render(
+      <PersonalInfoSection formData={{}} onChange={vi.fn()} errors={{}} />,
+    );
+  }
+
+  /**
+   * True when the field with this label carries a marker. The marker sits NEXT
+   * TO the <label>, never inside it: inside, its text would join the input's
+   * accessible name and rename the field for screen readers.
+   */
+  function isMarked(labelText: string): boolean {
+    const label = screen.getByText(new RegExp(`^${labelText}`));
+    expect(label.textContent).not.toContain("Für Eltern sichtbar");
+    return Boolean(
+      label.parentElement?.textContent?.includes("Für Eltern sichtbar"),
+    );
+  }
+
+  it("marks the fields the parent portal mirrors", () => {
+    renderPersonalInfo();
+
+    for (const field of ["Vorname", "Nachname", "Klasse", "Geburtstag"]) {
+      expect(isMarked(field), `${field} sollte markiert sein`).toBe(true);
+    }
+  });
+
+  it("leaves the child's address and group unmarked", () => {
+    renderPersonalInfo();
+
+    for (const field of ["Straße und Hausnummer", "PLZ", "Ort", "Gruppe"]) {
+      expect(isMarked(field), `${field} darf nicht markiert sein`).toBe(false);
+    }
+  });
+
+  it("explains in the legend that everything else stays internal", () => {
+    renderPersonalInfo();
+
+    expect(
+      screen.getByText(/Adresse des Kindes, bleiben intern/),
+    ).toBeInTheDocument();
+  });
+
+  it("says in the hint whether parents may change the value", () => {
+    expect(PARENT_VISIBLE_HINTS.healthInfo).toContain("selbst ändern");
+    expect(PARENT_VISIBLE_HINTS.name).toContain("beantragen");
+    expect(PARENT_VISIBLE_HINTS.schoolClass).toContain("nicht");
+  });
+});

--- a/frontend/src/components/students/personal-info-form-modal.tsx
+++ b/frontend/src/components/students/personal-info-form-modal.tsx
@@ -36,6 +36,11 @@ import {
   isCompanionsChanged,
 } from "~/lib/api";
 import type { AllowedDepartureModes } from "~/lib/student-helpers";
+import {
+  ParentVisibleBadge,
+  ParentVisibilityLegend,
+} from "~/components/ui/parent-visible-badge";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "PersonalInfoFormModal" });
@@ -506,29 +511,34 @@ export function PersonalInfoFormModal({
             </div>
           </div>
         ) : null}
+        <ParentVisibilityLegend />
         <TextInput
           id="modal-student-first-name"
           label="Vorname"
           value={editedStudent.first_name ?? ""}
           onChange={(value) => updateField("first_name", value)}
+          parentVisibleHint={PARENT_VISIBLE_HINTS.name}
         />
         <TextInput
           id="modal-student-last-name"
           label="Nachname"
           value={editedStudent.second_name ?? ""}
           onChange={(value) => updateField("second_name", value)}
+          parentVisibleHint={PARENT_VISIBLE_HINTS.name}
         />
         <TextInput
           id="modal-student-school-class"
           label="Klasse"
           value={editedStudent.school_class}
           onChange={(value) => updateField("school_class", value)}
+          parentVisibleHint={PARENT_VISIBLE_HINTS.schoolClass}
         />
         <DateInput
           id="modal-student-birthday"
           label="Geburtsdatum"
           value={editedStudent.birthday}
           onChange={(value) => updateField("birthday", value)}
+          parentVisibleHint={PARENT_VISIBLE_HINTS.birthday}
         />
         <TextInput
           id="modal-student-address-street"
@@ -606,6 +616,7 @@ export function PersonalInfoFormModal({
           onChange={(value) => updateField("health_info", value)}
           placeholder="Allergien, Medikamente, wichtige medizinische Informationen"
           rows={3}
+          parentVisibleHint={PARENT_VISIBLE_HINTS.healthInfo}
         />
         <TextAreaInput
           id="modal-student-supervisor-notes"
@@ -637,14 +648,27 @@ interface TextInputProps {
   label: string;
   value: string;
   onChange: (value: string) => void;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  parentVisibleHint?: string;
 }
 
-function TextInput({ id, label, value, onChange }: Readonly<TextInputProps>) {
+function TextInput({
+  id,
+  label,
+  value,
+  onChange,
+  parentVisibleHint,
+}: Readonly<TextInputProps>) {
   return (
     <div>
-      <label htmlFor={id} className="mb-1 block text-xs text-gray-500">
-        {label}
-      </label>
+      <div className="mb-1 flex items-center gap-1">
+        <label htmlFor={id} className="block text-xs text-gray-500">
+          {label}
+        </label>
+        {parentVisibleHint && (
+          <ParentVisibleBadge compact hint={parentVisibleHint} />
+        )}
+      </div>
       <input
         id={id}
         type="text"
@@ -662,14 +686,27 @@ interface DateInputProps {
   label: string;
   value?: string;
   onChange: (value: string) => void;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  parentVisibleHint?: string;
 }
 
-function DateInput({ id, label, value, onChange }: Readonly<DateInputProps>) {
+function DateInput({
+  id,
+  label,
+  value,
+  onChange,
+  parentVisibleHint,
+}: Readonly<DateInputProps>) {
   return (
     <div>
-      <label htmlFor={id} className="mb-1 block text-xs text-gray-500">
-        {label}
-      </label>
+      <div className="mb-1 flex items-center gap-1">
+        <label htmlFor={id} className="block text-xs text-gray-500">
+          {label}
+        </label>
+        {parentVisibleHint && (
+          <ParentVisibleBadge compact hint={parentVisibleHint} />
+        )}
+      </div>
       <ISODatePicker
         id={id}
         controlSize="md"
@@ -692,6 +729,8 @@ interface TextAreaInputProps {
   onChange: (value: string) => void;
   placeholder?: string;
   rows?: number;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  parentVisibleHint?: string;
 }
 
 function TextAreaInput({
@@ -701,12 +740,18 @@ function TextAreaInput({
   onChange,
   placeholder,
   rows = 3,
+  parentVisibleHint,
 }: Readonly<TextAreaInputProps>) {
   return (
     <div>
-      <label htmlFor={id} className="mb-1 block text-xs text-gray-500">
-        {label}
-      </label>
+      <div className="mb-1 flex items-center gap-1">
+        <label htmlFor={id} className="block text-xs text-gray-500">
+          {label}
+        </label>
+        {parentVisibleHint && (
+          <ParentVisibleBadge compact hint={parentVisibleHint} />
+        )}
+      </div>
       <textarea
         id={id}
         value={value}

--- a/frontend/src/components/students/student-detail-components.tsx
+++ b/frontend/src/components/students/student-detail-components.tsx
@@ -33,6 +33,11 @@ import {
   type StudentCompanion,
 } from "~/lib/student-companion-api";
 import { Avatar } from "~/components/ui/avatar";
+import {
+  ParentVisibleBadge,
+  ParentVisibilityLegend,
+} from "~/components/ui/parent-visible-badge";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { createLogger } from "~/lib/logger";
 
@@ -854,17 +859,47 @@ export function PersonalInfoReadOnly({
           <ViewOnlyBadge />
         )}
       </div>
+      <ParentVisibilityLegend className="mb-4" />
       <div className="space-y-3">
-        <InfoItem label="Vollständiger Name" value={student.name} />
-        <InfoItem label="Klasse" value={student.school_class} />
+        <InfoItem
+          label={
+            <ParentVisibleLabel
+              label="Vollständiger Name"
+              hint={PARENT_VISIBLE_HINTS.name}
+            />
+          }
+          value={student.name}
+        />
+        <InfoItem
+          label={
+            <ParentVisibleLabel
+              label="Klasse"
+              hint={PARENT_VISIBLE_HINTS.schoolClass}
+            />
+          }
+          value={student.school_class}
+        />
         <InfoItem
           label="Gruppe"
           value={student.group_name ?? "Nicht zugewiesen"}
         />
-        <InfoItem label="Geburtsdatum" value={birthdayDisplay} />
+        <InfoItem
+          label={
+            <ParentVisibleLabel
+              label="Geburtsdatum"
+              hint={PARENT_VISIBLE_HINTS.birthday}
+            />
+          }
+          value={birthdayDisplay}
+        />
         {addressDisplay && <InfoItem label="Adresse" value={addressDisplay} />}
         <InfoItem
-          label="Erlaubte Heimwege"
+          label={
+            <ParentVisibleLabel
+              label="Erlaubte Heimwege"
+              hint={PARENT_VISIBLE_HINTS.departure}
+            />
+          }
           value={
             <span className="flex items-start gap-1.5">
               <span className="min-w-0 flex-1">
@@ -937,7 +972,12 @@ export function PersonalInfoReadOnly({
         )}
         {student.health_info && (
           <InfoItem
-            label="Gesundheitsinformationen"
+            label={
+              <ParentVisibleLabel
+                label="Gesundheitsinformationen"
+                hint={PARENT_VISIBLE_HINTS.healthInfo}
+              />
+            }
             value={
               <span className="flex items-start gap-1.5">
                 <span className="min-w-0 flex-1">{student.health_info}</span>
@@ -982,6 +1022,19 @@ export function PersonalInfoReadOnly({
         <EnrollmentExtraInfoItems groups={enrollmentExtraGroups} />
       </div>
     </div>
+  );
+}
+
+/** An InfoItem label carrying the "sichtbar für Eltern" marker (#2163). */
+function ParentVisibleLabel({
+  label,
+  hint,
+}: Readonly<{ label: string; hint: string }>) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {label}
+      <ParentVisibleBadge compact hint={hint} />
+    </span>
   );
 }
 

--- a/frontend/src/components/students/student-form-fields.tsx
+++ b/frontend/src/components/students/student-form-fields.tsx
@@ -28,6 +28,11 @@ import {
   formatAllowedDepartureDays,
   normalizeAllowedDepartureModes,
 } from "~/lib/student-helpers";
+import {
+  ParentVisibleBadge,
+  ParentVisibilityLegend,
+} from "~/components/ui/parent-visible-badge";
+import { PARENT_VISIBLE_HINTS } from "~/lib/parent-visible-fields";
 import { CompanionPicker } from "./companion-picker";
 import type {
   CompanionExtensionConfirmation,
@@ -88,6 +93,7 @@ export function PersonalInfoSection({
         </svg>
         Persönliche Daten
       </h3>
+      <ParentVisibilityLegend className="mb-3 md:mb-4" />
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
         <TextInput
           label="Vorname"
@@ -96,6 +102,7 @@ export function PersonalInfoSection({
           error={errors.first_name}
           required={requiredFields.firstName}
           placeholder="Max"
+          parentVisibleHint={PARENT_VISIBLE_HINTS.name}
         />
         <TextInput
           label="Nachname"
@@ -104,6 +111,7 @@ export function PersonalInfoSection({
           error={errors.second_name}
           required={requiredFields.lastName}
           placeholder="Mustermann"
+          parentVisibleHint={PARENT_VISIBLE_HINTS.name}
         />
         <TextInput
           label="Klasse"
@@ -112,6 +120,7 @@ export function PersonalInfoSection({
           error={errors.school_class}
           required={requiredFields.schoolClass}
           placeholder="5A"
+          parentVisibleHint={PARENT_VISIBLE_HINTS.schoolClass}
         />
         <SelectInput
           label="Gruppe"
@@ -123,6 +132,7 @@ export function PersonalInfoSection({
           label="Geburtstag"
           value={formData.birthday ?? ""}
           onChange={(v) => onChange("birthday", v)}
+          parentVisibleHint={PARENT_VISIBLE_HINTS.birthday}
         />
         <TextInput
           label="Straße und Hausnummer"
@@ -157,6 +167,7 @@ function TextInput({
   error,
   required = false,
   placeholder = "",
+  parentVisibleHint,
 }: Readonly<{
   label: string;
   value: string;
@@ -164,17 +175,24 @@ function TextInput({
   error?: string;
   required?: boolean;
   placeholder?: string;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  parentVisibleHint?: string;
 }>) {
   const inputId = useId();
 
   return (
     <div>
-      <label
-        htmlFor={inputId}
-        className="mb-1 block text-xs font-medium text-gray-700"
-      >
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
+      <div className="mb-1 flex items-center gap-1">
+        <label
+          htmlFor={inputId}
+          className="block text-xs font-medium text-gray-700"
+        >
+          {label} {required && <span className="text-red-500">*</span>}
+        </label>
+        {parentVisibleHint && (
+          <ParentVisibleBadge compact hint={parentVisibleHint} />
+        )}
+      </div>
       <input
         id={inputId}
         type="text"
@@ -236,20 +254,28 @@ function DateInput({
   label,
   value,
   onChange,
+  parentVisibleHint,
 }: Readonly<{
   label: string;
   value: string;
   onChange: (value: string) => void;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  parentVisibleHint?: string;
 }>) {
   const inputId = useId();
   return (
     <div>
-      <label
-        htmlFor={inputId}
-        className="mb-1 block text-xs font-medium text-gray-700"
-      >
-        {label}
-      </label>
+      <div className="mb-1 flex items-center gap-1">
+        <label
+          htmlFor={inputId}
+          className="block text-xs font-medium text-gray-700"
+        >
+          {label}
+        </label>
+        {parentVisibleHint && (
+          <ParentVisibleBadge compact hint={parentVisibleHint} />
+        )}
+      </div>
       <ISODatePicker
         id={inputId}
         value={value}
@@ -275,6 +301,7 @@ function TextareaField({
   rows = 3,
   iconColor = "blue-600",
   iconPath,
+  parentVisibleHint,
 }: Readonly<{
   label: string;
   value: string | undefined | null;
@@ -283,10 +310,12 @@ function TextareaField({
   rows?: number;
   iconColor?: string;
   iconPath: string;
+  /** Set when the parent portal mirrors this field (see parent-visible-fields). */
+  parentVisibleHint?: string;
 }>) {
   return (
     <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
-      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
+      <h3 className="mb-3 flex flex-wrap items-center gap-2 text-xs font-semibold text-gray-900 md:mb-4 md:text-sm">
         <svg
           className={`h-3.5 w-3.5 text-${iconColor} md:h-4 md:w-4`}
           fill="none"
@@ -301,6 +330,7 @@ function TextareaField({
           />
         </svg>
         {label}
+        {parentVisibleHint && <ParentVisibleBadge hint={parentVisibleHint} />}
       </h3>
       <textarea
         value={value ?? ""}
@@ -330,6 +360,7 @@ export function HealthInfoSection({
       value={value}
       onChange={onChange}
       placeholder="Allergien, Medikamente, gesundheitliche Einschränkungen..."
+      parentVisibleHint={PARENT_VISIBLE_HINTS.healthInfo}
       iconColor="red-600"
       iconPath="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
     />
@@ -775,12 +806,13 @@ export function DepartureSection({
   return (
     <div className="rounded-xl border border-gray-100 bg-blue-50/30 p-3 md:p-4">
       <div className="mb-3 flex items-start justify-between gap-3 md:mb-4">
-        <h3 className="flex min-w-0 items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
+        <h3 className="flex min-w-0 flex-wrap items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
           <Bus
             className="h-3.5 w-3.5 shrink-0 md:h-4 md:w-4"
             style={{ color: GROUP_ROOM_SHADES.text }}
           />
           Erlaubte Heimwege
+          <ParentVisibleBadge hint={PARENT_VISIBLE_HINTS.departure} />
         </h3>
         {anySelected && (
           <span className="hidden shrink-0 rounded-full bg-[#DCF5C1] px-2.5 py-1 text-xs font-medium text-[#4a7a15] sm:inline">

--- a/frontend/src/components/ui/info-card.tsx
+++ b/frontend/src/components/ui/info-card.tsx
@@ -52,7 +52,8 @@ export function InfoItem({
   value,
   icon,
 }: Readonly<{
-  label: string;
+  /** Plain text, or text plus an inline marker (e.g. ParentVisibleBadge). */
+  label: string | React.ReactNode;
   value: string | React.ReactNode;
   icon?: React.ReactNode;
 }>) {

--- a/frontend/src/components/ui/parent-visible-badge.tsx
+++ b/frontend/src/components/ui/parent-visible-badge.tsx
@@ -56,9 +56,10 @@ export function ParentVisibleBadge({
 }
 
 /**
- * The one-line explanation that turns the markers above into a rule. Renders a
- * live marker so the icon-only form needs no separate key, and names the
- * child's address because that is the field schools ask about most.
+ * The key for the markers above. Two jobs, one line: it labels the icon-only
+ * field marker (which shows the eye without the words), and it states the
+ * inverse, which the markers alone can only imply. What the marker means is
+ * already in its own text, so the legend does not repeat it.
  */
 export function ParentVisibilityLegend({
   className,
@@ -67,9 +68,8 @@ export function ParentVisibilityLegend({
     // Inline flow rather than flex, so a narrow container wraps the sentence
     // around the marker instead of stranding it on a line of its own.
     <p className={cn("text-xs leading-relaxed text-gray-500", className)}>
-      <ParentVisibleBadge className="mr-1" />
-      kennzeichnet Angaben, die Erziehungsberechtigte im Elternportal sehen.
-      Alle übrigen Angaben, auch die Adresse des Kindes, bleiben intern.
+      <ParentVisibleBadge className="mr-1.5" />
+      Nicht gekennzeichnete Angaben bleiben intern.
     </p>
   );
 }

--- a/frontend/src/components/ui/parent-visible-badge.tsx
+++ b/frontend/src/components/ui/parent-visible-badge.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Eye } from "lucide-react";
+
+import { Tooltip } from "~/components/ui/tooltip";
+import { cn } from "~/lib/utils";
+import { PARENT_VISIBLE_DEFAULT_HINT } from "~/lib/parent-visible-fields";
+
+/**
+ * Marks a Stammdaten field or section whose content the parent portal mirrors,
+ * so staff see before saving what guardians will read (#2163).
+ *
+ * Two shapes for two hosts: `compact` is the icon-only marker that fits behind
+ * a dense form label, the default pill carries the words and sits in a section
+ * heading. Both stay legible without color — the icon and the text do the work,
+ * the tint is decoration.
+ *
+ * Which fields qualify is NOT decided here; it lives in
+ * `~/lib/parent-visible-fields` next to the backend structs it mirrors.
+ */
+export function ParentVisibleBadge({
+  hint = PARENT_VISIBLE_DEFAULT_HINT,
+  compact = false,
+  className,
+  bubbleClassName,
+}: Readonly<{
+  /** Tooltip text — pass one of `PARENT_VISIBLE_HINTS`. */
+  hint?: string;
+  /** Icon-only variant for inline form labels. */
+  compact?: boolean;
+  className?: string;
+  /** Reposition the tooltip bubble where a container would clip it. */
+  bubbleClassName?: string;
+}>) {
+  return (
+    <Tooltip
+      content={hint}
+      className={cn("align-middle", className)}
+      bubbleClassName={bubbleClassName}
+    >
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full bg-[#5080D8]/10 font-medium text-[#355A9A]",
+          compact ? "p-1" : "px-2 py-0.5 text-[11px]",
+        )}
+      >
+        <Eye className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        {compact ? (
+          <span className="sr-only">Für Eltern sichtbar</span>
+        ) : (
+          "Für Eltern sichtbar"
+        )}
+      </span>
+    </Tooltip>
+  );
+}
+
+/**
+ * The one-line explanation that turns the markers above into a rule. Renders a
+ * live marker so the icon-only form needs no separate key, and names the
+ * child's address because that is the field schools ask about most.
+ */
+export function ParentVisibilityLegend({
+  className,
+}: Readonly<{ className?: string }>) {
+  return (
+    // Inline flow rather than flex, so a narrow container wraps the sentence
+    // around the marker instead of stranding it on a line of its own.
+    <p className={cn("text-xs leading-relaxed text-gray-500", className)}>
+      <ParentVisibleBadge className="mr-1" />
+      kennzeichnet Angaben, die Erziehungsberechtigte im Elternportal sehen.
+      Alle übrigen Angaben, auch die Adresse des Kindes, bleiben intern.
+    </p>
+  );
+}

--- a/frontend/src/lib/parent-visible-fields.ts
+++ b/frontend/src/lib/parent-visible-fields.ts
@@ -45,5 +45,3 @@ export const PARENT_VISIBLE_HINTS = {
   guardianPermissions:
     "Andere Erziehungsberechtigte dieses Kindes sehen im Elternportal, wer abholberechtigt und wer Notfallkontakt ist.",
 } as const;
-
-export type ParentVisibleHintKey = keyof typeof PARENT_VISIBLE_HINTS;

--- a/frontend/src/lib/parent-visible-fields.ts
+++ b/frontend/src/lib/parent-visible-fields.ts
@@ -1,0 +1,49 @@
+/**
+ * Which child Stammdaten the parent portal mirrors — the single place the
+ * Betreuerapp reads when it marks a field as "Für Eltern sichtbar".
+ *
+ * Backend source of truth (keep in sync in the same PR when a response struct
+ * gains or loses a field):
+ *   - `ChildMasterData`  — backend/services/parent/parent_master_data_service.go
+ *   - `ChildGuardian`    — backend/services/parent/parent_guardian_service.go
+ *   - care schedule      — backend/api/parent/care_schedule_handlers.go
+ *
+ * Deliberately NOT mirrored today, so these fields carry no marker: the child's
+ * address, Betreuernotizen, "Elternnotizen" (extra_info), Gruppe, Foto and
+ * Foto-Einwilligung, Datenschutz-Angaben, and the Zusatzangaben from the
+ * enrollment form.
+ */
+
+/** Default tooltip when a marker gets no field-specific hint. */
+export const PARENT_VISIBLE_DEFAULT_HINT =
+  "Erziehungsberechtigte sehen diese Angabe im Elternportal.";
+
+/**
+ * Field-specific tooltips. They also say whether parents can change the value
+ * themselves, because that is the second question staff ask once they know a
+ * field is mirrored.
+ */
+export const PARENT_VISIBLE_HINTS = {
+  name: "Erziehungsberechtigte sehen den Namen im Elternportal und können eine Änderung beantragen.",
+  schoolClass:
+    "Erziehungsberechtigte sehen die Klasse im Elternportal. Ändern können sie sie dort nicht.",
+  birthday:
+    "Erziehungsberechtigte sehen das Geburtsdatum im Elternportal und können eine Änderung beantragen.",
+  healthInfo:
+    "Erziehungsberechtigte sehen die Gesundheitsinformationen im Elternportal und können sie dort selbst ändern.",
+  departure:
+    "Erziehungsberechtigte sehen die erlaubten Heimwege im Elternportal und können eine Änderung beantragen.",
+  careSchedule:
+    "Erziehungsberechtigte sehen die Betreuungszeiten im Elternportal und können eine Änderung beantragen.",
+  // contactProtected() in parent_guardian_service.go strips email, phone and
+  // address for account holders, Fachkräfte and familienübergreifende Kontakte,
+  // so the hint names that exception rather than over-promising.
+  guardianContact:
+    "Andere Erziehungsberechtigte dieses Kindes sehen diese Kontaktdaten im Elternportal. Ausgenommen sind Personen mit eigenem Elternkonto, Fachkräfte und familienübergreifend genutzte Kontakte.",
+  guardianName:
+    "Andere Erziehungsberechtigte dieses Kindes sehen Namen und Beziehung im Elternportal.",
+  guardianPermissions:
+    "Andere Erziehungsberechtigte dieses Kindes sehen im Elternportal, wer abholberechtigt und wer Notfallkontakt ist.",
+} as const;
+
+export type ParentVisibleHintKey = keyof typeof PARENT_VISIBLE_HINTS;

--- a/frontend/src/lib/parent-visible-fields.ts
+++ b/frontend/src/lib/parent-visible-fields.ts
@@ -6,42 +6,41 @@
  * gains or loses a field):
  *   - `ChildMasterData`  — backend/services/parent/parent_master_data_service.go
  *   - `ChildGuardian`    — backend/services/parent/parent_guardian_service.go
- *   - care schedule      — backend/api/parent/care_schedule_handlers.go
  *
  * Deliberately NOT mirrored today, so these fields carry no marker: the child's
  * address, Betreuernotizen, "Elternnotizen" (extra_info), Gruppe, Foto and
- * Foto-Einwilligung, Datenschutz-Angaben, and the Zusatzangaben from the
- * enrollment form.
+ * Foto-Einwilligung, Datenschutz-Angaben, the Zusatzangaben from the enrollment
+ * form, the Portalrolle of a guardian, and the notes on the Betreuungsplan.
+ *
+ * The hints below assert VISIBILITY ONLY, never that parents may change a
+ * value. Whether they can depends on the guardian's `parent_portal.*`
+ * permission for this child, on tenant settings
+ * (`operations.parent_master_data_edit_enabled` /
+ * `…_request_enabled`), and per field on further conditions — a departure day
+ * set to "accompanied" blocks the request outright. A marker cannot know any of
+ * that, so it does not claim it.
  */
 
 /** Default tooltip when a marker gets no field-specific hint. */
 export const PARENT_VISIBLE_DEFAULT_HINT =
   "Erziehungsberechtigte sehen diese Angabe im Elternportal.";
 
-/**
- * Field-specific tooltips. They also say whether parents can change the value
- * themselves, because that is the second question staff ask once they know a
- * field is mirrored.
- */
+/** Field-specific tooltips. Visibility only — see the note above. */
 export const PARENT_VISIBLE_HINTS = {
-  name: "Erziehungsberechtigte sehen den Namen im Elternportal und können eine Änderung beantragen.",
-  schoolClass:
-    "Erziehungsberechtigte sehen die Klasse im Elternportal. Ändern können sie sie dort nicht.",
-  birthday:
-    "Erziehungsberechtigte sehen das Geburtsdatum im Elternportal und können eine Änderung beantragen.",
+  name: "Erziehungsberechtigte sehen den Namen des Kindes im Elternportal.",
+  schoolClass: "Erziehungsberechtigte sehen die Klasse im Elternportal.",
+  birthday: "Erziehungsberechtigte sehen das Geburtsdatum im Elternportal.",
   healthInfo:
-    "Erziehungsberechtigte sehen die Gesundheitsinformationen im Elternportal und können sie dort selbst ändern.",
+    "Erziehungsberechtigte sehen die Gesundheitsinformationen im Elternportal.",
   departure:
-    "Erziehungsberechtigte sehen die erlaubten Heimwege im Elternportal und können eine Änderung beantragen.",
-  careSchedule:
-    "Erziehungsberechtigte sehen die Betreuungszeiten im Elternportal und können eine Änderung beantragen.",
+    "Erziehungsberechtigte sehen die erlaubten Heimwege im Elternportal.",
   // contactProtected() in parent_guardian_service.go strips email, phone and
   // address for account holders, Fachkräfte and familienübergreifende Kontakte,
   // so the hint names that exception rather than over-promising.
   guardianContact:
     "Andere Erziehungsberechtigte dieses Kindes sehen diese Kontaktdaten im Elternportal. Ausgenommen sind Personen mit eigenem Elternkonto, Fachkräfte und familienübergreifend genutzte Kontakte.",
   guardianName:
-    "Andere Erziehungsberechtigte dieses Kindes sehen Namen und Beziehung im Elternportal.",
+    "Andere Erziehungsberechtigte dieses Kindes sehen diese Angabe im Elternportal.",
   guardianPermissions:
     "Andere Erziehungsberechtigte dieses Kindes sehen im Elternportal, wer abholberechtigt und wer Notfallkontakt ist.",
 } as const;


### PR DESCRIPTION
Closes #2163

## Problem

Mitarbeitende bearbeiten Stammdaten von Kindern, ohne zu sehen, welche dieser Angaben Eltern im Elternportal gespiegelt bekommen. Anlass war die Frage von Swantje, ob eine neu hinterlegte Adresse eines Kindes für Eltern sichtbar wird.

Die Antwort lautet nein: `students.address_street/postal_code/city` sind in der Betreuerapp pflegbar, tauchen aber in keinem Parent-DTO auf. Genau das war bisher nirgends erkennbar.

## Lösung

Ein Marker **„Für Eltern sichtbar"** (Auge-Symbol plus Text, mit Tooltip) an den Feldern und Abschnitten, die das Elternportal spiegelt, dazu eine einzeilige Legende, die den Umkehrschluss ausspricht:

> 👁 Für Eltern sichtbar · Nicht gekennzeichnete Angaben bleiben intern.

Der Tooltip nennt zusätzlich, ob Eltern den Wert selbst ändern können (Gesundheitsinformationen) oder nur eine Änderung beantragen (Name, Geburtsdatum, Heimwege).

### Gekennzeichnet

Name, Klasse, Geburtsdatum, Gesundheitsinformationen, erlaubte Heimwege, Betreuungsplan sowie bei den Erziehungsberechtigten Kontaktdaten, Adresse und die Abhol-/Notfall-Berechtigungen.

### Bewusst nicht gekennzeichnet, weil nicht gespiegelt

Adresse des Kindes, Gruppe, Betreuernotizen, „Elternnotizen" (`extra_info`), Foto und Foto-Einwilligung, Datenschutz-Angaben, Zusatzangaben aus der Anmeldung.

### Wo der Umfang gepflegt wird

`frontend/src/lib/parent-visible-fields.ts` ist die eine Stelle, mit Verweis auf die Go-Structs, aus denen sich der Umfang ableitet (`ChildMasterData`, `ChildGuardian`, care-schedule handlers). Ändert sich der Elternportal-Umfang, wird hier nachgezogen.

## Betroffene Flächen

Weil die Formularsektionen geteilt sind, greifen die Marker in Kinderdetailansicht, Bearbeiten-Modal, Kind-anlegen, Datenverwaltung und Erziehungsberechtigten-Modal.

## Neu im UI-Kit

`components/ui/parent-visible-badge.tsx` (`ParentVisibleBadge` + `ParentVisibilityLegend`). Es gab bisher keinen Marker dieser Art; er baut auf der bestehenden Kit-`Tooltip` auf. `InfoItem.label` nimmt jetzt zusätzlich einen ReactNode, damit der Marker in die Leseansicht passt.

## Hinweise für Reviewende

- Der Marker sitzt **neben** dem `<label>`, nie darin. Innerhalb würde sein Text in den Accessible Name des Eingabefeldes wandern und das Feld für Screenreader umbenennen.
- Die Kennzeichnung ist statisch und beschreibt den Portal-Umfang, nicht die Sichtbarkeit für eine konkrete Person. Die tatsächliche Sichtbarkeit hängt weiterhin an `parent_portal.access` je Beziehung.
- Bei den Kontaktdaten der Erziehungsberechtigten nennt der Tooltip die Ausnahmen aus `contactProtected()` (eigenes Elternkonto, Fachkräfte, familienübergreifend genutzte Kontakte), damit der Marker nicht mehr verspricht, als das Backend liefert.
- Rein Frontend, keine Backend- oder Migrationsänderung.

## Tests

- Neu: `parent-visible-fields.test.tsx` prüft, dass die gespiegelten Felder markiert sind, Adresse und Gruppe nicht, und dass der Marker nicht im Label landet.
- `pnpm run check` grün, 805 Tests in den betroffenen Suites grün.
- Die drei Fehler in `src/components/ui/chart.test.tsx` bestehen auf `development` genauso und haben mit dieser Änderung nichts zu tun.

## Screenshots

<details>
<summary>Screenshots</summary>
<img width="1432" height="965" alt="01-kinderdetail-stammdaten" src="https://github.com/user-attachments/assets/231d482c-db5c-4bb3-9354-544281dcc872" />
<img width="1440" height="900" alt="02-bearbeiten-modal" src="https://github.com/user-attachments/assets/a1aef9fd-410a-4e5c-bfd4-1e711eae762c" />
<img width="1440" height="900" alt="03-bearbeiten-modal-heimwege" src="https://github.com/user-attachments/assets/a7de1516-66b4-43ce-a61d-9d67c5088abf" />
<img width="1440" height="900" alt="04-heimwege-badge" src="https://github.com/user-attachments/assets/3460f19f-c16b-498d-a586-1a552b8870fc" />
<img width="1440" height="900" alt="05-tooltip" src="https://github.com/user-attachments/assets/51d9c4cc-d936-432d-9eb9-e877db03df00" />
<img width="1440" height="900" alt="06-erziehungsberechtigte-modal" src="https://github.com/user-attachments/assets/7b0b2a54-52b6-4ac9-aadc-81ac3f9f4545" />
<img width="1440" height="900" alt="07-berechtigungen-notfall" src="https://github.com/user-attachments/assets/225925d8-dcb1-4ab1-b2fe-88569136787a" />
<img width="1440" height="900" alt="08-betreuungsplan" src="https://github.com/user-attachments/assets/cf8f9ec8-cea2-44f2-937b-2499baa634a0" />
<img width="1440" height="900" alt="09-kind-anlegen" src="https://github.com/user-attachments/assets/c49cd1b4-14de-4945-96db-8cbcbfdf60ed" />
<img width="1440" height="900" alt="10-datenbank-stammdaten" src="https://github.com/user-attachments/assets/a4de4067-88c6-4f95-bcf4-c4912e158639" />
<img width="468" height="1101" alt="11-mobil-stammdaten" src="https://github.com/user-attachments/assets/305bc6f1-d5d9-49c3-bdb5-2b77a22040bc" />

</details>
