### PR TITLE
Add operator device transfers between schools

### DIFF
--- a/backend/api/operator/api.go
+++ b/backend/api/operator/api.go
@@ -267,6 +267,8 @@ func (rs *Resource) mountProvisioningRoutes(r chi.Router) {
 		r.Get("/", rs.provisioningResource.ListAllDevices)
 		r.Post("/", rs.provisioningResource.CreateDevice)
 		r.Post("/{id}/set-api-key", rs.provisioningResource.SetDeviceAPIKey)
+		r.Get("/{id}/transfer-status", rs.provisioningResource.GetDeviceTransferStatus)
+		r.Post("/{id}/transfer", rs.provisioningResource.TransferDevice)
 		r.Delete("/{id}", rs.provisioningResource.DeleteDevice)
 	})
 

--- a/backend/api/operator/provisioning.go
+++ b/backend/api/operator/provisioning.go
@@ -610,6 +610,10 @@ func ProvisioningErrorRenderer(err error) render.Renderer {
 	var operatorDeviceNotFound *platformSvc.OperatorDeviceNotFoundError
 	var deviceInUse *platformSvc.DeviceInUseError
 	var deviceProtected *platformSvc.DeviceProtectedError
+	var deviceTransferProtected *platformSvc.DeviceTransferProtectedError
+	var deviceTransferBlocked *platformSvc.DeviceTransferBlockedError
+	var deviceTransferOrganizationMismatch *platformSvc.DeviceTransferOrganizationMismatchError
+	var deviceTransferSameSchool *platformSvc.DeviceTransferSameSchoolError
 	var personNotFound *platformSvc.PersonNotFoundError
 	var personActiveSupervisors *platformSvc.PersonHasActiveSupervisionsError
 	var authErr *authSvc.AuthError
@@ -660,6 +664,21 @@ func ProvisioningErrorRenderer(err error) render.Renderer {
 		return ErrConflict("Device is still referenced by attendance or session records and cannot be deleted")
 	case errors.As(err, &deviceProtected):
 		return ErrForbidden("This system device cannot be deleted")
+	case errors.As(err, &deviceTransferProtected):
+		return ErrForbidden("This system device cannot be transferred")
+	case errors.As(err, &deviceTransferBlocked):
+		switch deviceTransferBlocked.Reason {
+		case platformSvc.DeviceTransferBlockedOnline:
+			return ErrConflict("Device is online and cannot be transferred")
+		case platformSvc.DeviceTransferBlockedActiveSession:
+			return ErrConflict("Device has an active session and cannot be transferred")
+		default:
+			return ErrInternal("An error occurred")
+		}
+	case errors.As(err, &deviceTransferOrganizationMismatch):
+		return ErrForbidden("Device can only be transferred within its organization")
+	case errors.As(err, &deviceTransferSameSchool):
+		return ErrConflict("Device already belongs to the target school")
 	case errors.As(err, &personNotFound):
 		return ErrNotFound("Person not found")
 	case errors.As(err, &personActiveSupervisors):
@@ -758,6 +777,17 @@ type setDeviceAPIKeyRequest struct {
 	APIKey string `json:"api_key,omitempty"`
 }
 
+type transferDeviceRequest struct {
+	TargetSchoolID int64 `json:"target_school_id"`
+}
+
+func (req *transferDeviceRequest) Bind(_ *http.Request) error {
+	if req.TargetSchoolID <= 0 {
+		return errors.New("target_school_id is required")
+	}
+	return nil
+}
+
 func (req *setDeviceAPIKeyRequest) Bind(_ *http.Request) error {
 	req.APIKey = strings.TrimSpace(req.APIKey)
 	return nil
@@ -821,6 +851,38 @@ func (rs *ProvisioningResource) DeleteDevice(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	common.Respond(w, r, http.StatusOK, nil, "Device deleted successfully")
+}
+
+func (rs *ProvisioningResource) GetDeviceTransferStatus(w http.ResponseWriter, r *http.Request) {
+	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", "invalid device ID")
+	if !ok {
+		return
+	}
+	status, err := rs.service.GetDeviceTransferStatus(r.Context(), deviceID)
+	if err != nil {
+		common.RenderError(w, r, ProvisioningErrorRenderer(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, status, "Device transfer status retrieved successfully")
+}
+
+func (rs *ProvisioningResource) TransferDevice(w http.ResponseWriter, r *http.Request) {
+	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", "invalid device ID")
+	if !ok {
+		return
+	}
+	req := &transferDeviceRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, ErrInvalidRequest(err))
+		return
+	}
+	operatorID := int64(jwt.ClaimsFromCtx(r.Context()).ID)
+	device, err := rs.service.TransferDevice(r.Context(), deviceID, req.TargetSchoolID, operatorID, getClientIP(r))
+	if err != nil {
+		common.RenderError(w, r, ProvisioningErrorRenderer(err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, device, "Device transferred successfully")
 }
 
 func (rs *ProvisioningResource) ListSchoolPersons(w http.ResponseWriter, r *http.Request) {

--- a/backend/api/operator/provisioning.go
+++ b/backend/api/operator/provisioning.go
@@ -23,6 +23,11 @@ import (
 	"github.com/uptrace/bun"
 )
 
+const (
+	internalErrorMessage   = "An error occurred"
+	invalidDeviceIDMessage = "invalid device ID"
+)
+
 // ProvisioningResource handles operator tenant provisioning endpoints.
 type ProvisioningResource struct {
 	service                    platformSvc.OperatorProvisioningService
@@ -631,7 +636,7 @@ func ProvisioningErrorRenderer(err error) render.Renderer {
 			authErr.Op == "create invitation" && !errors.As(authErr.Err, &dbErr):
 			return ErrInvalidRequest(authErr.Err)
 		default:
-			return ErrInternal("An error occurred")
+			return ErrInternal(internalErrorMessage)
 		}
 	}
 
@@ -673,7 +678,7 @@ func ProvisioningErrorRenderer(err error) render.Renderer {
 		case platformSvc.DeviceTransferBlockedActiveSession:
 			return ErrConflict("Device has an active session and cannot be transferred")
 		default:
-			return ErrInternal("An error occurred")
+			return ErrInternal(internalErrorMessage)
 		}
 	case errors.As(err, &deviceTransferOrganizationMismatch):
 		return ErrForbidden("Device can only be transferred within its organization")
@@ -684,7 +689,7 @@ func ProvisioningErrorRenderer(err error) render.Renderer {
 	case errors.As(err, &personActiveSupervisors):
 		return ErrConflict("Person has active supervisions and cannot be deleted")
 	default:
-		return ErrInternal("An error occurred")
+		return ErrInternal(internalErrorMessage)
 	}
 }
 
@@ -817,7 +822,7 @@ func (rs *ProvisioningResource) CreateDevice(w http.ResponseWriter, r *http.Requ
 }
 
 func (rs *ProvisioningResource) SetDeviceAPIKey(w http.ResponseWriter, r *http.Request) {
-	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", "invalid device ID")
+	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", invalidDeviceIDMessage)
 	if !ok {
 		return
 	}
@@ -840,7 +845,7 @@ func (rs *ProvisioningResource) SetDeviceAPIKey(w http.ResponseWriter, r *http.R
 }
 
 func (rs *ProvisioningResource) DeleteDevice(w http.ResponseWriter, r *http.Request) {
-	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", "invalid device ID")
+	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", invalidDeviceIDMessage)
 	if !ok {
 		return
 	}
@@ -854,7 +859,7 @@ func (rs *ProvisioningResource) DeleteDevice(w http.ResponseWriter, r *http.Requ
 }
 
 func (rs *ProvisioningResource) GetDeviceTransferStatus(w http.ResponseWriter, r *http.Request) {
-	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", "invalid device ID")
+	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", invalidDeviceIDMessage)
 	if !ok {
 		return
 	}
@@ -867,7 +872,7 @@ func (rs *ProvisioningResource) GetDeviceTransferStatus(w http.ResponseWriter, r
 }
 
 func (rs *ProvisioningResource) TransferDevice(w http.ResponseWriter, r *http.Request) {
-	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", "invalid device ID")
+	deviceID, ok := common.ParseInt64IDWithError(w, r, "id", invalidDeviceIDMessage)
 	if !ok {
 		return
 	}

--- a/backend/api/operator/provisioning_internal_test.go
+++ b/backend/api/operator/provisioning_internal_test.go
@@ -50,6 +50,8 @@ type mockProvisioningService struct {
 	listOrganizationDevicesFn func(context.Context, int64) ([]platformSvc.OperatorDeviceInfo, error)
 	createDeviceFn            func(context.Context, int64, string, string, *string, *string, int64, net.IP) (*platformSvc.OperatorDeviceInfo, error)
 	setDeviceAPIKeyFn         func(context.Context, int64, *string, int64, net.IP) (*platformSvc.OperatorDeviceInfo, error)
+	getDeviceTransferStatusFn func(context.Context, int64) (*platformSvc.DeviceTransferStatus, error)
+	transferDeviceFn          func(context.Context, int64, int64, int64, net.IP) (*platformSvc.OperatorDeviceInfo, error)
 	softDeleteSchoolFn        func(int64) error
 	restoreSchoolFn           func(int64) error
 	softDeleteOrgFn           func(int64) error
@@ -188,6 +190,18 @@ func (m *mockProvisioningService) CreateDevice(ctx context.Context, schoolID int
 func (m *mockProvisioningService) SetDeviceAPIKey(ctx context.Context, deviceID int64, apiKey *string, operatorID int64, clientIP net.IP) (*platformSvc.OperatorDeviceInfo, error) {
 	if m.setDeviceAPIKeyFn != nil {
 		return m.setDeviceAPIKeyFn(ctx, deviceID, apiKey, operatorID, clientIP)
+	}
+	return nil, nil
+}
+func (m *mockProvisioningService) GetDeviceTransferStatus(ctx context.Context, deviceID int64) (*platformSvc.DeviceTransferStatus, error) {
+	if m.getDeviceTransferStatusFn != nil {
+		return m.getDeviceTransferStatusFn(ctx, deviceID)
+	}
+	return nil, nil
+}
+func (m *mockProvisioningService) TransferDevice(ctx context.Context, deviceID, targetSchoolID, operatorID int64, clientIP net.IP) (*platformSvc.OperatorDeviceInfo, error) {
+	if m.transferDeviceFn != nil {
+		return m.transferDeviceFn(ctx, deviceID, targetSchoolID, operatorID, clientIP)
 	}
 	return nil, nil
 }
@@ -1391,6 +1405,79 @@ func TestProvisioningResource_SetDeviceAPIKey_NotFound(t *testing.T) {
 	resource.SetDeviceAPIKey(rr, req)
 
 	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestProvisioningResource_GetDeviceTransferStatus(t *testing.T) {
+	lastSeen := time.Now().Add(-10 * time.Minute)
+	resource := NewProvisioningResource(&mockProvisioningService{
+		getDeviceTransferStatusFn: func(_ context.Context, deviceID int64) (*platformSvc.DeviceTransferStatus, error) {
+			assert.Equal(t, int64(17), deviceID)
+			return &platformSvc.DeviceTransferStatus{CanTransfer: true, LastSeen: &lastSeen}, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/operator/devices/17/transfer-status", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "17")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rr := httptest.NewRecorder()
+
+	resource.GetDeviceTransferStatus(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	body := decodeBody(t, rr)
+	data := body["data"].(map[string]any)
+	assert.Equal(t, true, data["can_transfer"])
+	assert.Equal(t, false, data["is_protected"])
+}
+
+func TestProvisioningResource_TransferDevice(t *testing.T) {
+	resource := NewProvisioningResource(&mockProvisioningService{
+		transferDeviceFn: func(_ context.Context, deviceID, targetSchoolID, operatorID int64, clientIP net.IP) (*platformSvc.OperatorDeviceInfo, error) {
+			assert.Equal(t, int64(17), deviceID)
+			assert.Equal(t, int64(23), targetSchoolID)
+			assert.Equal(t, int64(42), operatorID)
+			assert.Equal(t, "198.51.100.30", clientIP.String())
+			return &platformSvc.OperatorDeviceInfo{ID: 99, DeviceID: "DEV-17", SchoolID: targetSchoolID}, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/operator/devices/17/transfer", bytes.NewBufferString(`{"target_school_id":23}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "198.51.100.30:4444"
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "17")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	req = withOperatorClaims(req, 42)
+	rr := httptest.NewRecorder()
+
+	resource.TransferDevice(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	body := decodeBody(t, rr)
+	data := body["data"].(map[string]any)
+	assert.Equal(t, float64(99), data["id"])
+	assert.Equal(t, float64(23), data["school_id"])
+}
+
+func TestProvisioningResource_TransferDevice_Blocked(t *testing.T) {
+	resource := NewProvisioningResource(&mockProvisioningService{
+		transferDeviceFn: func(_ context.Context, deviceID, _ int64, _ int64, _ net.IP) (*platformSvc.OperatorDeviceInfo, error) {
+			return nil, &platformSvc.DeviceTransferBlockedError{DeviceID: deviceID, Reason: platformSvc.DeviceTransferBlockedOnline}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/operator/devices/17/transfer", bytes.NewBufferString(`{"target_school_id":23}`))
+	req.Header.Set("Content-Type", "application/json")
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "17")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	req = withOperatorClaims(req, 42)
+	rr := httptest.NewRecorder()
+
+	resource.TransferDevice(rr, req)
+
+	assert.Equal(t, http.StatusConflict, rr.Code)
 }
 
 // --- CreateSchoolAccount handler tests ---

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -438,6 +438,7 @@ GET /operator/auth/mfa/trusted-devices
 GET /operator/auth/passkeys
 GET /operator/auth/passkeys/
 GET /operator/devices/
+GET /operator/devices/{id}/transfer-status
 GET /operator/invitations/
 GET /operator/organizations/
 GET /operator/organizations/summaries
@@ -760,6 +761,7 @@ POST /operator/auth/passkeys/register/verify
 POST /operator/auth/refresh
 POST /operator/devices/
 POST /operator/devices/{id}/set-api-key
+POST /operator/devices/{id}/transfer
 POST /operator/invitations/
 POST /operator/invitations/{id}/resend
 POST /operator/organizations/

--- a/backend/database/migrations/001015268_device_transfers.go
+++ b/backend/database/migrations/001015268_device_transfers.go
@@ -1,0 +1,75 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	deviceTransfersVersion     = "1.15.268"
+	deviceTransfersDescription = "Allow operator device transfers while retaining tenant history"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     deviceTransfersVersion,
+		Description: deviceTransfersDescription,
+		DependsOn:   []string{enrollmentRestorationsAuditVersion},
+	})
+	Migrations.MustRegister(deviceTransfersUp, deviceTransfersDown)
+}
+
+func deviceTransfersUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.268: Adding device transfer history...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE iot.devices
+			ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ,
+			ADD COLUMN IF NOT EXISTS transferred_to_device_id BIGINT;
+
+		ALTER TABLE iot.devices
+			DROP CONSTRAINT IF EXISTS fk_iot_devices_transferred_to_device;
+		ALTER TABLE iot.devices
+			ADD CONSTRAINT fk_iot_devices_transferred_to_device
+			FOREIGN KEY (transferred_to_device_id)
+			REFERENCES iot.devices(id) ON DELETE SET NULL;
+
+		DROP INDEX IF EXISTS iot.idx_devices_tenant_device_id;
+		CREATE UNIQUE INDEX idx_devices_tenant_device_id_active
+			ON iot.devices (tenant_id, device_id)
+			WHERE archived_at IS NULL;
+
+		CREATE INDEX IF NOT EXISTS idx_iot_devices_transfer_target
+			ON iot.devices (transferred_to_device_id)
+			WHERE transferred_to_device_id IS NOT NULL;
+	`)
+	if err != nil {
+		return fmt.Errorf("add device transfer history: %w", err)
+	}
+	return nil
+}
+
+func deviceTransfersDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.268: Removing device transfer history...")
+	_, err := db.ExecContext(ctx, `
+		UPDATE iot.devices
+		SET device_id = LEFT(device_id, 220) || '-ARCHIVED-' || id
+		WHERE archived_at IS NOT NULL;
+
+		DROP INDEX IF EXISTS iot.idx_iot_devices_transfer_target;
+		DROP INDEX IF EXISTS iot.idx_devices_tenant_device_id_active;
+
+		ALTER TABLE iot.devices
+			DROP CONSTRAINT IF EXISTS fk_iot_devices_transferred_to_device,
+			DROP COLUMN IF EXISTS transferred_to_device_id,
+			DROP COLUMN IF EXISTS archived_at;
+
+		CREATE UNIQUE INDEX idx_devices_tenant_device_id
+			ON iot.devices (tenant_id, device_id);
+	`)
+	if err != nil {
+		return fmt.Errorf("remove device transfer history: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015269_device_transfers.go
+++ b/backend/database/migrations/001015269_device_transfers.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	deviceTransfersVersion     = "1.15.268"
+	deviceTransfersVersion     = "1.15.269"
 	deviceTransfersDescription = "Allow operator device transfers while retaining tenant history"
 )
 
@@ -22,7 +22,7 @@ func init() {
 }
 
 func deviceTransfersUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.268: Adding device transfer history...")
+	fmt.Println("Migration 1.15.269: Adding device transfer history...")
 	_, err := db.ExecContext(ctx, `
 		ALTER TABLE iot.devices
 			ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ,
@@ -51,7 +51,7 @@ func deviceTransfersUp(ctx context.Context, db *bun.DB) error {
 }
 
 func deviceTransfersDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.268: Removing device transfer history...")
+	fmt.Println("Rolling back migration 1.15.269: Removing device transfer history...")
 	_, err := db.ExecContext(ctx, `
 		UPDATE iot.devices
 		SET device_id = LEFT(device_id, 220) || '-ARCHIVED-' || id

--- a/backend/database/repositories/iot/device.go
+++ b/backend/database/repositories/iot/device.go
@@ -17,6 +17,7 @@ const (
 	tableIoTDevices    = "iot.devices"
 	whereDeviceIDEqual = "device_id = ?"
 	whereStatusEqual   = "status = ?"
+	whereNotArchived   = `"device".archived_at IS NULL`
 )
 
 // DeviceRepository implements iot.DeviceRepository interface
@@ -45,7 +46,8 @@ func (r *DeviceRepository) FindByID(ctx context.Context, id interface{}) (*iot.D
 		ColumnExpr(`"device".*`).
 		ColumnExpr(`"room".name AS room_name`).
 		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "device".room_id AND "room".tenant_id = "device".tenant_id`).
-		Where(`"device".id = ?`, id)
+		Where(`"device".id = ?`, id).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -60,6 +62,25 @@ func (r *DeviceRepository) FindByID(ctx context.Context, id interface{}) (*iot.D
 	return device, nil
 }
 
+// FindByIDForUpdate retrieves and locks a current device for a transfer.
+// The archived predicate is re-evaluated after a concurrent row lock wait, so
+// at most one transfer can archive a source device.
+func (r *DeviceRepository) FindByIDForUpdate(ctx context.Context, id int64) (*iot.Device, error) {
+	device := new(iot.Device)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(device).
+		ModelTableExpr(`iot.devices AS "device"`).
+		ColumnExpr(`"device".*`).
+		Where(`"device".id = ?`, id).
+		Where(whereNotArchived).
+		For("UPDATE")
+	query = base.WithTenantFilter(ctx, query, "device")
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "find by id for update", Err: err}
+	}
+	return device, nil
+}
+
 // FindByDeviceID retrieves a device by its deviceID
 func (r *DeviceRepository) FindByDeviceID(ctx context.Context, deviceID string) (*iot.Device, error) {
 	device := new(iot.Device)
@@ -69,7 +90,8 @@ func (r *DeviceRepository) FindByDeviceID(ctx context.Context, deviceID string) 
 		ColumnExpr(`"device".*`).
 		ColumnExpr(`"room".name AS room_name`).
 		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "device".room_id AND "room".tenant_id = "device".tenant_id`).
-		Where(whereDeviceIDEqual, deviceID)
+		Where(whereDeviceIDEqual, deviceID).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -91,7 +113,8 @@ func (r *DeviceRepository) FindByAPIKey(ctx context.Context, apiKey string) (*io
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(device).
 		ModelTableExpr(`iot.devices AS "device"`).
-		Where("api_key = ?", apiKey)
+		Where("api_key = ?", apiKey).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -113,7 +136,8 @@ func (r *DeviceRepository) FindByType(ctx context.Context, deviceType string) ([
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&devices).
 		ModelTableExpr(`iot.devices AS "device"`).
-		Where("device_type = ?", deviceType)
+		Where("device_type = ?", deviceType).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -135,7 +159,8 @@ func (r *DeviceRepository) FindByStatus(ctx context.Context, status iot.DeviceSt
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&devices).
 		ModelTableExpr(`iot.devices AS "device"`).
-		Where(whereStatusEqual, status)
+		Where(whereStatusEqual, status).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -157,7 +182,8 @@ func (r *DeviceRepository) FindByRegisteredBy(ctx context.Context, personID int6
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&devices).
 		ModelTableExpr(`iot.devices AS "device"`).
-		Where("registered_by_id = ?", personID)
+		Where("registered_by_id = ?", personID).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -213,7 +239,8 @@ func (r *DeviceRepository) UpdateStatus(ctx context.Context, deviceID string, st
 		Model((*iot.Device)(nil)).
 		ModelTableExpr(tableIoTDevices).
 		Set(whereStatusEqual, status).
-		Where(whereDeviceIDEqual, deviceID)
+		Where(whereDeviceIDEqual, deviceID).
+		Where("archived_at IS NULL")
 
 	if tenantID := tenant.FromContext(ctx); tenantID > 0 {
 		query = query.Where("tenant_id = ?", tenantID)
@@ -239,7 +266,8 @@ func (r *DeviceRepository) FindOfflineDevices(ctx context.Context, offlineSince 
 	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&devices).
 		ModelTableExpr(`iot.devices AS "device"`).
-		Where("last_seen < ? OR (last_seen IS NULL AND created_at < ?)", cutoffTime, cutoffTime)
+		Where("last_seen < ? OR (last_seen IS NULL AND created_at < ?)", cutoffTime, cutoffTime).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -267,7 +295,8 @@ func (r *DeviceRepository) CountDevicesByType(ctx context.Context) (map[string]i
 		Model((*iot.Device)(nil)).
 		ModelTableExpr(`iot.devices AS "device"`).
 		Column("device_type").
-		ColumnExpr("COUNT(*) AS count")
+		ColumnExpr("COUNT(*) AS count").
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 
@@ -300,7 +329,8 @@ func (r *DeviceRepository) List(ctx context.Context, filters map[string]interfac
 		ModelTableExpr(`iot.devices AS "device"`).
 		ColumnExpr(`"device".*`).
 		ColumnExpr(`"room".name AS room_name`).
-		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "device".room_id AND "room".tenant_id = "device".tenant_id`)
+		Join(`LEFT JOIN facilities.rooms AS "room" ON "room".id = "device".room_id AND "room".tenant_id = "device".tenant_id`).
+		Where(whereNotArchived)
 
 	query = base.WithTenantFilter(ctx, query, "device")
 

--- a/backend/database/repositories/iot/device_repository_test.go
+++ b/backend/database/repositories/iot/device_repository_test.go
@@ -98,6 +98,39 @@ func TestDeviceRepository_FindByDeviceID(t *testing.T) {
 	})
 }
 
+func TestDeviceRepository_ArchivedDevicesAreHistoricalOnly(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	scope := testpkg.NewTenantScope(t, db)
+	defer testpkg.CleanupTenantTestData(t, db, scope.TenantID)
+	repo := repositories.NewFactory(db).Device
+	ctx := testpkg.TenantContext(scope.TenantID)
+	deviceID := fmt.Sprintf("transfer-history-%d", time.Now().UnixNano())
+	apiKey := fmt.Sprintf("transfer-key-%d", time.Now().UnixNano())
+	source := &iot.Device{DeviceID: deviceID, DeviceType: "terminal", Status: iot.DeviceStatusInactive, APIKey: &apiKey}
+	require.NoError(t, repo.Create(ctx, source))
+	defer testpkg.CleanupTableRecords(t, db, "iot.devices", source.ID)
+
+	_, err := db.NewRaw(`UPDATE iot.devices SET archived_at = NOW(), api_key = NULL WHERE id = ?`, source.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = repo.FindByID(ctx, source.ID)
+	require.Error(t, err)
+	_, err = repo.FindByDeviceID(ctx, deviceID)
+	require.Error(t, err)
+	_, err = repo.FindByAPIKey(ctx, apiKey)
+	require.Error(t, err)
+	_, err = repo.FindByIDForUpdate(ctx, source.ID)
+	require.Error(t, err)
+
+	target := &iot.Device{DeviceID: deviceID, DeviceType: "terminal", Status: iot.DeviceStatusActive}
+	require.NoError(t, repo.Create(ctx, target), "an archived row must not reserve the current tenant/device identity")
+	defer testpkg.CleanupTableRecords(t, db, "iot.devices", target.ID)
+	found, err := repo.FindByDeviceID(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Equal(t, target.ID, found.ID)
+}
+
 func TestDeviceRepository_Update(t *testing.T) {
 	db := testpkg.SetupTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/backend/database/repositories/platform/operator_summaries_repository.go
+++ b/backend/database/repositories/platform/operator_summaries_repository.go
@@ -42,6 +42,7 @@ SELECT
 		FROM iot.devices AS "d"
 		INNER JOIN platform.schools AS "s" ON "s".id = "d".tenant_id
 		WHERE "s".deleted_at IS NULL
+			AND "d".archived_at IS NULL
 	) AS geraete_count
 `
 
@@ -81,6 +82,7 @@ device_agg AS (
 	FROM iot.devices AS "d"
 	INNER JOIN platform.schools AS "s" ON "s".id = "d".tenant_id
 	WHERE "s".deleted_at IS NULL
+		AND "d".archived_at IS NULL
 	GROUP BY "s".organization_id
 ),
 person_agg AS (
@@ -141,6 +143,7 @@ device_agg AS (
 	SELECT "d".tenant_id,
 		COUNT(*) AS geraete_count
 	FROM iot.devices AS "d"
+	WHERE "d".archived_at IS NULL
 	GROUP BY "d".tenant_id
 ),
 person_agg AS (
@@ -223,6 +226,7 @@ SELECT
 		SELECT COUNT(*)
 		FROM iot.devices AS "d"
 		WHERE "d".tenant_id = "s".id
+			AND "d".archived_at IS NULL
 	), 0) AS geraete_count,
 	COALESCE((
 		SELECT COUNT(*)
@@ -334,7 +338,7 @@ INNER JOIN platform.organizations AS "o" ON "o".id = "s".organization_id
 // via their explicit IsDeleted pre-check before reaching this query; the
 // SQL filter is the safety net for the global ListAllDevices path.
 func (r *OperatorSummariesRepository) ListDeviceRows(ctx context.Context, filter platform.OperatorDeviceFilter) ([]platform.OperatorDeviceRow, error) {
-	q := operatorDeviceQuery + ` WHERE "s".deleted_at IS NULL AND "o".deleted_at IS NULL`
+	q := operatorDeviceQuery + ` WHERE "s".deleted_at IS NULL AND "o".deleted_at IS NULL AND "d".archived_at IS NULL`
 	var args []interface{}
 	switch {
 	case filter.DeviceRowID != nil:

--- a/backend/models/iot/device.go
+++ b/backend/models/iot/device.go
@@ -28,14 +28,16 @@ const (
 type Device struct {
 	base.Model `bun:"schema:iot,table:devices"`
 	base.TenantModel
-	DeviceID       string       `bun:"device_id,notnull" json:"device_id"`
-	DeviceType     string       `bun:"device_type,notnull" json:"device_type"`
-	Name           *string      `bun:"name" json:"name,omitempty"`
-	Status         DeviceStatus `bun:"status,notnull,default:'active'" json:"status"`
-	APIKey         *string      `bun:"api_key,unique" json:"-"`              // Never expose API key in JSON
-	LastSeen       *time.Time   `bun:"last_seen" json:"last_seen,omitempty"` // Used as last_activity for health monitoring
-	RegisteredByID *int64       `bun:"registered_by_id" json:"registered_by_id,omitempty"`
-	RoomID         *int64       `bun:"room_id" json:"room_id,omitempty"`
+	DeviceID              string       `bun:"device_id,notnull" json:"device_id"`
+	DeviceType            string       `bun:"device_type,notnull" json:"device_type"`
+	Name                  *string      `bun:"name" json:"name,omitempty"`
+	Status                DeviceStatus `bun:"status,notnull,default:'active'" json:"status"`
+	APIKey                *string      `bun:"api_key,unique" json:"-"`              // Never expose API key in JSON
+	LastSeen              *time.Time   `bun:"last_seen" json:"last_seen,omitempty"` // Used as last_activity for health monitoring
+	RegisteredByID        *int64       `bun:"registered_by_id" json:"registered_by_id,omitempty"`
+	RoomID                *int64       `bun:"room_id" json:"room_id,omitempty"`
+	ArchivedAt            *time.Time   `bun:"archived_at" json:"-"`
+	TransferredToDeviceID *int64       `bun:"transferred_to_device_id" json:"-"`
 
 	// Relations
 

--- a/backend/models/iot/repository.go
+++ b/backend/models/iot/repository.go
@@ -13,6 +13,7 @@ type DeviceRepository interface {
 
 	// Domain-specific operations
 	FindByDeviceID(ctx context.Context, deviceID string) (*Device, error)
+	FindByIDForUpdate(ctx context.Context, id int64) (*Device, error)
 	FindByAPIKey(ctx context.Context, apiKey string) (*Device, error)
 	FindByType(ctx context.Context, deviceType string) ([]*Device, error)
 	FindByStatus(ctx context.Context, status DeviceStatus) ([]*Device, error)

--- a/backend/models/platform/operator_audit_log.go
+++ b/backend/models/platform/operator_audit_log.go
@@ -17,6 +17,7 @@ const (
 	ActionAddComment           = "add_comment"
 	ActionDeleteComment        = "delete_comment"
 	ActionRotateAPIKey         = "rotate_api_key"
+	ActionTransfer             = "transfer"
 	ActionHidePost             = "hide_post"
 	ActionUnhidePost           = "unhide_post"
 	ActionDeletePost           = "delete_post"

--- a/backend/services/active/session_service_internal_test.go
+++ b/backend/services/active/session_service_internal_test.go
@@ -33,6 +33,9 @@ func (d *deviceRepoForSessionUnitTest) Create(context.Context, *iotModels.Device
 func (d *deviceRepoForSessionUnitTest) FindByID(context.Context, interface{}) (*iotModels.Device, error) {
 	return nil, nil
 }
+func (d *deviceRepoForSessionUnitTest) FindByIDForUpdate(context.Context, int64) (*iotModels.Device, error) {
+	return nil, nil
+}
 func (d *deviceRepoForSessionUnitTest) Update(context.Context, *iotModels.Device) error {
 	return nil
 }

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1906,6 +1906,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		TeacherRepo:           repos.Teacher,
 		GroupSupervisorRepo:   repos.GroupSupervisor,
 		ActiveGroupRepo:       repos.ActiveGroup,
+		Settings:              settingsService,
 		InvitationService:     invitationService,
 		AuthService:           authService,
 		AuditLogRepo:          repos.OperatorAuditLog,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1905,6 +1905,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		AccountRepo:           repos.Account,
 		TeacherRepo:           repos.Teacher,
 		GroupSupervisorRepo:   repos.GroupSupervisor,
+		ActiveGroupRepo:       repos.ActiveGroup,
 		InvitationService:     invitationService,
 		AuthService:           authService,
 		AuditLogRepo:          repos.OperatorAuditLog,

--- a/backend/services/platform/error_helpers_test.go
+++ b/backend/services/platform/error_helpers_test.go
@@ -104,10 +104,10 @@ func TestIsForeignKeyViolation(t *testing.T) {
 }
 
 // ============================================================================
-// isSchoolLookupNotFound — additional edge case
+// isLookupNotFound — additional edge case
 // ============================================================================
 
 func TestIsSchoolLookupNotFound_DatabaseErrorWithOtherError(t *testing.T) {
 	err := &modelBase.DatabaseError{Op: "find school", Err: errors.New("connection refused")}
-	assert.False(t, isSchoolLookupNotFound(err))
+	assert.False(t, isLookupNotFound(err))
 }

--- a/backend/services/platform/errors.go
+++ b/backend/services/platform/errors.go
@@ -227,6 +227,51 @@ type DeviceProtectedError struct {
 	Reason   string
 }
 
+// DeviceTransferProtectedError is returned when a system-managed device must
+// remain assigned to its original school.
+type DeviceTransferProtectedError struct {
+	DeviceID int64
+	Reason   string
+}
+
+func (e *DeviceTransferProtectedError) Error() string {
+	return fmt.Sprintf("device with ID %d cannot be transferred: %s", e.DeviceID, e.Reason)
+}
+
+const (
+	DeviceTransferBlockedOnline        = "device_online"
+	DeviceTransferBlockedActiveSession = "active_session"
+)
+
+// DeviceTransferBlockedError reports live device state that must end before a transfer.
+type DeviceTransferBlockedError struct {
+	DeviceID int64
+	Reason   string
+}
+
+func (e *DeviceTransferBlockedError) Error() string {
+	return fmt.Sprintf("device with ID %d cannot be transferred: %s", e.DeviceID, e.Reason)
+}
+
+// DeviceTransferOrganizationMismatchError prevents moving devices across organization boundaries.
+type DeviceTransferOrganizationMismatchError struct {
+	SourceSchoolID int64
+	TargetSchoolID int64
+}
+
+func (e *DeviceTransferOrganizationMismatchError) Error() string {
+	return fmt.Sprintf("schools %d and %d belong to different organizations", e.SourceSchoolID, e.TargetSchoolID)
+}
+
+// DeviceTransferSameSchoolError reports a no-op transfer request.
+type DeviceTransferSameSchoolError struct {
+	SchoolID int64
+}
+
+func (e *DeviceTransferSameSchoolError) Error() string {
+	return fmt.Sprintf("device already belongs to school %d", e.SchoolID)
+}
+
 func (e *DeviceProtectedError) Error() string {
 	return fmt.Sprintf("device with ID %d is protected: %s", e.DeviceID, e.Reason)
 }

--- a/backend/services/platform/errors_test.go
+++ b/backend/services/platform/errors_test.go
@@ -107,6 +107,25 @@ func TestOperatorDeviceNotFoundError(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestDeviceTransferErrors(t *testing.T) {
+	assert.Equal(t,
+		"device with ID 11 cannot be transferred: protected",
+		(&platform.DeviceTransferProtectedError{DeviceID: 11, Reason: "protected"}).Error(),
+	)
+	assert.Equal(t,
+		"device with ID 12 cannot be transferred: device_online",
+		(&platform.DeviceTransferBlockedError{DeviceID: 12, Reason: platform.DeviceTransferBlockedOnline}).Error(),
+	)
+	assert.Equal(t,
+		"schools 13 and 14 belong to different organizations",
+		(&platform.DeviceTransferOrganizationMismatchError{SourceSchoolID: 13, TargetSchoolID: 14}).Error(),
+	)
+	assert.Equal(t,
+		"device already belongs to school 15",
+		(&platform.DeviceTransferSameSchoolError{SchoolID: 15}).Error(),
+	)
+}
+
 func TestPersonNotFoundError(t *testing.T) {
 	err := &platform.PersonNotFoundError{PersonID: 42}
 	assert.Equal(t, "person with ID 42 not found", err.Error())

--- a/backend/services/platform/operator_provisioning_service.go
+++ b/backend/services/platform/operator_provisioning_service.go
@@ -79,8 +79,8 @@ type DeviceTransferStatus struct {
 	ActiveSession *DeviceTransferSession `json:"active_session,omitempty"`
 }
 
-// ActiveDeviceSessionRepository is the narrow device-transfer session lookup dependency.
-type ActiveDeviceSessionRepository interface {
+// ActiveDeviceSessionFinder is the narrow device-transfer session lookup dependency.
+type ActiveDeviceSessionFinder interface {
 	FindActiveByDeviceIDWithNames(ctx context.Context, deviceID int64) (*activeModels.Group, error)
 }
 
@@ -178,7 +178,7 @@ type OperatorProvisioningServiceConfig struct {
 	AccountRepo           authModels.AccountRepository
 	TeacherRepo           userModels.TeacherRepository
 	GroupSupervisorRepo   activeModels.GroupSupervisorRepository
-	ActiveGroupRepo       ActiveDeviceSessionRepository
+	ActiveGroupRepo       ActiveDeviceSessionFinder
 	InvitationService     authSvc.InvitationService
 	AuthService           authSvc.AuthService
 	AuditLogRepo          platform.OperatorAuditLogRepository
@@ -1083,6 +1083,114 @@ func (s *operatorProvisioningService) GetDeviceTransferStatus(ctx context.Contex
 	return result, err
 }
 
+func (s *operatorProvisioningService) loadTransferSource(adminCtx context.Context, id, targetSchoolID int64) (*iotModels.Device, error) {
+	source, err := s.DeviceRepo.FindByIDForUpdate(adminCtx, id)
+	if err != nil {
+		if isDeviceLookupNotFound(err) {
+			return nil, &OperatorDeviceNotFoundError{DeviceID: id}
+		}
+		return nil, err
+	}
+	if source == nil {
+		return nil, &OperatorDeviceNotFoundError{DeviceID: id}
+	}
+	if source.DeviceID == iotModels.WebManualDeviceID {
+		return nil, &DeviceTransferProtectedError{DeviceID: id, Reason: "system device required for manual web check-ins"}
+	}
+	if source.TenantID == targetSchoolID {
+		return nil, &DeviceTransferSameSchoolError{SchoolID: targetSchoolID}
+	}
+	return source, nil
+}
+
+func (s *operatorProvisioningService) validateTransferDestination(adminCtx context.Context, source *iotModels.Device, targetSchoolID int64) error {
+	sourceSchool, err := s.SchoolRepo.FindByID(adminCtx, source.TenantID)
+	if err != nil {
+		return fmt.Errorf("TransferDevice: lookup source school: %w", err)
+	}
+	if sourceSchool == nil {
+		return &SchoolNotFoundError{SchoolID: source.TenantID}
+	}
+
+	targetSchool, err := s.SchoolRepo.FindByID(adminCtx, targetSchoolID)
+	if err != nil {
+		if isSchoolLookupNotFound(err) {
+			return &SchoolNotFoundError{SchoolID: targetSchoolID}
+		}
+		return fmt.Errorf("TransferDevice: lookup target school: %w", err)
+	}
+	if targetSchool == nil {
+		return &SchoolNotFoundError{SchoolID: targetSchoolID}
+	}
+	if targetSchool.IsDeleted() {
+		return &SchoolAlreadyDeletedError{SchoolID: targetSchoolID}
+	}
+	if !targetSchool.Active {
+		return &SchoolInactiveError{SchoolID: targetSchoolID}
+	}
+	if sourceSchool.OrganizationID != targetSchool.OrganizationID {
+		return &DeviceTransferOrganizationMismatchError{SourceSchoolID: source.TenantID, TargetSchoolID: targetSchoolID}
+	}
+	return nil
+}
+
+func (s *operatorProvisioningService) ensureDeviceTransferable(adminCtx context.Context, source *iotModels.Device) error {
+	status, err := s.transferStatus(adminCtx, source)
+	if err != nil {
+		return err
+	}
+	if status.IsOnline {
+		return &DeviceTransferBlockedError{DeviceID: source.ID, Reason: DeviceTransferBlockedOnline}
+	}
+	if status.ActiveSession != nil {
+		return &DeviceTransferBlockedError{DeviceID: source.ID, Reason: DeviceTransferBlockedActiveSession}
+	}
+	return nil
+}
+
+func (s *operatorProvisioningService) archiveAndCreateTransferredDevice(adminCtx context.Context, source *iotModels.Device, targetSchoolID int64) (*iotModels.Device, error) {
+	originalStatus := source.Status
+	var transferredAPIKey *string
+	if source.APIKey != nil {
+		key := *source.APIKey
+		transferredAPIKey = &key
+	}
+
+	now := time.Now()
+	source.ArchivedAt = &now
+	source.APIKey = nil
+	source.Status = iotModels.DeviceStatusInactive
+	source.RoomID = nil
+	source.RegisteredByID = nil
+	if err := s.DeviceRepo.Update(adminCtx, source); err != nil {
+		return nil, fmt.Errorf("TransferDevice: archive source: %w", err)
+	}
+
+	target := &iotModels.Device{
+		DeviceID:   source.DeviceID,
+		DeviceType: source.DeviceType,
+		Name:       source.Name,
+		Status:     originalStatus,
+		APIKey:     transferredAPIKey,
+	}
+	target.SetTenantID(targetSchoolID)
+	if err := s.DeviceRepo.Create(tenant.WithTenantID(adminCtx, targetSchoolID), target); err != nil {
+		if modelBase.IsUniqueViolation(err) {
+			if isAPIKeyConstraintViolation(err) {
+				return nil, &ConflictError{Err: fmt.Errorf("api_key already in use")}
+			}
+			return nil, &ConflictError{Err: fmt.Errorf("device_id already exists for target school")}
+		}
+		return nil, fmt.Errorf("TransferDevice: create target: %w", err)
+	}
+
+	source.TransferredToDeviceID = &target.ID
+	if err := s.DeviceRepo.Update(adminCtx, source); err != nil {
+		return nil, fmt.Errorf("TransferDevice: link source history: %w", err)
+	}
+	return target, nil
+}
+
 // TransferDevice moves the current device identity and API key to another school
 // while retaining the archived source row for historical foreign keys.
 func (s *operatorProvisioningService) TransferDevice(ctx context.Context, id, targetSchoolID, operatorID int64, clientIP net.IP) (*OperatorDeviceInfo, error) {
@@ -1092,98 +1200,19 @@ func (s *operatorProvisioningService) TransferDevice(ctx context.Context, id, ta
 
 	var result *OperatorDeviceInfo
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
-		source, findErr := s.DeviceRepo.FindByIDForUpdate(adminCtx, id)
-		if findErr != nil {
-			if isDeviceLookupNotFound(findErr) {
-				return &OperatorDeviceNotFoundError{DeviceID: id}
-			}
-			return findErr
+		source, err := s.loadTransferSource(adminCtx, id, targetSchoolID)
+		if err != nil {
+			return err
 		}
-		if source == nil {
-			return &OperatorDeviceNotFoundError{DeviceID: id}
+		if err := s.validateTransferDestination(adminCtx, source, targetSchoolID); err != nil {
+			return err
 		}
-		if source.DeviceID == iotModels.WebManualDeviceID {
-			return &DeviceTransferProtectedError{DeviceID: id, Reason: "system device required for manual web check-ins"}
+		if err := s.ensureDeviceTransferable(adminCtx, source); err != nil {
+			return err
 		}
-		if source.TenantID == targetSchoolID {
-			return &DeviceTransferSameSchoolError{SchoolID: targetSchoolID}
-		}
-
-		sourceSchool, sourceSchoolErr := s.SchoolRepo.FindByID(adminCtx, source.TenantID)
-		if sourceSchoolErr != nil {
-			return fmt.Errorf("TransferDevice: lookup source school: %w", sourceSchoolErr)
-		}
-		if sourceSchool == nil {
-			return &SchoolNotFoundError{SchoolID: source.TenantID}
-		}
-		targetSchool, targetSchoolErr := s.SchoolRepo.FindByID(adminCtx, targetSchoolID)
-		if targetSchoolErr != nil {
-			if isSchoolLookupNotFound(targetSchoolErr) {
-				return &SchoolNotFoundError{SchoolID: targetSchoolID}
-			}
-			return fmt.Errorf("TransferDevice: lookup target school: %w", targetSchoolErr)
-		}
-		if targetSchool == nil {
-			return &SchoolNotFoundError{SchoolID: targetSchoolID}
-		}
-		if targetSchool.IsDeleted() {
-			return &SchoolAlreadyDeletedError{SchoolID: targetSchoolID}
-		}
-		if !targetSchool.Active {
-			return &SchoolInactiveError{SchoolID: targetSchoolID}
-		}
-		if sourceSchool.OrganizationID != targetSchool.OrganizationID {
-			return &DeviceTransferOrganizationMismatchError{SourceSchoolID: source.TenantID, TargetSchoolID: targetSchoolID}
-		}
-
-		status, statusErr := s.transferStatus(adminCtx, source)
-		if statusErr != nil {
-			return statusErr
-		}
-		if status.IsOnline {
-			return &DeviceTransferBlockedError{DeviceID: id, Reason: DeviceTransferBlockedOnline}
-		}
-		if status.ActiveSession != nil {
-			return &DeviceTransferBlockedError{DeviceID: id, Reason: DeviceTransferBlockedActiveSession}
-		}
-
-		originalStatus := source.Status
-		var transferredAPIKey *string
-		if source.APIKey != nil {
-			key := *source.APIKey
-			transferredAPIKey = &key
-		}
-		now := time.Now()
-		source.ArchivedAt = &now
-		source.APIKey = nil
-		source.Status = iotModels.DeviceStatusInactive
-		source.RoomID = nil
-		source.RegisteredByID = nil
-		if updateErr := s.DeviceRepo.Update(adminCtx, source); updateErr != nil {
-			return fmt.Errorf("TransferDevice: archive source: %w", updateErr)
-		}
-
-		target := &iotModels.Device{
-			DeviceID:   source.DeviceID,
-			DeviceType: source.DeviceType,
-			Name:       source.Name,
-			Status:     originalStatus,
-			APIKey:     transferredAPIKey,
-		}
-		target.SetTenantID(targetSchoolID)
-		if createErr := s.DeviceRepo.Create(tenant.WithTenantID(adminCtx, targetSchoolID), target); createErr != nil {
-			if modelBase.IsUniqueViolation(createErr) {
-				if isAPIKeyConstraintViolation(createErr) {
-					return &ConflictError{Err: fmt.Errorf("api_key already in use")}
-				}
-				return &ConflictError{Err: fmt.Errorf("device_id already exists for target school")}
-			}
-			return fmt.Errorf("TransferDevice: create target: %w", createErr)
-		}
-
-		source.TransferredToDeviceID = &target.ID
-		if updateErr := s.DeviceRepo.Update(adminCtx, source); updateErr != nil {
-			return fmt.Errorf("TransferDevice: link source history: %w", updateErr)
+		target, err := s.archiveAndCreateTransferredDevice(adminCtx, source, targetSchoolID)
+		if err != nil {
+			return err
 		}
 
 		s.logAction(adminCtx, operatorID, platform.ActionTransfer, platform.ResourceDevice, &id, clientIP, map[string]any{

--- a/backend/services/platform/operator_provisioning_service.go
+++ b/backend/services/platform/operator_provisioning_service.go
@@ -60,6 +60,30 @@ type UpdateSchoolRequest struct {
 	Hidden         bool
 }
 
+const deviceTransferOnlineThreshold = 5 * time.Minute
+
+// DeviceTransferSession describes the open kiosk session blocking a transfer.
+type DeviceTransferSession struct {
+	ID           int64     `json:"id"`
+	StartedAt    time.Time `json:"started_at"`
+	ActivityName *string   `json:"activity_name,omitempty"`
+	RoomName     *string   `json:"room_name,omitempty"`
+}
+
+// DeviceTransferStatus is the operator-facing preflight result.
+type DeviceTransferStatus struct {
+	CanTransfer   bool                   `json:"can_transfer"`
+	IsOnline      bool                   `json:"is_online"`
+	IsProtected   bool                   `json:"is_protected"`
+	LastSeen      *time.Time             `json:"last_seen,omitempty"`
+	ActiveSession *DeviceTransferSession `json:"active_session,omitempty"`
+}
+
+// ActiveDeviceSessionRepository is the narrow device-transfer session lookup dependency.
+type ActiveDeviceSessionRepository interface {
+	FindActiveByDeviceIDWithNames(ctx context.Context, deviceID int64) (*activeModels.Group, error)
+}
+
 // OperatorProvisioningService handles operator-led tenant provisioning.
 type OperatorProvisioningService interface {
 	CreateOrganization(ctx context.Context, organization *platform.Organization, operatorID int64, clientIP net.IP) (*platform.Organization, error)
@@ -79,6 +103,8 @@ type OperatorProvisioningService interface {
 	ListOrganizationDevices(ctx context.Context, organizationID int64) ([]OperatorDeviceInfo, error)
 	CreateDevice(ctx context.Context, schoolID int64, deviceID, deviceType string, name, apiKey *string, operatorID int64, clientIP net.IP) (*OperatorDeviceInfo, error)
 	SetDeviceAPIKey(ctx context.Context, id int64, apiKey *string, operatorID int64, clientIP net.IP) (*OperatorDeviceInfo, error)
+	GetDeviceTransferStatus(ctx context.Context, id int64) (*DeviceTransferStatus, error)
+	TransferDevice(ctx context.Context, id, targetSchoolID, operatorID int64, clientIP net.IP) (*OperatorDeviceInfo, error)
 	SoftDeleteSchool(ctx context.Context, schoolID, operatorID int64, clientIP net.IP) error
 	RestoreSchool(ctx context.Context, schoolID, operatorID int64, clientIP net.IP) error
 	SoftDeleteOrganization(ctx context.Context, organizationID, operatorID int64, clientIP net.IP) error
@@ -152,6 +178,7 @@ type OperatorProvisioningServiceConfig struct {
 	AccountRepo           authModels.AccountRepository
 	TeacherRepo           userModels.TeacherRepository
 	GroupSupervisorRepo   activeModels.GroupSupervisorRepository
+	ActiveGroupRepo       ActiveDeviceSessionRepository
 	InvitationService     authSvc.InvitationService
 	AuthService           authSvc.AuthService
 	AuditLogRepo          platform.OperatorAuditLogRepository
@@ -992,6 +1019,186 @@ func (s *operatorProvisioningService) DeleteDevice(ctx context.Context, id int64
 
 		return nil
 	})
+}
+
+func isDeviceLookupNotFound(err error) bool {
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
+	var dbErr *modelBase.DatabaseError
+	return errors.As(err, &dbErr) && errors.Is(dbErr.Err, sql.ErrNoRows)
+}
+
+func (s *operatorProvisioningService) transferStatus(adminCtx context.Context, device *iotModels.Device) (*DeviceTransferStatus, error) {
+	status := &DeviceTransferStatus{LastSeen: device.LastSeen}
+	if device.DeviceID == iotModels.WebManualDeviceID {
+		status.IsProtected = true
+		return status, nil
+	}
+	if device.LastSeen != nil {
+		status.IsOnline = time.Since(*device.LastSeen) <= deviceTransferOnlineThreshold
+	}
+	if s.ActiveGroupRepo == nil {
+		return nil, fmt.Errorf("device transfer: active group repository is not configured")
+	}
+	group, err := s.ActiveGroupRepo.FindActiveByDeviceIDWithNames(adminCtx, device.ID)
+	if err != nil {
+		return nil, fmt.Errorf("device transfer: find active session: %w", err)
+	}
+	if group != nil {
+		session := &DeviceTransferSession{ID: group.ID, StartedAt: group.StartTime}
+		if group.ActualGroup != nil {
+			session.ActivityName = &group.ActualGroup.Name
+		}
+		if group.Room != nil {
+			session.RoomName = &group.Room.Name
+		}
+		status.ActiveSession = session
+	}
+	status.CanTransfer = !status.IsOnline && status.ActiveSession == nil
+	return status, nil
+}
+
+// GetDeviceTransferStatus returns current blockers without mutating the device.
+func (s *operatorProvisioningService) GetDeviceTransferStatus(ctx context.Context, id int64) (*DeviceTransferStatus, error) {
+	if id <= 0 {
+		return nil, &InvalidDataError{Err: fmt.Errorf("device id is required")}
+	}
+	var result *DeviceTransferStatus
+	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
+		device, findErr := s.DeviceRepo.FindByID(adminCtx, id)
+		if findErr != nil {
+			if isDeviceLookupNotFound(findErr) {
+				return &OperatorDeviceNotFoundError{DeviceID: id}
+			}
+			return findErr
+		}
+		if device == nil {
+			return &OperatorDeviceNotFoundError{DeviceID: id}
+		}
+		var statusErr error
+		result, statusErr = s.transferStatus(adminCtx, device)
+		return statusErr
+	})
+	return result, err
+}
+
+// TransferDevice moves the current device identity and API key to another school
+// while retaining the archived source row for historical foreign keys.
+func (s *operatorProvisioningService) TransferDevice(ctx context.Context, id, targetSchoolID, operatorID int64, clientIP net.IP) (*OperatorDeviceInfo, error) {
+	if id <= 0 || targetSchoolID <= 0 {
+		return nil, &InvalidDataError{Err: fmt.Errorf("device id and target_school_id are required")}
+	}
+
+	var result *OperatorDeviceInfo
+	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
+		source, findErr := s.DeviceRepo.FindByIDForUpdate(adminCtx, id)
+		if findErr != nil {
+			if isDeviceLookupNotFound(findErr) {
+				return &OperatorDeviceNotFoundError{DeviceID: id}
+			}
+			return findErr
+		}
+		if source == nil {
+			return &OperatorDeviceNotFoundError{DeviceID: id}
+		}
+		if source.DeviceID == iotModels.WebManualDeviceID {
+			return &DeviceTransferProtectedError{DeviceID: id, Reason: "system device required for manual web check-ins"}
+		}
+		if source.TenantID == targetSchoolID {
+			return &DeviceTransferSameSchoolError{SchoolID: targetSchoolID}
+		}
+
+		sourceSchool, sourceSchoolErr := s.SchoolRepo.FindByID(adminCtx, source.TenantID)
+		if sourceSchoolErr != nil {
+			return fmt.Errorf("TransferDevice: lookup source school: %w", sourceSchoolErr)
+		}
+		if sourceSchool == nil {
+			return &SchoolNotFoundError{SchoolID: source.TenantID}
+		}
+		targetSchool, targetSchoolErr := s.SchoolRepo.FindByID(adminCtx, targetSchoolID)
+		if targetSchoolErr != nil {
+			if isSchoolLookupNotFound(targetSchoolErr) {
+				return &SchoolNotFoundError{SchoolID: targetSchoolID}
+			}
+			return fmt.Errorf("TransferDevice: lookup target school: %w", targetSchoolErr)
+		}
+		if targetSchool == nil {
+			return &SchoolNotFoundError{SchoolID: targetSchoolID}
+		}
+		if targetSchool.IsDeleted() {
+			return &SchoolAlreadyDeletedError{SchoolID: targetSchoolID}
+		}
+		if !targetSchool.Active {
+			return &SchoolInactiveError{SchoolID: targetSchoolID}
+		}
+		if sourceSchool.OrganizationID != targetSchool.OrganizationID {
+			return &DeviceTransferOrganizationMismatchError{SourceSchoolID: source.TenantID, TargetSchoolID: targetSchoolID}
+		}
+
+		status, statusErr := s.transferStatus(adminCtx, source)
+		if statusErr != nil {
+			return statusErr
+		}
+		if status.IsOnline {
+			return &DeviceTransferBlockedError{DeviceID: id, Reason: DeviceTransferBlockedOnline}
+		}
+		if status.ActiveSession != nil {
+			return &DeviceTransferBlockedError{DeviceID: id, Reason: DeviceTransferBlockedActiveSession}
+		}
+
+		originalStatus := source.Status
+		var transferredAPIKey *string
+		if source.APIKey != nil {
+			key := *source.APIKey
+			transferredAPIKey = &key
+		}
+		now := time.Now()
+		source.ArchivedAt = &now
+		source.APIKey = nil
+		source.Status = iotModels.DeviceStatusInactive
+		source.RoomID = nil
+		source.RegisteredByID = nil
+		if updateErr := s.DeviceRepo.Update(adminCtx, source); updateErr != nil {
+			return fmt.Errorf("TransferDevice: archive source: %w", updateErr)
+		}
+
+		target := &iotModels.Device{
+			DeviceID:   source.DeviceID,
+			DeviceType: source.DeviceType,
+			Name:       source.Name,
+			Status:     originalStatus,
+			APIKey:     transferredAPIKey,
+		}
+		target.SetTenantID(targetSchoolID)
+		if createErr := s.DeviceRepo.Create(tenant.WithTenantID(adminCtx, targetSchoolID), target); createErr != nil {
+			if modelBase.IsUniqueViolation(createErr) {
+				if isAPIKeyConstraintViolation(createErr) {
+					return &ConflictError{Err: fmt.Errorf("api_key already in use")}
+				}
+				return &ConflictError{Err: fmt.Errorf("device_id already exists for target school")}
+			}
+			return fmt.Errorf("TransferDevice: create target: %w", createErr)
+		}
+
+		source.TransferredToDeviceID = &target.ID
+		if updateErr := s.DeviceRepo.Update(adminCtx, source); updateErr != nil {
+			return fmt.Errorf("TransferDevice: link source history: %w", updateErr)
+		}
+
+		s.logAction(adminCtx, operatorID, platform.ActionTransfer, platform.ResourceDevice, &id, clientIP, map[string]any{
+			"device_id":        source.DeviceID,
+			"source_device_id": id,
+			"target_device_id": target.ID,
+			"source_school_id": source.TenantID,
+			"target_school_id": targetSchoolID,
+		})
+
+		var queryErr error
+		result, queryErr = s.queryDeviceSingle(adminCtx, "TransferDevice", target.ID)
+		return queryErr
+	})
+	return result, err
 }
 
 func (s *operatorProvisioningService) ListSchoolPersons(ctx context.Context, schoolID int64) ([]OperatorPersonInfo, error) {

--- a/backend/services/platform/operator_provisioning_service.go
+++ b/backend/services/platform/operator_provisioning_service.go
@@ -18,6 +18,7 @@ import (
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
 	"github.com/moto-nrw/project-phoenix/models/platform"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -60,7 +61,10 @@ type UpdateSchoolRequest struct {
 	Hidden         bool
 }
 
-const deviceTransferOnlineThreshold = 5 * time.Minute
+// defaultDeviceOnlineWindow is the fallback online/offline cutoff used when no
+// settings resolver is wired or the per-tenant setting
+// iot.device_online_window_minutes cannot be resolved (issue #586).
+const defaultDeviceOnlineWindow = 5 * time.Minute
 
 // DeviceTransferSession describes the open kiosk session blocking a transfer.
 type DeviceTransferSession struct {
@@ -82,6 +86,13 @@ type DeviceTransferStatus struct {
 // ActiveDeviceSessionFinder is the narrow device-transfer session lookup dependency.
 type ActiveDeviceSessionFinder interface {
 	FindActiveByDeviceIDWithNames(ctx context.Context, deviceID int64) (*activeModels.Group, error)
+}
+
+// TenantSettingsResolver is the narrow settings dependency for resolving
+// per-tenant settings outside tenant middleware (operator requests carry no
+// tenant context).
+type TenantSettingsResolver interface {
+	ResolveIntForTenant(ctx context.Context, tenantID int64, key string) (int, error)
 }
 
 // OperatorProvisioningService handles operator-led tenant provisioning.
@@ -179,6 +190,7 @@ type OperatorProvisioningServiceConfig struct {
 	TeacherRepo           userModels.TeacherRepository
 	GroupSupervisorRepo   activeModels.GroupSupervisorRepository
 	ActiveGroupRepo       ActiveDeviceSessionFinder
+	Settings              TenantSettingsResolver
 	InvitationService     authSvc.InvitationService
 	AuthService           authSvc.AuthService
 	AuditLogRepo          platform.OperatorAuditLogRepository
@@ -345,7 +357,7 @@ func (s *operatorProvisioningService) UpdateSchool(ctx context.Context, id int64
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		existing, err := s.SchoolRepo.FindByID(adminCtx, id)
 		if err != nil {
-			if isSchoolLookupNotFound(err) {
+			if isLookupNotFound(err) {
 				return &SchoolNotFoundError{SchoolID: id}
 			}
 			return err
@@ -612,7 +624,7 @@ func (s *operatorProvisioningService) ListSchoolAccounts(ctx context.Context, sc
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		school, findErr := s.SchoolRepo.FindByID(adminCtx, schoolID)
 		if findErr != nil {
-			if isSchoolLookupNotFound(findErr) {
+			if isLookupNotFound(findErr) {
 				return &SchoolNotFoundError{SchoolID: schoolID}
 			}
 			return findErr
@@ -700,7 +712,7 @@ func (s *operatorProvisioningService) ListSchoolDevices(ctx context.Context, sch
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		school, findErr := s.SchoolRepo.FindByID(adminCtx, schoolID)
 		if findErr != nil {
-			if isSchoolLookupNotFound(findErr) {
+			if isLookupNotFound(findErr) {
 				return &SchoolNotFoundError{SchoolID: schoolID}
 			}
 			return findErr
@@ -814,7 +826,7 @@ func (s *operatorProvisioningService) CreateDevice(ctx context.Context, schoolID
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		school, findErr := s.SchoolRepo.FindByID(adminCtx, schoolID)
 		if findErr != nil {
-			if isSchoolLookupNotFound(findErr) {
+			if isLookupNotFound(findErr) {
 				return &SchoolNotFoundError{SchoolID: schoolID}
 			}
 			return findErr
@@ -1021,22 +1033,37 @@ func (s *operatorProvisioningService) DeleteDevice(ctx context.Context, id int64
 	})
 }
 
-func isDeviceLookupNotFound(err error) bool {
-	if errors.Is(err, sql.ErrNoRows) {
-		return true
+// deviceOnlineWindow resolves the tenant's iot.device_online_window_minutes
+// setting, falling back to defaultDeviceOnlineWindow when no resolver is wired
+// or the lookup fails. ctx must be the outer request context, not the admin-tx
+// context: ResolveIntForTenant opens its own tenant transaction, which the
+// nested-transaction guard rejects inside an admin transaction.
+func (s *operatorProvisioningService) deviceOnlineWindow(ctx context.Context, tenantID int64) time.Duration {
+	if s.Settings == nil {
+		return defaultDeviceOnlineWindow
 	}
-	var dbErr *modelBase.DatabaseError
-	return errors.As(err, &dbErr) && errors.Is(dbErr.Err, sql.ErrNoRows)
+	minutes, err := s.Settings.ResolveIntForTenant(ctx, tenantID, configModel.KeyDeviceOnlineWindowMinutes)
+	if err != nil {
+		s.getLogger().Warn("device transfer: resolve online window failed, using fallback",
+			slog.Int64("tenant_id", tenantID),
+			slog.Any("error", err),
+		)
+		return defaultDeviceOnlineWindow
+	}
+	if minutes <= 0 {
+		return defaultDeviceOnlineWindow
+	}
+	return time.Duration(minutes) * time.Minute
 }
 
-func (s *operatorProvisioningService) transferStatus(adminCtx context.Context, device *iotModels.Device) (*DeviceTransferStatus, error) {
+func (s *operatorProvisioningService) transferStatus(ctx, adminCtx context.Context, device *iotModels.Device) (*DeviceTransferStatus, error) {
 	status := &DeviceTransferStatus{LastSeen: device.LastSeen}
 	if device.DeviceID == iotModels.WebManualDeviceID {
 		status.IsProtected = true
 		return status, nil
 	}
 	if device.LastSeen != nil {
-		status.IsOnline = time.Since(*device.LastSeen) <= deviceTransferOnlineThreshold
+		status.IsOnline = time.Since(*device.LastSeen) <= s.deviceOnlineWindow(ctx, device.TenantID)
 	}
 	if s.ActiveGroupRepo == nil {
 		return nil, fmt.Errorf("device transfer: active group repository is not configured")
@@ -1068,7 +1095,7 @@ func (s *operatorProvisioningService) GetDeviceTransferStatus(ctx context.Contex
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		device, findErr := s.DeviceRepo.FindByID(adminCtx, id)
 		if findErr != nil {
-			if isDeviceLookupNotFound(findErr) {
+			if isLookupNotFound(findErr) {
 				return &OperatorDeviceNotFoundError{DeviceID: id}
 			}
 			return findErr
@@ -1077,7 +1104,7 @@ func (s *operatorProvisioningService) GetDeviceTransferStatus(ctx context.Contex
 			return &OperatorDeviceNotFoundError{DeviceID: id}
 		}
 		var statusErr error
-		result, statusErr = s.transferStatus(adminCtx, device)
+		result, statusErr = s.transferStatus(ctx, adminCtx, device)
 		return statusErr
 	})
 	return result, err
@@ -1086,7 +1113,7 @@ func (s *operatorProvisioningService) GetDeviceTransferStatus(ctx context.Contex
 func (s *operatorProvisioningService) loadTransferSource(adminCtx context.Context, id, targetSchoolID int64) (*iotModels.Device, error) {
 	source, err := s.DeviceRepo.FindByIDForUpdate(adminCtx, id)
 	if err != nil {
-		if isDeviceLookupNotFound(err) {
+		if isLookupNotFound(err) {
 			return nil, &OperatorDeviceNotFoundError{DeviceID: id}
 		}
 		return nil, err
@@ -1106,6 +1133,9 @@ func (s *operatorProvisioningService) loadTransferSource(adminCtx context.Contex
 func (s *operatorProvisioningService) validateTransferDestination(adminCtx context.Context, source *iotModels.Device, targetSchoolID int64) error {
 	sourceSchool, err := s.SchoolRepo.FindByID(adminCtx, source.TenantID)
 	if err != nil {
+		if isLookupNotFound(err) {
+			return &SchoolNotFoundError{SchoolID: source.TenantID}
+		}
 		return fmt.Errorf("TransferDevice: lookup source school: %w", err)
 	}
 	if sourceSchool == nil {
@@ -1114,7 +1144,7 @@ func (s *operatorProvisioningService) validateTransferDestination(adminCtx conte
 
 	targetSchool, err := s.SchoolRepo.FindByID(adminCtx, targetSchoolID)
 	if err != nil {
-		if isSchoolLookupNotFound(err) {
+		if isLookupNotFound(err) {
 			return &SchoolNotFoundError{SchoolID: targetSchoolID}
 		}
 		return fmt.Errorf("TransferDevice: lookup target school: %w", err)
@@ -1134,8 +1164,8 @@ func (s *operatorProvisioningService) validateTransferDestination(adminCtx conte
 	return nil
 }
 
-func (s *operatorProvisioningService) ensureDeviceTransferable(adminCtx context.Context, source *iotModels.Device) error {
-	status, err := s.transferStatus(adminCtx, source)
+func (s *operatorProvisioningService) ensureDeviceTransferable(ctx, adminCtx context.Context, source *iotModels.Device) error {
+	status, err := s.transferStatus(ctx, adminCtx, source)
 	if err != nil {
 		return err
 	}
@@ -1207,7 +1237,7 @@ func (s *operatorProvisioningService) TransferDevice(ctx context.Context, id, ta
 		if err := s.validateTransferDestination(adminCtx, source, targetSchoolID); err != nil {
 			return err
 		}
-		if err := s.ensureDeviceTransferable(adminCtx, source); err != nil {
+		if err := s.ensureDeviceTransferable(ctx, adminCtx, source); err != nil {
 			return err
 		}
 		target, err := s.archiveAndCreateTransferredDevice(adminCtx, source, targetSchoolID)
@@ -1235,7 +1265,7 @@ func (s *operatorProvisioningService) ListSchoolPersons(ctx context.Context, sch
 	err := tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		school, findErr := s.SchoolRepo.FindByID(adminCtx, schoolID)
 		if findErr != nil {
-			if isSchoolLookupNotFound(findErr) {
+			if isLookupNotFound(findErr) {
 				return &SchoolNotFoundError{SchoolID: schoolID}
 			}
 			return findErr
@@ -1399,7 +1429,7 @@ func (s *operatorProvisioningService) resolveAdminInviteContext(ctx context.Cont
 func (s *operatorProvisioningService) loadActiveSchool(ctx context.Context, schoolID int64) (*platform.School, error) {
 	school, err := s.SchoolRepo.FindByID(ctx, schoolID)
 	if err != nil {
-		if isSchoolLookupNotFound(err) {
+		if isLookupNotFound(err) {
 			return nil, &SchoolNotFoundError{SchoolID: schoolID}
 		}
 		return nil, err
@@ -1525,7 +1555,9 @@ func (s *operatorProvisioningService) logAction(ctx context.Context, operatorID 
 	}
 }
 
-func isSchoolLookupNotFound(err error) bool {
+// isLookupNotFound reports whether a repository FindByID-style error means
+// "no such row" (directly or wrapped in a DatabaseError), regardless of entity.
+func isLookupNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -1587,7 +1619,7 @@ func (s *operatorProvisioningService) SoftDeleteSchool(ctx context.Context, scho
 	return tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		school, err := s.SchoolRepo.FindByID(adminCtx, schoolID)
 		if err != nil {
-			if isSchoolLookupNotFound(err) {
+			if isLookupNotFound(err) {
 				return &SchoolNotFoundError{SchoolID: schoolID}
 			}
 			return err
@@ -1647,7 +1679,7 @@ func (s *operatorProvisioningService) RestoreSchool(ctx context.Context, schoolI
 	return tenant.WithAdminTxOrDirect(ctx, s.adminDB(), func(adminCtx context.Context) error {
 		school, err := s.SchoolRepo.FindByID(adminCtx, schoolID)
 		if err != nil {
-			if isSchoolLookupNotFound(err) {
+			if isLookupNotFound(err) {
 				return &SchoolNotFoundError{SchoolID: schoolID}
 			}
 			return err

--- a/backend/services/platform/operator_provisioning_service_internal_test.go
+++ b/backend/services/platform/operator_provisioning_service_internal_test.go
@@ -294,10 +294,10 @@ func TestNormalizeAdminInviteRequest(t *testing.T) {
 }
 
 func TestIsSchoolLookupNotFound(t *testing.T) {
-	assert.True(t, isSchoolLookupNotFound(sql.ErrNoRows))
-	assert.True(t, isSchoolLookupNotFound(&modelBase.DatabaseError{Op: "find", Err: sql.ErrNoRows}))
-	assert.False(t, isSchoolLookupNotFound(assert.AnError))
-	assert.False(t, isSchoolLookupNotFound(nil))
+	assert.True(t, isLookupNotFound(sql.ErrNoRows))
+	assert.True(t, isLookupNotFound(&modelBase.DatabaseError{Op: "find", Err: sql.ErrNoRows}))
+	assert.False(t, isLookupNotFound(assert.AnError))
+	assert.False(t, isLookupNotFound(nil))
 }
 
 func TestMapSchoolCreateConflict_NilSchool(t *testing.T) {
@@ -1041,12 +1041,12 @@ func TestWithAdminTx_ExistingTxInContext(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// isSchoolLookupNotFound — DatabaseError with non-ErrNoRows
+// isLookupNotFound — DatabaseError with non-ErrNoRows
 // ---------------------------------------------------------------------------
 
 func TestIsSchoolLookupNotFound_DatabaseErrorNonNoRows(t *testing.T) {
 	err := &modelBase.DatabaseError{Op: "find", Err: assert.AnError}
-	assert.False(t, isSchoolLookupNotFound(err))
+	assert.False(t, isLookupNotFound(err))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/services/platform/operator_provisioning_service_internal_test.go
+++ b/backend/services/platform/operator_provisioning_service_internal_test.go
@@ -112,6 +112,9 @@ func (s *internalDeviceRepoStub) FindByID(ctx context.Context, id interface{}) (
 	}
 	return nil, nil
 }
+func (s *internalDeviceRepoStub) FindByIDForUpdate(ctx context.Context, id int64) (*iotModels.Device, error) {
+	return s.FindByID(ctx, id)
+}
 func (s *internalDeviceRepoStub) Update(ctx context.Context, device *iotModels.Device) error {
 	if s.updateFn != nil {
 		return s.updateFn(ctx, device)

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -15,12 +15,14 @@ import (
 	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	facilitiesModels "github.com/moto-nrw/project-phoenix/models/facilities"
 	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	authSvc "github.com/moto-nrw/project-phoenix/services/auth"
 	"github.com/moto-nrw/project-phoenix/services/auth/authtest"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3804,6 +3806,62 @@ func TestOperatorProvisioningService_GetDeviceTransferStatus_SessionLookupFailur
 
 	require.Nil(t, status)
 	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_UsesTenantOnlineWindowSetting(t *testing.T) {
+	lastSeen := time.Now().Add(-10 * time.Minute)
+	device := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2", LastSeen: &lastSeen}
+	device.SetTenantID(10)
+
+	var resolvedTenantID int64
+	var resolvedKey string
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return device, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{},
+		Settings: &configtest.Mock{ResolveIntForTenantFn: func(_ context.Context, tenantID int64, key string) (int, error) {
+			resolvedTenantID = tenantID
+			resolvedKey = key
+			return 15, nil
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), device.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, int64(10), resolvedTenantID)
+	assert.Equal(t, configModel.KeyDeviceOnlineWindowMinutes, resolvedKey)
+	// Seen 10 minutes ago is inside the tenant's 15-minute window.
+	assert.True(t, status.IsOnline)
+	assert.False(t, status.CanTransfer)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_OnlineWindowResolveErrorFallsBack(t *testing.T) {
+	lastSeen := time.Now().Add(-10 * time.Minute)
+	device := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2", LastSeen: &lastSeen}
+	device.SetTenantID(10)
+
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return device, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{},
+		Settings: &configtest.Mock{ResolveIntForTenantFn: func(context.Context, int64, string) (int, error) {
+			return 0, assert.AnError
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), device.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	// Fallback window is 5 minutes; seen 10 minutes ago counts as offline.
+	assert.False(t, status.IsOnline)
+	assert.True(t, status.CanTransfer)
 }
 
 func TestOperatorProvisioningService_TransferDevice_ArchivesSourceAndPreservesIdentity(t *testing.T) {

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -90,7 +92,20 @@ func (m *mockOrganizationRepo) Restore(ctx context.Context, id int64) error {
 }
 
 type mockDeviceRepo struct {
-	createFn func(context.Context, *iotModels.Device) error
+	createFn            func(context.Context, *iotModels.Device) error
+	findByIDForUpdateFn func(context.Context, int64) (*iotModels.Device, error)
+	updateFn            func(context.Context, *iotModels.Device) error
+}
+
+type mockActiveDeviceSessionRepo struct {
+	findFn func(context.Context, int64) (*activeModels.Group, error)
+}
+
+func (m *mockActiveDeviceSessionRepo) FindActiveByDeviceIDWithNames(ctx context.Context, deviceID int64) (*activeModels.Group, error) {
+	if m.findFn != nil {
+		return m.findFn(ctx, deviceID)
+	}
+	return nil, nil
 }
 
 func (m *mockDeviceRepo) Create(ctx context.Context, device *iotModels.Device) error {
@@ -102,8 +117,19 @@ func (m *mockDeviceRepo) Create(ctx context.Context, device *iotModels.Device) e
 func (m *mockDeviceRepo) FindByID(context.Context, interface{}) (*iotModels.Device, error) {
 	return nil, nil
 }
-func (m *mockDeviceRepo) Update(context.Context, *iotModels.Device) error { return nil }
-func (m *mockDeviceRepo) Delete(context.Context, interface{}) error       { return nil }
+func (m *mockDeviceRepo) FindByIDForUpdate(ctx context.Context, id int64) (*iotModels.Device, error) {
+	if m.findByIDForUpdateFn != nil {
+		return m.findByIDForUpdateFn(ctx, id)
+	}
+	return m.FindByID(ctx, id)
+}
+func (m *mockDeviceRepo) Update(ctx context.Context, device *iotModels.Device) error {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, device)
+	}
+	return nil
+}
+func (m *mockDeviceRepo) Delete(context.Context, interface{}) error { return nil }
 func (m *mockDeviceRepo) List(context.Context, map[string]interface{}) ([]*iotModels.Device, error) {
 	return nil, nil
 }
@@ -3637,6 +3663,166 @@ func TestOperatorProvisioningService_SetDeviceAPIKey_RejectsInactiveSchool(t *te
 	require.ErrorAs(t, err, &inactiveErr)
 }
 
+func TestOperatorProvisioningService_GetDeviceTransferStatus_ReportsBlockers(t *testing.T) {
+	now := time.Now()
+	device := &iotModels.Device{
+		Model:      base.Model{ID: 200},
+		DeviceID:   "BURBACH-2",
+		DeviceType: "terminal",
+		Status:     iotModels.DeviceStatusActive,
+		LastSeen:   &now,
+	}
+	device.SetTenantID(10)
+
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return device, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{findFn: func(context.Context, int64) (*activeModels.Group, error) {
+			return &activeModels.Group{Model: base.Model{ID: 300}, StartTime: now.Add(-time.Hour)}, nil
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), 200)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.False(t, status.CanTransfer)
+	assert.True(t, status.IsOnline)
+	require.NotNil(t, status.ActiveSession)
+	assert.Equal(t, int64(300), status.ActiveSession.ID)
+}
+
+func TestOperatorProvisioningService_TransferDevice_ArchivesSourceAndPreservesIdentity(t *testing.T) {
+	apiKey := "dev_existing-key"
+	deviceName := "Burbach 2"
+	source := &iotModels.Device{
+		Model:      base.Model{ID: 200},
+		DeviceID:   "BURBACH-2",
+		DeviceType: "terminal",
+		Name:       &deviceName,
+		Status:     iotModels.DeviceStatusActive,
+		APIKey:     &apiKey,
+	}
+	source.SetTenantID(10)
+
+	var target *iotModels.Device
+	var updateSnapshots []iotModels.Device
+	var auditEntry *platformModels.OperatorAuditLog
+	deviceRepo := &mockDeviceRepo{
+		findByIDForUpdateFn: func(context.Context, int64) (*iotModels.Device, error) {
+			return source, nil
+		},
+		updateFn: func(_ context.Context, device *iotModels.Device) error {
+			updateSnapshots = append(updateSnapshots, *device)
+			return nil
+		},
+		createFn: func(_ context.Context, device *iotModels.Device) error {
+			device.ID = 201
+			target = device
+			return nil
+		},
+	}
+	summaries := &mockSummariesRepo{devicesFn: func(_ context.Context, filter platformModels.OperatorDeviceFilter) ([]platformModels.OperatorDeviceRow, error) {
+		require.NotNil(t, filter.DeviceRowID)
+		assert.Equal(t, int64(201), *filter.DeviceRowID)
+		return []platformModels.OperatorDeviceRow{{
+			ID: 201, DeviceID: "BURBACH-2", DeviceType: "terminal", Name: &deviceName,
+			Status: "active", APIKey: &apiKey, SchoolID: 20, SchoolName: "Walbach",
+			OrganizationID: 1, OrganizationName: "Talent OGS", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}}, nil
+	}}
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: summaries,
+		DeviceRepo:    deviceRepo,
+		SchoolRepo: &testpkg.SchoolRepoMock{FindByIDFn: func(_ context.Context, id int64) (*platformModels.School, error) {
+			return &platformModels.School{Model: base.Model{ID: id}, OrganizationID: 1, Name: map[int64]string{10: "Burbach", 20: "Walbach"}[id], Slug: fmt.Sprintf("school-%d", id), Subdomain: fmt.Sprintf("school-%d", id), Active: true}, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{},
+		AuditLogRepo: &mockAuditLogRepoShared{createFn: func(_ context.Context, entry *platformModels.OperatorAuditLog) error {
+			auditEntry = entry
+			return nil
+		}},
+	})
+
+	result, err := service.TransferDevice(context.Background(), 200, 20, 7, net.IPv4(127, 0, 0, 1))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(201), result.ID)
+	require.NotNil(t, target)
+	assert.Equal(t, int64(20), target.TenantID)
+	assert.Equal(t, "BURBACH-2", target.DeviceID)
+	require.NotNil(t, target.APIKey)
+	assert.Equal(t, apiKey, *target.APIKey)
+	assert.Nil(t, target.LastSeen)
+	require.Len(t, updateSnapshots, 2)
+	require.NotNil(t, updateSnapshots[0].ArchivedAt)
+	assert.Nil(t, updateSnapshots[0].APIKey)
+	assert.Equal(t, iotModels.DeviceStatusInactive, updateSnapshots[0].Status)
+	require.NotNil(t, updateSnapshots[1].TransferredToDeviceID)
+	assert.Equal(t, int64(201), *updateSnapshots[1].TransferredToDeviceID)
+	require.NotNil(t, auditEntry)
+	assert.Equal(t, platformModels.ActionTransfer, auditEntry.Action)
+}
+
+func TestOperatorProvisioningService_TransferDevice_RejectsDifferentOrganization(t *testing.T) {
+	source := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2", DeviceType: "terminal", Status: iotModels.DeviceStatusActive}
+	source.SetTenantID(10)
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepo{findByIDForUpdateFn: func(context.Context, int64) (*iotModels.Device, error) {
+			return source, nil
+		}},
+		SchoolRepo: &testpkg.SchoolRepoMock{FindByIDFn: func(_ context.Context, id int64) (*platformModels.School, error) {
+			return &platformModels.School{Model: base.Model{ID: id}, OrganizationID: id, Name: "School", Slug: fmt.Sprintf("school-%d", id), Subdomain: fmt.Sprintf("school-%d", id), Active: true}, nil
+		}},
+	})
+
+	result, err := service.TransferDevice(context.Background(), 200, 20, 7, nil)
+	require.Nil(t, result)
+	var mismatch *platformSvc.DeviceTransferOrganizationMismatchError
+	require.ErrorAs(t, err, &mismatch)
+}
+
+func TestOperatorProvisioningService_TransferDevice_OnlineDeviceDoesNotWrite(t *testing.T) {
+	now := time.Now()
+	source := &iotModels.Device{
+		Model:      base.Model{ID: 200},
+		DeviceID:   "BURBACH-2",
+		DeviceType: "terminal",
+		Status:     iotModels.DeviceStatusActive,
+		LastSeen:   &now,
+	}
+	source.SetTenantID(10)
+	writes := 0
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepo{
+			findByIDForUpdateFn: func(context.Context, int64) (*iotModels.Device, error) { return source, nil },
+			updateFn: func(context.Context, *iotModels.Device) error {
+				writes++
+				return nil
+			},
+			createFn: func(context.Context, *iotModels.Device) error {
+				writes++
+				return nil
+			},
+		},
+		SchoolRepo: &testpkg.SchoolRepoMock{FindByIDFn: func(_ context.Context, id int64) (*platformModels.School, error) {
+			return &platformModels.School{Model: base.Model{ID: id}, OrganizationID: 1, Name: "School", Slug: fmt.Sprintf("school-%d", id), Subdomain: fmt.Sprintf("school-%d", id), Active: true}, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{},
+	})
+
+	result, err := service.TransferDevice(context.Background(), 200, 20, 7, nil)
+
+	require.Nil(t, result)
+	var blocked *platformSvc.DeviceTransferBlockedError
+	require.ErrorAs(t, err, &blocked)
+	assert.Equal(t, platformSvc.DeviceTransferBlockedOnline, blocked.Reason)
+	assert.Zero(t, writes)
+}
+
 // TestOperatorProvisioningService_LoadActiveSchool_RejectsDeletedSchool tests
 // the private loadActiveSchool method indirectly via CreateSchoolAccount, which
 // calls loadActiveSchool as its first step.
@@ -3677,7 +3863,10 @@ func TestOperatorProvisioningService_LoadActiveSchool_RejectsDeletedSchool(t *te
 func (m *mockPersonRepo) AnonymizeAndSoftDelete(context.Context, int64) error { return nil }
 
 // Stub for the issue #585 refactor interface addition — unused here.
-func (m *mockSummariesRepo) ListDeviceRows(context.Context, platformModels.OperatorDeviceFilter) ([]platformModels.OperatorDeviceRow, error) {
+func (m *mockSummariesRepo) ListDeviceRows(ctx context.Context, filter platformModels.OperatorDeviceFilter) ([]platformModels.OperatorDeviceRow, error) {
+	if m.devicesFn != nil {
+		return m.devicesFn(ctx, filter)
+	}
 	return nil, nil
 }
 

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -15,6 +15,7 @@ import (
 	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	facilitiesModels "github.com/moto-nrw/project-phoenix/models/facilities"
 	iotModels "github.com/moto-nrw/project-phoenix/models/iot"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -3693,6 +3694,118 @@ func TestOperatorProvisioningService_GetDeviceTransferStatus_ReportsBlockers(t *
 	assert.Equal(t, int64(300), status.ActiveSession.ID)
 }
 
+func TestOperatorProvisioningService_GetDeviceTransferStatus_RejectsInvalidID(t *testing.T) {
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), 0)
+
+	require.Nil(t, status)
+	var invalidData *platformSvc.InvalidDataError
+	require.ErrorAs(t, err, &invalidData)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_ReportsProtectedDevice(t *testing.T) {
+	device := &iotModels.Device{
+		Model:    base.Model{ID: 200},
+		DeviceID: iotModels.WebManualDeviceID,
+	}
+	device.SetTenantID(10)
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return device, nil
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), device.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.True(t, status.IsProtected)
+	assert.False(t, status.CanTransfer)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_IncludesSessionNames(t *testing.T) {
+	startedAt := time.Now().Add(-time.Hour)
+	device := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2"}
+	device.SetTenantID(10)
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return device, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{findFn: func(context.Context, int64) (*activeModels.Group, error) {
+			return &activeModels.Group{
+				Model:       base.Model{ID: 300},
+				StartTime:   startedAt,
+				ActualGroup: &activityModels.Group{Name: "Mensa"},
+				Room:        &facilitiesModels.Room{Name: "Speisesaal"},
+			}, nil
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), device.ID)
+
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.NotNil(t, status.ActiveSession)
+	require.NotNil(t, status.ActiveSession.ActivityName)
+	assert.Equal(t, "Mensa", *status.ActiveSession.ActivityName)
+	require.NotNil(t, status.ActiveSession.RoomName)
+	assert.Equal(t, "Speisesaal", *status.ActiveSession.RoomName)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_NotFound(t *testing.T) {
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return nil, sql.ErrNoRows
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), 200)
+
+	require.Nil(t, status)
+	var notFound *platformSvc.OperatorDeviceNotFoundError
+	require.ErrorAs(t, err, &notFound)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_NilDeviceIsNotFound(t *testing.T) {
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return nil, nil
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), 200)
+
+	require.Nil(t, status)
+	var notFound *platformSvc.OperatorDeviceNotFoundError
+	require.ErrorAs(t, err, &notFound)
+}
+
+func TestOperatorProvisioningService_GetDeviceTransferStatus_SessionLookupFailure(t *testing.T) {
+	device := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2"}
+	device.SetTenantID(10)
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepoWithFind{findByIDFn: func(context.Context, interface{}) (*iotModels.Device, error) {
+			return device, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{findFn: func(context.Context, int64) (*activeModels.Group, error) {
+			return nil, assert.AnError
+		}},
+	})
+
+	status, err := service.GetDeviceTransferStatus(context.Background(), device.ID)
+
+	require.Nil(t, status)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
 func TestOperatorProvisioningService_TransferDevice_ArchivesSourceAndPreservesIdentity(t *testing.T) {
 	apiKey := "dev_existing-key"
 	deviceName := "Burbach 2"
@@ -3820,6 +3933,86 @@ func TestOperatorProvisioningService_TransferDevice_OnlineDeviceDoesNotWrite(t *
 	var blocked *platformSvc.DeviceTransferBlockedError
 	require.ErrorAs(t, err, &blocked)
 	assert.Equal(t, platformSvc.DeviceTransferBlockedOnline, blocked.Reason)
+	assert.Zero(t, writes)
+}
+
+func TestOperatorProvisioningService_TransferDevice_RejectsSameSchool(t *testing.T) {
+	source := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2"}
+	source.SetTenantID(10)
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepo{findByIDForUpdateFn: func(context.Context, int64) (*iotModels.Device, error) {
+			return source, nil
+		}},
+	})
+
+	result, err := service.TransferDevice(context.Background(), source.ID, source.TenantID, 7, nil)
+
+	require.Nil(t, result)
+	var sameSchool *platformSvc.DeviceTransferSameSchoolError
+	require.ErrorAs(t, err, &sameSchool)
+}
+
+func TestOperatorProvisioningService_TransferDevice_RejectsProtectedDevice(t *testing.T) {
+	source := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: iotModels.WebManualDeviceID}
+	source.SetTenantID(10)
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepo{findByIDForUpdateFn: func(context.Context, int64) (*iotModels.Device, error) {
+			return source, nil
+		}},
+	})
+
+	result, err := service.TransferDevice(context.Background(), source.ID, 20, 7, nil)
+
+	require.Nil(t, result)
+	var protected *platformSvc.DeviceTransferProtectedError
+	require.ErrorAs(t, err, &protected)
+}
+
+func TestOperatorProvisioningService_TransferDevice_RejectsInvalidIDs(t *testing.T) {
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+	})
+
+	result, err := service.TransferDevice(context.Background(), 0, 20, 7, nil)
+
+	require.Nil(t, result)
+	var invalidData *platformSvc.InvalidDataError
+	require.ErrorAs(t, err, &invalidData)
+}
+
+func TestOperatorProvisioningService_TransferDevice_ActiveSessionDoesNotWrite(t *testing.T) {
+	source := &iotModels.Device{Model: base.Model{ID: 200}, DeviceID: "BURBACH-2"}
+	source.SetTenantID(10)
+	writes := 0
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		DeviceRepo: &mockDeviceRepo{
+			findByIDForUpdateFn: func(context.Context, int64) (*iotModels.Device, error) { return source, nil },
+			updateFn: func(context.Context, *iotModels.Device) error {
+				writes++
+				return nil
+			},
+			createFn: func(context.Context, *iotModels.Device) error {
+				writes++
+				return nil
+			},
+		},
+		SchoolRepo: &testpkg.SchoolRepoMock{FindByIDFn: func(_ context.Context, id int64) (*platformModels.School, error) {
+			return &platformModels.School{Model: base.Model{ID: id}, OrganizationID: 1, Name: "School", Slug: fmt.Sprintf("school-%d", id), Subdomain: fmt.Sprintf("school-%d", id), Active: true}, nil
+		}},
+		ActiveGroupRepo: &mockActiveDeviceSessionRepo{findFn: func(context.Context, int64) (*activeModels.Group, error) {
+			return &activeModels.Group{Model: base.Model{ID: 300}, StartTime: time.Now().Add(-time.Hour)}, nil
+		}},
+	})
+
+	result, err := service.TransferDevice(context.Background(), source.ID, 20, 7, nil)
+
+	require.Nil(t, result)
+	var blocked *platformSvc.DeviceTransferBlockedError
+	require.ErrorAs(t, err, &blocked)
+	assert.Equal(t, platformSvc.DeviceTransferBlockedActiveSession, blocked.Reason)
 	assert.Zero(t, writes)
 }
 

--- a/backend/services/platform/operator_summaries_test.go
+++ b/backend/services/platform/operator_summaries_test.go
@@ -23,6 +23,7 @@ type mockSummariesRepo struct {
 	schoolsByOrg func(context.Context, int64) ([]*platformModels.SchoolSummary, error)
 	personsBySch func(context.Context, int64) ([]platformModels.OperatorPersonInfo, error)
 	personsByOrg func(context.Context, int64) ([]platformModels.OperatorPersonInfo, error)
+	devicesFn    func(context.Context, platformModels.OperatorDeviceFilter) ([]platformModels.OperatorDeviceRow, error)
 }
 
 func (m *mockSummariesRepo) Stats(ctx context.Context) (*platformModels.ProvisioningStats, error) {

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -242,7 +242,7 @@ func EnsureWebManualDevice(tb testing.TB, db *bun.DB) *iot.Device {
 	_, err := db.NewInsert().
 		Model(device).
 		ModelTableExpr(`iot.devices`).
-		On("CONFLICT (tenant_id, device_id) DO NOTHING").
+		On("CONFLICT (tenant_id, device_id) WHERE archived_at IS NULL DO NOTHING").
 		Exec(ctx)
 	require.NoError(tb, err, "Failed to ensure web manual device")
 

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -252,6 +252,8 @@ func EnsureWebManualDevice(tb testing.TB, db *bun.DB) *iot.Device {
 		Model(&existingDevice).
 		ModelTableExpr(`iot.devices AS "device"`).
 		Where(`"device".device_id = ?`, iot.WebManualDeviceID).
+		Where(`"device".tenant_id = ?`, device.TenantID).
+		Where(`"device".archived_at IS NULL`).
 		Scan(ctx)
 	require.NoError(tb, err, "Failed to fetch web manual device")
 

--- a/frontend/src/app/api/operator/provisioning/devices/[id]/transfer-status/route.test.ts
+++ b/frontend/src/app/api/operator/provisioning/devices/[id]/transfer-status/route.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { RouteContext } from "~/lib/route-wrapper-utils.server";
+
+const { mockAuth, mockFetch } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("~/server/auth/operator", () => ({
+  operatorAuth: mockAuth,
+  uncachedOperatorAuth: mockAuth,
+}));
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: () => "http://localhost:8080",
+}));
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { GET } from "./route";
+
+describe("GET /api/operator/provisioning/devices/[id]/transfer-status", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards an authenticated status request", async () => {
+    mockAuth.mockResolvedValue({ user: { token: "valid-token" } });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", data: { can_transfer: true } }),
+    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/operator/provisioning/devices/17/transfer-status",
+    );
+    const context: RouteContext = { params: Promise.resolve({ id: "17" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/operator/devices/17/transfer-status",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuth.mockResolvedValue(null);
+    const request = new NextRequest(
+      "http://localhost:3000/api/operator/provisioning/devices/17/transfer-status",
+    );
+    const context: RouteContext = { params: Promise.resolve({ id: "17" }) };
+
+    expect((await GET(request, context)).status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/api/operator/provisioning/devices/[id]/transfer-status/route.ts
+++ b/frontend/src/app/api/operator/provisioning/devices/[id]/transfer-status/route.ts
@@ -1,0 +1,7 @@
+import { proxyGet } from "~/lib/operator/route-wrapper.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+export const GET = proxyGet(
+  (params) =>
+    `/operator/devices/${requirePathSegmentParam(params)}/transfer-status`,
+);

--- a/frontend/src/app/api/operator/provisioning/devices/[id]/transfer/route.test.ts
+++ b/frontend/src/app/api/operator/provisioning/devices/[id]/transfer/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { RouteContext } from "~/lib/route-wrapper-utils.server";
+
+const { mockAuth, mockFetch } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("~/server/auth/operator", () => ({
+  operatorAuth: mockAuth,
+  uncachedOperatorAuth: mockAuth,
+}));
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+vi.mock("~/lib/server-api-url", () => ({
+  getServerApiUrl: () => "http://localhost:8080",
+}));
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { POST } from "./route";
+
+describe("POST /api/operator/provisioning/devices/[id]/transfer", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards an authenticated transfer", async () => {
+    mockAuth.mockResolvedValue({ user: { token: "valid-token" } });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", data: { id: 99 } }),
+    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/operator/provisioning/devices/17/transfer",
+      { method: "POST", body: JSON.stringify({ target_school_id: 23 }) },
+    );
+    const context: RouteContext = { params: Promise.resolve({ id: "17" }) };
+
+    const response = await POST(request, context);
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/operator/devices/17/transfer",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuth.mockResolvedValue(null);
+    const request = new NextRequest(
+      "http://localhost:3000/api/operator/provisioning/devices/17/transfer",
+      { method: "POST", body: JSON.stringify({ target_school_id: 23 }) },
+    );
+    const context: RouteContext = { params: Promise.resolve({ id: "17" }) };
+
+    expect((await POST(request, context)).status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/api/operator/provisioning/devices/[id]/transfer/route.ts
+++ b/frontend/src/app/api/operator/provisioning/devices/[id]/transfer/route.ts
@@ -1,0 +1,6 @@
+import { proxyPost } from "~/lib/operator/route-wrapper.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+export const POST = proxyPost(
+  (params) => `/operator/devices/${requirePathSegmentParam(params)}/transfer`,
+);

--- a/frontend/src/app/operator/devices/page.test.tsx
+++ b/frontend/src/app/operator/devices/page.test.tsx
@@ -7,6 +7,10 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("~/components/operator/transfer-device-modal", () => ({
+  TransferDeviceModal: () => null,
+}));
+
 const {
   mockUseSession,
   mockUseSWR,
@@ -506,7 +510,8 @@ describe("OperatorDevicesPage", () => {
 
     render(<OperatorDevicesPage />);
 
-    fireEvent.click(screen.getByTitle("Gerät löschen"));
+    fireEvent.click(screen.getByRole("button", { name: /Aktionen für/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Löschen" }));
 
     await waitFor(() => {
       expect(screen.getByText("Gerät löschen")).toBeInTheDocument();
@@ -549,12 +554,22 @@ describe("OperatorDevicesPage", () => {
     expect(screen.getByText("Neues Gerät")).toBeInTheDocument();
   });
 
-  it("shows Key ändern button for each device", () => {
+  it("shows device actions for each device", () => {
     withDefaultSWR({ allDevices: [mockDevice] });
 
     render(<OperatorDevicesPage />);
 
-    expect(screen.getByText("Key ändern")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Aktionen für/ }));
+
+    expect(
+      screen.getByRole("menuitem", { name: "Schule wechseln" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "API-Key ändern" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Löschen" }),
+    ).toBeInTheDocument();
   });
 
   it("opens the set api key modal from the devices table", async () => {
@@ -562,7 +577,8 @@ describe("OperatorDevicesPage", () => {
 
     render(<OperatorDevicesPage />);
 
-    fireEvent.click(screen.getByText("Key ändern"));
+    fireEvent.click(screen.getByRole("button", { name: /Aktionen für/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "API-Key ändern" }));
 
     await waitFor(() => {
       expect(screen.getByText("API-Key ändern")).toBeInTheDocument();

--- a/frontend/src/app/operator/devices/page.tsx
+++ b/frontend/src/app/operator/devices/page.tsx
@@ -7,7 +7,6 @@ import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWith
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
 import type { OperatorDevice } from "~/lib/operator/provisioning-helpers";
-import { createLogger } from "~/lib/logger";
 import {
   CardSkeletons,
   PlusIcon,
@@ -18,8 +17,8 @@ import { SetApiKeyModal } from "../provisioning/set-api-key-modal";
 import { OrgSchoolFilter } from "../provisioning/provisioning-tables-shared";
 import { useOrgSchoolFilter } from "../provisioning/use-org-school-filter";
 import { DevicesTable } from "~/components/operator/devices-table";
-
-const logger = createLogger({ component: "OperatorDevicesPage" });
+import { DeleteDeviceModal } from "~/components/operator/delete-device-modal";
+import { TransferDeviceModal } from "~/components/operator/transfer-device-modal";
 
 const DEVICE_SWR_PREFIXES = [
   "operator-all-devices",
@@ -43,18 +42,10 @@ function OperatorDevicesPageContent() {
 
   const [createDeviceOpen, setCreateDeviceOpen] = useState(false);
   const [setKeyDevice, setSetKeyDevice] = useState<OperatorDevice | null>(null);
-  const [deleteDevice, setDeleteDeviceRaw] = useState<OperatorDevice | null>(
+  const [transferDevice, setTransferDevice] = useState<OperatorDevice | null>(
     null,
   );
-  const [deleteConfirmed, setDeleteConfirmed] = useState(false);
-  const [deleteLoading, setDeleteLoading] = useState(false);
-  const [deleteError, setDeleteError] = useState("");
-
-  const setDeleteDevice = useCallback((device: OperatorDevice | null) => {
-    setDeleteDeviceRaw(device);
-    setDeleteConfirmed(false);
-    setDeleteError("");
-  }, []);
+  const [deleteDevice, setDeleteDevice] = useState<OperatorDevice | null>(null);
 
   const { mutate: globalMutate } = useSWRConfig();
 
@@ -107,27 +98,6 @@ function OperatorDevicesPageContent() {
         DEVICE_SWR_PREFIXES.some((p) => key.startsWith(p)),
     );
   }, [globalMutate]);
-
-  const handleDeleteDevice = useCallback(async () => {
-    if (!deleteDevice) return;
-    setDeleteLoading(true);
-    setDeleteError("");
-    try {
-      await operatorProvisioningService.deleteDevice(deleteDevice.id);
-      setDeleteDevice(null);
-      setDeleteConfirmed(false);
-      void refreshDevices();
-    } catch (err) {
-      logger.error("device_delete_failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      setDeleteError(
-        err instanceof Error ? err.message : "Fehler beim Löschen des Geräts",
-      );
-    } finally {
-      setDeleteLoading(false);
-    }
-  }, [deleteDevice, refreshDevices, setDeleteDevice]);
 
   const tabs = useMemo(
     () => ({
@@ -209,6 +179,7 @@ function OperatorDevicesPageContent() {
               devices={orgDevices}
               showSchool
               onSetKey={setSetKeyDevice}
+              onTransfer={setTransferDevice}
               onDelete={setDeleteDevice}
             />
           )}
@@ -228,6 +199,7 @@ function OperatorDevicesPageContent() {
               devices={allDevices}
               showSchool
               onSetKey={setSetKeyDevice}
+              onTransfer={setTransferDevice}
               onDelete={setDeleteDevice}
             />
           )}
@@ -262,6 +234,7 @@ function OperatorDevicesPageContent() {
             <DevicesTable
               devices={schoolDevices}
               onSetKey={setSetKeyDevice}
+              onTransfer={setTransferDevice}
               onDelete={setDeleteDevice}
             />
           )}
@@ -284,72 +257,17 @@ function OperatorDevicesPageContent() {
           void refreshDevices();
         }}
       />
-
-      {deleteDevice && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="mx-4 w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
-            <h3 className="text-lg font-semibold text-gray-900">
-              Gerät löschen
-            </h3>
-            <p className="mt-2 text-sm text-gray-600">
-              Möchten Sie das Gerät{" "}
-              <span className="font-mono font-medium">
-                {deleteDevice.deviceId}
-              </span>
-              {deleteDevice.name && ` (${deleteDevice.name})`} von{" "}
-              <span className="font-medium">{deleteDevice.schoolName}</span>{" "}
-              wirklich löschen?
-            </p>
-            <p className="mt-2 text-sm font-medium text-red-600">
-              Diese Aktion kann nicht rückgängig gemacht werden.
-            </p>
-
-            {deleteError && (
-              <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
-                {deleteError}
-              </div>
-            )}
-
-            {!deleteConfirmed ? (
-              <div className="mt-5 flex justify-end gap-3">
-                <button
-                  type="button"
-                  onClick={() => setDeleteDevice(null)}
-                  className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
-                >
-                  Abbrechen
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setDeleteConfirmed(true)}
-                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
-                >
-                  Ja, löschen
-                </button>
-              </div>
-            ) : (
-              <div className="mt-5 flex justify-end gap-3">
-                <button
-                  type="button"
-                  onClick={() => setDeleteDevice(null)}
-                  disabled={deleteLoading}
-                  className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-50"
-                >
-                  Abbrechen
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void handleDeleteDevice()}
-                  disabled={deleteLoading}
-                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
-                >
-                  {deleteLoading ? "Wird gelöscht..." : "Endgültig löschen"}
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
+      <TransferDeviceModal
+        device={transferDevice}
+        schools={activeSchools}
+        onClose={() => setTransferDevice(null)}
+        onTransferred={() => refreshDevices().then(() => undefined)}
+      />
+      <DeleteDeviceModal
+        device={deleteDevice}
+        onClose={() => setDeleteDevice(null)}
+        onDeleted={() => refreshDevices().then(() => undefined)}
+      />
     </div>
   );
 }

--- a/frontend/src/app/operator/organizations/[slug]/page.test.tsx
+++ b/frontend/src/app/operator/organizations/[slug]/page.test.tsx
@@ -14,6 +14,10 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/components/operator/transfer-device-modal", () => ({
+  TransferDeviceModal: () => null,
+}));
 import { Suspense } from "react";
 
 const {

--- a/frontend/src/app/operator/organizations/[slug]/page.tsx
+++ b/frontend/src/app/operator/organizations/[slug]/page.tsx
@@ -25,6 +25,7 @@ import { EntityHeaderCard } from "~/components/operator/entity-header-card";
 import { AccountsTable } from "~/components/operator/accounts-table";
 import { DevicesTable } from "~/components/operator/devices-table";
 import { DeleteDeviceModal } from "~/components/operator/delete-device-modal";
+import { TransferDeviceModal } from "~/components/operator/transfer-device-modal";
 import { PersonsTable } from "~/components/operator/persons-table";
 import { DataTable, DataTableStatusBadge } from "~/components/ui/data-table";
 import { buildSchoolColumns } from "~/components/operator/school-table-columns";
@@ -100,6 +101,9 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
   const [createSchoolOpen, setCreateSchoolOpen] = useState(false);
   const [createDeviceOpen, setCreateDeviceOpen] = useState(false);
   const [setKeyDevice, setSetKeyDevice] = useState<OperatorDevice | null>(null);
+  const [transferDevice, setTransferDevice] = useState<OperatorDevice | null>(
+    null,
+  );
   const [deleteDevice, setDeleteDevice] = useState<OperatorDevice | null>(null);
 
   const currentTabSearch = activeTab === "schulen" ? "" : `?tab=${activeTab}`;
@@ -567,6 +571,7 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
                 devices={orgDevices}
                 showSchool
                 onSetKey={setSetKeyDevice}
+                onTransfer={setTransferDevice}
                 onDelete={setDeleteDevice}
               />
             ) : (
@@ -675,6 +680,13 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
         onKeySet={() => {
           void mutateOrgDevices();
         }}
+      />
+
+      <TransferDeviceModal
+        device={transferDevice}
+        schools={organizationSchoolsForDeviceModal}
+        onClose={() => setTransferDevice(null)}
+        onTransferred={handleDeviceDeleted}
       />
 
       <DeleteDeviceModal

--- a/frontend/src/app/operator/organizations/[slug]/schools/[schoolSlug]/page.test.tsx
+++ b/frontend/src/app/operator/organizations/[slug]/schools/[schoolSlug]/page.test.tsx
@@ -13,6 +13,10 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/components/operator/transfer-device-modal", () => ({
+  TransferDeviceModal: () => null,
+}));
 import { Suspense } from "react";
 
 const {
@@ -504,10 +508,12 @@ describe("OperatorSchoolDetailPage", () => {
 
       await renderPage();
 
-      // The devices-table renders a "Löschen" button with title="Gerät löschen"
-      // — the school header's "Löschen" button uses a different title.
-      const rowDelete = await screen.findByTitle("Gerät löschen");
-      fireEvent.click(rowDelete);
+      fireEvent.click(
+        await screen.findByRole("button", {
+          name: /Aktionen für/,
+        }),
+      );
+      fireEvent.click(screen.getByRole("menuitem", { name: "Löschen" }));
 
       // The DeleteDeviceModal renders "Gerät löschen" as a heading.
       await waitFor(() => {
@@ -524,7 +530,12 @@ describe("OperatorSchoolDetailPage", () => {
 
       await renderPage();
 
-      fireEvent.click(await screen.findByTitle("Gerät löschen"));
+      fireEvent.click(
+        await screen.findByRole("button", {
+          name: /Aktionen für/,
+        }),
+      );
+      fireEvent.click(screen.getByRole("menuitem", { name: "Löschen" }));
 
       // Two-step confirm: click "Ja, löschen" then "Endgültig löschen"
       fireEvent.click(await screen.findByText("Ja, löschen"));

--- a/frontend/src/app/operator/organizations/[slug]/schools/[schoolSlug]/page.tsx
+++ b/frontend/src/app/operator/organizations/[slug]/schools/[schoolSlug]/page.tsx
@@ -26,6 +26,7 @@ import { EntityHeaderCard } from "~/components/operator/entity-header-card";
 import { AccountsTable } from "~/components/operator/accounts-table";
 import { DevicesTable } from "~/components/operator/devices-table";
 import { DeleteDeviceModal } from "~/components/operator/delete-device-modal";
+import { TransferDeviceModal } from "~/components/operator/transfer-device-modal";
 import { DeletePersonModal } from "~/components/operator/delete-person-modal";
 import { PersonsTable } from "~/components/operator/persons-table";
 import { DataTableStatusBadge } from "~/components/ui/data-table";
@@ -101,6 +102,9 @@ function OperatorSchoolDetailPageContent({ params }: PageProps) {
   const [createAccountOpen, setCreateAccountOpen] = useState(false);
   const [createDeviceOpen, setCreateDeviceOpen] = useState(false);
   const [setKeyDevice, setSetKeyDevice] = useState<OperatorDevice | null>(null);
+  const [transferDevice, setTransferDevice] = useState<OperatorDevice | null>(
+    null,
+  );
   const [deleteDevice, setDeleteDevice] = useState<OperatorDevice | null>(null);
   const [deletePersonTarget, setDeletePersonTarget] =
     useState<OperatorPerson | null>(null);
@@ -205,6 +209,14 @@ function OperatorSchoolDetailPageContent({ params }: PageProps) {
   const selectedSchoolForTable = useMemo(
     () => (school ? summaryToSchool(school) : null),
     [school],
+  );
+
+  const transferSchools = useMemo(
+    () =>
+      (schools ?? [])
+        .filter((item) => item.active && item.deletedAt == null)
+        .map(summaryToSchool),
+    [schools],
   );
 
   const openCaregiverModal = useCallback(
@@ -521,6 +533,7 @@ function OperatorSchoolDetailPageContent({ params }: PageProps) {
               <DevicesTable
                 devices={schoolDevices}
                 onSetKey={setSetKeyDevice}
+                onTransfer={setTransferDevice}
                 onDelete={setDeleteDevice}
               />
             ) : (
@@ -664,6 +677,13 @@ function OperatorSchoolDetailPageContent({ params }: PageProps) {
         onKeySet={() => {
           void mutateSchoolDevices();
         }}
+      />
+
+      <TransferDeviceModal
+        device={transferDevice}
+        schools={transferSchools}
+        onClose={() => setTransferDevice(null)}
+        onTransferred={handleDeviceDeleted}
       />
 
       <DeleteDeviceModal

--- a/frontend/src/components/operator/devices-table.tsx
+++ b/frontend/src/components/operator/devices-table.tsx
@@ -11,6 +11,11 @@ import {
 import { createLogger } from "~/lib/logger";
 import { DataTable } from "~/components/ui/data-table";
 import type { DataTableColumn } from "~/components/ui/data-table";
+import {
+  OverflowMenu,
+  type OverflowMenuEntry,
+} from "~/components/ui/page-header/OverflowMenu";
+import { ArrowRightLeft, KeyRound, Trash2 } from "lucide-react";
 
 const logger = createLogger({ component: "DevicesTable" });
 
@@ -83,6 +88,7 @@ interface DevicesTableProps {
   devices: OperatorDevice[];
   showSchool?: boolean;
   onSetKey?: (device: OperatorDevice) => void;
+  onTransfer?: (device: OperatorDevice) => void;
   onDelete?: (device: OperatorDevice) => void;
 }
 
@@ -90,6 +96,7 @@ export function DevicesTable({
   devices,
   showSchool = false,
   onSetKey,
+  onTransfer,
   onDelete,
 }: Readonly<DevicesTableProps>) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -190,39 +197,48 @@ export function DevicesTable({
       },
     );
 
-    if (onSetKey || onDelete) {
+    if (onSetKey || onTransfer || onDelete) {
       cols.push({
         key: "actions",
         header: "Aktionen",
-        render: (row) => (
-          <div className="flex items-center gap-2">
-            {onSetKey && (
-              <button
-                type="button"
-                onClick={() => onSetKey(row)}
-                className="rounded-lg border border-gray-200 px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
-                title="API-Key ändern"
-              >
-                Key ändern
-              </button>
-            )}
-            {onDelete && (
-              <button
-                type="button"
-                onClick={() => onDelete(row)}
-                className="rounded-lg border border-[#FF3130]/20 px-2 py-1 text-xs font-medium text-[#CC2626] transition-colors hover:bg-[#FF3130]/10 hover:text-[#FF3130]"
-                title="Gerät löschen"
-              >
-                Löschen
-              </button>
-            )}
-          </div>
-        ),
+        render: (row) => {
+          const items: OverflowMenuEntry[] = [];
+          if (onTransfer) {
+            items.push({
+              label: "Schule wechseln",
+              icon: <ArrowRightLeft className="h-4 w-4" aria-hidden="true" />,
+              onClick: () => onTransfer(row),
+            });
+          }
+          if (onSetKey) {
+            items.push({
+              label: "API-Key ändern",
+              icon: <KeyRound className="h-4 w-4" aria-hidden="true" />,
+              onClick: () => onSetKey(row),
+            });
+          }
+          if (onDelete) {
+            if (items.length > 0) items.push({ kind: "separator" });
+            items.push({
+              label: "Löschen",
+              icon: <Trash2 className="h-4 w-4" aria-hidden="true" />,
+              destructive: true,
+              onClick: () => onDelete(row),
+            });
+          }
+          return (
+            <OverflowMenu
+              items={items}
+              triggerSize="sm"
+              ariaLabel={`Aktionen für ${row.name || row.deviceId}`}
+            />
+          );
+        },
       });
     }
 
     return cols;
-  }, [showSchool, onSetKey, onDelete, copiedId, handleCopyApiKey]);
+  }, [showSchool, onSetKey, onTransfer, onDelete, copiedId, handleCopyApiKey]);
 
   return (
     <DataTable

--- a/frontend/src/components/operator/transfer-device-modal.test.tsx
+++ b/frontend/src/components/operator/transfer-device-modal.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const { mockGetStatus, mockTransfer, mockToastSuccess } = vi.hoisted(() => ({
+  mockGetStatus: vi.fn(),
+  mockTransfer: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}));
+
+vi.mock("~/lib/operator/provisioning-api", () => ({
+  operatorProvisioningService: {
+    getDeviceTransferStatus: mockGetStatus,
+    transferDevice: mockTransfer,
+  },
+}));
+
+vi.mock("~/contexts/ToastContext", () => ({
+  useToast: () => ({ success: mockToastSuccess }),
+}));
+
+vi.mock("~/components/ui/form-modal", () => ({
+  FormModal: ({
+    isOpen,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    title: string;
+    children: ReactNode;
+    footer: ReactNode;
+  }) =>
+    isOpen ? (
+      <section aria-label={title}>
+        <h2>{title}</h2>
+        {children}
+        {footer}
+      </section>
+    ) : null,
+}));
+
+vi.mock("~/components/ui/custom-select", () => ({
+  CustomSelect: ({
+    value,
+    options,
+    onChange,
+    disabled,
+  }: {
+    value: string;
+    options: { value: string; label: string }[];
+    onChange: (value: string) => void;
+    disabled: boolean;
+  }) => (
+    <select
+      aria-label="Zielschule"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      disabled={disabled}
+    >
+      <option value="">Bitte wählen</option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+import { TransferDeviceModal } from "./transfer-device-modal";
+import type {
+  OperatorDevice,
+  School,
+} from "~/lib/operator/provisioning-helpers";
+
+const device: OperatorDevice = {
+  id: "1",
+  deviceId: "BURBACH-2",
+  deviceType: "terminal",
+  name: "Burbach 2",
+  status: "active",
+  apiKey: "dev-key",
+  maskedApiKey: "dev-key",
+  lastSeen: null,
+  isOnline: false,
+  schoolId: "10",
+  schoolName: "Burbach",
+  organizationId: "5",
+  organizationName: "Talent OGS",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function school(id: string, name: string, organizationId = "5"): School {
+  return {
+    id,
+    organizationId,
+    name,
+    slug: name.toLowerCase(),
+    subdomain: name.toLowerCase(),
+    address: "",
+    city: "",
+    zip: "",
+    phone: "",
+    email: "",
+    active: true,
+    hidden: false,
+    deletedAt: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("TransferDeviceModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("filters destinations to the same organization and transfers", async () => {
+    mockGetStatus.mockResolvedValue({
+      canTransfer: true,
+      isOnline: false,
+      lastSeen: null,
+      activeSession: null,
+    });
+    mockTransfer.mockResolvedValue({
+      ...device,
+      id: "2",
+      schoolId: "20",
+      schoolName: "Walbach",
+    });
+    const onTransferred = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <TransferDeviceModal
+        device={device}
+        schools={[
+          school("10", "Burbach"),
+          school("20", "Walbach"),
+          school("30", "Fremdschule", "9"),
+        ]}
+        onClose={onClose}
+        onTransferred={onTransferred}
+      />,
+    );
+
+    await screen.findByText(
+      "Das Gerät ist offline und hat keine offene Sitzung.",
+    );
+    expect(screen.getByRole("option", { name: "Walbach" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Fremdschule" }),
+    ).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Zielschule"), {
+      target: { value: "20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Schule wechseln" }));
+
+    await waitFor(() => expect(mockTransfer).toHaveBeenCalledWith("1", "20"));
+    expect(onTransferred).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Burbach 2 wurde nach Walbach verschoben.",
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows online and session blockers and disables transfer", async () => {
+    mockGetStatus.mockResolvedValue({
+      canTransfer: false,
+      isOnline: true,
+      lastSeen: "2026-08-05T12:00:00Z",
+      activeSession: {
+        id: "77",
+        startedAt: "2026-08-05T11:00:00Z",
+        activityName: "Mensa",
+        roomName: "Speisesaal",
+      },
+    });
+
+    render(
+      <TransferDeviceModal
+        device={device}
+        schools={[school("10", "Burbach"), school("20", "Walbach")]}
+        onClose={vi.fn()}
+        onTransferred={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText(/Das Gerät ist online/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Offene Sitzung.*Mensa.*Speisesaal/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Schule wechseln" }),
+    ).toBeDisabled();
+    expect(mockTransfer).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/operator/transfer-device-modal.tsx
+++ b/frontend/src/components/operator/transfer-device-modal.tsx
@@ -29,6 +29,18 @@ interface TransferDeviceModalProps {
   readonly onTransferred: (device: OperatorDevice) => Promise<void> | void;
 }
 
+interface TransferDeviceContentProps {
+  readonly device: OperatorDevice;
+  readonly destinations: readonly School[];
+  readonly targetSchoolId: string;
+  readonly status: DeviceTransferStatus | null;
+  readonly statusLoading: boolean;
+  readonly error: string;
+  readonly schoolLabelId: string;
+  readonly onTargetSchoolChange: (schoolId: string) => void;
+  readonly onRefreshStatus: () => Promise<void>;
+}
+
 function formatTimestamp(value: string): string {
   return new Intl.DateTimeFormat("de-DE", {
     dateStyle: "short",
@@ -36,35 +48,48 @@ function formatTimestamp(value: string): string {
   }).format(new Date(value));
 }
 
-export function TransferDeviceModal({
-  device,
-  schools,
-  onClose,
-  onTransferred,
-}: TransferDeviceModalProps) {
-  const [targetSchoolId, setTargetSchoolId] = useState("");
+function getTransferDestinations(
+  device: OperatorDevice | null,
+  schools: readonly School[],
+): School[] {
+  const organizationId = device?.organizationId;
+  const sourceSchoolId = device?.schoolId;
+  if (organizationId == null || sourceSchoolId == null) return [];
+
+  return schools
+    .filter(
+      (school) =>
+        school.organizationId === organizationId &&
+        school.id !== sourceSchoolId &&
+        school.active &&
+        school.deletedAt == null,
+    )
+    .sort((left, right) => left.name.localeCompare(right.name, "de"));
+}
+
+function formatOnlineMessage(status: DeviceTransferStatus): string {
+  const lastSeen = status.lastSeen
+    ? ` (zuletzt gesehen ${formatTimestamp(status.lastSeen)})`
+    : "";
+  return `Das Gerät ist online${lastSeen}. Schalte es aus und warte mindestens fünf Minuten.`;
+}
+
+function formatSessionMessage(
+  session: NonNullable<DeviceTransferStatus["activeSession"]>,
+): string {
+  const activity = session.activityName ? ` · ${session.activityName}` : "";
+  const room = session.roomName ? ` · ${session.roomName}` : "";
+  return `Offene Sitzung seit ${formatTimestamp(session.startedAt)}${activity}${room}. Beende die Sitzung vor dem Verschieben.`;
+}
+
+function useDeviceTransferStatus(
+  device: OperatorDevice | null,
+  resetTargetSchool: () => void,
+) {
   const [status, setStatus] = useState<DeviceTransferStatus | null>(null);
   const [statusLoading, setStatusLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const statusRequestId = useRef(0);
-  const schoolLabelId = useId();
-  const { success: toastSuccess } = useToast();
-
-  const destinations = useMemo(
-    () =>
-      [...schools]
-        .filter(
-          (school) =>
-            device != null &&
-            school.organizationId === device.organizationId &&
-            school.id !== device.schoolId &&
-            school.active &&
-            school.deletedAt == null,
-        )
-        .sort((left, right) => left.name.localeCompare(right.name, "de")),
-    [device, schools],
-  );
 
   const refreshStatus = useCallback(async () => {
     if (!device) return;
@@ -90,18 +115,150 @@ export function TransferDeviceModal({
   }, [device]);
 
   useEffect(() => {
-    if (!device) {
-      statusRequestId.current += 1;
-      setTargetSchoolId("");
-      setStatus(null);
-      setError("");
-      return;
-    }
-    setTargetSchoolId("");
+    resetTargetSchool();
     setStatus(null);
     setError("");
+    if (!device) {
+      statusRequestId.current += 1;
+      return;
+    }
     void refreshStatus();
-  }, [device, refreshStatus]);
+  }, [device, refreshStatus, resetTargetSchool]);
+
+  return {
+    status,
+    statusLoading,
+    error,
+    setError,
+    refreshStatus,
+  };
+}
+
+function TransferDeviceContent({
+  device,
+  destinations,
+  targetSchoolId,
+  status,
+  statusLoading,
+  error,
+  schoolLabelId,
+  onTargetSchoolChange,
+  onRefreshStatus,
+}: TransferDeviceContentProps) {
+  const statusRetry = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="compact"
+      onClick={() => void onRefreshStatus()}
+      disabled={statusLoading}
+    >
+      Erneut prüfen
+    </Button>
+  );
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="text-sm text-gray-600">Aktuelle Schule</p>
+        <p className="mt-1 font-medium text-gray-900">{device.schoolName}</p>
+        <p className="mt-1 font-mono text-xs text-gray-500">
+          {device.deviceId}
+          {device.name ? ` · ${device.name}` : ""}
+        </p>
+      </div>
+
+      <Alert
+        type="info"
+        message="Geräte-ID und API-Key bleiben erhalten. Die Raumzuordnung wird entfernt; bisherige Anwesenheiten und Sitzungen bleiben bei der aktuellen Schule."
+      />
+
+      {statusLoading && status == null ? (
+        <output className="block text-sm text-gray-500">
+          Gerätestatus wird geprüft…
+        </output>
+      ) : null}
+
+      {status?.isOnline ? (
+        <Alert
+          type="warning"
+          message={formatOnlineMessage(status)}
+          action={statusRetry}
+        />
+      ) : null}
+
+      {status?.activeSession ? (
+        <Alert
+          type="warning"
+          message={formatSessionMessage(status.activeSession)}
+          action={statusRetry}
+        />
+      ) : null}
+
+      {status?.isProtected ? (
+        <Alert
+          type="warning"
+          message="Dieses Systemgerät wird für manuelle Web-Buchungen benötigt und kann nicht verschoben werden."
+        />
+      ) : null}
+
+      {status?.canTransfer ? (
+        <Alert
+          type="success"
+          message="Das Gerät ist offline und hat keine offene Sitzung."
+        />
+      ) : null}
+
+      {destinations.length > 0 ? (
+        <div className="space-y-2">
+          <span
+            id={schoolLabelId}
+            className="block text-sm font-medium text-gray-700"
+          >
+            Zielschule
+          </span>
+          <CustomSelect
+            value={targetSchoolId}
+            options={destinations.map((school) => ({
+              value: school.id,
+              label: school.name,
+            }))}
+            onChange={onTargetSchoolChange}
+            ariaLabelledBy={schoolLabelId}
+            placeholder="Zielschule wählen"
+            disabled={status?.canTransfer !== true || statusLoading}
+          />
+        </div>
+      ) : (
+        <Alert
+          type="warning"
+          message="Für diesen Träger gibt es keine weitere aktive Schule als Ziel."
+        />
+      )}
+
+      {error ? <Alert type="error" message={error} /> : null}
+    </div>
+  );
+}
+
+export function TransferDeviceModal({
+  device,
+  schools,
+  onClose,
+  onTransferred,
+}: TransferDeviceModalProps) {
+  const [targetSchoolId, setTargetSchoolId] = useState("");
+  const [saving, setSaving] = useState(false);
+  const schoolLabelId = useId();
+  const { success: toastSuccess } = useToast();
+  const resetTargetSchool = useCallback(() => setTargetSchoolId(""), []);
+  const { status, statusLoading, error, setError, refreshStatus } =
+    useDeviceTransferStatus(device, resetTargetSchool);
+
+  const destinations = useMemo(
+    () => getTransferDestinations(device, schools),
+    [device, schools],
+  );
 
   const handleTransfer = useCallback(async () => {
     if (!device || !targetSchoolId || !status?.canTransfer) return;
@@ -138,22 +295,11 @@ export function TransferDeviceModal({
     onClose,
     onTransferred,
     refreshStatus,
+    setError,
     status?.canTransfer,
     targetSchoolId,
     toastSuccess,
   ]);
-
-  const statusRetry = (
-    <Button
-      type="button"
-      variant="ghost"
-      size="compact"
-      onClick={() => void refreshStatus()}
-      disabled={statusLoading}
-    >
-      Erneut prüfen
-    </Button>
-  );
 
   return (
     <FormModal
@@ -185,88 +331,17 @@ export function TransferDeviceModal({
       }
     >
       {device ? (
-        <div className="space-y-5">
-          <div>
-            <p className="text-sm text-gray-600">Aktuelle Schule</p>
-            <p className="mt-1 font-medium text-gray-900">
-              {device.schoolName}
-            </p>
-            <p className="mt-1 font-mono text-xs text-gray-500">
-              {device.deviceId}
-              {device.name ? ` · ${device.name}` : ""}
-            </p>
-          </div>
-
-          <Alert
-            type="info"
-            message="Geräte-ID und API-Key bleiben erhalten. Die Raumzuordnung wird entfernt; bisherige Anwesenheiten und Sitzungen bleiben bei der aktuellen Schule."
-          />
-
-          {statusLoading && status == null ? (
-            <p role="status" className="text-sm text-gray-500">
-              Gerätestatus wird geprüft…
-            </p>
-          ) : null}
-
-          {status?.isOnline ? (
-            <Alert
-              type="warning"
-              message={`Das Gerät ist online${status.lastSeen ? ` (zuletzt gesehen ${formatTimestamp(status.lastSeen)})` : ""}. Schalte es aus und warte mindestens fünf Minuten.`}
-              action={statusRetry}
-            />
-          ) : null}
-
-          {status?.activeSession ? (
-            <Alert
-              type="warning"
-              message={`Offene Sitzung seit ${formatTimestamp(status.activeSession.startedAt)}${status.activeSession.activityName ? ` · ${status.activeSession.activityName}` : ""}${status.activeSession.roomName ? ` · ${status.activeSession.roomName}` : ""}. Beende die Sitzung vor dem Verschieben.`}
-              action={statusRetry}
-            />
-          ) : null}
-
-          {status?.isProtected ? (
-            <Alert
-              type="warning"
-              message="Dieses Systemgerät wird für manuelle Web-Buchungen benötigt und kann nicht verschoben werden."
-            />
-          ) : null}
-
-          {status?.canTransfer ? (
-            <Alert
-              type="success"
-              message="Das Gerät ist offline und hat keine offene Sitzung."
-            />
-          ) : null}
-
-          {destinations.length > 0 ? (
-            <div className="space-y-2">
-              <span
-                id={schoolLabelId}
-                className="block text-sm font-medium text-gray-700"
-              >
-                Zielschule
-              </span>
-              <CustomSelect
-                value={targetSchoolId}
-                options={destinations.map((school) => ({
-                  value: school.id,
-                  label: school.name,
-                }))}
-                onChange={setTargetSchoolId}
-                ariaLabelledBy={schoolLabelId}
-                placeholder="Zielschule wählen"
-                disabled={status?.canTransfer !== true || statusLoading}
-              />
-            </div>
-          ) : (
-            <Alert
-              type="warning"
-              message="Für diesen Träger gibt es keine weitere aktive Schule als Ziel."
-            />
-          )}
-
-          {error ? <Alert type="error" message={error} /> : null}
-        </div>
+        <TransferDeviceContent
+          device={device}
+          destinations={destinations}
+          targetSchoolId={targetSchoolId}
+          status={status}
+          statusLoading={statusLoading}
+          error={error}
+          schoolLabelId={schoolLabelId}
+          onTargetSchoolChange={setTargetSchoolId}
+          onRefreshStatus={refreshStatus}
+        />
       ) : null}
     </FormModal>
   );

--- a/frontend/src/components/operator/transfer-device-modal.tsx
+++ b/frontend/src/components/operator/transfer-device-modal.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { FormModal } from "~/components/ui/form-modal";
+import { useToast } from "~/contexts/ToastContext";
+import { isOperatorApiError } from "~/lib/operator/api-helpers";
+import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
+import type {
+  DeviceTransferStatus,
+  OperatorDevice,
+  School,
+} from "~/lib/operator/provisioning-helpers";
+
+interface TransferDeviceModalProps {
+  readonly device: OperatorDevice | null;
+  readonly schools: readonly School[];
+  readonly onClose: () => void;
+  readonly onTransferred: (device: OperatorDevice) => Promise<void> | void;
+}
+
+function formatTimestamp(value: string): string {
+  return new Intl.DateTimeFormat("de-DE", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+export function TransferDeviceModal({
+  device,
+  schools,
+  onClose,
+  onTransferred,
+}: TransferDeviceModalProps) {
+  const [targetSchoolId, setTargetSchoolId] = useState("");
+  const [status, setStatus] = useState<DeviceTransferStatus | null>(null);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const statusRequestId = useRef(0);
+  const schoolLabelId = useId();
+  const { success: toastSuccess } = useToast();
+
+  const destinations = useMemo(
+    () =>
+      [...schools]
+        .filter(
+          (school) =>
+            device != null &&
+            school.organizationId === device.organizationId &&
+            school.id !== device.schoolId &&
+            school.active &&
+            school.deletedAt == null,
+        )
+        .sort((left, right) => left.name.localeCompare(right.name, "de")),
+    [device, schools],
+  );
+
+  const refreshStatus = useCallback(async () => {
+    if (!device) return;
+    const requestId = ++statusRequestId.current;
+    setStatusLoading(true);
+    setError("");
+    try {
+      const nextStatus =
+        await operatorProvisioningService.getDeviceTransferStatus(device.id);
+      if (statusRequestId.current === requestId) setStatus(nextStatus);
+    } catch (statusError) {
+      if (statusRequestId.current === requestId) {
+        setStatus(null);
+        setError(
+          statusError instanceof Error
+            ? statusError.message
+            : "Der Gerätestatus konnte nicht geladen werden.",
+        );
+      }
+    } finally {
+      if (statusRequestId.current === requestId) setStatusLoading(false);
+    }
+  }, [device]);
+
+  useEffect(() => {
+    if (!device) {
+      statusRequestId.current += 1;
+      setTargetSchoolId("");
+      setStatus(null);
+      setError("");
+      return;
+    }
+    setTargetSchoolId("");
+    setStatus(null);
+    setError("");
+    void refreshStatus();
+  }, [device, refreshStatus]);
+
+  const handleTransfer = useCallback(async () => {
+    if (!device || !targetSchoolId || !status?.canTransfer) return;
+    setSaving(true);
+    setError("");
+    try {
+      const transferred = await operatorProvisioningService.transferDevice(
+        device.id,
+        targetSchoolId,
+      );
+      await onTransferred(transferred);
+      toastSuccess(
+        `${device.name || device.deviceId} wurde nach ${transferred.schoolName} verschoben.`,
+      );
+      onClose();
+    } catch (transferError) {
+      if (isOperatorApiError(transferError) && transferError.status === 409) {
+        setError(
+          "Das Gerät kann gerade nicht verschoben werden. Prüfe den aktuellen Status.",
+        );
+        await refreshStatus();
+      } else {
+        setError(
+          transferError instanceof Error
+            ? transferError.message
+            : "Das Gerät konnte nicht verschoben werden.",
+        );
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    device,
+    onClose,
+    onTransferred,
+    refreshStatus,
+    status?.canTransfer,
+    targetSchoolId,
+    toastSuccess,
+  ]);
+
+  const statusRetry = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="compact"
+      onClick={() => void refreshStatus()}
+      disabled={statusLoading}
+    >
+      Erneut prüfen
+    </Button>
+  );
+
+  return (
+    <FormModal
+      isOpen={device != null}
+      onClose={onClose}
+      title="Gerät verschieben"
+      size="md"
+      footer={
+        <>
+          <Button type="button" variant="outline" size="md" onClick={onClose}>
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            size="md"
+            onClick={() => void handleTransfer()}
+            isLoading={saving}
+            loadingText="Wird verschoben…"
+            disabled={
+              saving ||
+              statusLoading ||
+              status?.canTransfer !== true ||
+              targetSchoolId === ""
+            }
+          >
+            Schule wechseln
+          </Button>
+        </>
+      }
+    >
+      {device ? (
+        <div className="space-y-5">
+          <div>
+            <p className="text-sm text-gray-600">Aktuelle Schule</p>
+            <p className="mt-1 font-medium text-gray-900">
+              {device.schoolName}
+            </p>
+            <p className="mt-1 font-mono text-xs text-gray-500">
+              {device.deviceId}
+              {device.name ? ` · ${device.name}` : ""}
+            </p>
+          </div>
+
+          <Alert
+            type="info"
+            message="Geräte-ID und API-Key bleiben erhalten. Die Raumzuordnung wird entfernt; bisherige Anwesenheiten und Sitzungen bleiben bei der aktuellen Schule."
+          />
+
+          {statusLoading && status == null ? (
+            <p role="status" className="text-sm text-gray-500">
+              Gerätestatus wird geprüft…
+            </p>
+          ) : null}
+
+          {status?.isOnline ? (
+            <Alert
+              type="warning"
+              message={`Das Gerät ist online${status.lastSeen ? ` (zuletzt gesehen ${formatTimestamp(status.lastSeen)})` : ""}. Schalte es aus und warte mindestens fünf Minuten.`}
+              action={statusRetry}
+            />
+          ) : null}
+
+          {status?.activeSession ? (
+            <Alert
+              type="warning"
+              message={`Offene Sitzung seit ${formatTimestamp(status.activeSession.startedAt)}${status.activeSession.activityName ? ` · ${status.activeSession.activityName}` : ""}${status.activeSession.roomName ? ` · ${status.activeSession.roomName}` : ""}. Beende die Sitzung vor dem Verschieben.`}
+              action={statusRetry}
+            />
+          ) : null}
+
+          {status?.isProtected ? (
+            <Alert
+              type="warning"
+              message="Dieses Systemgerät wird für manuelle Web-Buchungen benötigt und kann nicht verschoben werden."
+            />
+          ) : null}
+
+          {status?.canTransfer ? (
+            <Alert
+              type="success"
+              message="Das Gerät ist offline und hat keine offene Sitzung."
+            />
+          ) : null}
+
+          {destinations.length > 0 ? (
+            <div className="space-y-2">
+              <span
+                id={schoolLabelId}
+                className="block text-sm font-medium text-gray-700"
+              >
+                Zielschule
+              </span>
+              <CustomSelect
+                value={targetSchoolId}
+                options={destinations.map((school) => ({
+                  value: school.id,
+                  label: school.name,
+                }))}
+                onChange={setTargetSchoolId}
+                ariaLabelledBy={schoolLabelId}
+                placeholder="Zielschule wählen"
+                disabled={status?.canTransfer !== true || statusLoading}
+              />
+            </div>
+          ) : (
+            <Alert
+              type="warning"
+              message="Für diesen Träger gibt es keine weitere aktive Schule als Ziel."
+            />
+          )}
+
+          {error ? <Alert type="error" message={error} /> : null}
+        </div>
+      ) : null}
+    </FormModal>
+  );
+}

--- a/frontend/src/lib/operator/provisioning-api.test.ts
+++ b/frontend/src/lib/operator/provisioning-api.test.ts
@@ -623,6 +623,60 @@ describe("OperatorProvisioningService", () => {
     });
   });
 
+  describe("device transfer", () => {
+    it("loads and maps transfer blockers", async () => {
+      mockOperatorFetch.mockResolvedValue({
+        can_transfer: false,
+        is_online: true,
+        last_seen: NOW,
+        active_session: {
+          id: 77,
+          started_at: NOW,
+          activity_name: "Mensa",
+          room_name: "Speisesaal",
+        },
+      });
+
+      const result =
+        await operatorProvisioningService.getDeviceTransferStatus("1/unsafe");
+
+      expect(mockOperatorFetch).toHaveBeenCalledWith(
+        "/api/operator/provisioning/devices/1%2Funsafe/transfer-status",
+      );
+      expect(result).toEqual({
+        canTransfer: false,
+        isOnline: true,
+        lastSeen: NOW,
+        activeSession: {
+          id: "77",
+          startedAt: NOW,
+          activityName: "Mensa",
+          roomName: "Speisesaal",
+        },
+      });
+    });
+
+    it("posts the numeric target school and maps the transferred device", async () => {
+      mockOperatorFetch.mockResolvedValue({
+        ...mockBackendDevice,
+        school_id: 20,
+        school_name: "Walbach",
+      });
+
+      const result = await operatorProvisioningService.transferDevice(
+        "1/unsafe",
+        "20",
+      );
+
+      expect(mockOperatorFetch).toHaveBeenCalledWith(
+        "/api/operator/provisioning/devices/1%2Funsafe/transfer",
+        { method: "POST", body: { target_school_id: 20 } },
+      );
+      expect(result.schoolId).toBe("20");
+      expect(result.schoolName).toBe("Walbach");
+    });
+  });
+
   describe("createSchoolAccount", () => {
     const mockAccountData = {
       email: "new@school.de",

--- a/frontend/src/lib/operator/provisioning-api.ts
+++ b/frontend/src/lib/operator/provisioning-api.ts
@@ -29,6 +29,8 @@ import type {
   CreateAccountRequest,
   UpdateOrganizationRequest,
   UpdateSchoolRequest,
+  BackendDeviceTransferStatus,
+  DeviceTransferStatus,
 } from "./provisioning-helpers";
 import {
   mapOrganization,
@@ -42,6 +44,7 @@ import {
   mapOperatorDevice,
   mapOperatorPerson,
   mapUnregisteredTagScan,
+  mapDeviceTransferStatus,
 } from "./provisioning-helpers";
 
 class OperatorProvisioningService {
@@ -190,6 +193,29 @@ class OperatorProvisioningService {
     const result = await operatorFetch<BackendOperatorDevice>(
       `/api/operator/provisioning/devices/${encodeURIComponent(deviceId)}/set-api-key`,
       { method: "POST", body: apiKey ? { api_key: apiKey } : {} },
+    );
+    return mapOperatorDevice(result);
+  }
+
+  async getDeviceTransferStatus(
+    deviceId: string,
+  ): Promise<DeviceTransferStatus> {
+    const result = await operatorFetch<BackendDeviceTransferStatus>(
+      `/api/operator/provisioning/devices/${encodeURIComponent(deviceId)}/transfer-status`,
+    );
+    return mapDeviceTransferStatus(result);
+  }
+
+  async transferDevice(
+    deviceId: string,
+    targetSchoolId: string,
+  ): Promise<OperatorDevice> {
+    const result = await operatorFetch<BackendOperatorDevice>(
+      `/api/operator/provisioning/devices/${encodeURIComponent(deviceId)}/transfer`,
+      {
+        method: "POST",
+        body: { target_school_id: Number(targetSchoolId) },
+      },
     );
     return mapOperatorDevice(result);
   }

--- a/frontend/src/lib/operator/provisioning-helpers.ts
+++ b/frontend/src/lib/operator/provisioning-helpers.ts
@@ -512,6 +512,53 @@ export function mapOperatorDevice(data: BackendOperatorDevice): OperatorDevice {
   };
 }
 
+interface BackendDeviceTransferSession {
+  id: number;
+  started_at: string;
+  activity_name?: string;
+  room_name?: string;
+}
+
+export interface BackendDeviceTransferStatus {
+  can_transfer: boolean;
+  is_online: boolean;
+  is_protected: boolean;
+  last_seen?: string;
+  active_session?: BackendDeviceTransferSession;
+}
+
+export interface DeviceTransferStatus {
+  canTransfer: boolean;
+  isOnline: boolean;
+  isProtected: boolean;
+  lastSeen: string | null;
+  activeSession: {
+    id: string;
+    startedAt: string;
+    activityName: string;
+    roomName: string;
+  } | null;
+}
+
+export function mapDeviceTransferStatus(
+  data: BackendDeviceTransferStatus,
+): DeviceTransferStatus {
+  return {
+    canTransfer: data.can_transfer,
+    isOnline: data.is_online,
+    isProtected: data.is_protected,
+    lastSeen: data.last_seen ?? null,
+    activeSession: data.active_session
+      ? {
+          id: data.active_session.id.toString(),
+          startedAt: data.active_session.started_at,
+          activityName: data.active_session.activity_name ?? "",
+          roomName: data.active_session.room_name ?? "",
+        }
+      : null,
+  };
+}
+
 // Slug helpers
 
 const SLUG_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;


### PR DESCRIPTION
All confirmed. The implementation matches the original description well — the only stale fact is the migration version number. Here's the finalized description:

---

## Summary
- add an operator-only device transfer workflow between active schools in the same organization
- preserve the device identity and API key while archiving the source row so attendance and session history stays intact
- block transfers for online devices, open sessions, and the protected manual web device
- expose transfer status and transfer endpoints through the backend and Next.js BFF
- add the transfer action and status-aware modal to all operator device views

## Data model
- add migration 1.15.269 with transfer history columns (`archived_at`, `transferred_to_device_id`) and an active-device partial unique index (`tenant_id, device_id WHERE archived_at IS NULL`)
- retain archived source rows while excluding them from normal device queries and operator summaries
- the online/offline cutoff used to decide transferability resolves from the tenant's `iot.device_online_window_minutes` setting (falling back to a 5-minute default), not a hardcoded value
- record successful transfers in the operator audit log

## Verification
- cd backend && go test ./...
- cd frontend && pnpm run check
- cd frontend && pnpm test -- --run
- pre-push: go vet, golangci-lint, deadcode, Knip, dependency-cruiser, frontend check
- agent-browser QA: transferred demo-device-002 from Demo School to Walbach Transfer QA; status and transfer requests returned 200
- database QA: archived source has no API key and points to the active target row; target retains the API key and device identity

## Screenshots
Screenshots were captured locally during browser QA. Native GitHub attachment upload is not available in this environment, so they are not hosted externally.
