### PR TITLE
fix(parents): Absturz nach Eltern-Login durch Doppel-Navigation

### DIFF
--- a/frontend/src/app/parents/login/page.test.tsx
+++ b/frontend/src/app/parents/login/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -204,6 +204,48 @@ describe("ParentLoginPage i18n", () => {
     expect(
       screen.getByRole("button", { name: "Signing in..." }),
     ).toBeDisabled();
+  });
+
+  it("releases the form when the session never arrives after a successful login", async () => {
+    // NextAuth holt die Session per fetchData(), das jeden Fetch-Fehler
+    // schluckt und null liefert. signIn meldet dann ok, status bleibt aber
+    // "unauthenticated" und der Redirect feuert nie — ohne Watchdog bliebe das
+    // Formular dauerhaft gesperrt und ohne Fehlermeldung zurück.
+    vi.useFakeTimers();
+    mocks.signIn.mockResolvedValue({ error: null });
+
+    try {
+      render(<ParentLoginPage />);
+
+      fireEvent.change(screen.getByLabelText("Email address"), {
+        target: { value: "parent@example.com" },
+      });
+      fireEvent.change(screen.getByLabelText("Password"), {
+        target: { value: "password123" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Signing in..." }),
+      ).toBeDisabled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(screen.getByRole("button", { name: "Sign in" })).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: "Forgot your password?" }),
+      ).toBeEnabled();
+      expect(screen.getByText("Login error. Please try again.")).toBeVisible();
+      expect(mocks.push).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("opens the password reset modal with localized parent copy", () => {

--- a/frontend/src/app/parents/login/page.test.tsx
+++ b/frontend/src/app/parents/login/page.test.tsx
@@ -21,6 +21,13 @@ vi.mock("next-auth/react", () => ({
   useSession: mocks.useSession,
 }));
 
+// parentPath() reads NEXT_PUBLIC_PARENTS_HOSTNAME and throws when it is unset,
+// which no unit-test env provides. The path mapping itself is covered by
+// parent-url.test.ts.
+vi.mock("~/lib/parent-url", () => ({
+  parentPath: (path: string) => path,
+}));
+
 vi.mock("next-intl", async () => {
   const en = (await import("~/i18n/messages/en.json")).default as Record<
     string,
@@ -154,6 +161,49 @@ describe("ParentLoginPage i18n", () => {
     await vi.waitFor(() => {
       expect(mocks.signOut).toHaveBeenCalledWith({ redirect: false });
     });
+  });
+
+  it("redirects to the parents portal once the session is published", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { scope: "parent", token: "valid-token" } },
+    });
+
+    render(<ParentLoginPage />);
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/parents");
+  });
+
+  it("leaves the redirect to the session and never pushes a second navigation", async () => {
+    // Two concurrent navigations to the same target left the App Router state
+    // as a pending thenable, and Next's conditional `use(state)` then rendered
+    // a different number of hooks ("Rendered more hooks than during the
+    // previous render") — the portal died right after login until a reload.
+    mocks.signIn.mockResolvedValue({ error: null });
+
+    render(<ParentLoginPage />);
+
+    fireEvent.change(screen.getByLabelText("Email address"), {
+      target: { value: "parent@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await vi.waitFor(() => {
+      expect(mocks.signIn).toHaveBeenCalledWith("parent-credentials", {
+        redirect: false,
+        email: "parent@example.com",
+        password: "password123",
+      });
+    });
+
+    expect(mocks.push).not.toHaveBeenCalled();
+    // The form stays locked until the session-driven redirect navigates away.
+    expect(
+      screen.getByRole("button", { name: "Signing in..." }),
+    ).toBeDisabled();
   });
 
   it("opens the password reset modal with localized parent copy", () => {

--- a/frontend/src/app/parents/login/page.tsx
+++ b/frontend/src/app/parents/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 // eslint-disable-next-line no-restricted-imports -- parent routes are not tenant-scoped
-import { redirect, useRouter } from "next/navigation";
+import { redirect } from "next/navigation";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Alert } from "~/components/ui/alert";
@@ -29,7 +29,6 @@ export default function ParentLoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
-  const router = useRouter();
   const { data: session, status } = useSession();
   // Ref prevents re-triggering signOut (not in effect deps → no loop).
   // Separate state controls the loading spinner for the UI.
@@ -72,6 +71,14 @@ export default function ParentLoginPage() {
     void check();
   }, [status, session]);
 
+  // Einzige Weiterleitung nach erfolgreichem Login. Sie greift, sobald NextAuth
+  // die neue Session veröffentlicht — auch für den Fall "bereits angemeldet,
+  // ruft /login direkt auf". handleSubmit darf daher NICHT zusätzlich
+  // router.push() feuern: zwei gleichzeitige Navigationen auf dasselbe Ziel
+  // lassen den App-Router-State als pending Thenable stehen, und das
+  // bedingte `use(state)` in Next' useActionQueue rendert dann eine
+  // unterschiedliche Anzahl Hooks ("Rendered more hooks than during the
+  // previous render", Seite bricht ab, erst ein Reload heilt es).
   if (isRedirectingToParent) {
     redirect(parentPath("/parents"));
   }
@@ -101,13 +108,15 @@ export default function ParentLoginPage() {
           invalid_credentials: t("errors.invalidCredentials"),
         };
         setError(errorMessages[result.code ?? ""] ?? t("errors.invalid"));
+        setIsLoading(false);
         return;
       }
 
-      router.push(parentPath("/parents"));
+      // Kein router.push hier — die Weiterleitung oben übernimmt. isLoading
+      // bleibt absichtlich stehen, damit das Formular bis zur Navigation
+      // gesperrt bleibt und niemand ein zweites Mal absendet.
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.generic"));
-    } finally {
       setIsLoading(false);
     }
   };

--- a/frontend/src/app/parents/login/page.tsx
+++ b/frontend/src/app/parents/login/page.tsx
@@ -19,6 +19,14 @@ import { LanguageSwitcher } from "~/components/parent/language-switcher";
 import { requestParentPasswordReset } from "~/lib/auth-api";
 import { parentPath } from "~/lib/parent-url";
 
+/**
+ * Wie lange nach einem erfolgreichen signIn auf die publizierte Session
+ * gewartet wird, bevor das Formular wieder freigegeben wird. Der Abruf geht an
+ * die eigene Route (/api/parent/auth/session), zehn Sekunden sind also
+ * reichlich und trotzdem kurz genug, dass niemand vor einem toten Screen sitzt.
+ */
+const SESSION_HANDOFF_TIMEOUT_MS = 10_000;
+
 export default function ParentLoginPage() {
   const t = useTranslations("parentLogin");
   const tAuthShell = useTranslations("parentAuthShell");
@@ -29,6 +37,9 @@ export default function ParentLoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
+  // True zwischen erfolgreichem signIn und der publizierten Session. Steuert
+  // den Watchdog weiter unten.
+  const [awaitingSession, setAwaitingSession] = useState(false);
   const { data: session, status } = useSession();
   // Ref prevents re-triggering signOut (not in effect deps → no loop).
   // Separate state controls the loading spinner for the UI.
@@ -70,6 +81,24 @@ export default function ParentLoginPage() {
     };
     void check();
   }, [status, session]);
+
+  // Watchdog für die Übergabe von signIn an die Session. signIn kann ok
+  // melden, ohne dass danach je eine Session ankommt: NextAuth holt sie per
+  // fetchData(), und das schluckt JEDEN Fetch-Fehler und liefert null
+  // (next-auth/lib/client.js). Ein einzelner wackliger GET auf
+  // /api/parent/auth/session lässt status damit auf "unauthenticated" stehen,
+  // der redirect() unten feuert nie. Ohne diesen Watchdog bliebe das Formular
+  // mit "Anmeldung läuft..." dauerhaft gesperrt und ohne Fehlermeldung
+  // zurück, und nur ein manueller Reload käme da wieder raus.
+  useEffect(() => {
+    if (!awaitingSession) return;
+    const timer = setTimeout(() => {
+      setAwaitingSession(false);
+      setIsLoading(false);
+      setError(t("errors.generic"));
+    }, SESSION_HANDOFF_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [awaitingSession, t]);
 
   // Einzige Weiterleitung nach erfolgreichem Login. Sie greift, sobald NextAuth
   // die neue Session veröffentlicht — auch für den Fall "bereits angemeldet,
@@ -114,7 +143,9 @@ export default function ParentLoginPage() {
 
       // Kein router.push hier — die Weiterleitung oben übernimmt. isLoading
       // bleibt absichtlich stehen, damit das Formular bis zur Navigation
-      // gesperrt bleibt und niemand ein zweites Mal absendet.
+      // gesperrt bleibt und niemand ein zweites Mal absendet; der Watchdog
+      // gibt es wieder frei, falls die Session ausbleibt.
+      setAwaitingSession(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.generic"));
       setIsLoading(false);


### PR DESCRIPTION
## Problem

Direkt nach dem Login ins Elternportal bricht die Startseite mit `Rendered more hooks than during the previous render.` ab, die Seite zeigt "This page couldn't load", erst ein Reload hilft. Reproduzierbar mit zwei Eltern-Konten, deterministisch, unabhängig von offenen Branches.

Der Call Stack enthält keinen einzigen App-Frame, alle 18 sind ignore-listed:

```
updateWorkInProgressHook -> updateMemo -> Object.useMemo
Router  (next/src/client/components/app-router.tsx:168)
AppRouter -> ServerRoot
```

Der Hook-Zähler kippt in Next selbst. `useActionQueue` endet mit

```js
return isThenable(stateWithDebugInfo) ? use(stateWithDebugInfo) : stateWithDebugInfo
```

Solange der App-Router-State ein pending Thenable ist, läuft ein Hook mehr als danach.

Ausgelöst wird das von der Loginseite, die nach erfolgreichem Login **zwei** Navigationen auf dasselbe Ziel feuert:

- den session-getriebenen `redirect(parentPath("/parents"))` aus dem Render, sobald die Session da ist (Next fängt das geworfene `NEXT_REDIRECT` ab und macht daraus ein `router.push`)
- zusätzlich `router.push(parentPath("/parents"))` im Submit-Handler

Gegenprobe: ruft man `/login` als bereits angemeldeter Elternteil auf, greift nur der `redirect()` und alles läuft sauber durch. Erst die Kombination im selben Tick kippt es.

Ein Scan über das gesamte Frontend nach echten Hook-Order-Verstößen (Hooks nach early return, in `if`/`for`-Blöcken, in `.map()`-Callbacks, conditional `&&`/`?:`) liefert null Treffer. Die Komponenten der Startseite haben alle feste Hook-Zahlen.

## Änderung

**1. Nur noch eine Navigation** (`ae4b90ada`)

`router.push` aus `handleSubmit` entfernt. Die Weiterleitung macht ausschließlich der session-getriebene `redirect()`, der ohnehin schon greift und zusätzlich den Fall "bereits angemeldet, ruft `/login` auf" abdeckt. `useRouter` fällt damit weg.

**2. Watchdog gegen ein hängendes Formular** (`fa062d2f6`)

Ohne das frühere `finally { setIsLoading(false) }` konnte der Erfolgspfad das Formular dauerhaft sperren: NextAuth holt die Session per `fetchData()` (`next-auth/lib/client.js:19-42`), und das schluckt jeden Fetch-Fehler und liefert `null`. Ein einzelner wackliger `GET /api/parent/auth/session` lässt `signIn` ok melden, `status` bleibt aber `unauthenticated`, der `redirect()` feuert nie. Zurück bliebe ein gesperrtes Formular mit "Anmeldung läuft...", ohne Fehlermeldung, aus dem nur ein manueller Reload herausführt.

Ein Watchdog gibt das Formular nach zehn Sekunden ohne Session wieder frei und zeigt die generische Anmeldefehlermeldung. Auf dem Erfolgspfad läuft er nie ab, weil die Weiterleitung die Seite lange vorher unmountet.

## Verifikation

Eigener Frontend-Container gegen denselben Backend- und DB-Stack, damit der laufende Dev-Stack unangetastet bleibt.

| Szenario | Ergebnis |
|---|---|
| Login mit zwei Eltern-Konten | landet direkt auf dem Dashboard, kein Fehler-Overlay, keine Page-Errors |
| `/login` als bereits angemeldeter Elternteil | leitet weiterhin weiter |
| Falsches Passwort | bleibt auf der Loginseite, "Ungültige Anmeldedaten", Formular wieder bedienbar |
| `GET /api/parent/auth/session` geblockt, t+5s | Formular gesperrt, "Anmeldung läuft..." (der alte tote Zustand) |
| dito, t+13s | Formular frei, "Anmeldefehler. Bitte versuchen Sie es erneut." |
| danach Netz frei, erneut abschicken | Dashboard, ohne Reload |

Tests: zwei neue Regressionstests (keine zweite Navigation nach erfolgreichem Login, Watchdog gibt das Formular frei) plus einer für den Redirect bei publizierter Session. 16 Tests unter `src/app/parents/` grün, die vier bestehenden Tests der Datei unverändert. `oxlint` und `tsc --noEmit` sauber.

## Bekannter gleicher Fall, bewusst nicht angefasst

`app/operator/login/page.tsx` hat dieselbe Doppel-Navigation (render-time `redirect()` plus `router.push` in `seedSessionWithTokens`). Nicht mitgefixt, weil `app/operator/login/page.test.tsx:205` `expect(mockPush).toHaveBeenCalledWith("/operator/suggestions")` festnagelt und `:209` den `mockRedirect` für den Bereits-angemeldet-Fall. Egal welche der beiden Navigationen man entfernt, eine der beiden Erwartungen fällt um. Das Operator-Login läuft zudem über MFA, also mit anderem Timing; dort reproduziert habe ich es nicht. Sollte als eigener Schritt entschieden werden.

## Screenshots

Werden nachgereicht.
