### PR TITLE
Release 2026-08-06 (2): Kontakt-Hochstufung bei Einladung und Eltern-Login-Fix

### DIFF
--- a/backend/api/guardians/account_status_internal_test.go
+++ b/backend/api/guardians/account_status_internal_test.go
@@ -4,7 +4,9 @@ import "testing"
 
 // TestGuardianAccountStatus locks the per-child derivation of the staff-facing
 // account status: an account only counts as "active" for a child when the
-// students_guardians link actually grants parent_portal.access (#2172).
+// students_guardians link actually grants parent_portal.access, and an open
+// invitation (e.g. a pending-approval role-upgrade request) outranks the
+// actionable "active_no_access" state (#2172).
 func TestGuardianAccountStatus(t *testing.T) {
 	cases := []struct {
 		name                                       string
@@ -13,7 +15,7 @@ func TestGuardianAccountStatus(t *testing.T) {
 	}{
 		{"account with access", true, true, false, "active"},
 		{"account without access on this child", true, false, false, "active_no_access"},
-		{"account without access, stale invite flag", true, false, true, "active_no_access"},
+		{"account without access, pending upgrade approval", true, false, true, "pending"},
 		{"no account, open invitation", false, false, true, "pending"},
 		{"no account, no invitation", false, false, false, "none"},
 	}

--- a/backend/api/guardians/account_status_internal_test.go
+++ b/backend/api/guardians/account_status_internal_test.go
@@ -1,0 +1,29 @@
+package guardians
+
+import "testing"
+
+// TestGuardianAccountStatus locks the per-child derivation of the staff-facing
+// account status: an account only counts as "active" for a child when the
+// students_guardians link actually grants parent_portal.access (#2172).
+func TestGuardianAccountStatus(t *testing.T) {
+	cases := []struct {
+		name                                       string
+		hasAccount, hasPortalAccess, invitePending bool
+		want                                       string
+	}{
+		{"account with access", true, true, false, "active"},
+		{"account without access on this child", true, false, false, "active_no_access"},
+		{"account without access, stale invite flag", true, false, true, "active_no_access"},
+		{"no account, open invitation", false, false, true, "pending"},
+		{"no account, no invitation", false, false, false, "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := guardianAccountStatus(tc.hasAccount, tc.hasPortalAccess, tc.invitePending)
+			if got != tc.want {
+				t.Fatalf("guardianAccountStatus(%v, %v, %v) = %q, want %q",
+					tc.hasAccount, tc.hasPortalAccess, tc.invitePending, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -221,15 +221,19 @@ type GuardianWithRelationship struct {
 // guardianAccountStatus derives the staff-facing account-status string.
 // hasPortalAccess is the per-child parent_portal.access permission on the
 // students_guardians link — an account is only "active" for THIS child when
-// the link actually grants access (#2172).
+// the link actually grants access (#2172). An open invitation outranks
+// "active_no_access": an account holder with a pending-approval role-upgrade
+// request must read as pending, not as an actionable no-access state that
+// invites staff to bypass the approval queue (mirrors the parent-side
+// relatedAccountStatus priority).
 func guardianAccountStatus(hasAccount, hasPortalAccess, invitationPending bool) string {
 	switch {
 	case hasAccount && hasPortalAccess:
 		return "active"
-	case hasAccount:
-		return "active_no_access"
 	case invitationPending:
 		return "pending"
+	case hasAccount:
+		return "active_no_access"
 	default:
 		return "none"
 	}

--- a/backend/api/guardians/handlers.go
+++ b/backend/api/guardians/handlers.go
@@ -210,16 +210,24 @@ type GuardianWithRelationship struct {
 	PickupNotes        *string           `json:"pickup_notes,omitempty"`
 	EmergencyPriority  int               `json:"emergency_priority"`
 	// AccountStatus is the portal-access state of this guardian for the staff
-	// "Erziehungsberechtigte" tab: "active" (has login), "pending" (invited,
-	// not yet accepted), or "none" (info on file, no account, can be invited).
+	// "Erziehungsberechtigte" tab: "active" (has login with access to this
+	// child), "active_no_access" (has login, but this child's link carries no
+	// parent_portal.access — e.g. a restrictive contact role, #2172),
+	// "pending" (invited, not yet accepted), or "none" (info on file, no
+	// account, can be invited).
 	AccountStatus string `json:"account_status"`
 }
 
 // guardianAccountStatus derives the staff-facing account-status string.
-func guardianAccountStatus(hasAccount, invitationPending bool) string {
+// hasPortalAccess is the per-child parent_portal.access permission on the
+// students_guardians link — an account is only "active" for THIS child when
+// the link actually grants access (#2172).
+func guardianAccountStatus(hasAccount, hasPortalAccess, invitationPending bool) string {
 	switch {
-	case hasAccount:
+	case hasAccount && hasPortalAccess:
 		return "active"
+	case hasAccount:
+		return "active_no_access"
 	case invitationPending:
 		return "pending"
 	default:
@@ -1068,7 +1076,11 @@ func (rs *Resource) getStudentGuardians(w http.ResponseWriter, r *http.Request) 
 			CanPickup:          gwr.Relationship.CanPickup,
 			PickupNotes:        gwr.Relationship.PickupNotes,
 			EmergencyPriority:  gwr.Relationship.EmergencyPriority,
-			AccountStatus:      guardianAccountStatus(gwr.Profile.HasAccount, gwr.InvitationPending),
+			AccountStatus: guardianAccountStatus(
+				gwr.Profile.HasAccount,
+				authorize.StudentGuardianHasPermission(gwr.Relationship, authorize.GuardianPermissionPortalAccess),
+				gwr.InvitationPending,
+			),
 		})
 	}
 

--- a/backend/api/guardians/related_accounts_handlers.go
+++ b/backend/api/guardians/related_accounts_handlers.go
@@ -91,6 +91,10 @@ func (rs *Resource) inviteGuardianToStudent(w http.ResponseWriter, r *http.Reque
 	})
 	if err != nil {
 		tenant.MarkRollback(r.Context())
+		if errors.Is(err, authSvc.ErrInviteSocialWorkerManaged) {
+			common.RenderError(w, r, common.ErrorForbidden(err))
+			return
+		}
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}

--- a/backend/api/guardians/related_accounts_handlers.go
+++ b/backend/api/guardians/related_accounts_handlers.go
@@ -140,6 +140,10 @@ func (rs *Resource) approveInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := rs.InvitationService.ApproveInvitation(r.Context(), invitationID, accountID); err != nil {
 		tenant.MarkRollback(r.Context())
+		if errors.Is(err, authSvc.ErrInviteSocialWorkerManaged) {
+			common.RenderError(w, r, common.ErrorForbidden(err))
+			return
+		}
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return
 	}

--- a/backend/api/guardians/related_accounts_handlers.go
+++ b/backend/api/guardians/related_accounts_handlers.go
@@ -22,6 +22,9 @@ type inviteToStudentRequest struct {
 	FirstName        string `json:"first_name"`
 	LastName         string `json:"last_name"`
 	RelationshipType string `json:"relationship_type"`
+	// ConfirmRoleUpgrade confirms upgrading an existing restrictive contact
+	// link to full access (#2172).
+	ConfirmRoleUpgrade bool `json:"confirm_role_upgrade"`
 }
 
 // inviteToStudentResponse echoes what the resolve did so the UI can show the
@@ -30,6 +33,9 @@ type inviteToStudentResponse struct {
 	Outcome           string `json:"outcome"`
 	GuardianProfileID string `json:"guardian_profile_id"`
 	InvitationID      string `json:"invitation_id,omitempty"`
+	// ExistingRole carries the current guardian role for the
+	// existing_contact_restricted outcome.
+	ExistingRole string `json:"existing_role,omitempty"`
 }
 
 // pendingApprovalResponse is the parent-initiated approval-queue row, with
@@ -44,6 +50,9 @@ type pendingApprovalResponse struct {
 	RequestedByEmail  string    `json:"requested_by_email,omitempty"`
 	CreatedAt         time.Time `json:"created_at"`
 	ExpiresAt         time.Time `json:"expires_at"`
+	// RoleUpgrade marks a request whose approval also upgrades an existing
+	// restrictive contact link to full portal access (#2172).
+	RoleUpgrade bool `json:"role_upgrade"`
 }
 
 // inviteGuardianToStudent invites a further guardian to a child by email.
@@ -71,13 +80,14 @@ func (rs *Resource) inviteGuardianToStudent(w http.ResponseWriter, r *http.Reque
 	}
 
 	result, err := rs.InvitationService.InviteToStudent(r.Context(), authSvc.InviteToStudentRequest{
-		StudentID:        studentID,
-		Email:            body.Email,
-		FirstName:        body.FirstName,
-		LastName:         body.LastName,
-		RelationshipType: body.RelationshipType,
-		CreatedBy:        accountID,
-		RequireApproval:  false,
+		StudentID:          studentID,
+		Email:              body.Email,
+		FirstName:          body.FirstName,
+		LastName:           body.LastName,
+		RelationshipType:   body.RelationshipType,
+		CreatedBy:          accountID,
+		RequireApproval:    false,
+		ConfirmRoleUpgrade: body.ConfirmRoleUpgrade,
 	})
 	if err != nil {
 		tenant.MarkRollback(r.Context())
@@ -166,6 +176,7 @@ func toInviteResponse(result *authSvc.InviteToStudentResult) inviteToStudentResp
 	resp := inviteToStudentResponse{
 		Outcome:           string(result.Outcome),
 		GuardianProfileID: strconv.FormatInt(result.GuardianProfileID, 10),
+		ExistingRole:      result.ExistingRole,
 	}
 	if result.InvitationID != nil {
 		resp.InvitationID = strconv.FormatInt(*result.InvitationID, 10)
@@ -183,6 +194,7 @@ func toPendingApprovalResponse(v *authSvc.PendingApprovalView) pendingApprovalRe
 		RequestedByEmail:  v.RequestedByEmail,
 		CreatedAt:         v.CreatedAt,
 		ExpiresAt:         v.ExpiresAt,
+		RoleUpgrade:       v.RoleUpgrade,
 	}
 	if v.StudentID > 0 {
 		resp.StudentID = strconv.FormatInt(v.StudentID, 10)

--- a/backend/api/guardians/related_accounts_handlers_test.go
+++ b/backend/api/guardians/related_accounts_handlers_test.go
@@ -1,0 +1,77 @@
+// Package guardians_test — staff invite endpoint tests for the restricted-
+// contact upgrade flow (#2172). Full-stack: real services + test DB, driven
+// through Router() with a signed admin JWT.
+package guardians_test
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	repositories "github.com/moto-nrw/project-phoenix/database/repositories"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func TestInviteGuardianToStudent_RestrictedContactRoundTrip(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Staff", "Invite", "8a")
+	profile := testpkg.CreateTestGuardianProfile(t, ctx.db, "staff-restricted")
+	tenantCtx := testpkg.TenantContext(1)
+	defer func() {
+		_, _ = ctx.db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = ctx.db.NewDelete().TableExpr("users.students_guardians").Where("student_id = ?", student.ID).Exec(context.Background())
+		_, _ = ctx.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+		_, _ = ctx.db.NewDelete().TableExpr("users.students").Where("id = ?", student.ID).Exec(context.Background())
+	}()
+
+	link := &userModels.StudentGuardian{
+		StudentID:         student.ID,
+		GuardianProfileID: profile.ID,
+		RelationshipType:  "other",
+		EmergencyPriority: 1,
+	}
+	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleEmergency)
+	link.SetTenantID(1)
+	repos := repositories.NewFactory(ctx.db)
+	require.NoError(t, repos.StudentGuardian.Create(tenantCtx, link))
+
+	router := ctx.resource.Router()
+	path := "/students/" + strconv.FormatInt(student.ID, 10) + "/invite"
+
+	// Without confirmation → detection outcome, no upgrade, existing_role set.
+	req := testutil.NewAuthenticatedRequest(t, "POST", path,
+		map[string]any{"email": *profile.Email},
+		bearer(t, testutil.DefaultTestClaims()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), `"outcome":"existing_contact_restricted"`)
+	assert.Contains(t, rr.Body.String(), `"existing_role":"emergency_contact"`)
+
+	current, err := repos.StudentGuardian.FindByStudentAndGuardianForUpdate(tenantCtx, student.ID, profile.ID)
+	require.NoError(t, err)
+	assert.Equal(t, authorize.GuardianRoleEmergency, current.GuardianRole, "unconfirmed invite must not change the link")
+
+	// With confirmation → resolve proceeds and the link is upgraded.
+	req = testutil.NewAuthenticatedRequest(t, "POST", path,
+		map[string]any{"email": *profile.Email, "confirm_role_upgrade": true},
+		bearer(t, testutil.DefaultTestClaims()),
+	)
+	rr = testutil.ExecuteRequest(router, req)
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), `"outcome":"invited"`)
+
+	current, err = repos.StudentGuardian.FindByStudentAndGuardianForUpdate(tenantCtx, student.ID, profile.ID)
+	require.NoError(t, err)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, current.GuardianRole)
+	assert.True(t, authorize.StudentGuardianHasPermission(current, authorize.GuardianPermissionPortalAccess))
+}

--- a/backend/api/guardians/related_accounts_handlers_test.go
+++ b/backend/api/guardians/related_accounts_handlers_test.go
@@ -75,3 +75,43 @@ func TestInviteGuardianToStudent_RestrictedContactRoundTrip(t *testing.T) {
 	assert.Equal(t, authorize.GuardianRoleLegalGuardian, current.GuardianRole)
 	assert.True(t, authorize.StudentGuardianHasPermission(current, authorize.GuardianPermissionPortalAccess))
 }
+
+func TestInviteGuardianToStudent_SocialWorkerLinkRefused(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Staff", "SocialWorker", "8b")
+	profile := testpkg.CreateTestGuardianProfile(t, ctx.db, "staff-social-worker")
+	tenantCtx := testpkg.TenantContext(1)
+	defer func() {
+		_, _ = ctx.db.NewDelete().TableExpr("users.students_guardians").Where("student_id = ?", student.ID).Exec(context.Background())
+		_, _ = ctx.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+		_, _ = ctx.db.NewDelete().TableExpr("users.students").Where("id = ?", student.ID).Exec(context.Background())
+	}()
+
+	link := &userModels.StudentGuardian{
+		StudentID:         student.ID,
+		GuardianProfileID: profile.ID,
+		RelationshipType:  "other",
+		EmergencyPriority: 1,
+	}
+	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleSocialWorker)
+	link.SetTenantID(1)
+	repos := repositories.NewFactory(ctx.db)
+	require.NoError(t, repos.StudentGuardian.Create(tenantCtx, link))
+
+	router := ctx.resource.Router()
+	path := "/students/" + strconv.FormatInt(student.ID, 10) + "/invite"
+
+	// Even a confirmed upgrade attempt is refused for a social-worker link.
+	req := testutil.NewAuthenticatedRequest(t, "POST", path,
+		map[string]any{"email": *profile.Email, "confirm_role_upgrade": true},
+		bearer(t, testutil.DefaultTestClaims()),
+	)
+	rr := testutil.ExecuteRequest(router, req)
+	require.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
+
+	current, err := repos.StudentGuardian.FindByStudentAndGuardianForUpdate(tenantCtx, student.ID, profile.ID)
+	require.NoError(t, err)
+	assert.Equal(t, authorize.GuardianRoleSocialWorker, current.GuardianRole, "link must be untouched")
+}

--- a/backend/api/parent/child_write_handlers.go
+++ b/backend/api/parent/child_write_handlers.go
@@ -473,6 +473,8 @@ func renderParentWriteError(w http.ResponseWriter, r *http.Request, err error) {
 		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, "staff_managed_guardian_protected"))
 	case errors.Is(err, authService.ErrCannotRemoveOwnAccess):
 		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, "cannot_remove_own_access"))
+	case errors.Is(err, authService.ErrInviteSocialWorkerManaged):
+		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, "guardian_social_worker_managed"))
 	case errors.Is(err, parentService.ErrGuardianManagementDisabled):
 		common.RenderError(w, r, common.ErrorForbiddenWithCode(err, "guardian_management_disabled"))
 	case errors.Is(err, parentService.ErrGuardianNotLinked):

--- a/backend/api/parent/me_handlers_test.go
+++ b/backend/api/parent/me_handlers_test.go
@@ -103,7 +103,7 @@ func (f *fakeParentService) MealPlanWeek(context.Context, int64, int64, timezone
 func (f *fakeParentService) ListRelatedAccounts(context.Context, int64, int64) ([]*parentService.RelatedAccount, error) {
 	return nil, nil
 }
-func (f *fakeParentService) InviteRelatedAccount(context.Context, int64, int64, string, string, string) (*parentService.InviteRelatedAccountResult, error) {
+func (f *fakeParentService) InviteRelatedAccount(context.Context, int64, int64, string, string, string, bool) (*parentService.InviteRelatedAccountResult, error) {
 	return nil, nil
 }
 func (f *fakeParentService) RemoveRelatedAccount(context.Context, int64, int64, int64) error {

--- a/backend/api/parent/related_accounts_handlers.go
+++ b/backend/api/parent/related_accounts_handlers.go
@@ -29,12 +29,18 @@ type inviteRelatedAccountRequest struct {
 	Email     string `json:"email"`
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
+	// ConfirmRoleUpgrade confirms upgrading an existing restrictive contact
+	// link to full access (#2172).
+	ConfirmRoleUpgrade bool `json:"confirm_role_upgrade"`
 }
 
 // inviteRelatedAccountResponse echoes the resolve outcome.
 type inviteRelatedAccountResponse struct {
 	Outcome           string `json:"outcome"`
 	GuardianProfileID string `json:"guardian_profile_id"`
+	// ExistingRole carries the current guardian role for the
+	// existing_contact_restricted outcome.
+	ExistingRole string `json:"existing_role,omitempty"`
 }
 
 // listRelatedAccounts returns the guardians linked to the parent's child with
@@ -88,7 +94,7 @@ func (rs *Resource) inviteRelatedAccount(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	result, err := rs.ParentService.InviteRelatedAccount(r.Context(), accountID, studentID, body.Email, body.FirstName, body.LastName)
+	result, err := rs.ParentService.InviteRelatedAccount(r.Context(), accountID, studentID, body.Email, body.FirstName, body.LastName, body.ConfirmRoleUpgrade)
 	if err != nil {
 		renderParentWriteError(w, r, err)
 		return
@@ -97,6 +103,7 @@ func (rs *Resource) inviteRelatedAccount(w http.ResponseWriter, r *http.Request)
 	common.Respond(w, r, http.StatusCreated, inviteRelatedAccountResponse{
 		Outcome:           result.Outcome,
 		GuardianProfileID: strconv.FormatInt(result.GuardianProfileID, 10),
+		ExistingRole:      result.ExistingRole,
 	}, "Guardian invited")
 }
 

--- a/backend/api/parent/related_accounts_handlers.go
+++ b/backend/api/parent/related_accounts_handlers.go
@@ -16,8 +16,11 @@ type relatedAccountResponse struct {
 	LastName          string `json:"last_name"`
 	Email             string `json:"email,omitempty"`
 	RelationshipType  string `json:"relationship_type"`
-	IsPrimary         bool   `json:"is_primary"`
-	Status            string `json:"status"`
+	// GuardianRole lets the panel hide the grant-access action for
+	// school-managed social-worker contacts (#2172).
+	GuardianRole string `json:"guardian_role,omitempty"`
+	IsPrimary    bool   `json:"is_primary"`
+	Status       string `json:"status"`
 	// IsSelf marks the requesting parent's own row; the UI hides the remove
 	// action for it since self-removal is rejected by the backend.
 	IsSelf bool `json:"is_self"`
@@ -69,6 +72,7 @@ func (rs *Resource) listRelatedAccounts(w http.ResponseWriter, r *http.Request) 
 			LastName:          a.LastName,
 			Email:             a.Email,
 			RelationshipType:  a.RelationshipType,
+			GuardianRole:      a.GuardianRole,
 			IsPrimary:         a.IsPrimary,
 			Status:            string(a.Status),
 			IsSelf:            a.IsSelf,

--- a/backend/api/parent/related_accounts_handlers_test.go
+++ b/backend/api/parent/related_accounts_handlers_test.go
@@ -155,3 +155,61 @@ func TestRelatedAccountsEndpoint_RemoveGate(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	})
 }
+
+// relAcctCaptureInvites records the invite request and returns a canned result,
+// so the handler's confirm_role_upgrade/existing_role passthrough is testable.
+type relAcctCaptureInvites struct {
+	authService.GuardianInvitationService
+	lastReq *authService.InviteToStudentRequest
+	result  *authService.InviteToStudentResult
+}
+
+func (s *relAcctCaptureInvites) InviteToStudent(_ context.Context, req authService.InviteToStudentRequest) (*authService.InviteToStudentResult, error) {
+	s.lastReq = &req
+	return s.result, nil
+}
+
+func newRelAcctRouterWithInvites(t *testing.T, db *bun.DB, invites authService.GuardianInvitationService) http.Handler {
+	t.Helper()
+	viper.Set("auth_jwt_secret", testJWTSecret)
+	viper.Set("auth_jwt_expiry", time.Hour)
+	repos := repositories.NewFactory(db)
+	svc := parentService.NewService(parentService.ServiceConfig{
+		ChildRepo:           repos.ParentChild,
+		StatusDayRepo:       repos.StudentStatusDay,
+		StudentRepo:         repos.Student,
+		Settings:            relAcctHandlerSettings{inviteMode: configModels.ParentInviteModeDirect},
+		GuardianInvites:     invites,
+		StudentGuardianRepo: repos.StudentGuardian,
+		GuardianProfileRepo: repos.GuardianProfile,
+		DB:                  db,
+		Logger:              slog.Default(),
+	})
+	rs := parent.NewResource(nil, svc, nil, nil, nil, db)
+	return rs.Router()
+}
+
+func TestRelatedAccountsEndpoint_ConfirmRoleUpgradePassthrough(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	invites := &relAcctCaptureInvites{result: &authService.InviteToStudentResult{
+		Outcome:           authService.InviteOutcomeExistingContactRestricted,
+		GuardianProfileID: chain.GuardianProfileID,
+		ExistingRole:      "emergency_contact",
+	}}
+	router := newRelAcctRouterWithInvites(t, db, invites)
+	token := parentToken(t, chain.AccountID)
+	sid := strconv.FormatInt(chain.StudentID, 10)
+
+	rr := doRequest(t, router, http.MethodPost, "/me/children/"+sid+"/related-accounts", token,
+		map[string]any{"email": "contact@example.test", "confirm_role_upgrade": true})
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+
+	require.NotNil(t, invites.lastReq)
+	assert.True(t, invites.lastReq.ConfirmRoleUpgrade, "confirm_role_upgrade must reach the invite service")
+	assert.Contains(t, rr.Body.String(), `"outcome":"existing_contact_restricted"`)
+	assert.Contains(t, rr.Body.String(), `"existing_role":"emergency_contact"`)
+}

--- a/backend/api/parent/related_accounts_handlers_test.go
+++ b/backend/api/parent/related_accounts_handlers_test.go
@@ -61,6 +61,16 @@ func (relAcctStubInvites) RevokeAccess(_ context.Context, _ authService.RevokeAc
 	return nil
 }
 
+// relAcctSocialWorkerInvites refuses every invite with the social-worker
+// sentinel, mirroring the service refusal for school-managed contacts (#2172).
+type relAcctSocialWorkerInvites struct {
+	authService.GuardianInvitationService
+}
+
+func (relAcctSocialWorkerInvites) InviteToStudent(_ context.Context, _ authService.InviteToStudentRequest) (*authService.InviteToStudentResult, error) {
+	return nil, &authService.AuthError{Op: "invite guardian to student", Err: authService.ErrInviteSocialWorkerManaged}
+}
+
 func newRelAcctRouter(t *testing.T, db *bun.DB, inviteMode string, canRemove bool) http.Handler {
 	t.Helper()
 	viper.Set("auth_jwt_secret", testJWTSecret)
@@ -212,4 +222,20 @@ func TestRelatedAccountsEndpoint_ConfirmRoleUpgradePassthrough(t *testing.T) {
 	assert.True(t, invites.lastReq.ConfirmRoleUpgrade, "confirm_role_upgrade must reach the invite service")
 	assert.Contains(t, rr.Body.String(), `"outcome":"existing_contact_restricted"`)
 	assert.Contains(t, rr.Body.String(), `"existing_role":"emergency_contact"`)
+}
+
+func TestRelatedAccountsEndpoint_SocialWorkerRefusedWithCode(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	router := newRelAcctRouterWithInvites(t, db, relAcctSocialWorkerInvites{})
+	token := parentToken(t, chain.AccountID)
+	sid := strconv.FormatInt(chain.StudentID, 10)
+
+	rr := doRequest(t, router, http.MethodPost, "/me/children/"+sid+"/related-accounts", token,
+		map[string]any{"email": "sozialdienst@example.test", "confirm_role_upgrade": true})
+	require.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), `"code":"guardian_social_worker_managed"`)
 }

--- a/backend/api/parent/related_accounts_handlers_test.go
+++ b/backend/api/parent/related_accounts_handlers_test.go
@@ -104,6 +104,8 @@ func TestRelatedAccountsEndpoint_List(t *testing.T) {
 	rr := doRequest(t, router, http.MethodGet, "/me/children/"+sid+"/related-accounts", token, nil)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	assert.Contains(t, rr.Body.String(), `"guardian_profile_id"`)
+	assert.Contains(t, rr.Body.String(), `"guardian_role":"primary_guardian"`,
+		"the per-child role must be exposed so the panel can gate social-worker rows")
 }
 
 func TestRelatedAccountsEndpoint_InviteGate(t *testing.T) {

--- a/backend/database/migrations/001015270_guardian_invitation_role_upgrade.go
+++ b/backend/database/migrations/001015270_guardian_invitation_role_upgrade.go
@@ -1,0 +1,54 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	guardianInvitationRoleUpgradeVersion     = "1.15.270"
+	guardianInvitationRoleUpgradeDescription = "Track pending guardian invitations that upgrade an existing restricted contact link on approval (#2172)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     guardianInvitationRoleUpgradeVersion,
+		Description: guardianInvitationRoleUpgradeDescription,
+		DependsOn:   []string{deviceTransfersVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return guardianInvitationRoleUpgradeUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return guardianInvitationRoleUpgradeDown(ctx, db)
+		},
+	)
+}
+
+func guardianInvitationRoleUpgradeUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.270: Tracking guardian-invitation role upgrades...")
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE auth.guardian_invitations
+			ADD COLUMN IF NOT EXISTS role_upgrade BOOLEAN NOT NULL DEFAULT FALSE;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("error adding role_upgrade: %w", err)
+	}
+	return nil
+}
+
+func guardianInvitationRoleUpgradeDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.270: dropping role_upgrade marker...")
+
+	if _, err := db.NewRaw(`
+		ALTER TABLE auth.guardian_invitations
+			DROP COLUMN IF EXISTS role_upgrade;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("error dropping role_upgrade: %w", err)
+	}
+	return nil
+}

--- a/backend/models/auth/guardian_invitation.go
+++ b/backend/models/auth/guardian_invitation.go
@@ -36,6 +36,12 @@ type GuardianInvitation struct {
 	// ProfileCreatedForInvitation is true only when this invite flow created
 	// the guardian profile specifically to back this invitation.
 	ProfileCreatedForInvitation bool `bun:"profile_created_for_invitation,notnull,default:false" json:"profile_created_for_invitation"`
+	// RoleUpgrade is true when approving this invitation must also upgrade the
+	// existing restrictive students_guardians link (emergency_contact/
+	// pickup_only/custom) to legal_guardian, because the invited person was
+	// already a restricted contact and the inviter confirmed the upgrade
+	// (#2172). Direct-mode invites apply the upgrade immediately instead.
+	RoleUpgrade bool `bun:"role_upgrade,notnull,default:false" json:"role_upgrade"`
 
 	// Relations (not stored in database)
 }

--- a/backend/services/auth/errors.go
+++ b/backend/services/auth/errors.go
@@ -88,6 +88,12 @@ var (
 	ErrCannotRemovePrimaryGuardian      = errors.New("the primary guardian cannot be removed by a parent")
 	ErrCannotRemoveStaffManagedGuardian = errors.New("staff-managed guardian contacts cannot be removed by a parent")
 	ErrCannotRemoveOwnAccess            = errors.New("a parent cannot remove their own access to a child")
+	// ErrInviteSocialWorkerManaged: the invited email belongs to a contact
+	// linked to this child as a social worker. That is a school-managed
+	// professional contact — the invite flow must never turn it into a legal
+	// guardian, so the invite is refused entirely (mirrors
+	// ErrGuardianSocialWorkerManaged on the parent edit paths).
+	ErrInviteSocialWorkerManaged = errors.New("a social-worker contact is managed by the school and cannot be invited to the parents portal")
 )
 
 // AuthError represents an authentication-related error

--- a/backend/services/auth/guardian_related_accounts.go
+++ b/backend/services/auth/guardian_related_accounts.go
@@ -217,13 +217,16 @@ func (s *guardianInvitationService) upgradeStudentLink(ctx context.Context, stud
 		return nil
 	}
 	// Defense in depth: a persisted RoleUpgrade flag must not promote a link
-	// that became a social-worker contact between request and approval.
+	// that became a social-worker contact between request and approval. The
+	// refusal is an error, not a silent skip — otherwise the caller would
+	// report success (and, on approval, send an invitation email) for access
+	// that was never granted.
 	if authorize.NormalizeGuardianRole(link.GuardianRole) == authorize.GuardianRoleSocialWorker {
-		s.getLogger().Warn("guardian contact upgrade skipped: social-worker link is school-managed",
+		s.getLogger().Warn("guardian contact upgrade refused: social-worker link is school-managed",
 			slog.Int64("student_id", studentID),
 			slog.Int64("guardian_profile_id", guardianProfileID),
 		)
-		return nil
+		return &AuthError{Op: op, Err: ErrInviteSocialWorkerManaged}
 	}
 	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleLegalGuardian)
 	if err := s.StudentGuardianRepo.Update(ctx, link); err != nil {
@@ -309,6 +312,9 @@ func (s *guardianInvitationService) resolveInviteNow(ctx context.Context, req In
 
 	// Existing account → access is granted by the link alone; no token needed.
 	if profile.HasAccount {
+		if err := s.closeSupersededApprovalRequests(ctx, profile.ID, req.StudentID); err != nil {
+			return nil, err
+		}
 		outcome := InviteOutcomeLinkedExistingAccount
 		if !linkCreated {
 			outcome = InviteOutcomeAlreadyLinked
@@ -419,6 +425,14 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 			openInvitation.ApprovalStatus = authModels.GuardianInvitationApprovalPending
 			openInvitation.ApprovedBy = nil
 			openInvitation.ApprovedAt = nil
+			// The reused row carries the leftover expiry of the older
+			// invitation, and guardianApprovalExpired gates approve/reject on
+			// it — a short remaining lifetime would lock staff out of a
+			// just-submitted request. Restart the window and drop the stale
+			// email tracking, exactly like the pending → not_required branch.
+			openInvitation.ExpiresAt = time.Now().Add(s.resolveTokenExpiry(ctx))
+			openInvitation.EmailSentAt = nil
+			openInvitation.EmailError = nil
 			if req.RequestedByParentAccountID != nil {
 				openInvitation.RequestedByAccountID = req.RequestedByParentAccountID
 			}
@@ -455,6 +469,37 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 	return invitation, nil
 }
 
+// closeSupersededApprovalRequests resolves parent-initiated requests for this
+// child that a direct link just overtook: the account now has access, so a
+// still-pending row would linger in the staff queue forever and approving it
+// later would be a no-op. Closing it mirrors how ApproveInvitation finishes an
+// invitation whose access comes from the link alone (not_required + accepted).
+func (s *guardianInvitationService) closeSupersededApprovalRequests(ctx context.Context, guardianProfileID, studentID int64) error {
+	now := time.Now()
+	open, err := s.openStudentInvitations(ctx, guardianProfileID, studentID, now)
+	if err != nil {
+		return &AuthError{Op: opGuardianInviteToStudent, Err: err}
+	}
+	for _, inv := range open {
+		if !inv.IsPendingApproval() {
+			continue
+		}
+		inv.ApprovalStatus = authModels.GuardianInvitationApprovalNotRequired
+		inv.ApprovedBy = nil
+		inv.ApprovedAt = nil
+		inv.AcceptedAt = &now
+		if err := s.InvitationRepo.Update(ctx, inv); err != nil {
+			return &AuthError{Op: opGuardianInviteToStudent, Err: err}
+		}
+		s.getLogger().Info("guardian approval request closed: access granted directly",
+			slog.Int64("invitation_id", inv.ID),
+			slog.Int64("student_id", studentID),
+			slog.Int64("guardian_profile_id", guardianProfileID),
+		)
+	}
+	return nil
+}
+
 func (s *guardianInvitationService) findOpenStudentInvitation(ctx context.Context, guardianProfileID, studentID int64) (*authModels.GuardianInvitation, error) {
 	invitations, err := s.openStudentInvitations(ctx, guardianProfileID, studentID, time.Now())
 	if err != nil {
@@ -468,7 +513,10 @@ func (s *guardianInvitationService) findOpenStudentInvitation(ctx context.Contex
 
 // ApproveInvitation resolves a pending parent-initiated request: it links the
 // child and either grants access to an existing account or dispatches the
-// invitation email.
+// invitation email. A promised role upgrade that can no longer be applied
+// (the link became a school-managed social-worker contact meanwhile) aborts
+// the approval: the request stays pending so staff can reject it, instead of
+// reporting success for access that was never granted.
 func (s *guardianInvitationService) ApproveInvitation(ctx context.Context, invitationID int64, approverAccountID int64) error {
 	invitation, err := s.InvitationRepo.FindByID(ctx, invitationID)
 	if err != nil {

--- a/backend/services/auth/guardian_related_accounts.go
+++ b/backend/services/auth/guardian_related_accounts.go
@@ -399,6 +399,28 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 				return nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
 			}
 		}
+		// Reverse transition: the caller requires approval-gating (a
+		// parent-confirmed upgrade), but the open invitation was created
+		// without it — an earlier staff direct invite (not_required) or an
+		// approved-but-not-yet-accepted request. Re-queue it as pending:
+		// otherwise the row never surfaces in the staff queue,
+		// ApproveInvitation (the only consumer of RoleUpgrade) can never
+		// fire, and the still-consumable token would grant an account
+		// without the promised access. Flipping to pending also freezes the
+		// outstanding token until staff decide
+		// (guardianInvitationTokenConsumable refuses pending tokens).
+		if approvalStatus == authModels.GuardianInvitationApprovalPending &&
+			openInvitation.ApprovalStatus != authModels.GuardianInvitationApprovalPending {
+			openInvitation.ApprovalStatus = authModels.GuardianInvitationApprovalPending
+			openInvitation.ApprovedBy = nil
+			openInvitation.ApprovedAt = nil
+			if req.RequestedByParentAccountID != nil {
+				openInvitation.RequestedByAccountID = req.RequestedByParentAccountID
+			}
+			if err := s.InvitationRepo.Update(ctx, openInvitation); err != nil {
+				return nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
+			}
+		}
 		// A re-invite that confirmed a restrictive-contact upgrade must stick
 		// the flag onto the reused row, or the approval would silently skip
 		// the upgrade (#2172).

--- a/backend/services/auth/guardian_related_accounts.go
+++ b/backend/services/auth/guardian_related_accounts.go
@@ -175,6 +175,14 @@ func (s *guardianInvitationService) detectRestrictedContact(ctx context.Context,
 	if authorize.IsFullGuardianRole(link.GuardianRole) {
 		return false, nil, nil
 	}
+	// A social worker is a school-managed professional contact, never a
+	// candidate for the legal-guardian upgrade — the parent edit paths reject
+	// every parent write to such a link (ErrGuardianSocialWorkerManaged), and
+	// the invite flow must not open a side door. Refuse the invite outright,
+	// with or without confirmation.
+	if authorize.NormalizeGuardianRole(link.GuardianRole) == authorize.GuardianRoleSocialWorker {
+		return false, nil, &AuthError{Op: opGuardianInviteToStudent, Err: ErrInviteSocialWorkerManaged}
+	}
 	if !req.ConfirmRoleUpgrade {
 		return false, &InviteToStudentResult{
 			Outcome:           InviteOutcomeExistingContactRestricted,
@@ -194,6 +202,15 @@ func (s *guardianInvitationService) upgradeStudentLink(ctx context.Context, stud
 		return &AuthError{Op: op, Err: err}
 	}
 	if authorize.IsFullGuardianRole(link.GuardianRole) {
+		return nil
+	}
+	// Defense in depth: a persisted RoleUpgrade flag must not promote a link
+	// that became a social-worker contact between request and approval.
+	if authorize.NormalizeGuardianRole(link.GuardianRole) == authorize.GuardianRoleSocialWorker {
+		s.getLogger().Warn("guardian contact upgrade skipped: social-worker link is school-managed",
+			slog.Int64("student_id", studentID),
+			slog.Int64("guardian_profile_id", guardianProfileID),
+		)
 		return nil
 	}
 	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleLegalGuardian)

--- a/backend/services/auth/guardian_related_accounts.go
+++ b/backend/services/auth/guardian_related_accounts.go
@@ -2,12 +2,14 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -44,6 +46,11 @@ type InviteToStudentRequest struct {
 	// RequireApproval queues the invite for staff approval instead of acting
 	// immediately. The handler decides this from guardians.parent_invite_mode.
 	RequireApproval bool
+	// ConfirmRoleUpgrade confirms upgrading an existing restrictive contact
+	// link (emergency_contact/pickup_only/custom) to legal_guardian. Without
+	// it, such an invite returns InviteOutcomeExistingContactRestricted with
+	// no side effects so the UI can ask first (#2172).
+	ConfirmRoleUpgrade bool
 }
 
 // InviteToStudentOutcome describes what the resolve logic did, so the UI can
@@ -61,6 +68,11 @@ const (
 	InviteOutcomeInvited InviteToStudentOutcome = "invited"
 	// InviteOutcomePendingApproval: a parent request was queued for staff.
 	InviteOutcomePendingApproval InviteToStudentOutcome = "pending_approval"
+	// InviteOutcomeExistingContactRestricted: the email belongs to an existing
+	// contact on this child with a restrictive role and no portal access.
+	// Nothing was changed; the caller must confirm the role upgrade
+	// (ConfirmRoleUpgrade) and retry (#2172).
+	InviteOutcomeExistingContactRestricted InviteToStudentOutcome = "existing_contact_restricted"
 )
 
 // InviteToStudentResult is returned by InviteToStudent.
@@ -68,6 +80,9 @@ type InviteToStudentResult struct {
 	Outcome           InviteToStudentOutcome
 	GuardianProfileID int64
 	InvitationID      *int64 // nil for auto-link / already-linked outcomes
+	// ExistingRole carries the current guardian role for the
+	// existing_contact_restricted outcome; empty otherwise.
+	ExistingRole string
 }
 
 type relatedAccountProfileResolution struct {
@@ -103,6 +118,19 @@ func (s *guardianInvitationService) InviteToStudent(ctx context.Context, req Inv
 	}
 
 	tenantID := tenant.FromContext(ctx)
+
+	// An existing restrictive contact link (emergency_contact/pickup_only/
+	// custom) would survive LinkIfNotExists untouched, leaving the invited
+	// account without parent_portal.access (#2172). Detect it up front — with
+	// no side effects — and require an explicit upgrade confirmation.
+	roleUpgrade, restricted, err := s.detectRestrictedContact(ctx, req, email)
+	if err != nil {
+		return nil, err
+	}
+	if restricted != nil {
+		return restricted, nil
+	}
+
 	resolved, err := s.findOrCreateProfileByEmail(ctx, email, req.FirstName, req.LastName, tenantID)
 	if err != nil {
 		return nil, err
@@ -113,12 +141,70 @@ func (s *guardianInvitationService) InviteToStudent(ctx context.Context, req Inv
 	}
 
 	if req.RequireApproval {
-		return s.queuePendingApproval(ctx, req, profile, tenantID, resolved.created)
+		return s.queuePendingApproval(ctx, req, profile, tenantID, resolved.created, roleUpgrade)
 	}
 	if err := s.attachExistingAccountByEmail(ctx, profile, email, tenantID); err != nil {
 		return nil, err
 	}
-	return s.resolveInviteNow(ctx, req, profile, tenantID, resolved.created)
+	return s.resolveInviteNow(ctx, req, profile, tenantID, resolved.created, roleUpgrade)
+}
+
+// detectRestrictedContact checks whether the invited email already belongs to a
+// contact on this child whose link has a restrictive role (no portal access).
+// Returns (roleUpgrade=true, nil, nil) when the caller confirmed the upgrade,
+// or a ready-made existing_contact_restricted result when confirmation is still
+// missing. Lookup-only — no rows are created or modified.
+func (s *guardianInvitationService) detectRestrictedContact(ctx context.Context, req InviteToStudentRequest, email string) (bool, *InviteToStudentResult, error) {
+	existing, err := s.GuardianProfileRepo.FindByEmail(ctx, email)
+	if err != nil {
+		if isNotFoundError(err) {
+			return false, nil, nil
+		}
+		return false, nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
+	}
+	if existing == nil {
+		return false, nil, nil
+	}
+	link, err := s.StudentGuardianRepo.FindByStudentAndGuardianForUpdate(ctx, req.StudentID, existing.ID)
+	if err != nil {
+		if errors.Is(err, userModels.ErrStudentGuardianNotFound) {
+			return false, nil, nil
+		}
+		return false, nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
+	}
+	if authorize.IsFullGuardianRole(link.GuardianRole) {
+		return false, nil, nil
+	}
+	if !req.ConfirmRoleUpgrade {
+		return false, &InviteToStudentResult{
+			Outcome:           InviteOutcomeExistingContactRestricted,
+			GuardianProfileID: existing.ID,
+			ExistingRole:      link.GuardianRole,
+		}, nil
+	}
+	return true, nil, nil
+}
+
+// upgradeStudentLink promotes an existing restrictive students_guardians link
+// to legal_guardian, recomputing the permission set server-side (#2172).
+// No-op when the link already carries a full guardian role.
+func (s *guardianInvitationService) upgradeStudentLink(ctx context.Context, studentID, guardianProfileID int64, op string) error {
+	link, err := s.StudentGuardianRepo.FindByStudentAndGuardianForUpdate(ctx, studentID, guardianProfileID)
+	if err != nil {
+		return &AuthError{Op: op, Err: err}
+	}
+	if authorize.IsFullGuardianRole(link.GuardianRole) {
+		return nil
+	}
+	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleLegalGuardian)
+	if err := s.StudentGuardianRepo.Update(ctx, link); err != nil {
+		return &AuthError{Op: op, Err: err}
+	}
+	s.getLogger().Info("guardian contact link upgraded to full access",
+		slog.Int64("student_id", studentID),
+		slog.Int64("guardian_profile_id", guardianProfileID),
+	)
+	return nil
 }
 
 // findOrCreateProfileByEmail returns the guardian profile for this email,
@@ -175,8 +261,9 @@ func (s *guardianInvitationService) attachExistingAccountByEmail(ctx context.Con
 }
 
 // resolveInviteNow links/invites immediately (staff invites, or parent invites
-// in "direct" mode).
-func (s *guardianInvitationService) resolveInviteNow(ctx context.Context, req InviteToStudentRequest, profile *userModels.GuardianProfile, tenantID int64, profileCreated bool) (*InviteToStudentResult, error) {
+// in "direct" mode). roleUpgrade applies a confirmed restrictive-contact
+// upgrade right away, so access does not depend on a later approval.
+func (s *guardianInvitationService) resolveInviteNow(ctx context.Context, req InviteToStudentRequest, profile *userModels.GuardianProfile, tenantID int64, profileCreated bool, roleUpgrade bool) (*InviteToStudentResult, error) {
 	rel := req.RelationshipType
 	if rel == "" {
 		rel = defaultRelationshipType
@@ -184,6 +271,11 @@ func (s *guardianInvitationService) resolveInviteNow(ctx context.Context, req In
 	linkCreated, err := s.ensureStudentLink(ctx, req.StudentID, profile.ID, rel, tenantID)
 	if err != nil {
 		return nil, err
+	}
+	if roleUpgrade {
+		if err := s.upgradeStudentLink(ctx, req.StudentID, profile.ID, opGuardianInviteToStudent); err != nil {
+			return nil, err
+		}
 	}
 
 	// Existing account → access is granted by the link alone; no token needed.
@@ -201,8 +293,9 @@ func (s *guardianInvitationService) resolveInviteNow(ctx context.Context, req In
 		return &InviteToStudentResult{Outcome: outcome, GuardianProfileID: profile.ID}, nil
 	}
 
-	// No account yet → issue a token invitation for this child.
-	invitation, err := s.createStudentInvitation(ctx, req, profile, tenantID, authModels.GuardianInvitationApprovalNotRequired, profileCreated)
+	// No account yet → issue a token invitation for this child. The upgrade
+	// (if any) was already applied above, so the row's flag stays false.
+	invitation, err := s.createStudentInvitation(ctx, req, profile, tenantID, authModels.GuardianInvitationApprovalNotRequired, profileCreated, false)
 	if err != nil {
 		return nil, err
 	}
@@ -217,9 +310,10 @@ func (s *guardianInvitationService) resolveInviteNow(ctx context.Context, req In
 
 // queuePendingApproval records a parent-initiated request awaiting staff
 // approval. No link is created and no email is sent until a staff member
-// approves it.
-func (s *guardianInvitationService) queuePendingApproval(ctx context.Context, req InviteToStudentRequest, profile *userModels.GuardianProfile, tenantID int64, profileCreated bool) (*InviteToStudentResult, error) {
-	invitation, err := s.createStudentInvitation(ctx, req, profile, tenantID, authModels.GuardianInvitationApprovalPending, profileCreated)
+// approves it. roleUpgrade is persisted on the invitation so the approval
+// step knows it must also upgrade the existing restrictive link.
+func (s *guardianInvitationService) queuePendingApproval(ctx context.Context, req InviteToStudentRequest, profile *userModels.GuardianProfile, tenantID int64, profileCreated bool, roleUpgrade bool) (*InviteToStudentResult, error) {
+	invitation, err := s.createStudentInvitation(ctx, req, profile, tenantID, authModels.GuardianInvitationApprovalPending, profileCreated, roleUpgrade)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +350,7 @@ func (s *guardianInvitationService) ensureStudentLink(ctx context.Context, stude
 
 // createStudentInvitation persists a guardian_invitations row carrying the
 // student and (for parent-initiated invites) the requesting account.
-func (s *guardianInvitationService) createStudentInvitation(ctx context.Context, req InviteToStudentRequest, profile *userModels.GuardianProfile, tenantID int64, approvalStatus string, profileCreated bool) (*authModels.GuardianInvitation, error) {
+func (s *guardianInvitationService) createStudentInvitation(ctx context.Context, req InviteToStudentRequest, profile *userModels.GuardianProfile, tenantID int64, approvalStatus string, profileCreated bool, roleUpgrade bool) (*authModels.GuardianInvitation, error) {
 	studentID := req.StudentID
 	openInvitation, err := s.findOpenStudentInvitation(ctx, profile.ID, studentID)
 	if err != nil {
@@ -276,6 +370,15 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 				return nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
 			}
 		}
+		// A re-invite that confirmed a restrictive-contact upgrade must stick
+		// the flag onto the reused row, or the approval would silently skip
+		// the upgrade (#2172).
+		if roleUpgrade && !openInvitation.RoleUpgrade {
+			openInvitation.RoleUpgrade = true
+			if err := s.InvitationRepo.Update(ctx, openInvitation); err != nil {
+				return nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
+			}
+		}
 		return openInvitation, nil
 	}
 	invitation := &authModels.GuardianInvitation{
@@ -287,6 +390,7 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 		RequestedByAccountID:        req.RequestedByParentAccountID,
 		ApprovalStatus:              approvalStatus,
 		ProfileCreatedForInvitation: profileCreated,
+		RoleUpgrade:                 roleUpgrade,
 	}
 	invitation.SetTenantID(tenantID)
 	if err := s.InvitationRepo.Create(ctx, invitation); err != nil {
@@ -341,6 +445,11 @@ func (s *guardianInvitationService) ApproveInvitation(ctx context.Context, invit
 	if invitation.StudentID != nil {
 		if _, err := s.ensureStudentLink(ctx, *invitation.StudentID, profile.ID, rel, invitation.TenantID); err != nil {
 			return err
+		}
+		if invitation.RoleUpgrade {
+			if err := s.upgradeStudentLink(ctx, *invitation.StudentID, profile.ID, opGuardianInviteApprove); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -542,6 +651,9 @@ type PendingApprovalView struct {
 	RequestedByEmail  string
 	CreatedAt         time.Time
 	ExpiresAt         time.Time
+	// RoleUpgrade marks a request whose approval also upgrades an existing
+	// restrictive contact link to full portal access (#2172).
+	RoleUpgrade bool
 }
 
 // ListPendingApprovalsDetailed returns the approval queue with guardian, child,
@@ -560,6 +672,7 @@ func (s *guardianInvitationService) ListPendingApprovalsDetailed(ctx context.Con
 			GuardianProfileID: inv.GuardianProfileID,
 			CreatedAt:         inv.CreatedAt,
 			ExpiresAt:         inv.ExpiresAt,
+			RoleUpgrade:       inv.RoleUpgrade,
 		}
 		s.fillGuardianFields(ctx, inv.GuardianProfileID, view)
 		if inv.StudentID != nil {

--- a/backend/services/auth/guardian_related_accounts.go
+++ b/backend/services/auth/guardian_related_accounts.go
@@ -49,7 +49,9 @@ type InviteToStudentRequest struct {
 	// ConfirmRoleUpgrade confirms upgrading an existing restrictive contact
 	// link (emergency_contact/pickup_only/custom) to legal_guardian. Without
 	// it, such an invite returns InviteOutcomeExistingContactRestricted with
-	// no side effects so the UI can ask first (#2172).
+	// no side effects so the UI can ask first (#2172). A PARENT-initiated
+	// confirmed upgrade is always queued for staff approval, even in direct
+	// invite mode — see InviteToStudent.
 	ConfirmRoleUpgrade bool
 }
 
@@ -140,7 +142,17 @@ func (s *guardianInvitationService) InviteToStudent(ctx context.Context, req Inv
 		return nil, &AuthError{Op: opGuardianInviteToStudent, Err: fmt.Errorf("guardian profile resolution failed")}
 	}
 
-	if req.RequireApproval {
+	// A confirmed upgrade of an existing restricted contact overrides a
+	// deliberate staff-set restriction (e.g. a custody-motivated pickup_only
+	// or emergency_contact role). When a PARENT asks for it, the request
+	// always goes through staff approval — even in direct invite mode.
+	// Staff-initiated invites keep applying immediately, and parents inviting
+	// brand-new contacts in direct mode are unaffected.
+	requireApproval := req.RequireApproval
+	if roleUpgrade && req.RequestedByParentAccountID != nil {
+		requireApproval = true
+	}
+	if requireApproval {
 		return s.queuePendingApproval(ctx, req, profile, tenantID, resolved.created, roleUpgrade)
 	}
 	if err := s.attachExistingAccountByEmail(ctx, profile, email, tenantID); err != nil {

--- a/backend/services/auth/guardian_related_accounts.go
+++ b/backend/services/auth/guardian_related_accounts.go
@@ -399,8 +399,8 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 				return nil, &AuthError{Op: opGuardianInviteToStudent, Err: err}
 			}
 		}
-		// Reverse transition: the caller requires approval-gating (a
-		// parent-confirmed upgrade), but the open invitation was created
+		// Reverse transition, ONLY for a confirmed role upgrade: the upgrade
+		// requires approval-gating, but the open invitation was created
 		// without it — an earlier staff direct invite (not_required) or an
 		// approved-but-not-yet-accepted request. Re-queue it as pending:
 		// otherwise the row never surfaces in the staff queue,
@@ -409,7 +409,12 @@ func (s *guardianInvitationService) createStudentInvitation(ctx context.Context,
 		// without the promised access. Flipping to pending also freezes the
 		// outstanding token until staff decide
 		// (guardianInvitationTokenConsumable refuses pending tokens).
-		if approvalStatus == authModels.GuardianInvitationApprovalPending &&
+		// The roleUpgrade gate is load-bearing: in staff_approval mode EVERY
+		// parent invite arrives with approvalStatus=pending, and a plain
+		// duplicate re-invite must not revert an already-resolved invitation
+		// (that would invalidate its live token and force a re-approval).
+		if roleUpgrade &&
+			approvalStatus == authModels.GuardianInvitationApprovalPending &&
 			openInvitation.ApprovalStatus != authModels.GuardianInvitationApprovalPending {
 			openInvitation.ApprovalStatus = authModels.GuardianInvitationApprovalPending
 			openInvitation.ApprovedBy = nil

--- a/backend/services/auth/guardian_related_accounts_test.go
+++ b/backend/services/auth/guardian_related_accounts_test.go
@@ -1005,3 +1005,95 @@ func TestInviteToStudent_FullRoleLink_NoConfirmationNeeded(t *testing.T) {
 		"full-role links must not trigger the restricted-contact confirmation")
 	assert.Empty(t, result.ExistingRole)
 }
+
+func TestInviteToStudent_SocialWorkerLink_RefusedEvenWithConfirmation(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Social", "Worker", "7g")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "social-worker-link")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleSocialWorker)
+
+	// Without confirmation → refused outright, never the confirmation outcome.
+	_, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID: student.ID,
+		Email:     *profile.Email,
+		CreatedBy: creatorID,
+	})
+	require.ErrorIs(t, err, authService.ErrInviteSocialWorkerManaged)
+
+	// With confirmation → still refused; the upgrade path must stay closed.
+	_, err = env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:          student.ID,
+		Email:              *profile.Email,
+		CreatedBy:          creatorID,
+		ConfirmRoleUpgrade: true,
+	})
+	require.ErrorIs(t, err, authService.ErrInviteSocialWorkerManaged)
+
+	// Approval mode (parent-shaped) → refused before anything is queued.
+	_, err = env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            true,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.ErrorIs(t, err, authService.ErrInviteSocialWorkerManaged)
+
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleSocialWorker, link.GuardianRole, "link must be untouched")
+	assert.False(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+	invitations, err := env.repos.GuardianInvitation.FindByGuardianProfileID(ctx, profile.ID)
+	require.NoError(t, err)
+	assert.Empty(t, invitations, "refusal must not create invitation rows")
+}
+
+func TestApproveInvitation_RoleUpgradeSkipsSocialWorkerLink(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Repurposed", "7h")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-repurposed")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleCustom)
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            true,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID)
+	defer env.cleanupInvitation(t, *result.InvitationID, profile.ID)
+
+	// The link becomes a school-managed social-worker contact between the
+	// request and the staff approval.
+	link := env.fetchLink(t, student.ID, profile.ID)
+	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleSocialWorker)
+	require.NoError(t, env.repos.StudentGuardian.Update(ctx, link))
+
+	require.NoError(t, env.service.ApproveInvitation(ctx, *result.InvitationID, creatorID))
+
+	link = env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleSocialWorker, link.GuardianRole,
+		"persisted upgrade flag must not promote a social-worker link")
+	assert.False(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+}

--- a/backend/services/auth/guardian_related_accounts_test.go
+++ b/backend/services/auth/guardian_related_accounts_test.go
@@ -1057,8 +1057,16 @@ func TestInviteToStudent_SocialWorkerLink_RefusedEvenWithConfirmation(t *testing
 	assert.Empty(t, invitations, "refusal must not create invitation rows")
 }
 
-func TestApproveInvitation_RoleUpgradeSkipsSocialWorkerLink(t *testing.T) {
-	env := setupGuardianInvitationTest(t)
+// TestApproveInvitation_RoleUpgradeRefusesSocialWorkerLink covers the case
+// where the link is repurposed to a school-managed social-worker contact
+// between the parent's confirmation and the staff approval. The upgrade can no
+// longer be applied, so the approval must fail loudly: approving anyway would
+// report success (and email an invitation) for access that was never granted.
+func TestApproveInvitation_RoleUpgradeRefusesSocialWorkerLink(t *testing.T) {
+	outbox := &stubOutboxEnqueuer{}
+	env := setupGuardianInvitationTest(t, func(cfg *authService.GuardianInvitationServiceConfig) {
+		cfg.OutboxEnqueuer = outbox
+	})
 	defer env.cleanup()
 
 	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Repurposed", "7h")
@@ -1090,12 +1098,20 @@ func TestApproveInvitation_RoleUpgradeSkipsSocialWorkerLink(t *testing.T) {
 	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleSocialWorker)
 	require.NoError(t, env.repos.StudentGuardian.Update(ctx, link))
 
-	require.NoError(t, env.service.ApproveInvitation(ctx, *result.InvitationID, creatorID))
+	err = env.service.ApproveInvitation(ctx, *result.InvitationID, creatorID)
+	require.ErrorIs(t, err, authService.ErrInviteSocialWorkerManaged)
 
 	link = env.fetchLink(t, student.ID, profile.ID)
 	assert.Equal(t, authorize.GuardianRoleSocialWorker, link.GuardianRole,
 		"persisted upgrade flag must not promote a social-worker link")
 	assert.False(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), *result.InvitationID)
+	require.NoError(t, err)
+	assert.Equal(t, authModels.GuardianInvitationApprovalPending, inv.ApprovalStatus,
+		"a refused upgrade must not mark the request approved")
+	assert.Nil(t, inv.ApprovedAt)
+	assert.Empty(t, outbox.requests, "no invitation email for access that was not granted")
 }
 
 // TestInviteToStudent_ConfirmedUpgrade_ParentDirectModeQueuesApproval verifies
@@ -1225,6 +1241,132 @@ func TestInviteToStudent_ConfirmedUpgrade_RequeuesOpenDirectInvitation(t *testin
 	link := env.fetchLink(t, student.ID, profile.ID)
 	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
 	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+}
+
+// TestInviteToStudent_ConfirmedUpgrade_RequeueRefreshesExpiry guards the
+// approval window of a re-queued row: the reused invitation carries the expiry
+// of the older invite, and approve/reject are gated on it. A nearly-expired
+// leftover must not lock staff out of a request submitted seconds ago.
+func TestInviteToStudent_ConfirmedUpgrade_RequeueRefreshesExpiry(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Expiry", "7k")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-expiry")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleCustom)
+
+	// Earlier staff direct invite, almost expired but still open.
+	studentID := student.ID
+	staleExpiry := time.Now().Add(2 * time.Minute)
+	sentAt := time.Now().Add(-46 * time.Hour)
+	emailError := "smtp timeout"
+	existing := &authModels.GuardianInvitation{
+		Token:             fmt.Sprintf("upgrade-expiry-%d", time.Now().UnixNano()),
+		GuardianProfileID: profile.ID,
+		CreatedBy:         creatorID,
+		ExpiresAt:         staleExpiry,
+		StudentID:         &studentID,
+		ApprovalStatus:    authModels.GuardianInvitationApprovalNotRequired,
+		EmailSentAt:       &sentAt,
+		EmailError:        &emailError,
+	}
+	existing.SetTenantID(1)
+	require.NoError(t, env.repos.GuardianInvitation.Create(ctx, existing))
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID)
+	require.Equal(t, existing.ID, *result.InvitationID)
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), existing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, authModels.GuardianInvitationApprovalPending, inv.ApprovalStatus)
+	assert.True(t, inv.ExpiresAt.After(staleExpiry.Add(time.Hour)),
+		"re-queued request must get a fresh approval window, not the leftover expiry")
+	assert.Nil(t, inv.EmailSentAt, "stale email tracking must be cleared")
+	assert.Nil(t, inv.EmailError)
+
+	// The freshly queued request is approvable.
+	require.NoError(t, env.service.ApproveInvitation(ctx, existing.ID, creatorID))
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
+}
+
+// TestInviteToStudent_DirectLinkClosesPendingApprovalRequest covers the
+// out-of-band resolution: a parent request is still queued when staff link the
+// same (already registered) account directly. The queued row must not be left
+// behind as a phantom entry that can never do anything.
+func TestInviteToStudent_DirectLinkClosesPendingApprovalRequest(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Superseded", "7l")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-superseded")
+	_, account := testpkg.CreateTestPersonWithAccount(t, env.db, "Superseded", "Account")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	require.NoError(t, env.repos.GuardianProfile.LinkAccount(ctx, profile.ID, account.ID))
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRolePickupOnly)
+
+	// Parent queues the upgrade request.
+	queued, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            true,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, queued.InvitationID)
+	assert.Equal(t, authService.InviteOutcomePendingApproval, queued.Outcome)
+
+	// Staff grant the same access directly instead of using the queue.
+	direct, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:          student.ID,
+		Email:              *profile.Email,
+		CreatedBy:          creatorID,
+		ConfirmRoleUpgrade: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authService.InviteOutcomeAlreadyLinked, direct.Outcome)
+
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
+	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), *queued.InvitationID)
+	require.NoError(t, err)
+	assert.NotEqual(t, authModels.GuardianInvitationApprovalPending, inv.ApprovalStatus,
+		"the superseded request must leave the approval queue")
+	assert.NotNil(t, inv.AcceptedAt, "access exists, so the request is resolved")
+
+	views, err := env.service.ListPendingApprovalsDetailed(ctx)
+	require.NoError(t, err)
+	for _, v := range views {
+		assert.NotEqual(t, *queued.InvitationID, v.InvitationID,
+			"no phantom entry may stay in the staff queue")
+	}
 }
 
 // TestInviteToStudent_PlainReinviteKeepsResolvedInvitation is the regression

--- a/backend/services/auth/guardian_related_accounts_test.go
+++ b/backend/services/auth/guardian_related_accounts_test.go
@@ -1149,3 +1149,80 @@ func TestInviteToStudent_ConfirmedUpgrade_ParentDirectModeQueuesApproval(t *test
 	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
 	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
 }
+
+// TestInviteToStudent_ConfirmedUpgrade_RequeuesOpenDirectInvitation reproduces
+// the reuse gap from the #2174 review: an open invitation created WITHOUT
+// approval (staff direct invite, not_required) exists when a parent confirms a
+// role upgrade. The reused row must be promoted to pending — otherwise it
+// never reaches the staff queue, ApproveInvitation never applies the persisted
+// upgrade, and the still-consumable token would grant an account without the
+// promised access.
+func TestInviteToStudent_ConfirmedUpgrade_RequeuesOpenDirectInvitation(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Requeue", "7j")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-requeue")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleCustom)
+
+	// Earlier staff direct invite: open, token emailed, no approval required.
+	studentID := student.ID
+	existing := &authModels.GuardianInvitation{
+		Token:             fmt.Sprintf("upgrade-requeue-%d", time.Now().UnixNano()),
+		GuardianProfileID: profile.ID,
+		CreatedBy:         creatorID,
+		ExpiresAt:         time.Now().Add(48 * time.Hour),
+		StudentID:         &studentID,
+		ApprovalStatus:    authModels.GuardianInvitationApprovalNotRequired,
+	}
+	existing.SetTenantID(1)
+	require.NoError(t, env.repos.GuardianInvitation.Create(ctx, existing))
+
+	// Parent confirms the upgrade (direct mode — approval is forced).
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            false,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID)
+	assert.Equal(t, existing.ID, *result.InvitationID, "open invitation must be reused")
+	assert.Equal(t, authService.InviteOutcomePendingApproval, result.Outcome)
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), existing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, authModels.GuardianInvitationApprovalPending, inv.ApprovalStatus,
+		"reused not_required invitation must be re-queued as pending")
+	assert.True(t, inv.RoleUpgrade)
+	require.NotNil(t, inv.RequestedByAccountID)
+	assert.Equal(t, creatorID, *inv.RequestedByAccountID, "queue must name the requesting parent")
+
+	// The request is visible in the staff queue and approval applies the
+	// upgrade.
+	views, err := env.service.ListPendingApprovalsDetailed(ctx)
+	require.NoError(t, err)
+	var view *authService.PendingApprovalView
+	for _, v := range views {
+		if v.InvitationID == existing.ID {
+			view = v
+		}
+	}
+	require.NotNil(t, view, "re-queued request must appear in the approval queue")
+	assert.True(t, view.RoleUpgrade)
+
+	require.NoError(t, env.service.ApproveInvitation(ctx, existing.ID, creatorID))
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
+	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+}

--- a/backend/services/auth/guardian_related_accounts_test.go
+++ b/backend/services/auth/guardian_related_accounts_test.go
@@ -1097,3 +1097,55 @@ func TestApproveInvitation_RoleUpgradeSkipsSocialWorkerLink(t *testing.T) {
 		"persisted upgrade flag must not promote a social-worker link")
 	assert.False(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
 }
+
+// TestInviteToStudent_ConfirmedUpgrade_ParentDirectModeQueuesApproval verifies
+// that a PARENT-confirmed upgrade of an existing restricted contact is queued
+// for staff approval even when the school runs direct invite mode: the upgrade
+// overrides a deliberate staff-set restriction, so it never applies without a
+// review step. Staff-shaped invites (no RequestedByParentAccountID) keep
+// resolving immediately — covered by the ConfirmedUpgrade_Direct* tests above.
+func TestInviteToStudent_ConfirmedUpgrade_ParentDirectModeQueuesApproval(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "ParentDirect", "7i")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-parent-direct")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRolePickupOnly)
+
+	// Parent-shaped invite in DIRECT mode (RequireApproval false) with a
+	// confirmed upgrade → queued, nothing applied yet.
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            false,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID)
+	defer env.cleanupInvitation(t, *result.InvitationID, profile.ID)
+	assert.Equal(t, authService.InviteOutcomePendingApproval, result.Outcome)
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), *result.InvitationID)
+	require.NoError(t, err)
+	assert.True(t, inv.RoleUpgrade, "queued request must persist the upgrade intent")
+	assert.Equal(t, authModels.GuardianInvitationApprovalPending, inv.ApprovalStatus)
+
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRolePickupOnly, link.GuardianRole, "no upgrade before approval")
+	assert.False(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+
+	// Approval applies the upgrade, exactly like staff_approval mode.
+	require.NoError(t, env.service.ApproveInvitation(ctx, *result.InvitationID, creatorID))
+	link = env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
+	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+}

--- a/backend/services/auth/guardian_related_accounts_test.go
+++ b/backend/services/auth/guardian_related_accounts_test.go
@@ -1226,3 +1226,76 @@ func TestInviteToStudent_ConfirmedUpgrade_RequeuesOpenDirectInvitation(t *testin
 	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
 	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
 }
+
+// TestInviteToStudent_PlainReinviteKeepsResolvedInvitation is the regression
+// guard for the #2174 review blocker: in staff_approval mode EVERY parent
+// invite is approval-gated, so a plain duplicate re-invite (no confirmed role
+// upgrade) that reuses an open, already-resolved invitation must NOT revert it
+// to pending — that would invalidate its live token and force a re-approval.
+// Only a confirmed role upgrade may re-queue a resolved invitation.
+func TestInviteToStudent_PlainReinviteKeepsResolvedInvitation(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "plain-reinvite")
+	creatorID := env.inviterAccountID(t)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+
+	for _, status := range []string{
+		authModels.GuardianInvitationApprovalApproved,
+		authModels.GuardianInvitationApprovalNotRequired,
+	} {
+		t.Run(status, func(t *testing.T) {
+			// One student per subtest: findOpenStudentInvitation is scoped by
+			// (profile, student), so the previous subtest's still-open
+			// invitation must not be a reuse candidate here.
+			student := testpkg.CreateTestStudent(t, env.db, "Plain", "Reinvite", "7k")
+			now := time.Now()
+			studentID := student.ID
+			existing := &authModels.GuardianInvitation{
+				Token:             fmt.Sprintf("plain-reinvite-%s-%d", status, now.UnixNano()),
+				GuardianProfileID: profile.ID,
+				CreatedBy:         creatorID,
+				ExpiresAt:         now.Add(48 * time.Hour),
+				StudentID:         &studentID,
+				ApprovalStatus:    status,
+			}
+			if status == authModels.GuardianInvitationApprovalApproved {
+				existing.ApprovedBy = &creatorID
+				existing.ApprovedAt = &now
+			}
+			existing.SetTenantID(1)
+			// Cleanup: the test-level defer deletes every invitation of this
+			// profile, so no per-subtest cleanup (which would also delete the
+			// shared profile).
+			require.NoError(t, env.repos.GuardianInvitation.Create(ctx, existing))
+
+			// Duplicate plain parent invite in staff_approval mode.
+			result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+				StudentID:                  student.ID,
+				Email:                      *profile.Email,
+				CreatedBy:                  creatorID,
+				RequestedByParentAccountID: &creatorID,
+				RequireApproval:            true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result.InvitationID)
+			assert.Equal(t, existing.ID, *result.InvitationID, "open invitation must be reused")
+
+			inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), existing.ID)
+			require.NoError(t, err)
+			assert.Equal(t, status, inv.ApprovalStatus,
+				"a plain re-invite must not revert a resolved invitation")
+			assert.False(t, inv.RoleUpgrade)
+			if status == authModels.GuardianInvitationApprovalApproved {
+				assert.NotNil(t, inv.ApprovedBy, "approval record must survive a duplicate submission")
+				assert.NotNil(t, inv.ApprovedAt)
+			}
+		})
+	}
+}

--- a/backend/services/auth/guardian_related_accounts_test.go
+++ b/backend/services/auth/guardian_related_accounts_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
@@ -737,4 +738,270 @@ func TestRejectInvitation_PreservesSharedPendingProfile(t *testing.T) {
 	inv, err := env.repos.GuardianInvitation.FindByID(ctx, *second.InvitationID)
 	require.NoError(t, err)
 	assert.Equal(t, authModels.GuardianInvitationApprovalPending, inv.ApprovalStatus)
+}
+
+// createRestrictedContactLink links a guardian profile to a student with a
+// restrictive preset role (no parent_portal.access), mirroring a
+// staff-maintained contact (#2172).
+func (env *guardianTestEnv) createRestrictedContactLink(t *testing.T, studentID, guardianProfileID int64, role string) {
+	t.Helper()
+	link := &users.StudentGuardian{
+		StudentID:         studentID,
+		GuardianProfileID: guardianProfileID,
+		RelationshipType:  "other",
+		EmergencyPriority: 1,
+	}
+	authorize.ApplyStudentGuardianRole(link, role)
+	link.SetTenantID(1)
+	require.NoError(t, env.repos.StudentGuardian.Create(testpkg.TenantContext(1), link))
+}
+
+// fetchLink reads the current student↔guardian link row.
+func (env *guardianTestEnv) fetchLink(t *testing.T, studentID, guardianProfileID int64) *users.StudentGuardian {
+	t.Helper()
+	link, err := env.repos.StudentGuardian.FindByStudentAndGuardianForUpdate(testpkg.TenantContext(1), studentID, guardianProfileID)
+	require.NoError(t, err)
+	return link
+}
+
+func TestInviteToStudent_RestrictedContact_RequiresConfirmation(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Restricted", "Contact", "7a")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "restricted-contact")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleEmergency)
+
+	// Staff-shaped invite without confirmation → detection, zero side effects.
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID: student.ID,
+		Email:     *profile.Email,
+		CreatedBy: creatorID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authService.InviteOutcomeExistingContactRestricted, result.Outcome)
+	assert.Equal(t, authorize.GuardianRoleEmergency, result.ExistingRole)
+	assert.Equal(t, profile.ID, result.GuardianProfileID)
+	assert.Nil(t, result.InvitationID)
+
+	// Parent-shaped invite (approval mode) without confirmation → same, and
+	// crucially nothing was queued.
+	parentResult, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authService.InviteOutcomeExistingContactRestricted, parentResult.Outcome)
+
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleEmergency, link.GuardianRole, "link role must be untouched")
+	invitations, err := env.repos.GuardianInvitation.FindByGuardianProfileID(ctx, profile.ID)
+	require.NoError(t, err)
+	assert.Empty(t, invitations, "detection must not create invitation rows")
+}
+
+func TestInviteToStudent_ConfirmedUpgrade_DirectNoAccount(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "NoAccount", "7b")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-no-account")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRolePickupOnly)
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:          student.ID,
+		Email:              *profile.Email,
+		CreatedBy:          creatorID,
+		ConfirmRoleUpgrade: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID, "no-account contact still needs a token invitation")
+	defer env.cleanupInvitation(t, *result.InvitationID, profile.ID)
+
+	assert.Equal(t, authService.InviteOutcomeInvited, result.Outcome)
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
+	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess),
+		"upgraded link must carry parent_portal.access")
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), *result.InvitationID)
+	require.NoError(t, err)
+	assert.False(t, inv.RoleUpgrade, "direct mode applies the upgrade immediately; the row flag stays false")
+}
+
+func TestInviteToStudent_ConfirmedUpgrade_DirectExistingAccount(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "HasAccount", "7c")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-has-account")
+	_, account := testpkg.CreateTestPersonWithAccount(t, env.db, "Upgrade", "Account")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	require.NoError(t, env.repos.GuardianProfile.LinkAccount(ctx, profile.ID, account.ID))
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleEmergency)
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:          student.ID,
+		Email:              *profile.Email,
+		CreatedBy:          creatorID,
+		ConfirmRoleUpgrade: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authService.InviteOutcomeAlreadyLinked, result.Outcome)
+	assert.Nil(t, result.InvitationID)
+
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole)
+	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess),
+		"existing account must gain access immediately")
+}
+
+func TestInviteToStudent_ConfirmedUpgrade_ApprovalPersistsFlagAndAppliesOnApprove(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Approval", "7d")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-approval")
+	_, account := testpkg.CreateTestPersonWithAccount(t, env.db, "Approval", "Account")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	require.NoError(t, env.repos.GuardianProfile.LinkAccount(ctx, profile.ID, account.ID))
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleCustom)
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            true,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID)
+	defer env.cleanupInvitation(t, *result.InvitationID, profile.ID)
+	assert.Equal(t, authService.InviteOutcomePendingApproval, result.Outcome)
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), *result.InvitationID)
+	require.NoError(t, err)
+	assert.True(t, inv.RoleUpgrade, "approval mode must persist the upgrade intent")
+	link := env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleCustom, link.GuardianRole, "no upgrade before approval")
+
+	// Staff sees the upgrade marker in the queue.
+	views, err := env.service.ListPendingApprovalsDetailed(ctx)
+	require.NoError(t, err)
+	var view *authService.PendingApprovalView
+	for _, v := range views {
+		if v.InvitationID == *result.InvitationID {
+			view = v
+		}
+	}
+	require.NotNil(t, view)
+	assert.True(t, view.RoleUpgrade)
+
+	require.NoError(t, env.service.ApproveInvitation(ctx, *result.InvitationID, creatorID))
+	link = env.fetchLink(t, student.ID, profile.ID)
+	assert.Equal(t, authorize.GuardianRoleLegalGuardian, link.GuardianRole, "approval must apply the upgrade")
+	assert.True(t, authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess))
+}
+
+func TestInviteToStudent_ConfirmedUpgrade_ReusedPendingInvitationGetsFlag(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Upgrade", "Reuse", "7e")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "upgrade-reuse")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleEmergency)
+	studentID := student.ID
+	existing := &authModels.GuardianInvitation{
+		Token:                fmt.Sprintf("upgrade-reuse-%d", time.Now().UnixNano()),
+		GuardianProfileID:    profile.ID,
+		CreatedBy:            creatorID,
+		ExpiresAt:            time.Now().Add(time.Hour),
+		StudentID:            &studentID,
+		RequestedByAccountID: &creatorID,
+		ApprovalStatus:       authModels.GuardianInvitationApprovalPending,
+	}
+	existing.SetTenantID(1)
+	require.NoError(t, env.repos.GuardianInvitation.Create(ctx, existing))
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID:                  student.ID,
+		Email:                      *profile.Email,
+		CreatedBy:                  creatorID,
+		RequestedByParentAccountID: &creatorID,
+		RequireApproval:            true,
+		ConfirmRoleUpgrade:         true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.InvitationID)
+	assert.Equal(t, existing.ID, *result.InvitationID, "open invitation must be reused")
+
+	inv, err := env.repos.GuardianInvitation.FindByID(context.Background(), existing.ID)
+	require.NoError(t, err)
+	assert.True(t, inv.RoleUpgrade, "reused invitation must carry the upgrade flag")
+}
+
+func TestInviteToStudent_FullRoleLink_NoConfirmationNeeded(t *testing.T) {
+	env := setupGuardianInvitationTest(t)
+	defer env.cleanup()
+
+	student := testpkg.CreateTestStudent(t, env.db, "Full", "Role", "7f")
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "full-role-link")
+	_, account := testpkg.CreateTestPersonWithAccount(t, env.db, "Full", "Account")
+	creatorID := env.inviterAccountID(t)
+	defer env.deleteStudentGuardianLinks(student.ID)
+	defer func() {
+		_, _ = env.db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+
+	ctx := testpkg.TenantContext(1)
+	require.NoError(t, env.repos.GuardianProfile.LinkAccount(ctx, profile.ID, account.ID))
+	env.createRestrictedContactLink(t, student.ID, profile.ID, authorize.GuardianRoleLegalGuardian)
+
+	result, err := env.service.InviteToStudent(ctx, authService.InviteToStudentRequest{
+		StudentID: student.ID,
+		Email:     *profile.Email,
+		CreatedBy: creatorID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authService.InviteOutcomeAlreadyLinked, result.Outcome,
+		"full-role links must not trigger the restricted-contact confirmation")
+	assert.Empty(t, result.ExistingRole)
 }

--- a/backend/services/parent/parent_related_accounts_service.go
+++ b/backend/services/parent/parent_related_accounts_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/uptrace/bun"
 
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -42,6 +43,10 @@ const (
 	// RelatedAccountNoAccount: a staff-maintained contact link without portal
 	// access and without an open invite.
 	RelatedAccountNoAccount RelatedAccountStatus = "no_account"
+	// RelatedAccountActiveNoAccess: the guardian has a portal account, but
+	// this child's link carries no parent_portal.access permission (e.g. a
+	// restrictive contact role) — the child is invisible to them (#2172).
+	RelatedAccountActiveNoAccess RelatedAccountStatus = "active_no_access"
 )
 
 // RelatedAccount is one guardian linked to a child, with portal-access status.
@@ -63,6 +68,9 @@ type RelatedAccount struct {
 type InviteRelatedAccountResult struct {
 	Outcome           string
 	GuardianProfileID int64
+	// ExistingRole carries the current guardian role for the
+	// existing_contact_restricted outcome; empty otherwise.
+	ExistingRole string
 }
 
 // ListRelatedAccounts returns every guardian linked to the child, annotated
@@ -88,7 +96,7 @@ func (s *service) ListRelatedAccounts(ctx context.Context, accountID, studentID 
 			if profile == nil {
 				continue
 			}
-			status := s.relatedAccountStatus(txCtx, profile, studentID)
+			status := s.relatedAccountStatus(txCtx, profile, link, studentID)
 			email := ""
 			if profile.Email != nil {
 				email = *profile.Email
@@ -112,25 +120,29 @@ func (s *service) ListRelatedAccounts(ctx context.Context, accountID, studentID 
 	return out, nil
 }
 
-func (s *service) relatedAccountStatus(ctx context.Context, profile *userModels.GuardianProfile, studentID int64) RelatedAccountStatus {
-	if profile.HasAccount {
+func (s *service) relatedAccountStatus(ctx context.Context, profile *userModels.GuardianProfile, link *userModels.StudentGuardian, studentID int64) RelatedAccountStatus {
+	hasAccess := authorize.StudentGuardianHasPermission(link, authorize.GuardianPermissionPortalAccess)
+	if profile.HasAccount && hasAccess {
 		return RelatedAccountActive
 	}
-	if s.GuardianInviteRepo == nil {
-		return RelatedAccountNoAccount
-	}
-	invitations, err := s.GuardianInviteRepo.FindByGuardianProfileID(ctx, profile.ID)
-	if err != nil {
-		return RelatedAccountNoAccount
-	}
-	now := time.Now()
-	for _, inv := range invitations {
-		if inv.StudentID == nil || *inv.StudentID != studentID {
-			continue
+	// An open invitation (e.g. a confirmed upgrade awaiting staff approval)
+	// wins over the stale account states below.
+	if s.GuardianInviteRepo != nil {
+		invitations, err := s.GuardianInviteRepo.FindByGuardianProfileID(ctx, profile.ID)
+		if err == nil {
+			now := time.Now()
+			for _, inv := range invitations {
+				if inv.StudentID == nil || *inv.StudentID != studentID {
+					continue
+				}
+				if authService.GuardianInvitationValid(inv, now) && inv.ApprovalStatus != authModels.GuardianInvitationApprovalRejected {
+					return RelatedAccountPending
+				}
+			}
 		}
-		if authService.GuardianInvitationValid(inv, now) && inv.ApprovalStatus != authModels.GuardianInvitationApprovalRejected {
-			return RelatedAccountPending
-		}
+	}
+	if profile.HasAccount {
+		return RelatedAccountActiveNoAccess
 	}
 	return RelatedAccountNoAccount
 }
@@ -138,7 +150,7 @@ func (s *service) relatedAccountStatus(ctx context.Context, profile *userModels.
 // InviteRelatedAccount invites a further guardian to the parent's child by
 // email. Gated by guardians.parent_invite_mode; staff_approval mode queues the
 // request instead of acting immediately.
-func (s *service) InviteRelatedAccount(ctx context.Context, accountID, studentID int64, email, firstName, lastName string) (*InviteRelatedAccountResult, error) {
+func (s *service) InviteRelatedAccount(ctx context.Context, accountID, studentID int64, email, firstName, lastName string, confirmRoleUpgrade bool) (*InviteRelatedAccountResult, error) {
 	if strings.TrimSpace(email) == "" {
 		return nil, ErrEmailRequired
 	}
@@ -170,6 +182,7 @@ func (s *service) InviteRelatedAccount(ctx context.Context, accountID, studentID
 			CreatedBy:                  accountID,
 			RequestedByParentAccountID: &requestedBy,
 			RequireApproval:            requireApproval,
+			ConfirmRoleUpgrade:         confirmRoleUpgrade,
 		})
 		if inviteErr != nil {
 			return inviteErr
@@ -183,6 +196,7 @@ func (s *service) InviteRelatedAccount(ctx context.Context, accountID, studentID
 	return &InviteRelatedAccountResult{
 		Outcome:           string(result.Outcome),
 		GuardianProfileID: result.GuardianProfileID,
+		ExistingRole:      result.ExistingRole,
 	}, nil
 }
 

--- a/backend/services/parent/parent_related_accounts_service.go
+++ b/backend/services/parent/parent_related_accounts_service.go
@@ -56,8 +56,12 @@ type RelatedAccount struct {
 	LastName          string
 	Email             string
 	RelationshipType  string
-	IsPrimary         bool
-	Status            RelatedAccountStatus
+	// GuardianRole is the per-child role preset on the link. The UI uses it to
+	// hide the grant-access action for school-managed social-worker contacts,
+	// which the invite flow refuses anyway (#2172).
+	GuardianRole string
+	IsPrimary    bool
+	Status       RelatedAccountStatus
 	// IsSelf marks the row belonging to the requesting parent's own account.
 	// The backend rejects self-removal (ErrCannotRemoveOwnAccess), so the UI
 	// uses this to hide the remove action on the caller's own row.
@@ -107,6 +111,7 @@ func (s *service) ListRelatedAccounts(ctx context.Context, accountID, studentID 
 				LastName:          profile.LastName,
 				Email:             email,
 				RelationshipType:  link.RelationshipType,
+				GuardianRole:      link.GuardianRole,
 				IsPrimary:         link.IsPrimary,
 				Status:            status,
 				IsSelf:            profile.AccountID != nil && *profile.AccountID == accountID,

--- a/backend/services/parent/parent_related_accounts_service_test.go
+++ b/backend/services/parent/parent_related_accounts_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	repositories "github.com/moto-nrw/project-phoenix/database/repositories"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
@@ -220,7 +221,7 @@ func TestInviteRelatedAccount_DisabledIsRejected(t *testing.T) {
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "x@example.test", "", "")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "x@example.test", "", "", false)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, parentService.ErrInviteDisabled))
 	assert.Nil(t, invites.lastInvite, "invite service must not be called when disabled")
@@ -233,7 +234,7 @@ func TestInviteRelatedAccount_DirectDelegatesWithoutApproval(t *testing.T) {
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "new@example.test", "Neue", "Person")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "new@example.test", "Neue", "Person", false)
 	require.NoError(t, err)
 	require.NotNil(t, invites.lastInvite)
 	assert.False(t, invites.lastInvite.RequireApproval, "direct mode must not require approval")
@@ -249,7 +250,7 @@ func TestInviteRelatedAccount_StaffApprovalRequiresApproval(t *testing.T) {
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "new@example.test", "", "")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "new@example.test", "", "", false)
 	require.NoError(t, err)
 	require.NotNil(t, invites.lastInvite)
 	assert.True(t, invites.lastInvite.RequireApproval, "staff_approval mode must queue for approval")
@@ -267,7 +268,7 @@ func TestInviteRelatedAccount_UnownedChildIsRejected(t *testing.T) {
 		_, _ = db.NewDelete().TableExpr("users.students").Where("id = ?", other.ID).Exec(context.Background())
 	}()
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, other.ID, "x@example.test", "", "")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, other.ID, "x@example.test", "", "", false)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, parentService.ErrChildNotLinked))
 	assert.Nil(t, invites.lastInvite, "invite must not fire for an unowned child")
@@ -376,7 +377,7 @@ func TestInviteRelatedAccount_EmptyEmailRejected(t *testing.T) {
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "   ", "", "")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "   ", "", "", false)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, parentService.ErrEmailRequired))
 	assert.Nil(t, invites.lastInvite)
@@ -388,7 +389,7 @@ func TestInviteRelatedAccount_InvalidEmailRejected(t *testing.T) {
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "not-an-email", "", "")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "not-an-email", "", "", false)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, parentService.ErrInvalidInviteInput))
 	assert.Nil(t, invites.lastInvite)
@@ -403,7 +404,7 @@ func TestRelatedAccounts_SettingsErrorsAreSurfaced(t *testing.T) {
 	chain := testpkg.CreateTestParentGuardianChain(t, db)
 	defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "x@example.test", "", "")
+	_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "x@example.test", "", "", false)
 	require.Error(t, err, "invite-mode resolve failure must surface")
 
 	err = svc.RemoveRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, chain.GuardianProfileID)
@@ -466,7 +467,7 @@ func TestRelatedAccounts_DelegateErrorsSurface(t *testing.T) {
 		chain := testpkg.CreateTestParentGuardianChain(t, db)
 		defer testpkg.CleanupParentGuardianChain(t, db, chain)
 
-		_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "x@example.test", "", "")
+		_, err := svc.InviteRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, "x@example.test", "", "", false)
 		require.Error(t, err)
 	})
 
@@ -479,4 +480,94 @@ func TestRelatedAccounts_DelegateErrorsSurface(t *testing.T) {
 		err := svc.RemoveRelatedAccount(context.Background(), chain.AccountID, chain.StudentID, chain.GuardianProfileID)
 		require.Error(t, err)
 	})
+}
+
+func TestListRelatedAccounts_AccountWithoutAccessIsActiveNoAccess(t *testing.T) {
+	svc, _, db := buildRelAcctService(t, configModels.ParentInviteModeDirect, false)
+	defer func() { _ = db.Close() }()
+
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+	repos := repositories.NewFactory(db)
+	ctx := testpkg.TenantContext(1)
+	profile := testpkg.CreateTestGuardianProfile(t, db, "active-no-access")
+	_, account := testpkg.CreateTestPersonWithAccount(t, db, "NoAccess", "Account")
+	defer func() {
+		_, _ = db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+	require.NoError(t, repos.GuardianProfile.LinkAccount(ctx, profile.ID, account.ID))
+	// Restrictive contact role → empty permission set, no parent_portal.access.
+	link := &userModels.StudentGuardian{
+		StudentID:         chain.StudentID,
+		GuardianProfileID: profile.ID,
+		RelationshipType:  "other",
+		EmergencyPriority: 1,
+	}
+	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleEmergency)
+	link.SetTenantID(1)
+	require.NoError(t, repos.StudentGuardian.Create(ctx, link))
+
+	accounts, err := svc.ListRelatedAccounts(context.Background(), chain.AccountID, chain.StudentID)
+	require.NoError(t, err)
+
+	var found *parentService.RelatedAccount
+	for _, account := range accounts {
+		if account.GuardianProfileID == profile.ID {
+			found = account
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, parentService.RelatedAccountActiveNoAccess, found.Status,
+		"an account without parent_portal.access on this child must not report as plainly active")
+}
+
+func TestListRelatedAccounts_AccountWithoutAccessWithOpenInviteIsPending(t *testing.T) {
+	svc, _, db := buildRelAcctService(t, configModels.ParentInviteModeDirect, false)
+	defer func() { _ = db.Close() }()
+
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+	repos := repositories.NewFactory(db)
+	ctx := testpkg.TenantContext(1)
+	profile := testpkg.CreateTestGuardianProfile(t, db, "no-access-pending")
+	_, account := testpkg.CreateTestPersonWithAccount(t, db, "NoAccessPending", "Account")
+	defer func() {
+		_, _ = db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", profile.ID).Exec(context.Background())
+		_, _ = db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", profile.ID).Exec(context.Background())
+	}()
+	require.NoError(t, repos.GuardianProfile.LinkAccount(ctx, profile.ID, account.ID))
+	link := &userModels.StudentGuardian{
+		StudentID:         chain.StudentID,
+		GuardianProfileID: profile.ID,
+		RelationshipType:  "other",
+		EmergencyPriority: 1,
+	}
+	authorize.ApplyStudentGuardianRole(link, authorize.GuardianRoleEmergency)
+	link.SetTenantID(1)
+	require.NoError(t, repos.StudentGuardian.Create(ctx, link))
+	studentID := chain.StudentID
+	invitation := &authModels.GuardianInvitation{
+		Token:             fmt.Sprintf("no-access-pending-%d", time.Now().UnixNano()),
+		GuardianProfileID: profile.ID,
+		CreatedBy:         chain.AccountID,
+		ExpiresAt:         time.Now().Add(time.Hour),
+		StudentID:         &studentID,
+		ApprovalStatus:    authModels.GuardianInvitationApprovalPending,
+		RoleUpgrade:       true,
+	}
+	invitation.SetTenantID(1)
+	require.NoError(t, repos.GuardianInvitation.Create(ctx, invitation))
+
+	accounts, err := svc.ListRelatedAccounts(context.Background(), chain.AccountID, chain.StudentID)
+	require.NoError(t, err)
+
+	var found *parentService.RelatedAccount
+	for _, account := range accounts {
+		if account.GuardianProfileID == profile.ID {
+			found = account
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, parentService.RelatedAccountPending, found.Status,
+		"an in-flight upgrade approval must show as pending, not active_no_access")
 }

--- a/backend/services/parent/parent_service.go
+++ b/backend/services/parent/parent_service.go
@@ -142,7 +142,9 @@ type Service interface {
 
 	// InviteRelatedAccount invites a further guardian to the child by email.
 	// Gated by guardians.parent_invite_mode; staff_approval queues the request.
-	InviteRelatedAccount(ctx context.Context, accountID, studentID int64, email, firstName, lastName string) (*InviteRelatedAccountResult, error)
+	// confirmRoleUpgrade confirms upgrading an existing restrictive contact
+	// link to full access (#2172).
+	InviteRelatedAccount(ctx context.Context, accountID, studentID int64, email, firstName, lastName string, confirmRoleUpgrade bool) (*InviteRelatedAccountResult, error)
 
 	// RemoveRelatedAccount removes another account's access to the child.
 	// Gated by guardians.parent_can_remove; the primary guardian is protected.

--- a/backend/services/users/guardian_interface.go
+++ b/backend/services/users/guardian_interface.go
@@ -122,9 +122,10 @@ type StudentWithRelationship struct {
 type GuardianWithRelationship struct {
 	Profile      *users.GuardianProfile
 	Relationship *users.StudentGuardian
-	// InvitationPending is true when the guardian has no portal account yet
-	// but an open (not accepted, not expired, not rejected) invitation exists.
-	// Lets the staff UI show "Einladung offen" and offer re-invite instead of
-	// a fresh invite.
+	// InvitationPending is true when an open (not accepted, not expired, not
+	// rejected) invitation exists: profile-wide for guardians without a portal
+	// account, and anchored to this child for guardians WITH an account (a
+	// pending-approval role-upgrade request, #2172). Lets the staff UI show
+	// "Einladung offen" instead of a misleading active/no-access state.
 	InvitationPending bool
 }

--- a/backend/services/users/guardian_service.go
+++ b/backend/services/users/guardian_service.go
@@ -537,24 +537,41 @@ func (s *GuardianService) GetStudentGuardians(ctx context.Context, studentID int
 		result = append(result, &GuardianWithRelationship{
 			Profile:           profile,
 			Relationship:      rel,
-			InvitationPending: !profile.HasAccount && s.hasOpenInvitation(ctx, profile.ID),
+			InvitationPending: s.invitationPendingForStudent(ctx, profile, rel.StudentID),
 		})
 	}
 
 	return result, nil
 }
 
+// invitationPendingForStudent decides whether the staff list should surface
+// "Einladung offen" for this guardian on this child. Guardians without an
+// account keep the historical profile-wide check (any open invite). Guardians
+// WITH an account can still have an open invitation — a pending-approval
+// role-upgrade request (#2172) — but only one anchored to this child counts,
+// so a sibling's invite never marks an unrelated row as pending.
+func (s *GuardianService) invitationPendingForStudent(ctx context.Context, profile *users.GuardianProfile, studentID int64) bool {
+	if !profile.HasAccount {
+		return s.hasOpenInvitation(ctx, profile.ID, 0)
+	}
+	return s.hasOpenInvitation(ctx, profile.ID, studentID)
+}
+
 // hasOpenInvitation reports whether the guardian profile has an invitation that
 // is neither accepted, expired, nor rejected — i.e. an outstanding invite the
-// staff UI should surface as "Einladung offen". Best-effort: a lookup error is
+// staff UI should surface as "Einladung offen". With studentID > 0, only
+// invitations anchored to that child count. Best-effort: a lookup error is
 // treated as "no pending invite" so the guardian list still renders.
-func (s *GuardianService) hasOpenInvitation(ctx context.Context, guardianProfileID int64) bool {
+func (s *GuardianService) hasOpenInvitation(ctx context.Context, guardianProfileID, studentID int64) bool {
 	invitations, err := s.GuardianInvitationRepo.FindByGuardianProfileID(ctx, guardianProfileID)
 	if err != nil {
 		return false
 	}
 	now := time.Now()
 	for _, inv := range invitations {
+		if studentID > 0 && (inv.StudentID == nil || *inv.StudentID != studentID) {
+			continue
+		}
 		if inv.IsAccepted() {
 			continue
 		}

--- a/backend/services/users/guardian_service_test.go
+++ b/backend/services/users/guardian_service_test.go
@@ -2565,3 +2565,67 @@ func TestGuardianService_ContactWritersShareProfileLock(t *testing.T) {
 		})
 	}
 }
+
+// TestGetStudentGuardians_AccountHolderPendingUpgradeApproval verifies the
+// #2172 staff-status fix: a guardian WITH a portal account counts as pending
+// only for an open invitation anchored to this child (a pending-approval
+// role-upgrade request) — never for a sibling's invite.
+func TestGetStudentGuardians_AccountHolderPendingUpgradeApproval(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	service := setupGuardianService(t, db)
+	ctx := testpkg.TenantContext(1)
+	repoFactory := repositories.NewFactory(db)
+
+	guardian := testpkg.CreateTestGuardianProfile(t, db, "acct-pending")
+	student := testpkg.CreateTestStudent(t, db, "AcctPending", "Student", "1a")
+	sibling := testpkg.CreateTestStudent(t, db, "AcctPending", "Sibling", "1a")
+	_, account := testpkg.CreateTestPersonWithAccount(t, db, "AcctPending", "Account")
+	defer func() {
+		_, _ = db.NewDelete().TableExpr("auth.guardian_invitations").Where("guardian_profile_id = ?", guardian.ID).Exec(context.Background())
+		_, _ = db.NewDelete().TableExpr("users.students_guardians").Where("guardian_profile_id = ?", guardian.ID).Exec(context.Background())
+		_, _ = db.NewDelete().TableExpr("users.guardian_profiles").Where("id = ?", guardian.ID).Exec(context.Background())
+		_, _ = db.NewDelete().TableExpr("users.students").Where("id IN (?, ?)", student.ID, sibling.ID).Exec(context.Background())
+	}()
+
+	require.NoError(t, repoFactory.GuardianProfile.LinkAccount(ctx, guardian.ID, account.ID))
+	_, err := service.LinkGuardianToStudent(ctx, users.StudentGuardianCreateRequest{
+		StudentID:         student.ID,
+		GuardianProfileID: guardian.ID,
+		RelationshipType:  "other",
+		GuardianRole:      authorize.GuardianRoleEmergency,
+	})
+	require.NoError(t, err)
+
+	// Open pending-approval upgrade request anchored to the SIBLING → this
+	// child's row must not read as pending.
+	siblingID := sibling.ID
+	inv := &authModels.GuardianInvitation{
+		Token:             fmt.Sprintf("acct-pending-%d", time.Now().UnixNano()),
+		GuardianProfileID: guardian.ID,
+		CreatedBy:         account.ID,
+		ExpiresAt:         time.Now().Add(48 * time.Hour),
+		StudentID:         &siblingID,
+		ApprovalStatus:    authModels.GuardianInvitationApprovalPending,
+		RoleUpgrade:       true,
+	}
+	inv.SetTenantID(1)
+	require.NoError(t, repoFactory.GuardianInvitation.Create(ctx, inv))
+
+	res, err := service.GetStudentGuardians(ctx, student.ID)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.False(t, res[0].InvitationPending,
+		"sibling-anchored invite must not mark this child pending")
+
+	// Re-anchored to THIS child → pending.
+	studentID := student.ID
+	inv.StudentID = &studentID
+	require.NoError(t, repoFactory.GuardianInvitation.Update(ctx, inv))
+
+	res, err = service.GetStudentGuardians(ctx, student.ID)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	assert.True(t, res[0].InvitationPending,
+		"account holder with a pending upgrade approval for this child must read as pending")
+}

--- a/frontend/src/app/api/parent/me/children/[studentId]/related-accounts/route.ts
+++ b/frontend/src/app/api/parent/me/children/[studentId]/related-accounts/route.ts
@@ -15,6 +15,8 @@ interface InviteBody {
   email: string;
   first_name?: string;
   last_name?: string;
+  // Confirms upgrading an existing restrictive contact link (#2172).
+  confirm_role_upgrade?: boolean;
 }
 
 // GET /api/parent/me/children/{studentId}/related-accounts

--- a/frontend/src/app/parents/login/page.test.tsx
+++ b/frontend/src/app/parents/login/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
@@ -204,6 +204,48 @@ describe("ParentLoginPage i18n", () => {
     expect(
       screen.getByRole("button", { name: "Signing in..." }),
     ).toBeDisabled();
+  });
+
+  it("releases the form when the session never arrives after a successful login", async () => {
+    // NextAuth holt die Session per fetchData(), das jeden Fetch-Fehler
+    // schluckt und null liefert. signIn meldet dann ok, status bleibt aber
+    // "unauthenticated" und der Redirect feuert nie — ohne Watchdog bliebe das
+    // Formular dauerhaft gesperrt und ohne Fehlermeldung zurück.
+    vi.useFakeTimers();
+    mocks.signIn.mockResolvedValue({ error: null });
+
+    try {
+      render(<ParentLoginPage />);
+
+      fireEvent.change(screen.getByLabelText("Email address"), {
+        target: { value: "parent@example.com" },
+      });
+      fireEvent.change(screen.getByLabelText("Password"), {
+        target: { value: "password123" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Signing in..." }),
+      ).toBeDisabled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(screen.getByRole("button", { name: "Sign in" })).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: "Forgot your password?" }),
+      ).toBeEnabled();
+      expect(screen.getByText("Login error. Please try again.")).toBeVisible();
+      expect(mocks.push).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("opens the password reset modal with localized parent copy", () => {

--- a/frontend/src/app/parents/login/page.test.tsx
+++ b/frontend/src/app/parents/login/page.test.tsx
@@ -21,6 +21,13 @@ vi.mock("next-auth/react", () => ({
   useSession: mocks.useSession,
 }));
 
+// parentPath() reads NEXT_PUBLIC_PARENTS_HOSTNAME and throws when it is unset,
+// which no unit-test env provides. The path mapping itself is covered by
+// parent-url.test.ts.
+vi.mock("~/lib/parent-url", () => ({
+  parentPath: (path: string) => path,
+}));
+
 vi.mock("next-intl", async () => {
   const en = (await import("~/i18n/messages/en.json")).default as Record<
     string,
@@ -154,6 +161,49 @@ describe("ParentLoginPage i18n", () => {
     await vi.waitFor(() => {
       expect(mocks.signOut).toHaveBeenCalledWith({ redirect: false });
     });
+  });
+
+  it("redirects to the parents portal once the session is published", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { scope: "parent", token: "valid-token" } },
+    });
+
+    render(<ParentLoginPage />);
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/parents");
+  });
+
+  it("leaves the redirect to the session and never pushes a second navigation", async () => {
+    // Two concurrent navigations to the same target left the App Router state
+    // as a pending thenable, and Next's conditional `use(state)` then rendered
+    // a different number of hooks ("Rendered more hooks than during the
+    // previous render") — the portal died right after login until a reload.
+    mocks.signIn.mockResolvedValue({ error: null });
+
+    render(<ParentLoginPage />);
+
+    fireEvent.change(screen.getByLabelText("Email address"), {
+      target: { value: "parent@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await vi.waitFor(() => {
+      expect(mocks.signIn).toHaveBeenCalledWith("parent-credentials", {
+        redirect: false,
+        email: "parent@example.com",
+        password: "password123",
+      });
+    });
+
+    expect(mocks.push).not.toHaveBeenCalled();
+    // The form stays locked until the session-driven redirect navigates away.
+    expect(
+      screen.getByRole("button", { name: "Signing in..." }),
+    ).toBeDisabled();
   });
 
   it("opens the password reset modal with localized parent copy", () => {

--- a/frontend/src/app/parents/login/page.tsx
+++ b/frontend/src/app/parents/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 // eslint-disable-next-line no-restricted-imports -- parent routes are not tenant-scoped
-import { redirect, useRouter } from "next/navigation";
+import { redirect } from "next/navigation";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Alert } from "~/components/ui/alert";
@@ -29,7 +29,6 @@ export default function ParentLoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
-  const router = useRouter();
   const { data: session, status } = useSession();
   // Ref prevents re-triggering signOut (not in effect deps → no loop).
   // Separate state controls the loading spinner for the UI.
@@ -72,6 +71,14 @@ export default function ParentLoginPage() {
     void check();
   }, [status, session]);
 
+  // Einzige Weiterleitung nach erfolgreichem Login. Sie greift, sobald NextAuth
+  // die neue Session veröffentlicht — auch für den Fall "bereits angemeldet,
+  // ruft /login direkt auf". handleSubmit darf daher NICHT zusätzlich
+  // router.push() feuern: zwei gleichzeitige Navigationen auf dasselbe Ziel
+  // lassen den App-Router-State als pending Thenable stehen, und das
+  // bedingte `use(state)` in Next' useActionQueue rendert dann eine
+  // unterschiedliche Anzahl Hooks ("Rendered more hooks than during the
+  // previous render", Seite bricht ab, erst ein Reload heilt es).
   if (isRedirectingToParent) {
     redirect(parentPath("/parents"));
   }
@@ -101,13 +108,15 @@ export default function ParentLoginPage() {
           invalid_credentials: t("errors.invalidCredentials"),
         };
         setError(errorMessages[result.code ?? ""] ?? t("errors.invalid"));
+        setIsLoading(false);
         return;
       }
 
-      router.push(parentPath("/parents"));
+      // Kein router.push hier — die Weiterleitung oben übernimmt. isLoading
+      // bleibt absichtlich stehen, damit das Formular bis zur Navigation
+      // gesperrt bleibt und niemand ein zweites Mal absendet.
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.generic"));
-    } finally {
       setIsLoading(false);
     }
   };

--- a/frontend/src/app/parents/login/page.tsx
+++ b/frontend/src/app/parents/login/page.tsx
@@ -19,6 +19,14 @@ import { LanguageSwitcher } from "~/components/parent/language-switcher";
 import { requestParentPasswordReset } from "~/lib/auth-api";
 import { parentPath } from "~/lib/parent-url";
 
+/**
+ * Wie lange nach einem erfolgreichen signIn auf die publizierte Session
+ * gewartet wird, bevor das Formular wieder freigegeben wird. Der Abruf geht an
+ * die eigene Route (/api/parent/auth/session), zehn Sekunden sind also
+ * reichlich und trotzdem kurz genug, dass niemand vor einem toten Screen sitzt.
+ */
+const SESSION_HANDOFF_TIMEOUT_MS = 10_000;
+
 export default function ParentLoginPage() {
   const t = useTranslations("parentLogin");
   const tAuthShell = useTranslations("parentAuthShell");
@@ -29,6 +37,9 @@ export default function ParentLoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
+  // True zwischen erfolgreichem signIn und der publizierten Session. Steuert
+  // den Watchdog weiter unten.
+  const [awaitingSession, setAwaitingSession] = useState(false);
   const { data: session, status } = useSession();
   // Ref prevents re-triggering signOut (not in effect deps → no loop).
   // Separate state controls the loading spinner for the UI.
@@ -70,6 +81,24 @@ export default function ParentLoginPage() {
     };
     void check();
   }, [status, session]);
+
+  // Watchdog für die Übergabe von signIn an die Session. signIn kann ok
+  // melden, ohne dass danach je eine Session ankommt: NextAuth holt sie per
+  // fetchData(), und das schluckt JEDEN Fetch-Fehler und liefert null
+  // (next-auth/lib/client.js). Ein einzelner wackliger GET auf
+  // /api/parent/auth/session lässt status damit auf "unauthenticated" stehen,
+  // der redirect() unten feuert nie. Ohne diesen Watchdog bliebe das Formular
+  // mit "Anmeldung läuft..." dauerhaft gesperrt und ohne Fehlermeldung
+  // zurück, und nur ein manueller Reload käme da wieder raus.
+  useEffect(() => {
+    if (!awaitingSession) return;
+    const timer = setTimeout(() => {
+      setAwaitingSession(false);
+      setIsLoading(false);
+      setError(t("errors.generic"));
+    }, SESSION_HANDOFF_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [awaitingSession, t]);
 
   // Einzige Weiterleitung nach erfolgreichem Login. Sie greift, sobald NextAuth
   // die neue Session veröffentlicht — auch für den Fall "bereits angemeldet,
@@ -114,7 +143,9 @@ export default function ParentLoginPage() {
 
       // Kein router.push hier — die Weiterleitung oben übernimmt. isLoading
       // bleibt absichtlich stehen, damit das Formular bis zur Navigation
-      // gesperrt bleibt und niemand ein zweites Mal absendet.
+      // gesperrt bleibt und niemand ein zweites Mal absendet; der Watchdog
+      // gibt es wieder frei, falls die Session ausbleibt.
+      setAwaitingSession(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("errors.generic"));
       setIsLoading(false);

--- a/frontend/src/components/admin/guardian-approval-queue.test.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.test.tsx
@@ -62,6 +62,7 @@ const sampleRequest: PendingApproval = {
   requestedByEmail: "karin.klein@email.de",
   createdAt: "2026-06-10T08:00:00Z",
   expiresAt: "2026-06-12T08:00:00Z",
+  roleUpgrade: false,
 };
 
 const staffApprovalMode = {
@@ -85,6 +86,23 @@ describe("GuardianApprovalQueue", () => {
     expect(screen.getByText("julia.schroeder@email.de")).toBeInTheDocument();
     expect(screen.getByText(/Felix Schneider/)).toBeInTheDocument();
     expect(screen.getByText(/karin.klein@email.de/)).toBeInTheDocument();
+    // A plain new-account request carries no upgrade hint.
+    expect(
+      screen.queryByText(/Stuft einen bestehenden Kontakt/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks requests that upgrade an existing contact", async () => {
+    mockList.mockResolvedValue([{ ...sampleRequest, roleUpgrade: true }]);
+    render(<GuardianApprovalQueue inviteModeState={{ status: "loading" }} />);
+    await waitFor(() =>
+      expect(screen.getByText("Julia Schröder")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(
+        "Stuft einen bestehenden Kontakt auf vollen Zugriff hoch.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows the empty state when there are no requests", async () => {

--- a/frontend/src/components/admin/guardian-approval-queue.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.tsx
@@ -280,6 +280,11 @@ export default function GuardianApprovalQueue({
                     <> · angefragt von {req.requestedByEmail}</>
                   )}
                 </p>
+                {req.roleUpgrade && (
+                  <p className="mt-1 text-xs text-gray-500">
+                    Stuft einen bestehenden Kontakt auf vollen Zugriff hoch.
+                  </p>
+                )}
               </div>
               <div className="flex flex-shrink-0 items-center gap-2">
                 <Button

--- a/frontend/src/components/admin/guardian-approval-queue.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.tsx
@@ -32,12 +32,13 @@ export type GuardianInviteModeState =
     }
   | { readonly status: "ready"; readonly mode: GuardianInviteMode };
 
-// Only staff_approval ever puts a request into this queue: "disabled" blocks
-// parent invites outright and "direct" sends them without a review step. An
-// empty list then means "configured away", not "nothing to do yet", so the
-// empty state says which of the two it is instead of leaving an admin to
-// wonder whether the page is broken. Loading and error states are handled
-// separately, so this copy always receives a validated mode.
+// "disabled" blocks parent invites outright and "direct" sends NEW invites
+// without a review step — but a parent-confirmed upgrade of an existing
+// restricted contact is always queued here, regardless of mode (#2172). An
+// empty list in the other two modes therefore mostly means "configured
+// away", so the empty state says which of the two it is instead of leaving
+// an admin to wonder whether the page is broken. Loading and error states
+// are handled separately, so this copy always receives a validated mode.
 function emptyStateCopy(inviteMode: GuardianInviteMode): {
   readonly configuredAway: boolean;
   readonly title: string;
@@ -56,7 +57,7 @@ function emptyStateCopy(inviteMode: GuardianInviteMode): {
       configuredAway: true,
       title: "Einladungen gehen ohne Freigabe raus",
       description:
-        "Eltern laden weitere Bezugspersonen aktuell direkt ein, ohne Bestätigung durch das Team. Diese Liste bleibt deshalb leer.",
+        "Eltern laden neue Bezugspersonen aktuell direkt ein, ohne Bestätigung durch das Team. Nur wenn Eltern einen bestehenden, eingeschränkten Kontakt auf vollen Zugriff hochstufen möchten, erscheint die Anfrage hier zur Freigabe.",
     };
   }
   return {

--- a/frontend/src/components/guardians/guardian-list.test.tsx
+++ b/frontend/src/components/guardians/guardian-list.test.tsx
@@ -240,6 +240,31 @@ describe("GuardianList", () => {
     expect(screen.queryByText("Zugriff gewähren")).not.toBeInTheDocument();
   });
 
+  it("offers re-invite for a pending guardian without an account", () => {
+    const guardian = {
+      ...mockGuardians[1]!,
+      accountStatus: "pending" as const,
+    };
+    render(<GuardianList guardians={[guardian]} onInvite={vi.fn()} />);
+
+    expect(screen.getByText("Einladung offen")).toBeInTheDocument();
+    expect(screen.getByText("Erneut einladen")).toBeInTheDocument();
+  });
+
+  it("hides the invite action while an account holder's upgrade approval is pending", () => {
+    const guardian = {
+      ...mockGuardians[1]!,
+      hasAccount: true,
+      accountStatus: "pending" as const,
+      guardianRole: "emergency_contact" as const,
+    };
+    render(<GuardianList guardians={[guardian]} onInvite={vi.fn()} />);
+
+    expect(screen.getByText("Einladung offen")).toBeInTheDocument();
+    expect(screen.queryByText("Erneut einladen")).not.toBeInTheDocument();
+    expect(screen.queryByText("Zugriff gewähren")).not.toBeInTheDocument();
+  });
+
   it("hides the invite action for school-managed social-worker contacts", () => {
     const guardian = {
       ...mockGuardians[1]!,

--- a/frontend/src/components/guardians/guardian-list.test.tsx
+++ b/frontend/src/components/guardians/guardian-list.test.tsx
@@ -209,4 +209,46 @@ describe("GuardianList", () => {
     expect(phoneCounts[0]).toHaveTextContent("2");
     expect(phoneCounts[1]).toHaveTextContent("0");
   });
+
+  it("shows the honest status and a grant-access action for active_no_access", () => {
+    const onInvite = vi.fn();
+    const guardian = {
+      ...mockGuardians[1]!,
+      hasAccount: true,
+      accountStatus: "active_no_access" as const,
+      guardianRole: "emergency_contact" as const,
+    };
+    render(<GuardianList guardians={[guardian]} onInvite={onInvite} />);
+
+    expect(
+      screen.getByText("Konto aktiv, kein Portalzugriff"),
+    ).toBeInTheDocument();
+    const grantButton = screen.getByText("Zugriff gewähren");
+    fireEvent.click(grantButton);
+    expect(onInvite).toHaveBeenCalledWith(guardian);
+  });
+
+  it("hides the invite action entirely for active accounts", () => {
+    const guardian = {
+      ...mockGuardians[1]!,
+      hasAccount: true,
+      accountStatus: "active" as const,
+    };
+    render(<GuardianList guardians={[guardian]} onInvite={vi.fn()} />);
+
+    expect(screen.queryByText("Einladen")).not.toBeInTheDocument();
+    expect(screen.queryByText("Zugriff gewähren")).not.toBeInTheDocument();
+  });
+
+  it("hides the invite action for school-managed social-worker contacts", () => {
+    const guardian = {
+      ...mockGuardians[1]!,
+      accountStatus: "active_no_access" as const,
+      guardianRole: "social_worker" as const,
+    };
+    render(<GuardianList guardians={[guardian]} onInvite={vi.fn()} />);
+
+    expect(screen.queryByText("Zugriff gewähren")).not.toBeInTheDocument();
+    expect(screen.queryByText("Einladen")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/guardians/guardian-list.tsx
+++ b/frontend/src/components/guardians/guardian-list.tsx
@@ -133,10 +133,16 @@ export default function GuardianList({
             {!readOnly && (
               <div className="flex flex-shrink-0 items-center gap-1">
                 {/* Social-worker contacts are school-managed: the backend
-                    refuses to invite or upgrade them, so no action is shown. */}
+                    refuses to invite or upgrade them, so no action is shown.
+                    A pending entry for an ACCOUNT holder is a role-upgrade
+                    request awaiting approval in the queue — there is no email
+                    to re-send and acting here would bypass the queue. */}
                 {onInvite &&
                   guardian.accountStatus !== "active" &&
                   guardian.guardianRole !== "social_worker" &&
+                  !(
+                    guardian.accountStatus === "pending" && guardian.hasAccount
+                  ) &&
                   guardian.email && (
                     <button
                       type="button"

--- a/frontend/src/components/guardians/guardian-list.tsx
+++ b/frontend/src/components/guardians/guardian-list.tsx
@@ -35,8 +35,27 @@ const ACCOUNT_STATUS_META: Record<
   { label: string; dot: string }
 > = {
   active: { label: "Konto aktiv", dot: LOCATION_COLORS.GROUP_ROOM },
+  active_no_access: {
+    label: "Konto aktiv, kein Portalzugriff",
+    dot: LOCATION_COLORS.SCHOOLYARD,
+  },
   pending: { label: "Einladung offen", dot: LOCATION_COLORS.SICK },
   none: { label: "Kein Konto", dot: LOCATION_COLORS.UNKNOWN },
+};
+
+// Label + tooltip for the invite action per account status. "active_no_access"
+// reuses the invite flow: the backend answers with the restricted-contact
+// confirmation, so the action reads as granting access, not re-inviting.
+const INVITE_ACTION_META: Record<
+  Exclude<GuardianAccountStatus, "active">,
+  { label: string; title: string }
+> = {
+  active_no_access: {
+    label: "Zugriff gewähren",
+    title: "Vollen Zugriff auf dieses Kind im Elternportal gewähren",
+  },
+  pending: { label: "Erneut einladen", title: "Einladung erneut senden" },
+  none: { label: "Einladen", title: "Zum Elternportal einladen" },
 };
 
 function AccountStatusBadge({
@@ -113,8 +132,11 @@ export default function GuardianList({
 
             {!readOnly && (
               <div className="flex flex-shrink-0 items-center gap-1">
+                {/* Social-worker contacts are school-managed: the backend
+                    refuses to invite or upgrade them, so no action is shown. */}
                 {onInvite &&
                   guardian.accountStatus !== "active" &&
+                  guardian.guardianRole !== "social_worker" &&
                   guardian.email && (
                     <button
                       type="button"
@@ -123,16 +145,16 @@ export default function GuardianList({
                       className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm font-medium transition-colors hover:bg-[#f0f9e4] disabled:opacity-50"
                       style={{ color: GROUP_ROOM_SHADES.text }}
                       title={
-                        guardian.accountStatus === "pending"
-                          ? "Einladung erneut senden"
-                          : "Zum Elternportal einladen"
+                        INVITE_ACTION_META[guardian.accountStatus ?? "none"]
+                          .title
                       }
                     >
                       <Send className="h-4 w-4" />
                       <span className="hidden sm:inline">
-                        {guardian.accountStatus === "pending"
-                          ? "Erneut einladen"
-                          : "Einladen"}
+                        {
+                          INVITE_ACTION_META[guardian.accountStatus ?? "none"]
+                            .label
+                        }
                       </span>
                     </button>
                   )}

--- a/frontend/src/components/guardians/student-guardian-manager.test.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.test.tsx
@@ -23,6 +23,7 @@ const mockAddGuardianPhoneNumber = vi.fn();
 const mockUpdateGuardianPhoneNumber = vi.fn();
 const mockDeleteGuardianPhoneNumber = vi.fn();
 const mockSetGuardianPrimaryPhone = vi.fn();
+const mockInviteGuardianToStudent = vi.fn();
 
 // Real subclass exported from the guardian-api mock so any code path that
 // branches on `err instanceof GuardianApiError` still resolves against the
@@ -69,6 +70,11 @@ vi.mock("@/lib/guardian-api", () => ({
     mockDeleteGuardianPhoneNumber(guardianId, phoneId),
   setGuardianPrimaryPhone: (guardianId: string, phoneId: string) =>
     mockSetGuardianPrimaryPhone(guardianId, phoneId),
+  inviteGuardianToStudent: (
+    studentId: string,
+    email: string,
+    options?: unknown,
+  ) => mockInviteGuardianToStudent(studentId, email, options),
 }));
 
 // Session mock — drives the admin-only "Komplett löschen" affordance. Default
@@ -98,10 +104,12 @@ vi.mock("./guardian-list", () => ({
   default: ({
     guardians,
     onEdit,
+    onInvite,
     readOnly,
   }: {
     guardians: GuardianWithRelationship[];
     onEdit?: (g: GuardianWithRelationship) => void;
+    onInvite?: (g: GuardianWithRelationship) => void;
     readOnly?: boolean;
   }) => (
     <div data-testid="guardian-list">
@@ -116,6 +124,15 @@ vi.mock("./guardian-list", () => ({
               data-testid={`edit-${g.id}`}
             >
               Edit {g.id}
+            </button>
+          )}
+          {!readOnly && onInvite && (
+            <button
+              type="button"
+              onClick={() => onInvite(g)}
+              data-testid={`invite-${g.id}`}
+            >
+              Invite {g.id}
             </button>
           )}
         </div>
@@ -1187,6 +1204,84 @@ describe("StudentGuardianManager", () => {
       await waitFor(() => {
         expect(mockFetchStudentGuardians).toHaveBeenCalledTimes(2);
       });
+    });
+  });
+
+  describe("Restricted-contact upgrade confirmation (#2172)", () => {
+    it("asks before upgrading and re-invites with the confirm flag", async () => {
+      mockInviteGuardianToStudent.mockResolvedValueOnce({
+        outcome: "existing_contact_restricted",
+        guardian_profile_id: "guardian-2",
+        existing_role: "emergency_contact",
+      });
+      mockInviteGuardianToStudent.mockResolvedValueOnce({
+        outcome: "already_linked",
+        guardian_profile_id: "guardian-2",
+      });
+
+      render(<StudentGuardianManager studentId="student-123" />);
+      await waitFor(() =>
+        expect(screen.getByTestId("guardian-list")).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByTestId("invite-guardian-2"));
+
+      // First call: plain invite, no confirm flag.
+      await waitFor(() =>
+        expect(mockInviteGuardianToStudent).toHaveBeenNthCalledWith(
+          1,
+          "student-123",
+          "hans@example.com",
+          { confirmRoleUpgrade: false },
+        ),
+      );
+      // The real ConfirmationModal renders via portal; it names the role.
+      expect(
+        await screen.findByText("Vollen Zugriff gewähren?"),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Notfallkontakt/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Zugriff gewähren" }));
+      await waitFor(() =>
+        expect(mockInviteGuardianToStudent).toHaveBeenNthCalledWith(
+          2,
+          "student-123",
+          "hans@example.com",
+          { confirmRoleUpgrade: true },
+        ),
+      );
+      await waitFor(() =>
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          "Hans Müller hat jetzt vollen Zugriff",
+        ),
+      );
+    });
+
+    it("cancelling the upgrade sends no second invite", async () => {
+      mockInviteGuardianToStudent.mockResolvedValueOnce({
+        outcome: "existing_contact_restricted",
+        guardian_profile_id: "guardian-2",
+        existing_role: "pickup_only",
+      });
+
+      render(<StudentGuardianManager studentId="student-123" />);
+      await waitFor(() =>
+        expect(screen.getByTestId("guardian-list")).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByTestId("invite-guardian-2"));
+      expect(
+        await screen.findByText("Vollen Zugriff gewähren?"),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Abbrechen" }));
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Vollen Zugriff gewähren?"),
+        ).not.toBeInTheDocument(),
+      );
+      expect(mockInviteGuardianToStudent).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/guardians/student-guardian-manager.tsx
+++ b/frontend/src/components/guardians/student-guardian-manager.tsx
@@ -12,7 +12,11 @@ import type {
   GuardianFormData,
   PhoneType,
 } from "@/lib/guardian-helpers";
-import { getGuardianFullName } from "@/lib/guardian-helpers";
+import {
+  getGuardianFullName,
+  GUARDIAN_ROLE_OPTIONS,
+} from "@/lib/guardian-helpers";
+import { ConfirmationModal } from "~/components/ui/modal";
 import type { RelationshipFormData } from "./guardian-form-modal";
 import {
   fetchStudentGuardians,
@@ -73,6 +77,13 @@ export default function StudentGuardianManager({
   const [invitingGuardianId, setInvitingGuardianId] = useState<string | null>(
     null,
   );
+  // Restricted-contact upgrade confirmation (#2172): the invite hit an
+  // existing contact whose link has no portal access; ask before upgrading
+  // the role to Erziehungsberechtigte/r.
+  const [upgradeInvite, setUpgradeInvite] = useState<{
+    guardian: GuardianWithRelationship;
+    existingRole?: string;
+  } | null>(null);
   const deletePreviewRequestIdRef = useRef(0);
   const { success: toastSuccess, error: toastError } = useToast();
 
@@ -341,11 +352,22 @@ export default function StudentGuardianManager({
   // Invite an existing guardian (info already on file) to the parents portal.
   // Uses their on-file email — no re-typing. The backend resolves the existing
   // profile and either sends an invite or links an account that already exists.
-  const handleInviteGuardian = async (guardian: GuardianWithRelationship) => {
+  const handleInviteGuardian = async (
+    guardian: GuardianWithRelationship,
+    confirmRoleUpgrade = false,
+  ) => {
     if (!guardian.email) return;
     setInvitingGuardianId(guardian.id);
     try {
-      const result = await inviteGuardianToStudent(studentId, guardian.email);
+      const result = await inviteGuardianToStudent(studentId, guardian.email, {
+        confirmRoleUpgrade,
+      });
+      if (result.outcome === "existing_contact_restricted") {
+        // Nothing happened yet: the contact's link carries a restrictive role
+        // without portal access. Confirm the upgrade first (#2172).
+        setUpgradeInvite({ guardian, existingRole: result.existing_role });
+        return;
+      }
       await loadGuardians();
       onUpdate?.();
       const name = getGuardianFullName(guardian);
@@ -353,7 +375,9 @@ export default function StudentGuardianManager({
         result.outcome === "invited"
           ? `Einladung an ${guardian.email} gesendet`
           : result.outcome === "already_linked"
-            ? `${name} ist bereits verbunden`
+            ? confirmRoleUpgrade
+              ? `${name} hat jetzt vollen Zugriff`
+              : `${name} ist bereits verbunden`
             : `${name} wurde mit dem vorhandenen Konto verbunden`;
       toastSuccess(message);
     } catch (err) {
@@ -694,6 +718,33 @@ export default function StudentGuardianManager({
         onConfirmFullDelete={handleConfirmFullDelete}
         onBack={handleBack}
       />
+
+      {/* Restricted-contact upgrade confirmation (#2172) */}
+      <ConfirmationModal
+        isOpen={upgradeInvite !== null}
+        onClose={() => setUpgradeInvite(null)}
+        onConfirm={() => {
+          if (!upgradeInvite) return;
+          const target = upgradeInvite.guardian;
+          setUpgradeInvite(null);
+          void handleInviteGuardian(target, true);
+        }}
+        title="Vollen Zugriff gewähren?"
+        confirmText="Zugriff gewähren"
+        cancelText="Abbrechen"
+      >
+        <p className="text-sm text-gray-600">
+          {upgradeInvite &&
+            `${getGuardianFullName(upgradeInvite.guardian)} ist bisher als ${
+              GUARDIAN_ROLE_OPTIONS.find(
+                (o) => o.value === upgradeInvite.existingRole,
+              )?.label ?? "eingeschränkter Kontakt"
+            } für dieses Kind eingetragen, ohne Zugriff auf die Eltern-App.`}{" "}
+          Mit der Einladung wird die Rolle auf Erziehungsberechtigte/r
+          hochgestuft und die Person erhält vollen Zugriff auf dieses Kind in
+          der Eltern-App.
+        </p>
+      </ConfirmationModal>
     </div>
   );
 }

--- a/frontend/src/components/parent/related-accounts-panel.test.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.test.tsx
@@ -1,29 +1,34 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import RelatedAccountsPanel from "./related-accounts-panel";
-import type { RelatedAccount } from "~/lib/parent-api";
+import { ParentApiError, type RelatedAccount } from "~/lib/parent-api";
 
 const mockList = vi.fn();
 const mockInvite = vi.fn();
 const mockRemove = vi.fn();
 
-vi.mock("~/lib/parent-api", () => ({
-  listRelatedAccounts: (studentId: string): unknown => mockList(studentId),
-  // Forward the options argument only when present, so the older two-argument
-  // assertions keep matching plain invites.
-  inviteRelatedAccount: (
-    studentId: string,
-    email: string,
-    options?: unknown,
-  ): unknown =>
-    options === undefined
-      ? mockInvite(studentId, email)
-      : mockInvite(studentId, email, options),
-  removeRelatedAccount: (
-    studentId: string,
-    guardianProfileId: string,
-  ): unknown => mockRemove(studentId, guardianProfileId),
-}));
+vi.mock("~/lib/parent-api", async (importOriginal) => {
+  // Keep the real ParentApiError class so instanceof checks in the panel work.
+  const actual = await importOriginal<typeof import("~/lib/parent-api")>();
+  return {
+    ParentApiError: actual.ParentApiError,
+    listRelatedAccounts: (studentId: string): unknown => mockList(studentId),
+    // Forward the options argument only when present, so the older
+    // two-argument assertions keep matching plain invites.
+    inviteRelatedAccount: (
+      studentId: string,
+      email: string,
+      options?: unknown,
+    ): unknown =>
+      options === undefined
+        ? mockInvite(studentId, email)
+        : mockInvite(studentId, email, options),
+    removeRelatedAccount: (
+      studentId: string,
+      guardianProfileId: string,
+    ): unknown => mockRemove(studentId, guardianProfileId),
+  };
+});
 
 vi.mock("~/components/ui/modal", () => ({
   ConfirmationModal: ({
@@ -175,6 +180,35 @@ describe("RelatedAccountsPanel", () => {
     await waitFor(() =>
       expect(mockInvite).toHaveBeenCalledWith("1", "oma@example.test"),
     );
+  });
+
+  it("explains that school-managed social-worker contacts cannot be invited", async () => {
+    mockInvite.mockRejectedValue(
+      new ParentApiError(
+        "a social-worker contact is managed by the school",
+        403,
+        "guardian_social_worker_managed",
+      ),
+    );
+    render(
+      <RelatedAccountsPanel studentId="1" canInvite={true} canRemove={false} />,
+    );
+    await waitFor(() => screen.getByText("Sabine Schneider"));
+
+    fireEvent.click(screen.getByRole("button", { name: /Einladen/ }));
+    fireEvent.change(screen.getByPlaceholderText("E-Mail-Adresse"), {
+      target: { value: "sozialdienst@example.test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Senden/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Dieser Kontakt wird von der Schule verwaltet und kann nicht über die Eltern-App eingeladen werden.",
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("upgrade-modal")).not.toBeInTheDocument();
   });
 
   it("removes a non-primary account but never the primary", async () => {

--- a/frontend/src/components/parent/related-accounts-panel.test.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.test.tsx
@@ -9,12 +9,48 @@ const mockRemove = vi.fn();
 
 vi.mock("~/lib/parent-api", () => ({
   listRelatedAccounts: (studentId: string): unknown => mockList(studentId),
-  inviteRelatedAccount: (studentId: string, email: string): unknown =>
-    mockInvite(studentId, email),
+  // Forward the options argument only when present, so the older two-argument
+  // assertions keep matching plain invites.
+  inviteRelatedAccount: (
+    studentId: string,
+    email: string,
+    options?: unknown,
+  ): unknown =>
+    options === undefined
+      ? mockInvite(studentId, email)
+      : mockInvite(studentId, email, options),
   removeRelatedAccount: (
     studentId: string,
     guardianProfileId: string,
   ): unknown => mockRemove(studentId, guardianProfileId),
+}));
+
+vi.mock("~/components/ui/modal", () => ({
+  ConfirmationModal: ({
+    isOpen,
+    onConfirm,
+    onClose,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="upgrade-modal">
+        <h3>{title}</h3>
+        {children}
+        <button type="button" onClick={onConfirm} data-testid="confirm-upgrade">
+          Zugriff gewähren
+        </button>
+        <button type="button" onClick={onClose} data-testid="cancel-upgrade">
+          Abbrechen
+        </button>
+      </div>
+    ) : null,
 }));
 
 const primaryActive: RelatedAccount = {
@@ -155,5 +191,134 @@ describe("RelatedAccountsPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Entfernen" }));
 
     await waitFor(() => expect(mockRemove).toHaveBeenCalledWith("1", "2"));
+  });
+
+  it("labels accounts without portal access honestly", async () => {
+    const noAccess: RelatedAccount = {
+      guardian_profile_id: "5",
+      first_name: "Nils",
+      last_name: "Notfall",
+      email: "nils.notfall@email.de",
+      relationship_type: "other",
+      is_primary: false,
+      status: "active_no_access",
+      is_self: false,
+    };
+    mockList.mockResolvedValue([primaryActive, noAccess]);
+    render(
+      <RelatedAccountsPanel
+        studentId="1"
+        canInvite={false}
+        canRemove={false}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Nils Notfall")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/Konto aktiv, kein Portalzugriff/),
+    ).toBeInTheDocument();
+    // Without invite rights there is no upgrade affordance.
+    expect(
+      screen.queryByRole("button", { name: "Zugriff gewähren" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("grants access to a no-access account via the row action", async () => {
+    const noAccess: RelatedAccount = {
+      guardian_profile_id: "5",
+      first_name: "Nils",
+      last_name: "Notfall",
+      email: "nils.notfall@email.de",
+      relationship_type: "other",
+      is_primary: false,
+      status: "active_no_access",
+      is_self: false,
+    };
+    mockList.mockResolvedValue([primaryActive, noAccess]);
+    mockInvite.mockResolvedValue({
+      outcome: "already_linked",
+      guardian_profile_id: "5",
+    });
+    render(
+      <RelatedAccountsPanel studentId="1" canInvite={true} canRemove={false} />,
+    );
+
+    await waitFor(() => screen.getByText("Nils Notfall"));
+    fireEvent.click(screen.getByRole("button", { name: "Zugriff gewähren" }));
+    expect(screen.getByTestId("upgrade-modal")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("confirm-upgrade"));
+    await waitFor(() =>
+      expect(mockInvite).toHaveBeenCalledWith("1", "nils.notfall@email.de", {
+        confirmRoleUpgrade: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Zugriff wurde gewährt.")).toBeInTheDocument(),
+    );
+  });
+
+  it("asks for confirmation when the invite hits a restricted contact", async () => {
+    mockInvite.mockResolvedValueOnce({
+      outcome: "existing_contact_restricted",
+      guardian_profile_id: "7",
+      existing_role: "emergency_contact",
+    });
+    mockInvite.mockResolvedValueOnce({
+      outcome: "invited",
+      guardian_profile_id: "7",
+    });
+    render(
+      <RelatedAccountsPanel studentId="1" canInvite={true} canRemove={false} />,
+    );
+    await waitFor(() => screen.getByText("Sabine Schneider"));
+
+    fireEvent.click(screen.getByRole("button", { name: /Einladen/ }));
+    fireEvent.change(screen.getByPlaceholderText("E-Mail-Adresse"), {
+      target: { value: "opa@example.test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Senden/ }));
+
+    // First call is the plain invite; it comes back restricted → modal names
+    // the existing role.
+    await waitFor(() =>
+      expect(screen.getByTestId("upgrade-modal")).toBeInTheDocument(),
+    );
+    expect(mockInvite).toHaveBeenNthCalledWith(1, "1", "opa@example.test");
+    expect(screen.getByText(/Notfallkontakt/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("confirm-upgrade"));
+    await waitFor(() =>
+      expect(mockInvite).toHaveBeenNthCalledWith(2, "1", "opa@example.test", {
+        confirmRoleUpgrade: true,
+      }),
+    );
+  });
+
+  it("cancelling the upgrade confirmation performs no second call", async () => {
+    mockInvite.mockResolvedValueOnce({
+      outcome: "existing_contact_restricted",
+      guardian_profile_id: "7",
+      existing_role: "pickup_only",
+    });
+    render(
+      <RelatedAccountsPanel studentId="1" canInvite={true} canRemove={false} />,
+    );
+    await waitFor(() => screen.getByText("Sabine Schneider"));
+
+    fireEvent.click(screen.getByRole("button", { name: /Einladen/ }));
+    fireEvent.change(screen.getByPlaceholderText("E-Mail-Adresse"), {
+      target: { value: "opa@example.test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Senden/ }));
+    await waitFor(() =>
+      expect(screen.getByTestId("upgrade-modal")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId("cancel-upgrade"));
+    expect(screen.queryByTestId("upgrade-modal")).not.toBeInTheDocument();
+    expect(mockInvite).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/parent/related-accounts-panel.test.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.test.tsx
@@ -271,8 +271,11 @@ describe("RelatedAccountsPanel", () => {
       is_self: false,
     };
     mockList.mockResolvedValue([primaryActive, noAccess]);
+    // Parent-confirmed upgrades are always queued for staff approval, even in
+    // direct invite mode (#2174 review), so the backend answers with
+    // pending_approval here.
     mockInvite.mockResolvedValue({
-      outcome: "already_linked",
+      outcome: "pending_approval",
       guardian_profile_id: "5",
     });
     render(
@@ -290,7 +293,11 @@ describe("RelatedAccountsPanel", () => {
       }),
     );
     await waitFor(() =>
-      expect(screen.getByText("Zugriff wurde gewährt.")).toBeInTheDocument(),
+      expect(
+        screen.getByText(
+          "Anfrage gesendet – wird von der Einrichtung geprüft.",
+        ),
+      ).toBeInTheDocument(),
     );
   });
 

--- a/frontend/src/components/parent/related-accounts-panel.test.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.test.tsx
@@ -294,6 +294,29 @@ describe("RelatedAccountsPanel", () => {
     );
   });
 
+  it("offers no grant-access action for a school-managed social-worker contact", async () => {
+    const socialWorker: RelatedAccount = {
+      guardian_profile_id: "6",
+      first_name: "Sonja",
+      last_name: "Sozialdienst",
+      email: "sonja.sozialdienst@email.de",
+      relationship_type: "other",
+      guardian_role: "social_worker",
+      is_primary: false,
+      status: "active_no_access",
+      is_self: false,
+    };
+    mockList.mockResolvedValue([primaryActive, socialWorker]);
+    render(
+      <RelatedAccountsPanel studentId="1" canInvite={true} canRemove={false} />,
+    );
+
+    await waitFor(() => screen.getByText("Sonja Sozialdienst"));
+    expect(
+      screen.queryByRole("button", { name: "Zugriff gewähren" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("asks for confirmation when the invite hits a restricted contact", async () => {
     mockInvite.mockResolvedValueOnce({
       outcome: "existing_contact_restricted",

--- a/frontend/src/components/parent/related-accounts-panel.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.tsx
@@ -6,6 +6,7 @@ import {
   listRelatedAccounts,
   inviteRelatedAccount,
   removeRelatedAccount,
+  ParentApiError,
   type RelatedAccount,
 } from "~/lib/parent-api";
 import { createLogger } from "~/lib/logger";
@@ -28,6 +29,18 @@ const STATUS_META: Record<RelatedAccount["status"], { label: string }> = {
 function guardianRoleLabel(role: string | undefined): string | null {
   const option = GUARDIAN_ROLE_OPTIONS.find((o) => o.value === role);
   return option?.label ?? null;
+}
+
+// Maps a failed invite to a German message. Social-worker contacts are
+// school-managed; the backend refuses to invite or upgrade them (#2172).
+function inviteErrorText(err: unknown, fallback: string): string {
+  if (
+    err instanceof ParentApiError &&
+    err.code === "guardian_social_worker_managed"
+  ) {
+    return "Dieser Kontakt wird von der Schule verwaltet und kann nicht über die Eltern-App eingeladen werden.";
+  }
+  return err instanceof Error ? err.message : fallback;
 }
 
 function initials(first: string, last: string): string {
@@ -120,7 +133,7 @@ export default function RelatedAccountsPanel({
       });
       setMessage({
         kind: "error",
-        text: err instanceof Error ? err.message : "Einladung fehlgeschlagen",
+        text: inviteErrorText(err, "Einladung fehlgeschlagen"),
       });
     } finally {
       setBusy(false);
@@ -159,7 +172,7 @@ export default function RelatedAccountsPanel({
       setUpgradePrompt(null);
       setMessage({
         kind: "error",
-        text: err instanceof Error ? err.message : "Freigabe fehlgeschlagen",
+        text: inviteErrorText(err, "Freigabe fehlgeschlagen"),
       });
     } finally {
       setBusy(false);

--- a/frontend/src/components/parent/related-accounts-panel.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.tsx
@@ -292,8 +292,11 @@ export default function RelatedAccountsPanel({
                     )}
                   </p>
                 </div>
+                {/* Social-worker contacts are school-managed: the backend
+                    refuses the upgrade, so the action is not offered. */}
                 {canInvite &&
                   acc.status === "active_no_access" &&
+                  acc.guardian_role !== "social_worker" &&
                   acc.email && (
                     <Button
                       type="button"

--- a/frontend/src/components/parent/related-accounts-panel.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.tsx
@@ -9,9 +9,11 @@ import {
   type RelatedAccount,
 } from "~/lib/parent-api";
 import { createLogger } from "~/lib/logger";
+import { GUARDIAN_ROLE_OPTIONS } from "~/lib/guardian-helpers";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Alert } from "~/components/ui/alert";
+import { ConfirmationModal } from "~/components/ui/modal";
 import { SectionCard } from "~/components/ui/section-card";
 
 const logger = createLogger({ component: "RelatedAccountsPanel" });
@@ -20,7 +22,13 @@ const STATUS_META: Record<RelatedAccount["status"], { label: string }> = {
   active: { label: "Konto aktiv" },
   pending: { label: "Einladung offen" },
   no_account: { label: "Kontakt ohne Konto" },
+  active_no_access: { label: "Konto aktiv, kein Portalzugriff" },
 };
+
+function guardianRoleLabel(role: string | undefined): string | null {
+  const option = GUARDIAN_ROLE_OPTIONS.find((o) => o.value === role);
+  return option?.label ?? null;
+}
 
 function initials(first: string, last: string): string {
   return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase() || "?";
@@ -43,6 +51,14 @@ export default function RelatedAccountsPanel({
   const [email, setEmail] = useState("");
   const [busy, setBusy] = useState(false);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  // Restricted-contact upgrade confirmation (#2172): set either from an
+  // invite that hit an existing restrictive contact, or from the per-row
+  // "Zugriff gewähren" action on a no-access account.
+  const [upgradePrompt, setUpgradePrompt] = useState<{
+    email: string;
+    name: string;
+    existingRole?: string;
+  } | null>(null);
   const [message, setMessage] = useState<{
     kind: "success" | "error";
     text: string;
@@ -76,6 +92,16 @@ export default function RelatedAccountsPanel({
     setMessage(null);
     try {
       const result = await inviteRelatedAccount(studentId, trimmed);
+      if (result.outcome === "existing_contact_restricted") {
+        // Existing contact without portal access: nothing happened yet, ask
+        // for the upgrade confirmation first.
+        setUpgradePrompt({
+          email: trimmed,
+          name: trimmed,
+          existingRole: result.existing_role,
+        });
+        return;
+      }
       setEmail("");
       setInviteOpen(false);
       await load();
@@ -95,6 +121,45 @@ export default function RelatedAccountsPanel({
       setMessage({
         kind: "error",
         text: err instanceof Error ? err.message : "Einladung fehlgeschlagen",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleConfirmUpgrade = async () => {
+    if (!upgradePrompt) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const result = await inviteRelatedAccount(
+        studentId,
+        upgradePrompt.email,
+        {
+          confirmRoleUpgrade: true,
+        },
+      );
+      setUpgradePrompt(null);
+      setEmail("");
+      setInviteOpen(false);
+      await load();
+      setMessage({
+        kind: "success",
+        text:
+          result.outcome === "pending_approval"
+            ? "Anfrage gesendet – wird von der Einrichtung geprüft."
+            : result.outcome === "invited"
+              ? `Einladung an ${upgradePrompt.email} gesendet.`
+              : "Zugriff wurde gewährt.",
+      });
+    } catch (err) {
+      logger.error("related_account_upgrade_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setUpgradePrompt(null);
+      setMessage({
+        kind: "error",
+        text: err instanceof Error ? err.message : "Freigabe fehlgeschlagen",
       });
     } finally {
       setBusy(false);
@@ -214,6 +279,25 @@ export default function RelatedAccountsPanel({
                     )}
                   </p>
                 </div>
+                {canInvite &&
+                  acc.status === "active_no_access" &&
+                  acc.email && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="compact"
+                      className="shrink-0"
+                      disabled={busy}
+                      onClick={() =>
+                        setUpgradePrompt({
+                          email: acc.email ?? "",
+                          name: name ?? "",
+                        })
+                      }
+                    >
+                      Zugriff gewähren
+                    </Button>
+                  )}
                 {canRemove &&
                   !acc.is_primary &&
                   !acc.is_self &&
@@ -256,6 +340,25 @@ export default function RelatedAccountsPanel({
           })
         )}
       </div>
+
+      <ConfirmationModal
+        isOpen={upgradePrompt !== null}
+        onClose={() => setUpgradePrompt(null)}
+        onConfirm={() => void handleConfirmUpgrade()}
+        title="Vollen Zugriff gewähren?"
+        confirmText="Zugriff gewähren"
+        cancelText="Abbrechen"
+        isConfirmLoading={busy}
+      >
+        <p className="text-sm text-gray-600">
+          {upgradePrompt &&
+            (guardianRoleLabel(upgradePrompt.existingRole)
+              ? `${upgradePrompt.name} ist bereits als ${guardianRoleLabel(upgradePrompt.existingRole)} für dieses Kind eingetragen, bisher ohne Zugriff auf die Eltern-App.`
+              : `${upgradePrompt.name} hat ein Konto, aber bisher keinen Zugriff auf dieses Kind in der Eltern-App.`)}{" "}
+          Mit der Bestätigung erhält diese Person vollen Zugriff auf dieses Kind
+          in der Eltern-App.
+        </p>
+      </ConfirmationModal>
     </SectionCard>
   );
 }

--- a/frontend/src/components/parent/related-accounts-panel.tsx
+++ b/frontend/src/components/parent/related-accounts-panel.tsx
@@ -371,7 +371,8 @@ export default function RelatedAccountsPanel({
             (guardianRoleLabel(upgradePrompt.existingRole)
               ? `${upgradePrompt.name} ist bereits als ${guardianRoleLabel(upgradePrompt.existingRole)} für dieses Kind eingetragen, bisher ohne Zugriff auf die Eltern-App.`
               : `${upgradePrompt.name} hat ein Konto, aber bisher keinen Zugriff auf dieses Kind in der Eltern-App.`)}{" "}
-          Mit der Bestätigung erhält diese Person vollen Zugriff auf dieses Kind
+          Mit der Bestätigung wird eine Anfrage an die Einrichtung gesendet.
+          Nach der Freigabe erhält diese Person vollen Zugriff auf dieses Kind
           in der Eltern-App.
         </p>
       </ConfirmationModal>

--- a/frontend/src/lib/guardian-api-related-accounts.test.ts
+++ b/frontend/src/lib/guardian-api-related-accounts.test.ts
@@ -126,6 +126,41 @@ describe("guardian-api related accounts", () => {
         "Failed to invite guardian",
       );
     });
+
+    it("sends confirm_role_upgrade only when confirming an upgrade", async () => {
+      const cap = mockFetch(
+        okJson({
+          status: "success",
+          data: { outcome: "already_linked", guardian_profile_id: "9" },
+        }),
+      );
+      await inviteGuardianToStudent("5", "a@b.de", {
+        confirmRoleUpgrade: true,
+      });
+      expect(JSON.parse(String(cap.init?.body))).toEqual({
+        email: "a@b.de",
+        first_name: "",
+        last_name: "",
+        relationship_type: "",
+        confirm_role_upgrade: true,
+      });
+    });
+
+    it("returns existing_role for the restricted-contact outcome", async () => {
+      mockFetch(
+        okJson({
+          status: "success",
+          data: {
+            outcome: "existing_contact_restricted",
+            guardian_profile_id: "9",
+            existing_role: "pickup_only",
+          },
+        }),
+      );
+      const result = await inviteGuardianToStudent("5", "a@b.de");
+      expect(result.outcome).toBe("existing_contact_restricted");
+      expect(result.existing_role).toBe("pickup_only");
+    });
   });
 
   describe("listPendingApprovals", () => {

--- a/frontend/src/lib/guardian-api.ts
+++ b/frontend/src/lib/guardian-api.ts
@@ -744,12 +744,16 @@ type InviteGuardianOutcome =
   | "linked_existing_account"
   | "already_linked"
   | "invited"
-  | "pending_approval";
+  | "pending_approval"
+  | "existing_contact_restricted";
 
 export interface InviteGuardianResult {
   outcome: InviteGuardianOutcome;
   guardian_profile_id: string;
   invitation_id?: string;
+  // Current guardian role for the existing_contact_restricted outcome, so the
+  // UI can name it in the upgrade confirmation (#2172).
+  existing_role?: string;
 }
 
 /**
@@ -765,6 +769,7 @@ export async function inviteGuardianToStudent(
     firstName?: string;
     lastName?: string;
     relationshipType?: string;
+    confirmRoleUpgrade?: boolean;
   },
 ): Promise<InviteGuardianResult> {
   const response = await fetch(`/api/guardians/students/${studentId}/invite`, {
@@ -775,6 +780,9 @@ export async function inviteGuardianToStudent(
       first_name: options?.firstName ?? "",
       last_name: options?.lastName ?? "",
       relationship_type: options?.relationshipType ?? "",
+      // Only sent when confirming an upgrade; a plain invite keeps the
+      // historical four-field body.
+      ...(options?.confirmRoleUpgrade ? { confirm_role_upgrade: true } : {}),
     }),
   });
 
@@ -1059,6 +1067,9 @@ export interface PendingApproval {
   requestedByEmail?: string;
   createdAt: string;
   expiresAt: string;
+  // Approving this request also upgrades an existing restrictive contact
+  // link to full portal access (#2172).
+  roleUpgrade: boolean;
 }
 
 interface BackendPendingApproval {
@@ -1071,6 +1082,7 @@ interface BackendPendingApproval {
   requested_by_email?: string;
   created_at: string;
   expires_at: string;
+  role_upgrade?: boolean;
 }
 
 function mapPendingApproval(data: BackendPendingApproval): PendingApproval {
@@ -1084,6 +1096,7 @@ function mapPendingApproval(data: BackendPendingApproval): PendingApproval {
     requestedByEmail: data.requested_by_email,
     createdAt: data.created_at,
     expiresAt: data.expires_at,
+    roleUpgrade: data.role_upgrade ?? false,
   };
 }
 

--- a/frontend/src/lib/guardian-helpers.ts
+++ b/frontend/src/lib/guardian-helpers.ts
@@ -116,9 +116,12 @@ export interface BackendGuardianPickerResponse {
 // Backend Student-Guardian Relationship
 
 // Portal-access state of a guardian, surfaced in the staff guardian list:
-// "active" = has a login account · "pending" = invited, not yet accepted ·
-// "none" = info on file, no account (can be invited).
-export type GuardianAccountStatus = "active" | "pending" | "none";
+// "active" = has a login account with access to this child ·
+// "active_no_access" = has a login account, but this child's link carries no
+// portal access (restrictive contact role, #2172) · "pending" = invited, not
+// yet accepted · "none" = info on file, no account (can be invited).
+export type GuardianAccountStatus =
+  "active" | "active_no_access" | "pending" | "none";
 
 // Guardian with Relationship (for student detail view)
 export interface GuardianWithRelationship extends Guardian {

--- a/frontend/src/lib/parent-api-related-accounts.test.ts
+++ b/frontend/src/lib/parent-api-related-accounts.test.ts
@@ -116,6 +116,38 @@ describe("parent-api related accounts", () => {
         "Einladen deaktiviert",
       );
     });
+
+    it("sends confirm_role_upgrade only when confirming an upgrade", async () => {
+      let body: unknown;
+      mockFetch(async (_input, init) => {
+        body = JSON.parse(String(init?.body));
+        return jsonResponse({
+          data: { outcome: "already_linked", guardian_profile_id: "11" },
+        });
+      });
+      await inviteRelatedAccount("3", "opa@x.de", { confirmRoleUpgrade: true });
+      expect(body).toEqual({
+        email: "opa@x.de",
+        first_name: "",
+        last_name: "",
+        confirm_role_upgrade: true,
+      });
+    });
+
+    it("returns existing_role for the restricted-contact outcome", async () => {
+      mockFetch(async () =>
+        jsonResponse({
+          data: {
+            outcome: "existing_contact_restricted",
+            guardian_profile_id: "11",
+            existing_role: "emergency_contact",
+          },
+        }),
+      );
+      const out = await inviteRelatedAccount("3", "opa@x.de");
+      expect(out.outcome).toBe("existing_contact_restricted");
+      expect(out.existing_role).toBe("emergency_contact");
+    });
   });
 
   describe("removeRelatedAccount", () => {

--- a/frontend/src/lib/parent-api.ts
+++ b/frontend/src/lib/parent-api.ts
@@ -226,7 +226,7 @@ export interface RelatedAccount {
   readonly email?: string;
   readonly relationship_type: string;
   readonly is_primary: boolean;
-  readonly status: "active" | "pending" | "no_account";
+  readonly status: "active" | "pending" | "no_account" | "active_no_access";
   // Marks the requesting parent's own row. Self-removal is rejected by the
   // backend, so the panel hides the remove action for it.
   readonly is_self: boolean;
@@ -908,13 +908,20 @@ export async function updateGuardianRelationship(
 export interface InviteRelatedAccountResult {
   readonly outcome: string;
   readonly guardian_profile_id: string;
+  // Current guardian role for the existing_contact_restricted outcome, so the
+  // UI can name it in the upgrade confirmation.
+  readonly existing_role?: string;
 }
 
 /** Invites a further guardian to the child by email. */
 export async function inviteRelatedAccount(
   studentId: string,
   email: string,
-  options?: { firstName?: string; lastName?: string },
+  options?: {
+    firstName?: string;
+    lastName?: string;
+    confirmRoleUpgrade?: boolean;
+  },
 ): Promise<InviteRelatedAccountResult> {
   return postJson<InviteRelatedAccountResult>(
     `/api/parent/me/children/${encodeURIComponent(studentId)}/related-accounts`,
@@ -922,6 +929,9 @@ export async function inviteRelatedAccount(
       email,
       first_name: options?.firstName ?? "",
       last_name: options?.lastName ?? "",
+      // Only sent when confirming an upgrade; a plain invite keeps the
+      // historical three-field body.
+      ...(options?.confirmRoleUpgrade ? { confirm_role_upgrade: true } : {}),
     },
   );
 }

--- a/frontend/src/lib/parent-api.ts
+++ b/frontend/src/lib/parent-api.ts
@@ -225,6 +225,9 @@ export interface RelatedAccount {
   readonly last_name: string;
   readonly email?: string;
   readonly relationship_type: string;
+  // Per-child role preset on the link; used to hide the grant-access action
+  // for school-managed social-worker contacts (#2172).
+  readonly guardian_role?: string;
   readonly is_primary: boolean;
   readonly status: "active" | "pending" | "no_account" | "active_no_access";
   // Marks the requesting parent's own row. Self-removal is rejected by the


### PR DESCRIPTION
## 🚀 Release 2026-08-06 (2)

Diese PR bringt den Stand von `development` nach `main`. Sie folgt wenige Stunden auf das Release vom Morgen (#2175) und enthält zwei Nachzügler aus dem Elternportal: die Hochstufung bereits erfasster Kontakte bei der Einladung samt ehrlichem Konto-Status (fünf offene Produktionsfälle) und den Absturz-Fix nach dem Eltern-Login.

> [!IMPORTANT]
> Dies ist eine reine Release-PR. Sie enthält keinen zusätzlichen Code über den bereits geprüften Stand von `development` hinaus.

| Umfang | Stand |
|---|---:|
| Commits | 11 |
| Enthaltene PRs | 2 |
| Geänderte Dateien | 35 |
| Diff | +2.409 / −102 Zeilen |
| Migrationen | 1 (1.15.270) |

## 👪 Einladung stuft bestehende Kontakte hoch, ehrlicher Konto-Status (#2174, schließt #2172 und #2171)

Lädt ein Primary Guardian oder die Schule eine Person ein, die am Kind bereits als restriktiver Kontakt hinterlegt ist (`emergency_contact`, `pickup_only`, `custom`), blieb die bestehende `students_guardians`-Zeile wegen `ON CONFLICT DO NOTHING` unangetastet. Das Konto war danach aktiv, hatte aber kein `parent_portal.access`: Das Kind blieb unsichtbar, während die Ansicht „Verbundene Konten" trotzdem „Konto aktiv" meldete. Fünf Produktionsfälle sind bekannt.

- **Ehrlicher Status**: Neuer Status `active_no_access` („Konto aktiv, kein Portalzugriff"), wenn das verknüpfte Konto auf dieser Kind-Verknüpfung keinen Portalzugriff hat. Betroffene Zeilen bekommen eine Aktion „Zugriff gewähren".
- **Einladung stuft hoch**: `InviteToStudent` erkennt die bestehende restriktive Verknüpfung vor jedem Schreibzugriff und liefert `existing_contact_restricted` ohne Seiteneffekte zurück. Elternportal und Staff-Kinderdetail zeigen einen Bestätigungsdialog mit der aktuellen Rolle; nach Bestätigung (`confirm_role_upgrade`) hebt der Server die Rolle über `authorize.ApplyStudentGuardianRole` auf `legal_guardian`. Keine neue Autorität, denn voller Zugriff war über eine Neu-Einladung ohnehin schon vergebbar.
- **Freigabepflicht respektiert**: Bei `guardians.parent_invite_mode = staff_approval` wird die Hochstufungs-Absicht auf `auth.guardian_invitations.role_upgrade` persistiert und erst bei der Freigabe angewendet. Lässt sich die versprochene Hochstufung dann nicht mehr anwenden (etwa weil die Verknüpfung inzwischen ein schulverwalteter Social-Worker-Kontakt ist), bricht die Freigabe ab, statt Erfolg für nie gewährten Zugriff zu melden. Die Anfrage bleibt offen und kann abgelehnt werden.
- Social-Worker-Verknüpfungen sind gegen Invite-Hochstufungen geschützt.

Bewusst nicht enthalten: der Daten-Backfill der fünf Produktionszeilen (wird separat mit den Schulen abgestimmt) und #2173 (fehlende Verknüpfungszeile, anderer Mechanismus).

## 🔑 Absturz nach dem Eltern-Login behoben (#2176)

Direkt nach dem Login brach die Startseite des Elternportals mit `Rendered more hooks than during the previous render.` ab, die Seite zeigte „This page couldn't load", erst ein Reload half. Ursache waren zwei Navigationen auf dasselbe Ziel im selben Tick: der session-getriebene `redirect()` aus dem Render und zusätzlich ein `router.push` im Submit-Handler. Der `router.push` ist entfernt, die Weiterleitung macht nur noch der `redirect()`, der auch den Fall „bereits angemeldet, ruft `/login` auf" abdeckt.

Dazu ein Watchdog gegen ein hängendes Formular: Bleibt die Session nach erfolgreichem `signIn` aus (NextAuth schluckt Fetch-Fehler beim Session-Abruf und liefert `null`), gibt der Watchdog das Formular nach zehn Sekunden wieder frei und zeigt die Anmeldefehlermeldung, statt es dauerhaft in „Anmeldung läuft..." zu sperren. Auf dem Erfolgspfad läuft er nie ab.

## 🗄️ Migrationen

| Version | Inhalt |
|---|---|
| 1.15.270 | `auth.guardian_invitations.role_upgrade` (BOOLEAN NOT NULL DEFAULT FALSE): merkt vorgemerkte Rollen-Hochstufungen bis zur Staff-Freigabe (#2174) |

Additive Spalte mit Default, kein Backfill, kein Datenumbau.

## ✅ Vor dem Merge

- [x] CI auf `development` grün (Build, Code Quality, main workflow, CodeQL, Stand `26a33ea2d`)
- [x] Beide enthaltenen PRs wurden einzeln geprüft und gemergt
- [x] Migration 1.15.270 läuft auf Staging durch (`deploy-staging` auf `26a33ea2d` erfolgreich)
- [ ] Deploy nach `main` beobachten (`deploy-remote.sh`, Rollback bei Exit 10/11)

## 📦 Enthaltene PRs

#2174 · #2176
