### PR TITLE
fix(active): Aktive-Gruppen-Kachel über activities-Template auflösen statt über education-IDs

### DIFF
--- a/backend/services/active/analytics_service.go
+++ b/backend/services/active/analytics_service.go
@@ -53,7 +53,7 @@ func (s *service) GetDashboardAnalytics(ctx context.Context) (*DashboardAnalytic
 
 	// Phase 6: Process active groups and calculate group metrics
 	activeGroupsCount, ogsGroupsCount, uniqueStudentsInRoomsOverall := processActiveGroups(
-		baseData.activeGroups, baseData.visitsByGroupID, baseData.educationGroupsByID, roomData,
+		baseData.activeGroups, baseData.visitsByGroupID, baseData.activityGroupsByID, roomData,
 	)
 	analytics.ActiveActivities = activeGroupsCount
 	analytics.ActiveOGSGroups = ogsGroupsCount
@@ -72,9 +72,9 @@ func (s *service) GetDashboardAnalytics(ctx context.Context) (*DashboardAnalytic
 	analytics.StudentsInHomeRoom = locationData.studentsInHomeRoom
 
 	// Phase 9: Build summary lists (using pre-loaded maps for O(1) name lookups)
-	analytics.RecentActivity = buildRecentActivity(baseData.activeGroups, baseData.activityGroupsByID, baseData.educationGroupsByID, roomData)
+	analytics.RecentActivity = buildRecentActivity(baseData.activeGroups, baseData.activityGroupsByID, roomData)
 	analytics.CurrentActivities = buildCurrentActivities(baseData.allActivityGroups, baseData.activeGroups, roomData)
-	analytics.ActiveGroupsSummary = buildActiveGroupsSummary(baseData.activeGroups, baseData.activityGroupsByID, baseData.educationGroupsByID, roomData)
+	analytics.ActiveGroupsSummary = buildActiveGroupsSummary(baseData.activeGroups, baseData.activityGroupsByID, roomData)
 
 	return analytics, nil
 }

--- a/backend/services/active/dashboard_helpers.go
+++ b/backend/services/active/dashboard_helpers.go
@@ -22,7 +22,6 @@ type dashboardBaseData struct {
 	allEducationGroups       []*educationModels.Group
 	allActivityGroups        []*activitiesModels.Group
 	activityGroupsByID       map[int64]*activitiesModels.Group
-	educationGroupsByID      map[int64]*educationModels.Group
 	activityCategories       int
 	supervisorsToday         int
 	visitsByGroupID          map[int64][]*active.Visit
@@ -61,7 +60,6 @@ func (s *service) fetchDashboardBaseData(ctx context.Context, today timezone.Dat
 		studentsPresent:          make(map[int64]bool),
 		visitsByGroupID:          make(map[int64][]*active.Visit),
 		activityGroupsByID:       make(map[int64]*activitiesModels.Group),
-		educationGroupsByID:      make(map[int64]*educationModels.Group),
 	}
 
 	// Get active visits
@@ -117,14 +115,17 @@ func (s *service) fetchDashboardBaseData(ctx context.Context, today timezone.Dat
 		return nil, err
 	}
 	data.allEducationGroups = allEducationGroups
-	for _, eg := range allEducationGroups {
-		data.educationGroupsByID[eg.ID] = eg
-	}
 
-	// Get activity groups (loaded once, used by name resolution and current activities).
-	// Non-critical: if this fails, dashboard still shows core metrics with fallback names.
+	// Get activity groups (loaded once, used by name resolution, OGS-group
+	// classification and current activities).
+	// Non-critical: if this fails, dashboard still shows core metrics with
+	// fallback names and an OGS-group count of zero — log it, never swallow it.
 	allActivityGroups, err := s.ActivityGroupRepo.List(ctx, nil)
-	if err == nil {
+	if err != nil {
+		s.getLogger().Warn("activity groups load failed, dashboard degrades to fallback names",
+			"error", err.Error(),
+		)
+	} else {
 		data.allActivityGroups = allActivityGroups
 		for _, ag := range allActivityGroups {
 			data.activityGroupsByID[ag.ID] = ag
@@ -246,9 +247,35 @@ func buildGroupToRoomLookup(allEducationGroups []*educationModels.Group) map[int
 	return lookup
 }
 
+// isOGSGroupTemplate reports whether a timetable template represents a
+// Betreuungsgruppe (OGS group), i.e. a care block bound to one concrete
+// education group.
+//
+// The binding MUST be read off the activities template. active.groups.group_id
+// is a foreign key to activities.groups(id) (fk_active_groups_group), never to
+// education.groups(id). Both tables draw from independent BIGSERIAL sequences,
+// so looking a session's group_id up in an education-keyed map matches by
+// numeric coincidence only — that was issue #2178.
+//
+// Both conditions are load-bearing:
+//   - Type == care excludes an AG whose Zielgruppe happens to be a group
+//     ("Fußball für die Bären"); such a template carries EducationGroupID too.
+//   - EducationGroupID != nil excludes care blocks that serve no specific
+//     group ("Mittagessen 1. Schicht", a Jahrgang-wide Hausaufgabenblock).
+//
+// Multi-target templates (activities.group_targets) need no extra handling:
+// a "gruppe" target list always mirrors its first entry into the scalar
+// EducationGroupID (normalizeDynamicTargets), and Group.validateEducationGroupTarget
+// makes that scalar mandatory for the type.
+func isOGSGroupTemplate(template *activitiesModels.Group) bool {
+	return template != nil &&
+		template.Type == activitiesModels.GroupTypeCare &&
+		template.EducationGroupID != nil
+}
+
 // processActiveGroups calculates metrics from active groups.
 // Returns total active count, OGS-only count, and unique students in rooms.
-func processActiveGroups(activeGroups []*active.Group, visitsByGroupID map[int64][]*active.Visit, educationGroupsByID map[int64]*educationModels.Group, roomData *dashboardRoomData) (int, int, map[int64]struct{}) {
+func processActiveGroups(activeGroups []*active.Group, visitsByGroupID map[int64][]*active.Visit, activityGroupsByID map[int64]*activitiesModels.Group, roomData *dashboardRoomData) (int, int, map[int64]struct{}) {
 	ogsGroupsCount := 0
 	uniqueStudentsInRoomsOverall := make(map[int64]struct{})
 
@@ -272,7 +299,7 @@ func processActiveGroups(activeGroups []*active.Group, visitsByGroupID map[int64
 		// (GroupID == nil, WP-B6) are never OGS-bound — they skip this
 		// classification entirely.
 		if templateID, ok := group.TemplateID(); ok {
-			if _, isOGS := educationGroupsByID[templateID]; isOGS {
+			if isOGSGroupTemplate(activityGroupsByID[templateID]) {
 				ogsGroupsCount++
 			}
 		}
@@ -374,7 +401,7 @@ func buildActiveGroupRoomLookup(activeGroups []*active.Group, roomData *dashboar
 }
 
 // buildRecentActivity builds the recent activity list
-func buildRecentActivity(activeGroups []*active.Group, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group, roomData *dashboardRoomData) []RecentActivity {
+func buildRecentActivity(activeGroups []*active.Group, activityGroupsByID map[int64]*activitiesModels.Group, roomData *dashboardRoomData) []RecentActivity {
 	recentActivity := []RecentActivity{}
 
 	for _, group := range activeGroups {
@@ -386,7 +413,7 @@ func buildRecentActivity(activeGroups []*active.Group, activityGroupsByID map[in
 			continue
 		}
 
-		groupName := resolveGroupName(group.GroupID, activityGroupsByID, educationGroupsByID)
+		groupName := resolveGroupName(group.GroupID, activityGroupsByID)
 		roomName := resolveRoomName(group.RoomID, roomData.roomByID)
 
 		// Count unique students
@@ -472,7 +499,7 @@ func determineActivityStatus(participants, maxCapacity int) string {
 }
 
 // buildActiveGroupsSummary builds the active groups summary list
-func buildActiveGroupsSummary(activeGroups []*active.Group, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group, roomData *dashboardRoomData) []ActiveGroupInfo {
+func buildActiveGroupsSummary(activeGroups []*active.Group, activityGroupsByID map[int64]*activitiesModels.Group, roomData *dashboardRoomData) []ActiveGroupInfo {
 	summary := []ActiveGroupInfo{}
 
 	for _, group := range activeGroups {
@@ -483,7 +510,7 @@ func buildActiveGroupsSummary(activeGroups []*active.Group, activityGroupsByID m
 			continue
 		}
 
-		groupName, groupType := resolveGroupNameAndType(group.GroupID, activityGroupsByID, educationGroupsByID)
+		groupName, groupType := resolveGroupNameAndType(group.GroupID, activityGroupsByID)
 		location := resolveRoomName(group.RoomID, roomData.roomByID)
 
 		studentCount := 0
@@ -504,36 +531,38 @@ func buildActiveGroupsSummary(activeGroups []*active.Group, activityGroupsByID m
 	return summary
 }
 
-// resolveGroupName gets the display name for a group via pre-loaded maps.
-// Spontaneous sessions (groupID == nil, WP-B6) return a generic label since
-// no template row exists to derive a name from.
-func resolveGroupName(groupID *int64, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group) string {
+// resolveGroupName gets the display name for a group via the pre-loaded
+// template map. Spontaneous sessions (groupID == nil, WP-B6) return a generic
+// label since no template row exists to derive a name from.
+//
+// groupID is an activities.groups.id — never look it up in an education-keyed
+// map (#2178).
+func resolveGroupName(groupID *int64, activityGroupsByID map[int64]*activitiesModels.Group) string {
 	if groupID == nil {
 		return "Spontane Aktivität"
 	}
 	if ag, ok := activityGroupsByID[*groupID]; ok {
 		return ag.Name
 	}
-	if eg, ok := educationGroupsByID[*groupID]; ok {
-		return eg.Name
-	}
 	return fmt.Sprintf("Gruppe %d", *groupID)
 }
 
 // resolveGroupNameAndType gets the display name and type for a group.
-// Education/OGS groups are checked first since they need the "ogs_group" type.
+// Both come from the session's activities template: care blocks bound to an
+// education group are typed "ogs_group", everything else "activity".
 // Spontaneous sessions (groupID == nil) are classified as "spontaneous".
-func resolveGroupNameAndType(groupID *int64, activityGroupsByID map[int64]*activitiesModels.Group, educationGroupsByID map[int64]*educationModels.Group) (string, string) {
+func resolveGroupNameAndType(groupID *int64, activityGroupsByID map[int64]*activitiesModels.Group) (string, string) {
 	if groupID == nil {
 		return "Spontane Aktivität", "spontaneous"
 	}
-	if eg, ok := educationGroupsByID[*groupID]; ok {
-		return eg.Name, "ogs_group"
+	ag, ok := activityGroupsByID[*groupID]
+	if !ok {
+		return fmt.Sprintf("Gruppe %d", *groupID), "activity"
 	}
-	if ag, ok := activityGroupsByID[*groupID]; ok {
-		return ag.Name, "activity"
+	if isOGSGroupTemplate(ag) {
+		return ag.Name, "ogs_group"
 	}
-	return fmt.Sprintf("Gruppe %d", *groupID), "activity"
+	return ag.Name, "activity"
 }
 
 // resolveRoomName gets the display name for a room

--- a/backend/services/active/dashboard_ogs_classification_internal_test.go
+++ b/backend/services/active/dashboard_ogs_classification_internal_test.go
@@ -1,0 +1,202 @@
+package active
+
+import (
+	"testing"
+	"time"
+
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	facilityModels "github.com/moto-nrw/project-phoenix/models/facilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The dashboard's OGS classification used to look a session's group_id up in a
+// map keyed by education.groups.id. active.groups.group_id is a foreign key to
+// activities.groups(id), and both tables draw from independent BIGSERIAL
+// sequences — so that lookup matched by numeric coincidence only (#2178).
+//
+// These fixtures deliberately collide: education group 7 and activities
+// template 7 exist side by side, exactly as they do in a freshly seeded
+// instance where both sequences start at 1.
+const (
+	collidingID           int64 = 7  // both an education group and an unrelated AG
+	careTemplateID        int64 = 44 // Betreuungsgruppe: care + education binding
+	careWithoutGroupID    int64 = 45 // care block serving no specific group
+	activityWithTargetID  int64 = 46 // AG whose Zielgruppe is a group
+	unknownTemplateID     int64 = 99 // no template row loaded
+	collidingEducationRef int64 = 7  // the education group the care template serves
+)
+
+func templateFixtures() map[int64]*activitiesModels.Group {
+	educationRef := collidingEducationRef
+
+	collidingActivity := &activitiesModels.Group{
+		Name:            "Fußball",
+		Type:            activitiesModels.GroupTypeActivity,
+		TargetGroupType: activitiesModels.TargetGroupTypeNone,
+	}
+	collidingActivity.ID = collidingID
+
+	careGroup := &activitiesModels.Group{
+		Name:             "Gruppenzeit Bären",
+		Type:             activitiesModels.GroupTypeCare,
+		TargetGroupType:  activitiesModels.TargetGroupTypeGruppe,
+		EducationGroupID: &educationRef,
+	}
+	careGroup.ID = careTemplateID
+
+	careWithoutGroup := &activitiesModels.Group{
+		Name:            "Mittagessen 1. Schicht",
+		Type:            activitiesModels.GroupTypeCare,
+		TargetGroupType: activitiesModels.TargetGroupTypeNone,
+	}
+	careWithoutGroup.ID = careWithoutGroupID
+
+	activityWithTarget := &activitiesModels.Group{
+		Name:             "Basteln für die Bären",
+		Type:             activitiesModels.GroupTypeActivity,
+		TargetGroupType:  activitiesModels.TargetGroupTypeGruppe,
+		EducationGroupID: &educationRef,
+	}
+	activityWithTarget.ID = activityWithTargetID
+
+	return map[int64]*activitiesModels.Group{
+		collidingID:          collidingActivity,
+		careTemplateID:       careGroup,
+		careWithoutGroupID:   careWithoutGroup,
+		activityWithTargetID: activityWithTarget,
+	}
+}
+
+func activeSession(id int64, templateID *int64, roomID int64) *activeModels.Group {
+	session := &activeModels.Group{
+		StartTime: time.Now().Add(-10 * time.Minute),
+		GroupID:   templateID,
+		RoomID:    roomID,
+	}
+	session.Model = modelBase.Model{ID: id}
+	return session
+}
+
+func emptyRoomData() *dashboardRoomData {
+	return &dashboardRoomData{
+		roomByID:        map[int64]*facilityModels.Room{},
+		occupiedRooms:   map[int64]bool{},
+		roomStudentsMap: map[int64]map[int64]struct{}{},
+	}
+}
+
+func TestIsOGSGroupTemplate(t *testing.T) {
+	templates := templateFixtures()
+
+	tests := []struct {
+		name     string
+		template *activitiesModels.Group
+		want     bool
+	}{
+		{"care block bound to an education group", templates[careTemplateID], true},
+		{"AG whose id collides with an education group id", templates[collidingID], false},
+		{"AG with a group Zielgruppe is not a Betreuungsgruppe", templates[activityWithTargetID], false},
+		{"care block without an education binding", templates[careWithoutGroupID], false},
+		{"missing template", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isOGSGroupTemplate(tt.template))
+		})
+	}
+}
+
+func TestProcessActiveGroupsCountsOnlyEducationBoundCareSessions(t *testing.T) {
+	templates := templateFixtures()
+	colliding := collidingID
+	care := careTemplateID
+	careOpen := careWithoutGroupID
+	targeted := activityWithTargetID
+	unknown := unknownTemplateID
+
+	sessions := []*activeModels.Group{
+		activeSession(1001, &colliding, 501), // must NOT count despite the id collision
+		activeSession(1002, &care, 502),      // the only real Betreuungsgruppe
+		activeSession(1003, &careOpen, 503),
+		activeSession(1004, &targeted, 504),
+		activeSession(1005, &unknown, 505),
+		activeSession(1006, nil, 506), // spontaneous session (WP-B6)
+	}
+
+	roomData := emptyRoomData()
+	totalCount, ogsCount, _ := processActiveGroups(sessions, map[int64][]*activeModels.Visit{}, templates, roomData)
+
+	assert.Equal(t, len(sessions), totalCount)
+	assert.Equal(t, 1, ogsCount, "only the education-bound care session is a Betreuungsgruppe")
+}
+
+// A dashboard whose activities templates failed to load must report zero OGS
+// groups rather than inventing them from colliding education ids.
+func TestProcessActiveGroupsWithoutTemplatesCountsNoOGSGroups(t *testing.T) {
+	colliding := collidingID
+	sessions := []*activeModels.Group{activeSession(1001, &colliding, 501)}
+
+	_, ogsCount, _ := processActiveGroups(
+		sessions,
+		map[int64][]*activeModels.Visit{},
+		map[int64]*activitiesModels.Group{},
+		emptyRoomData(),
+	)
+
+	assert.Equal(t, 0, ogsCount)
+}
+
+func TestResolveGroupNameAndTypeUsesTemplateNotEducationID(t *testing.T) {
+	templates := templateFixtures()
+	colliding := collidingID
+	care := careTemplateID
+	targeted := activityWithTargetID
+	unknown := unknownTemplateID
+
+	tests := []struct {
+		name     string
+		groupID  *int64
+		wantName string
+		wantType string
+	}{
+		{"colliding AG keeps its own name and type", &colliding, "Fußball", "activity"},
+		{"care session is an OGS group", &care, "Gruppenzeit Bären", "ogs_group"},
+		{"AG with group Zielgruppe stays an activity", &targeted, "Basteln für die Bären", "activity"},
+		{"unknown template falls back", &unknown, "Gruppe 99", "activity"},
+		{"spontaneous session", nil, "Spontane Aktivität", "spontaneous"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotType := resolveGroupNameAndType(tt.groupID, templates)
+			assert.Equal(t, tt.wantName, gotName)
+			assert.Equal(t, tt.wantType, gotType)
+
+			assert.Equal(t, tt.wantName, resolveGroupName(tt.groupID, templates),
+				"both resolvers must agree on the display name")
+		})
+	}
+}
+
+func TestBuildActiveGroupsSummaryLabelsCollidingSessionAsActivity(t *testing.T) {
+	templates := templateFixtures()
+	colliding := collidingID
+	care := careTemplateID
+
+	sessions := []*activeModels.Group{
+		activeSession(1001, &colliding, 501),
+		activeSession(1002, &care, 502),
+	}
+
+	summary := buildActiveGroupsSummary(sessions, templates, emptyRoomData())
+	require.Len(t, summary, 2)
+
+	assert.Equal(t, "Fußball", summary[0].Name)
+	assert.Equal(t, "activity", summary[0].Type)
+	assert.Equal(t, "Gruppenzeit Bären", summary[1].Name)
+	assert.Equal(t, "ogs_group", summary[1].Type)
+}


### PR DESCRIPTION
Closes #2178

## Problem

Die Dashboard-Kachel „Aktive Gruppen" hat zwei nicht zusammenhängende Zahlenräume verglichen.

`processActiveGroups` hat die `group_id` einer laufenden Session in einer Map nachgeschlagen, die mit `education.groups.id` verschlüsselt ist. `active.groups.group_id` ist aber ein Fremdschlüssel auf `activities.groups(id)`:

- `fk_active_groups_group` (`database/migrations/001004001_active_groups.go:66`)
- Composite-FK `fk_active_groups_group_tenant` auf dasselbe Ziel (`001015002_create_composite_fks.go:170`)
- Modellrelation `ActualGroup *activities.Group` mit `join:group_id=id` (`models/active/group.go:27`)

Beide Tabellen ziehen aus eigenständigen BIGSERIAL-Sequenzen. Ein Treffer war reine Zahlenkoinzidenz.

Derselbe Denkfehler steckte in `resolveGroupName` und `resolveGroupNameAndType`, letztere hat die education-Map sogar zuerst befragt. Bei überlappenden ID-Bereichen zeigte die Karte „Aktive Gruppen" damit den Namen einer fremden Gruppe und typisierte eine AG-Session als `ogs_group`.

## Der Wert war in beide Richtungen falsch

Auf der lokalen Dev-DB (Tenant 3, 12 offene Sessions):

| | offene Sessions | als OGS gezählt | tatsächlich gebunden |
|---|---|---|---|
| vorher | 12 | **0** | 5 |
| nachher | 12 | **5** | 5 |

Die glatte Null kam daher, dass die education-Gruppen dieses Tenants die IDs 36 bis 40 haben, die Session-Templates 63 bis 71. Keine Überschneidung.

Der Fall andersherum ist keine Theorie. Beide Sequenzen starten bei 1, und in derselben Dev-DB kollidieren die Bereiche für Tenant 2 deckungsgleich, innerhalb eines Tenants, so dass auch die Tenant-Filterung nicht rettet:

| id | `activities.groups.name` | angezeigt worden wäre |
|---|---|---|
| 1 | Hausaufgaben | Sternengruppe |
| 2 | Fußball | Bärengruppe |
| 3 | Basteln | Sonnengruppe |

## Lösung

Alle drei Stellen lösen die Session jetzt über ihr activities-Template auf. Neuer Helper `isOGSGroupTemplate`: eine Session zählt als Betreuungsgruppe, wenn ihr Template ein Care-Block ist, der an eine konkrete education-Gruppe gebunden ist.

Beide Bedingungen tragen:

- `type = 'care'` schließt eine AG aus, deren Zielgruppe zufällig eine Gruppe ist („Basteln für die Bären"). Solche Templates führen `education_group_id` ebenfalls.
- `education_group_id IS NOT NULL` schließt Care-Blöcke aus, die keiner bestimmten Gruppe dienen („Mittagessen 1. Schicht", ein jahrgangsweiter Hausaufgabenblock).

Das ist bewusst schärfer als der ursprüngliche Vorschlag im Issue. Der reine Nil-Check hätte AGs mit Zielgruppe „gruppe" mitgezählt. Ein Gate allein auf `target_group_type = 'gruppe'` wiederum hätte Alt-Templates verfehlt: Migration 1.15.182 hat die Spalte ohne Backfill auf `'none'` gesetzt, Care-Templates aus der Zeit davor tragen `education_group_id` bei `target_group_type = 'none'`.

Mehrfach-Zielgruppen (`activities.group_targets`) brauchen keine Sonderbehandlung. `normalizeDynamicTargets` spiegelt den ersten Target in die Skalarspalte, und `validateEducationGroupTarget` macht sie für den Typ verpflichtend.

Die Map `educationGroupsByID` ist damit ersatzlos entfallen, statt nur umgeleitet zu werden. Was es nicht mehr gibt, kann niemand versehentlich wieder falsch nachschlagen.

Zusätzlich: das Laden der activities-Gruppen hat seinen Fehler bisher stumm verschluckt. Diese Map trägt nach dem Fix die Klassifikation, ein stilles Scheitern hätte die Kachel wieder auf 0 gesetzt. Jetzt gibt es eine Warnung, die Degradierung auf Fallback-Namen bleibt.

## Verifikation

Zwei Server gegen dieselbe Dev-DB, alter Stand und Branch, echter Login, echter Endpoint `/api/active/analytics/dashboard`:

```
ALT   active_ogs_groups = 0 | active_activities = 12
        Schulhof Freispiel  -> activity
        WC                  -> activity
        Gruppenzeit Igel    -> activity
        Gruppenzeit Eulen   -> activity
        Gruppenzeit Delfine -> activity

NEU   active_ogs_groups = 5 | active_activities = 12
        Schulhof Freispiel  -> activity
        WC                  -> activity
        Gruppenzeit Igel    -> ogs_group
        Gruppenzeit Eulen   -> ogs_group
        Gruppenzeit Delfine -> ogs_group
```

`active_activities` bleibt unverändert, die Kachel „Aktive Aktivitäten" war nie betroffen.

## Tests

Der gesamte Pfad hatte keinen einzigen Test, deshalb ist der Fehler seit März unbemerkt geblieben. Neu in `dashboard_ogs_classification_internal_test.go`, mit absichtlich kollidierenden IDs (education 7 gegen AG 7):

- `TestIsOGSGroupTemplate` mit allen vier Template-Formen
- `TestProcessActiveGroupsCountsOnlyEducationBoundCareSessions` über sechs Sessions inklusive spontaner Session
- `TestProcessActiveGroupsWithoutTemplatesCountsNoOGSGroups` für den Fall, dass das Template-Laden scheitert
- `TestResolveGroupNameAndTypeUsesTemplateNotEducationID`
- `TestBuildActiveGroupsSummaryLabelsCollidingSessionAsActivity`

Grün: Package-Tests, `TestHermeticTestPatterns`, `TestHandlerLayerRatchet`, `TestServiceRepositoryRatchet`, `TestModelCeremonyRatchet`, `TestGDPRLogPIIRatchet`, golangci-lint.

`TestEndDailySessions*` fallen im breiten Paketlauf um. Das ist der bekannte Parallel-Flake auf der geteilten Test-DB, isoliert grün und unabhängig von dieser Änderung.

## Kein Frontend-Anteil

`group.type` wird im Dashboard nur als React-Key verwendet und nicht angezeigt. Sichtbar sind die Zahl auf der Kachel und die Namen in der Gruppenliste, beide sind jetzt korrekt.

## Bewusst nicht enthalten

Punkt 4 der Issue-To-do-Liste (soll der Seeder offene Sessions hinterlassen, damit die Kachel lokal überhaupt Werte zeigt) ist eine Seeder-Entscheidung und nicht Teil des Bugs.
