### PR TITLE
feat(students): Dokumente-Tab am Kind samt gemeinsamer Speicher-Schicht

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -510,13 +510,14 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		LockTemplateRecurrence: func(ctx context.Context) error {
 			return scheduleSvc.LockTenantRecurrenceWrites(ctx, db)
 		},
-		Broadcaster:        api.Services.RealtimeHub,
-		ParentEventEmitter: api.Services.ParentEventEmitter,
-		AbsenceNotifier:    api.Services.AbsenceNotifier,
-		StudentPhotos:      api.Services.StudentPhotos,
-		ListExportService:  api.Services.ListExport,
-		Logger:             logger.With("handler", "students"),
-		DB:                 db,
+		Broadcaster:            api.Services.RealtimeHub,
+		ParentEventEmitter:     api.Services.ParentEventEmitter,
+		AbsenceNotifier:        api.Services.AbsenceNotifier,
+		StudentPhotos:          api.Services.StudentPhotos,
+		StudentDocumentService: api.Services.StudentDocuments,
+		ListExportService:      api.Services.ListExport,
+		Logger:                 logger.With("handler", "students"),
+		DB:                     db,
 	})
 	api.Messaging = messagingAPI.NewResource(api.Services.Messaging, db)
 	api.Calendar = calendarAPI.NewResource(api.Services.Calendar, db, logger.With("handler", "calendar"))

--- a/backend/api/common/documents/coordinator.go
+++ b/backend/api/common/documents/coordinator.go
@@ -156,30 +156,6 @@ func (c *Coordinator) CleanupDocument(tenantID, ownerID, documentID int64, store
 	}
 }
 
-// CleanupQueued removes the bytes of an upload whose metadata never landed.
-func (c *Coordinator) CleanupQueued(tenantID, ownerID, cleanupID int64, storedName, source string) {
-	ctx := c.NewTenantContext(tenantID)
-	if err := c.Remove(ctx, tenantID, storedName); err != nil {
-		c.logger().Warn("document orphan cleanup failed",
-			"kind", c.Kind,
-			"owner_id", ownerID,
-			"cleanup_id", cleanupID,
-			"source", source,
-			"error", err,
-		)
-		return
-	}
-	if err := c.Store.MarkQueuedCleanupComplete(ctx, cleanupID); err != nil {
-		c.logger().Error("document orphan cleanup status update failed",
-			"kind", c.Kind,
-			"owner_id", ownerID,
-			"cleanup_id", cleanupID,
-			"source", source,
-			"error", err,
-		)
-	}
-}
-
 // ReleaseFailedUpload disposes of the bytes of an upload whose metadata could
 // not be persisted, and settles its queued intent: complete when the object is
 // gone, re-activated when removal failed so the scheduler retries.

--- a/backend/api/common/documents/coordinator.go
+++ b/backend/api/common/documents/coordinator.go
@@ -137,15 +137,21 @@ func (c *Coordinator) CleanupDocument(tenantID, ownerID, documentID int64, store
 	ctx := c.NewTenantContext(tenantID)
 	if err := c.Remove(ctx, tenantID, storedName); err != nil {
 		c.logger().Warn("document cleanup failed",
-			"kind", c.Kind, "owner_id", ownerID, "document_id", documentID,
-			"source", source, "error", err,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"document_id", documentID,
+			"source", source,
+			"error", err,
 		)
 		return
 	}
 	if err := c.Store.MarkFileDeleted(ctx, documentID); err != nil {
 		c.logger().Error("document cleanup status update failed",
-			"kind", c.Kind, "owner_id", ownerID, "document_id", documentID,
-			"source", source, "error", err,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"document_id", documentID,
+			"source", source,
+			"error", err,
 		)
 	}
 }
@@ -155,15 +161,21 @@ func (c *Coordinator) CleanupQueued(tenantID, ownerID, cleanupID int64, storedNa
 	ctx := c.NewTenantContext(tenantID)
 	if err := c.Remove(ctx, tenantID, storedName); err != nil {
 		c.logger().Warn("document orphan cleanup failed",
-			"kind", c.Kind, "owner_id", ownerID, "cleanup_id", cleanupID,
-			"source", source, "error", err,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"cleanup_id", cleanupID,
+			"source", source,
+			"error", err,
 		)
 		return
 	}
 	if err := c.Store.MarkQueuedCleanupComplete(ctx, cleanupID); err != nil {
 		c.logger().Error("document orphan cleanup status update failed",
-			"kind", c.Kind, "owner_id", ownerID, "cleanup_id", cleanupID,
-			"source", source, "error", err,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"cleanup_id", cleanupID,
+			"source", source,
+			"error", err,
 		)
 	}
 }
@@ -187,24 +199,32 @@ func (c *Coordinator) CleanupQueued(tenantID, ownerID, cleanupID int64, storedNa
 func (c *Coordinator) ReleaseFailedUpload(ctx context.Context, tenantID, ownerID int64, storedName string, rejectedBeforeCommit bool, cause error) {
 	if !rejectedBeforeCommit {
 		c.logger().Warn("document upload outcome undecided, leaving cleanup to the queued intent",
-			"kind", c.Kind, "owner_id", ownerID, "error", cause,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"error", cause,
 		)
 		return
 	}
 	if err := c.Remove(ctx, tenantID, storedName); err != nil {
 		c.logger().Error("document cleanup failed after upload error",
-			"kind", c.Kind, "owner_id", ownerID, "error", err,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"error", err,
 		)
 		if activateErr := c.Store.ActivateQueuedCleanup(ctx, storedName); activateErr != nil {
 			c.logger().Error("document cleanup intent activation failed",
-				"kind", c.Kind, "owner_id", ownerID, "error", activateErr,
+				"kind", c.Kind,
+				"owner_id", ownerID,
+				"error", activateErr,
 			)
 		}
 		return
 	}
 	if err := c.Store.MarkQueuedCleanupCompleteByFilename(ctx, storedName); err != nil {
 		c.logger().Warn("document cleanup intent completion failed",
-			"kind", c.Kind, "owner_id", ownerID, "error", err,
+			"kind", c.Kind,
+			"owner_id", ownerID,
+			"error", err,
 		)
 	}
 }

--- a/backend/api/common/documents/coordinator.go
+++ b/backend/api/common/documents/coordinator.go
@@ -172,14 +172,21 @@ func (c *Coordinator) CleanupQueued(tenantID, ownerID, cleanupID int64, storedNa
 // not be persisted, and settles its queued intent: complete when the object is
 // gone, re-activated when removal failed so the scheduler retries.
 //
-// A cancelled or timed-out metadata transaction is the one case that touches
-// neither. Its commit may still have landed, and deleting the object here
-// would strand a committed document row pointing at nothing. The intent
-// decides instead: a committed transaction has already settled it, a
-// rolled-back one leaves it queued for the scheduler.
-func (c *Coordinator) ReleaseFailedUpload(ctx context.Context, tenantID, ownerID int64, storedName string, cause error) {
-	if isUnresolved(cause) {
-		c.logger().Warn("document upload interrupted, leaving cleanup to the queued intent",
+// It does that ONLY when the caller can prove the metadata never landed —
+// rejectedBeforeCommit. Everything else is in doubt and must be left alone:
+// a transaction whose COMMIT failed to acknowledge (a dropped connection is
+// the classic case, not just a cancelled context) may well have committed on
+// the server, and removing the object here would strand a live document row
+// whose download 404s forever with no sweep able to notice.
+//
+// Leaving it alone is always safe, which is why it is the default. The queued
+// intent decides instead: a committed transaction settled it in the same
+// transaction, so the object stays; a rolled-back one leaves it queued and the
+// scheduler reclaims the bytes once the upload deadline has passed. The only
+// cost of being wrong in this direction is a few minutes of delay.
+func (c *Coordinator) ReleaseFailedUpload(ctx context.Context, tenantID, ownerID int64, storedName string, rejectedBeforeCommit bool, cause error) {
+	if !rejectedBeforeCommit {
+		c.logger().Warn("document upload outcome undecided, leaving cleanup to the queued intent",
 			"kind", c.Kind, "owner_id", ownerID, "error", cause,
 		)
 		return
@@ -200,11 +207,4 @@ func (c *Coordinator) ReleaseFailedUpload(ctx context.Context, tenantID, ownerID
 			"kind", c.Kind, "owner_id", ownerID, "error", err,
 		)
 	}
-}
-
-// isUnresolved reports whether an upload failure leaves the metadata
-// transaction's outcome undecided, in which case the object must not be
-// removed by this request.
-func isUnresolved(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }

--- a/backend/api/common/documents/coordinator.go
+++ b/backend/api/common/documents/coordinator.go
@@ -1,0 +1,210 @@
+// Package documents owns the part of a document upload that is neither
+// business logic nor persistence: getting bytes onto (and off) the storage
+// backend without ever leaving an orphan behind.
+//
+// The order is forced by HTTP, not by preference. Multipart input cannot be
+// replayed after a transaction commits, so the file must be written before
+// its metadata exists. That opens a window in which a crash leaves bytes with
+// no row pointing at them, which for a medical certificate is exactly the
+// kind of leftover that must not happen. The window is closed by writing a
+// durable cleanup intent BEFORE the object and settling it afterwards:
+//
+//	queue intent -> write object -> commit metadata -> settle intent
+//
+// Any step can die. An intent that is never settled becomes eligible for the
+// cleanup scheduler after a delay that is deliberately longer than the
+// request deadline, so the scheduler can never delete an upload that is still
+// in flight.
+package documents
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/moto-nrw/project-phoenix/internal/storage"
+)
+
+// Store is the subset of a domain's document service the coordinator needs to
+// settle cleanup bookkeeping. Each domain implements it over its own tables.
+type Store interface {
+	// MarkFileDeleted records that a document's bytes are gone.
+	MarkFileDeleted(ctx context.Context, documentID int64) error
+	// MarkQueuedCleanupComplete settles one orphan intent by ID.
+	MarkQueuedCleanupComplete(ctx context.Context, cleanupID int64) error
+	// MarkQueuedCleanupCompleteByFilename settles the intent of one object.
+	MarkQueuedCleanupCompleteByFilename(ctx context.Context, storedName string) error
+	// ActivateQueuedCleanup makes an intent eligible for retry right away.
+	ActivateQueuedCleanup(ctx context.Context, storedName string) error
+}
+
+// TenantContext produces a background context carrying a tenant, used by the
+// after-commit cleanup hooks that outlive the request.
+type TenantContext func(tenantID int64) context.Context
+
+// Coordinator moves document bytes for one domain.
+type Coordinator struct {
+	// Kind is the storage key prefix, e.g. "student-documents".
+	Kind    string
+	Backend storage.Backend
+	Store   Store
+	// NewTenantContext builds the context for post-request cleanup work.
+	NewTenantContext TenantContext
+	Logger           *slog.Logger
+}
+
+func (c *Coordinator) logger() *slog.Logger {
+	if c.Logger == nil {
+		return slog.Default()
+	}
+	return c.Logger
+}
+
+func (c *Coordinator) key(tenantID int64, storedName string) (string, error) {
+	return storage.TenantKey(c.Kind, tenantID, storedName)
+}
+
+// NewStoredName generates the storage name for a validated content type. The
+// display name never reaches the filesystem: a UUID cannot collide, cannot
+// carry a traversal payload, and leaks nothing about the content.
+func NewStoredName(extension string) (string, error) {
+	if extension == "" {
+		return "", errors.New("unsupported document content type")
+	}
+	id, err := uuid.NewV4()
+	if err != nil {
+		return "", errors.New("failed to generate document filename")
+	}
+	return id.String() + extension, nil
+}
+
+// Save writes the uploaded object privately and returns the stored size.
+func (c *Coordinator) Save(ctx context.Context, tenantID int64, storedName string, source io.Reader) (int64, error) {
+	key, err := c.key(tenantID, storedName)
+	if err != nil {
+		return 0, err
+	}
+	return c.Backend.Save(ctx, key, source, storage.SaveOptions{Private: true})
+}
+
+// Serve streams the object as a download named displayName. It returns false
+// when nothing was written, so the caller can still render an error.
+func (c *Coordinator) Serve(w http.ResponseWriter, r *http.Request, tenantID int64, storedName, displayName, contentType string) bool {
+	key, err := c.key(tenantID, storedName)
+	if err != nil {
+		return false
+	}
+	object, err := c.Backend.Open(r.Context(), key)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		if err := object.Close(); err != nil {
+			c.logger().Error("document close error", "error", err)
+		}
+	}()
+
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{
+		"filename": displayName,
+	}))
+	w.Header().Set("Content-Type", contentType)
+	// no-store: a revoked permission or a deleted document must not be
+	// served from a cache the application no longer controls.
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	http.ServeContent(w, r, displayName, object.ModTime(), object)
+	return true
+}
+
+// Remove deletes the stored object. A missing object counts as removed so
+// retries converge.
+func (c *Coordinator) Remove(ctx context.Context, tenantID int64, storedName string) error {
+	key, err := c.key(tenantID, storedName)
+	if err != nil {
+		return err
+	}
+	return c.Backend.Remove(ctx, key)
+}
+
+// CleanupDocument removes a soft-deleted document's bytes and records that
+// they are gone. Failures are logged, never propagated: the caller is a
+// post-commit hook whose transaction is already finished.
+func (c *Coordinator) CleanupDocument(tenantID, ownerID, documentID int64, storedName, source string) {
+	ctx := c.NewTenantContext(tenantID)
+	if err := c.Remove(ctx, tenantID, storedName); err != nil {
+		c.logger().Warn("document cleanup failed",
+			"kind", c.Kind, "owner_id", ownerID, "document_id", documentID,
+			"source", source, "error", err,
+		)
+		return
+	}
+	if err := c.Store.MarkFileDeleted(ctx, documentID); err != nil {
+		c.logger().Error("document cleanup status update failed",
+			"kind", c.Kind, "owner_id", ownerID, "document_id", documentID,
+			"source", source, "error", err,
+		)
+	}
+}
+
+// CleanupQueued removes the bytes of an upload whose metadata never landed.
+func (c *Coordinator) CleanupQueued(tenantID, ownerID, cleanupID int64, storedName, source string) {
+	ctx := c.NewTenantContext(tenantID)
+	if err := c.Remove(ctx, tenantID, storedName); err != nil {
+		c.logger().Warn("document orphan cleanup failed",
+			"kind", c.Kind, "owner_id", ownerID, "cleanup_id", cleanupID,
+			"source", source, "error", err,
+		)
+		return
+	}
+	if err := c.Store.MarkQueuedCleanupComplete(ctx, cleanupID); err != nil {
+		c.logger().Error("document orphan cleanup status update failed",
+			"kind", c.Kind, "owner_id", ownerID, "cleanup_id", cleanupID,
+			"source", source, "error", err,
+		)
+	}
+}
+
+// ReleaseFailedUpload disposes of the bytes of an upload whose metadata could
+// not be persisted, and settles its queued intent: complete when the object is
+// gone, re-activated when removal failed so the scheduler retries.
+//
+// A cancelled or timed-out metadata transaction is the one case that touches
+// neither. Its commit may still have landed, and deleting the object here
+// would strand a committed document row pointing at nothing. The intent
+// decides instead: a committed transaction has already settled it, a
+// rolled-back one leaves it queued for the scheduler.
+func (c *Coordinator) ReleaseFailedUpload(ctx context.Context, tenantID, ownerID int64, storedName string, cause error) {
+	if isUnresolved(cause) {
+		c.logger().Warn("document upload interrupted, leaving cleanup to the queued intent",
+			"kind", c.Kind, "owner_id", ownerID, "error", cause,
+		)
+		return
+	}
+	if err := c.Remove(ctx, tenantID, storedName); err != nil {
+		c.logger().Error("document cleanup failed after upload error",
+			"kind", c.Kind, "owner_id", ownerID, "error", err,
+		)
+		if activateErr := c.Store.ActivateQueuedCleanup(ctx, storedName); activateErr != nil {
+			c.logger().Error("document cleanup intent activation failed",
+				"kind", c.Kind, "owner_id", ownerID, "error", activateErr,
+			)
+		}
+		return
+	}
+	if err := c.Store.MarkQueuedCleanupCompleteByFilename(ctx, storedName); err != nil {
+		c.logger().Warn("document cleanup intent completion failed",
+			"kind", c.Kind, "owner_id", ownerID, "error", err,
+		)
+	}
+}
+
+// isUnresolved reports whether an upload failure leaves the metadata
+// transaction's outcome undecided, in which case the object must not be
+// removed by this request.
+func isUnresolved(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}

--- a/backend/api/common/upload.go
+++ b/backend/api/common/upload.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/randstr"
+	"github.com/moto-nrw/project-phoenix/internal/storage"
 )
 
 // AllowedImageTypes maps MIME types detected by http.DetectContentType to allowed image formats.
@@ -149,62 +151,33 @@ func saveUploadedFile(file io.Reader, targetDir, prefix, ext string) (string, er
 // filename (callers generate collision-free names, e.g. UUIDs). It creates
 // targetDir if it doesn't exist. Returns the full file path on disk.
 func SaveNamedFile(file io.Reader, targetDir, filename string) (string, error) {
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return "", errors.New("failed to create upload directory")
-	}
-
-	filePath := filepath.Join(targetDir, filename)
-	dst, err := os.Create(filePath)
-	if err != nil {
-		return "", errors.New("failed to save file")
-	}
-	defer func() {
-		if err := dst.Close(); err != nil {
-			slog.Default().Error("file close error", slog.String("error", err.Error()))
-		}
-	}()
-
-	if _, err := io.Copy(dst, file); err != nil {
-		// Clean up the partially written file
-		_ = os.Remove(filePath)
-		return "", errors.New("failed to save file")
-	}
-
-	return filePath, nil
+	return saveThroughStorage(file, targetDir, filename, storage.SaveOptions{})
 }
 
 // SavePrivateNamedFile writes a file that must never be exposed through a
 // static mount. Both the directory and file are owner-only so access remains
 // mediated by the authenticated download handler.
 func SavePrivateNamedFile(file io.Reader, targetDir, filename string) (string, error) {
-	if err := os.MkdirAll(targetDir, 0700); err != nil {
+	return saveThroughStorage(file, targetDir, filename, storage.SaveOptions{Private: true})
+}
+
+// saveThroughStorage funnels every write into the storage backend and keeps
+// returning an on-disk path so existing callers stay unchanged. The path is
+// derived from the same root the backend uses, so path and key can never
+// point at different files.
+func saveThroughStorage(file io.Reader, targetDir, filename string, opts storage.SaveOptions) (string, error) {
+	backend, dir, err := fileStore(targetDir)
+	if err != nil {
 		return "", errors.New("failed to create upload directory")
 	}
-	if err := os.Chmod(targetDir, 0700); err != nil {
-		return "", errors.New("failed to secure upload directory")
-	}
-
-	filePath := filepath.Join(targetDir, filename)
-	dst, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	key, err := storage.Key(filename)
 	if err != nil {
 		return "", errors.New("failed to save file")
 	}
-	defer func() {
-		if err := dst.Close(); err != nil {
-			slog.Default().Error("file close error", slog.String("error", err.Error()))
-		}
-	}()
-	if err := dst.Chmod(0600); err != nil {
-		_ = os.Remove(filePath)
-		return "", errors.New("failed to secure uploaded file")
-	}
-
-	if _, err := io.Copy(dst, file); err != nil {
-		_ = os.Remove(filePath)
+	if _, err := backend.Save(context.Background(), key, file, opts); err != nil {
 		return "", errors.New("failed to save file")
 	}
-
-	return filePath, nil
+	return filepath.Join(dir, filename), nil
 }
 
 // ServeFile serves a file from baseDir, validating the path stays within baseDir.
@@ -227,57 +200,92 @@ func servePublicFile(w http.ResponseWriter, r *http.Request, baseDir, filename, 
 		return
 	}
 
-	// Resolve relative paths using the discovered public directory
-	if !filepath.IsAbs(baseDir) {
-		if pubDir, err := ResolvePublicDir(); err == nil {
-			// Strip leading "public/" since pubDir already points to it
-			rel := strings.TrimPrefix(baseDir, "public/")
-			rel = strings.TrimPrefix(rel, "public")
-			if rel != "" {
-				baseDir = filepath.Join(pubDir, rel)
-			} else {
-				baseDir = pubDir
-			}
-		}
+	backend, _, err := fileStore(baseDir)
+	if err != nil {
+		http.NotFound(w, r)
+		return
 	}
-
-	absBase, err := filepath.Abs(baseDir)
+	key, err := storage.Key(filename)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
 
-	absPath := filepath.Join(absBase, filename)
-	if !strings.HasPrefix(absPath, absBase+string(os.PathSeparator)) {
-		http.NotFound(w, r)
-		return
-	}
-
-	file, err := os.Open(absPath)
+	object, err := backend.Open(r.Context(), key)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	defer func() {
-		if err := file.Close(); err != nil {
+		if err := object.Close(); err != nil {
 			slog.Default().Error("file close error", slog.String("error", err.Error()))
 		}
 	}()
 
 	w.Header().Set("Cache-Control", cacheControl)
-	http.ServeContent(w, r, filename, modTime(file), file)
+	http.ServeContent(w, r, filename, object.ModTime(), object)
 }
 
 // RemoveImage deletes a file from disk, logging any error.
-func RemoveImage(path string) {
-	if path == "" {
+func RemoveImage(filePath string) {
+	if filePath == "" {
 		return
 	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+	backend, _, err := fileStore(filepath.Dir(filePath))
+	if err != nil {
 		slog.Default().Error("failed to remove file",
-			slog.String("path", path),
+			slog.String("path", filePath),
+			slog.String("error", err.Error()))
+		return
+	}
+	key, err := storage.Key(filepath.Base(filePath))
+	if err != nil {
+		slog.Default().Error("failed to remove file",
+			slog.String("path", filePath),
+			slog.String("error", err.Error()))
+		return
+	}
+	if err := backend.Remove(context.Background(), key); err != nil {
+		slog.Default().Error("failed to remove file",
+			slog.String("path", filePath),
 			slog.String("error", err.Error()))
 	}
+}
+
+// fileStore returns the storage backend for one upload directory plus the
+// absolute directory it resolved to. Relative directories ("public/uploads/x")
+// are resolved against the discovered public directory; absolute ones are used
+// as given. This is the single place that answers "where do these bytes live",
+// and every read, write and delete of an upload goes through the backend it
+// returns — save, serve and remove therefore cannot disagree.
+func fileStore(baseDir string) (storage.Backend, string, error) {
+	dir := baseDir
+	if !filepath.IsAbs(dir) {
+		if pubDir, err := ResolvePublicDir(); err == nil {
+			// Strip leading "public/" since pubDir already points to it
+			rel := strings.TrimPrefix(dir, "public/")
+			rel = strings.TrimPrefix(rel, "public")
+			if rel != "" {
+				dir = filepath.Join(pubDir, rel)
+			} else {
+				dir = pubDir
+			}
+		}
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, "", errors.New("failed to resolve directory")
+	}
+	return storage.NewLocal(absDir), absDir, nil
+}
+
+// UploadsBackend returns the storage backend rooted at the uploads
+// directory. Document features address objects inside it by key
+// ({kind}/{tenant}/{name}) instead of assembling paths of their own.
+func UploadsBackend() (storage.Backend, error) {
+	backend, _, err := fileStore("public/uploads")
+	return backend, err
 }
 
 // ValidateFilename rejects filenames containing path traversal characters.

--- a/backend/api/config/settings_integration_test.go
+++ b/backend/api/config/settings_integration_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/moto-nrw/project-phoenix/api/common"
 	configAPI "github.com/moto-nrw/project-phoenix/api/config"
 	"github.com/moto-nrw/project-phoenix/api/testutil"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
@@ -313,7 +315,7 @@ func TestSettingsUploadLoginImage_Success(t *testing.T) {
 
 	// Clean up the uploaded file
 	t.Cleanup(func() {
-		filePath := filepath.Join("public", filepath.FromSlash(imageURL[1:]))
+		filePath := uploadedFilePath(t, imageURL)
 		_ = os.Remove(filePath)
 	})
 }
@@ -348,7 +350,7 @@ func TestSettingsUploadLoginImage_ReplacesOldImage(t *testing.T) {
 	response1 := testutil.ParseJSONResponse(t, rr1.Body.Bytes())
 	data1 := response1["data"].(map[string]interface{})
 	firstURL := data1["login_image_url"].(string)
-	firstPath := filepath.Join("public", filepath.FromSlash(firstURL[1:]))
+	firstPath := uploadedFilePath(t, firstURL)
 
 	// Verify first file exists on disk
 	_, err := os.Stat(firstPath)
@@ -365,7 +367,7 @@ func TestSettingsUploadLoginImage_ReplacesOldImage(t *testing.T) {
 	response2 := testutil.ParseJSONResponse(t, rr2.Body.Bytes())
 	data2 := response2["data"].(map[string]interface{})
 	secondURL := data2["login_image_url"].(string)
-	secondPath := filepath.Join("public", filepath.FromSlash(secondURL[1:]))
+	secondPath := uploadedFilePath(t, secondURL)
 
 	// Verify old file was cleaned up
 	_, err = os.Stat(firstPath)
@@ -379,6 +381,20 @@ func TestSettingsUploadLoginImage_ReplacesOldImage(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.Remove(secondPath)
 	})
+}
+
+// uploadedFilePath resolves a stored upload URL ("/uploads/login-images/x.png")
+// to its location on disk the same way the application does. Building the path
+// by hand from the working directory would only re-create the duplicated
+// path knowledge that api/common/upload.go now owns: save, serve and delete
+// all resolve through ResolvePublicDir, so the test has to as well.
+func uploadedFilePath(t *testing.T, storedURL string) string {
+	t.Helper()
+	baseDir := "public"
+	if resolved, err := common.ResolvePublicDir(); err == nil {
+		baseDir = resolved
+	}
+	return filepath.Join(baseDir, filepath.FromSlash(strings.TrimPrefix(storedURL, "/")))
 }
 
 func TestSettingsUploadLoginImage_InvalidFileType(t *testing.T) {

--- a/backend/api/enrollment/legal_document_handlers_test.go
+++ b/backend/api/enrollment/legal_document_handlers_test.go
@@ -143,14 +143,20 @@ func withFilenameParam(req *http.Request, filename string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
 }
 
+// writeEnrollmentLegalDocument plants a document where the application stores
+// it, by resolving the stored URL the same way upload, serve and delete do.
+// Joining "public" against the working directory instead would place the file
+// in the test package's directory while the handler looks under the resolved
+// public dir — the two only ever coincided by accident of call order.
 func writeEnrollmentLegalDocument(t *testing.T, filename string) (string, string) {
 	t.Helper()
-	dir := filepath.Join("public", "uploads", "enrollment-form-legal-documents")
-	require.NoError(t, os.MkdirAll(dir, 0755))
-	path := filepath.Join(dir, filename)
+	url := "/uploads/enrollment-form-legal-documents/" + filename
+	path, err := common.ResolveStoredPath("public", url, "/uploads/enrollment-form-legal-documents/")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
 	require.NoError(t, os.WriteFile(path, []byte("%PDF-1.4\n%test\n"), 0600))
 	t.Cleanup(func() { _ = os.Remove(path) })
-	return path, "/uploads/enrollment-form-legal-documents/" + filename
+	return path, url
 }
 
 func multipartPDFRequest(t *testing.T, fieldName, fileName string, content []byte) *http.Request {

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -81,6 +81,9 @@ func newScheduler(api *API, logger *slog.Logger) *scheduler.Scheduler {
 	if api.Staff != nil {
 		sched.SetStaffDocumentFileCleaner(api.Staff)
 	}
+	if api.Students != nil {
+		sched.SetStudentDocumentFileCleaner(api.Students)
+	}
 
 	return sched
 }

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -97,10 +97,12 @@ type ResourceConfig struct {
 	ParentEventEmitter *parentmessaging.Emitter
 	AbsenceNotifier    notificationsService.AbsenceNotifier
 	StudentPhotos      userService.StudentPhotoService
-	ListExportService  *listexport.RendererService
-	Logger             *slog.Logger
-	Now                func() time.Time
-	DB                 *bun.DB
+	// StudentDocumentService backs the child's Dokumente tab (#777).
+	StudentDocumentService userService.StudentDocumentService
+	ListExportService      *listexport.RendererService
+	Logger                 *slog.Logger
+	Now                    func() time.Time
+	DB                     *bun.DB
 }
 
 // NewResource creates a new students resource from the provided configuration.
@@ -252,6 +254,25 @@ func (rs *Resource) Router() chi.Router {
 		r.With(authorize.RequiresPermission(permissions.UsersUpdate)).Post("/{id}/photo", rs.uploadStudentPhoto)
 		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Delete("/{id}/photo", rs.deleteStudentPhoto)
 		r.With(authorize.RequiresPermission(permissions.UsersRead)).Get("/{id}/photo/{filename}", rs.serveStudentPhoto)
+
+		// Child documents (#777). The gate only proves the caller may reach
+		// the tab at all. Per-category authority (health → student_documents:health,
+		// Sorgerecht → student_documents:legal, the rest → users:update) is
+		// decided in the document service, which also filters the list down to
+		// the categories the caller may see.
+		//
+		// upload + download skip withTx so a slow 10 MB body or file stream
+		// doesn't pin a bun pool connection; those handlers open their own
+		// short transactions.
+		studentDocumentsGate := authorize.RequiresAnyPermission(
+			permissions.UsersUpdate,
+			permissions.StudentDocumentsHealth,
+			permissions.StudentDocumentsLegal,
+		)
+		r.With(studentDocumentsGate, withTx).Get("/{id}/documents", rs.listStudentDocuments)
+		r.With(studentDocumentsGate).Post("/{id}/documents", rs.uploadStudentDocument)
+		r.With(studentDocumentsGate).Get("/{id}/documents/{documentId}/download", rs.downloadStudentDocument)
+		r.With(studentDocumentsGate, withTx).Delete("/{id}/documents/{documentId}", rs.deleteStudentDocument)
 	})
 
 	// Device-authenticated routes for RFID devices.

--- a/backend/api/students/change_history_handlers.go
+++ b/backend/api/students/change_history_handlers.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/api/common"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/users"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 )
 
 // changeHistoryEntry is the per-child change-history row returned to the
@@ -93,8 +95,18 @@ func (rs *Resource) getStudentChangeHistory(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Document rows name a category and a filename ("Ärztliches Attest:
+	// Attest_Epilepsie.pdf"). Full access is not enough to read those: the
+	// Dokumente tab gates health and custody paperwork behind their own
+	// permissions, and a history that showed them anyway would simply be the
+	// way around that gate.
+	userPermissions := jwt.PermissionsFromCtx(r.Context())
+
 	entries := make([]changeHistoryEntry, 0, len(edits))
 	for _, e := range edits {
+		if !canSeeChangeHistoryEntry(e.FieldName, userPermissions) {
+			continue
+		}
 		entries = append(entries, changeHistoryEntry{
 			ID:        strconv.FormatInt(e.ID, 10),
 			Field:     e.FieldName,
@@ -106,6 +118,24 @@ func (rs *Resource) getStudentChangeHistory(w http.ResponseWriter, r *http.Reque
 	}
 
 	common.Respond(w, r, http.StatusOK, entries, "Change history retrieved successfully")
+}
+
+// canSeeChangeHistoryEntry filters document rows by the same per-category
+// permissions the document endpoints enforce. Everything else passes: those
+// fields are covered by the full-access gate above.
+//
+// A row whose category cannot be determined (the categoryless form written
+// before the category moved into the field name) is shown only to a caller who
+// may see every category — an unreadable label must not default to visible.
+func canSeeChangeHistoryEntry(fieldName string, userPermissions []string) bool {
+	if !auditModels.IsStudentDocumentField(fieldName) {
+		return true
+	}
+	category := auditModels.StudentDocumentCategoryFromField(fieldName)
+	if category == "" {
+		return usersSvc.CanSeeEveryStudentDocumentCategory(userPermissions)
+	}
+	return usersSvc.CanSeeStudentDocumentCategory(category, userPermissions)
 }
 
 func derefOrEmpty(p *string) string {

--- a/backend/api/students/document_cleanup.go
+++ b/backend/api/students/document_cleanup.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	documentModels "github.com/moto-nrw/project-phoenix/models/documents"
 )
 
 // CleanupOrphanedStudentDocumentFiles retries object removal independently of
@@ -14,6 +16,11 @@ import (
 // cover: a process that died between the object write and the metadata commit,
 // and a child who was deleted while some of their documents still had bytes on
 // disk (the rows cascade away, the queued cleanup intents do not).
+//
+// Each pass is capped at documents.CleanupBatchSize per list. The cap is
+// logged rather than silent: a pass that fills its batch has NOT reclaimed
+// everything, and reading "cleanup completed" without that qualifier would be
+// misleading. The next tick continues five minutes later.
 func (rs *Resource) CleanupOrphanedStudentDocumentFiles(ctx context.Context) (int, error) {
 	coordinator, err := rs.studentDocumentCoordinator()
 	if err != nil {
@@ -46,6 +53,7 @@ func (rs *Resource) CleanupOrphanedStudentDocumentFiles(ctx context.Context) (in
 			}
 			removed++
 		}
+		rs.logCleanupBatchFull(len(documents), "deleted")
 	}
 
 	cleanups, err := rs.StudentDocumentService.ListQueuedStudentDocumentFileCleanups(ctx)
@@ -71,6 +79,19 @@ func (rs *Resource) CleanupOrphanedStudentDocumentFiles(ctx context.Context) (in
 		}
 		removed++
 	}
+	rs.logCleanupBatchFull(len(cleanups), "orphan")
 
 	return removed, cleanupErr
+}
+
+// logCleanupBatchFull reports a pass that filled its batch. Without it a
+// bounded sweep would read as "everything reclaimed" in the logs while rows
+// were still waiting — a silent cap is worse than no cap.
+func (rs *Resource) logCleanupBatchFull(count int, source string) {
+	if count < documentModels.CleanupBatchSize {
+		return
+	}
+	rs.getLogger().Info("student document cleanup batch full, more pending",
+		"batch_size", documentModels.CleanupBatchSize,
+		"source", source)
 }

--- a/backend/api/students/document_cleanup.go
+++ b/backend/api/students/document_cleanup.go
@@ -30,13 +30,17 @@ func (rs *Resource) CleanupOrphanedStudentDocumentFiles(ctx context.Context) (in
 		for _, document := range documents {
 			if err := coordinator.Remove(ctx, document.TenantID, document.FilenameStored); err != nil {
 				rs.getLogger().Warn("student document cleanup failed",
-					"student_id", document.StudentID, "document_id", document.ID, "error", err)
+					"student_id", document.StudentID,
+					"document_id", document.ID,
+					"error", err)
 				cleanupErr = errors.Join(cleanupErr, err)
 				continue
 			}
 			if err := rs.StudentDocumentService.MarkFileDeleted(ctx, document.ID); err != nil {
 				rs.getLogger().Error("student document cleanup status update failed",
-					"student_id", document.StudentID, "document_id", document.ID, "error", err)
+					"student_id", document.StudentID,
+					"document_id", document.ID,
+					"error", err)
 				cleanupErr = errors.Join(cleanupErr, err)
 				continue
 			}
@@ -51,13 +55,17 @@ func (rs *Resource) CleanupOrphanedStudentDocumentFiles(ctx context.Context) (in
 	for _, cleanup := range cleanups {
 		if err := coordinator.Remove(ctx, cleanup.TenantID, cleanup.FilenameStored); err != nil {
 			rs.getLogger().Warn("student document orphan cleanup failed",
-				"student_id", cleanup.OwnerID, "cleanup_id", cleanup.ID, "error", err)
+				"student_id", cleanup.OwnerID,
+				"cleanup_id", cleanup.ID,
+				"error", err)
 			cleanupErr = errors.Join(cleanupErr, err)
 			continue
 		}
 		if err := rs.StudentDocumentService.MarkQueuedCleanupComplete(ctx, cleanup.ID); err != nil {
 			rs.getLogger().Error("student document orphan cleanup status update failed",
-				"student_id", cleanup.OwnerID, "cleanup_id", cleanup.ID, "error", err)
+				"student_id", cleanup.OwnerID,
+				"cleanup_id", cleanup.ID,
+				"error", err)
 			cleanupErr = errors.Join(cleanupErr, err)
 			continue
 		}

--- a/backend/api/students/document_cleanup.go
+++ b/backend/api/students/document_cleanup.go
@@ -1,0 +1,68 @@
+package students
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// CleanupOrphanedStudentDocumentFiles retries object removal independently of
+// document UI traffic. The scheduler calls it in each tenant transaction after
+// the upload grace period has elapsed.
+//
+// It is the only recovery path for two cases the request-scoped hooks cannot
+// cover: a process that died between the object write and the metadata commit,
+// and a child who was deleted while some of their documents still had bytes on
+// disk (the rows cascade away, the queued cleanup intents do not).
+func (rs *Resource) CleanupOrphanedStudentDocumentFiles(ctx context.Context) (int, error) {
+	coordinator, err := rs.studentDocumentCoordinator()
+	if err != nil {
+		return 0, fmt.Errorf("student document storage unavailable: %w", err)
+	}
+
+	removed := 0
+	var cleanupErr error
+
+	documents, err := rs.StudentDocumentService.ListDeletedStudentDocumentsPendingFileCleanups(ctx)
+	if err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("list deleted student documents: %w", err))
+	} else {
+		for _, document := range documents {
+			if err := coordinator.Remove(ctx, document.TenantID, document.FilenameStored); err != nil {
+				rs.getLogger().Warn("student document cleanup failed",
+					"student_id", document.StudentID, "document_id", document.ID, "error", err)
+				cleanupErr = errors.Join(cleanupErr, err)
+				continue
+			}
+			if err := rs.StudentDocumentService.MarkFileDeleted(ctx, document.ID); err != nil {
+				rs.getLogger().Error("student document cleanup status update failed",
+					"student_id", document.StudentID, "document_id", document.ID, "error", err)
+				cleanupErr = errors.Join(cleanupErr, err)
+				continue
+			}
+			removed++
+		}
+	}
+
+	cleanups, err := rs.StudentDocumentService.ListQueuedStudentDocumentFileCleanups(ctx)
+	if err != nil {
+		return removed, errors.Join(cleanupErr, fmt.Errorf("list queued student document cleanups: %w", err))
+	}
+	for _, cleanup := range cleanups {
+		if err := coordinator.Remove(ctx, cleanup.TenantID, cleanup.FilenameStored); err != nil {
+			rs.getLogger().Warn("student document orphan cleanup failed",
+				"student_id", cleanup.OwnerID, "cleanup_id", cleanup.ID, "error", err)
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+		if err := rs.StudentDocumentService.MarkQueuedCleanupComplete(ctx, cleanup.ID); err != nil {
+			rs.getLogger().Error("student document orphan cleanup status update failed",
+				"student_id", cleanup.OwnerID, "cleanup_id", cleanup.ID, "error", err)
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+		removed++
+	}
+
+	return removed, cleanupErr
+}

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -275,9 +275,14 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 
 	size, err := coordinator.Save(uploadCtx, tenantID, storedName, uploaded.File)
 	if err != nil {
-		if completeErr := rs.StudentDocumentService.MarkQueuedCleanupCompleteByFilename(r.Context(), storedName); completeErr != nil {
-			rs.getLogger().Warn("student document cleanup intent completion failed after write error",
-				"student_id", id, "error", completeErr)
+		// The intent is activated, not settled. A failed write removes its own
+		// partial object only best-effort, so declaring the bytes gone here
+		// would strand a half-written child document that nothing can reach
+		// again: no metadata row, no eligible intent, no scheduler path.
+		// Activating costs one no-op removal when the object really is gone.
+		if activateErr := rs.StudentDocumentService.ActivateQueuedCleanup(r.Context(), storedName); activateErr != nil {
+			rs.getLogger().Error("student document cleanup intent activation failed after write error",
+				"student_id", id, "error", activateErr)
 		}
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -204,7 +204,8 @@ func (rs *Resource) retryStudentDocumentCleanups(ctx context.Context, studentID 
 	documents, err := rs.StudentDocumentService.ListDeletedStudentDocumentsPendingFileCleanup(ctx, studentID, actor)
 	if err != nil {
 		rs.getLogger().Warn("student document cleanup retry lookup failed",
-			"student_id", studentID, "error", err)
+			"student_id", studentID,
+			"error", err)
 		return
 	}
 	for _, document := range documents {
@@ -256,7 +257,8 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 
 	if err := rs.StudentDocumentService.QueueStudentDocumentFileCleanup(r.Context(), id, storedName); err != nil {
 		rs.getLogger().Error("student document upload cleanup intent failed",
-			"student_id", id, "error", err)
+			"student_id", id,
+			"error", err)
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
@@ -280,7 +282,8 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 		// Activating costs one no-op removal when the object really is gone.
 		if activateErr := rs.StudentDocumentService.ActivateQueuedCleanup(r.Context(), storedName); activateErr != nil {
 			rs.getLogger().Error("student document cleanup intent activation failed after write error",
-				"student_id", id, "error", activateErr)
+				"student_id", id,
+				"error", activateErr)
 		}
 		common.RenderError(w, r, common.ErrorInternalServer(err))
 		return

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -303,6 +303,17 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// The write finished, but did it finish in time? Everything that keeps this
+	// upload's bookkeeping consistent hangs off the deadline: the queued intent
+	// becomes eligible three minutes after it, and a scheduler pass that
+	// settles the intent while the object is still being written would leave
+	// bytes behind that no sweep can find again. A backend that ignores its
+	// context — a future object store, a stalled mount — is enough for that, so
+	// the deadline is re-checked here rather than trusted.
+	if rs.abortExpiredUpload(w, r, uploadCtx, id, storedName) {
+		return
+	}
+
 	doc, err := rs.StudentDocumentService.CreateStudentDocument(uploadCtx, usersSvc.CreateStudentDocumentInput{
 		StudentID:       id,
 		Category:        category,
@@ -326,6 +337,28 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 
 	resp := newStudentDocumentResponse(doc)
 	common.Respond(w, r, http.StatusCreated, &resp, "Student document uploaded successfully")
+}
+
+// abortExpiredUpload ends an upload whose deadline passed while its bytes were
+// being written, and reports whether it did.
+//
+// The intent is activated rather than left alone: past the deadline the
+// scheduler may be about to settle it, or may already have settled it and
+// removed a half-written object that the write then re-created. Activating
+// while it is still open is what keeps the bytes reachable; if it is already
+// settled the update matches nothing, which is the case the deadline check
+// exists to make rare.
+func (rs *Resource) abortExpiredUpload(w http.ResponseWriter, r *http.Request, uploadCtx context.Context, studentID int64, storedName string) bool {
+	if uploadCtx.Err() == nil {
+		return false
+	}
+	if activateErr := rs.StudentDocumentService.ActivateQueuedCleanup(r.Context(), storedName); activateErr != nil {
+		rs.getLogger().Error("student document cleanup intent activation failed after deadline",
+			"student_id", studentID,
+			"error", activateErr)
+	}
+	common.RenderError(w, r, common.ErrorInternalServer(errors.New("upload exceeded its deadline")))
+	return true
 }
 
 // downloadStudentDocument serves GET /{id}/documents/{documentId}/download.

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -126,7 +126,8 @@ func isSensitiveStudentDocumentCategory(category string) bool {
 // renderStudentDocumentError maps document service errors onto HTTP responses.
 func renderStudentDocumentError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
-	case errors.Is(err, usersSvc.ErrStudentDocumentForbidden):
+	case errors.Is(err, usersSvc.ErrStudentDocumentForbidden),
+		errors.Is(err, usersSvc.ErrStudentDocumentNoAccess):
 		common.RenderError(w, r, common.ErrorForbidden(err))
 	case errors.Is(err, usersSvc.ErrStudentDocumentInvalid):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
@@ -180,9 +181,18 @@ func (rs *Resource) listStudentDocuments(w http.ResponseWriter, r *http.Request)
 	common.Respond(w, r, http.StatusOK, resp, "Student documents retrieved successfully")
 }
 
-// retryStudentDocumentCleanups schedules removal of objects left behind by an
-// earlier failure: soft-deleted documents whose unlink did not complete, and
-// orphaned uploads whose metadata never landed.
+// retryStudentDocumentCleanups schedules removal of objects whose unlink did
+// not finish, for the child in the URL only.
+//
+// It deliberately does NOT touch queued upload intents, for two reasons. They
+// are tenant-wide and uncapped, so a graduate purge could leave hundreds
+// eligible and hand the whole backlog to whoever next opens any child's tab —
+// hundreds of sequential unlinks and transactions inside one request. And the
+// intent scan takes its rows FOR UPDATE SKIP LOCKED to keep a concurrent
+// upload from having its bytes deleted, a lock that is released at COMMIT,
+// which is before an after-commit hook removes anything. The scheduler owns
+// that work instead: it removes inside the same transaction that holds the
+// lock, and it reaches every tenant within five minutes.
 func (rs *Resource) retryStudentDocumentCleanups(ctx context.Context, studentID int64, actor usersSvc.StudentDocumentActor, source string) {
 	coordinator, err := rs.studentDocumentCoordinator()
 	if err != nil {
@@ -191,28 +201,16 @@ func (rs *Resource) retryStudentDocumentCleanups(ctx context.Context, studentID 
 	}
 	tenantID := tenant.FromContext(ctx)
 
-	if documents, err := rs.StudentDocumentService.ListDeletedStudentDocumentsPendingFileCleanup(ctx, studentID, actor); err != nil {
-		rs.getLogger().Warn("student document cleanup retry lookup failed",
-			"student_id", studentID, "error", err)
-	} else {
-		for _, document := range documents {
-			docID, storedName := document.ID, document.FilenameStored
-			tenant.RegisterAfterCommit(ctx, func() {
-				coordinator.CleanupDocument(tenantID, studentID, docID, storedName, source)
-			})
-		}
-	}
-
-	cleanups, err := rs.StudentDocumentService.ListQueuedStudentDocumentFileCleanups(ctx)
+	documents, err := rs.StudentDocumentService.ListDeletedStudentDocumentsPendingFileCleanup(ctx, studentID, actor)
 	if err != nil {
-		rs.getLogger().Warn("student document orphan cleanup retry lookup failed",
+		rs.getLogger().Warn("student document cleanup retry lookup failed",
 			"student_id", studentID, "error", err)
 		return
 	}
-	for _, cleanup := range cleanups {
-		ownerID, cleanupID, storedName := cleanup.OwnerID, cleanup.ID, cleanup.FilenameStored
+	for _, document := range documents {
+		docID, storedName := document.ID, document.FilenameStored
 		tenant.RegisterAfterCommit(ctx, func() {
-			coordinator.CleanupQueued(tenantID, ownerID, cleanupID, storedName, source)
+			coordinator.CleanupDocument(tenantID, studentID, docID, storedName, source)
 		})
 	}
 }

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -249,6 +249,20 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 	}
 	defer common.CloseFile(uploaded.File)
 
+	category := r.FormValue("category")
+
+	// Authorize BEFORE anything is written. The route gate only proves the
+	// caller may reach documents at all, and every group supervisor holds
+	// users:update — without this, any of them could aim a 10 MB upload at any
+	// child ID in the school and force both a write into the shared uploads
+	// volume and a durable cleanup row, once per attempt, reclaimed only after
+	// the scheduler's grace delay. The transaction below re-checks; this is
+	// about not paying for a request that was never allowed.
+	if err := rs.StudentDocumentService.AuthorizeStudentDocumentUpload(r.Context(), id, category, actor); err != nil {
+		renderStudentDocumentError(w, r, err)
+		return
+	}
+
 	storedName, err := apiDocuments.NewStoredName(common.DocumentFileExtension(uploaded.ContentType))
 	if err != nil {
 		common.RenderError(w, r, common.ErrorInternalServer(err))
@@ -291,7 +305,7 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 
 	doc, err := rs.StudentDocumentService.CreateStudentDocument(uploadCtx, usersSvc.CreateStudentDocumentInput{
 		StudentID:       id,
-		Category:        r.FormValue("category"),
+		Category:        category,
 		FilenameDisplay: uploaded.Filename,
 		FilenameStored:  storedName,
 		SizeBytes:       size,

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -297,7 +297,14 @@ func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request
 		ContentType:     uploaded.ContentType,
 	}, actor)
 	if err != nil {
-		coordinator.ReleaseFailedUpload(r.Context(), tenantID, id, storedName, err)
+		// Only the two request-shaped rejections are decided before the
+		// metadata transaction opens, so only they prove the row never landed
+		// and let the bytes go immediately. Anything deeper — including a
+		// commit whose acknowledgement never arrived — is in doubt and is left
+		// to the queued intent.
+		rejectedBeforeCommit := errors.Is(err, usersSvc.ErrStudentDocumentInvalid) ||
+			errors.Is(err, usersSvc.ErrStudentDocumentForbidden)
+		coordinator.ReleaseFailedUpload(r.Context(), tenantID, id, storedName, rejectedBeforeCommit, err)
 		renderStudentDocumentError(w, r, err)
 		return
 	}

--- a/backend/api/students/documents_handlers.go
+++ b/backend/api/students/documents_handlers.go
@@ -1,0 +1,384 @@
+package students
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	apiDocuments "github.com/moto-nrw/project-phoenix/api/common/documents"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// Child documents (#777). The bytes go through the storage backend under
+// student-documents/{tenant_id}/{uuid}; only these handlers can reach them
+// (backend public/ has no static file server). Multipart parsing, content
+// validation and the storage dance live here, authority and audit live in the
+// document service — the same split as staff documents and student photos.
+
+const (
+	// maxStudentDocumentFile is the advertised upload cap; the multipart body
+	// cap adds headroom for boundaries and headers.
+	maxStudentDocumentFile = 10 * 1024 * 1024
+	maxStudentDocumentBody = maxStudentDocumentFile + 4096
+	// studentDocumentKind is the storage key prefix for child documents.
+	studentDocumentKind = "student-documents"
+)
+
+// studentDocumentCoordinator builds the storage coordinator for child
+// documents. It is constructed per request rather than stored on the Resource
+// so a bare test Resource stays usable.
+func (rs *Resource) studentDocumentCoordinator() (*apiDocuments.Coordinator, error) {
+	backend, err := common.UploadsBackend()
+	if err != nil {
+		return nil, err
+	}
+	return &apiDocuments.Coordinator{
+		Kind:             studentDocumentKind,
+		Backend:          backend,
+		Store:            rs.StudentDocumentService,
+		NewTenantContext: func(tenantID int64) context.Context { return tenant.WithTenantID(context.Background(), tenantID) },
+		Logger:           rs.getLogger(),
+	}, nil
+}
+
+// studentDocumentActor builds the service actor from the JWT: account id for
+// audit rows, display name for the change history, roles for the access log,
+// permissions for the per-category checks.
+func studentDocumentActor(r *http.Request) (usersSvc.StudentDocumentActor, error) {
+	claims := jwt.ClaimsFromCtx(r.Context())
+	if claims.ID == 0 {
+		return usersSvc.StudentDocumentActor{}, errors.New("invalid token: no account id")
+	}
+	return usersSvc.StudentDocumentActor{
+		AccountID: int64(claims.ID),
+		// The audit row snapshots the editor's name so the history still
+		// reads correctly after a rename or an account deletion.
+		Name:        strings.TrimSpace(strings.TrimSpace(claims.FirstName) + " " + strings.TrimSpace(claims.LastName)),
+		Role:        strings.Join(claims.Roles, ","),
+		Permissions: jwt.PermissionsFromCtx(r.Context()),
+	}, nil
+}
+
+// --- wire types ------------------------------------------------------------
+
+// StudentDocumentResponse is one document on the wire.
+type StudentDocumentResponse struct {
+	ID            int64     `json:"id"`
+	StudentID     int64     `json:"student_id"`
+	Category      string    `json:"category"`
+	CategoryLabel string    `json:"category_label"`
+	Filename      string    `json:"filename"`
+	SizeBytes     int64     `json:"size_bytes"`
+	ContentType   string    `json:"content_type"`
+	UploadedAt    time.Time `json:"uploaded_at"`
+	Sensitive     bool      `json:"sensitive"`
+}
+
+// StudentDocumentListResponse is the list GET: the documents the caller may
+// see plus the caller's visible categories (drives the filter and the upload
+// category picker).
+type StudentDocumentListResponse struct {
+	StudentID         int64                     `json:"student_id"`
+	Documents         []StudentDocumentResponse `json:"documents"`
+	VisibleCategories []StudentDocumentCategory `json:"visible_categories"`
+}
+
+// StudentDocumentCategory is one selectable category with its German label.
+type StudentDocumentCategory struct {
+	Value     string `json:"value"`
+	Label     string `json:"label"`
+	Sensitive bool   `json:"sensitive"`
+}
+
+func newStudentDocumentResponse(doc *userModels.StudentDocument) StudentDocumentResponse {
+	return StudentDocumentResponse{
+		ID:            doc.ID,
+		StudentID:     doc.StudentID,
+		Category:      doc.Category,
+		CategoryLabel: studentDocumentLabel(doc.Category),
+		Filename:      doc.FilenameDisplay,
+		SizeBytes:     doc.SizeBytes,
+		ContentType:   doc.ContentType,
+		UploadedAt:    doc.CreatedAt,
+		Sensitive:     isSensitiveStudentDocumentCategory(doc.Category),
+	}
+}
+
+func studentDocumentLabel(category string) string {
+	if label := userModels.StudentDocumentCategoryLabels[category]; label != "" {
+		return label
+	}
+	return category
+}
+
+func isSensitiveStudentDocumentCategory(category string) bool {
+	return userModels.IsHealthStudentDocumentCategory(category) ||
+		userModels.IsLegalStudentDocumentCategory(category)
+}
+
+// renderStudentDocumentError maps document service errors onto HTTP responses.
+func renderStudentDocumentError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, usersSvc.ErrStudentDocumentForbidden):
+		common.RenderError(w, r, common.ErrorForbidden(err))
+	case errors.Is(err, usersSvc.ErrStudentDocumentInvalid):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	case modelBase.IsNoRows(err):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	default:
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+	}
+}
+
+// --- handlers --------------------------------------------------------------
+
+// listStudentDocuments serves GET /{id}/documents?category=x.
+func (rs *Resource) listStudentDocuments(w http.ResponseWriter, r *http.Request) {
+	id, ok := common.ParseInt64IDWithError(w, r, "id", common.MsgInvalidStudentID)
+	if !ok {
+		return
+	}
+	actor, err := studentDocumentActor(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+
+	docs, visible, err := rs.StudentDocumentService.ListStudentDocuments(r.Context(), id, r.URL.Query().Get("category"), actor)
+	if err != nil {
+		renderStudentDocumentError(w, r, err)
+		return
+	}
+
+	// Retry only objects whose prior post-commit removal did not finish. The
+	// hooks run after this read transaction commits, so list queries never do
+	// storage I/O inside their tenant transaction.
+	rs.retryStudentDocumentCleanups(r.Context(), id, actor, "retry")
+
+	resp := &StudentDocumentListResponse{
+		StudentID:         id,
+		Documents:         make([]StudentDocumentResponse, 0, len(docs)),
+		VisibleCategories: make([]StudentDocumentCategory, 0, len(visible)),
+	}
+	for _, doc := range docs {
+		resp.Documents = append(resp.Documents, newStudentDocumentResponse(doc))
+	}
+	for _, category := range visible {
+		resp.VisibleCategories = append(resp.VisibleCategories, StudentDocumentCategory{
+			Value:     category,
+			Label:     studentDocumentLabel(category),
+			Sensitive: isSensitiveStudentDocumentCategory(category),
+		})
+	}
+	common.Respond(w, r, http.StatusOK, resp, "Student documents retrieved successfully")
+}
+
+// retryStudentDocumentCleanups schedules removal of objects left behind by an
+// earlier failure: soft-deleted documents whose unlink did not complete, and
+// orphaned uploads whose metadata never landed.
+func (rs *Resource) retryStudentDocumentCleanups(ctx context.Context, studentID int64, actor usersSvc.StudentDocumentActor, source string) {
+	coordinator, err := rs.studentDocumentCoordinator()
+	if err != nil {
+		rs.getLogger().Warn("student document cleanup retry unavailable", "error", err)
+		return
+	}
+	tenantID := tenant.FromContext(ctx)
+
+	if documents, err := rs.StudentDocumentService.ListDeletedStudentDocumentsPendingFileCleanup(ctx, studentID, actor); err != nil {
+		rs.getLogger().Warn("student document cleanup retry lookup failed",
+			"student_id", studentID, "error", err)
+	} else {
+		for _, document := range documents {
+			docID, storedName := document.ID, document.FilenameStored
+			tenant.RegisterAfterCommit(ctx, func() {
+				coordinator.CleanupDocument(tenantID, studentID, docID, storedName, source)
+			})
+		}
+	}
+
+	cleanups, err := rs.StudentDocumentService.ListQueuedStudentDocumentFileCleanups(ctx)
+	if err != nil {
+		rs.getLogger().Warn("student document orphan cleanup retry lookup failed",
+			"student_id", studentID, "error", err)
+		return
+	}
+	for _, cleanup := range cleanups {
+		ownerID, cleanupID, storedName := cleanup.OwnerID, cleanup.ID, cleanup.FilenameStored
+		tenant.RegisterAfterCommit(ctx, func() {
+			coordinator.CleanupQueued(tenantID, ownerID, cleanupID, storedName, source)
+		})
+	}
+}
+
+// uploadStudentDocument serves POST /{id}/documents (multipart: file +
+// category). The object is written before its metadata because multipart
+// input cannot be replayed after commit; CreateStudentDocument commits its
+// metadata transaction before returning, and this handler disposes of the
+// object on failure.
+func (rs *Resource) uploadStudentDocument(w http.ResponseWriter, r *http.Request) {
+	id, ok := common.ParseInt64IDWithError(w, r, "id", common.MsgInvalidStudentID)
+	if !ok {
+		return
+	}
+	actor, err := studentDocumentActor(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	tenantID := tenant.FromContext(r.Context())
+	if tenantID <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("no tenant context")))
+		return
+	}
+	coordinator, err := rs.studentDocumentCoordinator()
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	uploaded, err := common.ParseDocumentWithLimits(w, r, "file", maxStudentDocumentFile, maxStudentDocumentBody)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	defer common.CloseFile(uploaded.File)
+
+	storedName, err := apiDocuments.NewStoredName(common.DocumentFileExtension(uploaded.ContentType))
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	if err := rs.StudentDocumentService.QueueStudentDocumentFileCleanup(r.Context(), id, storedName); err != nil {
+		rs.getLogger().Error("student document upload cleanup intent failed",
+			"student_id", id, "error", err)
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	// The queued intent becomes eligible for the cleanup scheduler after a
+	// fixed delay, so every step that can still persist metadata for this
+	// object must be bounded well inside that delay: a stalled write or
+	// metadata transaction would otherwise commit a document row after the
+	// scheduler had already removed its bytes. The bookkeeping calls below
+	// deliberately stay on the request context so they still run once the
+	// upload deadline has fired.
+	uploadCtx, cancelUpload := context.WithTimeout(r.Context(), usersSvc.StudentDocumentUploadDeadline)
+	defer cancelUpload()
+
+	size, err := coordinator.Save(uploadCtx, tenantID, storedName, uploaded.File)
+	if err != nil {
+		if completeErr := rs.StudentDocumentService.MarkQueuedCleanupCompleteByFilename(r.Context(), storedName); completeErr != nil {
+			rs.getLogger().Warn("student document cleanup intent completion failed after write error",
+				"student_id", id, "error", completeErr)
+		}
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	doc, err := rs.StudentDocumentService.CreateStudentDocument(uploadCtx, usersSvc.CreateStudentDocumentInput{
+		StudentID:       id,
+		Category:        r.FormValue("category"),
+		FilenameDisplay: uploaded.Filename,
+		FilenameStored:  storedName,
+		SizeBytes:       size,
+		ContentType:     uploaded.ContentType,
+	}, actor)
+	if err != nil {
+		coordinator.ReleaseFailedUpload(r.Context(), tenantID, id, storedName, err)
+		renderStudentDocumentError(w, r, err)
+		return
+	}
+
+	resp := newStudentDocumentResponse(doc)
+	common.Respond(w, r, http.StatusCreated, &resp, "Student document uploaded successfully")
+}
+
+// downloadStudentDocument serves GET /{id}/documents/{documentId}/download.
+// The service refuses sensitive categories without an access-log row.
+func (rs *Resource) downloadStudentDocument(w http.ResponseWriter, r *http.Request) {
+	id, ok := common.ParseInt64IDWithError(w, r, "id", common.MsgInvalidStudentID)
+	if !ok {
+		return
+	}
+	docID, ok := common.ParseInt64IDWithError(w, r, "documentId", "invalid document ID")
+	if !ok {
+		return
+	}
+	actor, err := studentDocumentActor(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	coordinator, err := rs.studentDocumentCoordinator()
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	doc, err := rs.StudentDocumentService.ResolveStudentDocumentDownload(r.Context(), id, docID, actor)
+	if err != nil {
+		renderStudentDocumentError(w, r, err)
+		return
+	}
+
+	if !coordinator.Serve(w, r, tenant.FromContext(r.Context()), doc.FilenameStored, doc.FilenameDisplay, doc.ContentType) {
+		common.RenderError(w, r, common.ErrorNotFound(errors.New("document file not found")))
+	}
+}
+
+// deleteStudentDocument serves DELETE /{id}/documents/{documentId}: audited
+// soft delete of the metadata row, then removal of the bytes. The row
+// survives as the trail; the content does not.
+func (rs *Resource) deleteStudentDocument(w http.ResponseWriter, r *http.Request) {
+	id, ok := common.ParseInt64IDWithError(w, r, "id", common.MsgInvalidStudentID)
+	if !ok {
+		return
+	}
+	docID, ok := common.ParseInt64IDWithError(w, r, "documentId", "invalid document ID")
+	if !ok {
+		return
+	}
+	actor, err := studentDocumentActor(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+	coordinator, err := rs.studentDocumentCoordinator()
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+
+	doc, err := rs.StudentDocumentService.DeleteStudentDocument(r.Context(), id, docID, actor)
+	if err != nil {
+		if !modelBase.IsNoRows(err) {
+			renderStudentDocumentError(w, r, err)
+			return
+		}
+		// Already soft-deleted: the row is gone from the normal view but its
+		// bytes may still be there, so re-resolve and retry the removal
+		// instead of reporting a 404 the caller cannot act on.
+		doc, err = rs.StudentDocumentService.ResolveStudentDocumentCleanup(r.Context(), id, docID, actor)
+		if err != nil {
+			renderStudentDocumentError(w, r, err)
+			return
+		}
+	}
+
+	if !doc.IsFileDeleted() {
+		tenantID := tenant.FromContext(r.Context())
+		documentID, storedName := doc.ID, doc.FilenameStored
+		tenant.RegisterAfterCommit(r.Context(), func() {
+			coordinator.CleanupDocument(tenantID, id, documentID, storedName, "delete")
+		})
+	}
+	common.Respond(w, r, http.StatusOK, map[string]int64{"student_id": id}, "Student document deleted successfully")
+}

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -1798,6 +1798,27 @@ func (rs *Resource) deleteStudentTx(ctx context.Context, tenantID int64, student
 // and a child restored by a concurrent revert must not be deleted by a click
 // aimed at a graduate). Sharing one body keeps the companion lock protocol,
 // the photo capture and the person delete identical for both.
+// checkGraduateStateUnderLock re-decides the alumnus question against the
+// locked row, because the gate both delete paths passed ran on a snapshot.
+//
+// An ordinary delete must refuse a child who graduated in the meantime: it
+// HARD-deletes the very row graduation preserved, so a later transition revert
+// could never bring that child back and their history would be gone for good.
+// The purge refuses the mirror image — a revert that committed between the
+// caller picking the child off a list of graduates and this lock puts them
+// back in the roster, and deleting then removes an active child on the
+// strength of a state that no longer holds. Under the row lock the two
+// serialize either way (#405 review).
+func checkGraduateStateUnderLock(purgeGraduate bool, fresh *users.Student) error {
+	if fresh.IsAlumnus() == purgeGraduate {
+		return nil
+	}
+	if purgeGraduate {
+		return errStudentNoLongerGraduated
+	}
+	return errStudentGraduatedUnderLock
+}
+
 func (rs *Resource) deleteStudentTxMode(
 	ctx context.Context,
 	tenantID int64,
@@ -1830,25 +1851,8 @@ func (rs *Resource) deleteStudentTxMode(
 		return err
 	}
 
-	// The pre-transaction alumnus gate (parseAndGetStudent) ran on a snapshot. A
-	// grade transition that commits between that read and this lock turns the
-	// subject into a soft-deleted graduate, and a delete that proceeds anyway
-	// HARD-deletes the very row graduation preserved: the student and person rows
-	// are gone, so a transition revert can never bring that child back and their
-	// history is lost for good. Under the row lock the two serialize — either we
-	// hold the row and the transition waits for a child that no longer exists, or
-	// it committed first and we see the alumnus status and refuse (#405 review).
-	if !purgeGraduate && fresh.IsAlumnus() {
-		return errStudentGraduatedUnderLock
-	}
-
-	// Mirror image for the purge: the caller picked this child off a list of
-	// graduates, but a revert committing between that list and this lock puts
-	// them back in the roster. Deleting then would remove an active child on the
-	// strength of a state that no longer holds, so the purge refuses instead and
-	// the refreshed list simply no longer offers the action.
-	if purgeGraduate && !fresh.IsAlumnus() {
-		return errStudentNoLongerGraduated
+	if err := checkGraduateStateUnderLock(purgeGraduate, fresh); err != nil {
+		return err
 	}
 	if afterLock != nil {
 		if err := afterLock(ctx); err != nil {
@@ -1859,6 +1863,18 @@ func (rs *Resource) deleteStudentTxMode(
 	var photoToRemove string
 	if fresh.PhotoPath != nil {
 		photoToRemove = *fresh.PhotoPath
+	}
+
+	// Documents get the same treatment as the photo above, and for the same
+	// reason: this path hard-deletes the student row, so users.student_documents
+	// cascades away with it. Both recovery sweeps read those rows, so without an
+	// intent queued here — in this transaction, so it rolls back with a failed
+	// delete — the stored bytes would survive with nothing left pointing at
+	// them. That is the erasure this route exists to perform.
+	if rs.StudentDocumentService != nil {
+		if err := rs.StudentDocumentService.QueueCleanupForAllDocuments(ctx, student.ID); err != nil {
+			return err
+		}
 	}
 
 	if err := rs.StudentService.Delete(ctx, student.ID); err != nil {

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -48,6 +48,7 @@ DELETE /api/staff/{id}/vacation/opening
 DELETE /api/students/{id}
 DELETE /api/students/{id}/arrival-exceptions/{exceptionId}
 DELETE /api/students/{id}/arrival-notes/{noteId}
+DELETE /api/students/{id}/documents/{documentId}
 DELETE /api/students/{id}/photo
 DELETE /api/students/{id}/pickup-exceptions/{exceptionId}
 DELETE /api/students/{id}/pickup-notes/{noteId}
@@ -346,6 +347,8 @@ GET /api/students/{id}/companions
 GET /api/students/{id}/current-location
 GET /api/students/{id}/current-visit
 GET /api/students/{id}/delete-impact
+GET /api/students/{id}/documents
+GET /api/students/{id}/documents/{documentId}/download
 GET /api/students/{id}/enrollment-extra-fields
 GET /api/students/{id}/in-group-room
 GET /api/students/{id}/photo/{filename}
@@ -663,6 +666,7 @@ POST /api/students/pickup-times/bulk
 POST /api/students/status-days/bulk
 POST /api/students/{id}/arrival-exceptions
 POST /api/students/{id}/arrival-notes
+POST /api/students/{id}/documents
 POST /api/students/{id}/photo
 POST /api/students/{id}/pickup-exceptions
 POST /api/students/{id}/pickup-notes

--- a/backend/api/usercontext/usercontext_test.go
+++ b/backend/api/usercontext/usercontext_test.go
@@ -764,7 +764,12 @@ func TestUploadAvatar_Success(t *testing.T) {
 	assert.Contains(t, found.Avatar, "/uploads/avatars/global/")
 	assert.Equal(t, ".png", filepath.Ext(found.Avatar))
 
-	avatarFilePath := filepath.Join("public", filepath.FromSlash(found.Avatar[1:]))
+	// The upload goes through the storage backend, which resolves a relative
+	// upload directory against the discovered public dir. Rebuilding the path
+	// from the working directory would look for the avatar in the test
+	// package's directory instead of where the handler just wrote it.
+	avatarFilePath, err := common.ResolveStoredPath("public", found.Avatar, "/uploads/avatars/global/")
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = os.Remove(avatarFilePath)
 	})

--- a/backend/auth/authorize/permissions/constants.go
+++ b/backend/auth/authorize/permissions/constants.go
@@ -216,6 +216,19 @@ const (
 	StaffDocumentsHealth = ResourceStaffDocuments + ":health"
 )
 
+// Student document permissions (#777). student_documents:health gates
+// Attest, Impfnachweis and Medikamentenplan (Art. 9 GDPR health data);
+// student_documents:legal gates the Sorgerechtsnachweis, which is not Art. 9
+// but is at least as damaging in the wrong hands. Catalog-only like
+// staff_documents:health: admins match via the admin:* wildcard, and every
+// remaining category rides on users:update in the document service.
+const (
+	ResourceStudentDocuments = "student_documents"
+
+	StudentDocumentsHealth = ResourceStudentDocuments + ":health"
+	StudentDocumentsLegal  = ResourceStudentDocuments + ":legal"
+)
+
 // Grade Transition permissions (admin only)
 const (
 	GradeTransitionsRead   = "grade_transitions:read"

--- a/backend/database/migrations/001015270_student_documents.go
+++ b/backend/database/migrations/001015270_student_documents.go
@@ -1,0 +1,175 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	studentDocumentsVersion     = "1.15.270"
+	studentDocumentsDescription = "Create users.student_documents plus the student_documents:health and :legal permissions (#777)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     studentDocumentsVersion,
+		Description: studentDocumentsDescription,
+		DependsOn: []string{
+			compositePKIndexesVersion, // UNIQUE users.students(tenant_id, id) backs the composite FK
+		},
+	})
+
+	Migrations.MustRegister(studentDocumentsUp, studentDocumentsDown)
+}
+
+// studentDocumentsUp creates document storage for children (issue #777).
+//
+// Only metadata lives in the database — the bytes are stored through the
+// storage backend under student-documents/{tenant_id}/{uuid} and are
+// reachable exclusively through the permission-checked download handler
+// (there is no static file server for backend public/).
+//
+// deleted_at is a soft delete on purpose: the metadata row is the record of
+// what existed. The file itself is removed on delete; the row stays.
+// phoenix_tenant therefore gets no DELETE grant — deletion is an UPDATE
+// setting deleted_at/deleted_by.
+//
+// The cleanup table has NO foreign key to users.students, and that is
+// load-bearing rather than an oversight. Documents cascade away when a child
+// is deleted; a cleanup row that cascaded with them would leave the stored
+// bytes on disk with nothing left to point at them.
+//
+// student_documents:health gates Attest, Impfnachweis and Medikamentenplan
+// (Art. 9 GDPR health data); student_documents:legal gates the
+// Sorgerechtsnachweis. Both are catalog-only like staff_documents:health
+// (1.15.257): school admins match via the admin:* wildcard, and a dedicated
+// role can be granted either permission explicitly without another migration.
+// Every other category rides on the existing users:update permission. All
+// three checks live in the document service.
+func studentDocumentsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.270: Creating users.student_documents + student document permissions...")
+
+	if _, err := db.NewRaw(`
+		CREATE TABLE IF NOT EXISTS users.student_documents (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			student_id BIGINT NOT NULL,
+			category TEXT NOT NULL CHECK (category IN (
+				'betreuungsvertrag', 'abholvollmacht', 'schwimmerlaubnis',
+				'attest', 'impfnachweis', 'medikamentenplan',
+				'sorgerecht', 'sonstiges'
+			)),
+			filename_display TEXT NOT NULL,
+			filename_stored TEXT NOT NULL,
+			size_bytes BIGINT NOT NULL CHECK (size_bytes >= 0),
+			content_type TEXT NOT NULL,
+			uploaded_by BIGINT NOT NULL,
+			deleted_at TIMESTAMPTZ,
+			deleted_by BIGINT,
+			file_deleted_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT uq_student_documents_stored UNIQUE (filename_stored),
+			CONSTRAINT fk_student_documents_student
+				FOREIGN KEY (tenant_id, student_id)
+				REFERENCES users.students(tenant_id, id) ON DELETE CASCADE
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_student_documents_student
+			ON users.student_documents (tenant_id, student_id)
+			WHERE deleted_at IS NULL;
+
+		CREATE INDEX IF NOT EXISTS idx_student_documents_pending_file_cleanup
+			ON users.student_documents (tenant_id, student_id)
+			WHERE deleted_at IS NOT NULL AND file_deleted_at IS NULL;
+
+		CREATE TABLE IF NOT EXISTS users.student_document_file_cleanup (
+			id BIGSERIAL PRIMARY KEY,
+			tenant_id BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			owner_id BIGINT NOT NULL,
+			filename_stored TEXT NOT NULL,
+			retry_after TIMESTAMPTZ NOT NULL DEFAULT NOW() + INTERVAL '5 minutes',
+			cleaned_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT uq_student_document_file_cleanup UNIQUE (tenant_id, filename_stored)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_student_document_file_cleanup_pending
+			ON users.student_document_file_cleanup (tenant_id, retry_after, owner_id)
+			WHERE cleaned_at IS NULL;
+
+		DROP TRIGGER IF EXISTS update_student_documents_updated_at ON users.student_documents;
+		CREATE TRIGGER update_student_documents_updated_at
+		BEFORE UPDATE ON users.student_documents
+		FOR EACH ROW EXECUTE FUNCTION update_modified_column();
+
+		DROP TRIGGER IF EXISTS update_student_document_file_cleanup_updated_at ON users.student_document_file_cleanup;
+		CREATE TRIGGER update_student_document_file_cleanup_updated_at
+		BEFORE UPDATE ON users.student_document_file_cleanup
+		FOR EACH ROW EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE users.student_documents ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE users.student_documents FORCE ROW LEVEL SECURITY;
+		ALTER TABLE users.student_document_file_cleanup ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE users.student_document_file_cleanup FORCE ROW LEVEL SECURITY;
+
+		DO $$
+		BEGIN
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_policies
+				WHERE schemaname = 'users' AND tablename = 'student_documents'
+					AND policyname = 'tenant_isolation_users_student_documents'
+			) THEN
+				CREATE POLICY tenant_isolation_users_student_documents
+					ON users.student_documents
+					FOR ALL
+					USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+					WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+			END IF;
+
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_policies
+				WHERE schemaname = 'users' AND tablename = 'student_document_file_cleanup'
+					AND policyname = 'tenant_isolation_users_student_document_file_cleanup'
+			) THEN
+				CREATE POLICY tenant_isolation_users_student_document_file_cleanup
+					ON users.student_document_file_cleanup
+					FOR ALL
+					USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+					WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+			END IF;
+		END $$;
+
+		GRANT SELECT, INSERT, UPDATE ON users.student_documents TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE users.student_documents_id_seq TO phoenix_tenant;
+		REVOKE DELETE ON users.student_documents FROM phoenix_tenant;
+
+		GRANT SELECT, INSERT, UPDATE ON users.student_document_file_cleanup TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE users.student_document_file_cleanup_id_seq TO phoenix_tenant;
+		REVOKE DELETE ON users.student_document_file_cleanup FROM phoenix_tenant;
+
+		INSERT INTO auth.permissions (name, description, resource, action, is_system)
+		VALUES
+			('student_documents:health', 'Read, upload and delete child health documents (Attest, Impfnachweis, Medikamentenplan, Art. 9 GDPR health data)', 'student_documents', 'health', TRUE),
+			('student_documents:legal', 'Read, upload and delete child custody documents (Sorgerechtsnachweis)', 'student_documents', 'legal', TRUE)
+		ON CONFLICT (name) DO NOTHING;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed creating student documents objects: %w", err)
+	}
+	return nil
+}
+
+func studentDocumentsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.270: Dropping users.student_documents...")
+	if _, err := db.NewRaw(`
+		DELETE FROM auth.permissions WHERE name IN ('student_documents:health', 'student_documents:legal');
+		DROP TABLE IF EXISTS users.student_document_file_cleanup CASCADE;
+		DROP TABLE IF EXISTS users.student_documents CASCADE;
+	`).Exec(ctx); err != nil {
+		return fmt.Errorf("failed rolling back student documents objects: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015271_student_documents.go
+++ b/backend/database/migrations/001015271_student_documents.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	studentDocumentsVersion     = "1.15.270"
+	studentDocumentsVersion     = "1.15.271"
 	studentDocumentsDescription = "Create users.student_documents plus the student_documents:health and :legal permissions (#777)"
 )
 
@@ -49,7 +49,7 @@ func init() {
 // Every other category rides on the existing users:update permission. All
 // three checks live in the document service.
 func studentDocumentsUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.270: Creating users.student_documents + student document permissions...")
+	fmt.Println("Migration 1.15.271: Creating users.student_documents + student document permissions...")
 
 	if _, err := db.NewRaw(`
 		CREATE TABLE IF NOT EXISTS users.student_documents (
@@ -163,7 +163,7 @@ func studentDocumentsUp(ctx context.Context, db *bun.DB) error {
 }
 
 func studentDocumentsDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.270: Dropping users.student_documents...")
+	fmt.Println("Rolling back migration 1.15.271: Dropping users.student_documents...")
 	if _, err := db.NewRaw(`
 		DELETE FROM auth.permissions WHERE name IN ('student_documents:health', 'student_documents:legal');
 		DROP TABLE IF EXISTS users.student_document_file_cleanup CASCADE;

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -288,12 +288,23 @@ func (r *Repository[T, C]) MarkFileDeleted(ctx context.Context, documentID int64
 
 // QueueFileCleanup durably records the intent to remove an object before it
 // is written.
+//
+// A settled intent is REVIVED rather than left alone, and that is the whole
+// point of the conflict clause. Settling an intent is an update (cleaned_at is
+// stamped, the row stays), so every object that was ever uploaded leaves a
+// row behind under its stored name. Queueing again for that name — which is
+// exactly what deleting the owner does, since the document rows cascade away
+// and the intents are all that survive — would otherwise hit the unique index,
+// do nothing, and strand the bytes on disk with nothing left pointing at them.
 func (r *Repository[T, C]) QueueFileCleanup(ctx context.Context, cleanup C) error {
 	base.EnsureTenantID(ctx, cleanup)
 	if _, err := base.GetDB(ctx, r.db).NewInsert().
 		Model(cleanup).
 		ModelTableExpr(r.cleanupTableExpr()).
-		On("CONFLICT (tenant_id, filename_stored) DO NOTHING").
+		On("CONFLICT (tenant_id, filename_stored) DO UPDATE").
+		Set("cleaned_at = NULL").
+		Set("retry_after = EXCLUDED.retry_after").
+		Set("owner_id = EXCLUDED.owner_id").
 		Exec(ctx); err != nil {
 		return &modelBase.DatabaseError{Op: "queue " + r.cfg.Alias + " file cleanup", Err: err}
 	}

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -246,14 +246,19 @@ func (r *Repository[T, C]) ListDeletedPendingFileCleanupByOwnerID(ctx context.Co
 // soft_delete tag then hides the row from every subsequent select.
 func (r *Repository[T, C]) SoftDelete(ctx context.Context, document T, deletedBy int64) error {
 	now := time.Now()
-	res, err := base.GetDB(ctx, r.db).NewUpdate().
+	query := base.GetDB(ctx, r.db).NewUpdate().
 		Model(document).
 		ModelTableExpr(r.tableExpr()).
 		Set("deleted_at = ?", now).
 		Set("deleted_by = ?", deletedBy).
 		Where(r.col("id")+" = ?", document.GetID()).
-		Where(r.col("deleted_at") + " IS NULL").
-		Exec(ctx)
+		Where(r.col("deleted_at") + " IS NULL")
+	// Every other mutation here carries the same filter. RLS already blocks a
+	// cross-tenant match under phoenix_tenant, but not on a superuser or
+	// phoenix_admin connection — a CLI command or maintenance job would delete
+	// by bare id across schools.
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+	res, err := query.Exec(ctx)
 	if err != nil {
 		return &modelBase.DatabaseError{Op: "soft delete " + r.cfg.Alias, Err: err}
 	}

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -327,11 +327,23 @@ func (r *Repository[T, C]) ListQueuedFileCleanups(ctx context.Context) ([]C, err
 }
 
 // listQueuedFileCleanups returns eligible orphan rows and locks them for the
-// caller's transaction. FOR UPDATE SKIP LOCKED is load-bearing: an upload
-// whose metadata transaction has already stamped cleaned_at but not yet
-// committed holds that row lock, and skipping it keeps this pass from
-// deleting the bytes of a document that is about to exist. Concurrent cleanup
-// passes skip each other's rows for the same reason.
+// caller's transaction.
+//
+// CALLER CONTRACT: remove the objects inside the SAME transaction. The row
+// locks are released at COMMIT, so a caller that defers removal to an
+// after-commit hook holds no protection at all by the time it touches a byte.
+//
+// What the lock buys, for a caller that honours the contract: an upload whose
+// metadata transaction has already stamped cleaned_at but not yet committed
+// holds that row lock, and skipping it keeps this pass from deleting the bytes
+// of a document that is about to exist. Concurrent cleanup passes skip each
+// other's rows for the same reason.
+//
+// The lock is the second guard, not the only one. The first is time: an intent
+// stays ineligible for studentDocumentCleanupDelay (5 minutes) while the
+// upload that owns it is cut off after StudentDocumentUploadDeadline (2
+// minutes), so a still-running upload can never appear in this result set to
+// begin with.
 func (r *Repository[T, C]) listQueuedFileCleanups(ctx context.Context, where string, arg any) ([]C, error) {
 	var cleanups []C
 	query := base.GetDB(ctx, r.db).NewSelect().

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -1,0 +1,377 @@
+// Package documents implements the storage-agnostic metadata layer every
+// document feature shares: the rows, their soft delete, and the durable
+// cleanup intents that make an interrupted upload recoverable.
+//
+// It is generic over the concrete document type rather than polymorphic over
+// a single table. Each owning domain keeps its own table with a real
+// composite foreign key (tenant_id, owner_id), so the database still refuses
+// a document that points at nothing, while the ~300 lines of query plumbing
+// exist exactly once.
+package documents
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/documents"
+	"github.com/uptrace/bun"
+)
+
+// Config describes one domain's document tables. Every identifier here ends
+// up in SQL, so all values are compile-time constants owned by the domain's
+// repository constructor, never request input.
+type Config struct {
+	// Table is the schema-qualified document table ("users.student_documents").
+	Table string
+	// Alias is the SQL alias used for that table ("student_document").
+	Alias string
+	// OwnerColumn names the owning entity's FK column ("student_id").
+	OwnerColumn string
+	// OwnerTable and OwnerAlias support the "owner was deleted" cleanup
+	// sweep. OwnerTable empty disables that sweep for domains whose owner
+	// cannot be soft-deleted.
+	OwnerTable string
+	OwnerAlias string
+	// CleanupTable and CleanupAlias name the durable cleanup-intent table.
+	CleanupTable string
+	CleanupAlias string
+}
+
+// Repository is the generic document metadata repository.
+type Repository[T documents.Entity, C documents.CleanupEntity] struct {
+	db  *bun.DB
+	cfg Config
+}
+
+// NewRepository wires a document repository for one domain.
+func NewRepository[T documents.Entity, C documents.CleanupEntity](db *bun.DB, cfg Config) *Repository[T, C] {
+	return &Repository[T, C]{db: db, cfg: cfg}
+}
+
+func (r *Repository[T, C]) tableExpr() string {
+	return fmt.Sprintf(`%s AS "%s"`, r.cfg.Table, r.cfg.Alias)
+}
+
+func (r *Repository[T, C]) cleanupTableExpr() string {
+	return fmt.Sprintf(`%s AS "%s"`, r.cfg.CleanupTable, r.cfg.CleanupAlias)
+}
+
+func (r *Repository[T, C]) col(column string) string {
+	return fmt.Sprintf(`"%s".%s`, r.cfg.Alias, column)
+}
+
+func (r *Repository[T, C]) cleanupCol(column string) string {
+	return fmt.Sprintf(`"%s".%s`, r.cfg.CleanupAlias, column)
+}
+
+// newEntity allocates a concrete instance of the pointer type T so bun has
+// something to scan into.
+func newEntity[E any]() E {
+	entityType := reflect.TypeFor[E]()
+	if entityType.Kind() == reflect.Pointer {
+		entityType = entityType.Elem()
+	}
+	return reflect.New(entityType).Interface().(E)
+}
+
+// Create persists a document and hydrates database-generated values (ID and
+// timestamps) used in the upload response.
+func (r *Repository[T, C]) Create(ctx context.Context, document T) error {
+	if err := document.Validate(); err != nil {
+		return err
+	}
+	base.EnsureTenantID(ctx, document)
+	if _, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(document).
+		ModelTableExpr(r.tableExpr()).
+		Returning("*").
+		Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "create " + r.cfg.Alias, Err: err}
+	}
+	return nil
+}
+
+// FindForOwner loads one non-deleted document and enforces that it belongs to
+// the given owner — the URL names both IDs and they must agree.
+func (r *Repository[T, C]) FindForOwner(ctx context.Context, ownerID, documentID int64) (T, error) {
+	return r.findForOwner(ctx, ownerID, documentID, false)
+}
+
+// FindForOwnerIncludingDeleted loads a document by the owner/document URL pair
+// even after its metadata was soft-deleted, so filesystem cleanup can be
+// retried without exposing unrelated records.
+func (r *Repository[T, C]) FindForOwnerIncludingDeleted(ctx context.Context, ownerID, documentID int64) (T, error) {
+	return r.findForOwner(ctx, ownerID, documentID, true)
+}
+
+func (r *Repository[T, C]) findForOwner(ctx context.Context, ownerID, documentID int64, includeDeleted bool) (T, error) {
+	var zero T
+	document := newEntity[T]()
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(document).
+		ModelTableExpr(r.tableExpr()).
+		Where(r.col("id")+" = ?", documentID).
+		Where(r.col(r.cfg.OwnerColumn)+" = ?", ownerID)
+	if includeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+
+	if err := query.Scan(ctx); err != nil {
+		// sql.ErrNoRows stays wrapped so modelBase.IsNoRows classifies the
+		// missing (or foreign) document as a 404.
+		return zero, &modelBase.DatabaseError{Op: "find " + r.cfg.Alias, Err: err}
+	}
+	return document, nil
+}
+
+// ListByOwnerID returns the owner's non-deleted documents, newest first,
+// restricted to the given categories. The category list is the caller's
+// visibility set — empty means the caller may see no category at all, so the
+// result is empty without touching the database.
+func (r *Repository[T, C]) ListByOwnerID(ctx context.Context, ownerID int64, categories []string) ([]T, error) {
+	if len(categories) == 0 {
+		return []T{}, nil
+	}
+
+	var rows []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(r.tableExpr()).
+		Where(r.col(r.cfg.OwnerColumn)+" = ?", ownerID).
+		Where(r.col("category")+" IN (?)", bun.List(categories)).
+		Order("created_at DESC", "id DESC")
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list " + r.cfg.Alias, Err: err}
+	}
+	return rows, nil
+}
+
+// ListPendingFileCleanupByOwnerID returns documents whose stored bytes have
+// not been removed yet, including soft-deleted rows, for owner teardown.
+func (r *Repository[T, C]) ListPendingFileCleanupByOwnerID(ctx context.Context, ownerID int64) ([]T, error) {
+	var rows []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(r.tableExpr()).
+		Where(r.col(r.cfg.OwnerColumn)+" = ?", ownerID).
+		Where(r.col("file_deleted_at") + " IS NULL").
+		WhereAllWithDeleted()
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list pending " + r.cfg.Alias + " cleanup", Err: err}
+	}
+	return rows, nil
+}
+
+// ListOrphanedOwnerPendingFileCleanups returns every document whose owner is
+// soft-deleted and whose stored bytes still need removal. Domains without a
+// soft-deletable owner get an empty result.
+func (r *Repository[T, C]) ListOrphanedOwnerPendingFileCleanups(ctx context.Context) ([]T, error) {
+	if r.cfg.OwnerTable == "" {
+		return []T{}, nil
+	}
+	var rows []T
+	join := fmt.Sprintf(
+		`JOIN %s AS "%s" ON "%s".tenant_id = "%s".tenant_id AND "%s".id = "%s".%s`,
+		r.cfg.OwnerTable, r.cfg.OwnerAlias,
+		r.cfg.OwnerAlias, r.cfg.Alias,
+		r.cfg.OwnerAlias, r.cfg.Alias, r.cfg.OwnerColumn,
+	)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(r.tableExpr()).
+		Join(join).
+		Where(fmt.Sprintf(`"%s".deleted_at IS NOT NULL`, r.cfg.OwnerAlias)).
+		Where(r.col("file_deleted_at") + " IS NULL").
+		WhereAllWithDeleted()
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list orphaned " + r.cfg.Alias + " cleanup", Err: err}
+	}
+	return rows, nil
+}
+
+// ListDeletedPendingFileCleanups returns every soft-deleted document whose
+// stored bytes still need removal, independent of owner lifecycle state.
+func (r *Repository[T, C]) ListDeletedPendingFileCleanups(ctx context.Context) ([]T, error) {
+	var rows []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(r.tableExpr()).
+		Where(r.col("deleted_at") + " IS NOT NULL").
+		Where(r.col("file_deleted_at") + " IS NULL").
+		WhereAllWithDeleted()
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list deleted " + r.cfg.Alias + " cleanup", Err: err}
+	}
+	return rows, nil
+}
+
+// ListDeletedPendingFileCleanupByOwnerID limits retry candidates to
+// soft-deleted documents in the caller's visible categories.
+func (r *Repository[T, C]) ListDeletedPendingFileCleanupByOwnerID(ctx context.Context, ownerID int64, categories []string) ([]T, error) {
+	if len(categories) == 0 {
+		return []T{}, nil
+	}
+	var rows []T
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(r.tableExpr()).
+		Where(r.col(r.cfg.OwnerColumn)+" = ?", ownerID).
+		Where(r.col("category")+" IN (?)", bun.List(categories)).
+		Where(r.col("deleted_at") + " IS NOT NULL").
+		Where(r.col("file_deleted_at") + " IS NULL").
+		WhereAllWithDeleted()
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list pending deleted " + r.cfg.Alias + " cleanup", Err: err}
+	}
+	return rows, nil
+}
+
+// SoftDelete stamps deleted_at and deleted_by in one update. The model's
+// soft_delete tag then hides the row from every subsequent select.
+func (r *Repository[T, C]) SoftDelete(ctx context.Context, document T, deletedBy int64) error {
+	now := time.Now()
+	res, err := base.GetDB(ctx, r.db).NewUpdate().
+		Model(document).
+		ModelTableExpr(r.tableExpr()).
+		Set("deleted_at = ?", now).
+		Set("deleted_by = ?", deletedBy).
+		Where(r.col("id")+" = ?", document.GetID()).
+		Where(r.col("deleted_at") + " IS NULL").
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{Op: "soft delete " + r.cfg.Alias, Err: err}
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return &modelBase.DatabaseError{Op: "soft delete " + r.cfg.Alias, Err: err}
+	}
+	if affected == 0 {
+		return &modelBase.DatabaseError{Op: "soft delete " + r.cfg.Alias, Err: sql.ErrNoRows}
+	}
+	document.MarkSoftDeleted(now, deletedBy)
+	return nil
+}
+
+// MarkFileDeleted records that the stored bytes are gone so cleanup is never
+// retried for this document again.
+func (r *Repository[T, C]) MarkFileDeleted(ctx context.Context, documentID int64) error {
+	now := time.Now()
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model(newEntity[T]()).
+		ModelTableExpr(r.tableExpr()).
+		Set("file_deleted_at = ?", now).
+		Where(r.col("id")+" = ?", documentID).
+		Where(r.col("file_deleted_at") + " IS NULL").
+		WhereAllWithDeleted()
+	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "mark " + r.cfg.Alias + " file deleted", Err: err}
+	}
+	return nil
+}
+
+// QueueFileCleanup durably records the intent to remove an object before it
+// is written.
+func (r *Repository[T, C]) QueueFileCleanup(ctx context.Context, cleanup C) error {
+	base.EnsureTenantID(ctx, cleanup)
+	if _, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(cleanup).
+		ModelTableExpr(r.cleanupTableExpr()).
+		On("CONFLICT (tenant_id, filename_stored) DO NOTHING").
+		Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "queue " + r.cfg.Alias + " file cleanup", Err: err}
+	}
+	return nil
+}
+
+// ListQueuedFileCleanupByOwnerID returns eligible orphan rows for one owner.
+func (r *Repository[T, C]) ListQueuedFileCleanupByOwnerID(ctx context.Context, ownerID int64) ([]C, error) {
+	return r.listQueuedFileCleanups(ctx, r.cleanupCol("owner_id")+" = ?", ownerID)
+}
+
+// ListQueuedFileCleanups returns every eligible orphan row in the tenant.
+func (r *Repository[T, C]) ListQueuedFileCleanups(ctx context.Context) ([]C, error) {
+	return r.listQueuedFileCleanups(ctx, "", nil)
+}
+
+// listQueuedFileCleanups returns eligible orphan rows and locks them for the
+// caller's transaction. FOR UPDATE SKIP LOCKED is load-bearing: an upload
+// whose metadata transaction has already stamped cleaned_at but not yet
+// committed holds that row lock, and skipping it keeps this pass from
+// deleting the bytes of a document that is about to exist. Concurrent cleanup
+// passes skip each other's rows for the same reason.
+func (r *Repository[T, C]) listQueuedFileCleanups(ctx context.Context, where string, arg any) ([]C, error) {
+	var cleanups []C
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&cleanups).
+		ModelTableExpr(r.cleanupTableExpr()).
+		Where(r.cleanupCol("retry_after")+" <= ?", time.Now()).
+		Where(r.cleanupCol("cleaned_at") + " IS NULL").
+		For("UPDATE SKIP LOCKED")
+	if where != "" {
+		query = query.Where(where, arg)
+	}
+	query = base.WithTenantFilter(ctx, query, r.cfg.CleanupAlias)
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list queued " + r.cfg.Alias + " file cleanup", Err: err}
+	}
+	return cleanups, nil
+}
+
+// MarkQueuedFileCleanupComplete settles one intent by ID.
+func (r *Repository[T, C]) MarkQueuedFileCleanupComplete(ctx context.Context, cleanupID int64) error {
+	return r.markQueuedFileCleanupComplete(ctx, r.cleanupCol("id")+" = ?", cleanupID)
+}
+
+// MarkQueuedFileCleanupCompleteByFilename settles the intent belonging to one
+// stored object, which is how a successful upload retires its own intent.
+func (r *Repository[T, C]) MarkQueuedFileCleanupCompleteByFilename(ctx context.Context, filename string) error {
+	return r.markQueuedFileCleanupComplete(ctx, r.cleanupCol("filename_stored")+" = ?", filename)
+}
+
+// ActivateQueuedFileCleanupByFilename makes a failed upload eligible for retry
+// immediately after its inline cleanup failed.
+func (r *Repository[T, C]) ActivateQueuedFileCleanupByFilename(ctx context.Context, filename string) error {
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model(newEntity[C]()).
+		ModelTableExpr(r.cleanupTableExpr()).
+		Set("retry_after = ?", time.Now()).
+		Where(r.cleanupCol("filename_stored")+" = ?", filename).
+		Where(r.cleanupCol("cleaned_at") + " IS NULL")
+	query = base.WithTenantFilter(ctx, query, r.cfg.CleanupAlias)
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "activate queued " + r.cfg.Alias + " file cleanup", Err: err}
+	}
+	return nil
+}
+
+func (r *Repository[T, C]) markQueuedFileCleanupComplete(ctx context.Context, where string, arg any) error {
+	now := time.Now()
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model(newEntity[C]()).
+		ModelTableExpr(r.cleanupTableExpr()).
+		Set("cleaned_at = ?", now).
+		Where(where, arg).
+		Where(r.cleanupCol("cleaned_at") + " IS NULL")
+	query = base.WithTenantFilter(ctx, query, r.cfg.CleanupAlias)
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "mark queued " + r.cfg.Alias + " file cleanup complete", Err: err}
+	}
+	return nil
+}

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -223,6 +223,11 @@ func (r *Repository[T, C]) ListDeletedPendingFileCleanups(ctx context.Context) (
 
 // ListDeletedPendingFileCleanupByOwnerID limits retry candidates to
 // soft-deleted documents in the caller's visible categories.
+//
+// This one feeds the request path: the caller registers an after-commit hook
+// per row, each an unlink plus its own transaction. It is therefore capped at
+// documents.RequestCleanupRetryLimit rather than the sweep batch size — a page
+// view must never inherit a backlog.
 func (r *Repository[T, C]) ListDeletedPendingFileCleanupByOwnerID(ctx context.Context, ownerID int64, categories []string) ([]T, error) {
 	if len(categories) == 0 {
 		return []T{}, nil
@@ -235,7 +240,9 @@ func (r *Repository[T, C]) ListDeletedPendingFileCleanupByOwnerID(ctx context.Co
 		Where(r.col("category")+" IN (?)", bun.List(categories)).
 		Where(r.col("deleted_at") + " IS NOT NULL").
 		Where(r.col("file_deleted_at") + " IS NULL").
-		WhereAllWithDeleted()
+		WhereAllWithDeleted().
+		Order("id ASC").
+		Limit(documents.RequestCleanupRetryLimit)
 	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
 
 	if err := query.Scan(ctx, &rows); err != nil {

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -32,11 +32,6 @@ type Config struct {
 	Alias string
 	// OwnerColumn names the owning entity's FK column ("student_id").
 	OwnerColumn string
-	// OwnerTable and OwnerAlias support the "owner was deleted" cleanup
-	// sweep. OwnerTable empty disables that sweep for domains whose owner
-	// cannot be soft-deleted.
-	OwnerTable string
-	OwnerAlias string
 	// CleanupTable and CleanupAlias name the durable cleanup-intent table.
 	CleanupTable string
 	CleanupAlias string
@@ -168,35 +163,6 @@ func (r *Repository[T, C]) ListPendingFileCleanupByOwnerID(ctx context.Context, 
 
 	if err := query.Scan(ctx, &rows); err != nil {
 		return nil, &modelBase.DatabaseError{Op: "list pending " + r.cfg.Alias + " cleanup", Err: err}
-	}
-	return rows, nil
-}
-
-// ListOrphanedOwnerPendingFileCleanups returns every document whose owner is
-// soft-deleted and whose stored bytes still need removal. Domains without a
-// soft-deletable owner get an empty result.
-func (r *Repository[T, C]) ListOrphanedOwnerPendingFileCleanups(ctx context.Context) ([]T, error) {
-	if r.cfg.OwnerTable == "" {
-		return []T{}, nil
-	}
-	var rows []T
-	join := fmt.Sprintf(
-		`JOIN %s AS "%s" ON "%s".tenant_id = "%s".tenant_id AND "%s".id = "%s".%s`,
-		r.cfg.OwnerTable, r.cfg.OwnerAlias,
-		r.cfg.OwnerAlias, r.cfg.Alias,
-		r.cfg.OwnerAlias, r.cfg.Alias, r.cfg.OwnerColumn,
-	)
-	query := base.GetDB(ctx, r.db).NewSelect().
-		Model(&rows).
-		ModelTableExpr(r.tableExpr()).
-		Join(join).
-		Where(fmt.Sprintf(`"%s".deleted_at IS NOT NULL`, r.cfg.OwnerAlias)).
-		Where(r.col("file_deleted_at") + " IS NULL").
-		WhereAllWithDeleted()
-	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
-
-	if err := query.Scan(ctx, &rows); err != nil {
-		return nil, &modelBase.DatabaseError{Op: "list orphaned " + r.cfg.Alias + " cleanup", Err: err}
 	}
 	return rows, nil
 }

--- a/backend/database/repositories/documents/repository.go
+++ b/backend/database/repositories/documents/repository.go
@@ -210,7 +210,9 @@ func (r *Repository[T, C]) ListDeletedPendingFileCleanups(ctx context.Context) (
 		ModelTableExpr(r.tableExpr()).
 		Where(r.col("deleted_at") + " IS NOT NULL").
 		Where(r.col("file_deleted_at") + " IS NULL").
-		WhereAllWithDeleted()
+		WhereAllWithDeleted().
+		Order("id ASC").
+		Limit(documents.CleanupBatchSize)
 	query = base.WithTenantFilter(ctx, query, r.cfg.Alias)
 
 	if err := query.Scan(ctx, &rows); err != nil {
@@ -351,6 +353,8 @@ func (r *Repository[T, C]) listQueuedFileCleanups(ctx context.Context, where str
 		ModelTableExpr(r.cleanupTableExpr()).
 		Where(r.cleanupCol("retry_after")+" <= ?", time.Now()).
 		Where(r.cleanupCol("cleaned_at") + " IS NULL").
+		Order("id ASC").
+		Limit(documents.CleanupBatchSize).
 		For("UPDATE SKIP LOCKED")
 	if where != "" {
 		query = query.Where(where, arg)

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -86,7 +86,8 @@ type Factory struct {
 	StaffFinancialData userModels.StaffFinancialDataRepository
 
 	// Staff documents (#1424)
-	StaffDocument userModels.StaffDocumentRepository
+	StaffDocument   userModels.StaffDocumentRepository
+	StudentDocument userModels.StudentDocumentRepository
 
 	NotificationPreference userModels.NotificationPreferenceRepository
 
@@ -300,7 +301,8 @@ func NewFactory(db *bun.DB) *Factory {
 		StaffFinancialData: users.NewStaffFinancialDataRepository(db),
 
 		// Staff documents (#1424)
-		StaffDocument: users.NewStaffDocumentRepository(db),
+		StaffDocument:   users.NewStaffDocumentRepository(db),
+		StudentDocument: users.NewStudentDocumentRepository(db),
 
 		NotificationPreference: users.NewNotificationPreferenceRepository(db),
 

--- a/backend/database/repositories/users/student_document.go
+++ b/backend/database/repositories/users/student_document.go
@@ -19,10 +19,10 @@ type StudentDocumentRepository struct {
 // NewStudentDocumentRepository creates the student document metadata
 // repository.
 //
-// OwnerTable is intentionally left empty: children are hard-deleted, so there
-// is no "owner is soft-deleted" sweep to run. Their documents cascade away
-// and the stored bytes are reclaimed through cleanup intents queued before
-// the delete, which survive the cascade because they carry no student FK.
+// There is no "owner is soft-deleted" sweep here because children are
+// hard-deleted: their documents cascade away, and the stored bytes are
+// reclaimed through cleanup intents queued before the delete, which survive the
+// cascade because they carry no student FK.
 func NewStudentDocumentRepository(db *bun.DB) users.StudentDocumentRepository {
 	return &StudentDocumentRepository{
 		Repository: documents.NewRepository[*users.StudentDocument, *users.StudentDocumentFileCleanup](db, documents.Config{

--- a/backend/database/repositories/users/student_document.go
+++ b/backend/database/repositories/users/student_document.go
@@ -1,0 +1,36 @@
+package users
+
+import (
+	"github.com/moto-nrw/project-phoenix/database/repositories/documents"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/uptrace/bun"
+)
+
+// StudentDocumentRepository implements users.StudentDocumentRepository (#777).
+//
+// The whole implementation is the generic document repository plus a table
+// description. Everything that used to be copied per domain — soft delete,
+// tenant filtering, the FOR UPDATE SKIP LOCKED cleanup scan — lives once in
+// database/repositories/documents.
+type StudentDocumentRepository struct {
+	*documents.Repository[*users.StudentDocument, *users.StudentDocumentFileCleanup]
+}
+
+// NewStudentDocumentRepository creates the student document metadata
+// repository.
+//
+// OwnerTable is intentionally left empty: children are hard-deleted, so there
+// is no "owner is soft-deleted" sweep to run. Their documents cascade away
+// and the stored bytes are reclaimed through cleanup intents queued before
+// the delete, which survive the cascade because they carry no student FK.
+func NewStudentDocumentRepository(db *bun.DB) users.StudentDocumentRepository {
+	return &StudentDocumentRepository{
+		Repository: documents.NewRepository[*users.StudentDocument, *users.StudentDocumentFileCleanup](db, documents.Config{
+			Table:        "users.student_documents",
+			Alias:        "student_document",
+			OwnerColumn:  "student_id",
+			CleanupTable: "users.student_document_file_cleanup",
+			CleanupAlias: "student_document_file_cleanup",
+		}),
+	}
+}

--- a/backend/database/repositories/users/student_document_test.go
+++ b/backend/database/repositories/users/student_document_test.go
@@ -234,3 +234,38 @@ func TestStudentDocumentRepository_CleanupSweepIsBounded(t *testing.T) {
 	assert.Len(t, queued, documentModels.CleanupBatchSize,
 		"one pass must stop at the batch size, leaving the rest for the next tick")
 }
+
+// TestStudentDocumentRepository_RequestRetryIsBounded pins the tighter cap on
+// the query that feeds the request path. Each returned row becomes an unlink
+// plus a transaction after the response, so a page view must never inherit a
+// backlog left by an unreachable storage backend.
+func TestStudentDocumentRepository_RequestRetryIsBounded(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Rueckstand", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-backlog-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	overLimit := documentModels.RequestCleanupRetryLimit + 3
+	ids := make([]int64, 0, overLimit)
+	for i := range overLimit {
+		doc := newTestStudentDocument(student.ID, account.ID,
+			userModels.StudentDocumentCategorySonstiges,
+			fmt.Sprintf("rueckstand-%d.pdf", i),
+			fmt.Sprintf("rueckstand-%d-%d.pdf", time.Now().UnixNano(), i))
+		require.NoError(t, repo.Create(ctx, doc))
+		require.NoError(t, repo.SoftDelete(ctx, doc, account.ID))
+		ids = append(ids, doc.ID)
+	}
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", ids...)
+
+	pending, err := repo.ListDeletedPendingFileCleanupByOwnerID(ctx, student.ID, userModels.StudentDocumentCategories)
+	require.NoError(t, err)
+	assert.Len(t, pending, documentModels.RequestCleanupRetryLimit,
+		"one page view retries at most the request limit, the scheduler takes the rest")
+}

--- a/backend/database/repositories/users/student_document_test.go
+++ b/backend/database/repositories/users/student_document_test.go
@@ -1,6 +1,7 @@
 package users_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
 )
 
 // newTestStudentDocument builds a valid document row for a student.
@@ -192,6 +194,161 @@ func TestStudentDocumentRepository_CleanupIntentLifecycle(t *testing.T) {
 	queued, err = repo.ListQueuedFileCleanups(ctx)
 	require.NoError(t, err)
 	assert.Contains(t, storedNames(queued), name, "a re-queued object must become eligible again")
+}
+
+// TestStudentDocumentRepository_CreateRejectsInvalidRow proves the validation
+// runs before the insert. A row without a stored filename would be an orphan
+// from the moment it is written: nothing could ever find its bytes again, and
+// no cleanup pass could reclaim them.
+func TestStudentDocumentRepository_CreateRejectsInvalidRow(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Ungueltig", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-invalid-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	doc := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategoryAttest, "attest.pdf", "")
+	require.Error(t, repo.Create(ctx, doc))
+	assert.Zero(t, doc.ID, "a rejected row must never reach the table")
+}
+
+// TestStudentDocumentRepository_FindIncludingDeletedFeedsCleanupRetry covers the
+// lookup the cleanup retry depends on: once a document is soft-deleted the
+// ordinary find stops seeing it, but the handler still has to authorize a retry
+// of the unlink against the very row whose bytes are pending.
+func TestStudentDocumentRepository_FindIncludingDeletedFeedsCleanupRetry(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Nachlauf", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	otherStudent := testpkg.CreateTestStudent(t, db, "Fremd", "Nachlauf", "1b")
+	defer testpkg.CleanupActivityFixtures(t, db, otherStudent.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-retry-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	doc := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategorySonstiges, "nachlauf.pdf", storedName(t))
+	require.NoError(t, repo.Create(ctx, doc))
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", doc.ID)
+	require.NoError(t, repo.SoftDelete(ctx, doc, account.ID))
+
+	_, err := repo.FindForOwner(ctx, student.ID, doc.ID)
+	require.Error(t, err, "the ordinary lookup must not resurrect a deleted document")
+
+	found, err := repo.FindForOwnerIncludingDeleted(ctx, student.ID, doc.ID)
+	require.NoError(t, err)
+	assert.Equal(t, doc.ID, found.ID)
+	require.NotNil(t, found.DeletedAt)
+
+	// The owner check still holds: seeing deleted rows must not become a way
+	// to read another child's paperwork.
+	_, err = repo.FindForOwnerIncludingDeleted(ctx, otherStudent.ID, doc.ID)
+	require.Error(t, err)
+	assert.True(t, modelBase.IsNoRows(err), "foreign lookup must read as not-found")
+}
+
+// TestStudentDocumentRepository_PendingCleanupCoversLiveAndDeletedRows covers
+// what the child-deletion path reads. It has to see documents that are still
+// live, because the cascade is about to remove their rows while the bytes stay
+// on disk.
+func TestStudentDocumentRepository_PendingCleanupCoversLiveAndDeletedRows(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Abbau", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-teardown-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	live := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategorySonstiges, "aktiv.pdf", storedName(t)+"-live")
+	require.NoError(t, repo.Create(ctx, live))
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", live.ID)
+
+	gone := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategoryAbholvollmacht, "geloescht.pdf", storedName(t)+"-gone")
+	require.NoError(t, repo.Create(ctx, gone))
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", gone.ID)
+	require.NoError(t, repo.SoftDelete(ctx, gone, account.ID))
+
+	pending, err := repo.ListPendingFileCleanupByOwnerID(ctx, student.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int64{live.ID, gone.ID}, documentIDs(pending),
+		"deleting a child must reclaim the bytes of live documents too")
+
+	// The tenant-wide scheduler sweep only picks up soft-deleted rows: a live
+	// document's bytes are still in use.
+	deleted, err := repo.ListDeletedPendingFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, documentIDs(deleted), gone.ID)
+	assert.NotContains(t, documentIDs(deleted), live.ID)
+
+	// Once the bytes are gone neither list may offer the row again.
+	require.NoError(t, repo.MarkFileDeleted(ctx, gone.ID))
+	deleted, err = repo.ListDeletedPendingFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, documentIDs(deleted), gone.ID)
+	pending, err = repo.ListPendingFileCleanupByOwnerID(ctx, student.ID)
+	require.NoError(t, err)
+	assert.NotContains(t, documentIDs(pending), gone.ID)
+}
+
+// TestStudentDocumentRepository_QueuedCleanupsAreScopedAndSettleable covers the
+// per-owner view of the intent queue and settling an intent by its ID, which is
+// how the scheduler retires an object it has just unlinked.
+func TestStudentDocumentRepository_QueuedCleanupsAreScopedAndSettleable(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Warteschlange", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	otherStudent := testpkg.CreateTestStudent(t, db, "Warteschlange", "Andere", "1b")
+	defer testpkg.CleanupActivityFixtures(t, db, otherStudent.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	mine := queueCleanupIntent(t, db, repo, ctx, student.ID, storedName(t)+"-mine")
+	theirs := queueCleanupIntent(t, db, repo, ctx, otherStudent.ID, storedName(t)+"-theirs")
+
+	scoped, err := repo.ListQueuedFileCleanupByOwnerID(ctx, student.ID)
+	require.NoError(t, err)
+	assert.Contains(t, storedNames(scoped), mine.FilenameStored)
+	assert.NotContains(t, storedNames(scoped), theirs.FilenameStored)
+
+	require.NoError(t, repo.MarkQueuedFileCleanupComplete(ctx, mine.ID))
+	scoped, err = repo.ListQueuedFileCleanupByOwnerID(ctx, student.ID)
+	require.NoError(t, err)
+	assert.NotContains(t, storedNames(scoped), mine.FilenameStored,
+		"a settled intent must not be handed out again")
+}
+
+func queueCleanupIntent(t *testing.T, db *bun.DB, repo userModels.StudentDocumentRepository, ctx context.Context, ownerID int64, name string) *userModels.StudentDocumentFileCleanup {
+	t.Helper()
+	cleanup := &userModels.StudentDocumentFileCleanup{}
+	cleanup.OwnerID = ownerID
+	cleanup.FilenameStored = name
+	cleanup.RetryAfter = time.Now().Add(-time.Minute)
+	require.NoError(t, repo.QueueFileCleanup(ctx, cleanup))
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, db, "users.student_document_file_cleanup", cleanup.ID) })
+	return cleanup
+}
+
+func documentIDs(docs []*userModels.StudentDocument) []int64 {
+	ids := make([]int64, 0, len(docs))
+	for _, doc := range docs {
+		ids = append(ids, doc.ID)
+	}
+	return ids
 }
 
 func storedNames(cleanups []*userModels.StudentDocumentFileCleanup) []string {

--- a/backend/database/repositories/users/student_document_test.go
+++ b/backend/database/repositories/users/student_document_test.go
@@ -178,13 +178,19 @@ func TestStudentDocumentRepository_CleanupIntentLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, storedNames(queued), name, "a settled intent must not come back")
 
-	// Queueing the same object twice must not raise — the upload path and the
-	// deletion path can both reach for it.
+	// Queueing the same object again REVIVES the settled intent. Settling is
+	// an update, so the row outlives the upload it belonged to; deleting the
+	// child re-queues under the same stored name, and if that were a no-op the
+	// bytes would stay on disk with nothing left pointing at them.
 	duplicate := &userModels.StudentDocumentFileCleanup{}
 	duplicate.OwnerID = student.ID
 	duplicate.FilenameStored = name
 	duplicate.RetryAfter = time.Now()
 	require.NoError(t, repo.QueueFileCleanup(ctx, duplicate))
+
+	queued, err = repo.ListQueuedFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, storedNames(queued), name, "a re-queued object must become eligible again")
 }
 
 func storedNames(cleanups []*userModels.StudentDocumentFileCleanup) []string {

--- a/backend/database/repositories/users/student_document_test.go
+++ b/backend/database/repositories/users/student_document_test.go
@@ -1,0 +1,196 @@
+package users_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStudentDocument builds a valid document row for a student.
+func newTestStudentDocument(studentID, accountID int64, category, display, stored string) *userModels.StudentDocument {
+	doc := &userModels.StudentDocument{StudentID: studentID}
+	doc.Category = category
+	doc.FilenameDisplay = display
+	doc.FilenameStored = stored
+	doc.SizeBytes = 1234
+	doc.ContentType = "application/pdf"
+	doc.UploadedBy = accountID
+	return doc
+}
+
+func storedName(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("%d-%s.pdf", time.Now().UnixNano(), t.Name())
+}
+
+// TestStudentDocumentRepository_CreateAndList also proves the embedded
+// documents.File model maps onto users.student_documents: every shared column
+// comes from the embed, so a broken mapping fails right here rather than in
+// production.
+func TestStudentDocumentRepository_CreateAndList(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Doku", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	doc := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategoryAttest, "attest.pdf", storedName(t))
+	require.NoError(t, repo.Create(ctx, doc))
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", doc.ID)
+
+	require.NotZero(t, doc.ID, "Create must hydrate the generated ID")
+	require.False(t, doc.CreatedAt.IsZero(), "Create must hydrate created_at")
+	assert.Equal(t, student.TenantID, doc.TenantID, "tenant_id must be filled from context")
+	assert.Equal(t, int64(1234), doc.SizeBytes)
+
+	docs, err := repo.ListByOwnerID(ctx, student.ID, []string{userModels.StudentDocumentCategoryAttest})
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Equal(t, "attest.pdf", docs[0].FilenameDisplay)
+	assert.Equal(t, doc.FilenameStored, docs[0].FilenameStored)
+
+	// A category the caller cannot see must not leak through the list.
+	other, err := repo.ListByOwnerID(ctx, student.ID, []string{userModels.StudentDocumentCategorySonstiges})
+	require.NoError(t, err)
+	assert.Empty(t, other)
+
+	// No visible category at all means no query and no rows.
+	none, err := repo.ListByOwnerID(ctx, student.ID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+func TestStudentDocumentRepository_FindForOwnerRejectsForeignStudent(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Eigen", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	otherStudent := testpkg.CreateTestStudent(t, db, "Fremd", "Kind", "1b")
+	defer testpkg.CleanupActivityFixtures(t, db, otherStudent.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-foreign-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	doc := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategorySonstiges, "sonstiges.pdf", storedName(t))
+	require.NoError(t, repo.Create(ctx, doc))
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", doc.ID)
+
+	found, err := repo.FindForOwner(ctx, student.ID, doc.ID)
+	require.NoError(t, err)
+	assert.Equal(t, doc.ID, found.ID)
+
+	// The URL names both IDs; a mismatched pair must be a 404, not a leak.
+	_, err = repo.FindForOwner(ctx, otherStudent.ID, doc.ID)
+	require.Error(t, err)
+	assert.True(t, modelBase.IsNoRows(err), "foreign student lookup must read as not-found")
+}
+
+func TestStudentDocumentRepository_SoftDeleteHidesRowButKeepsIt(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Lösch", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-doc-del-%d@example.test", time.Now().UnixNano()))
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	doc := newTestStudentDocument(student.ID, account.ID, userModels.StudentDocumentCategoryBetreuungsvertrag, "vertrag.pdf", storedName(t))
+	require.NoError(t, repo.Create(ctx, doc))
+	defer testpkg.CleanupTableRecords(t, db, "users.student_documents", doc.ID)
+
+	require.NoError(t, repo.SoftDelete(ctx, doc, account.ID))
+	require.NotNil(t, doc.DeletedAt, "SoftDelete must stamp the in-memory row")
+	require.NotNil(t, doc.DeletedBy)
+
+	// Gone from the normal view...
+	visible, err := repo.ListByOwnerID(ctx, student.ID, userModels.StudentDocumentCategories)
+	require.NoError(t, err)
+	assert.Empty(t, visible)
+
+	// ...but still there as the record that it once existed, and still
+	// pending file cleanup.
+	pending, err := repo.ListDeletedPendingFileCleanupByOwnerID(ctx, student.ID, userModels.StudentDocumentCategories)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, doc.ID, pending[0].ID)
+
+	require.NoError(t, repo.MarkFileDeleted(ctx, doc.ID))
+	afterCleanup, err := repo.ListDeletedPendingFileCleanupByOwnerID(ctx, student.ID, userModels.StudentDocumentCategories)
+	require.NoError(t, err)
+	assert.Empty(t, afterCleanup, "a document whose bytes are gone must not be retried")
+
+	// Deleting twice must not silently succeed — the second call has nothing
+	// left to soft-delete.
+	require.Error(t, repo.SoftDelete(ctx, doc, account.ID))
+}
+
+func TestStudentDocumentRepository_CleanupIntentLifecycle(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Waise", "Kind", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	name := storedName(t)
+	cleanup := &userModels.StudentDocumentFileCleanup{}
+	cleanup.OwnerID = student.ID
+	cleanup.FilenameStored = name
+	// In the future: an intent must not be eligible while its upload may
+	// still be running.
+	cleanup.RetryAfter = time.Now().Add(time.Hour)
+	require.NoError(t, repo.QueueFileCleanup(ctx, cleanup))
+	require.NotZero(t, cleanup.ID)
+	defer testpkg.CleanupTableRecords(t, db, "users.student_document_file_cleanup", cleanup.ID)
+
+	queued, err := repo.ListQueuedFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, storedNames(queued), name, "an intent in the future must not be eligible yet")
+
+	// A failed upload activates its intent for immediate retry.
+	require.NoError(t, repo.ActivateQueuedFileCleanupByFilename(ctx, name))
+	queued, err = repo.ListQueuedFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, storedNames(queued), name)
+
+	require.NoError(t, repo.MarkQueuedFileCleanupCompleteByFilename(ctx, name))
+	queued, err = repo.ListQueuedFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, storedNames(queued), name, "a settled intent must not come back")
+
+	// Queueing the same object twice must not raise — the upload path and the
+	// deletion path can both reach for it.
+	duplicate := &userModels.StudentDocumentFileCleanup{}
+	duplicate.OwnerID = student.ID
+	duplicate.FilenameStored = name
+	duplicate.RetryAfter = time.Now()
+	require.NoError(t, repo.QueueFileCleanup(ctx, duplicate))
+}
+
+func storedNames(cleanups []*userModels.StudentDocumentFileCleanup) []string {
+	names := make([]string, 0, len(cleanups))
+	for _, cleanup := range cleanups {
+		names = append(names, cleanup.FilenameStored)
+	}
+	return names
+}

--- a/backend/database/repositories/users/student_document_test.go
+++ b/backend/database/repositories/users/student_document_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	documentModels "github.com/moto-nrw/project-phoenix/models/documents"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -199,4 +200,37 @@ func storedNames(cleanups []*userModels.StudentDocumentFileCleanup) []string {
 		names = append(names, cleanup.FilenameStored)
 	}
 	return names
+}
+
+// TestStudentDocumentRepository_CleanupSweepIsBounded pins the cap the
+// scheduler depends on. The sweep runs inside one tenant transaction, so an
+// uncapped pass after a cohort deletion would hold a connection through
+// thousands of unlink-and-mark pairs, and a deadline firing mid-pass would roll
+// back every completion mark it had written.
+func TestStudentDocumentRepository_CleanupSweepIsBounded(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	student := testpkg.CreateTestStudent(t, db, "Viele", "Dokumente", "1a")
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	repo := repositories.NewFactory(db).StudentDocument
+	ctx := testpkg.TenantContext(student.TenantID)
+
+	overBatch := documentModels.CleanupBatchSize + 5
+	ids := make([]int64, 0, overBatch)
+	for i := range overBatch {
+		cleanup := &userModels.StudentDocumentFileCleanup{}
+		cleanup.OwnerID = student.ID
+		cleanup.FilenameStored = fmt.Sprintf("bounded-%d-%d.pdf", time.Now().UnixNano(), i)
+		cleanup.RetryAfter = time.Now().Add(-time.Minute)
+		require.NoError(t, repo.QueueFileCleanup(ctx, cleanup))
+		ids = append(ids, cleanup.ID)
+	}
+	defer testpkg.CleanupTableRecords(t, db, "users.student_document_file_cleanup", ids...)
+
+	queued, err := repo.ListQueuedFileCleanups(ctx)
+	require.NoError(t, err)
+	assert.Len(t, queued, documentModels.CleanupBatchSize,
+		"one pass must stop at the batch size, leaving the rest for the next tick")
 }

--- a/backend/internal/storage/key.go
+++ b/backend/internal/storage/key.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"path"
+	"strconv"
+	"strings"
+)
+
+// Key builds a storage key from segments, rejecting anything that could
+// escape the backend root. It is the only supported way to construct a key:
+// hand-built strings bypass the traversal check that makes the Backend
+// contract safe.
+func Key(segments ...string) (string, error) {
+	if len(segments) == 0 {
+		return "", ErrInvalidKey
+	}
+	clean := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", ErrInvalidKey
+		}
+		if strings.ContainsAny(segment, `/\`) {
+			return "", ErrInvalidKey
+		}
+		if strings.Contains(segment, "..") {
+			return "", ErrInvalidKey
+		}
+		clean = append(clean, segment)
+	}
+	key := path.Join(clean...)
+	if key == "" || strings.HasPrefix(key, "/") || strings.Contains(key, "..") {
+		return "", ErrInvalidKey
+	}
+	return key, nil
+}
+
+// TenantKey builds the canonical per-tenant key for a document-style upload:
+// {kind}/{tenantID}/{name}. Tenant isolation on disk mirrors the row-level
+// isolation in the database, so a stray filename can never resolve into
+// another school's directory.
+func TenantKey(kind string, tenantID int64, name string) (string, error) {
+	if tenantID <= 0 {
+		return "", ErrInvalidKey
+	}
+	return Key(kind, strconv.FormatInt(tenantID, 10), name)
+}

--- a/backend/internal/storage/local.go
+++ b/backend/internal/storage/local.go
@@ -57,11 +57,34 @@ func (l *Local) resolve(key string) (string, error) {
 	return full, nil
 }
 
+// contextReader aborts a copy between chunks once ctx is done.
+//
+// It bounds the io.Copy LOOP, not a single blocked syscall: a read that hangs
+// inside the kernel still hangs. That is enough for what this guards — a
+// caller whose deadline is the only thing keeping its cleanup bookkeeping
+// consistent must not keep writing for minutes after that deadline passed.
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *contextReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}
+
 // Save writes r to the resolved path. The object is written directly rather
 // than through a temp file and rename: a failed write is removed before the
 // error returns, and every consumer treats a missing object as "upload did
 // not happen" anyway.
-func (l *Local) Save(_ context.Context, key string, r io.Reader, opts SaveOptions) (int64, error) {
+//
+// The copy honours ctx. An upload whose deadline exists to keep it inside its
+// cleanup window would otherwise be free to finish minutes late, re-creating
+// bytes whose cleanup intent the scheduler had already settled — leaving an
+// object no sweep can find again.
+func (l *Local) Save(ctx context.Context, key string, r io.Reader, opts SaveOptions) (int64, error) {
 	full, err := l.resolve(key)
 	if err != nil {
 		return 0, err
@@ -96,10 +119,15 @@ func (l *Local) Save(_ context.Context, key string, r io.Reader, opts SaveOption
 		return 0, errors.New("storage: failed to secure object")
 	}
 
-	written, copyErr := io.Copy(dst, r)
+	written, copyErr := io.Copy(dst, &contextReader{ctx: ctx, r: r})
 	closeErr := dst.Close()
 	if copyErr != nil || closeErr != nil {
 		_ = os.Remove(full)
+		if copyErr != nil && ctx.Err() != nil {
+			// Surface the cause: the caller decides differently for a
+			// deadline than for a disk error.
+			return 0, ctx.Err()
+		}
 		return 0, errors.New("storage: failed to write object")
 	}
 	return written, nil

--- a/backend/internal/storage/local.go
+++ b/backend/internal/storage/local.go
@@ -1,0 +1,160 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	publicDirMode  os.FileMode = 0o755
+	publicFileMode os.FileMode = 0o644
+	// Private objects stay owner-only in both directions: a 0700 directory
+	// keeps the names out of reach even when a file mode is later widened.
+	privateDirMode  os.FileMode = 0o700
+	privateFileMode os.FileMode = 0o600
+)
+
+// Local stores objects on the local filesystem below Root.
+//
+// Every path is rebuilt from Root plus the validated key and then verified to
+// still live inside Root, so a key that slips past Key() validation still
+// cannot escape.
+type Local struct {
+	Root string
+}
+
+// NewLocal returns a filesystem backend rooted at root.
+func NewLocal(root string) *Local {
+	return &Local{Root: root}
+}
+
+// localFile adapts *os.File to Object by caching the modification time
+// captured at open time.
+type localFile struct {
+	*os.File
+	modTime time.Time
+}
+
+func (f *localFile) ModTime() time.Time { return f.modTime }
+
+func (l *Local) resolve(key string) (string, error) {
+	if key == "" || strings.Contains(key, "..") || strings.HasPrefix(key, "/") {
+		return "", ErrInvalidKey
+	}
+	absRoot, err := filepath.Abs(l.Root)
+	if err != nil {
+		return "", ErrInvalidKey
+	}
+	full := filepath.Join(absRoot, filepath.FromSlash(key))
+	if full != absRoot && !strings.HasPrefix(full, absRoot+string(os.PathSeparator)) {
+		return "", ErrInvalidKey
+	}
+	return full, nil
+}
+
+// Save writes r to the resolved path. The object is written directly rather
+// than through a temp file and rename: a failed write is removed before the
+// error returns, and every consumer treats a missing object as "upload did
+// not happen" anyway.
+func (l *Local) Save(_ context.Context, key string, r io.Reader, opts SaveOptions) (int64, error) {
+	full, err := l.resolve(key)
+	if err != nil {
+		return 0, err
+	}
+
+	dirMode, fileMode := publicDirMode, publicFileMode
+	if opts.Private {
+		dirMode, fileMode = privateDirMode, privateFileMode
+	}
+
+	dir := filepath.Dir(full)
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return 0, errors.New("storage: failed to create directory")
+	}
+	if opts.Private {
+		// MkdirAll leaves an existing directory's mode alone, so a directory
+		// created before this key became private is tightened here.
+		if err := os.Chmod(dir, privateDirMode); err != nil {
+			return 0, errors.New("storage: failed to secure directory")
+		}
+	}
+
+	dst, err := os.OpenFile(full, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
+	if err != nil {
+		return 0, errors.New("storage: failed to create object")
+	}
+	// Chmod after create: the open mode is masked by umask, which would leave
+	// a private object group-readable on a permissive host.
+	if err := dst.Chmod(fileMode); err != nil {
+		_ = dst.Close()
+		_ = os.Remove(full)
+		return 0, errors.New("storage: failed to secure object")
+	}
+
+	written, copyErr := io.Copy(dst, r)
+	closeErr := dst.Close()
+	if copyErr != nil || closeErr != nil {
+		_ = os.Remove(full)
+		return 0, errors.New("storage: failed to write object")
+	}
+	return written, nil
+}
+
+// Open returns the stored object, or ErrNotFound.
+func (l *Local) Open(_ context.Context, key string) (Object, error) {
+	full, err := l.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, errors.New("storage: failed to open object")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, errors.New("storage: failed to stat object")
+	}
+	if info.IsDir() {
+		_ = file.Close()
+		return nil, ErrNotFound
+	}
+	return &localFile{File: file, modTime: info.ModTime()}, nil
+}
+
+// Remove deletes the object. A missing object is success so cleanup retries
+// converge instead of looping forever on an already-removed file.
+func (l *Local) Remove(_ context.Context, key string) error {
+	full, err := l.resolve(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(full); err != nil && !os.IsNotExist(err) {
+		return errors.New("storage: failed to remove object")
+	}
+	return nil
+}
+
+// Stat returns the stored size in bytes.
+func (l *Local) Stat(_ context.Context, key string) (int64, error) {
+	full, err := l.resolve(key)
+	if err != nil {
+		return 0, err
+	}
+	info, err := os.Stat(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, ErrNotFound
+		}
+		return 0, errors.New("storage: failed to stat object")
+	}
+	return info.Size(), nil
+}

--- a/backend/internal/storage/local_test.go
+++ b/backend/internal/storage/local_test.go
@@ -141,3 +141,66 @@ func TestLocalOpenMissingReturnsNotFound(t *testing.T) {
 		t.Fatalf("Stat missing = %v, want ErrNotFound", err)
 	}
 }
+
+// TestLocalSaveHonoursContext covers the deadline the document upload depends
+// on. Its cleanup intent becomes eligible three minutes after that deadline,
+// so a write allowed to run past it can re-create bytes whose intent the
+// scheduler already settled — an object no sweep can find again.
+func TestLocalSaveHonoursContext(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := backend.Save(ctx, "docs/1/late.pdf", bytes.NewReader([]byte("payload")), SaveOptions{Private: true})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Save with a done context = %v, want context.Canceled", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "1", "late.pdf")); !os.IsNotExist(err) {
+		t.Fatal("an aborted write must not leave its partial object behind")
+	}
+}
+
+// TestLocalSaveStopsMidStream proves the abort happens between chunks rather
+// than only before the first one: a copy already in flight when the deadline
+// passes must stop, not run to completion.
+func TestLocalSaveStopsMidStream(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancels itself once the copy has consumed its first chunk.
+	source := &cancelAfterFirstRead{
+		reader: bytes.NewReader(make([]byte, 1<<20)),
+		cancel: cancel,
+	}
+
+	_, err := backend.Save(ctx, "docs/1/stalled.pdf", source, SaveOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Save = %v, want context.Canceled", err)
+	}
+	if source.reads > 3 {
+		t.Fatalf("copy kept reading after cancellation: %d reads", source.reads)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "1", "stalled.pdf")); !os.IsNotExist(err) {
+		t.Fatal("an aborted write must not leave its partial object behind")
+	}
+}
+
+type cancelAfterFirstRead struct {
+	reader *bytes.Reader
+	cancel context.CancelFunc
+	reads  int
+}
+
+func (c *cancelAfterFirstRead) Read(p []byte) (int, error) {
+	n, err := c.reader.Read(p)
+	c.reads++
+	if c.reads == 1 {
+		c.cancel()
+	}
+	return n, err
+}

--- a/backend/internal/storage/local_test.go
+++ b/backend/internal/storage/local_test.go
@@ -16,6 +16,11 @@ func TestKeyRejectsTraversal(t *testing.T) {
 		{"staff-documents", "..", "etc"},
 		{"staff-documents", "a/b"},
 		{"staff-documents", ""},
+		{"staff-documents", "."},
+		{"staff-documents", `a\b`},
+		// Not a segment of its own, but still a traversal payload once the
+		// operating system normalises the path.
+		{"staff-documents", "a..b"},
 		{},
 	} {
 		if _, err := Key(segments...); !errors.Is(err, ErrInvalidKey) {
@@ -189,6 +194,94 @@ func TestLocalSaveStopsMidStream(t *testing.T) {
 		t.Fatal("an aborted write must not leave its partial object behind")
 	}
 }
+
+// TestLocalRefusesAFileAsADirectory covers the failure a stray key produces on
+// every operation: the caller must get an error rather than a half-written
+// object, because an upload that reports success without storing bytes leaves a
+// metadata row pointing at nothing.
+func TestLocalRefusesAFileAsADirectory(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+	ctx := context.Background()
+
+	if _, err := backend.Save(ctx, "blocker", bytes.NewReader([]byte("x")), SaveOptions{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := backend.Save(ctx, "blocker/child.pdf", bytes.NewReader([]byte("x")), SaveOptions{}); err == nil {
+		t.Fatal("Save below a plain file must fail")
+	}
+	if _, err := backend.Open(ctx, "blocker/child.pdf"); err == nil || errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open below a plain file = %v, want a real failure", err)
+	}
+	if _, err := backend.Stat(ctx, "blocker/child.pdf"); err == nil || errors.Is(err, ErrNotFound) {
+		t.Fatalf("Stat below a plain file = %v, want a real failure", err)
+	}
+}
+
+// TestLocalRefusesADirectoryAsAnObject pins that a key naming a directory never
+// reads as an object. Open must say "not found" rather than hand
+// http.ServeContent a directory handle.
+func TestLocalRefusesADirectoryAsAnObject(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+	ctx := context.Background()
+
+	if _, err := backend.Save(ctx, "docs/9/file.pdf", bytes.NewReader([]byte("x")), SaveOptions{}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := backend.Open(ctx, "docs/9"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open of a directory = %v, want ErrNotFound", err)
+	}
+	if _, err := backend.Save(ctx, "docs/9", bytes.NewReader([]byte("x")), SaveOptions{}); err == nil {
+		t.Fatal("Save over a directory must fail")
+	}
+	// A non-empty directory cannot be unlinked, and that failure has to reach
+	// the caller: cleanup marks an object done only when Remove succeeded.
+	if err := backend.Remove(ctx, "docs/9"); err == nil {
+		t.Fatal("Remove of a non-empty directory must fail")
+	}
+}
+
+// TestLocalSaveSurfacesReadFailure separates a broken source from a passed
+// deadline. Both abort the write, but only the deadline case may be reported as
+// a context error — the upload path decides its cleanup bookkeeping from it.
+func TestLocalSaveSurfacesReadFailure(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+
+	broken := errors.New("connection reset")
+	_, err := backend.Save(context.Background(), "docs/1/broken.pdf", failingReader{err: broken}, SaveOptions{})
+	if err == nil {
+		t.Fatal("Save with a failing source must fail")
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Save = %v, must not be reported as a context error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "docs", "1", "broken.pdf")); !os.IsNotExist(statErr) {
+		t.Fatal("a failed write must not leave its partial object behind")
+	}
+}
+
+// TestLocalRemoveAndStatRejectEscapingKey completes the traversal guard: Save
+// and Open already refuse to leave the root, and so must the two operations
+// that a cleanup sweep uses.
+func TestLocalRemoveAndStatRejectEscapingKey(t *testing.T) {
+	backend := NewLocal(t.TempDir())
+	ctx := context.Background()
+
+	if err := backend.Remove(ctx, "../escaped.txt"); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("Remove outside root = %v, want ErrInvalidKey", err)
+	}
+	if _, err := backend.Stat(ctx, "/etc/passwd"); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("Stat of an absolute key = %v, want ErrInvalidKey", err)
+	}
+}
+
+type failingReader struct{ err error }
+
+func (f failingReader) Read([]byte) (int, error) { return 0, f.err }
 
 type cancelAfterFirstRead struct {
 	reader *bytes.Reader

--- a/backend/internal/storage/local_test.go
+++ b/backend/internal/storage/local_test.go
@@ -1,0 +1,143 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKeyRejectsTraversal(t *testing.T) {
+	for _, segments := range [][]string{
+		{".."},
+		{"staff-documents", "..", "etc"},
+		{"staff-documents", "a/b"},
+		{"staff-documents", ""},
+		{},
+	} {
+		if _, err := Key(segments...); !errors.Is(err, ErrInvalidKey) {
+			t.Errorf("Key(%v) = nil error, want ErrInvalidKey", segments)
+		}
+	}
+}
+
+func TestTenantKeySeparatesTenants(t *testing.T) {
+	first, err := TenantKey("student-documents", 7, "a.pdf")
+	if err != nil {
+		t.Fatalf("TenantKey: %v", err)
+	}
+	second, err := TenantKey("student-documents", 8, "a.pdf")
+	if err != nil {
+		t.Fatalf("TenantKey: %v", err)
+	}
+	if first == second {
+		t.Fatal("keys of two tenants collided")
+	}
+	if first != "student-documents/7/a.pdf" {
+		t.Fatalf("unexpected key %q", first)
+	}
+	if _, err := TenantKey("student-documents", 0, "a.pdf"); !errors.Is(err, ErrInvalidKey) {
+		t.Fatal("tenant 0 must be rejected")
+	}
+}
+
+func TestLocalSaveOpenRemoveRoundTrip(t *testing.T) {
+	backend := NewLocal(t.TempDir())
+	ctx := context.Background()
+
+	written, err := backend.Save(ctx, "docs/9/file.pdf", bytes.NewReader([]byte("payload")), SaveOptions{})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if written != int64(len("payload")) {
+		t.Fatalf("Save returned %d bytes, want %d", written, len("payload"))
+	}
+
+	size, err := backend.Stat(ctx, "docs/9/file.pdf")
+	if err != nil || size != int64(len("payload")) {
+		t.Fatalf("Stat = %d, %v", size, err)
+	}
+
+	object, err := backend.Open(ctx, "docs/9/file.pdf")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	content, err := io.ReadAll(object)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := object.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if string(content) != "payload" {
+		t.Fatalf("content = %q", content)
+	}
+	if object.ModTime().IsZero() {
+		t.Fatal("ModTime must be set so ServeContent can send Last-Modified")
+	}
+
+	if err := backend.Remove(ctx, "docs/9/file.pdf"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := backend.Open(ctx, "docs/9/file.pdf"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open after Remove = %v, want ErrNotFound", err)
+	}
+	// Cleanup retries must converge, so removing a gone object stays success.
+	if err := backend.Remove(ctx, "docs/9/file.pdf"); err != nil {
+		t.Fatalf("second Remove: %v", err)
+	}
+}
+
+func TestLocalSavePrivateUsesOwnerOnlyPermissions(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+
+	if _, err := backend.Save(context.Background(), "docs/1/secret.pdf", bytes.NewReader([]byte("x")), SaveOptions{Private: true}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	fileInfo, err := os.Stat(filepath.Join(root, "docs", "1", "secret.pdf"))
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != privateFileMode {
+		t.Errorf("file mode = %o, want %o", perm, privateFileMode)
+	}
+
+	dirInfo, err := os.Stat(filepath.Join(root, "docs", "1"))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != privateDirMode {
+		t.Errorf("dir mode = %o, want %o", perm, privateDirMode)
+	}
+}
+
+func TestLocalRejectsEscapingKey(t *testing.T) {
+	root := t.TempDir()
+	backend := NewLocal(root)
+	outside := filepath.Join(filepath.Dir(root), "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := backend.Open(context.Background(), "../"+filepath.Base(outside)); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("Open outside root = %v, want ErrInvalidKey", err)
+	}
+	if _, err := backend.Save(context.Background(), "../escaped.txt", bytes.NewReader([]byte("x")), SaveOptions{}); !errors.Is(err, ErrInvalidKey) {
+		t.Fatal("Save outside root must be rejected")
+	}
+}
+
+func TestLocalOpenMissingReturnsNotFound(t *testing.T) {
+	backend := NewLocal(t.TempDir())
+	if _, err := backend.Open(context.Background(), "nope.pdf"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open missing = %v, want ErrNotFound", err)
+	}
+	if _, err := backend.Stat(context.Background(), "nope.pdf"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Stat missing = %v, want ErrNotFound", err)
+	}
+}

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -1,0 +1,58 @@
+// Package storage owns every byte the application writes outside the
+// database. Before it existed, six upload families each resolved their own
+// directory and called os.* inline, so save, serve and delete of the same
+// file could disagree about where it lived. Everything now goes through one
+// Backend, which makes that class of bug structural rather than a matter of
+// review discipline, and makes an object-store implementation a drop-in
+// replacement instead of a sweep through every handler.
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+// ErrNotFound is returned by Open and Stat when the key does not exist.
+// Callers translate it to 404 rather than 500.
+var ErrNotFound = errors.New("storage: object not found")
+
+// ErrInvalidKey marks a key that failed validation (traversal, empty
+// segment, absolute path). It never reaches the underlying medium.
+var ErrInvalidKey = errors.New("storage: invalid key")
+
+// Object is an open stored object. *os.File satisfies it, and http.ServeContent
+// needs exactly this shape (ReadSeeker plus a modification time).
+type Object interface {
+	io.ReadSeekCloser
+	ModTime() time.Time
+}
+
+// SaveOptions controls the visibility of a newly written object.
+//
+// Private is not a hint: it is the difference between a file that only the
+// owning process can read and one that a misconfigured static mount could
+// hand out. Personnel files and child documents are written private; avatars
+// and login images are not.
+type SaveOptions struct {
+	Private bool
+}
+
+// Backend stores and retrieves opaque byte objects addressed by key.
+//
+// A key is a slash-separated relative path ("staff-documents/12/uuid.pdf").
+// Implementations MUST reject keys that escape their root and MUST NOT
+// interpret the key beyond that check — the caller owns the layout.
+type Backend interface {
+	// Save writes r under key, replacing any existing object, and returns
+	// the number of bytes stored. A failed write leaves no partial object.
+	Save(ctx context.Context, key string, r io.Reader, opts SaveOptions) (int64, error)
+	// Open returns the stored object. The caller closes it.
+	Open(ctx context.Context, key string) (Object, error)
+	// Remove deletes the object. Removing a missing object is not an error,
+	// so cleanup retries are idempotent.
+	Remove(ctx context.Context, key string) error
+	// Stat returns the stored size in bytes.
+	Stat(ctx context.Context, key string) (int64, error)
+}

--- a/backend/models/audit/data_access_log.go
+++ b/backend/models/audit/data_access_log.go
@@ -36,6 +36,11 @@ const (
 	// Lohnabrechnungen. StudentID stays NULL; metadata carries staff_id,
 	// document_id and category.
 	ResourceTypeStaffDocumentDownload = "staff_document_download"
+	// ResourceTypeStudentDocumentDownload records serving a sensitive child
+	// document (#777): Attest, Impfnachweis and Medikamentenplan (Art. 9
+	// health data) plus the Sorgerechtsnachweis. Metadata carries student_id,
+	// document_id and category.
+	ResourceTypeStudentDocumentDownload = "student_document_download"
 )
 
 // DataAccessLog is an append-only record of a staff member viewing sensitive

--- a/backend/models/audit/data_access_log.go
+++ b/backend/models/audit/data_access_log.go
@@ -38,7 +38,8 @@ const (
 	ResourceTypeStaffDocumentDownload = "staff_document_download"
 	// ResourceTypeStudentDocumentDownload records serving a sensitive child
 	// document (#777): Attest, Impfnachweis and Medikamentenplan (Art. 9
-	// health data) plus the Sorgerechtsnachweis. Metadata carries student_id,
+	// health data) plus the Sorgerechtsnachweis. Unlike the staff rows above
+	// this one names a child, so StudentID is SET and metadata carries only
 	// document_id and category.
 	ResourceTypeStudentDocumentDownload = "student_document_download"
 )

--- a/backend/models/audit/student_document_field_test.go
+++ b/backend/models/audit/student_document_field_test.go
@@ -1,0 +1,55 @@
+package audit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The document field name carries its category (#777). Without it the change
+// history cannot be filtered by the same per-category permissions the Dokumente
+// tab enforces, and reading "Ärztliches Attest: Attest_Epilepsie.pdf" in the
+// Historie tab becomes a way around student_documents:health.
+func TestStudentDocumentFieldRoundTrip(t *testing.T) {
+	field := audit.StudentDocumentField("attest")
+	assert.Equal(t, "document_attest", field)
+	assert.Equal(t, "attest", audit.StudentDocumentCategoryFromField(field))
+	assert.True(t, audit.IsStudentDocumentField(field))
+}
+
+func TestStudentDocumentCategoryFromFieldIgnoresOtherFields(t *testing.T) {
+	// An ordinary field carries no category...
+	assert.Empty(t, audit.StudentDocumentCategoryFromField(audit.StudentFieldHealthInfo))
+	assert.False(t, audit.IsStudentDocumentField(audit.StudentFieldHealthInfo))
+
+	// ...and neither does the legacy categoryless form. A reader that cannot
+	// name the category must fall back to "show only to a caller who may see
+	// every category", so an unreadable label never passes as visible.
+	assert.Empty(t, audit.StudentDocumentCategoryFromField(audit.StudentFieldDocument))
+	assert.True(t, audit.IsStudentDocumentField(audit.StudentFieldDocument))
+}
+
+func TestStudentFieldEditValidateAcceptsDocumentFields(t *testing.T) {
+	newValue := "Ärztliches Attest: Attest.pdf"
+	edit := &audit.StudentFieldEdit{
+		StudentID:    91,
+		EditedBy:     7,
+		EditedByName: "Test Person",
+		FieldName:    audit.StudentDocumentField("attest"),
+		NewValue:     &newValue,
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, edit.Validate())
+
+	// The legacy categoryless form stays storable so old rows keep validating.
+	edit.FieldName = audit.StudentFieldDocument
+	require.NoError(t, edit.Validate())
+
+	// A prefix-less unknown field is still rejected: the shape check must not
+	// have opened the field vocabulary up in general.
+	edit.FieldName = "erfundenes_feld"
+	require.Error(t, edit.Validate())
+}

--- a/backend/models/audit/student_field_edit.go
+++ b/backend/models/audit/student_field_edit.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/models/base"
@@ -40,11 +41,20 @@ const (
 	StudentFieldDepartureDays          = "departure_days"
 	StudentFieldDepartureCompanionNote = "departure_companion_note"
 
-	// StudentFieldDocument records an upload or deletion in the child's
-	// document file (#777). The value carries the category label and the
-	// display filename, never the document's content: the audit trail must
-	// survive the file it describes, and it must not become a second copy of
-	// data the deletion was meant to remove.
+	// StudentFieldDocumentPrefix marks an upload or deletion in the child's
+	// document file (#777). The full field name carries the category
+	// ("document_attest"), because the reader of a change history must be
+	// filtered by the same per-category permissions the Dokumente tab
+	// enforces — otherwise the history becomes a side channel around them.
+	//
+	// The value carries the category label and the display filename, never
+	// the document's content: the trail must survive the file it describes,
+	// and must not become a second copy of what a deletion removed.
+	StudentFieldDocumentPrefix = "document_"
+
+	// StudentFieldDocument is the categoryless form. Nothing writes it any
+	// more; readers treat it as "category unknown" and show it only to a
+	// caller who may see every category.
 	StudentFieldDocument = "document"
 
 	// StudentFieldEditSystemActor identifies automated changes. edited_by has
@@ -53,6 +63,27 @@ const (
 	StudentFieldEditSystemActorID   int64 = 0
 	StudentFieldEditSystemActorName       = "System"
 )
+
+// StudentDocumentField builds the field name for a document event.
+func StudentDocumentField(category string) string {
+	return StudentFieldDocumentPrefix + category
+}
+
+// StudentDocumentCategoryFromField returns the category encoded in a document
+// field name, or "" when the field is not a categorised document field (a
+// non-document field, or the legacy categoryless form).
+func StudentDocumentCategoryFromField(field string) string {
+	if !strings.HasPrefix(field, StudentFieldDocumentPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(field, StudentFieldDocumentPrefix)
+}
+
+// IsStudentDocumentField reports whether the field records a document event,
+// in either the categorised or the legacy form.
+func IsStudentDocumentField(field string) bool {
+	return field == StudentFieldDocument || strings.HasPrefix(field, StudentFieldDocumentPrefix)
+}
 
 // Validate ensures the edit record is well-formed before persistence.
 func (e *StudentFieldEdit) Validate() error {
@@ -76,7 +107,12 @@ func (e *StudentFieldEdit) Validate() error {
 		StudentFieldDepartureCompanionNote, StudentFieldDocument:
 		// Valid field names
 	default:
-		return errors.New("invalid field name")
+		// Document fields carry their category in the name. The vocabulary of
+		// categories belongs to the users domain, so only the shape is checked
+		// here.
+		if StudentDocumentCategoryFromField(e.FieldName) == "" {
+			return errors.New("invalid field name")
+		}
 	}
 
 	if e.CreatedAt.IsZero() {

--- a/backend/models/audit/student_field_edit.go
+++ b/backend/models/audit/student_field_edit.go
@@ -40,6 +40,13 @@ const (
 	StudentFieldDepartureDays          = "departure_days"
 	StudentFieldDepartureCompanionNote = "departure_companion_note"
 
+	// StudentFieldDocument records an upload or deletion in the child's
+	// document file (#777). The value carries the category label and the
+	// display filename, never the document's content: the audit trail must
+	// survive the file it describes, and it must not become a second copy of
+	// data the deletion was meant to remove.
+	StudentFieldDocument = "document"
+
 	// StudentFieldEditSystemActor identifies automated changes. edited_by has
 	// no foreign key so zero can safely represent the scheduler without
 	// attributing its work to a real account.
@@ -66,7 +73,7 @@ func (e *StudentFieldEdit) Validate() error {
 	switch e.FieldName {
 	case StudentFieldStatus, StudentFieldSupervisorNotes, StudentFieldExtraInfo,
 		StudentFieldHealthInfo, StudentFieldPickupStatus, StudentFieldDepartureDays,
-		StudentFieldDepartureCompanionNote:
+		StudentFieldDepartureCompanionNote, StudentFieldDocument:
 		// Valid field names
 	default:
 		return errors.New("invalid field name")

--- a/backend/models/documents/file.go
+++ b/backend/models/documents/file.go
@@ -19,6 +19,14 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/base"
 )
 
+// CleanupBatchSize caps one storage-cleanup sweep pass. The sweep runs inside
+// a single tenant transaction, so an uncapped pass after a large deletion
+// would hold a pool connection through thousands of unlink-and-mark pairs —
+// and a context deadline firing mid-pass would roll back every completion mark
+// that pass had written, so the next one would start from zero. Bounded passes
+// commit their progress and resume on the next tick.
+const CleanupBatchSize = 200
+
 // File is the metadata of one stored document. The bytes live in the storage
 // backend under FilenameStored; only the owning domain's download handler can
 // reach them.

--- a/backend/models/documents/file.go
+++ b/backend/models/documents/file.go
@@ -1,0 +1,132 @@
+// Package documents holds the shape every uploaded document row shares,
+// independent of the entity it hangs off (a staff member, a child, later a
+// feedback post).
+//
+// Two things are deliberately NOT generic here. The owner reference stays on
+// the concrete type, because a document belongs to its owner through a real
+// composite foreign key (tenant_id, owner_id) that the database enforces; a
+// polymorphic entity_type/entity_id pair would trade that enforcement for a
+// column we can never trust. And authority stays with the owning domain,
+// because "who may see this category" is a different question for a payslip
+// than for a medical certificate.
+package documents
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// File is the metadata of one stored document. The bytes live in the storage
+// backend under FilenameStored; only the owning domain's download handler can
+// reach them.
+//
+// DeletedAt is a soft delete on purpose: deleting a document removes the
+// bytes immediately (GDPR wants the content gone now) while the row survives
+// as the record that the document once existed. FileDeletedAt records that
+// the bytes are actually gone, so a failed unlink can be retried without
+// guessing.
+type File struct {
+	base.Model
+	base.TenantModel
+	Category        string     `bun:"category,notnull" json:"category"`
+	FilenameDisplay string     `bun:"filename_display,notnull" json:"filename_display"`
+	FilenameStored  string     `bun:"filename_stored,notnull" json:"-"`
+	SizeBytes       int64      `bun:"size_bytes,notnull" json:"size_bytes"`
+	ContentType     string     `bun:"content_type,notnull" json:"content_type"`
+	UploadedBy      int64      `bun:"uploaded_by,notnull" json:"uploaded_by"`
+	DeletedAt       *time.Time `bun:"deleted_at,soft_delete,nullzero" json:"-"`
+	DeletedBy       *int64     `bun:"deleted_by" json:"-"`
+	FileDeletedAt   *time.Time `bun:"file_deleted_at" json:"-"`
+}
+
+// GetCategory returns the document's category.
+func (f *File) GetCategory() string { return f.Category }
+
+// GetFilenameStored returns the on-disk (storage backend) name.
+func (f *File) GetFilenameStored() string { return f.FilenameStored }
+
+// GetFilenameDisplay returns the name the uploader saw.
+func (f *File) GetFilenameDisplay() string { return f.FilenameDisplay }
+
+// IsFileDeleted reports whether the stored bytes are already gone.
+func (f *File) IsFileDeleted() bool { return f.FileDeletedAt != nil }
+
+// MarkSoftDeleted stamps the in-memory row after a successful soft delete so
+// the caller can respond without re-reading.
+func (f *File) MarkSoftDeleted(at time.Time, by int64) {
+	f.DeletedAt = &at
+	f.DeletedBy = &by
+}
+
+// ValidateFile checks the parts of a document row that are identical across
+// domains. The owner reference and the category vocabulary belong to the
+// concrete type and are validated there.
+func ValidateFile(f *File) error {
+	if strings.TrimSpace(f.Category) == "" {
+		return errors.New("category is required")
+	}
+	if strings.TrimSpace(f.FilenameDisplay) == "" {
+		return errors.New("filename_display is required")
+	}
+	if strings.TrimSpace(f.FilenameStored) == "" {
+		return errors.New("filename_stored is required")
+	}
+	if f.SizeBytes < 0 {
+		return errors.New("size_bytes must not be negative")
+	}
+	if strings.TrimSpace(f.ContentType) == "" {
+		return errors.New("content_type is required")
+	}
+	if f.UploadedBy <= 0 {
+		return errors.New("uploaded_by is required")
+	}
+	return nil
+}
+
+// FileCleanup is a durable intent to remove stored bytes. It is written
+// BEFORE the file is saved, so a process that dies between the write and the
+// metadata commit still leaves a record the cleanup scheduler can act on.
+//
+// It intentionally carries no foreign key to the owner: the failed request
+// may name an owner that was concurrently deleted, and the orphaned bytes
+// still have to go.
+type FileCleanup struct {
+	base.Model
+	base.TenantModel
+	OwnerID        int64      `bun:"owner_id,notnull"`
+	FilenameStored string     `bun:"filename_stored,notnull"`
+	RetryAfter     time.Time  `bun:"retry_after,notnull"`
+	CleanedAt      *time.Time `bun:"cleaned_at"`
+}
+
+// GetOwnerID returns the owner the failed upload was meant for.
+func (c *FileCleanup) GetOwnerID() int64 { return c.OwnerID }
+
+// GetFilenameStored returns the orphaned object's storage name.
+func (c *FileCleanup) GetFilenameStored() string { return c.FilenameStored }
+
+// Entity is what the generic document repository needs from a concrete
+// document type.
+type Entity interface {
+	base.Entity
+	base.TenantScoped
+	GetOwnerID() int64
+	GetCategory() string
+	GetFilenameStored() string
+	GetFilenameDisplay() string
+	IsFileDeleted() bool
+	MarkSoftDeleted(at time.Time, by int64)
+	Validate() error
+}
+
+// CleanupEntity is what the generic repository needs from a concrete cleanup
+// row.
+type CleanupEntity interface {
+	base.Entity
+	base.TenantScoped
+	GetOwnerID() int64
+	GetFilenameStored() string
+}

--- a/backend/models/documents/file.go
+++ b/backend/models/documents/file.go
@@ -27,6 +27,13 @@ import (
 // commit their progress and resume on the next tick.
 const CleanupBatchSize = 200
 
+// RequestCleanupRetryLimit caps how many stale objects a single page view will
+// try to reclaim. It is deliberately far smaller than CleanupBatchSize: a
+// request should mop up the odd straggler, never work through a backlog. If
+// the storage backend was unreachable for a while, that backlog belongs to the
+// scheduler, which is built for it and does not make a staff member wait.
+const RequestCleanupRetryLimit = 10
+
 // File is the metadata of one stored document. The bytes live in the storage
 // backend under FilenameStored; only the owning domain's download handler can
 // reach them.

--- a/backend/models/documents/file_test.go
+++ b/backend/models/documents/file_test.go
@@ -1,0 +1,106 @@
+package documents_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/documents"
+)
+
+func validFile() *documents.File {
+	f := &documents.File{
+		Category:        "attest",
+		FilenameDisplay: "Attest.pdf",
+		FilenameStored:  "0f5b9d4e-1d3a-4a2f-9a3c-1b2c3d4e5f60.pdf",
+		SizeBytes:       2048,
+		ContentType:     "application/pdf",
+		UploadedBy:      77,
+	}
+	return f
+}
+
+func TestValidateFileAcceptsACompleteRow(t *testing.T) {
+	if err := documents.ValidateFile(validFile()); err != nil {
+		t.Fatalf("ValidateFile = %v, want nil", err)
+	}
+	// Zero bytes is a degenerate but storable file; only a negative size is a
+	// bug, and it must not reach a column the download handler trusts.
+	zero := validFile()
+	zero.SizeBytes = 0
+	if err := documents.ValidateFile(zero); err != nil {
+		t.Fatalf("ValidateFile with a zero-byte file = %v, want nil", err)
+	}
+}
+
+func TestValidateFileRejectsIncompleteRows(t *testing.T) {
+	cases := map[string]func(*documents.File){
+		"missing category":         func(f *documents.File) { f.Category = "  " },
+		"missing display filename": func(f *documents.File) { f.FilenameDisplay = "" },
+		// Without the stored name nothing can ever find the bytes again, so
+		// the row would be an unreclaimable orphan from the moment it is written.
+		"missing stored filename": func(f *documents.File) { f.FilenameStored = " " },
+		"negative size":           func(f *documents.File) { f.SizeBytes = -1 },
+		"missing content type":    func(f *documents.File) { f.ContentType = "" },
+		"missing uploader":        func(f *documents.File) { f.UploadedBy = 0 },
+	}
+	for name, break_ := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := validFile()
+			break_(f)
+			if err := documents.ValidateFile(f); err == nil {
+				t.Fatalf("ValidateFile(%s) = nil, want an error", name)
+			}
+		})
+	}
+}
+
+func TestFileAccessors(t *testing.T) {
+	f := validFile()
+	if f.GetCategory() != "attest" {
+		t.Errorf("GetCategory = %q", f.GetCategory())
+	}
+	if f.GetFilenameStored() != f.FilenameStored {
+		t.Errorf("GetFilenameStored = %q", f.GetFilenameStored())
+	}
+	if f.GetFilenameDisplay() != "Attest.pdf" {
+		t.Errorf("GetFilenameDisplay = %q", f.GetFilenameDisplay())
+	}
+}
+
+// TestFileSoftDeleteIsNotFileDeletion pins the two-stage lifecycle the cleanup
+// scheduler depends on: a soft-deleted row whose bytes are still on disk must
+// keep reporting that its file needs removal, otherwise the sweep skips it and
+// the object stays forever.
+func TestFileSoftDeleteIsNotFileDeletion(t *testing.T) {
+	f := validFile()
+	if f.IsFileDeleted() {
+		t.Fatal("a fresh row must not claim its bytes are gone")
+	}
+
+	at := time.Now()
+	f.MarkSoftDeleted(at, 42)
+	if f.DeletedAt == nil || !f.DeletedAt.Equal(at) {
+		t.Fatalf("DeletedAt = %v, want %v", f.DeletedAt, at)
+	}
+	if f.DeletedBy == nil || *f.DeletedBy != 42 {
+		t.Fatalf("DeletedBy = %v, want 42", f.DeletedBy)
+	}
+	if f.IsFileDeleted() {
+		t.Fatal("soft-deleting the row must not mark the bytes as removed")
+	}
+
+	f.FileDeletedAt = &at
+	if !f.IsFileDeleted() {
+		t.Fatal("a stamped file_deleted_at must retire the object from cleanup")
+	}
+}
+
+func TestFileCleanupAccessors(t *testing.T) {
+	cleanup := &documents.FileCleanup{OwnerID: 9, FilenameStored: "orphan.pdf"}
+	if cleanup.GetOwnerID() != 9 {
+		t.Errorf("GetOwnerID = %d", cleanup.GetOwnerID())
+	}
+	if cleanup.GetFilenameStored() != "orphan.pdf" {
+		t.Errorf("GetFilenameStored = %q", cleanup.GetFilenameStored())
+	}
+}

--- a/backend/models/users/student_document.go
+++ b/backend/models/users/student_document.go
@@ -1,0 +1,135 @@
+package users
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moto-nrw/project-phoenix/models/documents"
+)
+
+// Student document categories (#777). Fixed enum, mirrored by the CHECK
+// constraint on users.student_documents.category — no free-text categories.
+//
+// The split is not cosmetic: it decides which permission a category needs.
+// Attest, Impfnachweis and Medikamentenplan are health data (Art. 9 GDPR);
+// Sorgerecht carries custody rulings, which are not Art. 9 but are at least
+// as damaging in the wrong hands. Both tiers are gated separately from the
+// ordinary paperwork an OGS office handles every day.
+const (
+	StudentDocumentCategoryBetreuungsvertrag = "betreuungsvertrag"
+	StudentDocumentCategoryAbholvollmacht    = "abholvollmacht"
+	StudentDocumentCategorySchwimmerlaubnis  = "schwimmerlaubnis"
+	StudentDocumentCategoryAttest            = "attest"
+	StudentDocumentCategoryImpfnachweis      = "impfnachweis"
+	StudentDocumentCategoryMedikamentenplan  = "medikamentenplan"
+	StudentDocumentCategorySorgerecht        = "sorgerecht"
+	StudentDocumentCategorySonstiges         = "sonstiges"
+)
+
+// StudentDocumentCategories lists every valid category in display order.
+var StudentDocumentCategories = []string{
+	StudentDocumentCategoryBetreuungsvertrag,
+	StudentDocumentCategoryAbholvollmacht,
+	StudentDocumentCategorySchwimmerlaubnis,
+	StudentDocumentCategoryAttest,
+	StudentDocumentCategoryImpfnachweis,
+	StudentDocumentCategoryMedikamentenplan,
+	StudentDocumentCategorySorgerecht,
+	StudentDocumentCategorySonstiges,
+}
+
+// StudentDocumentCategoryLabels maps each category to its German UI label.
+// The office never sees the storage key.
+var StudentDocumentCategoryLabels = map[string]string{
+	StudentDocumentCategoryBetreuungsvertrag: "Betreuungsvertrag",
+	StudentDocumentCategoryAbholvollmacht:    "Abholvollmacht",
+	StudentDocumentCategorySchwimmerlaubnis:  "Schwimmerlaubnis",
+	StudentDocumentCategoryAttest:            "Ärztliches Attest",
+	StudentDocumentCategoryImpfnachweis:      "Impfnachweis",
+	StudentDocumentCategoryMedikamentenplan:  "Medikamentenplan",
+	StudentDocumentCategorySorgerecht:        "Sorgerechtsnachweis",
+	StudentDocumentCategorySonstiges:         "Sonstiges",
+}
+
+// IsValidStudentDocumentCategory reports whether v is a known category value.
+func IsValidStudentDocumentCategory(v string) bool {
+	for _, c := range StudentDocumentCategories {
+		if c == v {
+			return true
+		}
+	}
+	return false
+}
+
+// IsHealthStudentDocumentCategory reports whether the category holds Art. 9
+// health data.
+func IsHealthStudentDocumentCategory(v string) bool {
+	switch v {
+	case StudentDocumentCategoryAttest,
+		StudentDocumentCategoryImpfnachweis,
+		StudentDocumentCategoryMedikamentenplan:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsLegalStudentDocumentCategory reports whether the category holds custody
+// or other court paperwork.
+func IsLegalStudentDocumentCategory(v string) bool {
+	return v == StudentDocumentCategorySorgerecht
+}
+
+// StudentDocument is one uploaded document belonging to a child (#777).
+// Only metadata — the bytes live in the storage backend under the stored
+// (UUID) name and are served exclusively through the permission-checked
+// download handler.
+type StudentDocument struct {
+	documents.File `bun:"schema:users,table:student_documents"`
+	StudentID      int64 `bun:"student_id,notnull" json:"student_id"`
+}
+
+// GetOwnerID satisfies documents.Entity.
+func (d *StudentDocument) GetOwnerID() int64 { return d.StudentID }
+
+// Validate ensures the document row is storable.
+func (d *StudentDocument) Validate() error {
+	if d.StudentID <= 0 {
+		return errors.New("student_id is required")
+	}
+	if !IsValidStudentDocumentCategory(d.Category) {
+		return errors.New("unknown document category")
+	}
+	return documents.ValidateFile(&d.File)
+}
+
+// StudentDocumentFileCleanup tracks an upload whose metadata could not be
+// committed, or whose child was deleted before the bytes were removed.
+//
+// It has no student foreign key on purpose. Deleting a child cascades the
+// document rows away; without a cleanup row that outlives the cascade, the
+// stored bytes would stay on disk forever with nothing pointing at them.
+type StudentDocumentFileCleanup struct {
+	documents.FileCleanup `bun:"schema:users,table:student_document_file_cleanup"`
+}
+
+// StudentDocumentRepository persists student document metadata. Soft delete
+// is a domain operation (deleted_at + deleted_by in one write) —
+// phoenix_tenant has no DELETE grant on the table.
+type StudentDocumentRepository interface {
+	Create(ctx context.Context, doc *StudentDocument) error
+	FindForOwner(ctx context.Context, studentID, documentID int64) (*StudentDocument, error)
+	FindForOwnerIncludingDeleted(ctx context.Context, studentID, documentID int64) (*StudentDocument, error)
+	ListByOwnerID(ctx context.Context, studentID int64, categories []string) ([]*StudentDocument, error)
+	ListPendingFileCleanupByOwnerID(ctx context.Context, studentID int64) ([]*StudentDocument, error)
+	ListDeletedPendingFileCleanups(ctx context.Context) ([]*StudentDocument, error)
+	ListDeletedPendingFileCleanupByOwnerID(ctx context.Context, studentID int64, categories []string) ([]*StudentDocument, error)
+	SoftDelete(ctx context.Context, doc *StudentDocument, deletedBy int64) error
+	MarkFileDeleted(ctx context.Context, documentID int64) error
+	QueueFileCleanup(ctx context.Context, cleanup *StudentDocumentFileCleanup) error
+	ListQueuedFileCleanups(ctx context.Context) ([]*StudentDocumentFileCleanup, error)
+	ListQueuedFileCleanupByOwnerID(ctx context.Context, studentID int64) ([]*StudentDocumentFileCleanup, error)
+	MarkQueuedFileCleanupComplete(ctx context.Context, cleanupID int64) error
+	MarkQueuedFileCleanupCompleteByFilename(ctx context.Context, filename string) error
+	ActivateQueuedFileCleanupByFilename(ctx context.Context, filename string) error
+}

--- a/backend/models/users/student_document_test.go
+++ b/backend/models/users/student_document_test.go
@@ -1,0 +1,72 @@
+package users_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStudentDocument(category string) *users.StudentDocument {
+	doc := &users.StudentDocument{StudentID: 91}
+	doc.Category = category
+	doc.FilenameDisplay = "Attest.pdf"
+	doc.FilenameStored = "0f5b9d4e-1d3a-4a2f-9a3c-1b2c3d4e5f60.pdf"
+	doc.SizeBytes = 2048
+	doc.ContentType = "application/pdf"
+	doc.UploadedBy = 7
+	return doc
+}
+
+// The category split is what decides which permission a document needs, so it
+// is worth pinning rather than trusting a switch statement: health paperwork
+// needs student_documents:health, custody rulings student_documents:legal, and
+// everything else stays with the office.
+func TestStudentDocumentCategoryTiers(t *testing.T) {
+	health := []string{
+		users.StudentDocumentCategoryAttest,
+		users.StudentDocumentCategoryImpfnachweis,
+		users.StudentDocumentCategoryMedikamentenplan,
+	}
+	for _, category := range users.StudentDocumentCategories {
+		assert.True(t, users.IsValidStudentDocumentCategory(category), category)
+		assert.NotEmpty(t, users.StudentDocumentCategoryLabels[category],
+			"every category needs a German label — the office never sees the storage key")
+
+		wantHealth := false
+		for _, h := range health {
+			if h == category {
+				wantHealth = true
+			}
+		}
+		assert.Equal(t, wantHealth, users.IsHealthStudentDocumentCategory(category), category)
+		assert.Equal(t, category == users.StudentDocumentCategorySorgerecht,
+			users.IsLegalStudentDocumentCategory(category), category)
+	}
+
+	assert.False(t, users.IsValidStudentDocumentCategory("erfundene_kategorie"))
+	assert.False(t, users.IsHealthStudentDocumentCategory("erfundene_kategorie"))
+	assert.False(t, users.IsLegalStudentDocumentCategory("erfundene_kategorie"))
+}
+
+func TestStudentDocumentValidate(t *testing.T) {
+	doc := newStudentDocument(users.StudentDocumentCategoryAttest)
+	require.NoError(t, doc.Validate())
+	assert.Equal(t, int64(91), doc.GetOwnerID())
+
+	// A free-text category would slip past the CHECK constraint's intent and,
+	// worse, past the permission mapping — an unknown category maps to the
+	// office permission, which is the weakest gate of the three.
+	unknown := newStudentDocument("erfundene_kategorie")
+	require.Error(t, unknown.Validate())
+
+	orphan := newStudentDocument(users.StudentDocumentCategorySonstiges)
+	orphan.StudentID = 0
+	require.Error(t, orphan.Validate())
+
+	// The shared file validation still applies through the embed.
+	nameless := newStudentDocument(users.StudentDocumentCategorySonstiges)
+	nameless.FilenameDisplay = ""
+	require.Error(t, nameless.Validate())
+}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -423,18 +423,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		logger.With("service", "staff_documents"),
 	)
 
-	// Child documents (#777): metadata + per-category authority for the
-	// child's Dokumente tab. Writes into the per-child change history and the
-	// data-access log.
-	studentDocumentService := users.NewStudentDocumentService(
-		db,
-		repos.StudentDocument,
-		repos.Student,
-		repos.StudentFieldEdit,
-		repos.DataAccessLog,
-		logger.With("service", "student_documents"),
-	)
-
 	// Initialize guardian service
 	guardianService := users.NewGuardianService(users.GuardianServiceDependencies{
 		GuardianProfileRepo:     repos.GuardianProfile,
@@ -1680,6 +1668,19 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		db,
 	)
 	users.WireStudentDocumentCleanup(studentDeletionService, repos.StudentDocument)
+
+	// Child documents (#777): metadata, per-category authority and the
+	// per-child access gate for the Dokumente tab. Needs the user context to
+	// answer "does this caller supervise this child", so it is wired after it.
+	studentDocumentService := users.NewStudentDocumentService(
+		db,
+		repos.StudentDocument,
+		repos.Student,
+		repos.StudentFieldEdit,
+		repos.DataAccessLog,
+		userContextService,
+		logger.With("service", "student_documents"),
+	)
 
 	enrollmentChangeRequestService := enrollment.NewChangeRequestService(enrollment.ChangeRequestServiceConfig{
 		ChangeRequestRepo:        repos.ChangeRequest,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -118,6 +118,7 @@ type Factory struct {
 	Users                    users.PersonService
 	Birthdays                users.BirthdayService
 	StaffDocuments           users.StaffDocumentService
+	StudentDocuments         users.StudentDocumentService
 	StaffOffboarding         users.StaffOffboardingService
 	CaregiverCapability      users.CaregiverCapabilityService
 	Guardian                 *users.GuardianService
@@ -420,6 +421,18 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.StaffMasterDataChange,
 		repos.DataAccessLog,
 		logger.With("service", "staff_documents"),
+	)
+
+	// Child documents (#777): metadata + per-category authority for the
+	// child's Dokumente tab. Writes into the per-child change history and the
+	// data-access log.
+	studentDocumentService := users.NewStudentDocumentService(
+		db,
+		repos.StudentDocument,
+		repos.Student,
+		repos.StudentFieldEdit,
+		repos.DataAccessLog,
+		logger.With("service", "student_documents"),
 	)
 
 	// Initialize guardian service
@@ -1666,6 +1679,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		repos.StudentDeletionAudit,
 		db,
 	)
+	users.WireStudentDocumentCleanup(studentDeletionService, repos.StudentDocument)
 
 	enrollmentChangeRequestService := enrollment.NewChangeRequestService(enrollment.ChangeRequestServiceConfig{
 		ChangeRequestRepo:        repos.ChangeRequest,
@@ -2095,6 +2109,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Users:                    usersService,
 		Birthdays:                birthdayService,
 		StaffDocuments:           staffDocumentService,
+		StudentDocuments:         studentDocumentService,
 		StaffOffboarding:         staffOffboardingService,
 		CaregiverCapability:      caregiverCapabilityService,
 		Guardian:                 guardianService,

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -88,6 +88,12 @@ type StaffDocumentFileCleaner interface {
 	CleanupOrphanedStaffDocumentFiles(ctx context.Context) (int, error)
 }
 
+// StudentDocumentFileCleaner removes objects whose child-document metadata
+// either never committed or was cascaded away by a child deletion.
+type StudentDocumentFileCleaner interface {
+	CleanupOrphanedStudentDocumentFiles(ctx context.Context) (int, error)
+}
+
 // SettingsResolver resolves setting values per tenant. Implemented by config.SettingsService.
 type SettingsResolver interface {
 	ResolveString(ctx context.Context, key string) (string, error)
@@ -108,6 +114,7 @@ type Scheduler struct {
 	feedbackCleaner            FeedbackCleaner
 	unregisteredTagScanCleaner UnregisteredTagScanCleaner
 	staffDocumentFileCleaner   StaffDocumentFileCleaner
+	studentDocumentFileCleaner StudentDocumentFileCleaner
 	materializer               scheduleSvc.MaterializationService
 	timetableCleanup           scheduleSvc.TimetableCleanupService
 	timeTrackingCleanup        active.TimeTrackingCleanupService
@@ -270,6 +277,12 @@ func (s *Scheduler) SetUnregisteredTagScanCleaner(cleaner UnregisteredTagScanCle
 // recovery worker. Nil disables the task for tests without file storage.
 func (s *Scheduler) SetStaffDocumentFileCleaner(cleaner StaffDocumentFileCleaner) {
 	s.staffDocumentFileCleaner = cleaner
+}
+
+// SetStudentDocumentFileCleaner wires the storage-backed child-document
+// recovery worker. Nil disables the task for tests without file storage.
+func (s *Scheduler) SetStudentDocumentFileCleaner(cleaner StudentDocumentFileCleaner) {
+	s.studentDocumentFileCleaner = cleaner
 }
 
 // SetMaterializer wires the timetable materialization service. When set, the
@@ -498,6 +511,7 @@ func (s *Scheduler) Start() {
 	// Recover orphaned staff-document files after interrupted uploads, even
 	// when no tenant user later opens the documents UI.
 	s.scheduleStaffDocumentFileCleanupTask()
+	s.scheduleStudentDocumentFileCleanupTask()
 
 	// Schedule abandoned session cleanup
 	s.scheduleSessionCleanupTask()

--- a/backend/services/scheduler/student_document_cleanup.go
+++ b/backend/services/scheduler/student_document_cleanup.go
@@ -1,0 +1,74 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const studentDocumentFileCleanupInterval = 5 * time.Minute
+
+// scheduleStudentDocumentFileCleanupTask registers recovery for objects left
+// behind by a process crash between the object write and the metadata commit,
+// and for documents whose child was deleted before their bytes were removed.
+func (s *Scheduler) scheduleStudentDocumentFileCleanupTask() {
+	if s.studentDocumentFileCleaner == nil {
+		s.getLogger().Info("student document file cleanup not configured")
+		return
+	}
+
+	s.registerTask("student-document-file-cleanup", "5m-poll", s.runStudentDocumentFileCleanupTask)
+}
+
+func (s *Scheduler) runStudentDocumentFileCleanupTask(task *ScheduledTask) {
+	s.runIntervalPolling(task, "panic in student document file cleanup task",
+		"student document file cleanup using interval polling",
+		0, func() time.Duration { return studentDocumentFileCleanupInterval }, s.checkAndRunStudentDocumentFileCleanup)
+}
+
+func (s *Scheduler) checkAndRunStudentDocumentFileCleanup(task *ScheduledTask) {
+	task.mu.Lock()
+	if task.Running {
+		task.mu.Unlock()
+		return
+	}
+	task.Running = true
+	task.mu.Unlock()
+	defer func() {
+		task.mu.Lock()
+		task.Running = false
+		task.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if err := s.forEachTenantIncludingInactive(ctx, "student-document-file-cleanup",
+		s.cleanupStudentDocumentFilesForTenant); err != nil {
+		s.getLogger().Error("student document file cleanup failed",
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// cleanupStudentDocumentFilesForTenant never propagates a per-object failure
+// to the caller. The pass runs inside the tenant transaction opened by
+// forEachTenantIncludingInactive, and the removals it records already happened
+// on disk. Returning an error would roll that transaction back and drop the
+// completion marks of every object that WAS removed, so those items would come
+// back on every later run for as long as one object keeps failing. Failures
+// are logged instead; the offending row stays pending and is retried next pass.
+func (s *Scheduler) cleanupStudentDocumentFilesForTenant(tenantCtx context.Context) error {
+	removed, err := s.studentDocumentFileCleaner.CleanupOrphanedStudentDocumentFiles(tenantCtx)
+	if removed > 0 {
+		s.getLogger().Info("student document file cleanup completed",
+			slog.Int("files_removed", removed),
+		)
+	}
+	if err != nil {
+		s.getLogger().Error("student document file cleanup incomplete",
+			slog.Int("files_removed", removed),
+			slog.String("error", err.Error()),
+		)
+	}
+	return nil
+}

--- a/backend/services/users/student_deletion_documents_test.go
+++ b/backend/services/users/student_deletion_documents_test.go
@@ -1,0 +1,112 @@
+package users_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStudentDeletionService_QueuesDocumentCleanupInsideTheTransaction covers
+// the only thing standing between deleting a child and their paperwork sitting
+// on disk forever (#777).
+//
+// The document rows carry a foreign key to the child and cascade away with
+// them. The cleanup intents deliberately do not, which is what lets them
+// outlive the cascade — but only if they are written before it, inside the same
+// transaction. Written afterwards, a crash strands the bytes with nothing left
+// pointing at them; written beforehand and outside, a deletion that then fails
+// leaves the scheduler about to delete a living child's documents.
+func TestStudentDeletionService_QueuesDocumentCleanupInsideTheTransaction(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := testpkg.TenantContext(1)
+	repos := repositories.NewFactory(db)
+	service := newStudentDeletionTestService(db, repos.DataDeletion, repos.StudentDeletionAudit)
+	usersService.WireStudentDocumentCleanup(service, repos.StudentDocument)
+
+	suffix := time.Now().UnixNano()
+	student := testpkg.CreateTestStudent(t, db, "Dokumente", fmt.Sprintf("Loeschung-%d", suffix), "1a")
+	actor := testpkg.CreateTestAccount(t, db, fmt.Sprintf("student-delete-docs-%d@example.test", suffix))
+
+	live := storeStudentDocument(t, ctx, repos.StudentDocument, student.ID, actor.ID,
+		userModels.StudentDocumentCategoryBetreuungsvertrag, fmt.Sprintf("vertrag-%d.pdf", suffix))
+	// Already soft-deleted, bytes not yet unlinked: still pending cleanup.
+	deleted := storeStudentDocument(t, ctx, repos.StudentDocument, student.ID, actor.ID,
+		userModels.StudentDocumentCategoryAttest, fmt.Sprintf("attest-%d.pdf", suffix))
+	require.NoError(t, repos.StudentDocument.SoftDelete(ctx, deleted, actor.ID))
+	// Bytes already gone: nothing left to reclaim, so no intent must appear.
+	settled := storeStudentDocument(t, ctx, repos.StudentDocument, student.ID, actor.ID,
+		userModels.StudentDocumentCategorySonstiges, fmt.Sprintf("erledigt-%d.pdf", suffix))
+	require.NoError(t, repos.StudentDocument.MarkFileDeleted(ctx, settled.ID))
+
+	t.Cleanup(func() {
+		_, err := db.ExecContext(context.Background(),
+			`DELETE FROM users.student_document_file_cleanup WHERE owner_id = ?`, student.ID)
+		require.NoError(t, err)
+		_, err = db.ExecContext(context.Background(),
+			`DELETE FROM audit.student_deletions WHERE student_id = ?`, student.ID)
+		require.NoError(t, err)
+		cleanupStudentDeletionTest(t, db,
+			[]int64{student.ID}, []int64{student.PersonID},
+			nil, nil, nil, []int64{actor.ID}, nil)
+	})
+
+	preview, err := service.Preview(ctx, student.ID)
+	require.NoError(t, err)
+
+	_, err = service.Delete(ctx, usersService.StudentDeletionInput{
+		StudentID:           student.ID,
+		ActorAccountID:      actor.ID,
+		ExpectedFingerprint: preview.Fingerprint,
+		ConfirmationName:    preview.ConfirmationName,
+		Reason:              usersService.StudentDeletionReasonTestData,
+		Acknowledged:        true,
+	})
+	require.NoError(t, err)
+
+	// The child and their document rows are gone...
+	assert.Zero(t, tableRowCount(t, db, "users.students", student.ID))
+	assert.Zero(t, tableRowCount(t, db, "users.student_documents", live.ID))
+	assert.Zero(t, tableRowCount(t, db, "users.student_documents", deleted.ID))
+
+	// ...and exactly the objects that still exist on disk are left in the
+	// queue, immediately eligible: no upload for them can still be in flight.
+	queued, err := repos.StudentDocument.ListQueuedFileCleanupByOwnerID(ctx, student.ID)
+	require.NoError(t, err)
+	names := make([]string, 0, len(queued))
+	for _, cleanup := range queued {
+		names = append(names, cleanup.FilenameStored)
+	}
+	assert.Contains(t, names, live.FilenameStored)
+	assert.Contains(t, names, deleted.FilenameStored)
+	assert.NotContains(t, names, settled.FilenameStored,
+		"an object whose bytes are already gone must not be queued again")
+}
+
+func storeStudentDocument(
+	t *testing.T,
+	ctx context.Context,
+	repo userModels.StudentDocumentRepository,
+	studentID, accountID int64,
+	category, stored string,
+) *userModels.StudentDocument {
+	t.Helper()
+	doc := &userModels.StudentDocument{StudentID: studentID}
+	doc.Category = category
+	doc.FilenameDisplay = category + ".pdf"
+	doc.FilenameStored = stored
+	doc.SizeBytes = 512
+	doc.ContentType = "application/pdf"
+	doc.UploadedBy = accountID
+	require.NoError(t, repo.Create(ctx, doc))
+	return doc
+}

--- a/backend/services/users/student_deletion_service.go
+++ b/backend/services/users/student_deletion_service.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
@@ -61,7 +62,54 @@ type studentDeletionService struct {
 	transitionRepo educationModels.GradeTransitionRepository
 	dataAuditRepo  auditModels.DataDeletionRepository
 	auditRepo      auditModels.StudentDeletionRepository
+	documentRepo   userModels.StudentDocumentRepository
 	txHandler      *modelBase.TxHandler
+}
+
+// WireStudentDocumentCleanup attaches the child-document repository to a
+// deletion service so deleting a child also queues storage cleanup for their
+// documents (#777). A service that does not support it is left untouched.
+func WireStudentDocumentCleanup(svc StudentDeletionService, repo userModels.StudentDocumentRepository) {
+	if setter, ok := svc.(interface {
+		SetDocumentRepository(userModels.StudentDocumentRepository)
+	}); ok {
+		setter.SetDocumentRepository(repo)
+	}
+}
+
+// SetDocumentRepository wires the child-document repository so a deletion can
+// queue storage cleanup intents for the child's documents (#777).
+//
+// This has to happen inside the deletion transaction. The document rows
+// cascade away with the child, so queueing afterwards would race a crash and
+// strand the bytes forever; queueing beforehand outside the transaction would
+// make the scheduler delete the documents of a child whose deletion then
+// failed. Nil keeps the pre-#777 behaviour for bare test services.
+func (s *studentDeletionService) SetDocumentRepository(repo userModels.StudentDocumentRepository) {
+	s.documentRepo = repo
+}
+
+// queueDocumentCleanup records an immediately-eligible cleanup intent for
+// every document of the child whose bytes still exist. The intents carry no
+// student foreign key, so they survive the cascade that removes the rows.
+func (s *studentDeletionService) queueDocumentCleanup(ctx context.Context, studentID int64) error {
+	if s.documentRepo == nil {
+		return nil
+	}
+	docs, err := s.documentRepo.ListPendingFileCleanupByOwnerID(ctx, studentID)
+	if err != nil {
+		return err
+	}
+	for _, doc := range docs {
+		cleanup := &userModels.StudentDocumentFileCleanup{}
+		cleanup.OwnerID = studentID
+		cleanup.FilenameStored = doc.FilenameStored
+		cleanup.RetryAfter = time.Now()
+		if err := s.documentRepo.QueueFileCleanup(ctx, cleanup); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func NewStudentDeletionService(
@@ -158,6 +206,11 @@ func (s *studentDeletionService) Delete(ctx context.Context, input StudentDeleti
 			return err
 		}
 
+		// Before the cascade: the document rows go with the child, the
+		// queued intents do not, and they are what gets the bytes off disk.
+		if err := s.queueDocumentCleanup(txCtx, input.StudentID); err != nil {
+			return err
+		}
 		if err := s.studentRepo.Delete(txCtx, input.StudentID); err != nil {
 			return err
 		}

--- a/backend/services/users/student_document_service.go
+++ b/backend/services/users/student_document_service.go
@@ -84,6 +84,13 @@ type StudentDocumentService interface {
 	// first, plus the actor's visible categories (the frontend builds its
 	// filter and upload choices from them).
 	ListStudentDocuments(ctx context.Context, studentID int64, category string, actor StudentDocumentActor) ([]*userModels.StudentDocument, []string, error)
+	// AuthorizeStudentDocumentUpload answers "may this caller add a document
+	// of this category to this child" WITHOUT writing anything. The upload
+	// handler calls it before it puts bytes on disk or a cleanup intent in
+	// the database, so an unauthorized request costs nothing but the request
+	// itself. CreateStudentDocument repeats both checks inside its own
+	// transaction, which stays the authoritative one.
+	AuthorizeStudentDocumentUpload(ctx context.Context, studentID int64, category string, actor StudentDocumentActor) error
 	// CreateStudentDocument persists the metadata row and the audit entry in
 	// one tenant transaction.
 	CreateStudentDocument(ctx context.Context, input CreateStudentDocumentInput, actor StudentDocumentActor) (*userModels.StudentDocument, error)
@@ -272,6 +279,20 @@ func (s *studentDocumentService) ListStudentDocuments(ctx context.Context, stude
 		return nil, nil, err
 	}
 	return docs, visible, nil
+}
+
+func (s *studentDocumentService) AuthorizeStudentDocumentUpload(ctx context.Context, studentID int64, category string, actor StudentDocumentActor) error {
+	if !userModels.IsValidStudentDocumentCategory(category) {
+		return fmt.Errorf("%w: unknown category", ErrStudentDocumentInvalid)
+	}
+	if err := s.requireCategoryPermission(category, actor); err != nil {
+		return err
+	}
+	tenantID := tenant.FromContext(ctx)
+	return tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		_, err := s.requireStudentAccess(ctx, studentID, actor)
+		return err
+	})
 }
 
 func (s *studentDocumentService) CreateStudentDocument(ctx context.Context, input CreateStudentDocumentInput, actor StudentDocumentActor) (*userModels.StudentDocument, error) {

--- a/backend/services/users/student_document_service.go
+++ b/backend/services/users/student_document_service.go
@@ -373,15 +373,22 @@ func (s *studentDocumentService) ResolveStudentDocumentDownload(ctx context.Cont
 				role = "unknown"
 			}
 			now := time.Now()
+			// The child goes in the student_id COLUMN, not into metadata. It
+			// is the column a per-child disclosure report reads, and its FK
+			// carries ON DELETE SET NULL — a copy in the JSONB would survive
+			// the child's deletion, which is the leftover that column exists
+			// to prevent. Staff-document downloads leave it NULL legitimately,
+			// because there no child is involved; here one is.
+			subject := studentID
 			if err := s.accessLog.Create(ctx, &auditModels.DataAccessLog{
 				ActorAccountID: actor.AccountID,
 				ActorRole:      role,
 				ResourceType:   auditModels.ResourceTypeStudentDocumentDownload,
+				StudentID:      &subject,
 				RangeStart:     now,
 				RangeEnd:       now,
 				AccessedAt:     now,
 				Metadata: map[string]interface{}{
-					"student_id":  studentID,
 					"document_id": doc.ID,
 					"category":    doc.Category,
 				},

--- a/backend/services/users/student_document_service.go
+++ b/backend/services/users/student_document_service.go
@@ -191,13 +191,6 @@ func (s *studentDocumentService) requireStudentAccess(ctx context.Context, stude
 	return student, nil
 }
 
-func (s *studentDocumentService) getLogger() *slog.Logger {
-	if s.logger == nil {
-		return slog.Default()
-	}
-	return s.logger
-}
-
 // studentDocumentCategoryPermission returns the permission a category
 // requires. The mapping is the whole point of the permission design — keep it
 // in one place.
@@ -229,6 +222,25 @@ func visibleStudentDocumentCategories(actor StudentDocumentActor) []string {
 		}
 	}
 	return visible
+}
+
+// CanSeeStudentDocumentCategory reports whether the given permissions cover a
+// document category. Exported so readers of derived data — the per-child
+// change history above all — can apply the same filter the Dokumente tab does,
+// instead of becoming a way around it.
+func CanSeeStudentDocumentCategory(category string, userPermissions []string) bool {
+	return authorize.HasPermission(studentDocumentCategoryPermission(category), userPermissions)
+}
+
+// CanSeeEveryStudentDocumentCategory reports whether the permissions cover
+// every category. Readers use it for rows whose category is unknown.
+func CanSeeEveryStudentDocumentCategory(userPermissions []string) bool {
+	for _, category := range userModels.StudentDocumentCategories {
+		if !CanSeeStudentDocumentCategory(category, userPermissions) {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *studentDocumentService) requireCategoryPermission(category string, actor StudentDocumentActor) error {
@@ -296,7 +308,7 @@ func (s *studentDocumentService) CreateStudentDocument(ctx context.Context, inpu
 		if _, err := s.requireStudentAccess(ctx, input.StudentID, actor); err != nil {
 			return err
 		}
-		if err := s.recordAudit(ctx, input.StudentID, actor, "", documentAuditValue(input.Category, input.FilenameDisplay)); err != nil {
+		if err := s.recordAudit(ctx, input.StudentID, actor, input.Category, "", documentAuditValue(input.Category, input.FilenameDisplay)); err != nil {
 			return err
 		}
 		if err := s.documents.Create(ctx, doc); err != nil {
@@ -389,7 +401,7 @@ func (s *studentDocumentService) DeleteStudentDocument(ctx context.Context, stud
 		if err := s.documents.SoftDelete(ctx, doc, actor.AccountID); err != nil {
 			return err
 		}
-		if err := s.recordAudit(ctx, studentID, actor, documentAuditValue(doc.Category, doc.FilenameDisplay), ""); err != nil {
+		if err := s.recordAudit(ctx, studentID, actor, doc.Category, documentAuditValue(doc.Category, doc.FilenameDisplay), ""); err != nil {
 			return err
 		}
 		deleted = doc
@@ -492,7 +504,7 @@ func (s *studentDocumentService) ActivateQueuedCleanup(ctx context.Context, stor
 }
 
 // recordAudit writes one document event into the child's change history.
-func (s *studentDocumentService) recordAudit(ctx context.Context, studentID int64, actor StudentDocumentActor, oldValue, newValue string) error {
+func (s *studentDocumentService) recordAudit(ctx context.Context, studentID int64, actor StudentDocumentActor, category, oldValue, newValue string) error {
 	actorName := strings.TrimSpace(actor.Name)
 	if actorName == "" {
 		actorName = "Unbekannt"
@@ -501,7 +513,7 @@ func (s *studentDocumentService) recordAudit(ctx context.Context, studentID int6
 		StudentID:    studentID,
 		EditedBy:     actor.AccountID,
 		EditedByName: actorName,
-		FieldName:    auditModels.StudentFieldDocument,
+		FieldName:    auditModels.StudentDocumentField(category),
 	}
 	if oldValue != "" {
 		edit.OldValue = &oldValue

--- a/backend/services/users/student_document_service.go
+++ b/backend/services/users/student_document_service.go
@@ -1,0 +1,470 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+// Student documents (#777, Dokumente tab of a child's profile). The route
+// gate only proves the caller may reach the tab at all — per-category
+// authority is decided here: health documents need student_documents:health
+// (Art. 9 GDPR), custody paperwork needs student_documents:legal, everything
+// else belongs to the directory maintainers (users:update).
+//
+// Two rules are hard, mirroring the staff document service: every upload and
+// delete writes an audit row in the same tenant transaction, and serving a
+// sensitive category is refused outright when the data-access log write
+// fails. An unlogged look at a child's medical certificate is worse than a
+// failed request.
+
+const (
+	// StudentDocumentUploadDeadline bounds every step an upload request may
+	// still perform once its cleanup intent exists: the object write and the
+	// metadata transaction. The handler enforces it, so no request can persist
+	// a document row after its queued intent became eligible for the cleanup
+	// scheduler.
+	StudentDocumentUploadDeadline = 2 * time.Minute
+
+	// studentDocumentCleanupDelay keeps a queued intent ineligible until well
+	// past StudentDocumentUploadDeadline. The difference is deliberate slack
+	// for a metadata transaction whose commit was still in flight when the
+	// deadline fired. It MUST stay larger than StudentDocumentUploadDeadline.
+	studentDocumentCleanupDelay = 5 * time.Minute
+)
+
+// ErrStudentDocumentInvalid marks a semantically invalid payload — HTTP 400.
+var ErrStudentDocumentInvalid = errors.New("invalid student document")
+
+// ErrStudentDocumentForbidden marks a category the caller's permissions do
+// not cover — HTTP 403.
+var ErrStudentDocumentForbidden = errors.New("student document category not permitted")
+
+// StudentDocumentActor identifies the acting account for permission checks
+// and audit rows.
+type StudentDocumentActor struct {
+	AccountID   int64
+	Name        string
+	Role        string
+	Permissions []string
+}
+
+// CreateStudentDocumentInput carries the metadata of an already-stored
+// upload. The handler owns the bytes (parse, magic-number validation, storage
+// write); the service owns authority, the metadata row and the audit trail.
+type CreateStudentDocumentInput struct {
+	StudentID       int64
+	Category        string
+	FilenameDisplay string
+	FilenameStored  string
+	SizeBytes       int64
+	ContentType     string
+}
+
+// StudentDocumentService is the business boundary of the child Dokumente tab.
+type StudentDocumentService interface {
+	// ListStudentDocuments returns the documents the actor may see, newest
+	// first, plus the actor's visible categories (the frontend builds its
+	// filter and upload choices from them).
+	ListStudentDocuments(ctx context.Context, studentID int64, category string, actor StudentDocumentActor) ([]*userModels.StudentDocument, []string, error)
+	// CreateStudentDocument persists the metadata row and the audit entry in
+	// one tenant transaction.
+	CreateStudentDocument(ctx context.Context, input CreateStudentDocumentInput, actor StudentDocumentActor) (*userModels.StudentDocument, error)
+	// ResolveStudentDocumentDownload authorizes the download and, for the
+	// sensitive categories, writes the data-access log row. No file is served
+	// when the returned error is non-nil.
+	ResolveStudentDocumentDownload(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error)
+	// DeleteStudentDocument soft-deletes the metadata row and writes the audit
+	// entry in one tenant transaction. The handler removes the bytes only
+	// after this transaction commits.
+	DeleteStudentDocument(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error)
+	// ResolveStudentDocumentCleanup authorizes a retry of the storage cleanup
+	// for a document that may already be soft-deleted.
+	ResolveStudentDocumentCleanup(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error)
+	// ListDeletedStudentDocumentsPendingFileCleanup returns authorized retry
+	// candidates whose previous unlink did not complete.
+	ListDeletedStudentDocumentsPendingFileCleanup(ctx context.Context, studentID int64, actor StudentDocumentActor) ([]*userModels.StudentDocument, error)
+	// ListDeletedStudentDocumentsPendingFileCleanups returns every
+	// soft-deleted document in the tenant whose bytes need scheduler recovery.
+	ListDeletedStudentDocumentsPendingFileCleanups(ctx context.Context) ([]*userModels.StudentDocument, error)
+	// QueueStudentDocumentFileCleanup durably records the cleanup intent
+	// before the object is written.
+	QueueStudentDocumentFileCleanup(ctx context.Context, studentID int64, storedName string) error
+	// QueueCleanupForAllDocuments queues an immediately-eligible intent for
+	// every document of a child whose bytes still exist. It is the step that
+	// keeps deleting a child from stranding their documents on disk: the
+	// document rows cascade away, the intents do not.
+	QueueCleanupForAllDocuments(ctx context.Context, studentID int64) error
+	// ListQueuedStudentDocumentFileCleanups returns orphaned upload objects in
+	// the tenant so retries do not depend on the referenced child.
+	ListQueuedStudentDocumentFileCleanups(ctx context.Context) ([]*userModels.StudentDocumentFileCleanup, error)
+
+	// The remaining methods implement the coordinator's Store interface.
+	MarkFileDeleted(ctx context.Context, documentID int64) error
+	MarkQueuedCleanupComplete(ctx context.Context, cleanupID int64) error
+	MarkQueuedCleanupCompleteByFilename(ctx context.Context, storedName string) error
+	ActivateQueuedCleanup(ctx context.Context, storedName string) error
+}
+
+type studentDocumentService struct {
+	db        *bun.DB
+	documents userModels.StudentDocumentRepository
+	students  userModels.StudentRepository
+	audit     auditModels.StudentFieldEditRepository
+	accessLog auditModels.DataAccessLogRepository
+	logger    *slog.Logger
+}
+
+// NewStudentDocumentService wires the child document service.
+func NewStudentDocumentService(
+	db *bun.DB,
+	documents userModels.StudentDocumentRepository,
+	students userModels.StudentRepository,
+	audit auditModels.StudentFieldEditRepository,
+	accessLog auditModels.DataAccessLogRepository,
+	logger *slog.Logger,
+) StudentDocumentService {
+	return &studentDocumentService{
+		db:        db,
+		documents: documents,
+		students:  students,
+		audit:     audit,
+		accessLog: accessLog,
+		logger:    logger,
+	}
+}
+
+func (s *studentDocumentService) getLogger() *slog.Logger {
+	if s.logger == nil {
+		return slog.Default()
+	}
+	return s.logger
+}
+
+// studentDocumentCategoryPermission returns the permission a category
+// requires. The mapping is the whole point of the permission design — keep it
+// in one place.
+func studentDocumentCategoryPermission(category string) string {
+	switch {
+	case userModels.IsHealthStudentDocumentCategory(category):
+		return permissions.StudentDocumentsHealth
+	case userModels.IsLegalStudentDocumentCategory(category):
+		return permissions.StudentDocumentsLegal
+	default:
+		return permissions.UsersUpdate
+	}
+}
+
+// studentDocumentCategorySensitive reports whether serving the category's
+// content requires a data-access log row.
+func studentDocumentCategorySensitive(category string) bool {
+	return userModels.IsHealthStudentDocumentCategory(category) ||
+		userModels.IsLegalStudentDocumentCategory(category)
+}
+
+// visibleStudentDocumentCategories filters the category enum down to what the
+// actor may see (wildcard-aware, so admin:* matches everything).
+func visibleStudentDocumentCategories(actor StudentDocumentActor) []string {
+	visible := make([]string, 0, len(userModels.StudentDocumentCategories))
+	for _, category := range userModels.StudentDocumentCategories {
+		if authorize.HasPermission(studentDocumentCategoryPermission(category), actor.Permissions) {
+			visible = append(visible, category)
+		}
+	}
+	return visible
+}
+
+func (s *studentDocumentService) requireCategoryPermission(category string, actor StudentDocumentActor) error {
+	if !authorize.HasPermission(studentDocumentCategoryPermission(category), actor.Permissions) {
+		return fmt.Errorf("%w: %s", ErrStudentDocumentForbidden, category)
+	}
+	return nil
+}
+
+func (s *studentDocumentService) ListStudentDocuments(ctx context.Context, studentID int64, category string, actor StudentDocumentActor) ([]*userModels.StudentDocument, []string, error) {
+	if _, err := s.students.FindByID(ctx, studentID); err != nil {
+		return nil, nil, err
+	}
+
+	visible := visibleStudentDocumentCategories(actor)
+	query := visible
+	if category != "" {
+		if !userModels.IsValidStudentDocumentCategory(category) {
+			return nil, nil, fmt.Errorf("%w: unknown category", ErrStudentDocumentInvalid)
+		}
+		if err := s.requireCategoryPermission(category, actor); err != nil {
+			return nil, nil, err
+		}
+		query = []string{category}
+	}
+
+	docs, err := s.documents.ListByOwnerID(ctx, studentID, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	return docs, visible, nil
+}
+
+func (s *studentDocumentService) CreateStudentDocument(ctx context.Context, input CreateStudentDocumentInput, actor StudentDocumentActor) (*userModels.StudentDocument, error) {
+	if s.audit == nil {
+		return nil, fmt.Errorf("student audit repository is not wired; refusing unaudited change")
+	}
+	if actor.AccountID <= 0 {
+		return nil, fmt.Errorf("actor account id is required")
+	}
+	if !userModels.IsValidStudentDocumentCategory(input.Category) {
+		return nil, fmt.Errorf("%w: unknown category", ErrStudentDocumentInvalid)
+	}
+	if err := s.requireCategoryPermission(input.Category, actor); err != nil {
+		return nil, err
+	}
+	input.FilenameDisplay = strings.TrimSpace(input.FilenameDisplay)
+	if input.FilenameDisplay == "" {
+		return nil, fmt.Errorf("%w: filename is required", ErrStudentDocumentInvalid)
+	}
+
+	doc := &userModels.StudentDocument{StudentID: input.StudentID}
+	doc.Category = input.Category
+	doc.FilenameDisplay = input.FilenameDisplay
+	doc.FilenameStored = input.FilenameStored
+	doc.SizeBytes = input.SizeBytes
+	doc.ContentType = input.ContentType
+	doc.UploadedBy = actor.AccountID
+	if err := doc.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrStudentDocumentInvalid, err.Error())
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		if _, err := s.students.FindByID(ctx, input.StudentID); err != nil {
+			return err
+		}
+		if err := s.recordAudit(ctx, input.StudentID, actor, "", documentAuditValue(input.Category, input.FilenameDisplay)); err != nil {
+			return err
+		}
+		if err := s.documents.Create(ctx, doc); err != nil {
+			return err
+		}
+		if err := s.documents.MarkQueuedFileCleanupCompleteByFilename(ctx, input.FilenameStored); err != nil {
+			return fmt.Errorf("complete document upload cleanup intent: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func (s *studentDocumentService) ResolveStudentDocumentDownload(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error) {
+	var document *userModels.StudentDocument
+	tenantID := tenant.FromContext(ctx)
+	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		if _, err := s.students.FindByID(ctx, studentID); err != nil {
+			return err
+		}
+		doc, err := s.documents.FindForOwner(ctx, studentID, documentID)
+		if err != nil {
+			return err
+		}
+		if err := s.requireCategoryPermission(doc.Category, actor); err != nil {
+			return err
+		}
+
+		if studentDocumentCategorySensitive(doc.Category) {
+			if s.accessLog == nil {
+				return fmt.Errorf("data access log repository is not wired; refusing unaudited document download")
+			}
+			if actor.AccountID <= 0 {
+				return fmt.Errorf("actor account id is required for document downloads")
+			}
+			role := strings.TrimSpace(actor.Role)
+			if role == "" {
+				role = "unknown"
+			}
+			now := time.Now()
+			if err := s.accessLog.Create(ctx, &auditModels.DataAccessLog{
+				ActorAccountID: actor.AccountID,
+				ActorRole:      role,
+				ResourceType:   auditModels.ResourceTypeStudentDocumentDownload,
+				RangeStart:     now,
+				RangeEnd:       now,
+				AccessedAt:     now,
+				Metadata: map[string]interface{}{
+					"student_id":  studentID,
+					"document_id": doc.ID,
+					"category":    doc.Category,
+				},
+			}); err != nil {
+				return fmt.Errorf("write document access audit: %w", err)
+			}
+		}
+		document = doc
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return document, nil
+}
+
+func (s *studentDocumentService) DeleteStudentDocument(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error) {
+	if s.audit == nil {
+		return nil, fmt.Errorf("student audit repository is not wired; refusing unaudited change")
+	}
+	if actor.AccountID <= 0 {
+		return nil, fmt.Errorf("actor account id is required")
+	}
+
+	var deleted *userModels.StudentDocument
+	tenantID := tenant.FromContext(ctx)
+	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		doc, err := s.documents.FindForOwner(ctx, studentID, documentID)
+		if err != nil {
+			return err
+		}
+		if err := s.requireCategoryPermission(doc.Category, actor); err != nil {
+			return err
+		}
+		if err := s.documents.SoftDelete(ctx, doc, actor.AccountID); err != nil {
+			return err
+		}
+		if err := s.recordAudit(ctx, studentID, actor, documentAuditValue(doc.Category, doc.FilenameDisplay), ""); err != nil {
+			return err
+		}
+		deleted = doc
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return deleted, nil
+}
+
+func (s *studentDocumentService) ResolveStudentDocumentCleanup(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error) {
+	doc, err := s.documents.FindForOwnerIncludingDeleted(ctx, studentID, documentID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.requireCategoryPermission(doc.Category, actor); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func (s *studentDocumentService) ListDeletedStudentDocumentsPendingFileCleanup(ctx context.Context, studentID int64, actor StudentDocumentActor) ([]*userModels.StudentDocument, error) {
+	return s.documents.ListDeletedPendingFileCleanupByOwnerID(ctx, studentID, visibleStudentDocumentCategories(actor))
+}
+
+func (s *studentDocumentService) ListDeletedStudentDocumentsPendingFileCleanups(ctx context.Context) ([]*userModels.StudentDocument, error) {
+	return s.documents.ListDeletedPendingFileCleanups(ctx)
+}
+
+func (s *studentDocumentService) QueueStudentDocumentFileCleanup(ctx context.Context, studentID int64, storedName string) error {
+	if studentID <= 0 || strings.TrimSpace(storedName) == "" {
+		return fmt.Errorf("%w: cleanup file details are required", ErrStudentDocumentInvalid)
+	}
+	return s.queueCleanup(ctx, studentID, storedName, time.Now().Add(studentDocumentCleanupDelay))
+}
+
+func (s *studentDocumentService) QueueCleanupForAllDocuments(ctx context.Context, studentID int64) error {
+	docs, err := s.documents.ListPendingFileCleanupByOwnerID(ctx, studentID)
+	if err != nil {
+		return err
+	}
+	for _, doc := range docs {
+		// Eligible immediately: the child is being deleted, so no upload for
+		// these objects can still be in flight.
+		if err := s.queueCleanup(ctx, studentID, doc.FilenameStored, time.Now()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *studentDocumentService) queueCleanup(ctx context.Context, studentID int64, storedName string, retryAfter time.Time) error {
+	tenantID := tenant.FromContext(ctx)
+	cleanup := &userModels.StudentDocumentFileCleanup{}
+	cleanup.OwnerID = studentID
+	cleanup.FilenameStored = storedName
+	cleanup.RetryAfter = retryAfter
+	return tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return s.documents.QueueFileCleanup(ctx, cleanup)
+	})
+}
+
+func (s *studentDocumentService) ListQueuedStudentDocumentFileCleanups(ctx context.Context) ([]*userModels.StudentDocumentFileCleanup, error) {
+	return s.documents.ListQueuedFileCleanups(ctx)
+}
+
+func (s *studentDocumentService) MarkFileDeleted(ctx context.Context, documentID int64) error {
+	tenantID := tenant.FromContext(ctx)
+	return tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return s.documents.MarkFileDeleted(ctx, documentID)
+	})
+}
+
+func (s *studentDocumentService) MarkQueuedCleanupComplete(ctx context.Context, cleanupID int64) error {
+	tenantID := tenant.FromContext(ctx)
+	return tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return s.documents.MarkQueuedFileCleanupComplete(ctx, cleanupID)
+	})
+}
+
+func (s *studentDocumentService) MarkQueuedCleanupCompleteByFilename(ctx context.Context, storedName string) error {
+	tenantID := tenant.FromContext(ctx)
+	return tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return s.documents.MarkQueuedFileCleanupCompleteByFilename(ctx, storedName)
+	})
+}
+
+func (s *studentDocumentService) ActivateQueuedCleanup(ctx context.Context, storedName string) error {
+	tenantID := tenant.FromContext(ctx)
+	return tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		return s.documents.ActivateQueuedFileCleanupByFilename(ctx, storedName)
+	})
+}
+
+// recordAudit writes one document event into the child's change history.
+func (s *studentDocumentService) recordAudit(ctx context.Context, studentID int64, actor StudentDocumentActor, oldValue, newValue string) error {
+	actorName := strings.TrimSpace(actor.Name)
+	if actorName == "" {
+		actorName = "Unbekannt"
+	}
+	edit := &auditModels.StudentFieldEdit{
+		StudentID:    studentID,
+		EditedBy:     actor.AccountID,
+		EditedByName: actorName,
+		FieldName:    auditModels.StudentFieldDocument,
+	}
+	if oldValue != "" {
+		edit.OldValue = &oldValue
+	}
+	if newValue != "" {
+		edit.NewValue = &newValue
+	}
+	if err := s.audit.CreateBatch(ctx, []*auditModels.StudentFieldEdit{edit}); err != nil {
+		return fmt.Errorf("write document audit: %w", err)
+	}
+	return nil
+}
+
+// documentAuditValue renders the audit cell: the German category label plus
+// the display filename.
+func documentAuditValue(category, filename string) string {
+	label := userModels.StudentDocumentCategoryLabels[category]
+	if label == "" {
+		label = category
+	}
+	return label + ": " + filename
+}

--- a/backend/services/users/student_document_service.go
+++ b/backend/services/users/student_document_service.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
@@ -49,6 +51,11 @@ var ErrStudentDocumentInvalid = errors.New("invalid student document")
 // ErrStudentDocumentForbidden marks a category the caller's permissions do
 // not cover — HTTP 403.
 var ErrStudentDocumentForbidden = errors.New("student document category not permitted")
+
+// ErrStudentDocumentNoAccess marks a child the caller may not reach at all —
+// HTTP 403. Separate from the category error because it answers a different
+// question: not "which drawer" but "whose file cabinet".
+var ErrStudentDocumentNoAccess = errors.New("no access to this child")
 
 // StudentDocumentActor identifies the acting account for permission checks
 // and audit rows.
@@ -116,13 +123,24 @@ type StudentDocumentService interface {
 	ActivateQueuedCleanup(ctx context.Context, storedName string) error
 }
 
+// StudentDocumentUserContext is the slice of the user context the document
+// service needs to answer "does this caller supervise this child". It is
+// authorize.StudentModifyUserContext, restated so the service depends on a
+// named interface rather than a package alias.
+type StudentDocumentUserContext interface {
+	GetCurrentStaff(ctx context.Context) (*userModels.Staff, error)
+	GetMyGroups(ctx context.Context) ([]*educationModels.Group, error)
+	GetMyActiveGroups(ctx context.Context) ([]*activeModels.Group, error)
+}
+
 type studentDocumentService struct {
-	db        *bun.DB
-	documents userModels.StudentDocumentRepository
-	students  userModels.StudentRepository
-	audit     auditModels.StudentFieldEditRepository
-	accessLog auditModels.DataAccessLogRepository
-	logger    *slog.Logger
+	db          *bun.DB
+	documents   userModels.StudentDocumentRepository
+	students    userModels.StudentRepository
+	audit       auditModels.StudentFieldEditRepository
+	accessLog   auditModels.DataAccessLogRepository
+	userContext StudentDocumentUserContext
+	logger      *slog.Logger
 }
 
 // NewStudentDocumentService wires the child document service.
@@ -132,16 +150,45 @@ func NewStudentDocumentService(
 	students userModels.StudentRepository,
 	audit auditModels.StudentFieldEditRepository,
 	accessLog auditModels.DataAccessLogRepository,
+	userContext StudentDocumentUserContext,
 	logger *slog.Logger,
 ) StudentDocumentService {
 	return &studentDocumentService{
-		db:        db,
-		documents: documents,
-		students:  students,
-		audit:     audit,
-		accessLog: accessLog,
-		logger:    logger,
+		db:          db,
+		documents:   documents,
+		students:    students,
+		audit:       audit,
+		accessLog:   accessLog,
+		userContext: userContext,
+		logger:      logger,
 	}
+}
+
+// requireStudentAccess enforces the per-child gate every other per-child
+// endpoint applies: admin, or supervisor of the child's group. The route gate
+// only proves the caller may reach documents at all — without this, a
+// supervisor holding users:update could read and delete the paperwork of every
+// child in the school, whatever gdpr.student_data_scope says.
+//
+// It lives here rather than in the handler because the upload and download
+// routes deliberately run without the tenant-transaction middleware (a slow
+// 10 MB body must not pin a pool connection), and this check needs to happen
+// inside the same transaction as the work it guards.
+func (s *studentDocumentService) requireStudentAccess(ctx context.Context, studentID int64, actor StudentDocumentActor) (*userModels.Student, error) {
+	student, err := s.students.FindByID(ctx, studentID)
+	if err != nil {
+		return nil, err
+	}
+	if authorize.HasAdminWildcard(actor.Permissions) {
+		return student, nil
+	}
+	if student.GroupID == nil {
+		return nil, ErrStudentDocumentNoAccess
+	}
+	if s.userContext == nil || !authorize.IsGroupSupervisor(ctx, *student.GroupID, s.userContext) {
+		return nil, ErrStudentDocumentNoAccess
+	}
+	return student, nil
 }
 
 func (s *studentDocumentService) getLogger() *slog.Logger {
@@ -192,7 +239,7 @@ func (s *studentDocumentService) requireCategoryPermission(category string, acto
 }
 
 func (s *studentDocumentService) ListStudentDocuments(ctx context.Context, studentID int64, category string, actor StudentDocumentActor) ([]*userModels.StudentDocument, []string, error) {
-	if _, err := s.students.FindByID(ctx, studentID); err != nil {
+	if _, err := s.requireStudentAccess(ctx, studentID, actor); err != nil {
 		return nil, nil, err
 	}
 
@@ -246,7 +293,7 @@ func (s *studentDocumentService) CreateStudentDocument(ctx context.Context, inpu
 
 	tenantID := tenant.FromContext(ctx)
 	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
-		if _, err := s.students.FindByID(ctx, input.StudentID); err != nil {
+		if _, err := s.requireStudentAccess(ctx, input.StudentID, actor); err != nil {
 			return err
 		}
 		if err := s.recordAudit(ctx, input.StudentID, actor, "", documentAuditValue(input.Category, input.FilenameDisplay)); err != nil {
@@ -270,7 +317,7 @@ func (s *studentDocumentService) ResolveStudentDocumentDownload(ctx context.Cont
 	var document *userModels.StudentDocument
 	tenantID := tenant.FromContext(ctx)
 	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
-		if _, err := s.students.FindByID(ctx, studentID); err != nil {
+		if _, err := s.requireStudentAccess(ctx, studentID, actor); err != nil {
 			return err
 		}
 		doc, err := s.documents.FindForOwner(ctx, studentID, documentID)
@@ -329,6 +376,9 @@ func (s *studentDocumentService) DeleteStudentDocument(ctx context.Context, stud
 	var deleted *userModels.StudentDocument
 	tenantID := tenant.FromContext(ctx)
 	err := tenant.WithTenantTx(ctx, s.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		if _, err := s.requireStudentAccess(ctx, studentID, actor); err != nil {
+			return err
+		}
 		doc, err := s.documents.FindForOwner(ctx, studentID, documentID)
 		if err != nil {
 			return err
@@ -352,6 +402,9 @@ func (s *studentDocumentService) DeleteStudentDocument(ctx context.Context, stud
 }
 
 func (s *studentDocumentService) ResolveStudentDocumentCleanup(ctx context.Context, studentID, documentID int64, actor StudentDocumentActor) (*userModels.StudentDocument, error) {
+	if _, err := s.requireStudentAccess(ctx, studentID, actor); err != nil {
+		return nil, err
+	}
 	doc, err := s.documents.FindForOwnerIncludingDeleted(ctx, studentID, documentID)
 	if err != nil {
 		return nil, err
@@ -363,6 +416,9 @@ func (s *studentDocumentService) ResolveStudentDocumentCleanup(ctx context.Conte
 }
 
 func (s *studentDocumentService) ListDeletedStudentDocumentsPendingFileCleanup(ctx context.Context, studentID int64, actor StudentDocumentActor) ([]*userModels.StudentDocument, error) {
+	if _, err := s.requireStudentAccess(ctx, studentID, actor); err != nil {
+		return nil, err
+	}
 	return s.documents.ListDeletedPendingFileCleanupByOwnerID(ctx, studentID, visibleStudentDocumentCategories(actor))
 }
 

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -277,6 +277,16 @@ func TestStudentDocumentService_SensitiveDownloadsAreLogged(t *testing.T) {
 	}
 	assert.EqualValues(t, attest.ID, logs[0].Metadata["document_id"])
 	assert.EqualValues(t, custody.ID, logs[1].Metadata["document_id"])
+
+	// The child belongs in the column, which is what a per-child disclosure
+	// report reads and what the FK detaches on deletion. A copy in the JSONB
+	// would outlive the child and defeat that.
+	for _, entry := range logs {
+		require.NotNil(t, entry.StudentID, "a child document download must name its child")
+		assert.Equal(t, s.studentID, *entry.StudentID)
+		assert.NotContains(t, entry.Metadata, "student_id",
+			"the child must not be duplicated into metadata, which no deletion can reach")
+	}
 }
 
 func TestStudentDocumentService_AuditTrailAndSoftDelete(t *testing.T) {

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -1,0 +1,321 @@
+package users_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// Child documents (#777): per-category authority (Attest/Impfnachweis/
+// Medikamentenplan → student_documents:health, Sorgerecht →
+// student_documents:legal, rest → users:update) is enforced in the service —
+// uploads, downloads, deletes AND list visibility. Every upload and delete
+// writes a change-history row; sensitive downloads write a data-access log row.
+
+type studentDocumentScenario struct {
+	db        *bun.DB
+	svc       usersSvc.StudentDocumentService
+	ctx       context.Context
+	studentID int64
+	account   int64
+}
+
+func newStudentDocumentScenario(t *testing.T) *studentDocumentScenario {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repos := repositories.NewFactory(db)
+	svc := usersSvc.NewStudentDocumentService(
+		db,
+		repos.StudentDocument,
+		repos.Student,
+		repos.StudentFieldEdit,
+		repos.DataAccessLog,
+		nil,
+	)
+
+	suffix := time.Now().UnixNano()
+	student := testpkg.CreateTestStudent(t, db, "Dokumente", fmt.Sprintf("Kind-%d", suffix), "1a")
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("kind-dokumente-%d@example.test", suffix))
+	t.Cleanup(func() {
+		cleanupStudentDocumentRows(t, db, student.ID)
+		testpkg.CleanupActivityFixtures(t, db, student.ID)
+		testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+	})
+
+	return &studentDocumentScenario{
+		db:        db,
+		svc:       svc,
+		ctx:       testpkg.TenantContext(student.TenantID),
+		studentID: student.ID,
+		account:   account.ID,
+	}
+}
+
+func cleanupStudentDocumentRows(t *testing.T, db *bun.DB, studentID int64) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `DELETE FROM users.student_documents WHERE student_id = ?`, studentID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM users.student_document_file_cleanup WHERE owner_id = ?`, studentID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DELETE FROM audit.student_field_edits WHERE student_id = ?`, studentID)
+	require.NoError(t, err)
+}
+
+func (s *studentDocumentScenario) actor(perms ...string) usersSvc.StudentDocumentActor {
+	return usersSvc.StudentDocumentActor{
+		AccountID:   s.account,
+		Name:        "Test Person",
+		Role:        "test",
+		Permissions: perms,
+	}
+}
+
+func (s *studentDocumentScenario) create(t *testing.T, category string, actor usersSvc.StudentDocumentActor) *userModels.StudentDocument {
+	t.Helper()
+	doc, err := s.svc.CreateStudentDocument(s.ctx, s.input(category), actor)
+	require.NoError(t, err)
+	return doc
+}
+
+func (s *studentDocumentScenario) input(category string) usersSvc.CreateStudentDocumentInput {
+	return usersSvc.CreateStudentDocumentInput{
+		StudentID:       s.studentID,
+		Category:        category,
+		FilenameDisplay: category + "-datei.pdf",
+		FilenameStored:  fmt.Sprintf("%s-%d.pdf", category, time.Now().UnixNano()),
+		SizeBytes:       42,
+		ContentType:     "application/pdf",
+	}
+}
+
+func (s *studentDocumentScenario) auditRows(t *testing.T) []*auditModels.StudentFieldEdit {
+	t.Helper()
+	var rows []*auditModels.StudentFieldEdit
+	err := s.db.NewSelect().
+		Model(&rows).
+		ModelTableExpr(`audit.student_field_edits AS "student_field_edit"`).
+		Where(`"student_field_edit".student_id = ?`, s.studentID).
+		Where(`"student_field_edit".field_name = ?`, auditModels.StudentFieldDocument).
+		Order("id ASC").
+		Scan(context.Background())
+	require.NoError(t, err)
+	return rows
+}
+
+func (s *studentDocumentScenario) accessLogRows(t *testing.T) []*auditModels.DataAccessLog {
+	t.Helper()
+	var rows []*auditModels.DataAccessLog
+	err := s.db.NewSelect().
+		Model(&rows).
+		ModelTableExpr(`audit.data_access_log AS "data_access_log"`).
+		Where(`"data_access_log".actor_account_id = ?`, s.account).
+		Order("id ASC").
+		Scan(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = s.db.ExecContext(context.Background(), `DELETE FROM audit.data_access_log WHERE actor_account_id = ?`, s.account)
+	})
+	return rows
+}
+
+func studentDocumentCategoriesOf(docs []*userModels.StudentDocument) []string {
+	out := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		out = append(out, doc.Category)
+	}
+	return out
+}
+
+func TestStudentDocumentService_CategoryAuthority(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+
+	office := s.actor("users:update")
+	health := s.actor("student_documents:health")
+	legal := s.actor("student_documents:legal")
+	admin := s.actor("admin:*")
+
+	// The office covers the everyday paperwork only.
+	s.create(t, userModels.StudentDocumentCategoryBetreuungsvertrag, office)
+	_, err := s.svc.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategoryAttest), office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+	_, err = s.svc.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategorySorgerecht), office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+
+	// The dedicated permissions cover exactly their tier and nothing else.
+	attest := s.create(t, userModels.StudentDocumentCategoryAttest, health)
+	sorgerecht := s.create(t, userModels.StudentDocumentCategorySorgerecht, legal)
+	_, err = s.svc.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategorySorgerecht), health)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+	_, err = s.svc.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategoryImpfnachweis), legal)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+
+	// List visibility follows the same mapping — a health document must not
+	// even appear in the office's list.
+	docs, visible, err := s.svc.ListStudentDocuments(s.ctx, s.studentID, "", office)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		userModels.StudentDocumentCategoryBetreuungsvertrag,
+		userModels.StudentDocumentCategoryAbholvollmacht,
+		userModels.StudentDocumentCategorySchwimmerlaubnis,
+		userModels.StudentDocumentCategorySonstiges,
+	}, visible)
+	assert.ElementsMatch(t, []string{userModels.StudentDocumentCategoryBetreuungsvertrag}, studentDocumentCategoriesOf(docs))
+
+	docs, visible, err = s.svc.ListStudentDocuments(s.ctx, s.studentID, "", health)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		userModels.StudentDocumentCategoryAttest,
+		userModels.StudentDocumentCategoryImpfnachweis,
+		userModels.StudentDocumentCategoryMedikamentenplan,
+	}, visible)
+	assert.ElementsMatch(t, []string{userModels.StudentDocumentCategoryAttest}, studentDocumentCategoriesOf(docs))
+
+	docs, visible, err = s.svc.ListStudentDocuments(s.ctx, s.studentID, "", admin)
+	require.NoError(t, err)
+	assert.Len(t, visible, len(userModels.StudentDocumentCategories))
+	assert.Len(t, docs, 3)
+
+	// A category filter outside the caller's authority is refused; inside it
+	// narrows.
+	_, _, err = s.svc.ListStudentDocuments(s.ctx, s.studentID, userModels.StudentDocumentCategoryAttest, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+	docs, _, err = s.svc.ListStudentDocuments(s.ctx, s.studentID, userModels.StudentDocumentCategoryAttest, health)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Equal(t, attest.ID, docs[0].ID)
+
+	// Deleting across the tier boundary is refused too — a 403 on upload would
+	// be worthless if delete were open.
+	_, err = s.svc.DeleteStudentDocument(s.ctx, s.studentID, sorgerecht.ID, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+}
+
+func TestStudentDocumentService_SensitiveDownloadsAreLogged(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+
+	office := s.actor("users:update")
+	health := s.actor("student_documents:health")
+	legal := s.actor("student_documents:legal")
+
+	everyday := s.create(t, userModels.StudentDocumentCategoryAbholvollmacht, office)
+	attest := s.create(t, userModels.StudentDocumentCategoryAttest, health)
+	custody := s.create(t, userModels.StudentDocumentCategorySorgerecht, legal)
+
+	// Foreign permissions never reach the bytes.
+	_, err := s.svc.ResolveStudentDocumentDownload(s.ctx, s.studentID, attest.ID, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+
+	// An ordinary category is served without an access-log row.
+	_, err = s.svc.ResolveStudentDocumentDownload(s.ctx, s.studentID, everyday.ID, office)
+	require.NoError(t, err)
+	assert.Empty(t, s.accessLogRows(t), "an everyday document must not inflate the access log")
+
+	// Both sensitive tiers write one row each, naming the document.
+	_, err = s.svc.ResolveStudentDocumentDownload(s.ctx, s.studentID, attest.ID, health)
+	require.NoError(t, err)
+	_, err = s.svc.ResolveStudentDocumentDownload(s.ctx, s.studentID, custody.ID, legal)
+	require.NoError(t, err)
+
+	logs := s.accessLogRows(t)
+	require.Len(t, logs, 2)
+	for _, entry := range logs {
+		assert.Equal(t, auditModels.ResourceTypeStudentDocumentDownload, entry.ResourceType)
+	}
+	assert.EqualValues(t, attest.ID, logs[0].Metadata["document_id"])
+	assert.EqualValues(t, custody.ID, logs[1].Metadata["document_id"])
+}
+
+func TestStudentDocumentService_AuditTrailAndSoftDelete(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+
+	doc := s.create(t, userModels.StudentDocumentCategorySonstiges, office)
+
+	rows := s.auditRows(t)
+	require.Len(t, rows, 1)
+	assert.Nil(t, rows[0].OldValue)
+	require.NotNil(t, rows[0].NewValue)
+	assert.Contains(t, *rows[0].NewValue, "sonstiges-datei.pdf")
+	assert.Equal(t, "Test Person", rows[0].EditedByName)
+
+	deleted, err := s.svc.DeleteStudentDocument(s.ctx, s.studentID, doc.ID, office)
+	require.NoError(t, err)
+	require.NotNil(t, deleted.DeletedAt)
+
+	rows = s.auditRows(t)
+	require.Len(t, rows, 2, "the delete must leave its own trail entry")
+	require.NotNil(t, rows[1].OldValue)
+	assert.Contains(t, *rows[1].OldValue, "sonstiges-datei.pdf")
+	assert.Nil(t, rows[1].NewValue)
+
+	// The row survives as the record that the document existed, but it is gone
+	// from the normal view and pending byte removal.
+	docs, _, err := s.svc.ListStudentDocuments(s.ctx, s.studentID, "", office)
+	require.NoError(t, err)
+	assert.Empty(t, docs)
+
+	pending, err := s.svc.ListDeletedStudentDocumentsPendingFileCleanup(s.ctx, s.studentID, office)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, doc.ID, pending[0].ID)
+}
+
+// TestStudentDocumentService_UploadIntentIsSettledOnSuccess pins the ordering
+// that makes an interrupted upload recoverable: the intent exists before the
+// object is written and is settled by the metadata transaction, so a
+// successful upload leaves nothing for the cleanup scheduler to delete.
+func TestStudentDocumentService_UploadIntentIsSettledOnSuccess(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+
+	input := s.input(userModels.StudentDocumentCategorySchwimmerlaubnis)
+	require.NoError(t, s.svc.QueueStudentDocumentFileCleanup(s.ctx, s.studentID, input.FilenameStored))
+
+	_, err := s.svc.CreateStudentDocument(s.ctx, input, office)
+	require.NoError(t, err)
+
+	// Make every intent eligible, then confirm the settled one stays out.
+	require.NoError(t, s.svc.ActivateQueuedCleanup(s.ctx, input.FilenameStored))
+	queued, err := s.svc.ListQueuedStudentDocumentFileCleanups(s.ctx)
+	require.NoError(t, err)
+	for _, cleanup := range queued {
+		assert.NotEqual(t, input.FilenameStored, cleanup.FilenameStored,
+			"a committed upload must not be reclaimed by the cleanup pass")
+	}
+}
+
+// TestStudentDocumentService_QueueCleanupForAllDocuments covers the child
+// deletion path. Documents cascade away with the child, so the intents queued
+// here are the only thing left that can get the bytes off disk.
+func TestStudentDocumentService_QueueCleanupForAllDocuments(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+
+	first := s.create(t, userModels.StudentDocumentCategorySonstiges, office)
+	second := s.create(t, userModels.StudentDocumentCategoryAbholvollmacht, office)
+
+	require.NoError(t, s.svc.QueueCleanupForAllDocuments(s.ctx, s.studentID))
+
+	queued, err := s.svc.ListQueuedStudentDocumentFileCleanups(s.ctx)
+	require.NoError(t, err)
+	names := make([]string, 0, len(queued))
+	for _, cleanup := range queued {
+		names = append(names, cleanup.FilenameStored)
+	}
+	assert.Contains(t, names, first.FilenameStored)
+	assert.Contains(t, names, second.FilenameStored)
+}

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -453,6 +453,259 @@ func TestStudentDocumentService_AuditFieldCarriesCategory(t *testing.T) {
 	assert.True(t, usersSvc.CanSeeEveryStudentDocumentCategory([]string{"admin:*"}))
 }
 
+// TestStudentDocumentService_RefusesToWriteWithoutAnAuditTrail pins the rule
+// that makes the Dokumente tab defensible: a service wired without its audit
+// repository must refuse the change rather than perform it silently. An
+// unlogged upload or deletion of a child's paperwork is worse than a failed
+// request.
+func TestStudentDocumentService_RefusesToWriteWithoutAnAuditTrail(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	repos := repositories.NewFactory(s.db)
+	unaudited := usersSvc.NewStudentDocumentService(
+		s.db,
+		repos.StudentDocument,
+		repos.Student,
+		nil,
+		repos.DataAccessLog,
+		stubDocumentUserContext{supervisedGroupIDs: []int64{s.groupID}},
+		nil,
+	)
+	office := s.actor("users:update")
+
+	_, err := unaudited.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategorySonstiges), office)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing unaudited change")
+
+	doc := s.create(t, userModels.StudentDocumentCategorySonstiges, office)
+	_, err = unaudited.DeleteStudentDocument(s.ctx, s.studentID, doc.ID, office)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing unaudited change")
+
+	// The document survived the refused deletion.
+	docs, _, err := s.svc.ListStudentDocuments(s.ctx, s.studentID, "", office)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	// The same holds for a sensitive download without a data-access log: no
+	// row, no file.
+	unlogged := usersSvc.NewStudentDocumentService(
+		s.db,
+		repos.StudentDocument,
+		repos.Student,
+		repos.StudentFieldEdit,
+		nil,
+		stubDocumentUserContext{supervisedGroupIDs: []int64{s.groupID}},
+		nil,
+	)
+	health := s.actor("student_documents:health")
+	attest := s.create(t, userModels.StudentDocumentCategoryAttest, health)
+	_, err = unlogged.ResolveStudentDocumentDownload(s.ctx, s.studentID, attest.ID, health)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing unaudited document download")
+
+	// An everyday category needs no access-log row, so it is still served.
+	everyday := s.create(t, userModels.StudentDocumentCategoryAbholvollmacht, office)
+	_, err = unlogged.ResolveStudentDocumentDownload(s.ctx, s.studentID, everyday.ID, office)
+	require.NoError(t, err)
+}
+
+// TestStudentDocumentService_RequiresAnActingAccount covers the other half of
+// the audit contract: every write and every logged download has to name the
+// person who performed it, so an anonymous actor is refused up front.
+func TestStudentDocumentService_RequiresAnActingAccount(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+	anonymous := usersSvc.StudentDocumentActor{Permissions: []string{"admin:*"}}
+
+	_, err := s.svc.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategorySonstiges), anonymous)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor account id is required")
+
+	doc := s.create(t, userModels.StudentDocumentCategoryAttest, s.actor("student_documents:health"))
+	_, err = s.svc.DeleteStudentDocument(s.ctx, s.studentID, doc.ID, anonymous)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor account id is required")
+
+	_, err = s.svc.ResolveStudentDocumentDownload(s.ctx, s.studentID, doc.ID, anonymous)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor account id is required")
+
+	// An everyday document is downloadable without an account, because nothing
+	// has to be logged for it.
+	everyday := s.create(t, userModels.StudentDocumentCategoryAbholvollmacht, office)
+	_, err = s.svc.ResolveStudentDocumentDownload(s.ctx, s.studentID, everyday.ID, anonymous)
+	require.NoError(t, err)
+}
+
+// TestStudentDocumentService_RejectsMalformedInput covers the payload checks
+// that keep an unusable row out of the table. A document whose display name is
+// blank cannot be identified in the UI, and a category outside the enum would
+// map to the weakest of the three permissions.
+func TestStudentDocumentService_RejectsMalformedInput(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+
+	unknown := s.input(userModels.StudentDocumentCategorySonstiges)
+	unknown.Category = "erfundene_kategorie"
+	_, err := s.svc.CreateStudentDocument(s.ctx, unknown, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentInvalid)
+
+	blank := s.input(userModels.StudentDocumentCategorySonstiges)
+	blank.FilenameDisplay = "   "
+	_, err = s.svc.CreateStudentDocument(s.ctx, blank, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentInvalid)
+
+	// Passes the input checks but fails the model's own validation, which is
+	// the last guard before the insert.
+	nameless := s.input(userModels.StudentDocumentCategorySonstiges)
+	nameless.FilenameStored = ""
+	_, err = s.svc.CreateStudentDocument(s.ctx, nameless, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentInvalid)
+
+	// The list filter validates its category too, before it decides whether the
+	// caller may see it.
+	_, _, err = s.svc.ListStudentDocuments(s.ctx, s.studentID, "erfundene_kategorie", office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentInvalid)
+
+	// A cleanup intent needs both halves or it can never be acted on.
+	require.ErrorIs(t, s.svc.QueueStudentDocumentFileCleanup(s.ctx, 0, "x.pdf"), usersSvc.ErrStudentDocumentInvalid)
+	require.ErrorIs(t, s.svc.QueueStudentDocumentFileCleanup(s.ctx, s.studentID, "  "), usersSvc.ErrStudentDocumentInvalid)
+
+	// None of it reached the table.
+	docs, _, err := s.svc.ListStudentDocuments(s.ctx, s.studentID, "", s.actor("admin:*"))
+	require.NoError(t, err)
+	assert.Empty(t, docs)
+}
+
+// TestStudentDocumentService_UnknownChildAndGrouplessChild covers the two ways
+// the per-child gate closes for a non-admin: the child does not exist, or the
+// child sits in no group and therefore has no supervisor to be.
+func TestStudentDocumentService_UnknownChildAndGrouplessChild(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+
+	_, _, err := s.svc.ListStudentDocuments(s.ctx, s.studentID+9_000_000, "", office)
+	require.Error(t, err, "an unknown child must not read as an empty document list")
+
+	groupless := testpkg.CreateTestStudent(t, s.db, "Ohne", fmt.Sprintf("Gruppe-%d", time.Now().UnixNano()), "1c")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, s.db, groupless.ID) })
+
+	_, _, err = s.svc.ListStudentDocuments(s.ctx, groupless.ID, "", office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentNoAccess)
+
+	// An admin still reaches them — the office role is exactly who handles a
+	// child that is not assigned to a group yet.
+	_, _, err = s.svc.ListStudentDocuments(s.ctx, groupless.ID, "", s.actor("admin:*"))
+	require.NoError(t, err)
+}
+
+// TestStudentDocumentService_CleanupRetryPathIsAuthorized covers the retry a
+// page view performs after a failed unlink. It has to reach a soft-deleted row,
+// and it has to apply the same category authority the tab does — otherwise
+// "retry the cleanup" becomes a way to confirm that a document exists.
+func TestStudentDocumentService_CleanupRetryPathIsAuthorized(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+	health := s.actor("student_documents:health")
+
+	attest := s.create(t, userModels.StudentDocumentCategoryAttest, health)
+	_, err := s.svc.DeleteStudentDocument(s.ctx, s.studentID, attest.ID, health)
+	require.NoError(t, err)
+
+	resolved, err := s.svc.ResolveStudentDocumentCleanup(s.ctx, s.studentID, attest.ID, health)
+	require.NoError(t, err)
+	assert.Equal(t, attest.FilenameStored, resolved.FilenameStored)
+
+	_, err = s.svc.ResolveStudentDocumentCleanup(s.ctx, s.studentID, attest.ID, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentForbidden)
+
+	_, err = s.svc.ResolveStudentDocumentCleanup(s.ctx, s.studentID, attest.ID+9_000_000, health)
+	require.Error(t, err)
+
+	// The tenant-wide sweep the scheduler runs sees the same row without any
+	// actor at all — it works on behalf of nobody.
+	sweep, err := s.svc.ListDeletedStudentDocumentsPendingFileCleanups(s.ctx)
+	require.NoError(t, err)
+	assert.Contains(t, documentIDsOf(sweep), attest.ID)
+
+	// Marking the bytes gone retires it from both views.
+	require.NoError(t, s.svc.MarkFileDeleted(s.ctx, attest.ID))
+	sweep, err = s.svc.ListDeletedStudentDocumentsPendingFileCleanups(s.ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, documentIDsOf(sweep), attest.ID)
+	retry, err := s.svc.ListDeletedStudentDocumentsPendingFileCleanup(s.ctx, s.studentID, health)
+	require.NoError(t, err)
+	assert.Empty(t, retry)
+}
+
+// TestStudentDocumentService_SettlesIntentsByIDAndName covers the two ways the
+// coordinator retires an intent: by ID after the scheduler unlinked the object,
+// and by stored name when the upload that owns it committed.
+func TestStudentDocumentService_SettlesIntentsByIDAndName(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+
+	byName := fmt.Sprintf("settle-name-%d.pdf", time.Now().UnixNano())
+	byID := fmt.Sprintf("settle-id-%d.pdf", time.Now().UnixNano())
+	require.NoError(t, s.svc.QueueStudentDocumentFileCleanup(s.ctx, s.studentID, byName))
+	require.NoError(t, s.svc.QueueStudentDocumentFileCleanup(s.ctx, s.studentID, byID))
+	// Both are queued five minutes out; activating makes them visible to a
+	// sweep, which is the state the coordinator settles them from.
+	require.NoError(t, s.svc.ActivateQueuedCleanup(s.ctx, byName))
+	require.NoError(t, s.svc.ActivateQueuedCleanup(s.ctx, byID))
+
+	queued, err := s.svc.ListQueuedStudentDocumentFileCleanups(s.ctx)
+	require.NoError(t, err)
+	require.Contains(t, cleanupNamesOf(queued), byName)
+	var target int64
+	for _, cleanup := range queued {
+		if cleanup.FilenameStored == byID {
+			target = cleanup.ID
+		}
+	}
+	require.NotZero(t, target)
+
+	require.NoError(t, s.svc.MarkQueuedCleanupCompleteByFilename(s.ctx, byName))
+	require.NoError(t, s.svc.MarkQueuedCleanupComplete(s.ctx, target))
+
+	queued, err = s.svc.ListQueuedStudentDocumentFileCleanups(s.ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, cleanupNamesOf(queued), byName)
+	assert.NotContains(t, cleanupNamesOf(queued), byID)
+}
+
+// TestStudentDocumentService_AuditNamesAnUnknownActor pins the fallback for an
+// actor whose display name never reached the service. The trail must still say
+// who acted, and "" in a history column reads as a bug rather than as a person.
+func TestStudentDocumentService_AuditNamesAnUnknownActor(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	nameless := usersSvc.StudentDocumentActor{
+		AccountID:   s.account,
+		Permissions: []string{"users:update"},
+	}
+
+	s.create(t, userModels.StudentDocumentCategorySonstiges, nameless)
+
+	rows := s.auditRows(t)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "Unbekannt", rows[0].EditedByName)
+}
+
+func documentIDsOf(docs []*userModels.StudentDocument) []int64 {
+	ids := make([]int64, 0, len(docs))
+	for _, doc := range docs {
+		ids = append(ids, doc.ID)
+	}
+	return ids
+}
+
+func cleanupNamesOf(cleanups []*userModels.StudentDocumentFileCleanup) []string {
+	names := make([]string, 0, len(cleanups))
+	for _, cleanup := range cleanups {
+		names = append(names, cleanup.FilenameStored)
+	}
+	return names
+}
+
 // TestStudentDocumentService_AuthorizeUploadWritesNothing pins the guard the
 // upload handler relies on: it must answer before any byte or cleanup row
 // exists, and it must answer the same way the transaction later does.

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -84,9 +84,14 @@ func (s *studentDocumentScenario) actor(perms ...string) usersSvc.StudentDocumen
 	}
 }
 
+// create mirrors what the upload handler does, intent first. Skipping that
+// step in tests hides the whole class of bug where a later re-queue collides
+// with the settled intent this leaves behind.
 func (s *studentDocumentScenario) create(t *testing.T, category string, actor usersSvc.StudentDocumentActor) *userModels.StudentDocument {
 	t.Helper()
-	doc, err := s.svc.CreateStudentDocument(s.ctx, s.input(category), actor)
+	input := s.input(category)
+	require.NoError(t, s.svc.QueueStudentDocumentFileCleanup(s.ctx, s.studentID, input.FilenameStored))
+	doc, err := s.svc.CreateStudentDocument(s.ctx, input, actor)
 	require.NoError(t, err)
 	return doc
 }

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	educationModels "github.com/moto-nrw/project-phoenix/models/education"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	usersSvc "github.com/moto-nrw/project-phoenix/services/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -28,6 +30,32 @@ type studentDocumentScenario struct {
 	ctx       context.Context
 	studentID int64
 	account   int64
+	groupID   int64
+}
+
+// stubDocumentUserContext answers the supervision question the document
+// service asks. It reports exactly the groups it was built with, so a test can
+// put the caller inside or outside the child's group.
+type stubDocumentUserContext struct {
+	supervisedGroupIDs []int64
+}
+
+func (s stubDocumentUserContext) GetCurrentStaff(context.Context) (*userModels.Staff, error) {
+	return nil, nil
+}
+
+func (s stubDocumentUserContext) GetMyGroups(context.Context) ([]*educationModels.Group, error) {
+	groups := make([]*educationModels.Group, 0, len(s.supervisedGroupIDs))
+	for _, id := range s.supervisedGroupIDs {
+		group := &educationModels.Group{}
+		group.ID = id
+		groups = append(groups, group)
+	}
+	return groups, nil
+}
+
+func (s stubDocumentUserContext) GetMyActiveGroups(context.Context) ([]*activeModels.Group, error) {
+	return nil, nil
 }
 
 func newStudentDocumentScenario(t *testing.T) *studentDocumentScenario {
@@ -36,6 +64,20 @@ func newStudentDocumentScenario(t *testing.T) *studentDocumentScenario {
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
 
+	suffix := time.Now().UnixNano()
+	group := testpkg.CreateTestEducationGroup(t, db, fmt.Sprintf("Dokumente-Gruppe-%d", suffix))
+	student := testpkg.CreateTestStudent(t, db, "Dokumente", fmt.Sprintf("Kind-%d", suffix), "1a")
+	// A child without a group is reachable only by admins, so the fixture has
+	// to sit in one for the supervisor cases to mean anything.
+	assignStudentGroup(t, db, student.ID, group.ID)
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("kind-dokumente-%d@example.test", suffix))
+	t.Cleanup(func() {
+		cleanupStudentDocumentRows(t, db, student.ID)
+		testpkg.CleanupActivityFixtures(t, db, student.ID)
+		testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+		testpkg.CleanupTableRecords(t, db, "education.groups", group.ID)
+	})
+
 	repos := repositories.NewFactory(db)
 	svc := usersSvc.NewStudentDocumentService(
 		db,
@@ -43,17 +85,9 @@ func newStudentDocumentScenario(t *testing.T) *studentDocumentScenario {
 		repos.Student,
 		repos.StudentFieldEdit,
 		repos.DataAccessLog,
+		stubDocumentUserContext{supervisedGroupIDs: []int64{group.ID}},
 		nil,
 	)
-
-	suffix := time.Now().UnixNano()
-	student := testpkg.CreateTestStudent(t, db, "Dokumente", fmt.Sprintf("Kind-%d", suffix), "1a")
-	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("kind-dokumente-%d@example.test", suffix))
-	t.Cleanup(func() {
-		cleanupStudentDocumentRows(t, db, student.ID)
-		testpkg.CleanupActivityFixtures(t, db, student.ID)
-		testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
-	})
 
 	return &studentDocumentScenario{
 		db:        db,
@@ -61,6 +95,7 @@ func newStudentDocumentScenario(t *testing.T) *studentDocumentScenario {
 		ctx:       testpkg.TenantContext(student.TenantID),
 		studentID: student.ID,
 		account:   account.ID,
+		groupID:   group.ID,
 	}
 }
 
@@ -323,4 +358,51 @@ func TestStudentDocumentService_QueueCleanupForAllDocuments(t *testing.T) {
 	}
 	assert.Contains(t, names, first.FilenameStored)
 	assert.Contains(t, names, second.FilenameStored)
+}
+
+// TestStudentDocumentService_ForeignChildIsUnreachable covers the per-child
+// gate. The route permissions only say the caller may open documents at all;
+// which children they may open is a separate question, and without this every
+// group supervisor holding users:update could read and delete the paperwork of
+// every child in the school.
+func TestStudentDocumentService_ForeignChildIsUnreachable(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+
+	// Same permissions, but supervising a different group.
+	repos := repositories.NewFactory(s.db)
+	outsider := usersSvc.NewStudentDocumentService(
+		s.db,
+		repos.StudentDocument,
+		repos.Student,
+		repos.StudentFieldEdit,
+		repos.DataAccessLog,
+		stubDocumentUserContext{supervisedGroupIDs: []int64{s.groupID + 100_000}},
+		nil,
+	)
+
+	office := s.actor("users:update")
+	doc := s.create(t, userModels.StudentDocumentCategoryBetreuungsvertrag, office)
+
+	_, _, err := outsider.ListStudentDocuments(s.ctx, s.studentID, "", office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentNoAccess)
+
+	_, err = outsider.ResolveStudentDocumentDownload(s.ctx, s.studentID, doc.ID, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentNoAccess)
+
+	_, err = outsider.DeleteStudentDocument(s.ctx, s.studentID, doc.ID, office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentNoAccess)
+
+	_, err = outsider.CreateStudentDocument(s.ctx, s.input(userModels.StudentDocumentCategorySonstiges), office)
+	require.ErrorIs(t, err, usersSvc.ErrStudentDocumentNoAccess)
+
+	// The document is untouched: the refusals are refusals, not silent no-ops.
+	docs, _, err := s.svc.ListStudentDocuments(s.ctx, s.studentID, "", office)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	// An admin reaches every child regardless of supervision — that is the
+	// office role the tab exists for.
+	adminDocs, _, err := outsider.ListStudentDocuments(s.ctx, s.studentID, "", s.actor("admin:*"))
+	require.NoError(t, err)
+	assert.Len(t, adminDocs, 1)
 }

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -442,3 +442,48 @@ func TestStudentDocumentService_AuditFieldCarriesCategory(t *testing.T) {
 	assert.False(t, usersSvc.CanSeeEveryStudentDocumentCategory(office))
 	assert.True(t, usersSvc.CanSeeEveryStudentDocumentCategory([]string{"admin:*"}))
 }
+
+// TestStudentDocumentService_AuthorizeUploadWritesNothing pins the guard the
+// upload handler relies on: it must answer before any byte or cleanup row
+// exists, and it must answer the same way the transaction later does.
+func TestStudentDocumentService_AuthorizeUploadWritesNothing(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+	office := s.actor("users:update")
+
+	// Wrong category for these permissions, unknown category, and a child the
+	// caller supervises nothing of — all refused up front.
+	require.ErrorIs(t,
+		s.svc.AuthorizeStudentDocumentUpload(s.ctx, s.studentID, userModels.StudentDocumentCategoryAttest, office),
+		usersSvc.ErrStudentDocumentForbidden)
+	require.ErrorIs(t,
+		s.svc.AuthorizeStudentDocumentUpload(s.ctx, s.studentID, "erfundene_kategorie", office),
+		usersSvc.ErrStudentDocumentInvalid)
+
+	repos := repositories.NewFactory(s.db)
+	outsider := usersSvc.NewStudentDocumentService(
+		s.db,
+		repos.StudentDocument,
+		repos.Student,
+		repos.StudentFieldEdit,
+		repos.DataAccessLog,
+		stubDocumentUserContext{supervisedGroupIDs: []int64{s.groupID + 100_000}},
+		nil,
+	)
+	require.ErrorIs(t,
+		outsider.AuthorizeStudentDocumentUpload(s.ctx, s.studentID, userModels.StudentDocumentCategorySonstiges, office),
+		usersSvc.ErrStudentDocumentNoAccess)
+
+	// None of those refusals left a trace — no document row, no cleanup intent,
+	// no audit entry.
+	docs, _, err := s.svc.ListStudentDocuments(s.ctx, s.studentID, "", s.actor("admin:*"))
+	require.NoError(t, err)
+	assert.Empty(t, docs)
+	queued, err := s.svc.ListQueuedStudentDocumentFileCleanups(s.ctx)
+	require.NoError(t, err)
+	assert.Empty(t, queued)
+	assert.Empty(t, s.auditRows(t))
+
+	// And the permitted combination passes, so the guard is not simply closed.
+	require.NoError(t,
+		s.svc.AuthorizeStudentDocumentUpload(s.ctx, s.studentID, userModels.StudentDocumentCategoryBetreuungsvertrag, office))
+}

--- a/backend/services/users/student_document_service_test.go
+++ b/backend/services/users/student_document_service_test.go
@@ -149,7 +149,7 @@ func (s *studentDocumentScenario) auditRows(t *testing.T) []*auditModels.Student
 		Model(&rows).
 		ModelTableExpr(`audit.student_field_edits AS "student_field_edit"`).
 		Where(`"student_field_edit".student_id = ?`, s.studentID).
-		Where(`"student_field_edit".field_name = ?`, auditModels.StudentFieldDocument).
+		Where(`"student_field_edit".field_name LIKE ?`, auditModels.StudentFieldDocumentPrefix+"%").
 		Order("id ASC").
 		Scan(context.Background())
 	require.NoError(t, err)
@@ -405,4 +405,40 @@ func TestStudentDocumentService_ForeignChildIsUnreachable(t *testing.T) {
 	adminDocs, _, err := outsider.ListStudentDocuments(s.ctx, s.studentID, "", s.actor("admin:*"))
 	require.NoError(t, err)
 	assert.Len(t, adminDocs, 1)
+}
+
+// TestStudentDocumentService_AuditFieldCarriesCategory pins the property the
+// change-history filter depends on. Without the category in the field name a
+// reader cannot tell a Sorgerechtsnachweis row from a Betreuungsvertrag row,
+// and the history becomes a way around the document permissions: a supervisor
+// without student_documents:health would read "Ärztliches Attest:
+// Attest_Epilepsie.pdf" in the Historie tab while the Dokumente tab hides that
+// very document.
+func TestStudentDocumentService_AuditFieldCarriesCategory(t *testing.T) {
+	s := newStudentDocumentScenario(t)
+
+	s.create(t, userModels.StudentDocumentCategoryAttest, s.actor("student_documents:health"))
+	s.create(t, userModels.StudentDocumentCategoryBetreuungsvertrag, s.actor("users:update"))
+
+	rows := s.auditRows(t)
+	require.Len(t, rows, 2)
+
+	fields := []string{rows[0].FieldName, rows[1].FieldName}
+	assert.Contains(t, fields, auditModels.StudentDocumentField(userModels.StudentDocumentCategoryAttest))
+	assert.Contains(t, fields, auditModels.StudentDocumentField(userModels.StudentDocumentCategoryBetreuungsvertrag))
+
+	// And the category survives the round trip a reader performs.
+	for _, row := range rows {
+		category := auditModels.StudentDocumentCategoryFromField(row.FieldName)
+		require.NotEmpty(t, category, "every document row must name its category")
+		assert.True(t, userModels.IsValidStudentDocumentCategory(category))
+	}
+
+	// The office permission covers the contract but not the medical note.
+	office := []string{"users:update"}
+	assert.True(t, usersSvc.CanSeeStudentDocumentCategory(userModels.StudentDocumentCategoryBetreuungsvertrag, office))
+	assert.False(t, usersSvc.CanSeeStudentDocumentCategory(userModels.StudentDocumentCategoryAttest, office))
+	assert.False(t, usersSvc.CanSeeStudentDocumentCategory(userModels.StudentDocumentCategorySorgerecht, office))
+	assert.False(t, usersSvc.CanSeeEveryStudentDocumentCategory(office))
+	assert.True(t, usersSvc.CanSeeEveryStudentDocumentCategory([]string{"admin:*"}))
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/change-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/change-history/page.tsx
@@ -54,6 +54,7 @@ const FIELD_LABELS: Record<string, string> = {
   pickup_status: "Abholung",
   departure_days: "Wochenplan (Abholung)",
   departure_companion_note: "Geht außerdem mit",
+  document: "Dokument",
 };
 
 function fieldLabel(field: string): string {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/change-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/change-history/page.tsx
@@ -57,7 +57,14 @@ const FIELD_LABELS: Record<string, string> = {
   document: "Dokument",
 };
 
+// Document rows carry their category in the field name ("document_attest") so
+// the backend can filter the history by the same per-category permissions the
+// Dokumente tab uses. The readable category is already part of the value, so
+// every variant renders under one label.
 function fieldLabel(field: string): string {
+  if (field.startsWith("document_")) {
+    return "Dokument";
+  }
   return FIELD_LABELS[field] ?? field;
 }
 

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -46,6 +46,7 @@ import {
 import { PersonalInfoFormModal } from "~/components/students/personal-info-form-modal";
 import { ParentMessagesCard } from "~/components/students/parent-messages-card";
 import { StudentEnrollmentsTab } from "~/components/students/student-enrollments-tab";
+import { StudentDokumenteTab } from "~/components/students/dokumente-tab";
 import {
   StudentCheckoutSection,
   StudentCheckinSection,
@@ -97,6 +98,7 @@ type StudentTabId =
   | "betreuungsplan"
   | "betreuungszeiten"
   | "anmeldungen"
+  | "dokumente"
   | "historie";
 
 const TAB_LABELS: Record<StudentTabId, string> = {
@@ -106,6 +108,7 @@ const TAB_LABELS: Record<StudentTabId, string> = {
   betreuungsplan: "Betreuungsplan",
   betreuungszeiten: "Betreuungszeiten",
   anmeldungen: "Anmeldungen",
+  dokumente: "Dokumente",
   historie: "Historie",
 };
 
@@ -118,6 +121,7 @@ const FULL_ACCESS_BASE_TABS: StudentTabId[] = [
   "erziehungsberechtigte",
   "betreuungsplan",
   "betreuungszeiten",
+  "dokumente",
   "historie",
 ];
 const LIMITED_ACCESS_BASE_TABS: StudentTabId[] = [
@@ -132,6 +136,7 @@ const FULL_ACCESS_TABS_WITH_ENROLLMENTS: StudentTabId[] = [
   "betreuungsplan",
   "betreuungszeiten",
   "anmeldungen",
+  "dokumente",
   "historie",
 ];
 const LIMITED_ACCESS_TABS_WITH_ENROLLMENTS: StudentTabId[] = [
@@ -165,6 +170,7 @@ function studentTabs(
   hasStudentReadAccess: boolean,
   canViewEnrollments: boolean,
   canViewCarePlan: boolean,
+  hasWriteAccess: boolean,
 ): StudentTabId[] {
   const base = hasStudentReadAccess
     ? canViewEnrollments
@@ -187,9 +193,17 @@ function studentTabs(
   // would only surface a permanently failing panel, and ?tab=betreuungsplan is
   // clamped away for the same reason. Widening staff access to a child's plan
   // is a backend (gdpr.student_data_scope) decision, not a frontend one.
-  return canViewCarePlan
+  const withCarePlan = canViewCarePlan
     ? base
     : base.filter((tab) => tab !== "betreuungsplan");
+  // Dokumente (#777) needs users:update or one of the two document
+  // permissions; the backend route rejects everyone else. hasWriteAccess is
+  // the same predicate the change-history entry already gates on, and both
+  // hold data of the same sensitivity class, so a read-only user never sees a
+  // tab that could only answer 403.
+  return hasWriteAccess
+    ? withCarePlan
+    : withCarePlan.filter((tab) => tab !== "dokumente");
 }
 
 // Shared classes for every tab panel. forceMount (below) keeps inactive panels
@@ -357,8 +371,14 @@ function StudentDetailPageContent() {
     sessionStatus === "authenticated" &&
     hasPermission(session, "schedules:read");
   const visibleTabs = useMemo(
-    () => studentTabs(hasFullAccess, canViewEnrollments, canViewCarePlan),
-    [canViewEnrollments, canViewCarePlan, hasFullAccess],
+    () =>
+      studentTabs(
+        hasFullAccess,
+        canViewEnrollments,
+        canViewCarePlan,
+        hasWriteAccess,
+      ),
+    [canViewEnrollments, canViewCarePlan, hasFullAccess, hasWriteAccess],
   );
   const tabResolutionTabs =
     sessionStatus === "loading"
@@ -1396,6 +1416,16 @@ function FullAccessView({
   useEffect(() => {
     if (activeTab === "nachrichten") setMessagesTabSeen(true);
   }, [activeTab]);
+  // Same deal for Dokumente (#777): the list request also sweeps for storage
+  // cleanup left over from an interrupted upload, so firing it on every
+  // student-detail load would put that work behind page views that never open
+  // the tab. Mount on first open, then keep it mounted so revisits don't refetch.
+  const [documentsTabSeen, setDocumentsTabSeen] = useState(
+    activeTab === "dokumente",
+  );
+  useEffect(() => {
+    if (activeTab === "dokumente") setDocumentsTabSeen(true);
+  }, [activeTab]);
   return (
     <>
       {(showCheckout || showCheckin || hasWriteAccess) && (
@@ -1521,6 +1551,10 @@ function FullAccessView({
             <StudentEnrollmentsTab studentId={studentId} />
           </TabsContent>
         ) : null}
+
+        <TabsContent value="dokumente" forceMount className={TAB_CONTENT_CLASS}>
+          {documentsTabSeen && <StudentDokumenteTab studentId={studentId} />}
+        </TabsContent>
 
         <TabsContent value="historie" forceMount className={TAB_CONTENT_CLASS}>
           <StudentHistorySection

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -170,7 +170,7 @@ function studentTabs(
   hasStudentReadAccess: boolean,
   canViewEnrollments: boolean,
   canViewCarePlan: boolean,
-  hasWriteAccess: boolean,
+  canViewDocuments: boolean,
 ): StudentTabId[] {
   const base = hasStudentReadAccess
     ? canViewEnrollments
@@ -196,12 +196,14 @@ function studentTabs(
   const withCarePlan = canViewCarePlan
     ? base
     : base.filter((tab) => tab !== "betreuungsplan");
-  // Dokumente (#777) needs users:update or one of the two document
-  // permissions; the backend route rejects everyone else. hasWriteAccess is
-  // the same predicate the change-history entry already gates on, and both
-  // hold data of the same sensitivity class, so a read-only user never sees a
-  // tab that could only answer 403.
-  return hasWriteAccess
+  // Dokumente (#777) mirrors the backend route gate exactly:
+  // RequiresAnyPermission(users:update, student_documents:health,
+  // student_documents:legal). Gating on write access instead would disagree in
+  // both directions — a group supervisor without users:update would see a tab
+  // that only answers 403, and a role holding just student_documents:health
+  // (which the migration exists to make grantable) could never reach the tab
+  // at all.
+  return canViewDocuments
     ? withCarePlan
     : withCarePlan.filter((tab) => tab !== "dokumente");
 }
@@ -370,15 +372,21 @@ function StudentDetailPageContent() {
   const canViewCarePlan =
     sessionStatus === "authenticated" &&
     hasPermission(session, "schedules:read");
+  // Same three permissions the backend route gate accepts (#777).
+  const canViewDocuments =
+    sessionStatus === "authenticated" &&
+    (hasPermission(session, "users:update") ||
+    hasPermission(session, "student_documents:health") ||
+      hasPermission(session, "student_documents:legal"));
   const visibleTabs = useMemo(
     () =>
       studentTabs(
         hasFullAccess,
         canViewEnrollments,
         canViewCarePlan,
-        hasWriteAccess,
+        canViewDocuments,
       ),
-    [canViewEnrollments, canViewCarePlan, hasFullAccess, hasWriteAccess],
+    [canViewEnrollments, canViewCarePlan, hasFullAccess, canViewDocuments],
   );
   const tabResolutionTabs =
     sessionStatus === "loading"

--- a/frontend/src/app/api/students/[id]/documents/[documentId]/download/route.ts
+++ b/frontend/src/app/api/students/[id]/documents/[documentId]/download/route.ts
@@ -51,11 +51,16 @@ async function GETHandler(
   }
 
   const headers = new Headers();
+  // This proxy is the only thing the browser talks to, so a header the backend
+  // sets but this list omits does not exist in production. nosniff is the one
+  // that matters here: an uploaded document must never be re-interpreted as
+  // something executable because a Content-Type looked wrong.
   for (const name of [
     "content-type",
     "content-disposition",
     "cache-control",
     "content-length",
+    "x-content-type-options",
   ]) {
     const value = upstream.headers.get(name);
     if (value) headers.set(name, value);

--- a/frontend/src/app/api/students/[id]/documents/[documentId]/download/route.ts
+++ b/frontend/src/app/api/students/[id]/documents/[documentId]/download/route.ts
@@ -1,0 +1,67 @@
+// Authenticated proxy streaming child document bytes (#777). Mirrors the
+// staff document serve proxy: inject the JWT server-side, refresh once on
+// 401, stream the body through with Content-Type and Content-Disposition
+// intact. Documents are served with `private, no-store`, so there is no
+// conditional-GET path to preserve.
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { auth, uncachedAuth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "StudentDocumentDownloadRoute" });
+
+async function GETHandler(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; documentId: string }> },
+) {
+  const { id, documentId } = await params;
+
+  const session = await auth();
+  const token = session?.user?.token;
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const backendUrl = `${getServerApiUrl()}/api/students/${encodeURIComponent(id)}/documents/${encodeURIComponent(documentId)}/download`;
+
+  const makeRequest = (bearer: string) =>
+    fetch(backendUrl, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${bearer}` },
+    });
+
+  let upstream = await makeRequest(token);
+  if (upstream.status === 401) {
+    const refreshed = await uncachedAuth();
+    if (refreshed?.user?.token && refreshed.user.token !== token) {
+      upstream = await makeRequest(refreshed.user.token);
+    }
+  }
+
+  if (!upstream.ok) {
+    logger.warn("student_document_download_proxy_non_ok", {
+      student_id: id,
+      document_id: documentId,
+      status: upstream.status,
+    });
+    return new NextResponse(null, { status: upstream.status });
+  }
+
+  const headers = new Headers();
+  for (const name of [
+    "content-type",
+    "content-disposition",
+    "cache-control",
+    "content-length",
+  ]) {
+    const value = upstream.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+
+  return new NextResponse(upstream.body, { status: 200, headers });
+}
+
+export const GET = withTenantAuth(GETHandler);

--- a/frontend/src/app/api/students/[id]/documents/[documentId]/route.ts
+++ b/frontend/src/app/api/students/[id]/documents/[documentId]/route.ts
@@ -1,0 +1,12 @@
+import { proxyDelete } from "~/lib/route-proxy.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+/**
+ * DELETE /api/students/[id]/documents/[documentId]
+ * Audited soft delete of one child document (#777); the backend removes the
+ * stored bytes after the metadata transaction commits.
+ */
+export const DELETE = proxyDelete(
+  (p) =>
+    `/api/students/${requirePathSegmentParam(p)}/documents/${requirePathSegmentParam(p, "documentId")}`,
+);

--- a/frontend/src/app/api/students/[id]/documents/route.ts
+++ b/frontend/src/app/api/students/[id]/documents/route.ts
@@ -1,0 +1,122 @@
+// Child documents (#777): list + multipart upload proxy. The backend owns the
+// authoritative magic-number validation and the per-category permission
+// checks; this route mirrors the size/MIME gate so oversized or obviously
+// wrong files never leave the Next.js server, and forwards the multipart body
+// unchanged. On 401 we refresh the access token via uncachedAuth() and retry
+// once, mirroring the staff document upload proxy.
+
+import type { NextRequest } from "next/server";
+import {
+  createFileUploadHandler,
+  FileValidationError,
+} from "~/lib/file-upload-wrapper.server";
+import { proxyGet } from "~/lib/route-proxy.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+import { uncachedAuth } from "~/server/auth";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "StudentDocumentsRoute" });
+
+export const GET = proxyGet(
+  (p) => `/api/students/${requirePathSegmentParam(p)}/documents`,
+);
+
+interface BackendDocumentResponse {
+  status?: string;
+  message?: string;
+  data?: unknown;
+}
+
+export const POST = createFileUploadHandler<unknown>(
+  async (request: NextRequest, formData: FormData, token: string) => {
+    const studentId = extractStudentIdFromUrl(request);
+
+    const file = formData.get("file");
+    if (!file || !(file instanceof File)) {
+      throw new FileValidationError("No document file provided", 400);
+    }
+    const category = formData.get("category");
+    if (typeof category !== "string" || category === "") {
+      throw new FileValidationError("No document category provided", 400);
+    }
+
+    const backendUrl = `${getServerApiUrl()}/api/students/${studentId}/documents`;
+    // Rebuild the form from the in-memory file so the body is re-readable for
+    // the post-refresh retry.
+    const buffer = await file.arrayBuffer();
+    const forwarded = new FormData();
+    forwarded.append(
+      "file",
+      new File([buffer], file.name, { type: file.type }),
+    );
+    forwarded.append("category", category);
+
+    const sendUpload = (bearer: string) =>
+      fetch(backendUrl, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${bearer}` },
+        body: forwarded,
+      });
+
+    let response = await sendUpload(token);
+    if (response.status === 401) {
+      const refreshed = await uncachedAuth();
+      if (refreshed?.user?.token && refreshed.user.token !== token) {
+        response = await sendUpload(refreshed.user.token);
+      }
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error("student_document_upload_proxy_failed", {
+        student_id: studentId,
+        status: response.status,
+        error: errorText,
+      });
+      // The "API error (XXX)" prefix keeps the backend's status code (400
+      // invalid file, 403 category permission, 404 child) intact through
+      // handleApiError instead of collapsing everything into a 500.
+      throw new Error(
+        `API error (${response.status}): ${errorText || "Upload fehlgeschlagen"}`,
+      );
+    }
+
+    const body = (await response.json()) as BackendDocumentResponse;
+    return body.data ?? {};
+  },
+  {
+    maxSizeInMB: 10,
+    // DOCX is an OOXML ZIP container, so browsers without the OOXML mapping
+    // label a valid .docx as a plain ZIP (or not at all). Accepting the ZIP
+    // labels here costs nothing: the extension gate below still requires
+    // .docx, and the backend rejects an archive that lacks the OOXML parts
+    // (api/common/upload_documents.go).
+    allowedMimeTypes: [
+      "",
+      "application/octet-stream",
+      "application/pdf",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/zip",
+      "application/x-zip-compressed",
+      "image/png",
+      "image/jpeg",
+      "image/jpg",
+    ],
+    allowedExtensions: [".pdf", ".docx", ".png", ".jpg", ".jpeg"],
+  },
+);
+
+// Pulls {id} out of the URL because createFileUploadHandler doesn't expose
+// `params` to the body callback. Throws so a regex drift can never silently
+// target the wrong child.
+function extractStudentIdFromUrl(request: NextRequest): string {
+  const match = request.nextUrl.pathname.match(
+    /\/students\/([^/]+)\/documents/,
+  );
+  const id = match?.[1];
+  if (!id) {
+    throw new Error("Could not extract student ID from request URL");
+  }
+  return id;
+}

--- a/frontend/src/components/students/dokumente-tab.tsx
+++ b/frontend/src/components/students/dokumente-tab.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { FileText, FileImage, File as FileIcon, Upload } from "lucide-react";
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Loading } from "~/components/ui/loading";
+import {
+  OverflowMenu,
+  type OverflowMenuEntry,
+} from "~/components/ui/page-header/OverflowMenu";
+import { SectionCard } from "~/components/ui/section-card";
+import {
+  SegmentedControl,
+  type SegmentedControlItem,
+} from "~/components/ui/segmented-control";
+import { StatusBadge } from "~/components/ui/status-badge";
+import { formatDate } from "~/lib/date-helpers";
+import { createLogger } from "~/lib/logger";
+import { formatFileSize } from "~/lib/staff-documents-api";
+import {
+  studentDocumentsService,
+  type StudentDocument,
+  type StudentDocumentList,
+} from "~/lib/student-documents-api";
+import { useSWRAuth } from "~/lib/swr";
+
+// Dokumente tab (#777): flat file list per child with upload, download,
+// audited delete and category filter. The backend already filters per
+// category permission (Attest/Impfnachweis/Medikamentenplan →
+// student_documents:health, Sorgerecht → student_documents:legal, rest →
+// users:update) and sends the caller's visible categories — the tab renders
+// exactly that, no client-side authority.
+
+const logger = createLogger({ component: "StudentDokumenteTab" });
+
+const ACCEPTED_FILE_TYPES = ".pdf,.docx,.png,.jpg,.jpeg";
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+function documentIcon(contentType: string) {
+  if (contentType.startsWith("image/")) {
+    return <FileImage className="h-4 w-4 text-gray-400" aria-hidden="true" />;
+  }
+  if (contentType === "application/pdf") {
+    return <FileText className="h-4 w-4 text-gray-400" aria-hidden="true" />;
+  }
+  return <FileIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />;
+}
+
+export function StudentDokumenteTab({
+  studentId,
+}: {
+  readonly studentId: string;
+}) {
+  const { data, isLoading, error, mutate } = useSWRAuth<StudentDocumentList>(
+    `student-documents-${studentId}`,
+    () => studentDocumentsService.list(studentId),
+  );
+
+  const [filter, setFilter] = useState<string>("alle");
+  const [uploadCategory, setUploadCategory] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [actionError, setActionError] = useState("");
+  const [dragActive, setDragActive] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<StudentDocument | null>(
+    null,
+  );
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const visibleCategories = useMemo(
+    () => data?.visibleCategories ?? [],
+    [data],
+  );
+  const documents = data?.documents ?? [];
+  const effectiveUploadCategory =
+    uploadCategory ?? visibleCategories[0]?.value ?? null;
+
+  const filterItems: readonly SegmentedControlItem<string>[] = [
+    { value: "alle", label: "Alle" },
+    ...visibleCategories.map((category) => ({
+      value: category.value,
+      label: category.label,
+    })),
+  ];
+
+  const filtered =
+    filter === "alle"
+      ? documents
+      : documents.filter((doc) => doc.category === filter);
+
+  const handleFiles = async (files: FileList | File[] | null) => {
+    const file = files?.[0];
+    if (!file || uploading) {
+      return;
+    }
+    if (!effectiveUploadCategory) {
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setActionError("Die Datei ist größer als 10 MB.");
+      return;
+    }
+    setActionError("");
+    setUploading(true);
+    try {
+      await studentDocumentsService.upload(
+        studentId,
+        file,
+        effectiveUploadCategory,
+      );
+      await mutate();
+    } catch (err) {
+      logger.error("student_document_upload_failed", {
+        student_id: studentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : "Dokument konnte nicht hochgeladen werden.",
+      );
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setDeleting(true);
+    setDeleteError("");
+    try {
+      await studentDocumentsService.delete(studentId, deleteTarget.id);
+      setDeleteTarget(null);
+      await mutate();
+    } catch (err) {
+      logger.error("student_document_delete_failed", {
+        student_id: studentId,
+        document_id: deleteTarget.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setDeleteError(
+        err instanceof Error
+          ? err.message
+          : "Dokument konnte nicht gelöscht werden.",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const columns: DataTableColumn<StudentDocument>[] = [
+    {
+      key: "filename",
+      header: "Dokument",
+      render: (doc) => (
+        <span className="flex min-w-0 items-center gap-2">
+          {documentIcon(doc.contentType)}
+          <span className="truncate text-sm font-medium text-gray-900">
+            {doc.filename}
+          </span>
+        </span>
+      ),
+      sortValue: (doc) => doc.filename.toLowerCase(),
+    },
+    {
+      key: "category",
+      header: "Kategorie",
+      render: (doc) => (
+        <StatusBadge
+          tone={doc.sensitive ? "blue" : "gray"}
+          label={doc.categoryLabel}
+          title={
+            doc.sensitive
+              ? "Besonders schützenswert — jeder Download wird protokolliert."
+              : undefined
+          }
+        />
+      ),
+      sortValue: (doc) => doc.categoryLabel,
+    },
+    {
+      key: "size",
+      header: "Größe",
+      render: (doc) => (
+        <span className="text-xs text-gray-500">
+          {formatFileSize(doc.sizeBytes)}
+        </span>
+      ),
+      sortValue: (doc) => doc.sizeBytes,
+    },
+    {
+      key: "uploaded",
+      header: "Hochgeladen",
+      render: (doc) => (
+        <span className="text-xs text-gray-500">
+          {formatDate(doc.uploadedAt)}
+        </span>
+      ),
+      sortValue: (doc) => doc.uploadedAt,
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      render: (doc) => {
+        const items: readonly OverflowMenuEntry[] = [
+          {
+            label: "Herunterladen",
+            href: studentDocumentsService.downloadUrl(studentId, doc.id),
+            external: true,
+            onClick: () => undefined,
+          },
+          { kind: "separator" },
+          {
+            label: "Löschen",
+            destructive: true,
+            onClick: () => {
+              setDeleteError("");
+              setDeleteTarget(doc);
+            },
+          },
+        ];
+        return (
+          <OverflowMenu
+            items={items}
+            ariaLabel={`Aktionen für ${doc.filename}`}
+          />
+        );
+      },
+    },
+  ];
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error || !data) {
+    return (
+      <Alert type="error" message="Dokumente konnten nicht geladen werden." />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <SectionCard
+        kicker="Kindakte"
+        title="Dokumente"
+        description="Dateien zum Kind. Uploads und Löschungen werden im Änderungsprotokoll festgehalten. Beim Löschen wird die Datei sofort entfernt, der Protokolleintrag bleibt."
+      >
+        {actionError !== "" && (
+          <div className="mb-4">
+            <Alert type="error" message={actionError} />
+          </div>
+        )}
+
+        {/* Upload row: category choice + drop zone */}
+        <div className="mb-5 space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <label
+              htmlFor="kind-dokument-kategorie"
+              className="text-xs font-medium text-gray-600"
+            >
+              Kategorie
+            </label>
+            <CustomSelect
+              id="kind-dokument-kategorie"
+              value={effectiveUploadCategory ?? ""}
+              options={visibleCategories.map((category) => ({
+                value: category.value,
+                label: category.label,
+              }))}
+              onChange={(value) => setUploadCategory(value)}
+              disabled={visibleCategories.length === 0}
+              // triggerClassName REPLACES the default trigger classes, and the
+              // base class carries a colorless `border` — without
+              // moto-content-surface the Tailwind-4 default (currentColor)
+              // paints it black.
+              triggerClassName="moto-content-surface h-9 w-56 hover:border-gray-300"
+            />
+          </div>
+
+          <div
+            className={`flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-6 text-center transition-colors ${
+              dragActive
+                ? "border-[#83CD2D] bg-[#83CD2D]/5"
+                : "border-gray-200 bg-gray-50/50"
+            }`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragActive(true);
+            }}
+            onDragLeave={() => setDragActive(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragActive(false);
+              void handleFiles(e.dataTransfer.files);
+            }}
+          >
+            <Upload className="h-5 w-5 text-gray-400" aria-hidden="true" />
+            <p className="text-sm text-gray-600">
+              Datei hierher ziehen oder{" "}
+              <Button
+                type="button"
+                variant="ghost"
+                size="compact"
+                className="text-[#5080D8]"
+                disabled={uploading || !effectiveUploadCategory}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {uploading ? "Wird hochgeladen…" : "Datei auswählen"}
+              </Button>
+            </p>
+            <p className="text-xs text-gray-400">
+              PDF, DOCX, PNG oder JPG · max. 10 MB
+            </p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_FILE_TYPES}
+              className="hidden"
+              aria-label="Dokument auswählen"
+              onChange={(e) => void handleFiles(e.target.files)}
+            />
+          </div>
+        </div>
+
+        {/* Category filter */}
+        {documents.length > 0 && filterItems.length > 2 && (
+          <div className="mb-4">
+            <SegmentedControl
+              variant="pills"
+              items={filterItems}
+              value={filter}
+              onChange={setFilter}
+              ariaLabel="Nach Kategorie filtern"
+            />
+          </div>
+        )}
+
+        <DataTable
+          columns={columns}
+          rows={filtered}
+          getRowKey={(doc) => doc.id}
+          defaultSortKey="uploaded"
+          defaultSortDirection="desc"
+          paginationResetKey={filter}
+          emptyState={
+            <EmptyState
+              icon={<FileText className="h-12 w-12" aria-hidden="true" />}
+              title={
+                filter === "alle"
+                  ? "Noch keine Dokumente"
+                  : "Keine Dokumente in dieser Kategorie"
+              }
+              description="Lade die erste Datei über den Bereich oben hoch."
+            />
+          }
+        />
+      </SectionCard>
+
+      <ConfirmDeleteModal
+        isOpen={deleteTarget !== null}
+        title="Dokument löschen"
+        description={
+          <>
+            <span className="font-medium">{deleteTarget?.filename}</span> wird
+            endgültig gelöscht. Der Vorgang wird im Änderungsprotokoll
+            festgehalten.
+          </>
+        }
+        gate={{ mode: "twoStep" }}
+        onConfirm={handleDelete}
+        onClose={() => {
+          if (!deleting) {
+            setDeleteTarget(null);
+          }
+        }}
+        loading={deleting}
+        error={deleteError}
+      />
+    </div>
+  );
+}

--- a/frontend/src/lib/student-documents-api.test.ts
+++ b/frontend/src/lib/student-documents-api.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSessionFetch = vi.hoisted(() => vi.fn());
+const mockGetCachedSession = vi.hoisted(() => vi.fn());
+
+vi.mock("./session-cache", () => ({
+  sessionFetch: mockSessionFetch,
+  getCachedSession: mockGetCachedSession,
+}));
+
+import { studentDocumentsService } from "./student-documents-api";
+
+const backendDocument = {
+  id: 91,
+  student_id: 42,
+  category: "attest",
+  category_label: "Ärztliches Attest",
+  filename: "Attest.pdf",
+  size_bytes: 20_480,
+  content_type: "application/pdf",
+  uploaded_at: "2026-08-05T09:30:00Z",
+  sensitive: true,
+};
+
+const visibleCategories = [
+  { value: "attest", label: "Ärztliches Attest", sensitive: true },
+  { value: "sonstiges", label: "Sonstiges", sensitive: false },
+];
+
+function pdf(): File {
+  return new File(["%PDF-1.4"], "Attest.pdf", { type: "application/pdf" });
+}
+
+describe("studentDocumentsService.list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps the backend row to the frontend shape", async () => {
+    mockSessionFetch.mockResolvedValueOnce(
+      Response.json(
+        {
+          data: {
+            student_id: 42,
+            documents: [backendDocument],
+            visible_categories: visibleCategories,
+          },
+        },
+        { status: 200 },
+      ),
+    );
+
+    const result = await studentDocumentsService.list("42");
+
+    expect(mockSessionFetch).toHaveBeenCalledWith("/api/students/42/documents");
+    // Backend int64 IDs arrive as numbers and have to reach the UI as strings.
+    expect(result.documents).toEqual([
+      {
+        id: "91",
+        studentId: "42",
+        category: "attest",
+        categoryLabel: "Ärztliches Attest",
+        filename: "Attest.pdf",
+        sizeBytes: 20_480,
+        contentType: "application/pdf",
+        uploadedAt: "2026-08-05T09:30:00Z",
+        sensitive: true,
+      },
+    ]);
+    // The caller's visible categories come straight from the backend: the tab
+    // must not decide for itself which categories it may show.
+    expect(result.visibleCategories).toEqual(visibleCategories);
+  });
+
+  it("returns an empty list when the child has no documents", async () => {
+    mockSessionFetch.mockResolvedValueOnce(
+      Response.json(
+        { data: { student_id: 42, documents: [], visible_categories: [] } },
+        { status: 200 },
+      ),
+    );
+
+    await expect(studentDocumentsService.list("42")).resolves.toEqual({
+      documents: [],
+      visibleCategories: [],
+    });
+  });
+
+  it("throws when the list request fails", async () => {
+    mockSessionFetch.mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: "Internal Server Error" }),
+    );
+
+    await expect(studentDocumentsService.list("42")).rejects.toThrow(
+      "Failed to fetch student documents: Internal Server Error",
+    );
+  });
+});
+
+describe("studentDocumentsService.upload", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    mockGetCachedSession.mockResolvedValue({ user: { token: "jwt-token" } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts multipart form data with a bearer token and no Content-Type", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+    await studentDocumentsService.upload("42", pdf(), "attest");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/students/42/documents");
+    expect(init.method).toBe("POST");
+    // Setting Content-Type here would clobber the multipart boundary the
+    // browser generates for a FormData body.
+    expect(init.headers).toEqual({ Authorization: "Bearer jwt-token" });
+
+    const body = init.body as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect((body.get("file") as File).name).toBe("Attest.pdf");
+    expect(body.get("category")).toBe("attest");
+  });
+
+  it("refuses to upload without a session token", async () => {
+    mockGetCachedSession.mockResolvedValueOnce(null);
+
+    await expect(
+      studentDocumentsService.upload("42", pdf(), "attest"),
+    ).rejects.toThrow("Authentifizierung erforderlich");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to upload when the session carries no token", async () => {
+    mockGetCachedSession.mockResolvedValueOnce({ user: {} });
+
+    await expect(
+      studentDocumentsService.upload("42", pdf(), "attest"),
+    ).rejects.toThrow("Authentifizierung erforderlich");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the backend error message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ error: "Datei zu groß." }, { status: 400 }),
+    );
+
+    await expect(
+      studentDocumentsService.upload("42", pdf(), "attest"),
+    ).rejects.toThrow("Datei zu groß.");
+  });
+
+  it("falls back to the generic message when the body carries no error", async () => {
+    fetchMock.mockResolvedValueOnce(Response.json({}, { status: 400 }));
+
+    await expect(
+      studentDocumentsService.upload("42", pdf(), "attest"),
+    ).rejects.toThrow("Dokument konnte nicht hochgeladen werden.");
+  });
+
+  it("falls back to the generic message on a non-JSON body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html>502</html>", { status: 502 }),
+    );
+
+    await expect(
+      studentDocumentsService.upload("42", pdf(), "attest"),
+    ).rejects.toThrow("Dokument konnte nicht hochgeladen werden.");
+  });
+
+  it("reports a missing category permission as such, whatever the body says", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ error: "forbidden" }, { status: 403 }),
+    );
+
+    // 403 on this route means the caller lacks the category's permission, so
+    // the raw backend wording would be less useful than the German hint.
+    await expect(
+      studentDocumentsService.upload("42", pdf(), "attest"),
+    ).rejects.toThrow("Keine Berechtigung für diese Dokument-Kategorie.");
+  });
+});
+
+describe("studentDocumentsService.delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes through the proxy route", async () => {
+    mockSessionFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(
+      studentDocumentsService.delete("42", "91"),
+    ).resolves.toBeUndefined();
+    expect(mockSessionFetch).toHaveBeenCalledWith(
+      "/api/students/42/documents/91",
+      { method: "DELETE" },
+    );
+  });
+
+  it("surfaces the backend error message", async () => {
+    mockSessionFetch.mockResolvedValueOnce(
+      Response.json({ error: "Dokument nicht gefunden." }, { status: 404 }),
+    );
+
+    await expect(studentDocumentsService.delete("42", "91")).rejects.toThrow(
+      "Dokument nicht gefunden.",
+    );
+  });
+
+  it("falls back to the generic delete message", async () => {
+    mockSessionFetch.mockResolvedValueOnce(
+      new Response("nope", { status: 500 }),
+    );
+
+    await expect(studentDocumentsService.delete("42", "91")).rejects.toThrow(
+      "Dokument konnte nicht gelöscht werden.",
+    );
+  });
+
+  it("reports a missing category permission as such", async () => {
+    mockSessionFetch.mockResolvedValueOnce(
+      Response.json({ error: "forbidden" }, { status: 403 }),
+    );
+
+    await expect(studentDocumentsService.delete("42", "91")).rejects.toThrow(
+      "Keine Berechtigung für diese Dokument-Kategorie.",
+    );
+  });
+});
+
+describe("studentDocumentsService.downloadUrl", () => {
+  it("points at the same-origin proxy route", () => {
+    // The bytes never sit behind a static mount — the download is gated by the
+    // authenticated handler, which also writes the audit row.
+    expect(studentDocumentsService.downloadUrl("42", "91")).toBe(
+      "/api/students/42/documents/91/download",
+    );
+  });
+});

--- a/frontend/src/lib/student-documents-api.ts
+++ b/frontend/src/lib/student-documents-api.ts
@@ -1,0 +1,158 @@
+// Child documents (#777): API client + type mapping for the Dokumente tab on
+// the child detail page. The backend decides per-category authority (Attest,
+// Impfnachweis, Medikamentenplan → student_documents:health, Sorgerecht →
+// student_documents:legal, rest → users:update) and returns only what the
+// caller may see plus the caller's visible categories.
+
+import { getCachedSession, sessionFetch } from "./session-cache";
+
+interface StudentDocumentCategoryOption {
+  value: string;
+  label: string;
+  /** Health or custody paperwork: every download is logged. */
+  sensitive: boolean;
+}
+
+export interface StudentDocument {
+  id: string;
+  studentId: string;
+  category: string;
+  categoryLabel: string;
+  filename: string;
+  sizeBytes: number;
+  contentType: string;
+  uploadedAt: string;
+  sensitive: boolean;
+}
+
+export interface StudentDocumentList {
+  documents: StudentDocument[];
+  visibleCategories: StudentDocumentCategoryOption[];
+}
+
+interface BackendStudentDocument {
+  id: number;
+  student_id: number;
+  category: string;
+  category_label: string;
+  filename: string;
+  size_bytes: number;
+  content_type: string;
+  uploaded_at: string;
+  sensitive: boolean;
+}
+
+interface BackendStudentDocumentCategory {
+  value: string;
+  label: string;
+  sensitive: boolean;
+}
+
+interface BackendStudentDocumentList {
+  student_id: number;
+  documents: BackendStudentDocument[];
+  visible_categories: BackendStudentDocumentCategory[];
+}
+
+function mapDocument(data: BackendStudentDocument): StudentDocument {
+  return {
+    id: data.id.toString(),
+    studentId: data.student_id.toString(),
+    category: data.category,
+    categoryLabel: data.category_label,
+    filename: data.filename,
+    sizeBytes: data.size_bytes,
+    contentType: data.content_type,
+    uploadedAt: data.uploaded_at,
+    sensitive: data.sensitive,
+  };
+}
+
+async function throwDocumentError(
+  response: Response,
+  fallback: string,
+): Promise<never> {
+  let message = fallback;
+  try {
+    const body = (await response.json()) as { error?: string };
+    if (body.error) {
+      message = body.error;
+    }
+  } catch {
+    // Non-JSON body — keep the fallback.
+  }
+  if (response.status === 403) {
+    message = "Keine Berechtigung für diese Dokument-Kategorie.";
+  }
+  throw new Error(message);
+}
+
+class StudentDocumentsService {
+  async list(studentId: string): Promise<StudentDocumentList> {
+    const response = await sessionFetch(`/api/students/${studentId}/documents`);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch student documents: ${response.statusText}`,
+      );
+    }
+    const json = (await response.json()) as {
+      data: BackendStudentDocumentList;
+    };
+    return {
+      documents: json.data.documents.map(mapDocument),
+      visibleCategories: json.data.visible_categories,
+    };
+  }
+
+  async upload(
+    studentId: string,
+    file: File,
+    category: string,
+  ): Promise<void> {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("category", category);
+
+    const session = await getCachedSession();
+    const token = session?.user?.token;
+    if (!token) {
+      throw new Error("Authentifizierung erforderlich");
+    }
+
+    // Raw fetch on purpose — sessionFetch forces Content-Type
+    // application/json, which would clobber the multipart boundary the
+    // browser sets for FormData bodies (same pattern as the staff document
+    // and student photo uploads).
+    const response = await fetch(`/api/students/${studentId}/documents`, {
+      method: "POST",
+      body: formData,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      await throwDocumentError(
+        response,
+        "Dokument konnte nicht hochgeladen werden.",
+      );
+    }
+  }
+
+  async delete(studentId: string, documentId: string): Promise<void> {
+    const response = await sessionFetch(
+      `/api/students/${studentId}/documents/${documentId}`,
+      { method: "DELETE" },
+    );
+    if (!response.ok) {
+      await throwDocumentError(
+        response,
+        "Dokument konnte nicht gelöscht werden.",
+      );
+    }
+  }
+
+  /** Same-origin proxy URL for the authenticated download. */
+  downloadUrl(studentId: string, documentId: string): string {
+    return `/api/students/${studentId}/documents/${documentId}/download`;
+  }
+}
+
+export const studentDocumentsService = new StudentDocumentsService();


### PR DESCRIPTION
Closes #777

## Worum es geht

Kinderunterlagen liegen heute außerhalb des Systems: Betreuungsverträge im Ordner, Atteste im Sekretariat, Abholvollmachten im Mailpostfach. Diese PR bringt einen **Dokumente-Tab an die Kind-Detailseite** und darunter die Speicher-Schicht, die dafür bisher gefehlt hat.

| | |
|---|---:|
| Commits | 22 |
| Geänderte Dateien | 38 |
| Zeilen | +4.726 / -108 |
| Migration | 1.15.271 |

---

## 1. Eine Speicher-Schicht für alle Uploads (`internal/storage`)

Bisher hat jede der sechs Upload-Familien (Avatare, Login-Bilder, Personalakten, Anmeldungs-PDFs, ...) ihr Zielverzeichnis selbst aufgelöst und inline `os.*` aufgerufen. Speichern, Ausliefern und Löschen derselben Datei konnten sich damit über den Pfad uneinig sein, und der Schutz gegen Path-Traversal war eine Frage der Review-Disziplin statt der Struktur.

Neu gibt es genau einen Weg nach draußen:

- `storage.Backend` mit `Save` / `Open` / `Remove` / `Stat`, dazu eine lokale Dateisystem-Implementierung (`storage.Local`)
- Keys werden ausschließlich über `storage.Key()` bzw. `storage.TenantKey()` gebaut. Traversal, absolute Pfade und leere Segmente fliegen dort raus, bevor sie das Medium erreichen.
- `SaveOptions{Private: true}` für alles, was nie über einen statischen Mount erreichbar sein darf (0700 / 0600 statt 0755 / 0644)
- `api/common/upload.go` läuft komplett über dieses Backend, gibt aber weiterhin Dateipfade zurück. **Alle bestehenden Aufrufer bleiben unverändert.**

Damit wird ein Objektspeicher (S3, MinIO) später ein Austausch der Implementierung statt eines Sweeps durch jeden einzelnen Handler.

---

## 2. Datenmodell (Migration 1.15.271)

`users.student_documents` hält **nur Metadaten**. Die Bytes liegen unter `public/uploads/student-documents/{tenant_id}/{uuid.ext}` und sind ausschließlich über den berechtigungsgeprüften Download-Handler erreichbar. Für diesen Unterpfad existiert bewusst kein statischer Mount.

Bewusst so gebaut:

- **Composite-FK** `(tenant_id, student_id)` auf `users.students(tenant_id, id)`. Ein Dokument kann strukturell nicht an einem Kind einer anderen Schule hängen.
- **RLS mit `FORCE ROW LEVEL SECURITY`** plus Tenant-Policy auf beiden neuen Tabellen
- **Soft Delete.** `phoenix_tenant` bekommt für beide Tabellen ausdrücklich **kein** `DELETE`-Grant. Löschen entfernt die Datei sofort (die DSGVO will den Inhalt weg), die Zeile bleibt als Nachweis darüber, dass das Dokument einmal existiert hat, samt `deleted_by`.
- `filename_stored` ist eine UUID. Der Anzeigename erreicht das Dateisystem nie: eine UUID kann nicht kollidieren, keine Traversal-Payload tragen und verrät nichts über den Inhalt.

### Kategorien

| Kategorie | Label | Gate |
|---|---|---|
| `betreuungsvertrag` | Betreuungsvertrag | `users:update` |
| `abholvollmacht` | Abholvollmacht | `users:update` |
| `schwimmerlaubnis` | Schwimmerlaubnis | `users:update` |
| `sonstiges` | Sonstiges | `users:update` |
| `attest` | Ärztliches Attest | `student_documents:health` |
| `impfnachweis` | Impfnachweis | `student_documents:health` |
| `medikamentenplan` | Medikamentenplan | `student_documents:health` |
| `sorgerecht` | Sorgerechtsnachweis | `student_documents:legal` |

---

## 3. Berechtigungen und DSGVO

Zwei neue Katalog-Permissions, analog zu `staff_documents:health` aus 1.15.257:

- **`student_documents:health`** deckt Attest, Impfnachweis und Medikamentenplan ab, also Gesundheitsdaten nach Art. 9 DSGVO
- **`student_documents:legal`** deckt den Sorgerechtsnachweis ab. Das ist kein Art. 9, in den falschen Händen aber mindestens genauso schädlich.

Katalog-Only heißt: Schulverwaltung greift über die `admin:*`-Wildcard, und eine eigene Rolle kann eine der beiden Permissions künftig einzeln bekommen, ohne dass es dafür eine weitere Migration braucht.

Wie das durchgesetzt wird:

- Das **Route-Gate** (`RequiresAnyPermission`) beantwortet nur die Frage, ob jemand den Tab überhaupt erreichen darf. Die Kategorie-Autorität entscheidet der Service, und zwar für Liste, Upload, Download und Löschen einzeln.
- Die Liste kommt bereits **gefiltert** zurück, zusammen mit den sichtbaren Kategorien des Aufrufers. Das Frontend baut Filter und Upload-Auswahl aus dieser Antwort und trifft keine eigene Rechteentscheidung.
- Jeder Download einer sensiblen Kategorie schreibt eine Zeile in `audit.data_access_log` (neuer Typ `student_document_download`, mit `student_id`, `document_id` und Kategorie). **Schlägt der Log-Write fehl, wird die Datei nicht ausgeliefert.** Ein ungeloggter Blick in das Attest eines Kindes ist schlimmer als ein fehlgeschlagener Request.
- Upload und Löschen schreiben ihre Audit-Zeile in derselben Tenant-Transaktion wie die Metadaten-Änderung.

### Mitgefixt: die Änderungshistorie war ein Nebeneingang

Die Historie eines Kindes zeigt Feldänderungen im Klartext, also bei Dokumenten "Ärztliches Attest: Attest_Epilepsie.pdf". Damit hätte jeder mit Vollzugriff die Existenz und den Dateinamen eines Attests lesen können, ohne `student_documents:health` zu besitzen, obwohl genau das der Sinn der Permission ist. Die Historie filtert Dokumentzeilen jetzt mit denselben Kategorie-Rechten. Eine Zeile, deren Kategorie sich nicht bestimmen lässt, sieht nur, wer alle Kategorien sehen darf: ein unlesbares Label darf nicht als sichtbar durchgehen.

---

## 4. Das eigentliche Problem: verwaiste Dateien

Ein Multipart-Body lässt sich nach einem Commit nicht wiederholen. Die Bytes müssen also **vor** der Metadaten-Zeile geschrieben werden, und damit gibt es ein Fenster, in dem ein Absturz eine Datei ohne Zeile hinterlässt. Bei einer Krankenakte ist das genau der Rest, der nicht liegen bleiben darf.

Gelöst über einen gemeinsamen Coordinator (`api/common/documents`) mit einer festen Reihenfolge:

```
Cleanup-Absicht speichern -> Objekt schreiben -> Metadaten committen -> Absicht abhaken
```

Jeder Schritt darf sterben. Eine nicht abgehakte Absicht wird nach einer Wartezeit für den Aufräum-Scheduler sichtbar.

Die Details, die den Unterschied machen:

- **Upload-Deadline 2 Minuten gegen `retry_after` von 5 Minuten.** Der Cleaner kann einen laufenden Upload nicht wegräumen, und ein Request, dessen Deadline abgelaufen ist, bricht ab, statt noch eine Zeile zu schreiben, deren Datei gerade zum Abschuss freigegeben wurde.
- **Die Cleanup-Tabelle hat bewusst keinen FK auf `users.students`.** Wird ein Kind gelöscht, kaskadieren die Dokumentzeilen weg. Eine Cleanup-Zeile, die mitkaskadiert, würde die Bytes für immer auf der Platte lassen, ohne dass noch irgendetwas darauf zeigt.
- **Beim Löschen eines Kindes** werden die Absichten deshalb innerhalb der Löschtransaktion geschrieben: davor und außerhalb wäre eine fehlgeschlagene Löschung ein Datenverlust, danach wäre ein Absturz ein Datenrest. Das gilt auch für den Graduate-Purge.
- **Bei einem Fehler nach dem Objekt-Write** wird nur dann aufgeräumt, wenn beweisbar ist, dass die Metadaten nie gelandet sind. Ein Commit, dessen Bestätigung unterwegs verloren ging (abgerissene Verbindung), kann serverseitig durchaus committet haben. Die Datei dann zu löschen, hieße ein lebendes Dokument zu erzeugen, dessen Download für immer 404 liefert. Im Zweifel bleibt alles liegen, die Absicht in der Warteschlange entscheidet.
- **Beide Sweeps sind gedeckelt und melden das.** Der Scheduler läuft alle 5 Minuten über maximal 200 Objekte pro Durchgang, ein Seitenaufruf räumt höchstens 10 Nachzügler mit auf. Ein voller Durchgang wird geloggt, denn ein stiller Deckel liest sich in den Logs wie "alles aufgeräumt".
- Der Scheduler-Durchgang **propagiert keinen Einzelfehler nach oben.** Er läuft in einer Tenant-Transaktion, und ein Rollback würde die Erledigt-Markierungen aller erfolgreich entfernten Objekte mitreißen. Fehler werden geloggt, die betroffene Zeile bleibt offen und kommt im nächsten Durchgang wieder.

---

## 5. Frontend

Neuer Tab **Dokumente** auf der Kind-Detailseite, plus die drei Proxy-Routen unter `/api/students/[id]/documents`.

- Flache Dateiliste, neueste zuerst, mit Kategoriefilter aus den sichtbaren Kategorien des Aufrufers
- Upload per Button oder Drag-and-Drop, PDF / DOCX / PNG / JPG, maximal 10 MB, Content-Type wird serverseitig über die Magic Number geprüft und nicht über die Endung
- Download und Löschen mit Bestätigungsdialog
- Sensible Kategorien sind in der Liste als solche gekennzeichnet
- Der Tab wird an genau denselben drei Permissions eingeblendet wie das Backend-Gate. Auf Schreibrechte zu gaten wäre in beide Richtungen falsch: eine Gruppenleitung ohne `users:update` bekäme einen Tab, der nur 403 antwortet, und eine Rolle mit ausschließlich `student_documents:health` käme nie an den Tab, obwohl die Migration genau dafür existiert.

### Neue Routen

```
GET    /api/students/{id}/documents
POST   /api/students/{id}/documents
GET    /api/students/{id}/documents/{documentId}/download
DELETE /api/students/{id}/documents/{documentId}
```

Upload und Download laufen ohne `withTx`, damit ein langsamer 10-MB-Body oder ein Datei-Stream keine Verbindung aus dem Pool blockiert. Beide öffnen ihre eigenen kurzen Transaktionen.

---

## 6. Abweichung vom Vorschlag im Issue

Das Issue skizziert eine zentrale, polymorphe `storage.attachments`-Tabelle mit `entity_type` / `entity_id`. Umgesetzt ist stattdessen: **generisch beim Speicher, konkret bei der Tabelle.**

Der Grund steht auch als Kommentar im Code. Ein Dokument hängt über einen echten Composite-FK `(tenant_id, owner_id)` an seinem Besitzer, den die Datenbank durchsetzt. Ein `entity_type` / `entity_id`-Paar tauscht diese Durchsetzung gegen eine Spalte, der man nie trauen kann, und macht das Kaskadieren beim Löschen zur Anwendungsaufgabe. Dazu kommt: "wer darf diese Kategorie sehen" ist bei einer Lohnabrechnung eine andere Frage als bei einem Attest. Diese Autorität gehört zur besitzenden Domäne, nicht in eine gemeinsame Tabelle.

Geteilt wird deshalb das, was tatsächlich überall gleich ist: die Speicher-Schicht, die Dateizeilen-Form (`models/documents.File`) und der Upload-Coordinator inklusive Orphan-Protokoll. Ein Attachment-Feature für Feedback oder Suggestions bringt danach eine Tabelle und seine Rechteentscheidung mit, den ganzen Rest erbt es.

---

## Tests

- `internal/storage`: Local-Backend inklusive Traversal-Ablehnung, privater Rechte und partieller Writes
- `repositories/users`: Dokument-Repository samt Cleanup-Warteschlange
- `services/users`: Kategorie-Rechte, Audit-Pflicht, Download-Verweigerung ohne Log-Write, Warteschlangen-Übergänge
- Route-Table-Golden aktualisiert

## Nach dem Deploy

- Migration 1.15.271 legt Tabellen, Policies, Grants und die beiden Permissions an. Ein Rollback (`down`) entfernt beides wieder.
- Das Verzeichnis `public/uploads` muss auf einem persistenten Volume liegen, sonst sind hochgeladene Dokumente nach einem Container-Neustart weg. Für Bilder galt das schon vorher, hier wiegt es schwerer.
- Wer außer der Schulverwaltung Gesundheits- oder Sorgerechtsunterlagen sehen soll, braucht die passende Permission explizit auf seiner Rolle.
