### PR TITLE
Betreuungsplan: Serien-Speichern über gekappte Vorgänger-Templates reparieren (Nachzügler ab Stichtag)

### DIFF
--- a/backend/api/timetable/templates_end.go
+++ b/backend/api/timetable/templates_end.go
@@ -74,7 +74,7 @@ func renderTemplateEndError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 	switch {
 	case errors.Is(err, scheduleSvc.ErrSplitTemplateNotFound):
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+		renderTemplateNotFound(w, r)
 	case errors.Is(err, scheduleSvc.ErrSplitInvalidInput):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 	default:

--- a/backend/api/timetable/templates_list.go
+++ b/backend/api/timetable/templates_list.go
@@ -227,8 +227,14 @@ func educationGroupIDFromRow(row templateRow) *int64 {
 }
 
 type templateResponse struct {
-	ID                     int64  `json:"id"`
-	Name                   string `json:"name"`
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	// ResolvedFromTemplateID is set when the requested id belonged to an
+	// already-capped predecessor segment of a split series and this response
+	// carries the living successor instead (#2187). The editor must write to
+	// `id` and pass the clicked occurrence's date as series_roster_from so a
+	// roster change reaches the predecessor's remaining occurrences.
+	ResolvedFromTemplateID *int64 `json:"resolved_from_template_id,omitempty"`
 	Type                   string `json:"type"`
 	CategoryID             int64  `json:"category_id"`
 	CategoryName           string `json:"category_name"`

--- a/backend/api/timetable/templates_series_test.go
+++ b/backend/api/timetable/templates_series_test.go
@@ -1,0 +1,177 @@
+// Handler tests for the #2187 split-series editor contract:
+//
+//   - GET /templates/{id}?period_id=N resolves an id that belongs to an
+//     already-capped predecessor segment to the living successor and reports
+//     the resolution via resolved_from_template_id; a genuine miss stays a 404
+//     carrying the stable code "template_not_found".
+//   - PUT /templates/{id} accepts series_roster_from (YYYY-MM-DD) and mirrors
+//     the saved roster onto the predecessor segment; a malformed value is a 400.
+//   - POST /templates/{id}/split rejects series_roster_from outright.
+//
+// Hermetic: real repos + real split service against the test DB, fixtures via
+// buildTemplateSetup, driven through the same router the split tests use.
+package timetable
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	activitiesRepo "github.com/moto-nrw/project-phoenix/database/repositories/activities"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// splitSeriesSetup builds the shared fixture of these tests: a source template
+// split once, so the source id is a fully capped predecessor of the successor.
+type splitSeriesSetup struct {
+	*templateSetup
+	router    chi.Router
+	oldID     int64
+	newID     int64
+	effective timezone.Date
+	periodID  int64
+}
+
+func buildSplitSeriesSetup(t *testing.T, name string) *splitSeriesSetup {
+	t.Helper()
+	mat := &mockMaterializationService{result: &scheduleSvc.MaterializationResult{}}
+	s := buildTemplateSetup(t, mat)
+	attachSplitService(s, mat)
+	router := splitRouter(s.ctx, s.res, []string{permissions.SchedulesManage})
+
+	created := createSourceTemplate(t, router, s, name+"-Quelle")
+	effective := timezone.TodayDate().AddDays(7)
+	w := doTemplateJSON(t, router, http.MethodPost,
+		fmt.Sprintf("/templates/%d/split", created.TemplateID),
+		splitBody(s, name+"-Nachfolger", effective))
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	split := decodeTemplateData[splitTemplateResponse](t, w)
+
+	period := createTemplateTestPeriod(t, s.db, name+"-Zeitraum")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.calendar_periods", period.ID) })
+
+	return &splitSeriesSetup{
+		templateSetup: s,
+		router:        router,
+		oldID:         created.TemplateID,
+		newID:         split.NewTemplateID,
+		effective:     effective,
+		periodID:      period.ID,
+	}
+}
+
+// decodeTemplateError reads the error envelope of a non-2xx response.
+func decodeTemplateError(t *testing.T, w *httptest.ResponseRecorder) struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+	Code   string `json:"code"`
+} {
+	t.Helper()
+	var out struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+		Code   string `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out), "body=%s", w.Body.String())
+	return out
+}
+
+func TestGetTemplate_ResolvesCappedPredecessorToLivingSuccessor(t *testing.T) {
+	s := buildSplitSeriesSetup(t, "Tpl-SeriesGet")
+	defer s.cleanupFn()
+
+	w := doTemplateJSON(t, s.router, http.MethodGet,
+		fmt.Sprintf("/templates/%d?period_id=%d", s.oldID, s.periodID), nil)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	resp := decodeTemplateData[templateResponse](t, w)
+	assert.Equal(t, s.newID, resp.ID, "the editor must be handed the living segment")
+	require.NotNil(t, resp.ResolvedFromTemplateID)
+	assert.Equal(t, s.oldID, *resp.ResolvedFromTemplateID,
+		"the response reports which id was resolved away")
+}
+
+func TestGetTemplate_UnknownTemplateReturns404WithCode(t *testing.T) {
+	s := buildSplitSeriesSetup(t, "Tpl-SeriesMiss")
+	defer s.cleanupFn()
+
+	unknownID := s.newID + 1_000_000
+	w := doTemplateJSON(t, s.router, http.MethodGet,
+		fmt.Sprintf("/templates/%d?period_id=%d", unknownID, s.periodID), nil)
+	require.Equal(t, http.StatusNotFound, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, templateNotFoundCode, decodeTemplateError(t, w).Code,
+		"a genuine miss must carry the stable error code the editor maps")
+}
+
+func TestUpdateTemplate_RejectsInvalidSeriesRosterFrom(t *testing.T) {
+	s := buildSplitSeriesSetup(t, "Tpl-SeriesBadDate")
+	defer s.cleanupFn()
+
+	body := createTemplateBody(s.templateSetup, "Tpl-SeriesBadDate-Update")
+	body["series_roster_from"] = "not-a-date"
+	w := doTemplateJSON(t, s.router, http.MethodPut, fmt.Sprintf("/templates/%d", s.newID), body)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, decodeTemplateError(t, w).Error, "series_roster_from")
+}
+
+func TestSplitTemplate_RejectsSeriesRosterFrom(t *testing.T) {
+	s := buildSplitSeriesSetup(t, "Tpl-SeriesSplitReject")
+	defer s.cleanupFn()
+
+	body := splitBody(s.templateSetup, "Tpl-SeriesSplitReject-Zweiter", s.effective.AddDays(7))
+	body["series_roster_from"] = timezone.TodayDate().String()
+	w := doTemplateJSON(t, s.router, http.MethodPost,
+		fmt.Sprintf("/templates/%d/split", s.newID), body)
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Contains(t, decodeTemplateError(t, w).Error, "series_roster_from is not supported on a split")
+}
+
+// TestUpdateTemplate_SeriesRosterFromReachesPredecessor is the API-level happy
+// path: a child added on the living segment with an anchor inside the capped
+// predecessor's window gets a bounded predecessor enrollment.
+func TestUpdateTemplate_SeriesRosterFromReachesPredecessor(t *testing.T) {
+	s := buildSplitSeriesSetup(t, "Tpl-SeriesRoster")
+	defer s.cleanupFn()
+
+	suffix := time.Now().UnixNano()
+	latecomer := testpkg.CreateTestStudent(t, s.db, "Tpl", fmt.Sprintf("Nachzuegler-%d", suffix), "3a")
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, s.db, "users.students", latecomer.ID)
+		testpkg.CleanupTableRecords(t, s.db, "users.persons", latecomer.PersonID)
+	})
+
+	anchor := timezone.TodayDate().AddDays(3)
+	body := createTemplateBody(s.templateSetup, "Tpl-SeriesRoster-Update")
+	body["student_ids"] = []int64{s.studentA, s.studentB, latecomer.ID}
+	body["series_roster_from"] = anchor.String()
+
+	w := doTemplateJSON(t, s.router, http.MethodPut, fmt.Sprintf("/templates/%d", s.newID), body)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	rows, err := activitiesRepo.NewStudentEnrollmentRepository(s.db).FindByGroupID(s.ctx, s.oldID)
+	require.NoError(t, err)
+	weekdays := make([]int, 0, 2)
+	for _, row := range rows {
+		if row.StudentID != latecomer.ID {
+			continue
+		}
+		assert.Equal(t, anchor, row.ValidFrom, "the predecessor row starts at the anchor")
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, s.effective, *row.ValidUntil, "and ends with the predecessor segment")
+		require.NotNil(t, row.Weekday, "predecessor rows are written weekday-explicit")
+		weekdays = append(weekdays, *row.Weekday)
+	}
+	assert.ElementsMatch(t,
+		[]int{activitiesModel.WeekdayMonday, activitiesModel.WeekdayWednesday}, weekdays,
+		"one bounded predecessor row per scheduled weekday")
+}

--- a/backend/api/timetable/templates_series_test.go
+++ b/backend/api/timetable/templates_series_test.go
@@ -4,8 +4,9 @@
 //     already-capped predecessor segment to the living successor and reports
 //     the resolution via resolved_from_template_id; a genuine miss stays a 404
 //     carrying the stable code "template_not_found".
-//   - PUT /templates/{id} accepts series_roster_from (YYYY-MM-DD) and mirrors
-//     the saved roster onto the predecessor segment; a malformed value is a 400.
+//   - PUT /templates/{id} accepts series_roster_from (YYYY-MM-DD) plus the
+//     scope of changed people and mirrors exactly that change onto the
+//     predecessor segment; a malformed date is a 400.
 //   - POST /templates/{id}/split rejects series_roster_from outright.
 //
 // Hermetic: real repos + real split service against the test DB, fixtures via
@@ -154,6 +155,7 @@ func TestUpdateTemplate_SeriesRosterFromReachesPredecessor(t *testing.T) {
 	body := createTemplateBody(s.templateSetup, "Tpl-SeriesRoster-Update")
 	body["student_ids"] = []int64{s.studentA, s.studentB, latecomer.ID}
 	body["series_roster_from"] = anchor.String()
+	body["series_roster_scope_student_ids"] = []int64{latecomer.ID}
 
 	w := doTemplateJSON(t, s.router, http.MethodPut, fmt.Sprintf("/templates/%d", s.newID), body)
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())

--- a/backend/api/timetable/templates_split.go
+++ b/backend/api/timetable/templates_split.go
@@ -128,6 +128,13 @@ func (req *splitTemplateRequest) Bind(r *http.Request) error {
 	if req.EffectiveDate == "" {
 		return errors.New("effective_date is required (YYYY-MM-DD)")
 	}
+	// series_roster_from (#2187) belongs to the in-place update of a chain-
+	// resolved living segment. A split's effective date lies inside its own
+	// open segment, so no predecessor reconciliation can apply — reject the
+	// field loudly instead of silently ignoring it.
+	if req.SeriesRosterFrom != nil {
+		return errors.New("series_roster_from is not supported on a split")
+	}
 	// req.Notes (nullableStr) shadows the embedded updateTemplateRequest.Notes,
 	// so the create/update length guard in the embedded Bind never sees the
 	// split note. Enforce the same 2000-char limit here (#1837 follow-up).
@@ -351,7 +358,7 @@ func renderTemplateSplitError(w http.ResponseWriter, r *http.Request, err error)
 	}
 	switch {
 	case errors.Is(err, scheduleSvc.ErrSplitTemplateNotFound):
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+		renderTemplateNotFound(w, r)
 	case errors.Is(err, scheduleSvc.ErrCategoryNotAssignable):
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("category is archived or unavailable")))
 	case errors.Is(err, scheduleSvc.ErrPlanningTrackNotFound), errors.Is(err, scheduleSvc.ErrPlanningTrackArchived):

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -67,6 +67,11 @@ type updateTemplateRequest struct {
 	// Without a scope, series_roster_from mirrors nothing.
 	SeriesRosterScopeStudentIDs []int64 `json:"series_roster_scope_student_ids,omitempty"`
 	SeriesRosterScopeStaffIDs   []int64 `json:"series_roster_scope_staff_ids,omitempty"`
+	// SeriesRosterScopeWeekdays narrows the mirroring to the weekdays this
+	// edit describes. A series that staffs each weekday separately (#2129) is
+	// edited one weekday at a time, so the predecessor's other weekdays must
+	// not be reconciled against it. Omitted = every weekday of the segment.
+	SeriesRosterScopeWeekdays []int `json:"series_roster_scope_weekdays,omitempty"`
 }
 
 func (req *updateTemplateRequest) Bind(_ *http.Request) error {
@@ -433,6 +438,7 @@ func buildUpdateTemplateInput(
 
 		SeriesRosterScopeStudentIDs: req.SeriesRosterScopeStudentIDs,
 		SeriesRosterScopeStaffIDs:   req.SeriesRosterScopeStaffIDs,
+		SeriesRosterScopeWeekdays:   req.SeriesRosterScopeWeekdays,
 	}
 }
 

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -72,6 +72,10 @@ type updateTemplateRequest struct {
 	// edited one weekday at a time, so the predecessor's other weekdays must
 	// not be reconciled against it. Omitted = every weekday of the segment.
 	SeriesRosterScopeWeekdays []int `json:"series_roster_scope_weekdays,omitempty"`
+	// SeriesRosterPrimaryChanged marks the Hauptbetreuung as part of this
+	// edit. primary_staff_id always names THIS segment's lead, so it may only
+	// travel to a predecessor row when the user actually moved it.
+	SeriesRosterPrimaryChanged bool `json:"series_roster_primary_changed,omitempty"`
 }
 
 func (req *updateTemplateRequest) Bind(_ *http.Request) error {
@@ -439,6 +443,7 @@ func buildUpdateTemplateInput(
 		SeriesRosterScopeStudentIDs: req.SeriesRosterScopeStudentIDs,
 		SeriesRosterScopeStaffIDs:   req.SeriesRosterScopeStaffIDs,
 		SeriesRosterScopeWeekdays:   req.SeriesRosterScopeWeekdays,
+		SeriesRosterPrimaryChanged:  req.SeriesRosterPrimaryChanged,
 	}
 }
 

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -54,6 +54,12 @@ type updateTemplateRequest struct {
 	// WeekdayAssignments overrides the shared roster for individual weekdays
 	// (#2129); omitted/empty resets the series to one shared roster.
 	WeekdayAssignments []weekdayAssignmentRequest `json:"weekday_assignments,omitempty"`
+	// SeriesRosterFrom (#2187, YYYY-MM-DD) extends the saved roster backwards
+	// over the template's split series: bounded predecessor segments
+	// overlapping [series_roster_from, this segment's valid_from) receive the
+	// same roster change. Sent by the editor only when it resolved a capped
+	// predecessor to this living segment AND the roster was edited.
+	SeriesRosterFrom *string `json:"series_roster_from,omitempty"`
 }
 
 func (req *updateTemplateRequest) Bind(_ *http.Request) error {
@@ -119,11 +125,12 @@ func (req *updateTemplateRequest) Bind(_ *http.Request) error {
 // parsedUpdateTemplate holds the request plus values derived from cheap format
 // validation (clock window, defaulted week pattern and cap).
 type parsedUpdateTemplate struct {
-	req             *updateTemplateRequest
-	startTime       time.Time
-	endTime         time.Time
-	weekPattern     int
-	maxParticipants int
+	req              *updateTemplateRequest
+	startTime        time.Time
+	endTime          time.Time
+	weekPattern      int
+	maxParticipants  int
+	seriesRosterFrom *timezone.Date
 }
 
 // parseUpdateTemplateRequest binds and format-validates the request. Format
@@ -143,12 +150,22 @@ func parseUpdateTemplateRequest(w http.ResponseWriter, r *http.Request) (*parsed
 	if !ok {
 		return nil, false
 	}
+	var seriesRosterFrom *timezone.Date
+	if req.SeriesRosterFrom != nil {
+		parsedDate, err := timezone.ParseDate(*req.SeriesRosterFrom)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid series_roster_from format, expected YYYY-MM-DD")))
+			return nil, false
+		}
+		seriesRosterFrom = &parsedDate
+	}
 	return &parsedUpdateTemplate{
-		req:             req,
-		startTime:       timing.startTime,
-		endTime:         timing.endTime,
-		weekPattern:     timing.weekPattern,
-		maxParticipants: timing.maxParticipants,
+		req:              req,
+		startTime:        timing.startTime,
+		endTime:          timing.endTime,
+		weekPattern:      timing.weekPattern,
+		maxParticipants:  timing.maxParticipants,
+		seriesRosterFrom: seriesRosterFrom,
 	}, true
 }
 
@@ -175,10 +192,62 @@ func (rs *Resource) getTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(templates) == 0 {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
-		return
+		templates, ok = rs.resolveTemplateForRead(w, r, id, periodID)
+		if !ok {
+			return
+		}
 	}
 	common.Respond(w, r, http.StatusOK, templates[0], "Template retrieved")
+}
+
+// templateNotFoundCode is the stable error code carried by every template 404
+// so clients can map the message without matching the English text (#2187).
+const templateNotFoundCode = "template_not_found"
+
+func renderTemplateNotFound(w http.ResponseWriter, r *http.Request) {
+	common.RenderError(w, r, common.ErrorNotFoundWithCode(errors.New("template not found"), templateNotFoundCode))
+}
+
+// resolveTemplateForRead retries an empty period-scoped template read against
+// the living segment of the same split series (#2187): the Betreuungsplan
+// grid hands the editor the template id an occurrence was materialized from,
+// which after a split can be a fully capped predecessor that the
+// valid_until-filtered read models no longer return. The response then
+// carries the living successor plus resolved_from_template_id so the client
+// writes to the right template. Renders the error response itself when it
+// returns ok=false.
+func (rs *Resource) resolveTemplateForRead(
+	w http.ResponseWriter,
+	r *http.Request,
+	requestedID int64,
+	periodID *int64,
+) ([]templateResponse, bool) {
+	resolvedID, changed, err := rs.TimetableData.ResolveLivingTemplateSegment(r.Context(), requestedID)
+	if err != nil {
+		if errors.Is(err, scheduleSvc.ErrTemplateSeriesFullyEnded) {
+			renderTemplateNotFound(w, r)
+			return nil, false
+		}
+		common.RenderError(w, r, common.ErrorInternalServerWrap("resolve template series failed", err))
+		return nil, false
+	}
+	if !changed {
+		// The template itself is the living segment — the empty read was a
+		// genuine miss (e.g. a foreign period_id) and stays a 404.
+		renderTemplateNotFound(w, r)
+		return nil, false
+	}
+	templates, err := rs.loadTemplates(r.Context(), &resolvedID, periodID)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("load template failed", err))
+		return nil, false
+	}
+	if len(templates) == 0 {
+		renderTemplateNotFound(w, r)
+		return nil, false
+	}
+	templates[0].ResolvedFromTemplateID = &requestedID
+	return templates, true
 }
 
 func (rs *Resource) updateTemplate(w http.ResponseWriter, r *http.Request) {
@@ -214,7 +283,7 @@ func (rs *Resource) updateTemplate(w http.ResponseWriter, r *http.Request) {
 			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("timetable templates can only be scheduled from Monday to Friday")))
 			return
 		}
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+		renderTemplateNotFound(w, r)
 		return
 	}
 	if err := validateLegacyTemplateWorkdays(templates[0].Schedules, parsed.req.Weekdays); err != nil {
@@ -353,6 +422,7 @@ func buildUpdateTemplateInput(
 		Targets:            targetModels(req.Targets),
 		WeekdayAssignments: toServiceWeekdayAssignments(req.WeekdayAssignments),
 		GradeLevelMax:      gradeLevelMax,
+		SeriesRosterFrom:   parsed.seriesRosterFrom,
 	}
 }
 
@@ -363,7 +433,7 @@ func buildUpdateTemplateInput(
 func renderUpdateTemplateError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, scheduleSvc.ErrTemplateSegmentNotEditable):
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+		renderTemplateNotFound(w, r)
 	case errors.Is(err, scheduleSvc.ErrCategoryNotAssignable):
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("category is archived or unavailable")))
 	case errors.Is(err, scheduleSvc.ErrPlanningTrackNotFound), errors.Is(err, scheduleSvc.ErrPlanningTrackArchived):
@@ -404,7 +474,7 @@ func (rs *Resource) archiveTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if n == 0 {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("template not found")))
+		renderTemplateNotFound(w, r)
 		return
 	}
 	common.Respond(w, r, http.StatusOK, map[string]any{"id": id}, "Template archived")

--- a/backend/api/timetable/templates_update.go
+++ b/backend/api/timetable/templates_update.go
@@ -60,6 +60,13 @@ type updateTemplateRequest struct {
 	// same roster change. Sent by the editor only when it resolved a capped
 	// predecessor to this living segment AND the roster was edited.
 	SeriesRosterFrom *string `json:"series_roster_from,omitempty"`
+	// SeriesRosterScope* name the people whose membership this edit actually
+	// changed. Only they are reconciled on the predecessor segments:
+	// student_ids / staff_ids above describe THIS segment and may legitimately
+	// differ from a predecessor's roster, so they are not its target set.
+	// Without a scope, series_roster_from mirrors nothing.
+	SeriesRosterScopeStudentIDs []int64 `json:"series_roster_scope_student_ids,omitempty"`
+	SeriesRosterScopeStaffIDs   []int64 `json:"series_roster_scope_staff_ids,omitempty"`
 }
 
 func (req *updateTemplateRequest) Bind(_ *http.Request) error {
@@ -423,6 +430,9 @@ func buildUpdateTemplateInput(
 		WeekdayAssignments: toServiceWeekdayAssignments(req.WeekdayAssignments),
 		GradeLevelMax:      gradeLevelMax,
 		SeriesRosterFrom:   parsed.seriesRosterFrom,
+
+		SeriesRosterScopeStudentIDs: req.SeriesRosterScopeStudentIDs,
+		SeriesRosterScopeStaffIDs:   req.SeriesRosterScopeStaffIDs,
 	}
 }
 

--- a/backend/services/schedule/template_end_cascade_integration_test.go
+++ b/backend/services/schedule/template_end_cascade_integration_test.go
@@ -55,6 +55,48 @@ func TestTemplateEnd_CascadesToCappedPredecessors(t *testing.T) {
 		"occurrences before the clicked date stay as history")
 }
 
+// TestTemplateEnd_FromCappedPredecessorAlsoEndsLivingSuccessor covers the path
+// the client actually takes: the grid renders an occurrence with the id of the
+// segment that materialized it, so "diesen und alle folgenden löschen" on a
+// first-week occurrence arrives on the CAPPED predecessor. The living
+// successor carries every later occurrence and must be ended along with it.
+func TestTemplateEnd_FromCappedPredecessorAlsoEndsLivingSuccessor(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	livingDay := c.secondBoundary
+	_, err := c.svc.MaterializeForTenant(
+		c.ctx, c.secondBoundary, c.secondBoundary.AddDays(6), scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	registerSplitInstancesForCleanup(t, c.scenarioSetup,
+		[]int64{c.livingID}, []timezone.Date{livingDay})
+	require.Len(t, listInstancesForDate(t, c.db, c.livingID, livingDay), 1)
+
+	result, err := c.factory.TemplateSplit.EndFromDate(c.ctx, scheduleSvc.TemplateEndInput{
+		TemplateID:    c.middleID,
+		EffectiveDate: c.anchor,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, c.middleID, result.TemplateID)
+
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.middleID) {
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.anchor, *row.ValidUntil,
+			"the clicked segment ends at the clicked date")
+	}
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.livingID) {
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.secondBoundary, *row.ValidUntil,
+			"and the living successor is ended too")
+	}
+
+	assert.Empty(t, listInstancesForDate(t, c.db, c.middleID, c.anchor))
+	assert.Empty(t, listInstancesForDate(t, c.db, c.livingID, livingDay),
+		"no live occurrence may survive on the successor")
+	assert.Len(t, listInstancesForDate(t, c.db, c.middleID, c.earlier), 1,
+		"occurrences before the clicked date stay as history")
+}
+
 func TestTemplateEnd_CascadeLeavesUnrelatedSeriesAlone(t *testing.T) {
 	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
 	defer c.runCleanup(t)

--- a/backend/services/schedule/template_end_cascade_integration_test.go
+++ b/backend/services/schedule/template_end_cascade_integration_test.go
@@ -1,0 +1,100 @@
+// Hermetic integration tests for the #2187 end cascade: "diesen und alle
+// folgenden löschen" chosen on an occurrence that still belongs to an
+// already-capped predecessor segment must also end THAT segment from the
+// clicked date, instead of leaving live occurrences behind on a template the
+// grid keeps rendering.
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateEnd_CascadesToCappedPredecessors(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	require.Len(t, listInstancesForDate(t, c.db, c.middleID, c.earlier), 1)
+	require.Len(t, listInstancesForDate(t, c.db, c.middleID, c.anchor), 1)
+
+	result, err := c.factory.TemplateSplit.EndFromDate(c.ctx, scheduleSvc.TemplateEndInput{
+		TemplateID:    c.livingID,
+		EffectiveDate: c.anchor,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, c.secondBoundary, result.EffectiveDate,
+		"the living segment itself is clamped to its own start")
+
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.middleID) {
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.anchor, *row.ValidUntil,
+			"the predecessor segment must end at the clicked date")
+	}
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.livingID) {
+		require.NotNil(t, row.ValidFrom)
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.secondBoundary, *row.ValidFrom)
+		assert.Equal(t, c.secondBoundary, *row.ValidUntil, "the living segment is fully capped")
+	}
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.rootID) {
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.firstBoundary, *row.ValidUntil,
+			"a segment that already ended before the clicked date is left alone")
+	}
+
+	assert.Empty(t, listInstancesForDate(t, c.db, c.middleID, c.anchor),
+		"planned predecessor occurrences from the clicked date are deleted")
+	assert.Len(t, listInstancesForDate(t, c.db, c.middleID, c.earlier), 1,
+		"occurrences before the clicked date stay as history")
+}
+
+func TestTemplateEnd_CascadeLeavesUnrelatedSeriesAlone(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	// A second, independent template of the same tenant, running on the same
+	// weekday and materialized over the same window.
+	other, err := c.factory.TimetableData.CreateTemplate(c.ctx, scheduleSvc.CreateTemplateInput{
+		Name:            fmt.Sprintf("Unrelated-%d", time.Now().UnixNano()),
+		Type:            activitiesModels.GroupTypeActivity,
+		Weekdays:        []int{activitiesModels.WeekdayMonday},
+		StartTime:       time.Date(2000, 1, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(2000, 1, 1, 10, 0, 0, 0, time.UTC),
+		RoomID:          c.roomID,
+		CategoryID:      c.categoryID,
+		MaxParticipants: 20,
+		RosterValidFrom: c.firstBoundary,
+		GradeLevelMax:   4,
+		StudentIDs:      []int64{c.students[0]},
+		StaffIDs:        []int64{c.staffID},
+		PrimaryStaffID:  &c.staffID,
+	})
+	require.NoError(t, err)
+	registerSuccessorCleanup(t, c.scenarioSetup, other.TemplateID)
+
+	_, err = c.svc.MaterializeForTenant(
+		c.ctx, c.firstBoundary, c.secondBoundary.AddDays(-1), scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	registerSplitInstancesForCleanup(t, c.scenarioSetup,
+		[]int64{other.TemplateID}, []timezone.Date{c.earlier, c.anchor})
+	require.Len(t, listInstancesForDate(t, c.db, other.TemplateID, c.anchor), 1)
+
+	_, err = c.factory.TemplateSplit.EndFromDate(c.ctx, scheduleSvc.TemplateEndInput{
+		TemplateID:    c.livingID,
+		EffectiveDate: c.anchor,
+	})
+	require.NoError(t, err)
+
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, other.TemplateID) {
+		assert.Nil(t, row.ValidUntil, "an unrelated template must keep its open recurrence")
+	}
+	assert.Len(t, listInstancesForDate(t, c.db, other.TemplateID, c.anchor), 1,
+		"an unrelated template keeps its planned occurrences")
+}

--- a/backend/services/schedule/template_end_service_unit_test.go
+++ b/backend/services/schedule/template_end_service_unit_test.go
@@ -265,6 +265,16 @@ func (r *templateEndUnitGroupRepo) FindByID(_ context.Context, _ any) (*activiti
 	return r.group, nil
 }
 
+// FindTemplateSeries backs the #2187 end cascade; the unit fixtures model a
+// single-segment lineage (the schedule fake returns no rows, so the cascade
+// finds no bounded predecessor and stays a no-op).
+func (r *templateEndUnitGroupRepo) FindTemplateSeries(_ context.Context, _ int64) ([]*activitiesModel.Group, error) {
+	if r.group == nil {
+		return nil, nil
+	}
+	return []*activitiesModel.Group{r.group}, nil
+}
+
 type templateEndUnitScheduleRepo struct {
 	activitiesModel.ScheduleRepository
 	schedules  []*activitiesModel.Schedule

--- a/backend/services/schedule/template_series.go
+++ b/backend/services/schedule/template_series.go
@@ -1,0 +1,136 @@
+// Package schedule — split-series segment resolution (#2187).
+//
+// A template split chains segments via activities.groups.series_root_id: every
+// capped predecessor keeps its schedules with an exclusive valid_until while
+// exactly one living segment stays open. The Betreuungsplan grid renders
+// occurrences with the template id that materialized them, so a click on a
+// first-school-week occurrence can carry a fully capped predecessor's id. The
+// helpers here resolve such an id to the segment that is still editable
+// without introducing a second recurrence mechanism: the lineage comes from
+// GroupRepository.FindTemplateSeries, the per-segment envelope from the same
+// commonScheduleValidityEnvelope invariant every template write enforces.
+package schedule
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+)
+
+// ErrTemplateSeriesFullyEnded is returned when a template id resolves to a
+// split lineage that has no open segment left (the whole series was ended or
+// archived). → 404.
+var ErrTemplateSeriesFullyEnded = errors.New("template series has no editable segment")
+
+// templateSeriesSegment is one segment of a template's split lineage plus its
+// schedule validity envelope. ValidUntil == nil marks the living segment —
+// the only one PUT /timetable/templates/{id} may edit.
+type templateSeriesSegment struct {
+	Group      *activitiesModel.Group
+	Weekdays   []int // distinct schedule weekdays, ascending
+	ValidFrom  *timezone.Date
+	ValidUntil *timezone.Date
+}
+
+// loadTemplateSeriesSegments resolves templateID to its stable split-series
+// root and returns every live segment of that lineage with its schedule
+// envelope, ordered by group id ascending. A sibling segment whose schedules
+// are missing or inconsistent is skipped with a warning — one corrupt segment
+// must not block resolving or reconciling the rest of the series — but the
+// requested template's own corruption stays a hard error so writes against it
+// keep failing loudly.
+func loadTemplateSeriesSegments(
+	ctx context.Context,
+	groupRepo activitiesModel.GroupRepository,
+	scheduleRepo activitiesModel.ScheduleRepository,
+	logger *slog.Logger,
+	templateID int64,
+) ([]templateSeriesSegment, error) {
+	groups, err := groupRepo.FindTemplateSeries(ctx, templateID)
+	if err != nil {
+		return nil, &ScheduleError{Op: "load template series: find lineage", Err: err}
+	}
+	segments := make([]templateSeriesSegment, 0, len(groups))
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+		schedules, err := scheduleRepo.FindByGroupID(ctx, group.ID)
+		if err != nil {
+			return nil, &ScheduleError{Op: "load template series: load schedules", Err: err}
+		}
+		if len(schedules) == 0 {
+			// A template without schedule rows has no recurrence to resolve
+			// against; it cannot be the living segment either.
+			continue
+		}
+		validFrom, validUntil, err := commonScheduleValidityEnvelope(schedules)
+		if err != nil {
+			if group.ID == templateID {
+				return nil, &ScheduleError{Op: "load template series: inspect schedule envelope", Err: err}
+			}
+			cmp.Or(logger, slog.Default()).Warn("skipping template series segment with inconsistent schedule envelope",
+				slog.Int64("template_id", templateID),
+				slog.Int64("segment_id", group.ID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		weekdays := make([]int, 0, len(schedules))
+		for _, schedule := range schedules {
+			if schedule != nil {
+				weekdays = append(weekdays, schedule.Weekday)
+			}
+		}
+		segments = append(segments, templateSeriesSegment{
+			Group:      group,
+			Weekdays:   uniqueSortedWeekdays(weekdays),
+			ValidFrom:  validFrom,
+			ValidUntil: validUntil,
+		})
+	}
+	return segments, nil
+}
+
+// livingTemplateSegment returns the segment whose schedules are still open
+// (exclusive valid_until unset). Several open segments would be a data
+// anomaly; the highest id — the newest successor — wins.
+func livingTemplateSegment(segments []templateSeriesSegment) *templateSeriesSegment {
+	var living *templateSeriesSegment
+	for i := range segments {
+		if segments[i].ValidUntil == nil {
+			living = &segments[i]
+		}
+	}
+	return living
+}
+
+// ResolveLivingTemplateSegment resolves a template id the Betreuungsplan grid
+// may have taken from an occurrence of an already-capped predecessor segment
+// to the still-editable segment of the same split series (#2187). Returns the
+// resolved id and whether it differs from the requested one. An unknown id or
+// a lineage with no open segment left returns ErrTemplateSeriesFullyEnded.
+func (s *TimetableDataService) ResolveLivingTemplateSegment(
+	ctx context.Context,
+	templateID int64,
+) (int64, bool, error) {
+	segments, err := loadTemplateSeriesSegments(
+		ctx,
+		s.deps.ActivityGroupRepo,
+		s.deps.ActivityScheduleRepo,
+		s.getLogger(),
+		templateID,
+	)
+	if err != nil {
+		return 0, false, err
+	}
+	living := livingTemplateSegment(segments)
+	if living == nil {
+		return 0, false, ErrTemplateSeriesFullyEnded
+	}
+	return living.Group.ID, living.Group.ID != templateID, nil
+}

--- a/backend/services/schedule/template_series_resolution_integration_test.go
+++ b/backend/services/schedule/template_series_resolution_integration_test.go
@@ -1,0 +1,186 @@
+// Hermetic integration tests for the #2187 split-series segment resolution.
+//
+// The Betreuungsplan grid renders every occurrence with the template id that
+// materialized it, so a click on a first-school-week block can carry the id of
+// a segment that has meanwhile been capped twice. ResolveLivingTemplateSegment
+// maps such an id back to the one segment of the lineage that is still
+// editable; a lineage without an open segment is a genuine miss.
+//
+// Fixtures: makeSeriesChain builds the T → S1 → S2 shape (one fully bounded
+// NON-root middle segment) on top of makeScenario. Unique tenant per test, all
+// rows cleaned up by scenarioSetup.runCleanup.
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// seriesChain is a two-split lineage T → S1 → S2:
+//
+//	rootID   schedules [-∞, firstBoundary)
+//	middleID schedules [firstBoundary, secondBoundary)   ← bounded NON-root
+//	livingID schedules [secondBoundary, ∞)
+type seriesChain struct {
+	*scenarioSetup
+	rootID         int64
+	middleID       int64
+	livingID       int64
+	weekdays       []int
+	firstBoundary  timezone.Date
+	secondBoundary timezone.Date
+}
+
+// makeSeriesChain builds the two-split chain on the given weekdays. The
+// scenario template starts with weekdays[0]; the remaining weekdays are added
+// as extra schedule rows sharing the scenario's timeframe, so every segment of
+// the resulting chain runs on all of them.
+func makeSeriesChain(t *testing.T, weekdays []int, firstBoundary, secondBoundary timezone.Date) *seriesChain {
+	t.Helper()
+	require.NotEmpty(t, weekdays)
+	require.True(t, firstBoundary.Before(secondBoundary), "chain boundaries must be ordered")
+
+	s := makeScenario(t, weekdays[0], firstBoundary)
+	for _, weekday := range weekdays[1:] {
+		row := &activitiesModels.Schedule{
+			Weekday:         weekday,
+			TimeframeID:     &s.timeframe.ID,
+			ActivityGroupID: s.template.ID,
+			WeekPattern:     0,
+		}
+		row.SetTenantID(s.tenantID)
+		_, err := s.db.NewInsert().Model(row).ModelTableExpr(`activities.schedules`).Exec(s.ctx)
+		require.NoError(t, err)
+		s.registerCleanup("activities.schedules", row.ID)
+	}
+
+	middleInput := baseSplitInput(s, firstBoundary, fmt.Sprintf("Chain-Middle-%d", time.Now().UnixNano()))
+	middleInput.Weekdays = weekdays
+	middle, err := s.factory.TemplateSplit.Split(s.ctx, middleInput)
+	require.NoError(t, err)
+	registerSuccessorCleanup(t, s, middle.NewTemplateID)
+
+	livingInput := baseSplitInput(s, secondBoundary, fmt.Sprintf("Chain-Living-%d", time.Now().UnixNano()))
+	livingInput.TemplateID = middle.NewTemplateID
+	livingInput.Weekdays = weekdays
+	living, err := s.factory.TemplateSplit.Split(s.ctx, livingInput)
+	require.NoError(t, err)
+	registerSuccessorCleanup(t, s, living.NewTemplateID)
+
+	chain := &seriesChain{
+		scenarioSetup:  s,
+		rootID:         s.template.ID,
+		middleID:       middle.NewTemplateID,
+		livingID:       living.NewTemplateID,
+		weekdays:       weekdays,
+		firstBoundary:  firstBoundary,
+		secondBoundary: secondBoundary,
+	}
+	chain.registerSweep(t)
+	chain.assertShape(t)
+	return chain
+}
+
+// registerSweep deletes everything still attached to the chain's groups at
+// teardown. The tests below create roster and instance rows the per-id
+// registrations cannot know about, and the group rows (registered by
+// registerSuccessorCleanup) can only be deleted once their children are gone.
+func (c *seriesChain) registerSweep(t *testing.T) {
+	t.Helper()
+	ids := []int64{c.rootID, c.middleID, c.livingID}
+	c.extraCleanups = append([]func(){func() {
+		exec := func(table, where string, args ...any) {
+			_, err := c.db.NewDelete().TableExpr(table).Where(where, args...).Exec(c.ctx)
+			require.NoError(t, err)
+		}
+		exec("schedule.instance_students",
+			`instance_id IN (SELECT id FROM schedule.activity_instances WHERE activity_group_id IN (?))`, bun.List(ids))
+		exec("schedule.instance_staff",
+			`instance_id IN (SELECT id FROM schedule.activity_instances WHERE activity_group_id IN (?))`, bun.List(ids))
+		exec("schedule.activity_instances", `activity_group_id IN (?)`, bun.List(ids))
+		exec("activities.student_enrollments", `activity_group_id IN (?)`, bun.List(ids))
+		exec("activities.supervisors", `group_id IN (?)`, bun.List(ids))
+		exec("activities.schedules", `activity_group_id IN (?)`, bun.List(ids))
+	}}, c.extraCleanups...)
+}
+
+// assertShape pins the envelope the roster and cascade tests rely on.
+func (c *seriesChain) assertShape(t *testing.T) {
+	t.Helper()
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.rootID) {
+		assert.Nil(t, row.ValidFrom, "root segment keeps its open start")
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.firstBoundary, *row.ValidUntil)
+	}
+	middle := loadSplitSchedules(t, c.scenarioSetup, c.middleID)
+	require.Len(t, middle, len(c.weekdays))
+	for _, row := range middle {
+		require.NotNil(t, row.ValidFrom)
+		require.NotNil(t, row.ValidUntil)
+		assert.Equal(t, c.firstBoundary, *row.ValidFrom)
+		assert.Equal(t, c.secondBoundary, *row.ValidUntil, "middle segment must be fully bounded")
+	}
+	for _, row := range loadSplitSchedules(t, c.scenarioSetup, c.livingID) {
+		require.NotNil(t, row.ValidFrom)
+		assert.Equal(t, c.secondBoundary, *row.ValidFrom)
+		assert.Nil(t, row.ValidUntil, "living segment stays open")
+	}
+}
+
+func TestResolveLivingTemplateSegment_ResolvesCappedPredecessor(t *testing.T) {
+	chain := makeSeriesChain(t, []int{activitiesModels.WeekdayMonday}, futureMonday(1), futureMonday(3))
+	defer chain.runCleanup(t)
+
+	resolved, changed, err := chain.factory.TimetableData.ResolveLivingTemplateSegment(chain.ctx, chain.middleID)
+	require.NoError(t, err)
+	assert.Equal(t, chain.livingID, resolved, "a bounded middle segment resolves to the living successor")
+	assert.True(t, changed)
+
+	resolved, changed, err = chain.factory.TimetableData.ResolveLivingTemplateSegment(chain.ctx, chain.rootID)
+	require.NoError(t, err)
+	assert.Equal(t, chain.livingID, resolved, "the series root resolves to the living successor too")
+	assert.True(t, changed)
+}
+
+func TestResolveLivingTemplateSegment_LeavesOpenTemplateAlone(t *testing.T) {
+	chain := makeSeriesChain(t, []int{activitiesModels.WeekdayMonday}, futureMonday(1), futureMonday(3))
+	defer chain.runCleanup(t)
+
+	resolved, changed, err := chain.factory.TimetableData.ResolveLivingTemplateSegment(chain.ctx, chain.livingID)
+	require.NoError(t, err)
+	assert.Equal(t, chain.livingID, resolved)
+	assert.False(t, changed, "the living segment must not report a resolution")
+}
+
+func TestResolveLivingTemplateSegment_ErrorsOnFullyEndedSeries(t *testing.T) {
+	chain := makeSeriesChain(t, []int{activitiesModels.WeekdayMonday}, futureMonday(1), futureMonday(3))
+	defer chain.runCleanup(t)
+
+	t.Run("unknown template id", func(t *testing.T) {
+		// Far above every id this tenant's fixtures produced — an id that
+		// resolves to no lineage at all.
+		unknownID := chain.livingID + 1_000_000
+		_, _, err := chain.factory.TimetableData.ResolveLivingTemplateSegment(chain.ctx, unknownID)
+		assert.ErrorIs(t, err, scheduleSvc.ErrTemplateSeriesFullyEnded)
+	})
+
+	t.Run("every segment ended", func(t *testing.T) {
+		_, err := chain.factory.TemplateSplit.EndFromDate(chain.ctx, scheduleSvc.TemplateEndInput{
+			TemplateID:    chain.livingID,
+			EffectiveDate: chain.secondBoundary,
+		})
+		require.NoError(t, err)
+
+		_, _, err = chain.factory.TimetableData.ResolveLivingTemplateSegment(chain.ctx, chain.middleID)
+		assert.ErrorIs(t, err, scheduleSvc.ErrTemplateSeriesFullyEnded,
+			"a lineage without an open segment has nothing left to edit")
+	})
+}

--- a/backend/services/schedule/template_series_roster.go
+++ b/backend/services/schedule/template_series_roster.go
@@ -186,10 +186,12 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 	if !rowFrom.Before(*rowUntil) {
 		return nil
 	}
-	segmentWeekdays := intersectWeekdays(seg.Weekdays, in.Weekdays)
+	// The weekday universe is the PREDECESSOR's own recurrence. in.Weekdays
+	// describes the living successor, which a split may have moved to other
+	// days entirely — intersecting with it wrote a Monday row for a clicked
+	// Wednesday, or skipped the segment outright (#2187 review).
+	segmentWeekdays := uniqueSortedWeekdays(seg.Weekdays)
 	if len(segmentWeekdays) == 0 {
-		// The predecessor runs on none of the submitted weekdays — weekday
-		// changes are a non-roster edit and never retro-apply.
 		return nil
 	}
 	// A per-weekday series (#2129) is edited one weekday at a time, so the
@@ -363,11 +365,19 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 	scope map[int64]struct{},
 ) ([]int64, error) {
 	scoped := weekdays.edited
+	// in.PrimaryStaffID names the LIVING segment's Hauptbetreuung. Stamping it
+	// onto a predecessor row would silently make the successor's lead the
+	// predecessor's too — the weekday- and period-scoped row outranks the
+	// existing shared one, and the ensure_single_primary_supervisor trigger
+	// clears the old flag outright. The flag therefore only travels when the
+	// edit actually changed the Hauptbetreuung (#2187 review).
 	primaryWanted := make(map[seriesWeekdayPerson]bool)
-	for _, row := range staffRows {
-		for _, weekday := range coveredSeriesWeekdays(row.Weekday, scoped, scoped) {
-			if row.IsPrimary {
-				primaryWanted[seriesWeekdayPerson{weekday: weekday, personID: row.PersonID}] = true
+	if in.SeriesRosterPrimaryChanged {
+		for _, row := range staffRows {
+			for _, weekday := range coveredSeriesWeekdays(row.Weekday, scoped, scoped) {
+				if row.IsPrimary {
+					primaryWanted[seriesWeekdayPerson{weekday: weekday, personID: row.PersonID}] = true
+				}
 			}
 		}
 	}
@@ -393,7 +403,8 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 		}
 		if seriesRowStaysCorrect(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) &&
 			wantedOnAllWeekdays(want, covered, row.StaffID, false) &&
-			primaryFlagMatches(primaryWanted, covered, row.StaffID, row.IsPrimary) {
+			(!in.SeriesRosterPrimaryChanged ||
+				primaryFlagMatches(primaryWanted, covered, row.StaffID, row.IsPrimary)) {
 			for _, weekday := range covered {
 				satisfied[seriesWeekdayPerson{weekday: weekday, personID: row.StaffID}] = true
 			}
@@ -500,7 +511,7 @@ func (s *TimetableDataService) reconcilePredecessorInstanceStaff(
 		existing[instanceStudentPair{instanceID: row.InstanceID, studentID: row.StaffID}] = row
 	}
 
-	created, removed := 0, 0
+	created, removed, repointed := 0, 0, 0
 	for _, inst := range instances {
 		periodID := int64(0)
 		if inst.CalendarPeriodID != nil {
@@ -528,6 +539,19 @@ func (s *TimetableDataService) reconcilePredecessorInstanceStaff(
 				}
 				existing[key] = fresh
 				created++
+			case desired && exists && instanceStaffRowIsStillPlanned(row):
+				// A moved Hauptbetreuung changes no membership, so without this
+				// branch the occurrence kept pointing at the old lead while the
+				// template rows already named the new one (#2187 review).
+				wantPrimary := hasPrimary && staffID == primaryStaffID
+				if row.IsPrimary == wantPrimary {
+					continue
+				}
+				row.IsPrimary = wantPrimary
+				if _, err := s.deps.InstanceStaffRepo.UpdateColumns(ctx, row, "is_primary"); err != nil {
+					return &ScheduleError{Op: "reconcile predecessor staff: update primary", Err: err}
+				}
+				repointed++
 			case !desired && exists && instanceStaffRowIsStillPlanned(row):
 				if err := s.deps.InstanceStaffRepo.Delete(ctx, row.ID); err != nil {
 					return &ScheduleError{Op: "reconcile predecessor staff: remove staff", Err: err}
@@ -537,12 +561,13 @@ func (s *TimetableDataService) reconcilePredecessorInstanceStaff(
 			}
 		}
 	}
-	if created > 0 || removed > 0 {
+	if created > 0 || removed > 0 || repointed > 0 {
 		s.getLogger().Info("reconciled materialized staff after series roster change",
 			slog.Int64("template_id", templateID),
 			slog.Int("staff", len(staffIDs)),
 			slog.Int("rows_created", created),
 			slog.Int("rows_removed", removed),
+			slog.Int("rows_repointed", repointed),
 		)
 	}
 	return nil

--- a/backend/services/schedule/template_series_roster.go
+++ b/backend/services/schedule/template_series_roster.go
@@ -6,9 +6,9 @@
 // segment of the same split series: a child enrolled from Tue 18.08. has to
 // stand on the 18.08. list even when the first school week still materialized
 // from the capped predecessor. PUT /timetable/templates/{id} therefore accepts
-// an optional series_roster_from anchor; when set, the roster saved onto the
-// living segment is additionally mirrored onto the bounded predecessor
-// segments overlapping [anchor, living valid_from):
+// an optional series_roster_from anchor plus the scope of people the edit
+// actually changed; when both are set, that change is mirrored onto the
+// bounded predecessor segments overlapping [anchor, living valid_from):
 //
 //   - added people gain a bounded, weekday-explicit row
 //     [max(anchor, segment valid_from), segment valid_until)
@@ -17,6 +17,11 @@
 //   - already-correct rows, protected rows (enrollment_request_child_id,
 //     selected_weekdays), other-period rows, and unrelated bounded windows are
 //     never touched
+//
+// Everyone outside the submitted scope is left alone on purpose: the roster
+// written to the living segment describes THAT segment (a split may have
+// changed it), so it is not the predecessor's target set. Reconciling against
+// it wholesale would retire predecessor-only members nobody touched.
 //
 // The anchor does NOT change how the living segment itself is written —
 // templateRosterValidFrom stays authoritative there; this pass only extends
@@ -58,6 +63,14 @@ func (s *TimetableDataService) reconcileSeriesPredecessorRoster(
 	if in.SeriesRosterFrom == nil {
 		return nil
 	}
+	studentScope := int64Set(in.SeriesRosterScopeStudentIDs)
+	staffScope := int64Set(in.SeriesRosterScopeStaffIDs)
+	if len(studentScope) == 0 && len(staffScope) == 0 {
+		// The anchor alone says nothing about WHO changed, and the submitted
+		// roster is not the predecessor's target set — without a scope there is
+		// nothing that may safely be mirrored.
+		return nil
+	}
 	anchor := *in.SeriesRosterFrom
 	if today := timezone.TodayDate(); anchor.Before(today) {
 		// History is never rewritten; a stale client anchor degrades to "from
@@ -85,7 +98,7 @@ func (s *TimetableDataService) reconcileSeriesPredecessorRoster(
 		if !segmentIsReconcilablePredecessor(seg, in.TemplateID, anchor, livingValidFrom) {
 			continue
 		}
-		if err := s.reconcilePredecessorSegmentRoster(ctx, in, tenantID, seg, anchor, roster); err != nil {
+		if err := s.reconcilePredecessorSegmentRoster(ctx, in, tenantID, seg, anchor, roster, studentScope, staffScope); err != nil {
 			return err
 		}
 		reconciled++
@@ -135,7 +148,7 @@ type seriesWeekdayPerson struct {
 // reconcilePredecessorSegmentRoster aligns ONE bounded predecessor segment's
 // enrollment and supervisor rows (and their already-materialized occurrences)
 // with the desired roster, inside [max(anchor, segment valid_from), segment
-// valid_until).
+// valid_until) — restricted to the people the edit actually changed.
 func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 	ctx context.Context,
 	in TemplateUpdateInput,
@@ -143,6 +156,7 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 	seg *templateSeriesSegment,
 	anchor timezone.Date,
 	roster resolvedTemplateRoster,
+	studentScope, staffScope map[int64]struct{},
 ) error {
 	rowFrom := anchor
 	if seg.ValidFrom != nil && rowFrom.Before(*seg.ValidFrom) {
@@ -159,9 +173,6 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 		return nil
 	}
 
-	wantStudents := desiredSeriesRoster(roster.Students, scoped)
-	wantStaff := desiredSeriesRoster(roster.Staff, scoped)
-
 	// Snapshots BEFORE any write: they classify the existing rows and double
 	// as the prior state for the instance reconcilers, which is what keeps a
 	// child staff had hand-removed from one occurrence from being resurrected.
@@ -174,14 +185,28 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 		return &ScheduleError{Op: "update template: load predecessor supervisors", Err: err}
 	}
 
+	// A weekday already supplied by an externally-owned row (care offering,
+	// weekday selection) must not gain a second, editor-owned row — the same
+	// rule the canonical template write applies.
+	protectedCoverage := buildProtectedStudentCoverage(
+		protectedPredecessorEnrollments(priorEnrollments, rowFrom, rowUntil),
+		scoped,
+		func(row *activitiesModel.StudentEnrollment) bool {
+			return rosterPeriodApplies(row.CalendarPeriodID, in.CalendarPeriodID)
+		},
+	)
+	wantStudents := desiredSeriesRoster(
+		excludeProtectedStudentWeekdays(roster.Students, protectedCoverage), scoped)
+	wantStaff := desiredSeriesRoster(roster.Staff, scoped)
+
 	touchedStudents, err := s.reconcilePredecessorEnrollmentRows(
-		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, wantStudents, priorEnrollments,
+		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, wantStudents, priorEnrollments, studentScope,
 	)
 	if err != nil {
 		return err
 	}
 	touchedStaff, err := s.reconcilePredecessorSupervisorRows(
-		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, roster.Staff, wantStaff, priorSupervisors,
+		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, roster.Staff, wantStaff, priorSupervisors, staffScope,
 	)
 	if err != nil {
 		return err
@@ -205,7 +230,8 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 
 // reconcilePredecessorEnrollmentRows diffs the segment's enrollment rows
 // against the desired student roster and returns the students whose coverage
-// changed (rows created, closed, or deleted).
+// changed (rows created, closed, or deleted). Students outside scope — the
+// people this edit actually changed — are ignored entirely.
 func (s *TimetableDataService) reconcilePredecessorEnrollmentRows(
 	ctx context.Context,
 	in TemplateUpdateInput,
@@ -216,11 +242,15 @@ func (s *TimetableDataService) reconcilePredecessorEnrollmentRows(
 	scoped []int,
 	want map[seriesWeekdayPerson]bool,
 	priorRows []*activitiesModel.StudentEnrollment,
+	scope map[int64]struct{},
 ) ([]int64, error) {
 	satisfied := make(map[seriesWeekdayPerson]bool)
 	touched := make(map[int64]bool)
 	for _, row := range priorRows {
 		if row == nil || enrollmentIsProtected(row) {
+			continue
+		}
+		if _, inScope := scope[row.StudentID]; !inScope {
 			continue
 		}
 		if !rosterPeriodApplies(row.CalendarPeriodID, in.CalendarPeriodID) {
@@ -260,6 +290,9 @@ func (s *TimetableDataService) reconcilePredecessorEnrollmentRows(
 		if satisfied[key] {
 			continue
 		}
+		if _, inScope := scope[key.personID]; !inScope {
+			continue
+		}
 		weekday := key.weekday
 		enrollment := &activitiesModel.StudentEnrollment{
 			StudentID:        key.personID,
@@ -292,6 +325,7 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 	staffRows []resolvedRosterRow,
 	want map[seriesWeekdayPerson]bool,
 	priorRows []*activitiesModel.SupervisorPlanned,
+	scope map[int64]struct{},
 ) ([]int64, error) {
 	primaryWanted := make(map[seriesWeekdayPerson]bool)
 	for _, row := range staffRows {
@@ -306,6 +340,9 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 	touched := make(map[int64]bool)
 	for _, row := range priorRows {
 		if row == nil {
+			continue
+		}
+		if _, inScope := scope[row.StaffID]; !inScope {
 			continue
 		}
 		if !rosterPeriodApplies(row.CalendarPeriodID, in.CalendarPeriodID) {
@@ -344,6 +381,9 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 
 	for _, key := range sortedSeriesWants(want) {
 		if satisfied[key] {
+			continue
+		}
+		if _, inScope := scope[key.personID]; !inScope {
 			continue
 		}
 		weekday := key.weekday
@@ -570,6 +610,39 @@ func sortedSeriesWants(want map[seriesWeekdayPerson]bool) []seriesWeekdayPerson 
 		return keys[i].personID < keys[j].personID
 	})
 	return keys
+}
+
+// int64Set indexes the submitted reconciliation scope; non-positive ids are
+// dropped so a malformed payload cannot widen it.
+func int64Set(ids []int64) map[int64]struct{} {
+	set := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		if id > 0 {
+			set[id] = struct{}{}
+		}
+	}
+	return set
+}
+
+// protectedPredecessorEnrollments returns the externally-owned rows of a
+// segment that overlap the reconciliation window — the rows whose weekday
+// coverage the editor may not duplicate.
+func protectedPredecessorEnrollments(
+	rows []*activitiesModel.StudentEnrollment,
+	rowFrom timezone.Date,
+	rowUntil *timezone.Date,
+) []*activitiesModel.StudentEnrollment {
+	out := make([]*activitiesModel.StudentEnrollment, 0, len(rows))
+	for _, row := range rows {
+		if row == nil || !enrollmentIsProtected(row) {
+			continue
+		}
+		if !validityWindowsOverlap(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 func sortedInt64Keys(set map[int64]bool) []int64 {

--- a/backend/services/schedule/template_series_roster.go
+++ b/backend/services/schedule/template_series_roster.go
@@ -1,0 +1,582 @@
+// Package schedule — roster reconciliation across split-series predecessors
+// (#2187, "Nachzügler").
+//
+// A roster change made "ab Datum D" must be true on every occurrence from D
+// on, including occurrences that belong to an already-capped predecessor
+// segment of the same split series: a child enrolled from Tue 18.08. has to
+// stand on the 18.08. list even when the first school week still materialized
+// from the capped predecessor. PUT /timetable/templates/{id} therefore accepts
+// an optional series_roster_from anchor; when set, the roster saved onto the
+// living segment is additionally mirrored onto the bounded predecessor
+// segments overlapping [anchor, living valid_from):
+//
+//   - added people gain a bounded, weekday-explicit row
+//     [max(anchor, segment valid_from), segment valid_until)
+//   - removed people have their segment rows closed at the anchor (or deleted
+//     when they only started there)
+//   - already-correct rows, protected rows (enrollment_request_child_id,
+//     selected_weekdays), other-period rows, and unrelated bounded windows are
+//     never touched
+//
+// The anchor does NOT change how the living segment itself is written —
+// templateRosterValidFrom stays authoritative there; this pass only extends
+// the change backwards over the chain. Non-roster fields (name, time, room,
+// weekdays) deliberately do not retro-apply to predecessor windows: those
+// segments' recurrence is closed history, only roster membership is a fact
+// about children and staff that must be right on the day.
+//
+// Because the materializer is insert-only, the enrollment/supervisor writes
+// alone would not change already-planned occurrences. The same surgical
+// instance reconcilers the offering resync uses close that gap (students via
+// RosterReconciler.ReconcileSourcedTemplateRosters, staff via the mirror pass
+// below); a wholesale re-plan of the predecessor window would wipe
+// per-occurrence hand edits and is deliberately avoided.
+package schedule
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"sort"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+// reconcileSeriesPredecessorRoster mirrors the update's saved roster onto the
+// bounded predecessor segments of the template's split series, from
+// in.SeriesRosterFrom on. No-op without the anchor. Runs inside the update's
+// tenant transaction, after lockTenantRecurrenceWrites — the chain cannot
+// shift between the segment read and the writes.
+func (s *TimetableDataService) reconcileSeriesPredecessorRoster(
+	ctx context.Context,
+	in TemplateUpdateInput,
+	tenantID int64,
+	livingValidFrom *timezone.Date,
+) error {
+	if in.SeriesRosterFrom == nil {
+		return nil
+	}
+	anchor := *in.SeriesRosterFrom
+	if today := timezone.TodayDate(); anchor.Before(today) {
+		// History is never rewritten; a stale client anchor degrades to "from
+		// today on" instead of erroring a save that is otherwise valid.
+		anchor = today
+	}
+	segments, err := loadTemplateSeriesSegments(
+		ctx,
+		s.deps.ActivityGroupRepo,
+		s.deps.ActivityScheduleRepo,
+		s.getLogger(),
+		in.TemplateID,
+	)
+	if err != nil {
+		return err
+	}
+	roster, err := resolveTemplateRoster(in.Weekdays, in.StudentIDs, in.StaffIDs, in.PrimaryStaffID, in.WeekdayAssignments)
+	if err != nil {
+		return &ScheduleError{Op: "update template: resolve series roster", Err: err}
+	}
+
+	reconciled := 0
+	for i := range segments {
+		seg := &segments[i]
+		if !segmentIsReconcilablePredecessor(seg, in.TemplateID, anchor, livingValidFrom) {
+			continue
+		}
+		if err := s.reconcilePredecessorSegmentRoster(ctx, in, tenantID, seg, anchor, roster); err != nil {
+			return err
+		}
+		reconciled++
+	}
+	if reconciled > 0 {
+		s.getLogger().Info("reconciled split-series predecessor rosters",
+			slog.Int64("template_id", in.TemplateID),
+			slog.String("series_roster_from", anchor.String()),
+			slog.Int("segments", reconciled),
+		)
+	}
+	return nil
+}
+
+// segmentIsReconcilablePredecessor filters the lineage down to the bounded
+// predecessor segments whose window still reaches into [anchor, ∞) and lies
+// before the living segment. Empty windows (valid_from == valid_until — the
+// degenerate shape a same-day split leaves behind) materialize nothing and
+// are skipped.
+func segmentIsReconcilablePredecessor(
+	seg *templateSeriesSegment,
+	livingTemplateID int64,
+	anchor timezone.Date,
+	livingValidFrom *timezone.Date,
+) bool {
+	if seg.Group == nil || seg.Group.ID == livingTemplateID || seg.ValidUntil == nil {
+		return false
+	}
+	if seg.ValidFrom != nil && !seg.ValidFrom.Before(*seg.ValidUntil) {
+		return false // empty window
+	}
+	if !seg.ValidUntil.After(anchor) {
+		return false // the segment ended before the change takes effect
+	}
+	if livingValidFrom != nil && seg.ValidFrom != nil && !seg.ValidFrom.Before(*livingValidFrom) {
+		return false
+	}
+	return true
+}
+
+// seriesWeekdayPerson keys a desired or satisfied roster membership.
+type seriesWeekdayPerson struct {
+	weekday  int
+	personID int64
+}
+
+// reconcilePredecessorSegmentRoster aligns ONE bounded predecessor segment's
+// enrollment and supervisor rows (and their already-materialized occurrences)
+// with the desired roster, inside [max(anchor, segment valid_from), segment
+// valid_until).
+func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
+	ctx context.Context,
+	in TemplateUpdateInput,
+	tenantID int64,
+	seg *templateSeriesSegment,
+	anchor timezone.Date,
+	roster resolvedTemplateRoster,
+) error {
+	rowFrom := anchor
+	if seg.ValidFrom != nil && rowFrom.Before(*seg.ValidFrom) {
+		rowFrom = *seg.ValidFrom
+	}
+	rowUntil := seg.ValidUntil
+	if !rowFrom.Before(*rowUntil) {
+		return nil
+	}
+	scoped := intersectWeekdays(seg.Weekdays, in.Weekdays)
+	if len(scoped) == 0 {
+		// The predecessor runs on none of the submitted weekdays — weekday
+		// changes are a non-roster edit and never retro-apply.
+		return nil
+	}
+
+	wantStudents := desiredSeriesRoster(roster.Students, scoped)
+	wantStaff := desiredSeriesRoster(roster.Staff, scoped)
+
+	// Snapshots BEFORE any write: they classify the existing rows and double
+	// as the prior state for the instance reconcilers, which is what keeps a
+	// child staff had hand-removed from one occurrence from being resurrected.
+	priorEnrollments, err := s.deps.StudentEnrollmentRepo.FindByGroupID(ctx, seg.Group.ID)
+	if err != nil {
+		return &ScheduleError{Op: "update template: load predecessor enrollments", Err: err}
+	}
+	priorSupervisors, err := s.deps.ActivitySupervisorRepo.FindByGroupID(ctx, seg.Group.ID)
+	if err != nil {
+		return &ScheduleError{Op: "update template: load predecessor supervisors", Err: err}
+	}
+
+	touchedStudents, err := s.reconcilePredecessorEnrollmentRows(
+		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, wantStudents, priorEnrollments,
+	)
+	if err != nil {
+		return err
+	}
+	touchedStaff, err := s.reconcilePredecessorSupervisorRows(
+		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, roster.Staff, wantStaff, priorSupervisors,
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(touchedStudents) > 0 && s.deps.ActivityInstanceRepo != nil && s.deps.InstanceStudentRepo != nil {
+		reconciler := NewRosterReconciler(s.deps.ActivityInstanceRepo, s.deps.InstanceStudentRepo, s.deps.StudentEnrollmentRepo, s.deps.Logger)
+		if _, _, err := reconciler.ReconcileSourcedTemplateRosters(
+			ctx, seg.Group.ID, touchedStudents, rowFrom, priorEnrollments,
+		); err != nil {
+			return &ScheduleError{Op: "update template: reconcile predecessor occurrences", Err: err}
+		}
+	}
+	if len(touchedStaff) > 0 && s.deps.ActivityInstanceRepo != nil && s.deps.InstanceStaffRepo != nil {
+		if err := s.reconcilePredecessorInstanceStaff(ctx, seg.Group.ID, touchedStaff, rowFrom, priorSupervisors); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reconcilePredecessorEnrollmentRows diffs the segment's enrollment rows
+// against the desired student roster and returns the students whose coverage
+// changed (rows created, closed, or deleted).
+func (s *TimetableDataService) reconcilePredecessorEnrollmentRows(
+	ctx context.Context,
+	in TemplateUpdateInput,
+	tenantID int64,
+	seg *templateSeriesSegment,
+	rowFrom timezone.Date,
+	rowUntil *timezone.Date,
+	scoped []int,
+	want map[seriesWeekdayPerson]bool,
+	priorRows []*activitiesModel.StudentEnrollment,
+) ([]int64, error) {
+	satisfied := make(map[seriesWeekdayPerson]bool)
+	touched := make(map[int64]bool)
+	for _, row := range priorRows {
+		if row == nil || enrollmentIsProtected(row) {
+			continue
+		}
+		if !rosterPeriodApplies(row.CalendarPeriodID, in.CalendarPeriodID) {
+			continue
+		}
+		covered := coveredSeriesWeekdays(row.Weekday, seg.Weekdays, scoped)
+		if len(covered) == 0 {
+			continue
+		}
+		if !validityWindowsOverlap(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) {
+			continue
+		}
+		if seriesRowStaysCorrect(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) &&
+			wantedOnAllWeekdays(want, covered, row.StudentID, false) {
+			for _, weekday := range covered {
+				satisfied[seriesWeekdayPerson{weekday: weekday, personID: row.StudentID}] = true
+			}
+			continue
+		}
+		action := classifyOwnedRosterRetirement(row.ValidFrom, row.ValidUntil, true, rowFrom, rowUntil)
+		switch action {
+		case rosterRetirementDelete:
+			if err := s.deps.StudentEnrollmentRepo.Delete(ctx, row.ID); err != nil {
+				return nil, &ScheduleError{Op: "update template: delete predecessor enrollment", Err: err}
+			}
+		case rosterRetirementClose:
+			if err := s.deps.StudentEnrollmentRepo.SetValidUntilByID(ctx, row.ID, rowFrom); err != nil {
+				return nil, &ScheduleError{Op: "update template: close predecessor enrollment", Err: err}
+			}
+		default:
+			continue // unrelated bounded window — survives untouched
+		}
+		touched[row.StudentID] = true
+	}
+
+	for _, key := range sortedSeriesWants(want) {
+		if satisfied[key] {
+			continue
+		}
+		weekday := key.weekday
+		enrollment := &activitiesModel.StudentEnrollment{
+			StudentID:        key.personID,
+			ActivityGroupID:  seg.Group.ID,
+			ValidFrom:        rowFrom,
+			ValidUntil:       cloneOptionalDate(rowUntil),
+			CalendarPeriodID: in.CalendarPeriodID,
+			Weekday:          &weekday,
+		}
+		enrollment.SetTenantID(tenantID)
+		if err := s.deps.StudentEnrollmentRepo.Create(ctx, enrollment); err != nil {
+			return nil, &ScheduleError{Op: "update template: create predecessor enrollment", Err: err}
+		}
+		touched[key.personID] = true
+	}
+	return sortedInt64Keys(touched), nil
+}
+
+// reconcilePredecessorSupervisorRows is the staff twin of the enrollment diff.
+// A kept row must also match the desired is_primary flag on every weekday it
+// covers, so a primary change propagates like a membership change.
+func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
+	ctx context.Context,
+	in TemplateUpdateInput,
+	tenantID int64,
+	seg *templateSeriesSegment,
+	rowFrom timezone.Date,
+	rowUntil *timezone.Date,
+	scoped []int,
+	staffRows []resolvedRosterRow,
+	want map[seriesWeekdayPerson]bool,
+	priorRows []*activitiesModel.SupervisorPlanned,
+) ([]int64, error) {
+	primaryWanted := make(map[seriesWeekdayPerson]bool)
+	for _, row := range staffRows {
+		for _, weekday := range coveredSeriesWeekdays(row.Weekday, scoped, scoped) {
+			if row.IsPrimary {
+				primaryWanted[seriesWeekdayPerson{weekday: weekday, personID: row.PersonID}] = true
+			}
+		}
+	}
+
+	satisfied := make(map[seriesWeekdayPerson]bool)
+	touched := make(map[int64]bool)
+	for _, row := range priorRows {
+		if row == nil {
+			continue
+		}
+		if !rosterPeriodApplies(row.CalendarPeriodID, in.CalendarPeriodID) {
+			continue
+		}
+		covered := coveredSeriesWeekdays(row.Weekday, seg.Weekdays, scoped)
+		if len(covered) == 0 {
+			continue
+		}
+		if !validityWindowsOverlap(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) {
+			continue
+		}
+		if seriesRowStaysCorrect(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) &&
+			wantedOnAllWeekdays(want, covered, row.StaffID, false) &&
+			primaryFlagMatches(primaryWanted, covered, row.StaffID, row.IsPrimary) {
+			for _, weekday := range covered {
+				satisfied[seriesWeekdayPerson{weekday: weekday, personID: row.StaffID}] = true
+			}
+			continue
+		}
+		action := classifyOwnedRosterRetirement(row.ValidFrom, row.ValidUntil, true, rowFrom, rowUntil)
+		switch action {
+		case rosterRetirementDelete:
+			if err := s.deps.ActivitySupervisorRepo.Delete(ctx, row.ID); err != nil {
+				return nil, &ScheduleError{Op: "update template: delete predecessor supervisor", Err: err}
+			}
+		case rosterRetirementClose:
+			if err := s.deps.ActivitySupervisorRepo.SetValidUntilByID(ctx, row.ID, rowFrom); err != nil {
+				return nil, &ScheduleError{Op: "update template: close predecessor supervisor", Err: err}
+			}
+		default:
+			continue
+		}
+		touched[row.StaffID] = true
+	}
+
+	for _, key := range sortedSeriesWants(want) {
+		if satisfied[key] {
+			continue
+		}
+		weekday := key.weekday
+		supervisor := &activitiesModel.SupervisorPlanned{
+			StaffID:          key.personID,
+			GroupID:          seg.Group.ID,
+			IsPrimary:        primaryWanted[key],
+			ValidFrom:        rowFrom,
+			ValidUntil:       cloneOptionalDate(rowUntil),
+			CalendarPeriodID: in.CalendarPeriodID,
+			Weekday:          &weekday,
+		}
+		supervisor.SetTenantID(tenantID)
+		if err := s.deps.ActivitySupervisorRepo.Create(ctx, supervisor); err != nil {
+			return nil, &ScheduleError{Op: "update template: create predecessor supervisor", Err: err}
+		}
+		touched[key.personID] = true
+	}
+	return sortedInt64Keys(touched), nil
+}
+
+// reconcilePredecessorInstanceStaff aligns schedule.instance_staff on ONE
+// template's already-materialized, still-planned occurrences with the
+// template's current activities.supervisors rows, restricted to the given
+// staff — the supervisor twin of ReconcileSourcedTemplateRosters. Rows
+// recording a real decision (a substitution, an absence, a sick-cascade
+// stamp) are never touched, and a staff member a planner had removed from one
+// occurrence by hand is not resurrected (priorSupervisors semantics).
+func (s *TimetableDataService) reconcilePredecessorInstanceStaff(
+	ctx context.Context,
+	templateID int64,
+	staffIDs []int64,
+	from timezone.Date,
+	priorSupervisors []*activitiesModel.SupervisorPlanned,
+) error {
+	if templateID <= 0 || len(staffIDs) == 0 {
+		return nil
+	}
+	if today := timezone.TodayDate(); from.Before(today) {
+		from = today
+	}
+	all, err := s.deps.ActivityInstanceRepo.FindPlannedTemplateBackedFrom(ctx, from)
+	if err != nil {
+		return &ScheduleError{Op: "reconcile predecessor staff: load future instances", Err: err}
+	}
+	instances := make([]*scheduleModel.ActivityInstance, 0, len(all))
+	instanceIDs := make([]int64, 0, len(all))
+	for _, inst := range all {
+		if inst.ActivityGroupID == nil || *inst.ActivityGroupID != templateID {
+			continue
+		}
+		instances = append(instances, inst)
+		instanceIDs = append(instanceIDs, inst.ID)
+	}
+	if len(instances) == 0 {
+		return nil
+	}
+
+	supervisors, err := s.deps.ActivitySupervisorRepo.FindByGroupID(ctx, templateID)
+	if err != nil {
+		return &ScheduleError{Op: "reconcile predecessor staff: load supervisors", Err: err}
+	}
+	byStaff := make(map[int64][]*activitiesModel.SupervisorPlanned, len(supervisors))
+	for _, sup := range supervisors {
+		byStaff[sup.StaffID] = append(byStaff[sup.StaffID], sup)
+	}
+	priorByStaff := make(map[int64][]*activitiesModel.SupervisorPlanned, len(priorSupervisors))
+	for _, sup := range priorSupervisors {
+		priorByStaff[sup.StaffID] = append(priorByStaff[sup.StaffID], sup)
+	}
+
+	existingRows, err := s.deps.InstanceStaffRepo.FindByInstanceIDs(ctx, instanceIDs)
+	if err != nil {
+		return &ScheduleError{Op: "reconcile predecessor staff: load existing rows", Err: err}
+	}
+	existing := make(map[instanceStudentPair]*scheduleModel.InstanceStaff, len(existingRows))
+	for _, row := range existingRows {
+		existing[instanceStudentPair{instanceID: row.InstanceID, studentID: row.StaffID}] = row
+	}
+
+	created, removed := 0, 0
+	for _, inst := range instances {
+		periodID := int64(0)
+		if inst.CalendarPeriodID != nil {
+			periodID = *inst.CalendarPeriodID
+		}
+		primaryStaffID, hasPrimary := effectivePrimarySupervisor(supervisors, inst.Date, periodID)
+		for _, staffID := range staffIDs {
+			desired := supervisorsPlanStaffOn(byStaff[staffID], inst.Date, periodID)
+			key := instanceStudentPair{instanceID: inst.ID, studentID: staffID}
+			row, exists := existing[key]
+			switch {
+			case desired && !exists:
+				if supervisorsPlanStaffOn(priorByStaff[staffID], inst.Date, periodID) {
+					// The pre-edit rows already planned this occurrence and the
+					// row is gone regardless — a hand removal that stays.
+					continue
+				}
+				fresh := &scheduleModel.InstanceStaff{
+					InstanceID: inst.ID,
+					StaffID:    staffID,
+					IsPrimary:  hasPrimary && staffID == primaryStaffID,
+				}
+				if err := s.deps.InstanceStaffRepo.Create(ctx, fresh); err != nil {
+					return &ScheduleError{Op: "reconcile predecessor staff: add staff", Err: err}
+				}
+				existing[key] = fresh
+				created++
+			case !desired && exists && instanceStaffRowIsStillPlanned(row):
+				if err := s.deps.InstanceStaffRepo.Delete(ctx, row.ID); err != nil {
+					return &ScheduleError{Op: "reconcile predecessor staff: remove staff", Err: err}
+				}
+				delete(existing, key)
+				removed++
+			}
+		}
+	}
+	if created > 0 || removed > 0 {
+		s.getLogger().Info("reconciled materialized staff after series roster change",
+			slog.Int64("template_id", templateID),
+			slog.Int("staff", len(staffIDs)),
+			slog.Int("rows_created", created),
+			slog.Int("rows_removed", removed),
+		)
+	}
+	return nil
+}
+
+// supervisorsPlanStaffOn reports whether any of the rows plans its staff
+// member on the occurrence date.
+func supervisorsPlanStaffOn(rows []*activitiesModel.SupervisorPlanned, date timezone.Date, periodID int64) bool {
+	for _, sup := range rows {
+		if isSupervisorValidOn(sup, date, periodID) {
+			return true
+		}
+	}
+	return false
+}
+
+// instanceStaffRowIsStillPlanned reports whether a staff assignment is still
+// purely a plan: no substitution, no absence, no sick-cascade stamp. Only such
+// rows may be removed when the roster stops covering the staff member.
+func instanceStaffRowIsStillPlanned(row *scheduleModel.InstanceStaff) bool {
+	return !row.IsSubstitute && !row.IsAbsent && row.AbsenceReason == nil && row.SickAbsenceID == nil
+}
+
+// desiredSeriesRoster expands the resolved roster rows into (weekday, person)
+// wants inside the scoped weekdays. A nil-weekday row applies to every scoped
+// weekday; an explicit row only to its own.
+func desiredSeriesRoster(rows []resolvedRosterRow, scoped []int) map[seriesWeekdayPerson]bool {
+	want := make(map[seriesWeekdayPerson]bool)
+	for _, row := range rows {
+		for _, weekday := range coveredSeriesWeekdays(row.Weekday, scoped, scoped) {
+			want[seriesWeekdayPerson{weekday: weekday, personID: row.PersonID}] = true
+		}
+	}
+	return want
+}
+
+// coveredSeriesWeekdays returns the scoped weekdays a roster row covers: all
+// of them for a shared (nil weekday) row bounded by the row's own universe,
+// or the single explicit weekday when it is scoped.
+func coveredSeriesWeekdays(rowWeekday *int, universe, scoped []int) []int {
+	if rowWeekday != nil {
+		if slices.Contains(scoped, *rowWeekday) {
+			return []int{*rowWeekday}
+		}
+		return nil
+	}
+	return intersectWeekdays(universe, scoped)
+}
+
+func intersectWeekdays(left, right []int) []int {
+	rightSet := make(map[int]struct{}, len(right))
+	for _, weekday := range right {
+		rightSet[weekday] = struct{}{}
+	}
+	out := make([]int, 0, len(left))
+	for _, weekday := range uniqueSortedWeekdays(left) {
+		if _, ok := rightSet[weekday]; ok {
+			out = append(out, weekday)
+		}
+	}
+	return out
+}
+
+// seriesRowStaysCorrect reports whether an existing row already covers the
+// reconciliation window exactly: it starts at or before the window and ends
+// with the segment.
+func seriesRowStaysCorrect(validFrom timezone.Date, validUntil *timezone.Date, rowFrom timezone.Date, rowUntil *timezone.Date) bool {
+	return !validFrom.After(rowFrom) && optionalDatesEqual(validUntil, rowUntil)
+}
+
+func wantedOnAllWeekdays(want map[seriesWeekdayPerson]bool, weekdays []int, personID int64, whenEmpty bool) bool {
+	if len(weekdays) == 0 {
+		return whenEmpty
+	}
+	for _, weekday := range weekdays {
+		if !want[seriesWeekdayPerson{weekday: weekday, personID: personID}] {
+			return false
+		}
+	}
+	return true
+}
+
+func primaryFlagMatches(primaryWanted map[seriesWeekdayPerson]bool, weekdays []int, personID int64, isPrimary bool) bool {
+	for _, weekday := range weekdays {
+		if primaryWanted[seriesWeekdayPerson{weekday: weekday, personID: personID}] != isPrimary {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedSeriesWants(want map[seriesWeekdayPerson]bool) []seriesWeekdayPerson {
+	keys := make([]seriesWeekdayPerson, 0, len(want))
+	for key := range want {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].weekday != keys[j].weekday {
+			return keys[i].weekday < keys[j].weekday
+		}
+		return keys[i].personID < keys[j].personID
+	})
+	return keys
+}
+
+func sortedInt64Keys(set map[int64]bool) []int64 {
+	out := make([]int64, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/backend/services/schedule/template_series_roster.go
+++ b/backend/services/schedule/template_series_roster.go
@@ -139,6 +139,26 @@ func segmentIsReconcilablePredecessor(
 	return true
 }
 
+// weekdayScope carries the weekdays a reconciliation pass may act on: the ones
+// this edit describes (edited) and every weekday the segment shares with the
+// submitted recurrence (segment). They differ only for a per-weekday series
+// (#2129), whose occurrence editor shows exactly one weekday's roster.
+type weekdayScope struct {
+	edited  []int
+	segment []int
+}
+
+// reachesBeyondEdit reports whether a roster row also covers weekdays this
+// edit does not describe. Such a row is left alone entirely: retiring it to
+// satisfy the edited weekday would silently change the others too, while the
+// create loop only writes rows for the edited weekdays.
+func (w weekdayScope) reachesBeyondEdit(rowWeekday *int, segmentWeekdays, covered []int) bool {
+	if len(w.edited) == len(w.segment) {
+		return false
+	}
+	return len(coveredSeriesWeekdays(rowWeekday, segmentWeekdays, w.segment)) != len(covered)
+}
+
 // seriesWeekdayPerson keys a desired or satisfied roster membership.
 type seriesWeekdayPerson struct {
 	weekday  int
@@ -166,11 +186,21 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 	if !rowFrom.Before(*rowUntil) {
 		return nil
 	}
-	scoped := intersectWeekdays(seg.Weekdays, in.Weekdays)
-	if len(scoped) == 0 {
+	segmentWeekdays := intersectWeekdays(seg.Weekdays, in.Weekdays)
+	if len(segmentWeekdays) == 0 {
 		// The predecessor runs on none of the submitted weekdays — weekday
 		// changes are a non-roster edit and never retro-apply.
 		return nil
+	}
+	// A per-weekday series (#2129) is edited one weekday at a time, so the
+	// submitted roster describes only that weekday. Judging the predecessor's
+	// other weekdays against it would retire rows nobody touched.
+	scoped := segmentWeekdays
+	if len(in.SeriesRosterScopeWeekdays) > 0 {
+		scoped = intersectWeekdays(segmentWeekdays, in.SeriesRosterScopeWeekdays)
+		if len(scoped) == 0 {
+			return nil
+		}
 	}
 
 	// Snapshots BEFORE any write: they classify the existing rows and double
@@ -200,13 +230,17 @@ func (s *TimetableDataService) reconcilePredecessorSegmentRoster(
 	wantStaff := desiredSeriesRoster(roster.Staff, scoped)
 
 	touchedStudents, err := s.reconcilePredecessorEnrollmentRows(
-		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, wantStudents, priorEnrollments, studentScope,
+		ctx, in, tenantID, seg, rowFrom, rowUntil,
+		weekdayScope{edited: scoped, segment: segmentWeekdays},
+		wantStudents, priorEnrollments, studentScope,
 	)
 	if err != nil {
 		return err
 	}
 	touchedStaff, err := s.reconcilePredecessorSupervisorRows(
-		ctx, in, tenantID, seg, rowFrom, rowUntil, scoped, roster.Staff, wantStaff, priorSupervisors, staffScope,
+		ctx, in, tenantID, seg, rowFrom, rowUntil,
+		weekdayScope{edited: scoped, segment: segmentWeekdays},
+		roster.Staff, wantStaff, priorSupervisors, staffScope,
 	)
 	if err != nil {
 		return err
@@ -239,11 +273,12 @@ func (s *TimetableDataService) reconcilePredecessorEnrollmentRows(
 	seg *templateSeriesSegment,
 	rowFrom timezone.Date,
 	rowUntil *timezone.Date,
-	scoped []int,
+	weekdays weekdayScope,
 	want map[seriesWeekdayPerson]bool,
 	priorRows []*activitiesModel.StudentEnrollment,
 	scope map[int64]struct{},
 ) ([]int64, error) {
+	scoped := weekdays.edited
 	satisfied := make(map[seriesWeekdayPerson]bool)
 	touched := make(map[int64]bool)
 	for _, row := range priorRows {
@@ -257,7 +292,7 @@ func (s *TimetableDataService) reconcilePredecessorEnrollmentRows(
 			continue
 		}
 		covered := coveredSeriesWeekdays(row.Weekday, seg.Weekdays, scoped)
-		if len(covered) == 0 {
+		if len(covered) == 0 || weekdays.reachesBeyondEdit(row.Weekday, seg.Weekdays, covered) {
 			continue
 		}
 		if !validityWindowsOverlap(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) {
@@ -321,12 +356,13 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 	seg *templateSeriesSegment,
 	rowFrom timezone.Date,
 	rowUntil *timezone.Date,
-	scoped []int,
+	weekdays weekdayScope,
 	staffRows []resolvedRosterRow,
 	want map[seriesWeekdayPerson]bool,
 	priorRows []*activitiesModel.SupervisorPlanned,
 	scope map[int64]struct{},
 ) ([]int64, error) {
+	scoped := weekdays.edited
 	primaryWanted := make(map[seriesWeekdayPerson]bool)
 	for _, row := range staffRows {
 		for _, weekday := range coveredSeriesWeekdays(row.Weekday, scoped, scoped) {
@@ -349,7 +385,7 @@ func (s *TimetableDataService) reconcilePredecessorSupervisorRows(
 			continue
 		}
 		covered := coveredSeriesWeekdays(row.Weekday, seg.Weekdays, scoped)
-		if len(covered) == 0 {
+		if len(covered) == 0 || weekdays.reachesBeyondEdit(row.Weekday, seg.Weekdays, covered) {
 			continue
 		}
 		if !validityWindowsOverlap(row.ValidFrom, row.ValidUntil, rowFrom, rowUntil) {

--- a/backend/services/schedule/template_series_roster_integration_test.go
+++ b/backend/services/schedule/template_series_roster_integration_test.go
@@ -562,6 +562,161 @@ func TestSeriesRoster_WeekdayScopedEditLeavesOtherWeekdaysAlone(t *testing.T) {
 	assert.Equal(t, c.anchor, mondayRow.ValidFrom)
 }
 
+// dropLivingScheduleWeekday narrows the LIVING segment's recurrence while the
+// capped predecessor keeps running that weekday — the shape a split that moves
+// the series to fewer days leaves behind. The predecessor's occurrences still
+// exist on the dropped weekday, so a click can land on one.
+func (c *seriesChain) dropLivingScheduleWeekday(t *testing.T, weekday int) {
+	t.Helper()
+	res, err := c.db.NewDelete().
+		TableExpr(`activities.schedules`).
+		Where(`activity_group_id = ?`, c.livingID).
+		Where(`weekday = ?`, weekday).
+		Where(`tenant_id = ?`, c.tenantID).
+		Exec(c.ctx)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+}
+
+// TestSeriesRoster_ReachesTheClickedWeekdayTheSuccessorNoLongerRuns: the
+// predecessor's own recurrence decides which weekdays its rows cover. When the
+// split narrowed the successor to Monday, a Wednesday occurrence of the
+// predecessor is still clickable — and the child added there has to land on
+// Wednesday, not on Monday.
+func TestSeriesRoster_ReachesTheClickedWeekdayTheSuccessorNoLongerRuns(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday, activitiesModels.WeekdayWednesday})
+	defer c.runCleanup(t)
+
+	c.dropLivingScheduleWeekday(t, activitiesModels.WeekdayWednesday)
+	added := c.students[2]
+	wednesdayAfterAnchor := c.anchor.AddDays(2)
+	require.Equal(t, time.Wednesday, wednesdayAfterAnchor.Weekday())
+
+	in := c.livingUpdateInput(t,
+		[]int64{c.students[0], c.students[1], added}, []int64{c.staffID}, &c.staffID)
+	// The body carries the SUCCESSOR's recurrence, which no longer runs Wednesday.
+	in.Weekdays = []int{activitiesModels.WeekdayMonday}
+	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{added}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	weekdays := make([]int, 0, 2)
+	for _, row := range enrollmentsFor(t, c.scenarioSetup, c.middleID, added) {
+		require.NotNil(t, row.Weekday)
+		weekdays = append(weekdays, *row.Weekday)
+	}
+	assert.ElementsMatch(t,
+		[]int{activitiesModels.WeekdayMonday, activitiesModels.WeekdayWednesday}, weekdays,
+		"the predecessor's own weekdays decide the coverage, not the successor's")
+
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, wednesdayAfterAnchor), added,
+		"the clicked Wednesday occurrence gains the child")
+}
+
+// TestSeriesRoster_NarrowedSuccessorLeavesTheOtherWeekdayIntact: with a
+// per-weekday edit against a successor that no longer runs Wednesday, a shared
+// predecessor row still covering Wednesday must be left alone instead of being
+// closed for a Monday-only change.
+func TestSeriesRoster_NarrowedSuccessorLeavesTheOtherWeekdayIntact(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday, activitiesModels.WeekdayWednesday})
+	defer c.runCleanup(t)
+
+	c.dropLivingScheduleWeekday(t, activitiesModels.WeekdayWednesday)
+	removed := c.students[1]
+	sharedRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, removed)
+	require.NotEmpty(t, sharedRows, "the carried row spans both weekdays")
+
+	in := c.livingUpdateInput(t, []int64{c.students[0]}, []int64{c.staffID}, &c.staffID)
+	in.Weekdays = []int{activitiesModels.WeekdayMonday}
+	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{removed}
+	in.SeriesRosterScopeWeekdays = []int{activitiesModels.WeekdayMonday}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	assert.Equal(t, sharedRows, enrollmentsFor(t, c.scenarioSetup, c.middleID, removed),
+		"a shared row covering the untouched Wednesday is not half-retired")
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor.AddDays(2)), removed,
+		"and the Wednesday occurrence keeps the child")
+}
+
+// TestSeriesRoster_NewSupervisorDoesNotInheritTheSuccessorsLead: primary_staff_id
+// names the LIVING segment's Hauptbetreuung. Mirroring a membership change must
+// not hand the predecessor's lead to that person.
+func TestSeriesRoster_NewSupervisorDoesNotInheritTheSuccessorsLead(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	newLead := c.addStaff(t, "Lead")
+	students := []int64{c.students[0], c.students[1]}
+
+	in := c.livingUpdateInput(t, students, []int64{c.staffID, newLead}, &newLead)
+	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStaffIDs = []int64{newLead}
+	// The Hauptbetreuung itself was NOT part of this edit.
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	rows := supervisorsFor(t, c.scenarioSetup, c.middleID, newLead)
+	require.Len(t, rows, 1)
+	assert.False(t, rows[0].IsPrimary,
+		"the successor's lead does not become the predecessor's by joining its roster")
+
+	for _, row := range supervisorsFor(t, c.scenarioSetup, c.middleID, c.staffID) {
+		assert.True(t, row.IsPrimary, "the predecessor keeps its own Hauptbetreuung")
+	}
+}
+
+// TestSeriesRoster_PrimaryChangeReachesMaterializedOccurrences: a pure
+// Hauptbetreuung move changes no membership, so the occurrence rows are only
+// corrected when the reconciler also updates existing ones.
+func TestSeriesRoster_PrimaryChangeReachesMaterializedOccurrences(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	newLead := c.addStaff(t, "Wechsel")
+	students := []int64{c.students[0], c.students[1]}
+
+	joined := c.livingUpdateInput(t, students, []int64{c.staffID, newLead}, &c.staffID)
+	joined.SeriesRosterFrom = &c.anchor
+	joined.SeriesRosterScopeStaffIDs = []int64{newLead}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, joined))
+	require.Equal(t, c.staffID, instanceStaffPrimaryOn(t, c.scenarioSetup, c.middleID, c.anchor))
+
+	moved := c.livingUpdateInput(t, students, []int64{c.staffID, newLead}, &newLead)
+	moved.SeriesRosterFrom = &c.anchor
+	moved.SeriesRosterScopeStaffIDs = []int64{c.staffID, newLead}
+	moved.SeriesRosterPrimaryChanged = true
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, moved))
+
+	assert.Equal(t, newLead, instanceStaffPrimaryOn(t, c.scenarioSetup, c.middleID, c.anchor),
+		"the already-planned occurrence follows the moved Hauptbetreuung")
+	assert.Equal(t, c.staffID, instanceStaffPrimaryOn(t, c.scenarioSetup, c.middleID, c.earlier),
+		"occurrences before the anchor keep the old lead")
+}
+
+// instanceStaffPrimaryOn returns the staff id flagged primary on the group's
+// occurrence of that date; 0 when none is.
+func instanceStaffPrimaryOn(t *testing.T, s *scenarioSetup, groupID int64, date timezone.Date) int64 {
+	t.Helper()
+	ids := make([]int64, 0)
+	err := s.db.NewSelect().
+		TableExpr(`schedule.instance_staff AS "row"`).
+		ColumnExpr(`"row".staff_id`).
+		Join(`JOIN schedule.activity_instances AS "inst" ON "inst".id = "row".instance_id`).
+		Where(`"inst".activity_group_id = ?`, groupID).
+		Where(`"inst".date = ?`, date).
+		Where(`"inst".tenant_id = ?`, s.tenantID).
+		Where(`"row".is_primary`).
+		Scan(s.ctx, &ids)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(ids), 1, "an occurrence must not carry two leads")
+	if len(ids) == 0 {
+		return 0
+	}
+	return ids[0]
+}
+
 // TestSeriesRoster_ReconcilesSupervisorsAcrossPredecessor covers the staff twin
 // of the roster pass, including the rule that an instance_staff row carrying a
 // real decision (here: an absence) is never removed.

--- a/backend/services/schedule/template_series_roster_integration_test.go
+++ b/backend/services/schedule/template_series_roster_integration_test.go
@@ -509,6 +509,59 @@ func TestSeriesRoster_WeekdayScopedAddOnlyTouchesThatWeekday(t *testing.T) {
 		"the Wednesday occurrence after the anchor must stay unchanged")
 }
 
+// TestSeriesRoster_WeekdayScopedEditLeavesOtherWeekdaysAlone: a per-weekday
+// series is edited one weekday at a time, so the submitted roster describes
+// only that weekday. The predecessor's rows for the other weekdays must not be
+// judged against it — neither a weekday-explicit row nor a shared one that
+// also covers days this edit says nothing about.
+func TestSeriesRoster_WeekdayScopedEditLeavesOtherWeekdaysAlone(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday, activitiesModels.WeekdayWednesday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	wednesday := activitiesModels.WeekdayWednesday
+	// The child already stands on the predecessor's WEDNESDAY, and no longer
+	// on the successor at all.
+	wednesdayOnly := c.insertPredecessorEnrollment(t, added, func(row *activitiesModels.StudentEnrollment) {
+		row.Weekday = &wednesday
+	})
+	sharedRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, c.students[1])
+	require.NotEmpty(t, sharedRows, "the carried roster row spans both weekdays")
+
+	shared := []int64{c.students[0]}
+	in := c.livingUpdateInput(t, shared, []int64{c.staffID}, &c.staffID)
+	in.WeekdayAssignments = []scheduleSvc.WeekdayRosterAssignment{{
+		Weekday:        activitiesModels.WeekdayMonday,
+		StudentIDs:     []int64{c.students[0], added},
+		StaffIDs:       []int64{c.staffID},
+		PrimaryStaffID: &c.staffID,
+	}}
+	in.SeriesRosterFrom = &c.anchor
+	// The planner opened a MONDAY occurrence: they added one child there and
+	// the shared list no longer names students[1].
+	in.SeriesRosterScopeStudentIDs = []int64{added, c.students[1]}
+	in.SeriesRosterScopeWeekdays = []int{activitiesModels.WeekdayMonday}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	kept := c.reloadEnrollment(t, wednesdayOnly.ID)
+	assert.Equal(t, wednesdayOnly.ValidFrom, kept.ValidFrom,
+		"the child's Wednesday row belongs to a weekday this edit does not describe")
+	assert.Equal(t, wednesdayOnly.ValidUntil, kept.ValidUntil)
+
+	assert.Equal(t, sharedRows, enrollmentsFor(t, c.scenarioSetup, c.middleID, c.students[1]),
+		"a shared row covering Wednesday too is left alone rather than half-retired")
+
+	mondayRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
+	var mondayRow *activitiesModels.StudentEnrollment
+	for _, row := range mondayRows {
+		if row.Weekday != nil && *row.Weekday == activitiesModels.WeekdayMonday {
+			mondayRow = row
+		}
+	}
+	require.NotNil(t, mondayRow, "the edited weekday still gains its row")
+	assert.Equal(t, c.anchor, mondayRow.ValidFrom)
+}
+
 // TestSeriesRoster_ReconcilesSupervisorsAcrossPredecessor covers the staff twin
 // of the roster pass, including the rule that an instance_staff row carrying a
 // real decision (here: an absence) is never removed.

--- a/backend/services/schedule/template_series_roster_integration_test.go
+++ b/backend/services/schedule/template_series_roster_integration_test.go
@@ -1,0 +1,441 @@
+// Hermetic integration tests for the #2187 "Nachzügler" roster reconciliation:
+// a roster change saved on the living segment with series_roster_from = D must
+// also be true on the occurrences of an already-capped predecessor segment
+// from D on — both in activities.student_enrollments / activities.supervisors
+// AND on the occurrences that were already materialized from that predecessor.
+//
+// Chain shape (makeSeriesChain): T → S1[b1, b2) → S2[b2, ∞), with S1's
+// occurrences materialized. The anchor D is a scheduled day inside [b1, b2).
+package schedule_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rosterChain is a seriesChain whose middle segment already has materialized
+// occurrences, plus the two dates the assertions use: `anchor` is the day the
+// roster change takes effect from, `earlier` a scheduled day before it.
+type rosterChain struct {
+	*seriesChain
+	anchor  timezone.Date
+	earlier timezone.Date
+}
+
+func makeRosterChain(t *testing.T, weekdays []int) *rosterChain {
+	t.Helper()
+	firstBoundary := futureMonday(1)
+	secondBoundary := futureMonday(3)
+	chain := makeSeriesChain(t, weekdays, firstBoundary, secondBoundary)
+	// Materialize the middle segment's whole window (exclusive end), so every
+	// occurrence on the grid belongs to the bounded predecessor.
+	_, err := chain.svc.MaterializeForTenant(
+		chain.ctx, firstBoundary, secondBoundary.AddDays(-1), scheduleSvc.MaterializationSourceManual)
+	require.NoError(t, err)
+	return &rosterChain{
+		seriesChain: chain,
+		anchor:      firstBoundary.AddDays(7),
+		earlier:     firstBoundary,
+	}
+}
+
+// livingUpdateInput builds the service-level equivalent of a PUT on the
+// chain's living segment: same fields, same timeframe, the given roster.
+func (c *seriesChain) livingUpdateInput(
+	t *testing.T,
+	studentIDs, staffIDs []int64,
+	primaryStaffID *int64,
+) scheduleSvc.TemplateUpdateInput {
+	t.Helper()
+	group := reloadSplitGroup(t, c.scenarioSetup, c.livingID)
+	schedules := loadSplitSchedules(t, c.scenarioSetup, c.livingID)
+	require.NotEmpty(t, schedules)
+	require.NotNil(t, schedules[0].TimeframeID)
+	return scheduleSvc.TemplateUpdateInput{
+		TemplateID: c.livingID,
+		Fields: activitiesModels.TemplateFieldsUpdate{
+			Name:            group.Name,
+			Type:            group.Type,
+			CategoryID:      group.CategoryID,
+			RoomID:          c.roomID,
+			MaxParticipants: group.MaxParticipants,
+			TargetGroupType: group.TargetGroupType,
+		},
+		Weekdays:        c.weekdays,
+		TimeframeID:     *schedules[0].TimeframeID,
+		RosterValidFrom: c.secondBoundary,
+		GradeLevelMax:   4,
+		StudentIDs:      studentIDs,
+		StaffIDs:        staffIDs,
+		PrimaryStaffID:  primaryStaffID,
+	}
+}
+
+// addStaff creates one extra staff member for the chain's tenant.
+func (c *seriesChain) addStaff(t *testing.T, label string) int64 {
+	t.Helper()
+	staff := testpkg.CreateTestStaffForTenant(t, c.db, c.tenantID, "Extra",
+		fmt.Sprintf("%s-%d", label, time.Now().UnixNano()))
+	c.extraCleanups = append(c.extraCleanups, func() {
+		testpkg.CleanupTableRecords(t, c.db, "users.staff", staff.ID)
+		testpkg.CleanupTableRecords(t, c.db, "users.persons", staff.PersonID)
+	})
+	return staff.ID
+}
+
+func enrollmentsFor(t *testing.T, s *scenarioSetup, groupID, studentID int64) []*activitiesModels.StudentEnrollment {
+	t.Helper()
+	var out []*activitiesModels.StudentEnrollment
+	for _, row := range loadSplitEnrollments(t, s, groupID) {
+		if row.StudentID == studentID {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func supervisorsFor(t *testing.T, s *scenarioSetup, groupID, staffID int64) []*activitiesModels.SupervisorPlanned {
+	t.Helper()
+	var out []*activitiesModels.SupervisorPlanned
+	for _, row := range loadSplitSupervisors(t, s, groupID) {
+		if row.StaffID == staffID {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+// instanceStudentIDsOn returns the students planned on the group's occurrence
+// of that date (empty when the occurrence has no roster row at all).
+func instanceStudentIDsOn(t *testing.T, s *scenarioSetup, groupID int64, date timezone.Date) []int64 {
+	t.Helper()
+	ids := make([]int64, 0)
+	err := s.db.NewSelect().
+		TableExpr(`schedule.instance_students AS "row"`).
+		ColumnExpr(`"row".student_id`).
+		Join(`JOIN schedule.activity_instances AS "inst" ON "inst".id = "row".instance_id`).
+		Where(`"inst".activity_group_id = ?`, groupID).
+		Where(`"inst".date = ?`, date).
+		Where(`"inst".tenant_id = ?`, s.tenantID).
+		OrderExpr(`"row".student_id ASC`).
+		Scan(s.ctx, &ids)
+	require.NoError(t, err)
+	return ids
+}
+
+func instanceStaffIDsOn(t *testing.T, s *scenarioSetup, groupID int64, date timezone.Date) []int64 {
+	t.Helper()
+	ids := make([]int64, 0)
+	err := s.db.NewSelect().
+		TableExpr(`schedule.instance_staff AS "row"`).
+		ColumnExpr(`"row".staff_id`).
+		Join(`JOIN schedule.activity_instances AS "inst" ON "inst".id = "row".instance_id`).
+		Where(`"inst".activity_group_id = ?`, groupID).
+		Where(`"inst".date = ?`, date).
+		Where(`"inst".tenant_id = ?`, s.tenantID).
+		OrderExpr(`"row".staff_id ASC`).
+		Scan(s.ctx, &ids)
+	require.NoError(t, err)
+	return ids
+}
+
+// deleteInstanceStudentRow removes ONE student's row from ONE occurrence, the
+// way a supervisor does it by hand in the planner.
+func deleteInstanceStudentRow(t *testing.T, s *scenarioSetup, groupID, studentID int64, date timezone.Date) {
+	t.Helper()
+	res, err := s.db.NewDelete().
+		TableExpr(`schedule.instance_students`).
+		Where(`student_id = ?`, studentID).
+		Where(`instance_id IN (
+			SELECT id FROM schedule.activity_instances
+			WHERE activity_group_id = ? AND date = ? AND tenant_id = ?
+		)`, groupID, date, s.tenantID).
+		Exec(s.ctx)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected, "expected exactly one hand-removable roster row")
+}
+
+// TestSeriesRoster_AddsChildAcrossCappedPredecessor is the core acceptance
+// criterion of #2187: a child added "ab D" stands on the D list even though
+// that day still materialized from the capped predecessor segment.
+func TestSeriesRoster_AddsChildAcrossCappedPredecessor(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	kept := []int64{c.students[0], c.students[1]}
+	added := c.students[2]
+	rootBefore := loadSplitEnrollments(t, c.scenarioSetup, c.rootID)
+	require.Empty(t, enrollmentsFor(t, c.scenarioSetup, c.middleID, added),
+		"the added child must not already be on the predecessor")
+
+	in := c.livingUpdateInput(t, append(append([]int64{}, kept...), added), []int64{c.staffID}, &c.staffID)
+	in.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	predecessorRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
+	require.Len(t, predecessorRows, 1, "one bounded row per scheduled weekday")
+	row := predecessorRows[0]
+	assert.Equal(t, c.anchor, row.ValidFrom, "the predecessor row starts at the anchor")
+	require.NotNil(t, row.ValidUntil)
+	assert.Equal(t, c.secondBoundary, *row.ValidUntil, "and ends with the predecessor segment")
+	require.NotNil(t, row.Weekday, "predecessor rows are written weekday-explicit")
+	assert.Equal(t, activitiesModels.WeekdayMonday, *row.Weekday)
+
+	livingRows := enrollmentsFor(t, c.scenarioSetup, c.livingID, added)
+	require.Len(t, livingRows, 1)
+	assert.Nil(t, livingRows[0].ValidUntil, "the living segment keeps its own open roster row")
+
+	assert.Equal(t, rootBefore, loadSplitEnrollments(t, c.scenarioSetup, c.rootID),
+		"segments that ended before the anchor are never rewritten")
+
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added,
+		"the already-materialized occurrence on the anchor must gain the child")
+	assert.NotContains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.earlier), added,
+		"occurrences before the anchor stay untouched")
+}
+
+func TestSeriesRoster_RemovesChildAcrossCappedPredecessor(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	removed := c.students[1]
+	require.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), removed)
+
+	in := c.livingUpdateInput(t, []int64{c.students[0]}, []int64{c.staffID}, &c.staffID)
+	in.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, removed)
+	require.Len(t, rows, 1, "the carried row is closed, not duplicated")
+	assert.Equal(t, c.firstBoundary, rows[0].ValidFrom, "its start stays where it was")
+	require.NotNil(t, rows[0].ValidUntil)
+	assert.Equal(t, c.anchor, *rows[0].ValidUntil, "the row now ends at the anchor")
+
+	assert.NotContains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), removed,
+		"the anchor occurrence loses the child")
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.earlier), removed,
+		"the occurrence before the anchor keeps them")
+}
+
+func TestSeriesRoster_NoopWithoutSeriesRosterFrom(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	before := loadSplitEnrollments(t, c.scenarioSetup, c.middleID)
+
+	in := c.livingUpdateInput(t,
+		[]int64{c.students[0], c.students[1], added}, []int64{c.staffID}, &c.staffID)
+	// SeriesRosterFrom deliberately unset.
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	assert.Equal(t, before, loadSplitEnrollments(t, c.scenarioSetup, c.middleID),
+		"without the anchor the predecessor segment is not touched at all")
+	assert.NotContains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added)
+}
+
+// TestSeriesRoster_SkipsProtectedPredecessorEnrollments pins that rows owned by
+// another workflow (an enrollment request child, a weekday-selection row) are
+// never rewritten by the series pass.
+func TestSeriesRoster_SkipsProtectedPredecessorEnrollments(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	requestChildID := createSplitRequestChild(t, c.scenarioSetup, added)
+	protectedByRequest := c.insertPredecessorEnrollment(t, added, func(row *activitiesModels.StudentEnrollment) {
+		row.EnrollmentRequestChildID = &requestChildID
+	})
+	protectedByWeekdays := c.insertPredecessorEnrollment(t, c.students[0], func(row *activitiesModels.StudentEnrollment) {
+		row.SelectedWeekdays = []int{activitiesModels.WeekdayMonday}
+	})
+
+	in := c.livingUpdateInput(t,
+		[]int64{c.students[0], c.students[1], added}, []int64{c.staffID}, &c.staffID)
+	in.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	for _, want := range []*activitiesModels.StudentEnrollment{protectedByRequest, protectedByWeekdays} {
+		got := c.reloadEnrollment(t, want.ID)
+		assert.Equal(t, want.ValidFrom, got.ValidFrom, "protected row start must survive")
+		assert.Equal(t, want.ValidUntil, got.ValidUntil, "protected row end must survive")
+		assert.Equal(t, want.Weekday, got.Weekday)
+		assert.Equal(t, want.SelectedWeekdays, got.SelectedWeekdays)
+		assert.Equal(t, want.EnrollmentRequestChildID, got.EnrollmentRequestChildID)
+	}
+}
+
+// insertPredecessorEnrollment writes one bounded [firstBoundary, secondBoundary)
+// enrollment row onto the middle segment, customized by mutate.
+func (c *seriesChain) insertPredecessorEnrollment(
+	t *testing.T,
+	studentID int64,
+	mutate func(*activitiesModels.StudentEnrollment),
+) *activitiesModels.StudentEnrollment {
+	t.Helper()
+	validUntil := c.secondBoundary
+	row := &activitiesModels.StudentEnrollment{
+		StudentID:       studentID,
+		ActivityGroupID: c.middleID,
+		ValidFrom:       c.firstBoundary,
+		ValidUntil:      &validUntil,
+	}
+	mutate(row)
+	row.SetTenantID(c.tenantID)
+	_, err := c.db.NewInsert().Model(row).ModelTableExpr(`activities.student_enrollments`).Exec(c.ctx)
+	require.NoError(t, err)
+	c.registerCleanup("activities.student_enrollments", row.ID)
+	return row
+}
+
+func (c *seriesChain) reloadEnrollment(t *testing.T, id int64) *activitiesModels.StudentEnrollment {
+	t.Helper()
+	var row activitiesModels.StudentEnrollment
+	err := c.db.NewSelect().Model(&row).
+		ModelTableExpr(`activities.student_enrollments AS "student_enrollment"`).
+		Where(`"student_enrollment".id = ?`, id).
+		Where(`"student_enrollment".tenant_id = ?`, c.tenantID).
+		Scan(c.ctx)
+	require.NoError(t, err)
+	return &row
+}
+
+// TestSeriesRoster_PreservesHandRemovedChildOnPredecessorOccurrence: once staff
+// removed a child from ONE occurrence by hand, a later series roster save must
+// not resurrect that row, while newly gained coverage still creates rows.
+func TestSeriesRoster_PreservesHandRemovedChildOnPredecessorOccurrence(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	roster := []int64{c.students[0], c.students[1], added}
+
+	first := c.livingUpdateInput(t, roster, []int64{c.staffID}, &c.staffID)
+	first.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, first))
+	require.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added)
+
+	// Staff strikes the child from that single occurrence.
+	deleteInstanceStudentRow(t, c.scenarioSetup, c.middleID, added, c.anchor)
+
+	// Same roster, but the anchor now reaches back to the segment start: the
+	// child's predecessor row is rewritten, so the instance pass runs again.
+	second := c.livingUpdateInput(t, roster, []int64{c.staffID}, &c.staffID)
+	second.SeriesRosterFrom = &c.firstBoundary
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, second))
+
+	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
+	require.Len(t, rows, 1)
+	assert.Equal(t, c.firstBoundary, rows[0].ValidFrom, "the widened anchor moved the row start")
+
+	assert.NotContains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added,
+		"a hand-removed occurrence row must not be resurrected")
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.earlier), added,
+		"newly gained coverage still reaches the earlier occurrence")
+}
+
+// TestSeriesRoster_WeekdayScopedAddOnlyTouchesThatWeekday: a per-weekday
+// deviation must retro-apply to that weekday only.
+func TestSeriesRoster_WeekdayScopedAddOnlyTouchesThatWeekday(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday, activitiesModels.WeekdayWednesday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	shared := []int64{c.students[0], c.students[1]}
+	wednesdayAfterAnchor := c.anchor.AddDays(2)
+	require.Equal(t, time.Wednesday, wednesdayAfterAnchor.Weekday())
+
+	in := c.livingUpdateInput(t, shared, []int64{c.staffID}, &c.staffID)
+	in.WeekdayAssignments = []scheduleSvc.WeekdayRosterAssignment{{
+		Weekday:        activitiesModels.WeekdayMonday,
+		StudentIDs:     append(append([]int64{}, shared...), added),
+		StaffIDs:       []int64{c.staffID},
+		PrimaryStaffID: &c.staffID,
+	}}
+	in.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
+	require.Len(t, rows, 1, "only the deviating weekday gets a predecessor row")
+	require.NotNil(t, rows[0].Weekday)
+	assert.Equal(t, activitiesModels.WeekdayMonday, *rows[0].Weekday)
+
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added,
+		"the Monday occurrence gains the child")
+	assert.NotContains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, wednesdayAfterAnchor), added,
+		"the Wednesday occurrence after the anchor must stay unchanged")
+}
+
+// TestSeriesRoster_ReconcilesSupervisorsAcrossPredecessor covers the staff twin
+// of the roster pass, including the rule that an instance_staff row carrying a
+// real decision (here: an absence) is never removed.
+func TestSeriesRoster_ReconcilesSupervisorsAcrossPredecessor(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	extraStaff := c.addStaff(t, "Sub")
+	students := []int64{c.students[0], c.students[1]}
+
+	added := c.livingUpdateInput(t, students, []int64{c.staffID, extraStaff}, &c.staffID)
+	added.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, added))
+
+	rows := supervisorsFor(t, c.scenarioSetup, c.middleID, extraStaff)
+	require.Len(t, rows, 1)
+	assert.Equal(t, c.anchor, rows[0].ValidFrom)
+	require.NotNil(t, rows[0].ValidUntil)
+	assert.Equal(t, c.secondBoundary, *rows[0].ValidUntil)
+	require.NotNil(t, rows[0].Weekday)
+	assert.Equal(t, activitiesModels.WeekdayMonday, *rows[0].Weekday)
+	assert.False(t, rows[0].IsPrimary, "the primary supervisor did not change")
+
+	assert.Contains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), extraStaff,
+		"the anchor occurrence gains the staff member")
+	assert.NotContains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.earlier), extraStaff,
+		"occurrences before the anchor stay untouched")
+
+	// The staff member is marked absent on that one occurrence — a recorded
+	// decision the removal below must not delete.
+	c.markInstanceStaffAbsent(t, extraStaff, c.anchor)
+
+	removed := c.livingUpdateInput(t, students, []int64{c.staffID}, &c.staffID)
+	removed.SeriesRosterFrom = &c.anchor
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, removed))
+
+	rows = supervisorsFor(t, c.scenarioSetup, c.middleID, extraStaff)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].ValidUntil)
+	assert.Equal(t, c.anchor, *rows[0].ValidUntil, "the predecessor supervision closes at the anchor")
+
+	assert.Contains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), extraStaff,
+		"an absence row is a recorded decision and survives the removal")
+	assert.Contains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), c.staffID,
+		"the remaining supervisor keeps their assignment")
+}
+
+func (c *seriesChain) markInstanceStaffAbsent(t *testing.T, staffID int64, date timezone.Date) {
+	t.Helper()
+	res, err := c.db.NewUpdate().
+		TableExpr(`schedule.instance_staff`).
+		Set(`is_absent = TRUE`).
+		Where(`staff_id = ?`, staffID).
+		Where(`instance_id IN (
+			SELECT id FROM schedule.activity_instances
+			WHERE activity_group_id = ? AND date = ? AND tenant_id = ?
+		)`, c.middleID, date, c.tenantID).
+		Exec(c.ctx)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+}

--- a/backend/services/schedule/template_series_roster_integration_test.go
+++ b/backend/services/schedule/template_series_roster_integration_test.go
@@ -180,6 +180,7 @@ func TestSeriesRoster_AddsChildAcrossCappedPredecessor(t *testing.T) {
 
 	in := c.livingUpdateInput(t, append(append([]int64{}, kept...), added), []int64{c.staffID}, &c.staffID)
 	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{added}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
 
 	predecessorRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
@@ -213,6 +214,7 @@ func TestSeriesRoster_RemovesChildAcrossCappedPredecessor(t *testing.T) {
 
 	in := c.livingUpdateInput(t, []int64{c.students[0]}, []int64{c.staffID}, &c.staffID)
 	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{removed}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
 
 	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, removed)
@@ -225,6 +227,36 @@ func TestSeriesRoster_RemovesChildAcrossCappedPredecessor(t *testing.T) {
 		"the anchor occurrence loses the child")
 	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.earlier), removed,
 		"the occurrence before the anchor keeps them")
+}
+
+// TestSeriesRoster_KeepsPredecessorOnlyChildOutsideScope pins the rule that
+// makes the mirroring safe: the saved roster describes the LIVING segment, so
+// a child who only ever stood on the predecessor (a split may have dropped
+// them) must survive a save that removes somebody else.
+func TestSeriesRoster_KeepsPredecessorOnlyChildOutsideScope(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	predecessorOnly := c.insertPredecessorEnrollment(t, c.students[2], func(*activitiesModels.StudentEnrollment) {})
+	removed := c.students[1]
+
+	in := c.livingUpdateInput(t, []int64{c.students[0]}, []int64{c.staffID}, &c.staffID)
+	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{removed}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	kept := c.reloadEnrollment(t, predecessorOnly.ID)
+	assert.Equal(t, predecessorOnly.ValidFrom, kept.ValidFrom,
+		"a child outside the edit's scope keeps their predecessor row")
+	assert.Equal(t, predecessorOnly.ValidUntil, kept.ValidUntil)
+	require.Len(t, enrollmentsFor(t, c.scenarioSetup, c.middleID, c.students[2]), 1,
+		"and gains no second row either")
+
+	removedRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, removed)
+	require.Len(t, removedRows, 1)
+	require.NotNil(t, removedRows[0].ValidUntil)
+	assert.Equal(t, c.anchor, *removedRows[0].ValidUntil,
+		"the child the edit did touch is still closed at the anchor")
 }
 
 func TestSeriesRoster_NoopWithoutSeriesRosterFrom(t *testing.T) {
@@ -263,6 +295,7 @@ func TestSeriesRoster_SkipsProtectedPredecessorEnrollments(t *testing.T) {
 	in := c.livingUpdateInput(t,
 		[]int64{c.students[0], c.students[1], added}, []int64{c.staffID}, &c.staffID)
 	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{added, c.students[0]}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
 
 	for _, want := range []*activitiesModels.StudentEnrollment{protectedByRequest, protectedByWeekdays} {
@@ -273,6 +306,12 @@ func TestSeriesRoster_SkipsProtectedPredecessorEnrollments(t *testing.T) {
 		assert.Equal(t, want.SelectedWeekdays, got.SelectedWeekdays)
 		assert.Equal(t, want.EnrollmentRequestChildID, got.EnrollmentRequestChildID)
 	}
+
+	// The weekday the protected row already supplies must not gain a second,
+	// editor-owned row — a duplicate would keep the child in the group after
+	// the Betreuungsanfrage is withdrawn.
+	assert.Len(t, enrollmentsFor(t, c.scenarioSetup, c.middleID, added), 1,
+		"a protected row is not supplemented on the weekday it already covers")
 }
 
 // insertPredecessorEnrollment writes one bounded [firstBoundary, secondBoundary)
@@ -322,6 +361,7 @@ func TestSeriesRoster_PreservesHandRemovedChildOnPredecessorOccurrence(t *testin
 
 	first := c.livingUpdateInput(t, roster, []int64{c.staffID}, &c.staffID)
 	first.SeriesRosterFrom = &c.anchor
+	first.SeriesRosterScopeStudentIDs = []int64{added}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, first))
 	require.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added)
 
@@ -332,6 +372,7 @@ func TestSeriesRoster_PreservesHandRemovedChildOnPredecessorOccurrence(t *testin
 	// child's predecessor row is rewritten, so the instance pass runs again.
 	second := c.livingUpdateInput(t, roster, []int64{c.staffID}, &c.staffID)
 	second.SeriesRosterFrom = &c.firstBoundary
+	second.SeriesRosterScopeStudentIDs = []int64{added}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, second))
 
 	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
@@ -363,6 +404,7 @@ func TestSeriesRoster_WeekdayScopedAddOnlyTouchesThatWeekday(t *testing.T) {
 		PrimaryStaffID: &c.staffID,
 	}}
 	in.SeriesRosterFrom = &c.anchor
+	in.SeriesRosterScopeStudentIDs = []int64{added}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
 
 	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
@@ -388,6 +430,7 @@ func TestSeriesRoster_ReconcilesSupervisorsAcrossPredecessor(t *testing.T) {
 
 	added := c.livingUpdateInput(t, students, []int64{c.staffID, extraStaff}, &c.staffID)
 	added.SeriesRosterFrom = &c.anchor
+	added.SeriesRosterScopeStaffIDs = []int64{extraStaff}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, added))
 
 	rows := supervisorsFor(t, c.scenarioSetup, c.middleID, extraStaff)
@@ -410,6 +453,7 @@ func TestSeriesRoster_ReconcilesSupervisorsAcrossPredecessor(t *testing.T) {
 
 	removed := c.livingUpdateInput(t, students, []int64{c.staffID}, &c.staffID)
 	removed.SeriesRosterFrom = &c.anchor
+	removed.SeriesRosterScopeStaffIDs = []int64{extraStaff}
 	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, removed))
 
 	rows = supervisorsFor(t, c.scenarioSetup, c.middleID, extraStaff)

--- a/backend/services/schedule/template_series_roster_integration_test.go
+++ b/backend/services/schedule/template_series_roster_integration_test.go
@@ -259,6 +259,97 @@ func TestSeriesRoster_KeepsPredecessorOnlyChildOutsideScope(t *testing.T) {
 		"the child the edit did touch is still closed at the anchor")
 }
 
+// TestSeriesRoster_PastAnchorClampsToTodayAndSegmentStart covers the two
+// clamps a real "Alle Termine der Serie" save runs into: history is never
+// rewritten (a stale client anchor degrades to today), and a row may not start
+// before the segment it belongs to.
+func TestSeriesRoster_PastAnchorClampsToTodayAndSegmentStart(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	staleAnchor := timezone.TodayDate().AddDays(-7)
+
+	in := c.livingUpdateInput(t,
+		[]int64{c.students[0], c.students[1], added}, []int64{c.staffID}, &c.staffID)
+	in.SeriesRosterFrom = &staleAnchor
+	in.SeriesRosterScopeStudentIDs = []int64{added}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+
+	rows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
+	require.Len(t, rows, 1)
+	assert.Equal(t, c.firstBoundary, rows[0].ValidFrom,
+		"the row starts with the segment, never before it and never in the past")
+	require.NotNil(t, rows[0].ValidUntil)
+	assert.Equal(t, c.secondBoundary, *rows[0].ValidUntil)
+
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.earlier), added,
+		"the whole predecessor window is covered from its own start")
+}
+
+// TestSeriesRoster_SecondIdenticalSaveKeepsRowsUntouched pins that the pass is
+// idempotent: rows that already cover the window exactly are recognised as
+// satisfied instead of being closed and rewritten on every save.
+func TestSeriesRoster_SecondIdenticalSaveKeepsRowsUntouched(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	added := c.students[2]
+	extraStaff := c.addStaff(t, "Twice")
+	roster := []int64{c.students[0], c.students[1], added}
+
+	save := func() {
+		in := c.livingUpdateInput(t, roster, []int64{c.staffID, extraStaff}, &c.staffID)
+		in.SeriesRosterFrom = &c.anchor
+		in.SeriesRosterScopeStudentIDs = []int64{added}
+		in.SeriesRosterScopeStaffIDs = []int64{extraStaff}
+		require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, in))
+	}
+
+	save()
+	studentRows := enrollmentsFor(t, c.scenarioSetup, c.middleID, added)
+	staffRows := supervisorsFor(t, c.scenarioSetup, c.middleID, extraStaff)
+	require.Len(t, studentRows, 1)
+	require.Len(t, staffRows, 1)
+
+	save()
+
+	assert.Equal(t, studentRows, enrollmentsFor(t, c.scenarioSetup, c.middleID, added),
+		"an already-correct enrollment row survives the second save unchanged")
+	assert.Equal(t, staffRows, supervisorsFor(t, c.scenarioSetup, c.middleID, extraStaff),
+		"and so does the supervisor row")
+	assert.Contains(t, instanceStudentIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), added)
+	assert.Contains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), extraStaff)
+}
+
+// TestSeriesRoster_RemovedStaffLosesPlannedOccurrenceRows is the counterpart to
+// the absence case: a purely planned instance_staff row carries no decision, so
+// removing the supervisor from the series must clear it from the predecessor's
+// occurrences too.
+func TestSeriesRoster_RemovedStaffLosesPlannedOccurrenceRows(t *testing.T) {
+	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
+	defer c.runCleanup(t)
+
+	extraStaff := c.addStaff(t, "Planned")
+	students := []int64{c.students[0], c.students[1]}
+
+	added := c.livingUpdateInput(t, students, []int64{c.staffID, extraStaff}, &c.staffID)
+	added.SeriesRosterFrom = &c.anchor
+	added.SeriesRosterScopeStaffIDs = []int64{extraStaff}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, added))
+	require.Contains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), extraStaff)
+
+	removed := c.livingUpdateInput(t, students, []int64{c.staffID}, &c.staffID)
+	removed.SeriesRosterFrom = &c.anchor
+	removed.SeriesRosterScopeStaffIDs = []int64{extraStaff}
+	require.NoError(t, c.factory.TimetableData.UpdateTemplate(c.ctx, removed))
+
+	assert.NotContains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), extraStaff,
+		"a plan-only assignment is removed from the occurrence as well")
+	assert.Contains(t, instanceStaffIDsOn(t, c.scenarioSetup, c.middleID, c.anchor), c.staffID,
+		"the remaining supervisor keeps theirs")
+}
+
 func TestSeriesRoster_NoopWithoutSeriesRosterFrom(t *testing.T) {
 	c := makeRosterChain(t, []int{activitiesModels.WeekdayMonday})
 	defer c.runCleanup(t)

--- a/backend/services/schedule/template_series_roster_mock_test.go
+++ b/backend/services/schedule/template_series_roster_mock_test.go
@@ -1,0 +1,436 @@
+// Mock-driven tests for the #2187 split-series roster reconciliation: the
+// repository-failure branches and the row classifications the DB-backed suite
+// cannot set up cheaply (a row of another calendar period, a row outside the
+// reconciliation window, a sibling segment with a broken schedule envelope).
+//
+// Everything here is stack-allocated: the fakes embed the repository
+// interfaces and implement only the handful of methods this code path calls,
+// the same shape template_end_service_unit_test.go uses.
+package schedule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	seriesMockLivingID = int64(9001)
+	seriesMockOldID    = int64(9002)
+	seriesMockTenantID = int64(9003)
+	seriesMockStudent  = int64(9101)
+	seriesMockStaff    = int64(9201)
+)
+
+var errSeriesMock = errors.New("repository exploded")
+
+func seriesMockAnchor() timezone.Date { return timezone.TodayDate().AddDays(7) }
+
+func seriesMockUntil() timezone.Date { return timezone.TodayDate().AddDays(21) }
+
+// ---------------------------------------------------------------- fakes ----
+
+type seriesMockGroupRepo struct {
+	activitiesModel.GroupRepository
+	groups []*activitiesModel.Group
+	err    error
+}
+
+func (r *seriesMockGroupRepo) FindTemplateSeries(context.Context, int64) ([]*activitiesModel.Group, error) {
+	return r.groups, r.err
+}
+
+type seriesMockScheduleRepo struct {
+	activitiesModel.ScheduleRepository
+	byGroup map[int64][]*activitiesModel.Schedule
+	err     error
+}
+
+func (r *seriesMockScheduleRepo) FindByGroupID(_ context.Context, groupID int64) ([]*activitiesModel.Schedule, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.byGroup[groupID], nil
+}
+
+type seriesMockEnrollmentRepo struct {
+	activitiesModel.StudentEnrollmentRepository
+	rows      []*activitiesModel.StudentEnrollment
+	findErr   error
+	createErr error
+	closeErr  error
+	deleteErr error
+	created   []*activitiesModel.StudentEnrollment
+	closed    []int64
+	deleted   []int64
+}
+
+func (r *seriesMockEnrollmentRepo) FindByGroupID(context.Context, int64) ([]*activitiesModel.StudentEnrollment, error) {
+	return r.rows, r.findErr
+}
+
+func (r *seriesMockEnrollmentRepo) Create(_ context.Context, row *activitiesModel.StudentEnrollment) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, row)
+	return nil
+}
+
+func (r *seriesMockEnrollmentRepo) SetValidUntilByID(_ context.Context, id int64, _ timezone.Date) error {
+	if r.closeErr != nil {
+		return r.closeErr
+	}
+	r.closed = append(r.closed, id)
+	return nil
+}
+
+func (r *seriesMockEnrollmentRepo) Delete(_ context.Context, id any) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	if numeric, ok := id.(int64); ok {
+		r.deleted = append(r.deleted, numeric)
+	}
+	return nil
+}
+
+type seriesMockSupervisorRepo struct {
+	activitiesModel.SupervisorPlannedRepository
+	rows      []*activitiesModel.SupervisorPlanned
+	findErr   error
+	createErr error
+	closeErr  error
+	deleteErr error
+	created   []*activitiesModel.SupervisorPlanned
+	closed    []int64
+	deleted   []int64
+}
+
+func (r *seriesMockSupervisorRepo) FindByGroupID(context.Context, int64) ([]*activitiesModel.SupervisorPlanned, error) {
+	return r.rows, r.findErr
+}
+
+func (r *seriesMockSupervisorRepo) Create(_ context.Context, row *activitiesModel.SupervisorPlanned) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, row)
+	return nil
+}
+
+func (r *seriesMockSupervisorRepo) SetValidUntilByID(_ context.Context, id int64, _ timezone.Date) error {
+	if r.closeErr != nil {
+		return r.closeErr
+	}
+	r.closed = append(r.closed, id)
+	return nil
+}
+
+func (r *seriesMockSupervisorRepo) Delete(_ context.Context, id any) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	if numeric, ok := id.(int64); ok {
+		r.deleted = append(r.deleted, numeric)
+	}
+	return nil
+}
+
+// -------------------------------------------------------------- fixtures ----
+
+func seriesMockGroup(id int64) *activitiesModel.Group {
+	group := &activitiesModel.Group{Name: "Series mock", IsTemplate: true}
+	group.ID = id
+	return group
+}
+
+func seriesMockSchedule(groupID int64, from timezone.Date, until *timezone.Date) *activitiesModel.Schedule {
+	start := from
+	return &activitiesModel.Schedule{
+		Weekday:         activitiesModel.WeekdayMonday,
+		ActivityGroupID: groupID,
+		ValidFrom:       &start,
+		ValidUntil:      until,
+	}
+}
+
+// seriesMockChain wires a two-segment lineage: a bounded predecessor
+// [today, anchor+14) and the living segment that starts where it ends.
+func seriesMockChain(
+	enrollments *seriesMockEnrollmentRepo,
+	supervisors *seriesMockSupervisorRepo,
+) *TimetableDataService {
+	until := seriesMockUntil()
+	return NewTimetableDataService(TimetableDataDependencies{
+		ActivityGroupRepo: &seriesMockGroupRepo{groups: []*activitiesModel.Group{
+			seriesMockGroup(seriesMockOldID), seriesMockGroup(seriesMockLivingID),
+		}},
+		ActivityScheduleRepo: &seriesMockScheduleRepo{byGroup: map[int64][]*activitiesModel.Schedule{
+			seriesMockOldID:    {seriesMockSchedule(seriesMockOldID, timezone.TodayDate(), &until)},
+			seriesMockLivingID: {seriesMockSchedule(seriesMockLivingID, until, nil)},
+		}},
+		StudentEnrollmentRepo:  enrollments,
+		ActivitySupervisorRepo: supervisors,
+	})
+}
+
+func seriesMockInput() TemplateUpdateInput {
+	anchor := seriesMockAnchor()
+	return TemplateUpdateInput{
+		TemplateID:                  seriesMockLivingID,
+		Weekdays:                    []int{activitiesModel.WeekdayMonday},
+		StudentIDs:                  []int64{seriesMockStudent},
+		StaffIDs:                    []int64{seriesMockStaff},
+		SeriesRosterFrom:            &anchor,
+		SeriesRosterScopeStudentIDs: []int64{seriesMockStudent},
+		SeriesRosterScopeStaffIDs:   []int64{seriesMockStaff},
+	}
+}
+
+// ----------------------------------------------------------------- tests ----
+
+func TestReconcileSeriesPredecessorRoster_NoScopeIsANoop(t *testing.T) {
+	enrollments := &seriesMockEnrollmentRepo{}
+	svc := seriesMockChain(enrollments, &seriesMockSupervisorRepo{})
+
+	in := seriesMockInput()
+	in.SeriesRosterScopeStudentIDs = nil
+	in.SeriesRosterScopeStaffIDs = nil
+
+	require.NoError(t, svc.reconcileSeriesPredecessorRoster(t.Context(), in, seriesMockTenantID, nil))
+	assert.Empty(t, enrollments.created,
+		"an anchor without a scope must not write anything to a predecessor")
+}
+
+func TestReconcileSeriesPredecessorRoster_CreatesBoundedRows(t *testing.T) {
+	enrollments := &seriesMockEnrollmentRepo{}
+	supervisors := &seriesMockSupervisorRepo{}
+	svc := seriesMockChain(enrollments, supervisors)
+
+	require.NoError(t, svc.reconcileSeriesPredecessorRoster(
+		t.Context(), seriesMockInput(), seriesMockTenantID, nil))
+
+	require.Len(t, enrollments.created, 1)
+	assert.Equal(t, seriesMockAnchor(), enrollments.created[0].ValidFrom)
+	require.NotNil(t, enrollments.created[0].ValidUntil)
+	assert.Equal(t, seriesMockUntil(), *enrollments.created[0].ValidUntil)
+	require.NotNil(t, enrollments.created[0].Weekday)
+	assert.Equal(t, activitiesModel.WeekdayMonday, *enrollments.created[0].Weekday)
+	require.Len(t, supervisors.created, 1)
+	assert.Equal(t, seriesMockStaff, supervisors.created[0].StaffID)
+}
+
+func TestReconcileSeriesPredecessorRoster_RepositoryFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		build  func() *TimetableDataService
+		mutate func(*TemplateUpdateInput)
+	}{
+		{
+			name: "lineage lookup fails",
+			build: func() *TimetableDataService {
+				return NewTimetableDataService(TimetableDataDependencies{
+					ActivityGroupRepo:    &seriesMockGroupRepo{err: errSeriesMock},
+					ActivityScheduleRepo: &seriesMockScheduleRepo{},
+				})
+			},
+		},
+		{
+			name: "schedule lookup fails",
+			build: func() *TimetableDataService {
+				return NewTimetableDataService(TimetableDataDependencies{
+					ActivityGroupRepo: &seriesMockGroupRepo{groups: []*activitiesModel.Group{
+						seriesMockGroup(seriesMockLivingID),
+					}},
+					ActivityScheduleRepo: &seriesMockScheduleRepo{err: errSeriesMock},
+				})
+			},
+		},
+		{
+			name: "predecessor enrollments cannot be read",
+			build: func() *TimetableDataService {
+				return seriesMockChain(&seriesMockEnrollmentRepo{findErr: errSeriesMock}, &seriesMockSupervisorRepo{})
+			},
+		},
+		{
+			name: "predecessor supervisors cannot be read",
+			build: func() *TimetableDataService {
+				return seriesMockChain(&seriesMockEnrollmentRepo{}, &seriesMockSupervisorRepo{findErr: errSeriesMock})
+			},
+		},
+		{
+			name: "creating the predecessor enrollment fails",
+			build: func() *TimetableDataService {
+				return seriesMockChain(&seriesMockEnrollmentRepo{createErr: errSeriesMock}, &seriesMockSupervisorRepo{})
+			},
+		},
+		{
+			name: "creating the predecessor supervision fails",
+			build: func() *TimetableDataService {
+				return seriesMockChain(&seriesMockEnrollmentRepo{}, &seriesMockSupervisorRepo{createErr: errSeriesMock})
+			},
+		},
+		{
+			name: "closing a retired enrollment fails",
+			build: func() *TimetableDataService {
+				until := seriesMockUntil()
+				return seriesMockChain(&seriesMockEnrollmentRepo{
+					rows:     []*activitiesModel.StudentEnrollment{seriesMockEnrollmentRow(1, timezone.TodayDate(), &until, nil)},
+					closeErr: errSeriesMock,
+				}, &seriesMockSupervisorRepo{})
+			},
+			// The child is gone from the saved roster, so their predecessor row
+			// has to be closed at the anchor.
+			mutate: func(in *TemplateUpdateInput) { in.StudentIDs = nil },
+		},
+		{
+			name: "closing a retired supervision fails",
+			build: func() *TimetableDataService {
+				until := seriesMockUntil()
+				return seriesMockChain(&seriesMockEnrollmentRepo{}, &seriesMockSupervisorRepo{
+					rows:     []*activitiesModel.SupervisorPlanned{seriesMockSupervisorRow(1, timezone.TodayDate(), &until, nil)},
+					closeErr: errSeriesMock,
+				})
+			},
+			mutate: func(in *TemplateUpdateInput) { in.StaffIDs = nil },
+		},
+		{
+			name: "deleting an enrollment that only started after the anchor fails",
+			build: func() *TimetableDataService {
+				until := seriesMockUntil()
+				return seriesMockChain(&seriesMockEnrollmentRepo{
+					rows: []*activitiesModel.StudentEnrollment{
+						seriesMockEnrollmentRow(1, seriesMockAnchor().AddDays(1), &until, nil),
+					},
+					deleteErr: errSeriesMock,
+				}, &seriesMockSupervisorRepo{})
+			},
+			// Nothing of the row survives the anchor, so it is deleted outright
+			// instead of being capped.
+			mutate: func(in *TemplateUpdateInput) { in.StudentIDs = nil },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := seriesMockInput()
+			if tc.mutate != nil {
+				tc.mutate(&in)
+			}
+			err := tc.build().reconcileSeriesPredecessorRoster(t.Context(), in, seriesMockTenantID, nil)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errSeriesMock)
+		})
+	}
+}
+
+// TestReconcileSeriesPredecessorRoster_SkipsUnrelatedRows pins the three
+// classifications that make an existing row none of this pass's business.
+func TestReconcileSeriesPredecessorRoster_SkipsUnrelatedRows(t *testing.T) {
+	otherPeriod := int64(4242)
+	longPast := timezone.TodayDate().AddDays(-90)
+	pastEnd := timezone.TodayDate().AddDays(-60)
+	wednesday := activitiesModel.WeekdayWednesday
+	until := seriesMockUntil()
+
+	enrollments := &seriesMockEnrollmentRepo{rows: []*activitiesModel.StudentEnrollment{
+		// Another calendar period — owned by a different planning window.
+		seriesMockEnrollmentRow(11, timezone.TodayDate(), &until, &otherPeriod),
+		// A weekday the edit does not describe.
+		func() *activitiesModel.StudentEnrollment {
+			row := seriesMockEnrollmentRow(12, timezone.TodayDate(), &until, nil)
+			row.Weekday = &wednesday
+			return row
+		}(),
+		// A window that ended long before the reconciliation window.
+		seriesMockEnrollmentRow(13, longPast, &pastEnd, nil),
+	}}
+	supervisors := &seriesMockSupervisorRepo{rows: []*activitiesModel.SupervisorPlanned{
+		seriesMockSupervisorRow(21, timezone.TodayDate(), &until, &otherPeriod),
+		func() *activitiesModel.SupervisorPlanned {
+			row := seriesMockSupervisorRow(22, timezone.TodayDate(), &until, nil)
+			row.Weekday = &wednesday
+			return row
+		}(),
+		seriesMockSupervisorRow(23, longPast, &pastEnd, nil),
+	}}
+
+	svc := seriesMockChain(enrollments, supervisors)
+	require.NoError(t, svc.reconcileSeriesPredecessorRoster(
+		t.Context(), seriesMockInput(), seriesMockTenantID, nil))
+
+	assert.Empty(t, enrollments.closed, "unrelated enrollment rows are never rewritten")
+	assert.Empty(t, enrollments.deleted)
+	assert.Empty(t, supervisors.closed, "unrelated supervisor rows are never rewritten")
+	assert.Empty(t, supervisors.deleted)
+	assert.Len(t, enrollments.created, 1, "the wanted membership is still written")
+	assert.Len(t, supervisors.created, 1)
+}
+
+// TestLoadTemplateSeriesSegments_SkipsBrokenSibling: one corrupt sibling must
+// not block resolving the rest of the lineage, while the requested template's
+// own corruption stays a hard error.
+func TestLoadTemplateSeriesSegments_SkipsBrokenSibling(t *testing.T) {
+	until := seriesMockUntil()
+	other := until.AddDays(7)
+	broken := []*activitiesModel.Schedule{
+		seriesMockSchedule(seriesMockOldID, timezone.TodayDate(), &until),
+		seriesMockSchedule(seriesMockOldID, timezone.TodayDate(), &other),
+	}
+	groupRepo := &seriesMockGroupRepo{groups: []*activitiesModel.Group{
+		seriesMockGroup(seriesMockOldID), seriesMockGroup(seriesMockLivingID),
+	}}
+	scheduleRepo := &seriesMockScheduleRepo{byGroup: map[int64][]*activitiesModel.Schedule{
+		seriesMockOldID:    broken,
+		seriesMockLivingID: {seriesMockSchedule(seriesMockLivingID, until, nil)},
+	}}
+
+	segments, err := loadTemplateSeriesSegments(t.Context(), groupRepo, scheduleRepo, nil, seriesMockLivingID)
+	require.NoError(t, err)
+	require.Len(t, segments, 1, "the broken sibling is skipped with a warning")
+	assert.Equal(t, seriesMockLivingID, segments[0].Group.ID)
+
+	_, err = loadTemplateSeriesSegments(t.Context(), groupRepo, scheduleRepo, nil, seriesMockOldID)
+	require.Error(t, err, "the requested template's own envelope must fail loudly")
+}
+
+func TestResolveLivingTemplateSegment_PropagatesLineageErrors(t *testing.T) {
+	svc := NewTimetableDataService(TimetableDataDependencies{
+		ActivityGroupRepo:    &seriesMockGroupRepo{err: errSeriesMock},
+		ActivityScheduleRepo: &seriesMockScheduleRepo{},
+	})
+
+	_, _, err := svc.ResolveLivingTemplateSegment(t.Context(), seriesMockLivingID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSeriesMock)
+}
+
+func seriesMockEnrollmentRow(id int64, from timezone.Date, until *timezone.Date, periodID *int64) *activitiesModel.StudentEnrollment {
+	row := &activitiesModel.StudentEnrollment{
+		StudentID:        seriesMockStudent,
+		ActivityGroupID:  seriesMockOldID,
+		ValidFrom:        from,
+		ValidUntil:       until,
+		CalendarPeriodID: periodID,
+	}
+	row.ID = id
+	return row
+}
+
+func seriesMockSupervisorRow(id int64, from timezone.Date, until *timezone.Date, periodID *int64) *activitiesModel.SupervisorPlanned {
+	row := &activitiesModel.SupervisorPlanned{
+		StaffID:          seriesMockStaff,
+		GroupID:          seriesMockOldID,
+		ValidFrom:        from,
+		ValidUntil:       until,
+		CalendarPeriodID: periodID,
+	}
+	row.ID = id
+	return row
+}

--- a/backend/services/schedule/template_series_roster_pure_test.go
+++ b/backend/services/schedule/template_series_roster_pure_test.go
@@ -102,6 +102,24 @@ func TestCoveredSeriesWeekdays(t *testing.T) {
 		"a shared row covers its own universe intersected with the scope")
 }
 
+func TestWeekdayScopeReachesBeyondEdit(t *testing.T) {
+	segment := []int{activitiesModel.WeekdayMonday, activitiesModel.WeekdayWednesday}
+	monday := activitiesModel.WeekdayMonday
+	wednesday := activitiesModel.WeekdayWednesday
+
+	full := weekdayScope{edited: segment, segment: segment}
+	assert.False(t, full.reachesBeyondEdit(nil, segment, segment),
+		"an edit describing every weekday can act on a shared row")
+
+	narrow := weekdayScope{edited: []int{monday}, segment: segment}
+	assert.True(t, narrow.reachesBeyondEdit(nil, segment, []int{monday}),
+		"a shared row also covers the weekday this edit says nothing about")
+	assert.False(t, narrow.reachesBeyondEdit(&monday, segment, []int{monday}),
+		"a row explicit to the edited weekday covers nothing else")
+	assert.True(t, narrow.reachesBeyondEdit(&wednesday, segment, nil),
+		"and one explicit to another weekday is not this edit's business")
+}
+
 func TestWantedOnAllWeekdays(t *testing.T) {
 	const personID = 77
 	want := map[seriesWeekdayPerson]bool{

--- a/backend/services/schedule/template_series_roster_pure_test.go
+++ b/backend/services/schedule/template_series_roster_pure_test.go
@@ -1,0 +1,177 @@
+// Pure unit tests for the decision helpers of the #2187 split-series roster
+// reconciliation. They carry the branches the DB-backed tests cannot reach
+// cheaply: which segments qualify, which weekdays a roster row covers, and
+// when a kept row is already correct. No database, no fixtures — every value
+// here is a stack-allocated struct.
+package schedule
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	"github.com/stretchr/testify/assert"
+)
+
+func seriesDate(day int) timezone.Date {
+	return timezone.NewDate(2026, 8, day)
+}
+
+func datePtr(day int) *timezone.Date {
+	d := seriesDate(day)
+	return &d
+}
+
+func TestSegmentIsReconcilablePredecessor(t *testing.T) {
+	group := &activitiesModel.Group{}
+	group.ID = 4711
+
+	tests := []struct {
+		name            string
+		seg             templateSeriesSegment
+		livingID        int64
+		anchor          timezone.Date
+		livingValidFrom *timezone.Date
+		want            bool
+	}{
+		{
+			name:     "bounded predecessor reaching past the anchor",
+			seg:      templateSeriesSegment{Group: group, ValidFrom: datePtr(3), ValidUntil: datePtr(17)},
+			livingID: 999,
+			anchor:   seriesDate(10),
+			want:     true,
+		},
+		{
+			name:     "the living segment itself",
+			seg:      templateSeriesSegment{Group: group, ValidFrom: datePtr(3), ValidUntil: datePtr(17)},
+			livingID: group.ID,
+			anchor:   seriesDate(10),
+		},
+		{
+			name:     "still open, so not a predecessor",
+			seg:      templateSeriesSegment{Group: group, ValidFrom: datePtr(3)},
+			livingID: 999,
+			anchor:   seriesDate(10),
+		},
+		{
+			name:     "empty window left behind by a same-day split",
+			seg:      templateSeriesSegment{Group: group, ValidFrom: datePtr(17), ValidUntil: datePtr(17)},
+			livingID: 999,
+			anchor:   seriesDate(10),
+		},
+		{
+			name:     "ended before the change takes effect",
+			seg:      templateSeriesSegment{Group: group, ValidFrom: datePtr(3), ValidUntil: datePtr(10)},
+			livingID: 999,
+			anchor:   seriesDate(10),
+		},
+		{
+			name:            "starts at or after the living segment",
+			seg:             templateSeriesSegment{Group: group, ValidFrom: datePtr(17), ValidUntil: datePtr(24)},
+			livingID:        999,
+			anchor:          seriesDate(10),
+			livingValidFrom: datePtr(17),
+		},
+		{
+			name:     "no group row",
+			seg:      templateSeriesSegment{ValidFrom: datePtr(3), ValidUntil: datePtr(17)},
+			livingID: 999,
+			anchor:   seriesDate(10),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			seg := tc.seg
+			assert.Equal(t, tc.want,
+				segmentIsReconcilablePredecessor(&seg, tc.livingID, tc.anchor, tc.livingValidFrom))
+		})
+	}
+}
+
+func TestCoveredSeriesWeekdays(t *testing.T) {
+	monday := activitiesModel.WeekdayMonday
+	friday := activitiesModel.WeekdayFriday
+	scoped := []int{activitiesModel.WeekdayMonday, activitiesModel.WeekdayWednesday}
+
+	assert.Equal(t, []int{monday}, coveredSeriesWeekdays(&monday, scoped, scoped),
+		"an explicit weekday inside the scope covers exactly itself")
+	assert.Nil(t, coveredSeriesWeekdays(&friday, scoped, scoped),
+		"an explicit weekday outside the scope covers nothing")
+	assert.Equal(t, []int{monday}, coveredSeriesWeekdays(nil, []int{monday}, scoped),
+		"a shared row covers its own universe intersected with the scope")
+}
+
+func TestWantedOnAllWeekdays(t *testing.T) {
+	const personID = 77
+	want := map[seriesWeekdayPerson]bool{
+		{weekday: activitiesModel.WeekdayMonday, personID: personID}: true,
+	}
+
+	assert.True(t, wantedOnAllWeekdays(want, []int{activitiesModel.WeekdayMonday}, personID, false))
+	assert.False(t, wantedOnAllWeekdays(want,
+		[]int{activitiesModel.WeekdayMonday, activitiesModel.WeekdayWednesday}, personID, false),
+		"one uncovered weekday is enough to reject the row")
+	assert.True(t, wantedOnAllWeekdays(want, nil, personID, true),
+		"the caller decides what an empty weekday set means")
+}
+
+func TestPrimaryFlagMatches(t *testing.T) {
+	const personID = 77
+	primaryWanted := map[seriesWeekdayPerson]bool{
+		{weekday: activitiesModel.WeekdayMonday, personID: personID}: true,
+	}
+	weekdays := []int{activitiesModel.WeekdayMonday}
+
+	assert.True(t, primaryFlagMatches(primaryWanted, weekdays, personID, true))
+	assert.False(t, primaryFlagMatches(primaryWanted, weekdays, personID, false),
+		"a supervisor who should be primary but is not needs rewriting")
+	assert.False(t, primaryFlagMatches(primaryWanted,
+		[]int{activitiesModel.WeekdayWednesday}, personID, true),
+		"and so does one who is primary on a weekday that does not want it")
+}
+
+func TestSeriesRowStaysCorrect(t *testing.T) {
+	assert.True(t, seriesRowStaysCorrect(seriesDate(3), datePtr(17), seriesDate(10), datePtr(17)),
+		"a row starting before the window and ending with the segment is already right")
+	assert.False(t, seriesRowStaysCorrect(seriesDate(12), datePtr(17), seriesDate(10), datePtr(17)),
+		"a row starting inside the window does not cover it")
+	assert.False(t, seriesRowStaysCorrect(seriesDate(3), datePtr(12), seriesDate(10), datePtr(17)),
+		"nor does one ending before the segment")
+}
+
+func TestProtectedPredecessorEnrollments(t *testing.T) {
+	requestChildID := int64(4242)
+	protectedByRequest := &activitiesModel.StudentEnrollment{
+		StudentID:                101,
+		ValidFrom:                seriesDate(3),
+		ValidUntil:               datePtr(17),
+		EnrollmentRequestChildID: &requestChildID,
+	}
+	protectedButElsewhere := &activitiesModel.StudentEnrollment{
+		StudentID:        102,
+		ValidFrom:        seriesDate(24),
+		ValidUntil:       datePtr(31),
+		SelectedWeekdays: []int{activitiesModel.WeekdayMonday},
+	}
+	editorOwned := &activitiesModel.StudentEnrollment{
+		StudentID:  103,
+		ValidFrom:  seriesDate(3),
+		ValidUntil: datePtr(17),
+	}
+
+	got := protectedPredecessorEnrollments(
+		[]*activitiesModel.StudentEnrollment{nil, protectedByRequest, protectedButElsewhere, editorOwned},
+		seriesDate(10), datePtr(17),
+	)
+	assert.Equal(t, []*activitiesModel.StudentEnrollment{protectedByRequest}, got,
+		"only externally-owned rows overlapping the reconciliation window count")
+}
+
+func TestInt64SetDropsNonPositiveIDs(t *testing.T) {
+	set := int64Set([]int64{101, 0, -3, 101})
+	assert.Len(t, set, 1)
+	_, ok := set[101]
+	assert.True(t, ok)
+	assert.Empty(t, int64Set(nil), "no scope means nothing may be mirrored")
+}

--- a/backend/services/schedule/template_split_service.go
+++ b/backend/services/schedule/template_split_service.go
@@ -806,7 +806,7 @@ func (s *TemplateSplitService) endFromDateInTransaction(
 	if err != nil {
 		return nil, &ScheduleError{Op: "end template: delete planned instances", Err: err}
 	}
-	cascadeDeleted, err := s.cascadeEndToSeriesPredecessors(ctx, old.ID, requestedFrom)
+	cascadeDeleted, err := s.cascadeEndToSeriesSegments(ctx, old.ID, requestedFrom)
 	if err != nil {
 		return nil, err
 	}
@@ -838,16 +838,19 @@ func (s *TemplateSplitService) endFromDateInTransaction(
 	}, nil
 }
 
-// cascadeEndToSeriesPredecessors caps every already-bounded segment of the
-// same split series whose window still reaches into [requestedFrom, ∞) and
-// removes its planned occurrences (#2187). "Diesen und alle folgenden
-// löschen" must not leave live occurrences at or after the chosen date on a
-// predecessor segment the grid still renders as clickable. capAt never
-// inverts a window: a date before the segment start degrades the segment to
-// an empty window (valid_until == valid_from), the same shape a same-day
-// split leaves behind. Returns the planned instances deleted across all
-// cascaded segments.
-func (s *TemplateSplitService) cascadeEndToSeriesPredecessors(
+// cascadeEndToSeriesSegments caps every OTHER segment of the same split series
+// whose window still reaches into [requestedFrom, ∞) and removes its planned
+// occurrences (#2187). "Diesen und alle folgenden löschen" must leave no live
+// occurrence at or after the chosen date anywhere in the lineage — and the
+// grid renders occurrences with the id of the segment that materialized them,
+// so the request can just as well arrive on a capped predecessor while the
+// living successor carries the later occurrences. The cascade therefore runs
+// over the whole lineage in both directions, the still-open segment included.
+// capAt never inverts a window: a date before the segment start degrades the
+// segment to an empty window (valid_until == valid_from), the same shape a
+// same-day split leaves behind. Returns the planned instances deleted across
+// all cascaded segments.
+func (s *TemplateSplitService) cascadeEndToSeriesSegments(
 	ctx context.Context,
 	templateID int64,
 	requestedFrom timezone.Date,
@@ -859,14 +862,14 @@ func (s *TemplateSplitService) cascadeEndToSeriesPredecessors(
 	var deleted int64
 	for i := range segments {
 		seg := &segments[i]
-		if seg.Group == nil || seg.Group.ID == templateID || seg.ValidUntil == nil {
+		if seg.Group == nil || seg.Group.ID == templateID {
 			continue
 		}
 		capAt := requestedFrom
 		if seg.ValidFrom != nil && capAt.Before(*seg.ValidFrom) {
 			capAt = *seg.ValidFrom
 		}
-		if !capAt.Before(*seg.ValidUntil) {
+		if seg.ValidUntil != nil && !capAt.Before(*seg.ValidUntil) {
 			continue // the segment already ends at or before the requested date
 		}
 		enrollments, supervisors, err := s.loadSegmentRosterCandidates(ctx, seg.Group.ID, capAt, seg.ValidUntil)
@@ -876,13 +879,24 @@ func (s *TemplateSplitService) cascadeEndToSeriesPredecessors(
 		if err := s.capSplitSource(ctx, seg.Group.ID, capAt, enrollments, supervisors, seg.ValidUntil); err != nil {
 			return deleted, err
 		}
+		// Same guard the requested segment gets: ending a lineage a care
+		// offering still depends on must fail, no matter which segment of it
+		// the request came in on.
+		if err := s.validateCareOfferingSeries(ctx, seg.Group.ID); err != nil {
+			return deleted, templateCareOfferingValidationError(
+				ctx,
+				"end template: validate linked care offerings",
+				"ending the recurrence is incompatible with an existing care offering",
+				err,
+			)
+		}
 		segmentID := seg.Group.ID
 		n, err := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, capAt, nil, &segmentID, false)
 		if err != nil {
-			return deleted, &ScheduleError{Op: "end template: delete predecessor planned instances", Err: err}
+			return deleted, &ScheduleError{Op: "end template: delete cascaded segment planned instances", Err: err}
 		}
 		deleted += n
-		s.getLogger().Info("end cascade capped series predecessor",
+		s.getLogger().Info("end cascade capped series segment",
 			slog.Int64("template_id", templateID),
 			slog.Int64("segment_id", segmentID),
 			slog.String("cap_at", capAt.String()),

--- a/backend/services/schedule/template_split_service.go
+++ b/backend/services/schedule/template_split_service.go
@@ -752,6 +752,11 @@ func (s *TemplateSplitService) endFromDateInTransaction(
 	if err != nil {
 		return nil, err
 	}
+	// The raw requested date drives the predecessor cascade below: normalize
+	// clamps to THIS segment's valid_from, but "diesen und alle folgenden
+	// löschen" from a date inside an earlier bounded segment must also cap that
+	// segment (#2187).
+	requestedFrom := in.EffectiveDate
 	effectiveDate, sourceValidUntil, err := s.normalizeEffectiveDateInSegment(ctx, old.ID, in.EffectiveDate, "end template", true)
 	if err != nil {
 		return nil, err
@@ -801,6 +806,11 @@ func (s *TemplateSplitService) endFromDateInTransaction(
 	if err != nil {
 		return nil, &ScheduleError{Op: "end template: delete planned instances", Err: err}
 	}
+	cascadeDeleted, err := s.cascadeEndToSeriesPredecessors(ctx, old.ID, requestedFrom)
+	if err != nil {
+		return nil, err
+	}
+	deleted += cascadeDeleted
 
 	// Ending a series deletes planned instances outside the CRUD broadcast
 	// paths — invalidate the staffing caches (#1844).
@@ -826,6 +836,60 @@ func (s *TemplateSplitService) endFromDateInTransaction(
 		CappedEnrollments: cappedEnrollments,
 		CappedSupervisors: cappedSupervisors,
 	}, nil
+}
+
+// cascadeEndToSeriesPredecessors caps every already-bounded segment of the
+// same split series whose window still reaches into [requestedFrom, ∞) and
+// removes its planned occurrences (#2187). "Diesen und alle folgenden
+// löschen" must not leave live occurrences at or after the chosen date on a
+// predecessor segment the grid still renders as clickable. capAt never
+// inverts a window: a date before the segment start degrades the segment to
+// an empty window (valid_until == valid_from), the same shape a same-day
+// split leaves behind. Returns the planned instances deleted across all
+// cascaded segments.
+func (s *TemplateSplitService) cascadeEndToSeriesPredecessors(
+	ctx context.Context,
+	templateID int64,
+	requestedFrom timezone.Date,
+) (int64, error) {
+	segments, err := loadTemplateSeriesSegments(ctx, s.deps.GroupRepo, s.deps.ScheduleRepo, s.getLogger(), templateID)
+	if err != nil {
+		return 0, err
+	}
+	var deleted int64
+	for i := range segments {
+		seg := &segments[i]
+		if seg.Group == nil || seg.Group.ID == templateID || seg.ValidUntil == nil {
+			continue
+		}
+		capAt := requestedFrom
+		if seg.ValidFrom != nil && capAt.Before(*seg.ValidFrom) {
+			capAt = *seg.ValidFrom
+		}
+		if !capAt.Before(*seg.ValidUntil) {
+			continue // the segment already ends at or before the requested date
+		}
+		enrollments, supervisors, err := s.loadSegmentRosterCandidates(ctx, seg.Group.ID, capAt, seg.ValidUntil)
+		if err != nil {
+			return deleted, err
+		}
+		if err := s.capSplitSource(ctx, seg.Group.ID, capAt, enrollments, supervisors, seg.ValidUntil); err != nil {
+			return deleted, err
+		}
+		segmentID := seg.Group.ID
+		n, err := s.deps.InstanceRepo.DeletePlannedNonSpontaneousInWindow(ctx, capAt, nil, &segmentID, false)
+		if err != nil {
+			return deleted, &ScheduleError{Op: "end template: delete predecessor planned instances", Err: err}
+		}
+		deleted += n
+		s.getLogger().Info("end cascade capped series predecessor",
+			slog.Int64("template_id", templateID),
+			slog.Int64("segment_id", segmentID),
+			slog.String("cap_at", capAt.String()),
+			slog.Int64("deleted_instances", n),
+		)
+	}
+	return deleted, nil
 }
 
 // validateSplitInput checks the semantic rules the handler's Bind cannot:

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -64,6 +64,15 @@ type TemplateUpdateInput struct {
 	// roster anchor (RosterValidFrom stays authoritative there). Nil = the
 	// update touches only this segment, exactly as before.
 	SeriesRosterFrom *timezone.Date
+	// SeriesRosterScopeStudentIDs / SeriesRosterScopeStaffIDs name the people
+	// whose membership this edit actually changed. Only they are reconciled on
+	// the predecessor segments; everyone else keeps their predecessor rows.
+	// StudentIDs/StaffIDs describe the LIVING segment and may legitimately
+	// differ from a predecessor's roster (a split can change the roster), so
+	// treating them as the predecessor's absolute target set would silently
+	// drop predecessor-only members. Empty scopes = nothing to mirror.
+	SeriesRosterScopeStudentIDs []int64
+	SeriesRosterScopeStaffIDs   []int64
 }
 
 // UpdateTemplate replaces a template's editable fields, schedules, and roster

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -79,6 +79,11 @@ type TemplateUpdateInput struct {
 	// be judged against it. Empty = every weekday the segment shares with the
 	// submitted recurrence.
 	SeriesRosterScopeWeekdays []int
+	// SeriesRosterPrimaryChanged marks the Hauptbetreuung itself as part of
+	// this edit. PrimaryStaffID always names the LIVING segment's lead, so
+	// without this flag a newly mirrored supervisor row would stamp that lead
+	// onto the predecessor and outrank its own.
+	SeriesRosterPrimaryChanged bool
 }
 
 // UpdateTemplate replaces a template's editable fields, schedules, and roster

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -57,6 +57,13 @@ type TemplateUpdateInput struct {
 	// GradeLevelMax is the caller's validated snapshot of
 	// enrollment.grade_level_max. Missing or out-of-range values are rejected.
 	GradeLevelMax int
+	// SeriesRosterFrom extends the saved roster backwards over the split
+	// series (#2187): when set, the roster is additionally reconciled onto the
+	// bounded predecessor segments overlapping [SeriesRosterFrom, this
+	// segment's valid_from). It does NOT change the living segment's own
+	// roster anchor (RosterValidFrom stays authoritative there). Nil = the
+	// update touches only this segment, exactly as before.
+	SeriesRosterFrom *timezone.Date
 }
 
 // UpdateTemplate replaces a template's editable fields, schedules, and roster
@@ -219,6 +226,9 @@ func (s *TimetableDataService) updateTemplateLocked(
 		return err
 	}
 	if err := s.reconcileManualRosterInstances(ctx, in, previousSourceOfferingID, validFrom, retiredStudentIDs); err != nil {
+		return err
+	}
+	if err := s.reconcileSeriesPredecessorRoster(ctx, in, tenantID, validFrom); err != nil {
 		return err
 	}
 	if s.deps.ValidateCareOfferingSeries == nil {

--- a/backend/services/schedule/template_update_service.go
+++ b/backend/services/schedule/template_update_service.go
@@ -73,6 +73,12 @@ type TemplateUpdateInput struct {
 	// drop predecessor-only members. Empty scopes = nothing to mirror.
 	SeriesRosterScopeStudentIDs []int64
 	SeriesRosterScopeStaffIDs   []int64
+	// SeriesRosterScopeWeekdays narrows the mirroring to the weekdays this
+	// edit describes. The occurrence editor of a per-weekday series (#2129)
+	// shows ONE weekday's roster, so the predecessor's other weekdays must not
+	// be judged against it. Empty = every weekday the segment shares with the
+	// submitted recurrence.
+	SeriesRosterScopeWeekdays []int
 }
 
 // UpdateTemplate replaces a template's editable fields, schedules, and roster

--- a/backend/test/hermetic_verification_test.go
+++ b/backend/test/hermetic_verification_test.go
@@ -307,6 +307,7 @@ func checkMissingSetupTestDB(t *testing.T, root string) []string {
 		"setupAutoApproveIntegrationEnv",  // services/enrollment auto-approve integration tests — wraps setupRolloverTest
 		"setupGuardianInvitationTest",     // services/auth guardian invitation + related-accounts tests — wraps SetupTestDB
 		"makeScenario",                    // services/schedule materialization/split integration tests — wraps SetupTestDB
+		"makeRosterChain",                 // services/schedule split-series roster tests (#2187) — wraps makeSeriesChain → makeScenario
 		"makeMoveSetup",                   // services/schedule staff-pool/move tests (#1884) — wraps SetupTestDB
 		"buildDevSetup",                   // api/timetable deviations/protocol tests — wraps SetupTestDB
 		"setupCheckinServiceTest",         // services/iot/checkin CheckinService tests — wraps SetupAPITest (issue #575 B8)

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -54,6 +54,7 @@ import {
   type LifecycleAction,
 } from "~/components/timetable/instance-detail-modal";
 import { StaffPoolSlideOver } from "~/components/timetable/staff-pool-slide-over";
+import { timetableSeriesErrorMessage } from "~/components/timetable/event-form/scope-error-message";
 import { TimetableAddMenu } from "~/components/timetable/timetable-add-menu";
 import { MonthPlannerGrid } from "~/components/timetable/month-planner-grid";
 import { PeriodSwitcherDropdown } from "~/components/timetable/period-switcher-dropdown";
@@ -912,9 +913,10 @@ function TimetablesContent() {
           error: err instanceof Error ? err.message : String(err),
         });
         toast.error(
-          err instanceof Error
-            ? err.message
-            : "Folgetermine konnten nicht gelöscht werden",
+          timetableSeriesErrorMessage(
+            err,
+            "Folgetermine konnten nicht gelöscht werden",
+          ),
         );
         throw err;
       }

--- a/frontend/src/components/timetable/event-form/scope-error-message.test.ts
+++ b/frontend/src/components/timetable/event-form/scope-error-message.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { timetableSeriesErrorMessage } from "./scope-error-message";
+
+// Issue #2187: saving a series scope against a capped predecessor segment of a
+// split chain used to surface raw backend text. These pin the German mapping.
+
+const FALLBACK = "Der Termin konnte nicht gespeichert werden.";
+
+const TEMPLATE_GONE =
+  "Der Regeltermin konnte nicht geladen werden. Bitte laden Sie die Seite neu und öffnen Sie den Termin erneut.";
+
+function apiError(
+  message: string,
+  extra: { httpStatus?: number; code?: string },
+): Error {
+  return Object.assign(new Error(message), extra);
+}
+
+describe("timetableSeriesErrorMessage (#2187)", () => {
+  it("maps the template_not_found code to a reload hint", () => {
+    expect(
+      timetableSeriesErrorMessage(
+        apiError("template not found", { code: "template_not_found" }),
+        FALLBACK,
+      ),
+    ).toBe(TEMPLATE_GONE);
+  });
+
+  it("maps a past effective date before the status ladder", () => {
+    expect(
+      timetableSeriesErrorMessage(
+        apiError("effective_date must not be in the past", { httpStatus: 400 }),
+        FALLBACK,
+      ),
+    ).toBe(
+      "Der Stichtag liegt in der Vergangenheit. Bitte einen künftigen Termin der Serie wählen.",
+    );
+  });
+
+  it.each([
+    [401, "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an."],
+    [403, "Sie haben keine Berechtigung für diese Änderung."],
+    [404, TEMPLATE_GONE],
+    [
+      409,
+      "Der Regeltermin wurde zwischenzeitlich geändert. Bitte laden Sie die Seite neu.",
+    ],
+    [503, FALLBACK],
+  ])("maps HTTP %i to its German message", (httpStatus, expected) => {
+    expect(
+      timetableSeriesErrorMessage(
+        apiError("backend detail", { httpStatus }),
+        FALLBACK,
+      ),
+    ).toBe(expected);
+  });
+
+  it("passes an informative backend message through", () => {
+    expect(
+      timetableSeriesErrorMessage(
+        new Error("Endzeit muss nach der Startzeit liegen"),
+        FALLBACK,
+      ),
+    ).toBe("Endzeit muss nach der Startzeit liegen");
+  });
+
+  it("falls back when the error carries no message", () => {
+    expect(timetableSeriesErrorMessage("boom", FALLBACK)).toBe(FALLBACK);
+    expect(timetableSeriesErrorMessage(new Error(""), FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/frontend/src/components/timetable/event-form/scope-error-message.ts
+++ b/frontend/src/components/timetable/event-form/scope-error-message.ts
@@ -1,0 +1,58 @@
+/**
+ * German user text for failures of a series-scoped Regeltermin save.
+ *
+ * Issue #2187: a split series is a chain of templates, and the client may
+ * still hold the id of a capped predecessor segment. Saving against such an
+ * id used to surface the raw backend text ("template not found"), which reads
+ * like data loss to a school user. The backend now resolves the chain forward;
+ * everything it still rejects gets a message that says what to do next.
+ *
+ * Informative backend 400 texts are passed through on purpose — they name the
+ * concrete field or conflict and are more useful than a generic sentence.
+ */
+export function timetableSeriesErrorMessage(
+  err: unknown,
+  fallback: string,
+): string {
+  const raw = err instanceof Error ? err.message : "";
+
+  if (raw.includes("effective_date must not be in the past")) {
+    return "Der Stichtag liegt in der Vergangenheit. Bitte einen künftigen Termin der Serie wählen.";
+  }
+
+  // Duck-typed: TimetableApiError is not exported, and tests mock the module.
+  const code = readStringProp(err, "code");
+  if (code === "template_not_found") return TEMPLATE_GONE_MESSAGE;
+
+  const httpStatus = readNumberProp(err, "httpStatus");
+  if (httpStatus !== undefined) {
+    if (httpStatus === 401) {
+      return "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an.";
+    }
+    if (httpStatus === 403) {
+      return "Sie haben keine Berechtigung für diese Änderung.";
+    }
+    if (httpStatus === 404) return TEMPLATE_GONE_MESSAGE;
+    if (httpStatus === 409) {
+      return "Der Regeltermin wurde zwischenzeitlich geändert. Bitte laden Sie die Seite neu.";
+    }
+    if (httpStatus >= 500) return fallback;
+  }
+
+  return raw !== "" ? raw : fallback;
+}
+
+const TEMPLATE_GONE_MESSAGE =
+  "Der Regeltermin konnte nicht geladen werden. Bitte laden Sie die Seite neu und öffnen Sie den Termin erneut.";
+
+function readStringProp(err: unknown, key: string): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const value = (err as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumberProp(err: unknown, key: string): number | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const value = (err as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+}

--- a/frontend/src/components/timetable/event-form/use-event-form.ts
+++ b/frontend/src/components/timetable/event-form/use-event-form.ts
@@ -2225,15 +2225,25 @@ export function useEventForm({
         ? changedRosterIDs(form.studentIds, initialStudentIDsSnapshot)
         : [];
       const staffScope = staffRosterTouched.current ? changedStaffIDs() : [];
-      const rosterChanged = studentScope.length > 0 || staffScope.length > 0;
       // #2187 review: with per-weekday rosters this form describes exactly ONE
       // weekday, so the mirroring must not judge the predecessor's other
       // weekdays against it. A series with one shared roster sends no weekday
       // scope — there the edit really does describe every weekday.
-      const scopeWeekdays =
-        template.weekdayAssignments.length > 0
-          ? [isoWeekday(initialInstance.date)]
-          : [];
+      const editedWeekday = isoWeekday(initialInstance.date);
+      const perWeekdaySeries = template.weekdayAssignments.length > 0;
+      const scopeWeekdays = perWeekdaySeries ? [editedWeekday] : [];
+      // A per-weekday successor only carries assignments for the weekdays it
+      // still runs. When the split moved it off the clicked one, the body says
+      // nothing about that day, so there is nothing to mirror — sending the
+      // anchor anyway would judge the predecessor against a roster that never
+      // mentioned the weekday.
+      const weekdayDescribed =
+        !perWeekdaySeries ||
+        template.weekdayAssignments.some(
+          (assignment) => assignment.weekday === editedWeekday,
+        );
+      const rosterChanged =
+        weekdayDescribed && (studentScope.length > 0 || staffScope.length > 0);
       await timetableService.updateTemplate(seriesTemplateId, {
         ...body,
         ...(rosterChanged
@@ -2247,6 +2257,11 @@ export function useEventForm({
                 : {}),
               ...(scopeWeekdays.length > 0
                 ? { series_roster_scope_weekdays: scopeWeekdays }
+                : {}),
+              // primary_staff_id names the successor's Hauptbetreuung; it may
+              // only reach a predecessor row when the user moved it.
+              ...(primaryStaffTouched()
+                ? { series_roster_primary_changed: true }
                 : {}),
             }
           : {}),

--- a/frontend/src/components/timetable/event-form/use-event-form.ts
+++ b/frontend/src/components/timetable/event-form/use-event-form.ts
@@ -1424,6 +1424,89 @@ export function useEventForm({
   };
 
   /**
+   * The ids whose membership actually changed in this session (#2187). This
+   * is what the backend needs to reconcile the split chain's capped
+   * predecessors: the submitted roster describes the LIVING segment, whose
+   * membership may legitimately differ from a predecessor's, so it is not the
+   * predecessor's target set — reconciling against it would drop children who
+   * only ever stood on the predecessor.
+   */
+  const changedRosterIDs = (
+    next: readonly string[],
+    before: readonly string[],
+  ): number[] => {
+    const nextSet = new Set(next);
+    const beforeSet = new Set(before);
+    const changed = new Set<string>();
+    for (const id of next) if (!beforeSet.has(id)) changed.add(id);
+    for (const id of before) if (!nextSet.has(id)) changed.add(id);
+    return [...changed]
+      .map(Number)
+      .filter((id) => Number.isFinite(id) && id > 0);
+  };
+
+  /**
+   * Staff scope for the chain reconciliation: membership changes plus both
+   * sides of a changed Hauptbetreuung, whose is_primary flag has to be
+   * rewritten on the predecessor rows as well.
+   */
+  const changedStaffIDs = (): number[] => {
+    const changed = changedRosterIDs(form.staffIds, initialStaffIDsSnapshot);
+    if (form.primaryStaffId !== initialPrimaryStaffIDSnapshot) {
+      for (const id of [form.primaryStaffId, initialPrimaryStaffIDSnapshot]) {
+        const numeric = Number(id);
+        if (
+          id &&
+          Number.isFinite(numeric) &&
+          numeric > 0 &&
+          !changed.includes(numeric)
+        ) {
+          changed.push(numeric);
+        }
+      }
+    }
+    return changed;
+  };
+
+  /**
+   * Scalar fields to echo back from the fetched template on the chain path
+   * (#2187). The form was seeded from a PREDECESSOR occurrence while the PUT
+   * targets the living successor, which the split may have deliberately given
+   * a different time, room, name or Planungsschiene. Only fields the user
+   * actually edited may overwrite the successor's values; the rest are sent
+   * back unchanged so a roster save cannot silently revert that future change.
+   * (Predecessor windows keep their own values either way — non-roster fields
+   * never retro-apply.)
+   */
+  const chainPreservedScalars = (
+    template: TimetableTemplate,
+  ): Partial<UpdateTemplateBody> => {
+    if (!initialInstance) return {};
+    const schedule = template.schedules[0];
+    const preserved: Partial<UpdateTemplateBody> = {};
+    if (form.title.trim() === initialInstance.title.trim()) {
+      preserved.name = template.name;
+    }
+    if (form.startTime === initialInstance.startTime && schedule) {
+      preserved.start_time = schedule.startTime;
+    }
+    if (form.endTime === initialInstance.endTime && schedule) {
+      preserved.end_time = schedule.endTime;
+    }
+    if (form.roomId === initialInstance.roomId && template.roomId) {
+      preserved.room_id = Number(template.roomId);
+    }
+    if (
+      (form.planningTrackId || "") === (initialInstance.planningTrackId ?? "")
+    ) {
+      preserved.planning_track_id = template.planningTrackId
+        ? Number(template.planningTrackId)
+        : null;
+    }
+    return preserved;
+  };
+
+  /**
    * Weekday assignments to send from the occurrence-scope editor (#2129).
    *
    * That editor shows ONE roster because it was opened on one occurrence, so
@@ -2064,7 +2147,15 @@ export function useEventForm({
     seriesTemplateId: string,
   ) => {
     if (!initialInstance) return;
-    const body = templateBodyFromForm(template, roomId);
+    const chainResolved = template.resolvedFromTemplateId !== undefined;
+    // #2187: on the chain path the write targets the living successor, whose
+    // untouched fields must survive the save — see chainPreservedScalars.
+    const body = chainResolved
+      ? {
+          ...templateBodyFromForm(template, roomId),
+          ...chainPreservedScalars(template),
+        }
+      : templateBodyFromForm(template, roomId);
     const scopeProbes = seriesCoverageProbes(
       template,
       body,
@@ -2076,25 +2167,39 @@ export function useEventForm({
     // and the backend resolved the template to the living successor. That
     // successor cannot be split at the occurrence date (it lies before the
     // successor's valid_from), and it does not need to be: "from D on" IS the
-    // whole remaining series. Update it in place; a touched roster addition-
-    // ally carries series_roster_from so the backend mirrors the roster
-    // change onto the predecessor's remaining occurrences (the clicked one
-    // included).
-    if (template.resolvedFromTemplateId !== undefined) {
+    // whole remaining series. Update it in place; a changed roster addition-
+    // ally carries series_roster_from plus the ids that actually changed, so
+    // the backend mirrors exactly that change onto the predecessor's
+    // remaining occurrences (the clicked one included) and leaves everyone
+    // else on those occurrences alone.
+    if (chainResolved) {
       const rosterFrom =
         typedScope === "following" ? initialInstance.date : berlinTodayISO();
-      const rosterTouched =
-        studentRosterTouched.current || staffRosterTouched.current;
+      const studentScope = studentRosterTouched.current
+        ? changedRosterIDs(form.studentIds, initialStudentIDsSnapshot)
+        : [];
+      const staffScope = staffRosterTouched.current ? changedStaffIDs() : [];
+      const rosterChanged = studentScope.length > 0 || staffScope.length > 0;
       await timetableService.updateTemplate(seriesTemplateId, {
         ...body,
-        ...(rosterTouched ? { series_roster_from: rosterFrom } : {}),
+        ...(rosterChanged
+          ? {
+              series_roster_from: rosterFrom,
+              ...(studentScope.length > 0
+                ? { series_roster_scope_student_ids: studentScope }
+                : {}),
+              ...(staffScope.length > 0
+                ? { series_roster_scope_staff_ids: staffScope }
+                : {}),
+            }
+          : {}),
       });
       if (await replanTemplateFuture(seriesTemplateId, periodEnd)) {
-        toastSuccess(
-          typedScope === "following"
-            ? `Regeltermin ab ${formatDate(rosterFrom)} geändert`
-            : "Regeltermin gespeichert",
-        );
+        // No Stichdatum in the message: on the chain path the roster change
+        // reaches back to rosterFrom, but title/time/room only apply from the
+        // successor's own start — naming one date would claim more than was
+        // written.
+        toastSuccess("Regeltermin gespeichert");
       } else {
         toastWarning(FOLLOW_UP_WARNING);
       }

--- a/frontend/src/components/timetable/event-form/use-event-form.ts
+++ b/frontend/src/components/timetable/event-form/use-event-form.ts
@@ -30,6 +30,7 @@ import {
   type PlanningTrack,
 } from "~/lib/planning-track-api";
 import { staffService } from "~/lib/staff-api";
+import { timetableSeriesErrorMessage } from "./scope-error-message";
 import { getSchoolYear } from "~/lib/student-helpers";
 import { useTenant } from "~/lib/tenant-context";
 import { timetableService } from "~/lib/timetable-api";
@@ -281,7 +282,10 @@ export function useEventForm({
     roomId: number;
     template: TimetableTemplate;
     periodEnd: string | undefined;
-    groupId: string;
+    // The RESOLVED series template id (#2187): after a split chain
+    // resolution this is the living successor, not the clicked occurrence's
+    // own activityGroupId.
+    seriesTemplateId: string;
   } | null>(null);
   // #1875: a series edit that would discard single-occurrence changes is
   // deferred here until the user confirms the loss (with the concrete dates).
@@ -1398,6 +1402,28 @@ export function useEventForm({
     id ? calendarPeriods.find((period) => period.id === id) : undefined;
 
   /**
+   * Applies what the user changed in THIS session (next vs. before) on top of
+   * a base roster (#2187). Used when the fetched template is the split
+   * chain's living successor rather than the clicked occurrence's own
+   * template: the form's list describes the PREDECESSOR's occurrence, so
+   * writing it wholesale would overwrite the successor's roster and promote
+   * per-occurrence overrides into the permanent series. Keep = base minus the
+   * ids the user removed; plus the ids the user added.
+   */
+  const applyRosterDelta = (
+    base: readonly string[],
+    next: readonly string[],
+    before: readonly string[],
+  ): string[] => {
+    const removed = new Set(before.filter((id) => !next.includes(id)));
+    const kept = base.filter((id) => !removed.has(id));
+    const added = next.filter(
+      (id) => !before.includes(id) && !kept.includes(id),
+    );
+    return [...kept, ...added];
+  };
+
+  /**
    * Weekday assignments to send from the occurrence-scope editor (#2129).
    *
    * That editor shows ONE roster because it was opened on one occurrence, so
@@ -1418,6 +1444,10 @@ export function useEventForm({
       : undefined;
     const staffWasEdited = staffRosterTouched.current;
     const studentsWereEdited = studentRosterTouched.current;
+    // #2187: against a chain-resolved successor the form lists describe the
+    // predecessor's occurrence — apply only the user's delta on top of the
+    // successor's own weekday roster instead of replacing it.
+    const chainResolved = template.resolvedFromTemplateId !== undefined;
     return template.weekdayAssignments.map((assignment) => {
       if (
         (!staffWasEdited && !studentsWereEdited) ||
@@ -1432,17 +1462,30 @@ export function useEventForm({
             : undefined,
         };
       }
+      const weekdayStaffIDs = staffWasEdited
+        ? chainResolved
+          ? applyRosterDelta(
+              assignment.staffIds,
+              form.staffIds,
+              initialStaffIDsSnapshot,
+            )
+          : staffIDs
+        : assignment.staffIds;
+      const weekdayStudentIDs = studentsWereEdited
+        ? chainResolved
+          ? applyRosterDelta(
+              assignment.studentIds,
+              form.studentIds,
+              initialStudentIDsSnapshot,
+            )
+          : studentIDs
+        : assignment.studentIds;
       return {
         weekday: assignment.weekday,
-        staff_ids: (staffWasEdited ? staffIDs : assignment.staffIds).map(
-          Number,
-        ),
-        student_ids: (studentsWereEdited
-          ? studentIDs
-          : assignment.studentIds
-        ).map(Number),
+        staff_ids: weekdayStaffIDs.map(Number),
+        student_ids: weekdayStudentIDs.map(Number),
         primary_staff_id: staffWasEdited
-          ? primaryStaffId && staffIDs.includes(primaryStaffId)
+          ? primaryStaffId && weekdayStaffIDs.includes(primaryStaffId)
             ? Number(primaryStaffId)
             : undefined
           : assignment.primaryStaffId
@@ -1470,13 +1513,29 @@ export function useEventForm({
     // users:read is unavailable, the occurrence snapshot is authoritative only
     // for the single-instance scope; an all/following write targets the fetched
     // template and must preserve that template's own roster instead.
+    // #2187: when the template was chain-resolved to the living successor,
+    // the form lists were seeded from the PREDECESSOR's occurrence — apply
+    // only the user's delta on top of the successor's roster.
+    const chainResolved = template.resolvedFromTemplateId !== undefined;
     const templateStudentIDs =
       studentRosterEditable && studentRosterTouched.current
-        ? form.studentIds
+        ? chainResolved
+          ? applyRosterDelta(
+              template.studentIds,
+              form.studentIds,
+              initialStudentIDsSnapshot,
+            )
+          : form.studentIds
         : template.studentIds;
     const templateStaffIDs =
       staffRosterEditable && staffRosterTouched.current
-        ? form.staffIds
+        ? chainResolved
+          ? applyRosterDelta(
+              template.staffIds,
+              form.staffIds,
+              initialStaffIDsSnapshot,
+            )
+          : form.staffIds
         : template.staffIds;
     const primaryStaffId =
       staffRosterEditable && staffRosterTouched.current
@@ -1883,10 +1942,15 @@ export function useEventForm({
       return [];
     }
     // #2135: never probe before the segment's own series start (validFrom).
+    // #2187: a chain-resolved save also covers the predecessor window BEFORE
+    // the successor's validFrom — clamping to it would skip exactly the days
+    // being edited.
     const from = latestISODate(
       period.startDate,
       fromISO,
-      template.schedules[0]?.validFrom ?? "",
+      template.resolvedFromTemplateId !== undefined
+        ? ""
+        : (template.schedules[0]?.validFrom ?? ""),
     );
     // Without replanActivityGroupId the backend cannot apply the segment's
     // validity envelope, so the probe caps itself at the schedules'
@@ -1960,7 +2024,12 @@ export function useEventForm({
       fromISO,
       weekdays: body.weekdays,
       weekPattern: body.week_pattern ?? 0,
-      validFrom: validity?.validFrom,
+      // #2187: a chain-resolved save also covers the predecessor window
+      // before the successor's validFrom.
+      validFrom:
+        template.resolvedFromTemplateId !== undefined
+          ? undefined
+          : validity?.validFrom,
       validUntil: validity?.validUntil,
     });
     return findFirstClosingDayConflict(closingDayRanges, dates);
@@ -1971,15 +2040,10 @@ export function useEventForm({
       scope,
       error: err instanceof Error ? err.message : String(err),
     });
-    const raw =
-      err instanceof Error
-        ? err.message
-        : "Termin konnte nicht gespeichert werden";
-    // Backend rejects splits whose effective date already passed; the
-    // raw English message is meaningless to school staff.
-    const msg = raw.includes("effective_date must not be in the past")
-      ? "Der Stichtag liegt in der Vergangenheit. Bitte einen künftigen Termin der Serie wählen."
-      : raw;
+    const msg = timetableSeriesErrorMessage(
+      err,
+      "Termin konnte nicht gespeichert werden",
+    );
     setPendingSeriesEdit(null);
     setScopeClosingDayWarning(null);
     setLostEdits(null);
@@ -1997,7 +2061,7 @@ export function useEventForm({
     roomId: number,
     template: TimetableTemplate,
     periodEnd: string | undefined,
-    groupId: string,
+    seriesTemplateId: string,
   ) => {
     if (!initialInstance) return;
     const body = templateBodyFromForm(template, roomId);
@@ -2005,9 +2069,38 @@ export function useEventForm({
       template,
       body,
       typedScope === "following" ? initialInstance.date : berlinTodayISO(),
-      typedScope === "all" ? groupId : undefined,
+      typedScope === "all" ? seriesTemplateId : undefined,
     );
     await checkCoverageBeforeSave(scopeProbes);
+    // #2187: the clicked occurrence belonged to a capped predecessor segment
+    // and the backend resolved the template to the living successor. That
+    // successor cannot be split at the occurrence date (it lies before the
+    // successor's valid_from), and it does not need to be: "from D on" IS the
+    // whole remaining series. Update it in place; a touched roster addition-
+    // ally carries series_roster_from so the backend mirrors the roster
+    // change onto the predecessor's remaining occurrences (the clicked one
+    // included).
+    if (template.resolvedFromTemplateId !== undefined) {
+      const rosterFrom =
+        typedScope === "following" ? initialInstance.date : berlinTodayISO();
+      const rosterTouched =
+        studentRosterTouched.current || staffRosterTouched.current;
+      await timetableService.updateTemplate(seriesTemplateId, {
+        ...body,
+        ...(rosterTouched ? { series_roster_from: rosterFrom } : {}),
+      });
+      if (await replanTemplateFuture(seriesTemplateId, periodEnd)) {
+        toastSuccess(
+          typedScope === "following"
+            ? `Regeltermin ab ${formatDate(rosterFrom)} geändert`
+            : "Regeltermin gespeichert",
+        );
+      } else {
+        toastWarning(FOLLOW_UP_WARNING);
+      }
+      onSaved({ kind: "series", seriesId: seriesTemplateId });
+      return;
+    }
     if (typedScope === "following") {
       const effectiveDate = initialInstance.date;
       const chunks = chunkDateRange(
@@ -2015,7 +2108,7 @@ export function useEventForm({
         periodEnd ?? weekTo ?? effectiveDate,
         MATERIALIZE_CHUNK_DAYS,
       );
-      const split = await timetableService.splitTemplate(groupId, {
+      const split = await timetableService.splitTemplate(seriesTemplateId, {
         ...body,
         effective_date: effectiveDate,
         materialize_from: effectiveDate,
@@ -2032,14 +2125,14 @@ export function useEventForm({
           const result = await timetableService.replanWeek(
             chunk.from,
             chunk.to,
-            groupId,
+            seriesTemplateId,
           );
           if (result.warnings.some((w) => w.code === "no_active_period")) {
             break;
           }
         } catch (chunkErr) {
           logger.error("series_replan_chunk_failed", {
-            template_id: groupId,
+            template_id: seriesTemplateId,
             from: chunk.from,
             to: chunk.to,
             error:
@@ -2056,13 +2149,13 @@ export function useEventForm({
       }
       onSaved({ kind: "series", seriesId: split.newTemplateId });
     } else {
-      await timetableService.updateTemplate(groupId, body);
-      if (await replanTemplateFuture(groupId, periodEnd)) {
+      await timetableService.updateTemplate(seriesTemplateId, body);
+      if (await replanTemplateFuture(seriesTemplateId, periodEnd)) {
         toastSuccess("Regeltermin gespeichert");
       } else {
         toastWarning(FOLLOW_UP_WARNING);
       }
-      onSaved({ kind: "series", seriesId: groupId });
+      onSaved({ kind: "series", seriesId: seriesTemplateId });
     }
   };
 
@@ -2071,28 +2164,32 @@ export function useEventForm({
     roomId,
     template,
     periodEnd,
-    groupId,
+    seriesTemplateId,
   }: {
     typedScope: "all" | "following";
     roomId: number;
     template: TimetableTemplate;
     periodEnd: string | undefined;
-    groupId: string;
+    seriesTemplateId: string;
   }) => {
     if (!initialInstance) return;
     // #1875: before rebuilding the series, check whether single-occurrence
     // edits in the affected window would be discarded. "following" also
     // rematerializes individually-deleted occurrences; "all" preserves them.
+    // A chain-resolved save (#2187) is a same-template update, not a split —
+    // it preserves individually-deleted occurrences, so counting them would
+    // warn about losses that cannot happen.
     const editsFrom =
       typedScope === "following" ? initialInstance.date : berlinTodayISO();
     const editsTo = periodEnd ?? weekTo ?? editsFrom;
     let lost: EditedInWindowResult | null = null;
     try {
       const probe = await timetableService.countEditedInWindow(
-        groupId,
+        seriesTemplateId,
         editsFrom,
         editsTo,
-        typedScope === "following",
+        typedScope === "following" &&
+          template.resolvedFromTemplateId === undefined,
       );
       if (probe.count > 0) lost = probe;
     } catch (probeErr) {
@@ -2107,12 +2204,24 @@ export function useEventForm({
         scope: typedScope,
         result: lost,
         onConfirm: () =>
-          performSeriesEdit(typedScope, roomId, template, periodEnd, groupId),
+          performSeriesEdit(
+            typedScope,
+            roomId,
+            template,
+            periodEnd,
+            seriesTemplateId,
+          ),
       });
       return;
     }
 
-    await performSeriesEdit(typedScope, roomId, template, periodEnd, groupId);
+    await performSeriesEdit(
+      typedScope,
+      roomId,
+      template,
+      periodEnd,
+      seriesTemplateId,
+    );
     setPendingSeriesEdit(null);
     onClose();
   };
@@ -2151,6 +2260,17 @@ export function useEventForm({
         groupId,
         form.calendarPeriodId,
       );
+      // #2187: the occurrence may belong to a capped predecessor of a split
+      // chain; the backend then returns the living successor. Every series-
+      // scope write from here on targets THAT template, never the
+      // occurrence's own activityGroupId.
+      const seriesTemplateId = template.id;
+      if (template.resolvedFromTemplateId !== undefined) {
+        logger.info("series_template_chain_resolved", {
+          occurrence_template_id: groupId,
+          resolved_template_id: seriesTemplateId,
+        });
+      }
       const templateCalendarPeriodId =
         resolveTemplateCalendarPeriodId(template);
       const periodEnd =
@@ -2171,7 +2291,7 @@ export function useEventForm({
           roomId: pending.roomId,
           template,
           periodEnd,
-          groupId,
+          seriesTemplateId,
         });
         return;
       }
@@ -2181,7 +2301,7 @@ export function useEventForm({
         roomId: pending.roomId,
         template,
         periodEnd,
-        groupId,
+        seriesTemplateId,
       });
     } catch (err) {
       handleScopeError(scope, err);
@@ -2202,7 +2322,7 @@ export function useEventForm({
         roomId: warning.roomId,
         template: warning.template,
         periodEnd: warning.periodEnd,
-        groupId: warning.groupId,
+        seriesTemplateId: warning.seriesTemplateId,
       });
     } catch (err) {
       handleScopeError(warning.scope, err);

--- a/frontend/src/components/timetable/event-form/use-event-form.ts
+++ b/frontend/src/components/timetable/event-form/use-event-form.ts
@@ -1446,13 +1446,22 @@ export function useEventForm({
   };
 
   /**
+   * Whether the user changed the Hauptbetreuung in this session. The staff
+   * roster is marked "touched" by any membership edit (#2187 review), so on
+   * the chain path this narrower predicate decides whether the form's value
+   * may overwrite the successor's own choice.
+   */
+  const primaryStaffTouched = () =>
+    form.primaryStaffId !== initialPrimaryStaffIDSnapshot;
+
+  /**
    * Staff scope for the chain reconciliation: membership changes plus both
    * sides of a changed Hauptbetreuung, whose is_primary flag has to be
    * rewritten on the predecessor rows as well.
    */
   const changedStaffIDs = (): number[] => {
     const changed = changedRosterIDs(form.staffIds, initialStaffIDsSnapshot);
-    if (form.primaryStaffId !== initialPrimaryStaffIDSnapshot) {
+    if (primaryStaffTouched()) {
       for (const id of [form.primaryStaffId, initialPrimaryStaffIDSnapshot]) {
         const numeric = Number(id);
         if (
@@ -1480,30 +1489,52 @@ export function useEventForm({
    */
   const chainPreservedScalars = (
     template: TimetableTemplate,
-  ): Partial<UpdateTemplateBody> => {
-    if (!initialInstance) return {};
+  ): { preserved: Partial<UpdateTemplateBody>; edited: boolean } => {
+    if (!initialInstance) return { preserved: {}, edited: false };
     const schedule = template.schedules[0];
     const preserved: Partial<UpdateTemplateBody> = {};
-    if (form.title.trim() === initialInstance.title.trim()) {
-      preserved.name = template.name;
+    let edited = false;
+    const keep = <K extends keyof UpdateTemplateBody>(
+      untouched: boolean,
+      key: K,
+      value: UpdateTemplateBody[K],
+    ) => {
+      if (untouched) {
+        preserved[key] = value;
+      } else {
+        edited = true;
+      }
+    };
+    keep(
+      form.title.trim() === initialInstance.title.trim(),
+      "name",
+      template.name,
+    );
+    if (schedule) {
+      keep(
+        form.startTime === initialInstance.startTime,
+        "start_time",
+        schedule.startTime,
+      );
+      keep(
+        form.endTime === initialInstance.endTime,
+        "end_time",
+        schedule.endTime,
+      );
     }
-    if (form.startTime === initialInstance.startTime && schedule) {
-      preserved.start_time = schedule.startTime;
+    if (template.roomId) {
+      keep(
+        form.roomId === initialInstance.roomId,
+        "room_id",
+        Number(template.roomId),
+      );
     }
-    if (form.endTime === initialInstance.endTime && schedule) {
-      preserved.end_time = schedule.endTime;
-    }
-    if (form.roomId === initialInstance.roomId && template.roomId) {
-      preserved.room_id = Number(template.roomId);
-    }
-    if (
-      (form.planningTrackId || "") === (initialInstance.planningTrackId ?? "")
-    ) {
-      preserved.planning_track_id = template.planningTrackId
-        ? Number(template.planningTrackId)
-        : null;
-    }
-    return preserved;
+    keep(
+      (form.planningTrackId || "") === (initialInstance.planningTrackId ?? ""),
+      "planning_track_id",
+      template.planningTrackId ? Number(template.planningTrackId) : null,
+    );
+    return { preserved, edited };
   };
 
   /**
@@ -1563,13 +1594,20 @@ export function useEventForm({
             )
           : studentIDs
         : assignment.studentIds;
+      // #2187 review: same rule as for the shared roster — an untouched
+      // Hauptbetreuung must not travel from the predecessor's occurrence onto
+      // this weekday of the successor.
+      const weekdayPrimary =
+        chainResolved && !primaryStaffTouched()
+          ? assignment.primaryStaffId
+          : primaryStaffId;
       return {
         weekday: assignment.weekday,
         staff_ids: weekdayStaffIDs.map(Number),
         student_ids: weekdayStudentIDs.map(Number),
         primary_staff_id: staffWasEdited
-          ? primaryStaffId && weekdayStaffIDs.includes(primaryStaffId)
-            ? Number(primaryStaffId)
+          ? weekdayPrimary && weekdayStaffIDs.includes(weekdayPrimary)
+            ? Number(weekdayPrimary)
             : undefined
           : assignment.primaryStaffId
             ? Number(assignment.primaryStaffId)
@@ -1620,9 +1658,17 @@ export function useEventForm({
             )
           : form.staffIds
         : template.staffIds;
+    // #2187 review: the Hauptbetreuung is a scalar, not a delta — and the form
+    // holds the PREDECESSOR occurrence's value. Any staff membership edit sets
+    // staffRosterTouched, so without the narrower "did they change the primary"
+    // check a chain save would silently revert a Hauptbetreuung the split set
+    // deliberately (or clear it, when the old primary is no longer on the
+    // successor's roster).
     const primaryStaffId =
       staffRosterEditable && staffRosterTouched.current
-        ? form.primaryStaffId || template.primaryStaffId
+        ? chainResolved && !primaryStaffTouched()
+          ? template.primaryStaffId
+          : form.primaryStaffId || template.primaryStaffId
         : template.primaryStaffId;
     return {
       name: form.title.trim(),
@@ -2150,11 +2196,11 @@ export function useEventForm({
     const chainResolved = template.resolvedFromTemplateId !== undefined;
     // #2187: on the chain path the write targets the living successor, whose
     // untouched fields must survive the save — see chainPreservedScalars.
+    const chainScalars = chainResolved
+      ? chainPreservedScalars(template)
+      : { preserved: {}, edited: false };
     const body = chainResolved
-      ? {
-          ...templateBodyFromForm(template, roomId),
-          ...chainPreservedScalars(template),
-        }
+      ? { ...templateBodyFromForm(template, roomId), ...chainScalars.preserved }
       : templateBodyFromForm(template, roomId);
     const scopeProbes = seriesCoverageProbes(
       template,
@@ -2180,6 +2226,14 @@ export function useEventForm({
         : [];
       const staffScope = staffRosterTouched.current ? changedStaffIDs() : [];
       const rosterChanged = studentScope.length > 0 || staffScope.length > 0;
+      // #2187 review: with per-weekday rosters this form describes exactly ONE
+      // weekday, so the mirroring must not judge the predecessor's other
+      // weekdays against it. A series with one shared roster sends no weekday
+      // scope — there the edit really does describe every weekday.
+      const scopeWeekdays =
+        template.weekdayAssignments.length > 0
+          ? [isoWeekday(initialInstance.date)]
+          : [];
       await timetableService.updateTemplate(seriesTemplateId, {
         ...body,
         ...(rosterChanged
@@ -2191,15 +2245,24 @@ export function useEventForm({
               ...(staffScope.length > 0
                 ? { series_roster_scope_staff_ids: staffScope }
                 : {}),
+              ...(scopeWeekdays.length > 0
+                ? { series_roster_scope_weekdays: scopeWeekdays }
+                : {}),
             }
           : {}),
       });
       if (await replanTemplateFuture(seriesTemplateId, periodEnd)) {
-        // No Stichdatum in the message: on the chain path the roster change
-        // reaches back to rosterFrom, but title/time/room only apply from the
-        // successor's own start — naming one date would claim more than was
-        // written.
-        toastSuccess("Regeltermin gespeichert");
+        // The roster change reaches back to rosterFrom, but title, time, room
+        // and Planungsschiene belong to the successor's own window and start
+        // where it starts. Naming rosterFrom for all of them would claim more
+        // than was written, so an edited scalar says which date it takes
+        // effect from (#2187 review) and everything else stays generic.
+        const successorFrom = template.schedules[0]?.validFrom;
+        toastSuccess(
+          chainScalars.edited && successorFrom
+            ? `Regeltermin gespeichert. Zeit, Raum und Titel gelten ab ${formatDate(successorFrom)}.`
+            : "Regeltermin gespeichert",
+        );
       } else {
         toastWarning(FOLLOW_UP_WARNING);
       }

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -4750,10 +4750,19 @@ describe("TimetableEventModal", () => {
         expect(mockUpdateTemplate).toHaveBeenCalledWith(
           "88",
           expect.objectContaining({
-            name: "Mensa",
+            // The successor's OWN title and time survive: the form was seeded
+            // from the predecessor's occurrence ("Mensa", 12:00), and a split
+            // may have changed these fields for the future on purpose. Only a
+            // field the user actually edits may overwrite them.
+            name: "Yoga",
+            start_time: "14:00",
+            end_time: "15:00",
             // The clicked occurrence's date, so the backend mirrors the roster
             // change onto the predecessor's remaining occurrences.
             series_roster_from: "2026-05-04",
+            // ...restricted to the child the user actually added — everyone
+            // else keeps their predecessor rows.
+            series_roster_scope_student_ids: [21],
           }),
         ),
       );
@@ -4793,6 +4802,63 @@ describe("TimetableEventModal", () => {
         ),
       );
       expect(mockSplitTemplate).not.toHaveBeenCalled();
+    });
+
+    it("still writes a scalar field the user actually edited", async () => {
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      renderModal({ initialInstance: chainInstance });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      fireEvent.change(screen.getByLabelText("Start*"), {
+        target: { value: "12:30" },
+      });
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          expect.objectContaining({
+            // Edited → the user's value wins.
+            start_time: "12:30",
+            // Untouched → the successor keeps its own.
+            end_time: "15:00",
+            name: "Yoga",
+          }),
+        ),
+      );
+    });
+
+    it("scopes the reconciliation to a removed child only", async () => {
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      renderModal({
+        initialInstance: { ...chainInstance, studentIds: ["21"] },
+      });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await goToStep(3);
+      await screen.findByText("Max Kind");
+      // The child was on the occurrence — this click removes them.
+      fireEvent.click(screen.getByRole("checkbox", { name: /Max Kind/ }));
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          expect.objectContaining({
+            series_roster_from: "2026-05-04",
+            series_roster_scope_student_ids: [21],
+            student_ids: [],
+          }),
+        ),
+      );
     });
 
     it("omits series_roster_from when the roster was not touched", async () => {

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -4855,6 +4855,43 @@ describe("TimetableEventModal", () => {
       );
     });
 
+    it("omits series_roster_primary_changed unless the Hauptbetreuung moved", async () => {
+      mockGetAllStaff.mockResolvedValue([
+        { id: "11", name: "Ada Staff" },
+        { id: "13", name: "Cem Staff" },
+      ]);
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      renderModal({
+        initialInstance: {
+          ...chainInstance,
+          staff: [
+            {
+              staffId: "11",
+              isPrimary: true,
+              isAbsent: false,
+              isSubstitute: false,
+            },
+          ],
+        },
+      });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await goToStep(3);
+      await screen.findByText("Cem Staff");
+      fireEvent.click(screen.getByRole("checkbox", { name: /Cem Staff/ }));
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() => expect(mockUpdateTemplate).toHaveBeenCalled());
+      const body = mockUpdateTemplate.mock.calls[0]?.[1] as unknown;
+      // A pure membership change must not let the successor's lead travel onto
+      // the predecessor's rows.
+      expect(body).not.toHaveProperty("series_roster_primary_changed");
+    });
+
     it("still writes a scalar field the user actually edited", async () => {
       mockGetTemplate.mockResolvedValue(resolvedSuccessor);
       renderModal({ initialInstance: chainInstance });

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -4804,6 +4804,57 @@ describe("TimetableEventModal", () => {
       expect(mockSplitTemplate).not.toHaveBeenCalled();
     });
 
+    it("keeps the successor's Hauptbetreuung when only the staff list changed", async () => {
+      // The predecessor occurrence is led by 11, the successor by 12 — a
+      // deliberate change made at the split. Adding a third supervisor marks
+      // the staff roster as touched but says nothing about the Hauptbetreuung.
+      mockGetAllStaff.mockResolvedValue([
+        { id: "11", name: "Ada Staff" },
+        { id: "12", name: "Bo Staff" },
+        { id: "13", name: "Cem Staff" },
+      ]);
+      mockGetTemplate.mockResolvedValue({
+        ...resolvedSuccessor,
+        staffIds: ["11", "12"],
+        primaryStaffId: "12",
+      });
+      renderModal({
+        initialInstance: {
+          ...chainInstance,
+          staff: [
+            {
+              staffId: "11",
+              isPrimary: true,
+              isAbsent: false,
+              isSubstitute: false,
+            },
+          ],
+        },
+      });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await goToStep(3);
+      await screen.findByText("Cem Staff");
+      fireEvent.click(screen.getByRole("checkbox", { name: /Cem Staff/ }));
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          expect.objectContaining({
+            primary_staff_id: 12,
+            staff_ids: [11, 12, 13],
+            // Only the added supervisor is reconciled on the predecessor.
+            series_roster_scope_staff_ids: [13],
+          }),
+        ),
+      );
+    });
+
     it("still writes a scalar field the user actually edited", async () => {
       mockGetTemplate.mockResolvedValue(resolvedSuccessor);
       renderModal({ initialInstance: chainInstance });

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -4710,4 +4710,223 @@ describe("TimetableEventModal", () => {
       screen.getByRole("option", { name: "Benutzerdefiniert …" }),
     ).toBeInTheDocument();
   });
+
+  // #2187: a series that was already split is a CHAIN of templates. The
+  // clicked occurrence can still carry the id of a capped predecessor
+  // segment; the backend then resolves it forward and returns the living
+  // successor, flagged via `resolvedFromTemplateId`. Every series-scope write
+  // must target that successor — and must update it in place instead of
+  // splitting it, because the occurrence date lies before the successor's
+  // valid_from and cannot be a split point.
+  describe("#2187 split-chain resolution", () => {
+    /** What the backend returns for the capped predecessor id "87". */
+    const resolvedSuccessor: TimetableTemplate = {
+      ...template,
+      id: "88",
+      resolvedFromTemplateId: "87",
+    };
+
+    /** An occurrence still pointing at the capped predecessor segment. */
+    const chainInstance: EnrichedInstance = {
+      ...savedInstance,
+      activityGroupId: "87",
+    };
+
+    it("updates the resolved successor instead of splitting for 'Ab jetzt dauerhaft'", async () => {
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      const { onSaved } = renderModal({ initialInstance: chainInstance });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await goToStep(3);
+      await screen.findByText("Max Kind");
+      fireEvent.click(screen.getByRole("checkbox", { name: /Max Kind/ }));
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          expect.objectContaining({
+            name: "Mensa",
+            // The clicked occurrence's date, so the backend mirrors the roster
+            // change onto the predecessor's remaining occurrences.
+            series_roster_from: "2026-05-04",
+          }),
+        ),
+      );
+      // The successor IS the whole remaining series — nothing left to split.
+      expect(mockSplitTemplate).not.toHaveBeenCalled();
+      // The template was fetched via the occurrence's own (stale) id.
+      expect(mockGetTemplate).toHaveBeenCalledWith("87", "5");
+      // The follow-up re-plan runs against the RESOLVED id, not "87".
+      await waitFor(() => expect(mockReplanWeek).toHaveBeenCalled());
+      for (const call of mockReplanWeek.mock.calls) {
+        expect(call[2]).toBe("88");
+      }
+      expect(onSaved).toHaveBeenCalledWith({ kind: "series", seriesId: "88" });
+    });
+
+    it("sends today's series_roster_from for 'Alle Termine der Serie'", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-05-06T10:00:00"));
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      renderModal({ initialInstance: chainInstance });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await goToStep(3);
+      await screen.findByText("Max Kind");
+      fireEvent.click(screen.getByRole("checkbox", { name: /Max Kind/ }));
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Alle Termine der Serie/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          // "Alle Termine" starts at today, not at the clicked occurrence.
+          expect.objectContaining({ series_roster_from: "2026-05-06" }),
+        ),
+      );
+      expect(mockSplitTemplate).not.toHaveBeenCalled();
+    });
+
+    it("omits series_roster_from when the roster was not touched", async () => {
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      renderModal({ initialInstance: chainInstance });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      fireEvent.change(screen.getByLabelText("Titel*"), {
+        target: { value: "Mensa neu" },
+      });
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          expect.objectContaining({ name: "Mensa neu" }),
+        ),
+      );
+      // A title-only edit must not ask the backend to rewrite past rosters.
+      const body = mockUpdateTemplate.mock.calls[0]?.[1] as unknown;
+      expect(body).not.toHaveProperty("series_roster_from");
+      expect(mockSplitTemplate).not.toHaveBeenCalled();
+    });
+
+    it("still splits when the backend did not resolve a chain", async () => {
+      // Control case: no resolvedFromTemplateId → the pre-#2187 split path.
+      mockGetTemplate.mockResolvedValue(template);
+      renderModal({
+        initialInstance: { ...savedInstance, activityGroupId: "7" },
+      });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockSplitTemplate).toHaveBeenCalledWith(
+          "7",
+          expect.objectContaining({ effective_date: "2026-05-04" }),
+        ),
+      );
+      expect(mockUpdateTemplate).not.toHaveBeenCalled();
+    });
+
+    it("merges an added child into the successor roster instead of overwriting it", async () => {
+      // 999 exists only on the successor — the occurrence snapshot (101, 105)
+      // predates it. Writing the form list wholesale would delete that child.
+      mockFetchStudents.mockResolvedValue({
+        students: [
+          { id: "101", name: "Anna Alt", school_class: "1a" },
+          { id: "105", name: "Bea Alt", school_class: "1a" },
+          { id: "7", name: "Cem Neu", school_class: "1b" },
+        ],
+      });
+      mockGetTemplate.mockResolvedValue({
+        ...resolvedSuccessor,
+        studentIds: ["101", "105", "999"],
+      });
+      renderModal({
+        initialInstance: { ...chainInstance, studentIds: ["101", "105"] },
+      });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await goToStep(3);
+      await screen.findByText("Cem Neu");
+      fireEvent.click(screen.getByRole("checkbox", { name: /Cem Neu/ }));
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateTemplate).toHaveBeenCalledWith(
+          "88",
+          // Successor roster kept in full, the user's addition appended.
+          expect.objectContaining({ student_ids: [101, 105, 999, 7] }),
+        ),
+      );
+    });
+
+    it("shows the German message when the series template cannot be loaded", async () => {
+      mockGetTemplate.mockRejectedValue(
+        Object.assign(new Error("template not found"), {
+          httpStatus: 404,
+          code: "template_not_found",
+        }),
+      );
+      const { onClose } = renderModal({ initialInstance: chainInstance });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Alle Termine der Serie/ }),
+      );
+
+      const message =
+        "Der Regeltermin konnte nicht geladen werden. Bitte laden Sie die Seite neu und öffnen Sie den Termin erneut.";
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith(message));
+      expect(await screen.findByText(message)).toBeInTheDocument();
+      expect(mockUpdateTemplate).not.toHaveBeenCalled();
+      expect(mockSplitTemplate).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("passes the resolved id and no deletion count to the lost-edits probe", async () => {
+      mockGetTemplate.mockResolvedValue(resolvedSuccessor);
+      renderModal({ initialInstance: chainInstance });
+
+      await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+      await clickSave();
+      await screen.findByText("Wiederholenden Termin ändern");
+      fireEvent.click(
+        screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }),
+      );
+
+      // In-place update, not a split: individually deleted occurrences survive,
+      // so counting them would warn about a loss that cannot happen.
+      await waitFor(() =>
+        expect(mockCountEditedInWindow).toHaveBeenCalledWith(
+          "88",
+          expect.any(String),
+          expect.any(String),
+          false,
+        ),
+      );
+    });
+  });
 });

--- a/frontend/src/lib/timetable-api.test.ts
+++ b/frontend/src/lib/timetable-api.test.ts
@@ -271,6 +271,32 @@ describe("timetableService", () => {
     );
   });
 
+  it("passes series_roster_from through to the update body (#2187)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: backendTemplate }));
+
+    const body = {
+      name: "Yoga",
+      type: "activity" as const,
+      weekdays: [1],
+      start_time: "14:00",
+      end_time: "15:00",
+      room_id: 3,
+      category_id: 2,
+      calendar_period_id: 5,
+      series_roster_from: "2026-06-01",
+    };
+
+    await timetableService.updateTemplate("7", body);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/timetable/templates/7",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    );
+  });
+
   it("loads a single template, splits a template, and ends it from an effective date", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ data: backendTemplate }))

--- a/frontend/src/lib/timetable-helpers.test.ts
+++ b/frontend/src/lib/timetable-helpers.test.ts
@@ -895,6 +895,58 @@ describe("backend mappers", () => {
     });
   });
 
+  it("maps the chain-resolved predecessor id onto a template (#2187)", () => {
+    const tpl = mapTemplates({
+      templates: [
+        {
+          id: 9,
+          name: "Yoga",
+          type: "activity",
+          category_id: 2,
+          category_name: "AG",
+          is_open: true,
+          max_participants: 12,
+          target_group_type: "none",
+          enrollment_count: 0,
+          supervisor_count: 0,
+          required_staff_count: 0,
+          assigned_staff_count: 0,
+          resolved_from_template_id: 87,
+          schedules: [],
+        },
+      ],
+    }).templates[0];
+
+    expect(tpl?.resolvedFromTemplateId).toBe("87");
+  });
+
+  it("leaves the chain-resolved id undefined when absent or null (#2187)", () => {
+    const base = {
+      id: 9,
+      name: "Yoga",
+      type: "activity" as const,
+      category_id: 2,
+      category_name: "AG",
+      is_open: true,
+      max_participants: 12,
+      target_group_type: "none" as const,
+      enrollment_count: 0,
+      supervisor_count: 0,
+      required_staff_count: 0,
+      assigned_staff_count: 0,
+      schedules: [],
+    };
+
+    expect(
+      mapTemplates({ templates: [base] }).templates[0]?.resolvedFromTemplateId,
+    ).toBeUndefined();
+    expect(
+      mapTemplates({
+        templates: [{ ...base, resolved_from_template_id: null }],
+      }).templates[0]?.resolvedFromTemplateId,
+    ).toBeUndefined();
+  });
+
   it("maps the offering-source rule and per-weekday rosters (#2137/#2129)", () => {
     const tpl = mapTemplates({
       templates: [

--- a/frontend/src/lib/timetable-helpers.ts
+++ b/frontend/src/lib/timetable-helpers.ts
@@ -983,6 +983,11 @@ export function mapTemplates(raw: BackendTemplatesResponse): TemplatesResponse {
         weekday: assignment.weekday,
         studentIds: (assignment.student_ids ?? []).map(String),
       })),
+      resolvedFromTemplateId:
+        template.resolved_from_template_id !== undefined &&
+        template.resolved_from_template_id !== null
+          ? String(template.resolved_from_template_id)
+          : undefined,
     })),
   };
 }

--- a/frontend/src/lib/timetable-types.ts
+++ b/frontend/src/lib/timetable-types.ts
@@ -1011,6 +1011,14 @@ export type UpdateTemplateBody = Omit<
    * chain-resolved.
    */
   series_roster_from?: string;
+  /**
+   * The people whose membership this edit actually changed. Only they are
+   * reconciled on the capped predecessor segments — `student_ids`/`staff_ids`
+   * describe the living segment, whose roster may legitimately differ from a
+   * predecessor's, so they are not the predecessor's target set (#2187).
+   */
+  series_roster_scope_student_ids?: number[];
+  series_roster_scope_staff_ids?: number[];
 };
 
 /**

--- a/frontend/src/lib/timetable-types.ts
+++ b/frontend/src/lib/timetable-types.ts
@@ -462,6 +462,12 @@ export interface TimetableTemplate {
   weekdayAssignments: TemplateWeekdayAssignment[];
   /** Read-only enrollment-owned child coverage, used when changing roster mode. */
   protectedStudentAssignments?: TemplateProtectedStudentAssignment[];
+  /**
+   * Set when the backend resolved a capped predecessor segment of a split
+   * series forward to this living successor (#2187); holds the id the client
+   * originally requested.
+   */
+  resolvedFromTemplateId?: string;
 }
 
 /** One weekday's staff and child roster of a Regeltermin (#2129). */
@@ -537,6 +543,7 @@ export interface BackendTimetableTemplate {
   weekday_assignments?: BackendTemplateWeekdayAssignment[] | null;
   protected_student_assignments?:
     BackendTemplateProtectedStudentAssignment[] | null;
+  resolved_from_template_id?: number | null;
 }
 
 interface BackendTemplateWeekdayAssignment {
@@ -997,6 +1004,13 @@ export type UpdateTemplateBody = Omit<
    * `null`, not `undefined`, to be honored (#1565).
    */
   list_kind?: TimetableListKind | null;
+  /**
+   * Roster changes in this body additionally take effect from this calendar
+   * day (YYYY-MM-DD) and are reconciled across the split chain's capped
+   * predecessor segments (#2187). Sent only when the template was
+   * chain-resolved.
+   */
+  series_roster_from?: string;
 };
 
 /**

--- a/frontend/src/lib/timetable-types.ts
+++ b/frontend/src/lib/timetable-types.ts
@@ -1019,6 +1019,13 @@ export type UpdateTemplateBody = Omit<
    */
   series_roster_scope_student_ids?: number[];
   series_roster_scope_staff_ids?: number[];
+  /**
+   * The ISO weekdays this edit describes. Sent only for a series that staffs
+   * each weekday separately (#2129), where the occurrence editor shows one
+   * weekday's roster: the predecessor's other weekdays must not be judged
+   * against it. Omitted for a shared roster, which really does cover them all.
+   */
+  series_roster_scope_weekdays?: number[];
 };
 
 /**

--- a/frontend/src/lib/timetable-types.ts
+++ b/frontend/src/lib/timetable-types.ts
@@ -1026,6 +1026,12 @@ export type UpdateTemplateBody = Omit<
    * against it. Omitted for a shared roster, which really does cover them all.
    */
   series_roster_scope_weekdays?: number[];
+  /**
+   * Set when this edit moved the Hauptbetreuung. `primary_staff_id` always
+   * names the living segment's lead, so it may only be stamped onto a
+   * predecessor row when the user actually changed it (#2187).
+   */
+  series_roster_primary_changed?: boolean;
 };
 
 /**


### PR DESCRIPTION
I'll inspect the finished diff against `origin/development` and the original description so the PR text matches what's actually shipping.Closes #2187

## Problem

Die Wochenansicht des Betreuungsplans rendert Vorkommen mit der Template-ID, aus der sie materialisiert wurden. Nach einem Template-Split kann diese ID zu einem vollständig gekappten Vorgänger-Segment gehören (alle Schedules mit `valid_until`), das sämtliche Template-Read-Models per `s.valid_until IS NULL` ausschließen. Ein Serien-Speichern aus so einem Vorkommen ("Ab jetzt dauerhaft" / "Alle Termine der Serie") lief in `GET /api/timetable/templates/{id}` → 404 und endete im rohen Toast **"template not found"**. Der Nachzügler war für diesen Tag schlicht nicht eintragbar (Prod, Tenant 6, 07.08.).

Selbst mit repariertem Read hätte eine Anmeldung auf dem lebenden Nachfolger (valid_from = Mi) das Di-Vorkommen nie erreicht: materialisierte Instanzen snapshoten Kinder pro Template, der Materializer ist insert-only.

## Fix

**Backend**
- `GET /templates/{id}`: leerer Read fällt auf die Split-Kette zurück (`series_root_id` + Schedule-Envelopes über die bestehenden Primitiven — kein zweiter Recurrence-Mechanismus) und liefert das lebende Segment plus `resolved_from_template_id`.
- `PUT /templates/{id}` akzeptiert optional `series_roster_from` (YYYY-MM-DD) sowie Scope-Felder (`series_roster_scope_student_ids` / `_staff_ids` / `_weekdays`, `series_roster_primary_changed`). Nur die tatsächlich geänderten Personen werden auf gekappte Vorgänger-Segmente in `[Anker, valid_from des lebenden Segments)` gespiegelt — ohne Scope spiegelt der Anker nichts. Begrenzte, wochentags-explizite Zeilen `[max(Anker, Segmentstart), Segmentende)` beim Hinzufügen, Kappen/Löschen beim Entfernen. Bereits materialisierte geplante Vorkommen werden chirurgisch nachgezogen (`RosterReconciler` für Kinder, Personal-Pendant für Supervisoren). Geschützte Zeilen (`enrollment_request_child_id`, `selected_weekdays`), Hand-Entfernungen auf einzelnen Vorkommen, Vertretungs-/Krankheits-Zeilen und fremde Perioden-Fenster bleiben unangetastet. Der Anker ändert NICHT den Roster-Anker des lebenden Segments; ein Re-Plan des Vorgänger-Fensters wird bewusst vermieden (würde Hand-Edits löschen).
- `POST /templates/{id}/end` kaskadiert die Kappung über die Split-Kette: Segmente, deren Fenster in `[effective_date, ∞)` hineinreicht, werden mitbeendet — auch wenn der Request auf einem gekappten Vorgänger ankommt und der lebende Nachfolger die späteren Vorkommen trägt. "Diesen und alle folgenden löschen" kann keine lebenden Vorkommen auf einem klickbaren Vorgänger zurücklassen.
- Alle Template-404s tragen jetzt `code: "template_not_found"` (Message unverändert).

**Frontend**
- Alle Serien-Writes (Split, Update, Re-Plan, Coverage-Probes, Lost-Edits-Probe) zielen auf die aufgelöste `template.id` statt auf `instance.activityGroupId`.
- Chain-Fall: Update in place statt Split (das Vorkommens-Datum liegt vor dem `valid_from` des Nachfolgers); `series_roster_from` und Scope-IDs werden nur gesendet, wenn der Roster angefasst wurde. "following" → Vorkommens-Datum, "all" → heute.
- Angefasste Roster werden als **Delta** auf den Nachfolger-Roster angewendet (shared + pro Wochentag) — ein Speichern aus einem Vorgänger-Vorkommen kann den Nachfolger-Roster nicht überschreiben und keine Einzel-Overrides zur Serie befördern. Unangetastete Skalare (Titel, Zeit, Raum, …) und die Hauptbetreuung des Nachfolgers bleiben erhalten, sofern der User sie nicht selbst ändert.
- Verbleibende Fehlerpfade zeigen deutsche Meldungen (`scope-error-message.ts`: `template_not_found`-Code, Status-Leiter 401/403/404/409/5xx; informative Backend-400-Texte werden bewusst durchgereicht).

## Bewusste Grenzen

- Nicht-Roster-Felder (Zeit, Raum, Name, Wochentage) wirken NICHT rückwirkend auf Vorgänger-Fenster — deren Recurrence ist abgeschlossene Historie; nur Roster-Mitgliedschaft muss am Tag stimmen. Bei gemischten Chain-Saves meldet der Toast Skalar-Änderungen ab dem `valid_from` des Nachfolgers.
- Gekappte Segmente bleiben per direktem PUT nicht editierbar (`ErrTemplateSegmentNotEditable` unverändert); die Spiegelung ist interne Orchestrierung des Updates auf dem lebenden Segment.
- Die Lost-Edits-Probe prüft nur das lebende Segment; auf dem Chain-Pfad ist das unkritisch, weil die chirurgischen Reconciler Hand-Edits erhalten. Falls jemand die Reconciler später durch einen Re-Plan ersetzt, muss die Probe mitgezogen werden.

## Tests

**Backend** (hermetisch, Zwei-Split-Kette T→S1→S2, damit `series_root_id`-Auflösung greift):
- Ketten-Auflösung (`ResolveLivingTemplateSegment`)
- Roster hin und zurück über die Split-Grenze inkl. `instance_students` / `instance_staff` auf bereits materialisierten Vorkommen, Scope-Schutz, wochentags-scoped Edits, Hauptbetreuung
- End-Kaskade (inkl. Request auf gekapptem Vorgänger)
- API-Kontrakt (`resolved_from_template_id`, 404-Code, Feld-Validierung, Split-Ablehnung von `series_roster_from`)
- Pure/Mock-Helfer für Segmentfilter, geschützte Enrollments, Scope-Noops

**Frontend:**
- Modal-Suite `#2187 split-chain resolution` (Update statt Split, Anker following/all, Delta-Merge, Scope-IDs, Hauptbetreuung, Skalare, Lost-Edits-Probe, deutscher 404-Toast)
- Error-Mapping (`scope-error-message`), Helper-Mapping (`resolved_from_template_id`), API-Durchreichung von `series_roster_from`

## E2E (lokal, echte UI)

Prod-Shape nachgestellt (zwei Splits von "Lernzeit Klasse 3": Vorgänger deckt exakt Mo+Di, Nachfolger offen ab Mi), dann:
1. **Vorher** (development): Di-Vorkommen → Kind hinzufügen → "Ab jetzt dauerhaft" → roter Toast "template not found", `GET /templates/11 → 404`.
2. **Nachher**: identischer Flow → Erfolgstoast "Regeltermin gespeichert"; Wire zeigt `GET /templates/11 → 200` (aufgelöst auf 12) und `PUT /templates/12` mit `series_roster_from` plus Scope-IDs, kein `/split`. DB: begrenzte Zeile auf dem Vorgänger + offene Zeile auf dem Nachfolger, `instance_students`-Zeile auf dem bereits materialisierten Di-Vorkommen. Kind steht auf der Di-Karte, Mo unverändert.
3. **Entfernen** symmetrisch über die ganze Kette (beide Zeilen gekappt, alle Instanz-Zeilen weg, kein halber Zustand).
4. **"Alle Termine der Serie"** versorgt alle Segmente ab heute.
5. **Restfehler** (lebendes Segment archiviert, stale Tab) → deutsche Meldung.

Screenshots des kompletten Ablaufs werden als Kommentar-Anhänge nachgereicht.
