### PR TITLE
feat: Lehrkraft-Rolle mit Klassen-Scope als Fundament für die Lehreransicht (#1772)

### DIFF
--- a/backend/api/active/schulhof_handlers_test.go
+++ b/backend/api/active/schulhof_handlers_test.go
@@ -74,6 +74,10 @@ func (m *mockUserContextService) GetMyGroups(ctx context.Context) ([]*education.
 	return nil, errors.New("not implemented")
 }
 
+func (m *mockUserContextService) GetMySchoolClasses(ctx context.Context) ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m *mockUserContextService) ResolveSSESubscription(context.Context) (*usercontextsvc.SSESubscription, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/api/auth/invitation_handlers.go
+++ b/backend/api/auth/invitation_handlers.go
@@ -162,7 +162,8 @@ func renderCreateInvitationError(w http.ResponseWriter, r *http.Request, err err
 	case errors.Is(err, authService.ErrRoleNotAssignable),
 		errors.Is(err, authService.ErrRoleForeignTenant),
 		errors.Is(err, authService.ErrRoleGuardianNotAssignable),
-		errors.Is(err, authService.ErrRoleLegacyTeacherNotAssignable):
+		errors.Is(err, authService.ErrRoleLegacyTeacherNotAssignable),
+		errors.Is(err, authService.ErrLehrkraftNoCaregiver):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 		return true
 	}

--- a/backend/api/staff/api.go
+++ b/backend/api/staff/api.go
@@ -108,9 +108,14 @@ func (rs *Resource) Router() chi.Router {
 
 		// School class assignments (#1772): which classes a Lehrkraft is
 		// responsible for. Reading rides on users:read like the other staff
-		// detail reads; replacing the set is a staff-admin write.
+		// detail reads. Replacing the set is deliberately users:manage, NOT
+		// users:update: the ordinary user role holds users:update, and these
+		// rows scope the Lehrkraft student day view — a self-service PUT
+		// would be a self-granted widening of future student-data access
+		// (same reasoning as /payroll-number and /stammdaten/bank-steuer
+		// using a stricter tier).
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/school-classes", rs.getStaffSchoolClasses)
-		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}/school-classes", rs.updateStaffSchoolClasses)
+		r.With(authorize.RequiresPermission(permissions.UsersManage), withTx).Put("/{id}/school-classes", rs.updateStaffSchoolClasses)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/substitutions", rs.getStaffSubstitutions)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/available", rs.getAvailableStaff)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/available-for-substitution", rs.getAvailableForSubstitution)

--- a/backend/api/staff/api.go
+++ b/backend/api/staff/api.go
@@ -105,6 +105,12 @@ func (rs *Resource) Router() chi.Router {
 		// Other staff reads require users:read permission.
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/avatar", rs.serveStaffAvatar)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/groups", rs.getStaffGroups)
+
+		// School class assignments (#1772): which classes a Lehrkraft is
+		// responsible for. Reading rides on users:read like the other staff
+		// detail reads; replacing the set is a staff-admin write.
+		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/school-classes", rs.getStaffSchoolClasses)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}/school-classes", rs.updateStaffSchoolClasses)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/{id}/substitutions", rs.getStaffSubstitutions)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/available", rs.getAvailableStaff)
 		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/available-for-substitution", rs.getAvailableForSubstitution)

--- a/backend/api/staff/school_class_handlers.go
+++ b/backend/api/staff/school_class_handlers.go
@@ -1,0 +1,90 @@
+package staff
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	educationSvc "github.com/moto-nrw/project-phoenix/services/education"
+)
+
+// SchoolClassesResponse is the wire shape of a staff member's school class
+// assignments (#1772).
+type SchoolClassesResponse struct {
+	StaffID       int64    `json:"staff_id"`
+	SchoolClasses []string `json:"school_classes"`
+}
+
+// SchoolClassesRequest is the PUT body replacing a staff member's school
+// class assignments.
+type SchoolClassesRequest struct {
+	SchoolClasses []string `json:"school_classes"`
+}
+
+// Bind implements render.Binder
+func (req *SchoolClassesRequest) Bind(_ *http.Request) error {
+	if req.SchoolClasses == nil {
+		return errors.New("school_classes is required")
+	}
+	return nil
+}
+
+// schoolClassErrorRules classifies the class-teacher service sentinels:
+// unknown staff → 404, empty class name → 400.
+var schoolClassErrorRules = []common.ErrorRule{
+	{Target: educationSvc.ErrStaffNotFound, Render: func(error) render.Renderer {
+		return common.ErrorNotFound(errors.New(common.MsgStaffNotFound))
+	}},
+	{Target: educationSvc.ErrEmptySchoolClass, Render: common.ErrorInvalidRequest},
+}
+
+func renderSchoolClassError(w http.ResponseWriter, r *http.Request, err error) {
+	common.RenderError(w, r, common.RenderWithRules(err, schoolClassErrorRules, common.ErrorInternalServer))
+}
+
+// getStaffSchoolClasses returns the school classes assigned to a staff member.
+func (rs *Resource) getStaffSchoolClasses(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New(common.MsgInvalidStaffID)))
+		return
+	}
+
+	classes, err := rs.EducationService.GetStaffSchoolClasses(r.Context(), id)
+	if err != nil {
+		renderSchoolClassError(w, r, err)
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, SchoolClassesResponse{StaffID: id, SchoolClasses: classes}, "School classes retrieved successfully")
+}
+
+// updateStaffSchoolClasses replaces the school class assignments of a staff
+// member with the submitted set.
+func (rs *Resource) updateStaffSchoolClasses(w http.ResponseWriter, r *http.Request) {
+	id, err := common.ParseID(r)
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New(common.MsgInvalidStaffID)))
+		return
+	}
+
+	req := &SchoolClassesRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+
+	if err := rs.EducationService.SetStaffSchoolClasses(r.Context(), id, req.SchoolClasses); err != nil {
+		renderSchoolClassError(w, r, err)
+		return
+	}
+
+	classes, err := rs.EducationService.GetStaffSchoolClasses(r.Context(), id)
+	if err != nil {
+		renderSchoolClassError(w, r, err)
+		return
+	}
+
+	common.Respond(w, r, http.StatusOK, SchoolClassesResponse{StaffID: id, SchoolClasses: classes}, "School classes updated successfully")
+}

--- a/backend/api/staff/school_class_handlers.go
+++ b/backend/api/staff/school_class_handlers.go
@@ -32,6 +32,12 @@ func (req *SchoolClassesRequest) Bind(_ *http.Request) error {
 
 // schoolClassErrorRules classifies the class-teacher service sentinels:
 // unknown staff → 404, empty class name → 400.
+//
+// Rendered through common.UnwrapRenderer so the user-facing branches carry
+// just the sentinel message (ErrEmptySchoolClass is a deliberate German
+// string) instead of EducationError's "education: {Op}: …" prefix; the 500
+// fallback keeps the wrapped error for the logs. Same pattern as
+// api/groups/errors.go.
 var schoolClassErrorRules = []common.ErrorRule{
 	{Target: educationSvc.ErrStaffNotFound, Render: func(error) render.Renderer {
 		return common.ErrorNotFound(errors.New(common.MsgStaffNotFound))
@@ -39,8 +45,10 @@ var schoolClassErrorRules = []common.ErrorRule{
 	{Target: educationSvc.ErrEmptySchoolClass, Render: common.ErrorInvalidRequest},
 }
 
+var renderSchoolClass = common.UnwrapRenderer[*educationSvc.EducationError](schoolClassErrorRules, common.ErrorInternalServer)
+
 func renderSchoolClassError(w http.ResponseWriter, r *http.Request, err error) {
-	common.RenderError(w, r, common.RenderWithRules(err, schoolClassErrorRules, common.ErrorInternalServer))
+	common.RenderError(w, r, renderSchoolClass(err))
 }
 
 // getStaffSchoolClasses returns the school classes assigned to a staff member.

--- a/backend/api/staff/school_class_handlers.go
+++ b/backend/api/staff/school_class_handlers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/render"
 	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	educationSvc "github.com/moto-nrw/project-phoenix/services/education"
 )
 
@@ -83,7 +84,15 @@ func (rs *Resource) updateStaffSchoolClasses(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := rs.EducationService.SetStaffSchoolClasses(r.Context(), id, req.SchoolClasses); err != nil {
+	// The audit actor is the authenticated account (like bank-steuer): a
+	// users:manage holder need not have a staff mapping.
+	claims := jwt.ClaimsFromCtx(r.Context())
+	if claims.ID == 0 {
+		common.RenderError(w, r, common.ErrorUnauthorized(errors.New("invalid token")))
+		return
+	}
+
+	if err := rs.EducationService.SetStaffSchoolClasses(r.Context(), id, req.SchoolClasses, int64(claims.ID)); err != nil {
 		renderSchoolClassError(w, r, err)
 		return
 	}

--- a/backend/api/staff/school_classes_api_test.go
+++ b/backend/api/staff/school_classes_api_test.go
@@ -1,6 +1,6 @@
 // Router-level tests for /api/staff/{id}/school-classes (#1772): reading
 // rides on users:read like the other staff detail reads, replacing the set is
-// a users:update staff-admin write.
+// a users:manage admin write (the rows scope the Lehrkraft student day view).
 package staff_test
 
 import (
@@ -23,16 +23,20 @@ func TestSchoolClassesAPI(t *testing.T) {
 	})
 	base := fmt.Sprintf("/staff/%d/school-classes", target.ID)
 
-	// Permission split: users:read may read but not write; the write tier is
-	// users:update.
+	// Permission split: users:read may read but not write. The write tier is
+	// deliberately users:manage — users:update is held by the ordinary user
+	// role, and these rows scope the Lehrkraft student day view, so a
+	// users:update PUT would be a self-service grant of student-data scope.
 	rec := ctx.put(base, `{"school_classes":["1a"]}`, "users:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+	rec = ctx.put(base, `{"school_classes":["1a"]}`, "users:update")
 	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
 	rec = ctx.get(base, "visits:read")
 	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
 
 	// Roundtrip: set, then read back. The response carries the deduped,
 	// trimmed set in class order.
-	rec = ctx.put(base, `{"school_classes":["2b","1a"," 1A "]}`, "users:update")
+	rec = ctx.put(base, `{"school_classes":["2b","1a"," 1A "]}`, "users:manage")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	assert.Contains(t, rec.Body.String(), `"school_classes":["1a","2b"]`)
 
@@ -41,20 +45,20 @@ func TestSchoolClassesAPI(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"school_classes":["1a","2b"]`)
 
 	// Replacing shrinks the set.
-	rec = ctx.put(base, `{"school_classes":["3c"]}`, "users:update")
+	rec = ctx.put(base, `{"school_classes":["3c"]}`, "users:manage")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	assert.Contains(t, rec.Body.String(), `"school_classes":["3c"]`)
 
 	// Blank class names are caller errors; the message is the bare German
 	// sentinel, not the "education: {Op}: …" wrapper (rendered via
 	// UnwrapRenderer — the UI shows this string verbatim).
-	rec = ctx.put(base, `{"school_classes":["  "]}`, "users:update")
+	rec = ctx.put(base, `{"school_classes":["  "]}`, "users:manage")
 	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 	assert.Contains(t, rec.Body.String(), `"Klassenname darf nicht leer sein"`)
 	assert.NotContains(t, rec.Body.String(), "education:")
 
 	// Missing field is a caller error too.
-	rec = ctx.put(base, `{}`, "users:update")
+	rec = ctx.put(base, `{}`, "users:manage")
 	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
 }
 
@@ -68,7 +72,7 @@ func TestSchoolClassesAPI_UnknownStaff(t *testing.T) {
 	rec := ctx.get(base, "users:read")
 	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
 
-	rec = ctx.put(base, `{"school_classes":["1a"]}`, "users:update")
+	rec = ctx.put(base, `{"school_classes":["1a"]}`, "users:manage")
 	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
 }
 

--- a/backend/api/staff/school_classes_api_test.go
+++ b/backend/api/staff/school_classes_api_test.go
@@ -45,9 +45,13 @@ func TestSchoolClassesAPI(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 	assert.Contains(t, rec.Body.String(), `"school_classes":["3c"]`)
 
-	// Blank class names are caller errors.
+	// Blank class names are caller errors; the message is the bare German
+	// sentinel, not the "education: {Op}: …" wrapper (rendered via
+	// UnwrapRenderer — the UI shows this string verbatim).
 	rec = ctx.put(base, `{"school_classes":["  "]}`, "users:update")
 	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"Klassenname darf nicht leer sein"`)
+	assert.NotContains(t, rec.Body.String(), "education:")
 
 	// Missing field is a caller error too.
 	rec = ctx.put(base, `{}`, "users:update")

--- a/backend/api/staff/school_classes_api_test.go
+++ b/backend/api/staff/school_classes_api_test.go
@@ -1,0 +1,75 @@
+// Router-level tests for /api/staff/{id}/school-classes (#1772): reading
+// rides on users:read like the other staff detail reads, replacing the set is
+// a users:update staff-admin write.
+package staff_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchoolClassesAPI(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+	target := testpkg.CreateTestStaff(t, ctx.tc.db, "SchoolClasses", fmt.Sprintf("API-%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		cleanupClassTeacherAssignments(t, ctx, target.ID)
+		testpkg.CleanupStaffFixtures(t, ctx.tc.db, target.ID)
+	})
+	base := fmt.Sprintf("/staff/%d/school-classes", target.ID)
+
+	// Permission split: users:read may read but not write; the write tier is
+	// users:update.
+	rec := ctx.put(base, `{"school_classes":["1a"]}`, "users:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+	rec = ctx.get(base, "visits:read")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+
+	// Roundtrip: set, then read back. The response carries the deduped,
+	// trimmed set in class order.
+	rec = ctx.put(base, `{"school_classes":["2b","1a"," 1A "]}`, "users:update")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"school_classes":["1a","2b"]`)
+
+	rec = ctx.get(base, "users:read")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"school_classes":["1a","2b"]`)
+
+	// Replacing shrinks the set.
+	rec = ctx.put(base, `{"school_classes":["3c"]}`, "users:update")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), `"school_classes":["3c"]`)
+
+	// Blank class names are caller errors.
+	rec = ctx.put(base, `{"school_classes":["  "]}`, "users:update")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+
+	// Missing field is a caller error too.
+	rec = ctx.put(base, `{}`, "users:update")
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+}
+
+func TestSchoolClassesAPI_UnknownStaff(t *testing.T) {
+	ctx := setupOverviewAPI(t)
+	ghost := testpkg.CreateTestStaff(t, ctx.tc.db, "SchoolClasses", fmt.Sprintf("Ghost-%d", time.Now().UnixNano()))
+	ghostID := ghost.ID
+	testpkg.CleanupStaffFixtures(t, ctx.tc.db, ghost.ID)
+	base := fmt.Sprintf("/staff/%d/school-classes", ghostID)
+
+	rec := ctx.get(base, "users:read")
+	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+
+	rec = ctx.put(base, `{"school_classes":["1a"]}`, "users:update")
+	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+}
+
+func cleanupClassTeacherAssignments(t *testing.T, ctx *overviewAPIContext, staffID int64) {
+	t.Helper()
+	tenantCtx := testpkg.TenantContext(1)
+	_, _ = ctx.tc.db.NewDelete().TableExpr("education.class_teachers").Where("staff_id = ?", staffID).Exec(tenantCtx)
+}

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -318,6 +318,7 @@ GET /api/staff/{id}/documents/{documentId}/download
 GET /api/staff/{id}/groups
 GET /api/staff/{id}/payroll-number
 GET /api/staff/{id}/schedule
+GET /api/staff/{id}/school-classes
 GET /api/staff/{id}/stammdaten
 GET /api/staff/{id}/stammdaten/bank-steuer
 GET /api/staff/{id}/substitutions
@@ -848,6 +849,7 @@ PUT /api/staff/pin
 PUT /api/staff/{id}
 PUT /api/staff/{id}/payroll-number
 PUT /api/staff/{id}/schedule
+PUT /api/staff/{id}/school-classes
 PUT /api/staff/{id}/stammdaten/arbeitsvertrag
 PUT /api/staff/{id}/stammdaten/bank-steuer
 PUT /api/staff/{id}/stammdaten/kontakt

--- a/backend/api/usercontext/avatar_access_test.go
+++ b/backend/api/usercontext/avatar_access_test.go
@@ -41,6 +41,10 @@ func (m *mockAvatarUserContextService) GetMyGroups(context.Context) ([]*educatio
 	return nil, errors.New("not implemented")
 }
 
+func (m *mockAvatarUserContextService) GetMySchoolClasses(context.Context) ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m *mockAvatarUserContextService) ResolveSSESubscription(context.Context) (*usercontextsvc.SSESubscription, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/auth/authorize/permissions/constants.go
+++ b/backend/auth/authorize/permissions/constants.go
@@ -237,3 +237,15 @@ const (
 	GradeTransitionsDelete = "grade_transitions:delete"
 	GradeTransitionsApply  = "grade_transitions:apply"
 )
+
+// Class day view permission (#1772). class_day:read gates the read-only
+// per-class daily handoff view for the lehrkraft system role. It is
+// deliberately NOT users:read: holders see only students of the school
+// classes assigned to them via education.class_teachers, never the
+// tenant-wide student directory, so the generic /api/students routes stay
+// closed to them.
+const (
+	ResourceClassDay = "class_day"
+
+	ClassDayRead = ResourceClassDay + ":read"
+)

--- a/backend/auth/authorize/visit_access_test.go
+++ b/backend/auth/authorize/visit_access_test.go
@@ -34,6 +34,7 @@ func setupVisitAccessServices(t *testing.T, db *bun.DB) (education.Service, user
 	eduService := education.NewService(
 		repos.Group,
 		repos.GroupTeacher,
+		repos.ClassTeacher,
 		repos.GroupSubstitution,
 		repos.Room,
 		repos.Teacher,

--- a/backend/database/migrations/001015277_class_teachers.go
+++ b/backend/database/migrations/001015277_class_teachers.go
@@ -1,0 +1,117 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	classTeachersVersion     = "1.15.277"
+	classTeachersDescription = "Staff-to-school-class assignments for the Lehrkraft scope (#1772)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     classTeachersVersion,
+		Description: classTeachersDescription,
+		DependsOn:   []string{studentDocumentsVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return classTeachersUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return classTeachersDown(ctx, db)
+		},
+	)
+}
+
+// classTeachersUp creates education.class_teachers (#1772): one row assigns a
+// staff member to one school class. The class is the free-text
+// users.students.school_class value — deliberately no class entity, matched
+// via LOWER(BTRIM(...)) like the existing student class filters. The
+// assignment is what scopes the read-only Lehrkraft class day view.
+func classTeachersUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.277: Staff-to-school-class assignments...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS education.class_teachers (
+			id           BIGSERIAL PRIMARY KEY,
+			tenant_id    BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			staff_id     BIGINT NOT NULL,
+			school_class TEXT NOT NULL,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT fk_class_teachers_staff FOREIGN KEY (tenant_id, staff_id)
+				REFERENCES users.staff(tenant_id, id) ON DELETE CASCADE,
+			CONSTRAINT chk_class_teachers_school_class CHECK (BTRIM(school_class) <> '')
+		);
+
+		CREATE UNIQUE INDEX IF NOT EXISTS uniq_class_teachers_staff_class
+			ON education.class_teachers (tenant_id, staff_id, LOWER(BTRIM(school_class)));
+
+		CREATE INDEX IF NOT EXISTS idx_class_teachers_tenant_class
+			ON education.class_teachers (tenant_id, LOWER(BTRIM(school_class)));
+
+		DROP TRIGGER IF EXISTS update_class_teachers_updated_at ON education.class_teachers;
+		CREATE TRIGGER update_class_teachers_updated_at
+		BEFORE UPDATE ON education.class_teachers
+		FOR EACH ROW
+		EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE education.class_teachers ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE education.class_teachers FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_education_class_teachers ON education.class_teachers;
+		CREATE POLICY tenant_isolation_education_class_teachers ON education.class_teachers
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON education.class_teachers TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE education.class_teachers_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating education.class_teachers: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func classTeachersDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.277: Dropping education.class_teachers...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		DROP TABLE IF EXISTS education.class_teachers;
+	`)
+	if err != nil {
+		return fmt.Errorf("error dropping education.class_teachers: %w", err)
+	}
+
+	return tx.Commit()
+}

--- a/backend/database/migrations/001015278_lehrkraft_role.go
+++ b/backend/database/migrations/001015278_lehrkraft_role.go
@@ -38,7 +38,7 @@ func init() {
 //     for system roles automatically (createStaffAndTeacherIfSystemRole). No
 //     users.teachers caregiver profile is ever created — the name is NOT in
 //     shouldCreateTeacherForRole, and the caregiver_enabled upgrade is
-//     refused for this role (isLehrkraftSystemRole guards invitation
+//     refused for this role (IsLehrkraftSystemRole guards invitation
 //     creation and both acceptance branches).
 //   - base_role 'user' (the CHECK allows admin/user/guardian only); the name
 //     differs from the retired "teacher" role, which the assignment policy

--- a/backend/database/migrations/001015278_lehrkraft_role.go
+++ b/backend/database/migrations/001015278_lehrkraft_role.go
@@ -35,9 +35,11 @@ func init() {
 // Deliberate choices:
 //   - A system role, not a per-tenant custom role: every school gets it
 //     without setup, and the invitation flow creates the users.staff record
-//     for system roles automatically (createStaffAndTeacherIfSystemRole). The
-//     name is NOT in shouldCreateTeacherForRole, so no users.teachers
-//     caregiver profile is created — a Lehrkraft supervises no OGS group.
+//     for system roles automatically (createStaffAndTeacherIfSystemRole). No
+//     users.teachers caregiver profile is ever created — the name is NOT in
+//     shouldCreateTeacherForRole, and the caregiver_enabled upgrade is
+//     refused for this role (isLehrkraftSystemRole guards invitation
+//     creation and both acceptance branches).
 //   - base_role 'user' (the CHECK allows admin/user/guardian only); the name
 //     differs from the retired "teacher" role, which the assignment policy
 //     blocks by name.

--- a/backend/database/migrations/001015278_lehrkraft_role.go
+++ b/backend/database/migrations/001015278_lehrkraft_role.go
@@ -1,0 +1,110 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	lehrkraftRoleVersion     = "1.15.278"
+	lehrkraftRoleDescription = "Lehrkraft system role with class_day:read permission (#1772)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     lehrkraftRoleVersion,
+		Description: lehrkraftRoleDescription,
+		DependsOn:   []string{classTeachersVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return lehrkraftRoleUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return lehrkraftRoleDown(ctx, db)
+		},
+	)
+}
+
+// lehrkraftRoleUp adds the platform system role "lehrkraft" (#1772): a school
+// teacher who gets a read-only per-class day view and nothing else.
+//
+// Deliberate choices:
+//   - A system role, not a per-tenant custom role: every school gets it
+//     without setup, and the invitation flow creates the users.staff record
+//     for system roles automatically (createStaffAndTeacherIfSystemRole). The
+//     name is NOT in shouldCreateTeacherForRole, so no users.teachers
+//     caregiver profile is created — a Lehrkraft supervises no OGS group.
+//   - base_role 'user' (the CHECK allows admin/user/guardian only); the name
+//     differs from the retired "teacher" role, which the assignment policy
+//     blocks by name.
+//   - Its only permission is class_day:read. No users:read: the generic
+//     student directory routes stay closed, scoping happens exclusively via
+//     education.class_teachers.
+//
+// The insert guards with WHERE NOT EXISTS instead of ON CONFLICT: since
+// migration 1.14.3 the uniqueness of system role names is a partial index
+// (WHERE tenant_id IS NULL), which a bare ON CONFLICT (name) cannot target.
+func lehrkraftRoleUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.278: Lehrkraft system role with class_day:read...")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO auth.roles (name, description, is_system, base_role, tenant_id)
+		SELECT 'lehrkraft',
+		       'Lehrkraft mit Lesezugriff auf die Tagesansicht der zugewiesenen Klassen',
+		       TRUE,
+		       'user',
+		       NULL
+		WHERE NOT EXISTS (
+			SELECT 1 FROM auth.roles WHERE name = 'lehrkraft' AND tenant_id IS NULL
+		)
+	`); err != nil {
+		return fmt.Errorf("error inserting lehrkraft role: %w", err)
+	}
+
+	return grantPermissionToRoles(ctx, db, permissionSpec{
+		Name:        "class_day:read",
+		Description: "Tagesansicht der zugewiesenen Klassen einsehen",
+		Resource:    "class_day",
+		Action:      "read",
+	}, "admin", "lehrkraft")
+}
+
+func lehrkraftRoleDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.278: Removing lehrkraft role and class_day:read...")
+
+	if err := dropPermission(ctx, db, "class_day:read"); err != nil {
+		return err
+	}
+
+	return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM auth.account_roles
+			WHERE role_id IN (
+				SELECT id FROM auth.roles WHERE name = 'lehrkraft' AND tenant_id IS NULL
+			)
+		`); err != nil {
+			return fmt.Errorf("error removing lehrkraft account roles: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM auth.role_permissions
+			WHERE role_id IN (
+				SELECT id FROM auth.roles WHERE name = 'lehrkraft' AND tenant_id IS NULL
+			)
+		`); err != nil {
+			return fmt.Errorf("error removing lehrkraft role permissions: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM auth.roles WHERE name = 'lehrkraft' AND tenant_id IS NULL
+		`); err != nil {
+			return fmt.Errorf("error removing lehrkraft role: %w", err)
+		}
+
+		return nil
+	})
+}

--- a/backend/database/migrations/001015279_class_teacher_transition_history.go
+++ b/backend/database/migrations/001015279_class_teacher_transition_history.go
@@ -1,0 +1,120 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	classTeacherTransitionHistoryVersion     = "1.15.279"
+	classTeacherTransitionHistoryDescription = "Ledger of class-teacher assignment rewrites per grade transition (#1772)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     classTeacherTransitionHistoryVersion,
+		Description: classTeacherTransitionHistoryDescription,
+		DependsOn:   []string{lehrkraftRoleVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return classTeacherTransitionHistoryUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return classTeacherTransitionHistoryDown(ctx, db)
+		},
+	)
+}
+
+// classTeacherTransitionHistoryUp creates
+// education.grade_transition_class_teachers (#1772): the exact ledger of what
+// a grade-transition apply did to education.class_teachers — 'removed' rows
+// it deleted (with their original display form), 'created' rows it inserted.
+// The revert replays this ledger instead of guessing a reverse rename from
+// the mappings, which cannot distinguish a row the apply renamed into "2a"
+// from a pre-existing "2a" assignment it never touched. Mirrors
+// education.grade_transition_history on the student side.
+func classTeacherTransitionHistoryUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.279: Class-teacher transition ledger...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS education.grade_transition_class_teachers (
+			id            BIGSERIAL PRIMARY KEY,
+			tenant_id     BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			transition_id BIGINT NOT NULL REFERENCES education.grade_transitions(id) ON DELETE CASCADE,
+			staff_id      BIGINT NOT NULL,
+			school_class  TEXT NOT NULL,
+			action        TEXT NOT NULL,
+			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT fk_gtct_staff FOREIGN KEY (tenant_id, staff_id)
+				REFERENCES users.staff(tenant_id, id) ON DELETE CASCADE,
+			CONSTRAINT chk_gtct_school_class CHECK (BTRIM(school_class) <> ''),
+			CONSTRAINT chk_gtct_action CHECK (action IN ('removed', 'created'))
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_gtct_tenant_transition
+			ON education.grade_transition_class_teachers (tenant_id, transition_id);
+
+		DROP TRIGGER IF EXISTS update_grade_transition_class_teachers_updated_at ON education.grade_transition_class_teachers;
+		CREATE TRIGGER update_grade_transition_class_teachers_updated_at
+		BEFORE UPDATE ON education.grade_transition_class_teachers
+		FOR EACH ROW
+		EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE education.grade_transition_class_teachers ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE education.grade_transition_class_teachers FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_education_grade_transition_class_teachers ON education.grade_transition_class_teachers;
+		CREATE POLICY tenant_isolation_education_grade_transition_class_teachers ON education.grade_transition_class_teachers
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON education.grade_transition_class_teachers TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE education.grade_transition_class_teachers_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating education.grade_transition_class_teachers: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func classTeacherTransitionHistoryDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.279: Dropping education.grade_transition_class_teachers...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		DROP TABLE IF EXISTS education.grade_transition_class_teachers;
+	`)
+	if err != nil {
+		return fmt.Errorf("error dropping education.grade_transition_class_teachers: %w", err)
+	}
+
+	return tx.Commit()
+}

--- a/backend/database/repositories/education/class_teacher.go
+++ b/backend/database/repositories/education/class_teacher.go
@@ -1,0 +1,70 @@
+// backend/database/repositories/education/class_teacher.go
+package education
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	"github.com/uptrace/bun"
+)
+
+// ClassTeacherRepository implements education.ClassTeacherRepository
+type ClassTeacherRepository struct {
+	*base.Repository[*education.ClassTeacher]
+	db *bun.DB
+}
+
+// NewClassTeacherRepository creates a new ClassTeacherRepository
+func NewClassTeacherRepository(db *bun.DB) education.ClassTeacherRepository {
+	repo := base.NewRepository[*education.ClassTeacher](db, "education.class_teachers", "ClassTeacher")
+	repo.TenantScoped = true
+	return &ClassTeacherRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindByStaff retrieves all class assignments for a staff member
+func (r *ClassTeacherRepository) FindByStaff(ctx context.Context, staffID int64) ([]*education.ClassTeacher, error) {
+	var classTeachers []*education.ClassTeacher
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&classTeachers).
+		ModelTableExpr(`education.class_teachers AS "class_teacher"`).
+		Where(`"class_teacher".staff_id = ?`, staffID).
+		OrderExpr(`LOWER(BTRIM("class_teacher".school_class)) ASC`)
+
+	query = base.WithTenantFilter(ctx, query, "class_teacher")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by staff",
+			Err: err,
+		}
+	}
+
+	return classTeachers, nil
+}
+
+// DeleteByStaffID removes all class assignments for a staff member. Used by
+// staff offboarding, where the staff row is only soft-deleted and the
+// ON DELETE CASCADE therefore never cleans up assignments.
+func (r *ClassTeacherRepository) DeleteByStaffID(ctx context.Context, staffID int64) (int64, error) {
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model((*education.ClassTeacher)(nil)).
+		ModelTableExpr(`education.class_teachers AS "class_teacher"`).
+		Where(`"class_teacher".staff_id = ?`, staffID)
+
+	query = base.WithTenantFilter(ctx, query, "class_teacher")
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return 0, &modelBase.DatabaseError{
+			Op:  "delete by staff id",
+			Err: err,
+		}
+	}
+	rows, _ := result.RowsAffected()
+	return rows, nil
+}

--- a/backend/database/repositories/education/class_teacher_repository_test.go
+++ b/backend/database/repositories/education/class_teacher_repository_test.go
@@ -1,0 +1,109 @@
+package education_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// cleanupClassTeacherRecords removes class-teacher assignments directly
+func cleanupClassTeacherRecords(t *testing.T, db *bun.DB, ids ...int64) {
+	t.Helper()
+	for _, id := range ids {
+		testpkg.CleanupTableRecords(t, db, "education.class_teachers", id)
+	}
+}
+
+func TestClassTeacherRepository_Create(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ClassTeacher
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("creates class assignment", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTCreate", "Staff")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+
+		ct := &education.ClassTeacher{
+			StaffID:     staff.ID,
+			SchoolClass: "1a",
+		}
+
+		err := repo.Create(ctx, ct)
+		require.NoError(t, err)
+		assert.NotZero(t, ct.ID)
+
+		cleanupClassTeacherRecords(t, db, ct.ID)
+	})
+
+	t.Run("rejects duplicate class case-insensitively", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTDupe", "Staff")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+
+		first := testpkg.CreateTestClassTeacher(t, db, staff.ID, "1a")
+		defer cleanupClassTeacherRecords(t, db, first.ID)
+
+		dupe := &education.ClassTeacher{
+			StaffID:     staff.ID,
+			SchoolClass: " 1A ",
+		}
+		err := repo.Create(ctx, dupe)
+		require.Error(t, err, "LOWER(BTRIM(...)) unique index must treat 1a and 1A as the same class")
+	})
+}
+
+func TestClassTeacherRepository_FindByStaff(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ClassTeacher
+	ctx := testpkg.TenantContext(1)
+
+	staff := testpkg.CreateTestStaff(t, db, "CTFind", "Staff")
+	other := testpkg.CreateTestStaff(t, db, "CTFind", "Other")
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+	defer testpkg.CleanupStaffFixtures(t, db, other.ID)
+
+	ctB := testpkg.CreateTestClassTeacher(t, db, staff.ID, "2b")
+	ctA := testpkg.CreateTestClassTeacher(t, db, staff.ID, "1a")
+	ctOther := testpkg.CreateTestClassTeacher(t, db, other.ID, "3c")
+	defer cleanupClassTeacherRecords(t, db, ctA.ID, ctB.ID, ctOther.ID)
+
+	assignments, err := repo.FindByStaff(ctx, staff.ID)
+	require.NoError(t, err)
+	require.Len(t, assignments, 2, "must not see the other staff member's assignment")
+	assert.Equal(t, "1a", assignments[0].SchoolClass, "assignments are ordered by normalized class")
+	assert.Equal(t, "2b", assignments[1].SchoolClass)
+}
+
+func TestClassTeacherRepository_DeleteByStaffID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repo := repositories.NewFactory(db).ClassTeacher
+	ctx := testpkg.TenantContext(1)
+
+	staff := testpkg.CreateTestStaff(t, db, "CTDelete", "Offboarded")
+	other := testpkg.CreateTestStaff(t, db, "CTDelete", "Stays")
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+	defer testpkg.CleanupStaffFixtures(t, db, other.ID)
+
+	ctA := testpkg.CreateTestClassTeacher(t, db, staff.ID, "1a")
+	ctB := testpkg.CreateTestClassTeacher(t, db, staff.ID, "2b")
+	ctOther := testpkg.CreateTestClassTeacher(t, db, other.ID, "1a")
+	defer cleanupClassTeacherRecords(t, db, ctA.ID, ctB.ID, ctOther.ID)
+
+	affected, err := repo.DeleteByStaffID(ctx, staff.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), affected)
+
+	remaining, err := repo.FindByStaff(ctx, other.ID)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1, "the other staff member's assignment must survive")
+}

--- a/backend/database/repositories/education/grade_transition.go
+++ b/backend/database/repositories/education/grade_transition.go
@@ -535,6 +535,56 @@ func (r *GradeTransitionRepository) GetHistory(ctx context.Context, transitionID
 	return history, nil
 }
 
+// CreateClassTeacherHistoryBatch records what an apply did to
+// education.class_teachers (#1772). One transition applies at most once
+// (a reverted transition can never be re-applied), so entries are never
+// cleared or rewritten.
+func (r *GradeTransitionRepository) CreateClassTeacherHistoryBatch(ctx context.Context, history []*education.GradeTransitionClassTeacher) error {
+	if len(history) == 0 {
+		return nil
+	}
+
+	for _, h := range history {
+		if err := h.Validate(); err != nil {
+			return err
+		}
+		base.EnsureTenantID(ctx, h)
+	}
+
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(&history).
+		ModelTableExpr(`education.grade_transition_class_teachers`).
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "create class teacher history batch",
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// GetClassTeacherHistory retrieves the class-teacher ledger of a transition.
+func (r *GradeTransitionRepository) GetClassTeacherHistory(ctx context.Context, transitionID int64) ([]*education.GradeTransitionClassTeacher, error) {
+	var history []*education.GradeTransitionClassTeacher
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`education.grade_transition_class_teachers AS "gtct"`).
+		ColumnExpr(`"gtct".*`).
+		Where(`"gtct".`+whereTransitionID, transitionID).
+		Order("created_at ASC")
+
+	query = base.WithTenantFilter(ctx, query, "gtct")
+
+	if err := query.Scan(ctx, &history); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get class teacher history",
+			Err: err,
+		}
+	}
+
+	return history, nil
+}
+
 // GetDistinctClasses retrieves all distinct school_class values from students
 func (r *GradeTransitionRepository) GetDistinctClasses(ctx context.Context) ([]string, error) {
 	var classes []string

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -97,6 +97,7 @@ type Factory struct {
 	// Education domain
 	Group             educationModels.GroupRepository
 	GroupTeacher      educationModels.GroupTeacherRepository
+	ClassTeacher      educationModels.ClassTeacherRepository
 	GroupSubstitution educationModels.GroupSubstitutionRepository
 	GradeTransition   educationModels.GradeTransitionRepository
 
@@ -312,6 +313,7 @@ func NewFactory(db *bun.DB) *Factory {
 		// Education repositories
 		Group:             education.NewGroupRepository(db),
 		GroupTeacher:      education.NewGroupTeacherRepository(db),
+		ClassTeacher:      education.NewClassTeacherRepository(db),
 		GroupSubstitution: education.NewGroupSubstitutionRepository(db),
 		GradeTransition:   education.NewGradeTransitionRepository(db),
 

--- a/backend/internal/schoolclass/schoolclass.go
+++ b/backend/internal/schoolclass/schoolclass.go
@@ -13,6 +13,15 @@ const (
 	MaxGradeLevel        = 13
 )
 
+// Normalize maps a school class name onto the identity used for matching:
+// trimmed and lowercased. users.students.school_class is free text, so "1a",
+// " 1a " and "1A" must count as the same class everywhere — the DB side uses
+// LOWER(BTRIM(school_class)) indexes, and Go-side comparisons must apply the
+// same rule or class scoping silently misses students.
+func Normalize(class string) string {
+	return strings.ToLower(strings.TrimSpace(class))
+}
+
 // GradePrefix returns the first run of ASCII digits in a school class name
 // ("2a" -> "2", "Klasse 12b" -> "12"), or "" when the class contains no
 // grade number ("Bienen"). Despite the historical name, the number need not

--- a/backend/models/audit/staff_master_data_change.go
+++ b/backend/models/audit/staff_master_data_change.go
@@ -21,6 +21,12 @@ const (
 	// the Dokumente tab (#1424): field_name is the category, old/new carry
 	// the display filename (upload: old empty; delete: new empty).
 	StammdatenSectionDokumente = "dokumente"
+	// StammdatenSectionSchoolClasses records rewrites of a staff member's
+	// school class assignments (#1772): old/new carry the joined class
+	// lists. These rows scope the Lehrkraft student day view, so every
+	// change needs a trace. ChangedBy is the authenticated account ID (like
+	// bank-steuer): the users:manage holder need not have a staff mapping.
+	StammdatenSectionSchoolClasses = "school-classes"
 )
 
 // StaffMasterDataChange is an append-only audit row for one changed
@@ -54,7 +60,8 @@ func (c *StaffMasterDataChange) Validate() error {
 	}
 	switch c.Section {
 	case StammdatenSectionPerson, StammdatenSectionKontakt, StammdatenSectionArbeitsvertrag,
-		StammdatenSectionQualifikation, StammdatenSectionBankSteuer, StammdatenSectionDokumente:
+		StammdatenSectionQualifikation, StammdatenSectionBankSteuer, StammdatenSectionDokumente,
+		StammdatenSectionSchoolClasses:
 		// valid
 	default:
 		return errors.New("unknown stammdaten section")

--- a/backend/models/education/class_teacher.go
+++ b/backend/models/education/class_teacher.go
@@ -1,0 +1,34 @@
+package education
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// ClassTeacher assigns a staff member to a school class (#1772). The class is
+// the free-text users.students.school_class value, matched case-insensitively
+// on LOWER(BTRIM(...)) — there is deliberately no class entity: assignments
+// are redone every school year anyway, and the grade-transition tooling
+// rewrites the student strings. SchoolClass stores the display form as
+// entered; comparisons must go through schoolclass.Normalize.
+type ClassTeacher struct {
+	base.Model `bun:"schema:education,table:class_teachers"`
+	base.TenantModel
+	StaffID     int64  `bun:"staff_id,notnull" json:"staff_id"`
+	SchoolClass string `bun:"school_class,notnull" json:"school_class"`
+}
+
+// Validate ensures class teacher data is valid
+func (ct *ClassTeacher) Validate() error {
+	if ct.StaffID <= 0 {
+		return errors.New("staff ID is required")
+	}
+
+	if strings.TrimSpace(ct.SchoolClass) == "" {
+		return errors.New("school class is required")
+	}
+
+	return nil
+}

--- a/backend/models/education/grade_transition.go
+++ b/backend/models/education/grade_transition.go
@@ -188,6 +188,11 @@ type GradeTransitionRepository interface {
 	CreateHistoryBatch(ctx context.Context, history []*GradeTransitionHistory) error
 	GetHistory(ctx context.Context, transitionID int64) ([]*GradeTransitionHistory, error)
 
+	// Class-teacher ledger (#1772): what the apply did to
+	// education.class_teachers, replayed exactly by the revert.
+	CreateClassTeacherHistoryBatch(ctx context.Context, history []*GradeTransitionClassTeacher) error
+	GetClassTeacherHistory(ctx context.Context, transitionID int64) ([]*GradeTransitionClassTeacher, error)
+
 	// Bulk operations
 	GetDistinctClasses(ctx context.Context) ([]string, error)
 	GetStudentCountByClass(ctx context.Context, className string) (int, error)

--- a/backend/models/education/grade_transition_class_teacher.go
+++ b/backend/models/education/grade_transition_class_teacher.go
@@ -1,0 +1,50 @@
+package education
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// Actions recorded in the class-teacher transition ledger.
+const (
+	// ClassTeacherActionRemoved marks a class_teachers row the apply deleted,
+	// preserving its original display form for the revert.
+	ClassTeacherActionRemoved = "removed"
+	// ClassTeacherActionCreated marks a class_teachers row the apply
+	// inserted; the revert deletes it again if it still exists.
+	ClassTeacherActionCreated = "created"
+)
+
+// GradeTransitionClassTeacher is one ledger entry of what a grade-transition
+// apply did to education.class_teachers (#1772). The revert replays these
+// entries exactly instead of reversing the class mappings — a reverse rename
+// cannot distinguish a row the apply renamed into a class from a pre-existing
+// assignment of that class it never touched. Mirrors GradeTransitionHistory
+// on the student side.
+type GradeTransitionClassTeacher struct {
+	base.Model `bun:"schema:education,table:grade_transition_class_teachers"`
+	base.TenantModel
+	TransitionID int64  `bun:"transition_id,notnull" json:"transition_id"`
+	StaffID      int64  `bun:"staff_id,notnull" json:"staff_id"`
+	SchoolClass  string `bun:"school_class,notnull" json:"school_class"`
+	Action       string `bun:"action,notnull" json:"action"`
+}
+
+// Validate ensures ledger entry data is valid
+func (h *GradeTransitionClassTeacher) Validate() error {
+	if h.TransitionID <= 0 {
+		return errors.New("transition ID is required")
+	}
+	if h.StaffID <= 0 {
+		return errors.New("staff ID is required")
+	}
+	if strings.TrimSpace(h.SchoolClass) == "" {
+		return errors.New("school class is required")
+	}
+	if h.Action != ClassTeacherActionRemoved && h.Action != ClassTeacherActionCreated {
+		return errors.New("action must be removed or created")
+	}
+	return nil
+}

--- a/backend/models/education/repository.go
+++ b/backend/models/education/repository.go
@@ -72,6 +72,19 @@ type GroupTeacherRepository interface {
 	ListGroupTeacherBlockers(ctx context.Context, teacherID, tenantID int64) ([]users.BlockerGroup, error)
 }
 
+// ClassTeacherRepository defines operations for managing staff-to-school-class
+// assignments (#1772). School classes are free-text strings; every class
+// comparison uses LOWER(BTRIM(...)) — see models/education.ClassTeacher.
+type ClassTeacherRepository interface {
+	base.CRUDRepository[*ClassTeacher]
+	// FindByStaff returns the class assignments of one staff member.
+	FindByStaff(ctx context.Context, staffID int64) ([]*ClassTeacher, error)
+	// DeleteByStaffID removes all class assignments for a staff member
+	// (staff offboarding cleanup — staff rows are only soft-deleted, so the
+	// FK cascade never fires).
+	DeleteByStaffID(ctx context.Context, staffID int64) (int64, error)
+}
+
 // GroupSubstitutionRepository defines operations for managing group substitutions
 type GroupSubstitutionRepository interface {
 	base.CRUDRepository[*GroupSubstitution]

--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -192,7 +192,7 @@ func (s *invitationService) ensureRoleAssignable(ctx context.Context, req Invita
 	// caregiver profile — refuse the combination at creation, before any
 	// token exists (#1772). Checked before the OperatorGrant early-return:
 	// the invariant holds for operator-created invitations too.
-	if req.CaregiverEnabled && isLehrkraftSystemRole(role) {
+	if req.CaregiverEnabled && IsLehrkraftSystemRole(role) {
 		return &AuthError{Op: opCreateInvitation, Err: ErrLehrkraftNoCaregiver}
 	}
 
@@ -623,7 +623,7 @@ func (s *invitationService) assignCaregiverRoleIfRequested(ctx context.Context, 
 	}
 	// Defense in depth for tokens minted before the creation-side check
 	// existed: a Lehrkraft invitation never receives the user role (#1772).
-	if isLehrkraftSystemRole(role) {
+	if IsLehrkraftSystemRole(role) {
 		return nil
 	}
 
@@ -680,7 +680,7 @@ func (s *invitationService) createStaffAndTeacherIfSystemRole(
 
 	// A Lehrkraft never gets a caregiver profile, caregiver_enabled or not —
 	// same invariant as assignCaregiverRoleIfRequested (#1772).
-	caregiverUpgrade := invitation.CaregiverEnabled && !isLehrkraftSystemRole(role)
+	caregiverUpgrade := invitation.CaregiverEnabled && !IsLehrkraftSystemRole(role)
 	if !shouldCreateTeacherForRole(role.Name) && !caregiverUpgrade {
 		return nil
 	}

--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -188,6 +188,14 @@ func (s *invitationService) ensureRoleAssignable(ctx context.Context, req Invita
 		return &AuthError{Op: opCreateInvitation, Err: err}
 	}
 
+	// The caregiver upgrade would hand a Lehrkraft the full user role plus a
+	// caregiver profile — refuse the combination at creation, before any
+	// token exists (#1772). Checked before the OperatorGrant early-return:
+	// the invariant holds for operator-created invitations too.
+	if req.CaregiverEnabled && isLehrkraftSystemRole(role) {
+		return &AuthError{Op: opCreateInvitation, Err: ErrLehrkraftNoCaregiver}
+	}
+
 	if req.OperatorGrant {
 		return nil
 	}
@@ -613,6 +621,11 @@ func (s *invitationService) assignCaregiverRoleIfRequested(ctx context.Context, 
 	if shouldCreateTeacherForRole(role.Name) {
 		return nil
 	}
+	// Defense in depth for tokens minted before the creation-side check
+	// existed: a Lehrkraft invitation never receives the user role (#1772).
+	if isLehrkraftSystemRole(role) {
+		return nil
+	}
 
 	userRole, err := ResolveSystemRoleByName(ctx, s.roleRepo, authModels.BaseRoleUser)
 	if err != nil {
@@ -665,7 +678,10 @@ func (s *invitationService) createStaffAndTeacherIfSystemRole(
 		return &AuthError{Op: "create staff", Err: err}
 	}
 
-	if !shouldCreateTeacherForRole(role.Name) && !invitation.CaregiverEnabled {
+	// A Lehrkraft never gets a caregiver profile, caregiver_enabled or not —
+	// same invariant as assignCaregiverRoleIfRequested (#1772).
+	caregiverUpgrade := invitation.CaregiverEnabled && !isLehrkraftSystemRole(role)
+	if !shouldCreateTeacherForRole(role.Name) && !caregiverUpgrade {
 		return nil
 	}
 

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -524,6 +524,10 @@ func TestShouldCreateTeacherForRole(t *testing.T) {
 	require.True(t, shouldCreateTeacherForRole("Teacher"))
 	require.True(t, shouldCreateTeacherForRole("user"))
 	require.False(t, shouldCreateTeacherForRole("admin"))
+	// A Lehrkraft (#1772) gets the staff record every system role gets, but
+	// deliberately no users.teachers caregiver profile: it supervises no OGS
+	// group, its scope comes from education.class_teachers.
+	require.False(t, shouldCreateTeacherForRole("lehrkraft"))
 }
 
 func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(t *testing.T) {

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -552,11 +552,11 @@ func TestShouldCreateTeacherForRole(t *testing.T) {
 // both acceptance branches; a school's custom role sharing the label is a
 // different role and stays eligible.
 func TestIsLehrkraftSystemRole(t *testing.T) {
-	require.True(t, isLehrkraftSystemRole(&authModel.Role{Name: "lehrkraft", IsSystem: true}))
-	require.True(t, isLehrkraftSystemRole(&authModel.Role{Name: " Lehrkraft ", IsSystem: true}))
-	require.False(t, isLehrkraftSystemRole(&authModel.Role{Name: "lehrkraft", IsSystem: false}))
-	require.False(t, isLehrkraftSystemRole(&authModel.Role{Name: "user", IsSystem: true}))
-	require.False(t, isLehrkraftSystemRole(nil))
+	require.True(t, IsLehrkraftSystemRole(&authModel.Role{Name: "lehrkraft", IsSystem: true}))
+	require.True(t, IsLehrkraftSystemRole(&authModel.Role{Name: " Lehrkraft ", IsSystem: true}))
+	require.False(t, IsLehrkraftSystemRole(&authModel.Role{Name: "lehrkraft", IsSystem: false}))
+	require.False(t, IsLehrkraftSystemRole(&authModel.Role{Name: "user", IsSystem: true}))
+	require.False(t, IsLehrkraftSystemRole(nil))
 }
 
 func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(t *testing.T) {

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -184,6 +184,24 @@ func TestInvitationEmailFailureRecordsError(t *testing.T) {
 	require.Len(t, flaky.Messages(), 0)
 }
 
+func TestCreateInvitationRejectsLehrkraftCaregiverCombo(t *testing.T) {
+	service, _, _, roleRepo, _, _, _, _, cleanup := newInvitationTestEnv(t)
+	t.Cleanup(cleanup)
+
+	// The lehrkraft system role (#1772) holds only class_day:read; the
+	// caregiver upgrade would add the full user role plus a caregiver
+	// profile, so the combination must be refused at creation.
+	roleRepo.roles[3] = &authModel.Role{Model: baseModel.Model{ID: 3}, Name: "lehrkraft", IsSystem: true}
+
+	_, err := service.CreateInvitation(context.Background(), InvitationRequest{
+		Email:            "lehrkraft@example.com",
+		RoleID:           3,
+		CreatedBy:        42,
+		CaregiverEnabled: true,
+	})
+	require.ErrorIs(t, err, ErrLehrkraftNoCaregiver)
+}
+
 func TestCreateInvitationInvalidatesExistingTokens(t *testing.T) {
 	service, invitations, _, _, _, _, _, _, cleanup := newInvitationTestEnv(t)
 	t.Cleanup(cleanup)
@@ -528,6 +546,17 @@ func TestShouldCreateTeacherForRole(t *testing.T) {
 	// deliberately no users.teachers caregiver profile: it supervises no OGS
 	// group, its scope comes from education.class_teachers.
 	require.False(t, shouldCreateTeacherForRole("lehrkraft"))
+}
+
+// The caregiver upgrade (#1772) is refused for the lehrkraft SYSTEM role in
+// both acceptance branches; a school's custom role sharing the label is a
+// different role and stays eligible.
+func TestIsLehrkraftSystemRole(t *testing.T) {
+	require.True(t, isLehrkraftSystemRole(&authModel.Role{Name: "lehrkraft", IsSystem: true}))
+	require.True(t, isLehrkraftSystemRole(&authModel.Role{Name: " Lehrkraft ", IsSystem: true}))
+	require.False(t, isLehrkraftSystemRole(&authModel.Role{Name: "lehrkraft", IsSystem: false}))
+	require.False(t, isLehrkraftSystemRole(&authModel.Role{Name: "user", IsSystem: true}))
+	require.False(t, isLehrkraftSystemRole(nil))
 }
 
 func TestAcceptInvitation_AdminCaregiverEnabledCreatesUserRoleAndTeacherProfile(t *testing.T) {

--- a/backend/services/auth/role_assignment_policy.go
+++ b/backend/services/auth/role_assignment_policy.go
@@ -13,6 +13,22 @@ import (
 // before they moved to the user role.
 const legacyTeacherRoleName = "teacher"
 
+// lehrkraftRoleName is the school-teacher system role (#1772). Its whole
+// point is holding ONLY class_day:read — no tenant-wide student directory,
+// no caregiver profile. The caregiver upgrade (caregiver_enabled on an
+// invitation adds the user role plus a users.teachers profile) would undo
+// exactly that, so it is refused for this role.
+const lehrkraftRoleName = "lehrkraft"
+
+// isLehrkraftSystemRole reports whether the role is the platform lehrkraft
+// system role. Name-matched and narrowed to system roles like the legacy
+// teacher block: a school's own custom role that happens to share the label
+// is a different role with school-chosen permissions.
+func isLehrkraftSystemRole(role *authModels.Role) bool {
+	return role != nil && role.IsSystem &&
+		strings.EqualFold(strings.TrimSpace(role.Name), lehrkraftRoleName)
+}
+
 // Which roles may be handed out when an account is attached to a school. Shared
 // by every path that grants school access — operator provisioning, the
 // operator-led school-access management (issue #1021) and the tenant-side
@@ -38,6 +54,12 @@ var (
 	// assignable at this school, but the acting account is not allowed to hand
 	// it out — granting an admin-tier role requires users:manage.
 	ErrRoleGrantNotPermitted = errors.New("Du darfst diese Rolle nicht vergeben") //nolint:staticcheck // ST1005: user-facing German message
+
+	// ErrLehrkraftNoCaregiver is returned when an invitation combines the
+	// lehrkraft role with caregiver_enabled — the upgrade would grant the
+	// full user role and a caregiver profile, defeating the role's
+	// class-scoped read-only design (#1772).
+	ErrLehrkraftNoCaregiver = errors.New("Die Rolle 'Lehrkraft' kann nicht mit Betreuungsrechten kombiniert werden") //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // ValidateAssignableSchoolRole resolves a role and rejects it when it must not

--- a/backend/services/auth/role_assignment_policy.go
+++ b/backend/services/auth/role_assignment_policy.go
@@ -20,11 +20,11 @@ const legacyTeacherRoleName = "teacher"
 // exactly that, so it is refused for this role.
 const lehrkraftRoleName = "lehrkraft"
 
-// isLehrkraftSystemRole reports whether the role is the platform lehrkraft
+// IsLehrkraftSystemRole reports whether the role is the platform lehrkraft
 // system role. Name-matched and narrowed to system roles like the legacy
 // teacher block: a school's own custom role that happens to share the label
 // is a different role with school-chosen permissions.
-func isLehrkraftSystemRole(role *authModels.Role) bool {
+func IsLehrkraftSystemRole(role *authModels.Role) bool {
 	return role != nil && role.IsSystem &&
 		strings.EqualFold(strings.TrimSpace(role.Name), lehrkraftRoleName)
 }

--- a/backend/services/auth/role_assignment_policy_test.go
+++ b/backend/services/auth/role_assignment_policy_test.go
@@ -78,6 +78,16 @@ func TestValidateAssignableSchoolRole(t *testing.T) {
 		assert.Equal(t, roleID, role.ID)
 	})
 
+	t.Run("accepts the lehrkraft system role", func(t *testing.T) {
+		// Seeded by migration 1.15.278 (#1772): assignable like every other
+		// platform system role — the name-based block hits only "teacher".
+		lehrkraftRole := testpkg.GetOrCreateTestRole(t, db, "lehrkraft")
+
+		role, err := authSvc.ValidateAssignableSchoolRole(ctx, roleRepo, lehrkraftRole.ID, homeTenantID)
+		require.NoError(t, err)
+		assert.Equal(t, lehrkraftRole.ID, role.ID)
+	})
+
 	t.Run("rejects the retired teacher role", func(t *testing.T) {
 		// The fixtures suffix role names to keep them unique, so the legacy
 		// role has to be inserted under its exact historical name.

--- a/backend/services/education/class_teacher_service.go
+++ b/backend/services/education/class_teacher_service.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/education"
 )
 
@@ -50,7 +52,12 @@ func (s *service) GetStaffSchoolClasses(ctx context.Context, staffID int64) ([]s
 // and a case-only edit ("1a" -> "1A") updates the stored display form in
 // place. Class names are deliberately NOT validated against the current
 // student classes: assignments may be created before students are imported.
-func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string) error {
+//
+// changedBy is the authenticated account ID; every actual change lands as one
+// audit.staff_master_data_changes row in the same transaction — these
+// assignments scope the Lehrkraft student day view, so no rewrite may happen
+// without a trace.
+func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string, changedBy int64) error {
 	const op = "SetStaffSchoolClasses"
 
 	if err := s.requireStaff(ctx, op, staffID); err != nil {
@@ -98,7 +105,59 @@ func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, clas
 		}
 	}
 
+	if err := s.auditSchoolClassChange(ctx, staffID, changedBy, current, wanted); err != nil {
+		return &EducationError{Op: op, Err: err}
+	}
+
 	return nil
+}
+
+// auditSchoolClassChange records one audit row per actual change of the
+// assignment set, in the same transaction as the writes. No-op when nothing
+// changed or no audit trail is wired (tests, CLI).
+func (s *service) auditSchoolClassChange(
+	ctx context.Context,
+	staffID, changedBy int64,
+	current []*education.ClassTeacher,
+	wanted map[string]string,
+) error {
+	if s.masterDataAudit == nil {
+		return nil
+	}
+
+	oldClasses := make([]string, 0, len(current))
+	for _, assignment := range current {
+		oldClasses = append(oldClasses, assignment.SchoolClass)
+	}
+	newClasses := make([]string, 0, len(wanted))
+	for _, display := range wanted {
+		newClasses = append(newClasses, display)
+	}
+	sortSchoolClasses(oldClasses)
+	sortSchoolClasses(newClasses)
+
+	oldValue := strings.Join(oldClasses, ", ")
+	newValue := strings.Join(newClasses, ", ")
+	if oldValue == newValue {
+		return nil
+	}
+
+	return s.masterDataAudit.Create(ctx, &auditModels.StaffMasterDataChange{
+		StaffID:   staffID,
+		ChangedBy: changedBy,
+		Section:   auditModels.StammdatenSectionSchoolClasses,
+		FieldName: "school_classes",
+		OldValue:  oldValue,
+		NewValue:  newValue,
+	})
+}
+
+// sortSchoolClasses orders class names by their normalized identity so the
+// audit old/new values are stable regardless of input order.
+func sortSchoolClasses(classes []string) {
+	sort.Slice(classes, func(i, j int) bool {
+		return schoolclass.Normalize(classes[i]) < schoolclass.Normalize(classes[j])
+	})
 }
 
 // dedupeSchoolClasses trims the submitted class names and dedupes them by

--- a/backend/services/education/class_teacher_service.go
+++ b/backend/services/education/class_teacher_service.go
@@ -2,17 +2,33 @@ package education
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"strings"
 
 	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
 	"github.com/moto-nrw/project-phoenix/models/education"
 )
 
+// requireStaff resolves the staff existence check shared by both class
+// operations. Only a genuine no-row outcome becomes ErrStaffNotFound (the API
+// maps it to 404); any other failure (aborted tenant tx, dropped connection)
+// keeps its cause and surfaces as a 500 instead of a lying "nicht gefunden".
+func (s *service) requireStaff(ctx context.Context, op string, staffID int64) error {
+	if _, err := s.staffRepo.FindByID(ctx, staffID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &EducationError{Op: op, Err: ErrStaffNotFound}
+		}
+		return &EducationError{Op: op, Err: err}
+	}
+	return nil
+}
+
 // GetStaffSchoolClasses returns the school classes assigned to a staff
 // member, in class order, as the display strings they were entered with.
 func (s *service) GetStaffSchoolClasses(ctx context.Context, staffID int64) ([]string, error) {
-	if _, err := s.staffRepo.FindByID(ctx, staffID); err != nil {
-		return nil, &EducationError{Op: "GetStaffSchoolClasses", Err: ErrStaffNotFound}
+	if err := s.requireStaff(ctx, "GetStaffSchoolClasses", staffID); err != nil {
+		return nil, err
 	}
 
 	assignments, err := s.classTeacherRepo.FindByStaff(ctx, staffID)
@@ -30,33 +46,44 @@ func (s *service) GetStaffSchoolClasses(ctx context.Context, staffID int64) ([]s
 // SetStaffSchoolClasses replaces the staff member's class assignments with
 // the submitted set. Classes are compared via schoolclass.Normalize, so "1a"
 // and " 1A " count as the same assignment; unchanged rows are kept (diff, not
-// delete-all) so their IDs and timestamps survive a resubmit of the same set.
-// Class names are deliberately NOT validated against the current student
-// classes: assignments may be created before students are imported.
+// delete-all) so their IDs and timestamps survive a resubmit of the same set,
+// and a case-only edit ("1a" -> "1A") updates the stored display form in
+// place. Class names are deliberately NOT validated against the current
+// student classes: assignments may be created before students are imported.
 func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string) error {
-	if _, err := s.staffRepo.FindByID(ctx, staffID); err != nil {
-		return &EducationError{Op: "SetStaffSchoolClasses", Err: ErrStaffNotFound}
+	const op = "SetStaffSchoolClasses"
+
+	if err := s.requireStaff(ctx, op, staffID); err != nil {
+		return err
 	}
 
 	wanted, err := dedupeSchoolClasses(classes)
 	if err != nil {
-		return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+		return &EducationError{Op: op, Err: err}
 	}
 
 	current, err := s.classTeacherRepo.FindByStaff(ctx, staffID)
 	if err != nil {
-		return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+		return &EducationError{Op: op, Err: err}
 	}
 
-	currentByKey := make(map[string]int64, len(current))
+	currentByKey := make(map[string]*education.ClassTeacher, len(current))
 	for _, assignment := range current {
-		currentByKey[schoolclass.Normalize(assignment.SchoolClass)] = assignment.ID
+		currentByKey[schoolclass.Normalize(assignment.SchoolClass)] = assignment
 	}
 
-	for key, id := range currentByKey {
-		if _, keep := wanted[key]; !keep {
-			if err := s.classTeacherRepo.Delete(ctx, id); err != nil {
-				return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+	for key, assignment := range currentByKey {
+		display, keep := wanted[key]
+		if !keep {
+			if err := s.classTeacherRepo.Delete(ctx, assignment.ID); err != nil {
+				return &EducationError{Op: op, Err: err}
+			}
+			continue
+		}
+		if assignment.SchoolClass != display {
+			assignment.SchoolClass = display
+			if err := s.classTeacherRepo.Update(ctx, assignment); err != nil {
+				return &EducationError{Op: op, Err: err}
 			}
 		}
 	}
@@ -67,7 +94,7 @@ func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, clas
 		}
 		assignment := &education.ClassTeacher{StaffID: staffID, SchoolClass: display}
 		if err := s.classTeacherRepo.Create(ctx, assignment); err != nil {
-			return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+			return &EducationError{Op: op, Err: err}
 		}
 	}
 

--- a/backend/services/education/class_teacher_service.go
+++ b/backend/services/education/class_teacher_service.go
@@ -74,6 +74,16 @@ func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, clas
 		return &EducationError{Op: op, Err: err}
 	}
 
+	// Snapshot the display strings BEFORE the diff loop: the in-place update
+	// below mutates the same rows `current` points at, and the audit must
+	// record what stood in the DB when the request arrived — a case-only
+	// rename would otherwise compare the new value against itself and skip
+	// the trail.
+	oldClasses := make([]string, 0, len(current))
+	for _, assignment := range current {
+		oldClasses = append(oldClasses, assignment.SchoolClass)
+	}
+
 	currentByKey := make(map[string]*education.ClassTeacher, len(current))
 	for _, assignment := range current {
 		currentByKey[schoolclass.Normalize(assignment.SchoolClass)] = assignment
@@ -105,7 +115,7 @@ func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, clas
 		}
 	}
 
-	if err := s.auditSchoolClassChange(ctx, staffID, changedBy, current, wanted); err != nil {
+	if err := s.auditSchoolClassChange(ctx, staffID, changedBy, oldClasses, wanted); err != nil {
 		return &EducationError{Op: op, Err: err}
 	}
 
@@ -113,22 +123,20 @@ func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, clas
 }
 
 // auditSchoolClassChange records one audit row per actual change of the
-// assignment set, in the same transaction as the writes. No-op when nothing
-// changed or no audit trail is wired (tests, CLI).
+// assignment set, in the same transaction as the writes. oldClasses is the
+// pre-write snapshot of the display strings — never the (by now mutated) rows
+// themselves. No-op when nothing changed or no audit trail is wired (tests,
+// CLI).
 func (s *service) auditSchoolClassChange(
 	ctx context.Context,
 	staffID, changedBy int64,
-	current []*education.ClassTeacher,
+	oldClasses []string,
 	wanted map[string]string,
 ) error {
 	if s.masterDataAudit == nil {
 		return nil
 	}
 
-	oldClasses := make([]string, 0, len(current))
-	for _, assignment := range current {
-		oldClasses = append(oldClasses, assignment.SchoolClass)
-	}
 	newClasses := make([]string, 0, len(wanted))
 	for _, display := range wanted {
 		newClasses = append(newClasses, display)

--- a/backend/services/education/class_teacher_service.go
+++ b/backend/services/education/class_teacher_service.go
@@ -1,0 +1,92 @@
+package education
+
+import (
+	"context"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
+	"github.com/moto-nrw/project-phoenix/models/education"
+)
+
+// GetStaffSchoolClasses returns the school classes assigned to a staff
+// member, in class order, as the display strings they were entered with.
+func (s *service) GetStaffSchoolClasses(ctx context.Context, staffID int64) ([]string, error) {
+	if _, err := s.staffRepo.FindByID(ctx, staffID); err != nil {
+		return nil, &EducationError{Op: "GetStaffSchoolClasses", Err: ErrStaffNotFound}
+	}
+
+	assignments, err := s.classTeacherRepo.FindByStaff(ctx, staffID)
+	if err != nil {
+		return nil, &EducationError{Op: "GetStaffSchoolClasses", Err: err}
+	}
+
+	classes := make([]string, 0, len(assignments))
+	for _, assignment := range assignments {
+		classes = append(classes, assignment.SchoolClass)
+	}
+	return classes, nil
+}
+
+// SetStaffSchoolClasses replaces the staff member's class assignments with
+// the submitted set. Classes are compared via schoolclass.Normalize, so "1a"
+// and " 1A " count as the same assignment; unchanged rows are kept (diff, not
+// delete-all) so their IDs and timestamps survive a resubmit of the same set.
+// Class names are deliberately NOT validated against the current student
+// classes: assignments may be created before students are imported.
+func (s *service) SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string) error {
+	if _, err := s.staffRepo.FindByID(ctx, staffID); err != nil {
+		return &EducationError{Op: "SetStaffSchoolClasses", Err: ErrStaffNotFound}
+	}
+
+	wanted, err := dedupeSchoolClasses(classes)
+	if err != nil {
+		return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+	}
+
+	current, err := s.classTeacherRepo.FindByStaff(ctx, staffID)
+	if err != nil {
+		return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+	}
+
+	currentByKey := make(map[string]int64, len(current))
+	for _, assignment := range current {
+		currentByKey[schoolclass.Normalize(assignment.SchoolClass)] = assignment.ID
+	}
+
+	for key, id := range currentByKey {
+		if _, keep := wanted[key]; !keep {
+			if err := s.classTeacherRepo.Delete(ctx, id); err != nil {
+				return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+			}
+		}
+	}
+
+	for key, display := range wanted {
+		if _, exists := currentByKey[key]; exists {
+			continue
+		}
+		assignment := &education.ClassTeacher{StaffID: staffID, SchoolClass: display}
+		if err := s.classTeacherRepo.Create(ctx, assignment); err != nil {
+			return &EducationError{Op: "SetStaffSchoolClasses", Err: err}
+		}
+	}
+
+	return nil
+}
+
+// dedupeSchoolClasses trims the submitted class names and dedupes them by
+// their normalized identity, keeping the first display form. An entry that is
+// empty after trimming is a caller error, not something to skip silently.
+func dedupeSchoolClasses(classes []string) (map[string]string, error) {
+	wanted := make(map[string]string, len(classes))
+	for _, class := range classes {
+		key := schoolclass.Normalize(class)
+		if key == "" {
+			return nil, ErrEmptySchoolClass
+		}
+		if _, seen := wanted[key]; !seen {
+			wanted[key] = strings.TrimSpace(class)
+		}
+	}
+	return wanted, nil
+}

--- a/backend/services/education/class_teacher_service_test.go
+++ b/backend/services/education/class_teacher_service_test.go
@@ -168,6 +168,12 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b"}, actor.ID))
 		assert.Equal(t, 2, auditCount(), "a replace is a change")
 
+		// A case-only rename mutates the same rows the audit snapshot is
+		// derived from — the trail must still record it (the exact casing
+		// decides how a grade transition matches this teacher).
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2B"}, actor.ID))
+		assert.Equal(t, 3, auditCount(), "a case-only rename is a change and must be audited")
+
 		var row struct {
 			ChangedBy int64  `bun:"changed_by"`
 			OldValue  string `bun:"old_value"`
@@ -183,8 +189,8 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 			Scan(ctx, &row)
 		require.NoError(t, err)
 		assert.Equal(t, actor.ID, row.ChangedBy)
-		assert.Equal(t, "1a", row.OldValue)
-		assert.Equal(t, "2b", row.NewValue)
+		assert.Equal(t, "2b", row.OldValue, "the audit must snapshot the pre-write display form")
+		assert.Equal(t, "2B", row.NewValue)
 	})
 
 	t.Run("rejects blank class names", func(t *testing.T) {

--- a/backend/services/education/class_teacher_service_test.go
+++ b/backend/services/education/class_teacher_service_test.go
@@ -1,0 +1,135 @@
+package education_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	educationSvc "github.com/moto-nrw/project-phoenix/services/education"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func setupClassTeacherService(t *testing.T, db *bun.DB) (educationSvc.Service, *repositories.Factory) {
+	t.Helper()
+	repos := repositories.NewFactory(db)
+	svc := educationSvc.NewService(
+		repos.Group,
+		repos.GroupTeacher,
+		repos.ClassTeacher,
+		repos.GroupSubstitution,
+		repos.Room,
+		repos.Teacher,
+		repos.Staff,
+		repos.Student,
+	)
+	return svc, repos
+}
+
+func cleanupClassAssignments(t *testing.T, db *bun.DB, staffID int64) {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	_, _ = db.NewDelete().TableExpr("education.class_teachers").Where("staff_id = ?", staffID).Exec(ctx)
+}
+
+func TestSetStaffSchoolClasses(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, repos := setupClassTeacherService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	t.Run("assigns and reads classes", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Assign")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "1a"}))
+
+		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1a", "2b"}, classes)
+	})
+
+	t.Run("dedupes case-insensitively and trims", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Dedupe")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", " 1A ", "2b"}))
+
+		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1a", "2b"}, classes)
+	})
+
+	t.Run("resubmitting the same set keeps existing rows", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Resubmit")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "2b"}))
+		before, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
+		require.NoError(t, err)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "1a"}))
+		after, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
+		require.NoError(t, err)
+
+		require.Len(t, after, len(before))
+		for i := range before {
+			assert.Equal(t, before[i].ID, after[i].ID, "unchanged assignments must keep their row")
+		}
+	})
+
+	t.Run("replaces the set with a diff", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Replace")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "2b"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "3c"}))
+
+		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"2b", "3c"}, classes)
+	})
+
+	t.Run("clears assignments with an empty set", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Clear")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{}))
+
+		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
+		require.NoError(t, err)
+		assert.Empty(t, classes)
+	})
+
+	t.Run("rejects blank class names", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Blank")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+
+		err := svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "   "})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, educationSvc.ErrEmptySchoolClass))
+	})
+
+	t.Run("rejects unknown staff", func(t *testing.T) {
+		ghost := testpkg.CreateTestStaff(t, db, "CTSvc", "Ghost")
+		ghostID := ghost.ID
+		testpkg.CleanupStaffFixtures(t, db, ghost.ID)
+
+		err := svc.SetStaffSchoolClasses(ctx, ghostID, []string{"1a"})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, educationSvc.ErrStaffNotFound))
+
+		_, err = svc.GetStaffSchoolClasses(ctx, ghostID)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, educationSvc.ErrStaffNotFound))
+	})
+}

--- a/backend/services/education/class_teacher_service_test.go
+++ b/backend/services/education/class_teacher_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	educationSvc "github.com/moto-nrw/project-phoenix/services/education"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,13 @@ func setupClassTeacherService(t *testing.T, db *bun.DB) (educationSvc.Service, *
 		repos.Staff,
 		repos.Student,
 	)
+	// Same duck-typed wiring the service factory uses: assignment rewrites
+	// must land in the Stammdaten audit trail.
+	if auditAware, ok := svc.(interface {
+		SetMasterDataAudit(auditModels.StaffMasterDataChangeCreator)
+	}); ok {
+		auditAware.SetMasterDataAudit(repos.StaffMasterDataChange)
+	}
 	return svc, repos
 }
 
@@ -41,12 +49,15 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 	svc, repos := setupClassTeacherService(t, db)
 	ctx := testpkg.TenantContext(1)
 
+	actor := testpkg.CreateTestAccount(t, db, "class-teacher-actor@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, actor.ID)
+
 	t.Run("assigns and reads classes", func(t *testing.T) {
 		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Assign")
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer cleanupClassAssignments(t, db, staff.ID)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "1a"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "1a"}, actor.ID))
 
 		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
 		require.NoError(t, err)
@@ -58,7 +69,7 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer cleanupClassAssignments(t, db, staff.ID)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", " 1A ", "2b"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", " 1A ", "2b"}, actor.ID))
 
 		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
 		require.NoError(t, err)
@@ -70,11 +81,11 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer cleanupClassAssignments(t, db, staff.ID)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "2b"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "2b"}, actor.ID))
 		before, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
 		require.NoError(t, err)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "1a"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "1a"}, actor.ID))
 		after, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
 		require.NoError(t, err)
 
@@ -89,12 +100,12 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer cleanupClassAssignments(t, db, staff.ID)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}, actor.ID))
 		before, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
 		require.NoError(t, err)
 		require.Len(t, before, 1)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1A"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1A"}, actor.ID))
 		after, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
 		require.NoError(t, err)
 		require.Len(t, after, 1)
@@ -107,8 +118,8 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer cleanupClassAssignments(t, db, staff.ID)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "2b"}))
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "3c"}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "2b"}, actor.ID))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b", "3c"}, actor.ID))
 
 		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
 		require.NoError(t, err)
@@ -120,19 +131,67 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 		defer cleanupClassAssignments(t, db, staff.ID)
 
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}))
-		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{}))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}, actor.ID))
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{}, actor.ID))
 
 		classes, err := svc.GetStaffSchoolClasses(ctx, staff.ID)
 		require.NoError(t, err)
 		assert.Empty(t, classes)
 	})
 
+	t.Run("audits every actual change, skips no-ops", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Audit")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+		defer func() {
+			tenantCtx := testpkg.TenantContext(1)
+			_, _ = db.NewDelete().TableExpr("audit.staff_master_data_changes").
+				Where("staff_id = ?", staff.ID).Exec(tenantCtx)
+		}()
+
+		auditCount := func() int {
+			count, err := db.NewSelect().
+				TableExpr("audit.staff_master_data_changes").
+				Where("staff_id = ?", staff.ID).
+				Where("section = ?", auditModels.StammdatenSectionSchoolClasses).
+				Count(ctx)
+			require.NoError(t, err)
+			return count
+		}
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}, actor.ID))
+		assert.Equal(t, 1, auditCount(), "the initial assignment is a change")
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}, actor.ID))
+		assert.Equal(t, 1, auditCount(), "a no-op resubmit must not write a row")
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"2b"}, actor.ID))
+		assert.Equal(t, 2, auditCount(), "a replace is a change")
+
+		var row struct {
+			ChangedBy int64  `bun:"changed_by"`
+			OldValue  string `bun:"old_value"`
+			NewValue  string `bun:"new_value"`
+		}
+		err := db.NewSelect().
+			TableExpr("audit.staff_master_data_changes").
+			Column("changed_by", "old_value", "new_value").
+			Where("staff_id = ?", staff.ID).
+			Where("section = ?", auditModels.StammdatenSectionSchoolClasses).
+			OrderExpr("id DESC").
+			Limit(1).
+			Scan(ctx, &row)
+		require.NoError(t, err)
+		assert.Equal(t, actor.ID, row.ChangedBy)
+		assert.Equal(t, "1a", row.OldValue)
+		assert.Equal(t, "2b", row.NewValue)
+	})
+
 	t.Run("rejects blank class names", func(t *testing.T) {
 		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Blank")
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
 
-		err := svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "   "})
+		err := svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a", "   "}, actor.ID)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, educationSvc.ErrEmptySchoolClass))
 	})
@@ -142,7 +201,7 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		ghostID := ghost.ID
 		testpkg.CleanupStaffFixtures(t, db, ghost.ID)
 
-		err := svc.SetStaffSchoolClasses(ctx, ghostID, []string{"1a"})
+		err := svc.SetStaffSchoolClasses(ctx, ghostID, []string{"1a"}, actor.ID)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, educationSvc.ErrStaffNotFound))
 

--- a/backend/services/education/class_teacher_service_test.go
+++ b/backend/services/education/class_teacher_service_test.go
@@ -84,6 +84,24 @@ func TestSetStaffSchoolClasses(t *testing.T) {
 		}
 	})
 
+	t.Run("case-only edit updates the stored display form in place", func(t *testing.T) {
+		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "CaseEdit")
+		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		defer cleanupClassAssignments(t, db, staff.ID)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1a"}))
+		before, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
+		require.NoError(t, err)
+		require.Len(t, before, 1)
+
+		require.NoError(t, svc.SetStaffSchoolClasses(ctx, staff.ID, []string{"1A"}))
+		after, err := repos.ClassTeacher.FindByStaff(ctx, staff.ID)
+		require.NoError(t, err)
+		require.Len(t, after, 1)
+		assert.Equal(t, before[0].ID, after[0].ID, "a case edit must not recreate the row")
+		assert.Equal(t, "1A", after[0].SchoolClass, "the submitted casing must win")
+	})
+
 	t.Run("replaces the set with a diff", func(t *testing.T) {
 		staff := testpkg.CreateTestStaff(t, db, "CTSvc", "Replace")
 		defer testpkg.CleanupStaffFixtures(t, db, staff.ID)

--- a/backend/services/education/education_service.go
+++ b/backend/services/education/education_service.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/education"
 	"github.com/moto-nrw/project-phoenix/models/facilities"
@@ -30,12 +31,24 @@ type service struct {
 	// that decides group access (#2084). Optional: services constructed without
 	// one (tests, CLI) simply emit nothing, they never fail the write.
 	broadcaster realtime.Broadcaster
+
+	// masterDataAudit records class assignment rewrites (#1772) in
+	// audit.staff_master_data_changes. Optional like the broadcaster.
+	masterDataAudit auditModels.StaffMasterDataChangeCreator
 }
 
 // SetBroadcaster wires the SSE hub after construction, matching the
 // duck-typed SetBroadcaster block the service factory already uses for every
 // other broadcasting service.
 func (s *service) SetBroadcaster(b realtime.Broadcaster) { s.broadcaster = b }
+
+// SetMasterDataAudit wires the append-only Stammdaten audit trail after
+// construction (#1772): class assignment rewrites scope the Lehrkraft student
+// day view, so SetStaffSchoolClasses records every change. Optional like the
+// broadcaster — services constructed without it (tests, CLI) skip the trail.
+func (s *service) SetMasterDataAudit(creator auditModels.StaffMasterDataChangeCreator) {
+	s.masterDataAudit = creator
+}
 
 // announceGroupAccessChanged queues the tenant-wide invalidation for a write
 // that changed who may open which group. Education writes funnel through here,

--- a/backend/services/education/education_service.go
+++ b/backend/services/education/education_service.go
@@ -19,6 +19,7 @@ import (
 type service struct {
 	groupRepo        education.GroupRepository
 	groupTeacherRepo education.GroupTeacherRepository
+	classTeacherRepo education.ClassTeacherRepository
 	substitutionRepo education.GroupSubstitutionRepository
 	roomRepo         facilities.RoomRepository
 	teacherRepo      users.TeacherRepository
@@ -48,6 +49,7 @@ func (s *service) announceGroupAccessChanged(ctx context.Context, source string)
 func NewService(
 	groupRepo education.GroupRepository,
 	groupTeacherRepo education.GroupTeacherRepository,
+	classTeacherRepo education.ClassTeacherRepository,
 	substitutionRepo education.GroupSubstitutionRepository,
 	roomRepo facilities.RoomRepository,
 	teacherRepo users.TeacherRepository,
@@ -57,6 +59,7 @@ func NewService(
 	return &service{
 		groupRepo:        groupRepo,
 		groupTeacherRepo: groupTeacherRepo,
+		classTeacherRepo: classTeacherRepo,
 		substitutionRepo: substitutionRepo,
 		roomRepo:         roomRepo,
 		teacherRepo:      teacherRepo,

--- a/backend/services/education/education_service_test.go
+++ b/backend/services/education/education_service_test.go
@@ -25,6 +25,7 @@ func setupEducationService(t *testing.T, db *bun.DB) educationSvc.Service {
 	return educationSvc.NewService(
 		repoFactory.Group,
 		repoFactory.GroupTeacher,
+		repoFactory.ClassTeacher,
 		repoFactory.GroupSubstitution,
 		repoFactory.Room,
 		repoFactory.Teacher,

--- a/backend/services/education/errors.go
+++ b/backend/services/education/errors.go
@@ -9,6 +9,8 @@ import (
 var (
 	ErrGroupNotFound           = errors.New("education group not found")
 	ErrTeacherNotFound         = errors.New("teacher not found")
+	ErrStaffNotFound           = errors.New("staff member not found")
+	ErrEmptySchoolClass        = errors.New("Klassenname darf nicht leer sein") //nolint:staticcheck // ST1005: user-facing German message
 	ErrGroupTeacherNotFound    = errors.New("group-teacher relationship not found")
 	ErrSubstitutionNotFound    = errors.New("substitution not found")
 	ErrRoomNotFound            = errors.New("room not found")

--- a/backend/services/education/grade_transition_class_teachers.go
+++ b/backend/services/education/grade_transition_class_teachers.go
@@ -145,13 +145,25 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(
 // removed are restored with their original display form. Rows the apply never
 // touched — a pre-existing assignment of a rename target, say — have no
 // ledger entry and stay untouched, which is exactly what the mapping-derived
-// reverse rename could not guarantee. Assignments the admin changed between
-// apply and revert win: a created row already deleted is skipped, a restore
-// colliding with a current assignment is skipped, and a restore for a staff
-// member offboarded since the apply is skipped too (offboarding cleared
-// their assignments; the soft-deleted staff row would otherwise satisfy the
-// FK and resurrect scope for a person the normal write path 404s on).
-func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Context, transitionID int64) error {
+// reverse rename could not guarantee.
+//
+// Assignments the admin changed between apply and revert win. Concretely:
+//   - a created row the admin already deleted is not deleted again, AND its
+//     paired removed entry is not restored — the admin deliberately took the
+//     class away from this teacher, and restoring the pre-apply name would
+//     silently re-grant student-data scope (a removed entry whose rename
+//     target has no created ledger entry at all — merge dedupe, graduation —
+//     has no such pair and restores as before);
+//   - a restore colliding with a current assignment is skipped;
+//   - a restore for a staff member offboarded since the apply is skipped too
+//     (offboarding cleared their assignments; the soft-deleted staff row
+//     would otherwise satisfy the FK and resurrect scope for a person the
+//     normal write path 404s on).
+func (s *GradeTransitionService) revertClassTeacherAssignments(
+	ctx context.Context,
+	transitionID int64,
+	mappings []*education.GradeTransitionMapping,
+) error {
 	if s.classTeacherRepo == nil {
 		return nil
 	}
@@ -163,6 +175,8 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Conte
 	if len(ledger) == 0 {
 		return nil
 	}
+
+	renames := classTeacherRenames(mappings)
 
 	liveStaff, err := s.liveLedgerStaff(ctx, ledger)
 	if err != nil {
@@ -183,16 +197,24 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Conte
 		current[staffClass{assignment.StaffID, schoolclass.Normalize(assignment.SchoolClass)}] = assignment
 	}
 
+	// ledgerCreated: (staff, class) pairs the apply inserted at all.
+	// deletedCreated: the subset this revert actually found and deleted —
+	// a pair in the first set but not the second was removed by the admin
+	// after the apply, and its paired restore must not happen.
+	ledgerCreated := make(map[staffClass]bool)
+	deletedCreated := make(map[staffClass]bool)
 	for _, entry := range ledger {
 		if entry.Action != education.ClassTeacherActionCreated {
 			continue
 		}
 		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
+		ledgerCreated[key] = true
 		if row, ok := current[key]; ok {
 			if err := s.classTeacherRepo.Delete(ctx, row.ID); err != nil {
 				return fmt.Errorf("failed to delete class teacher assignment: %w", err)
 			}
 			delete(current, key)
+			deletedCreated[key] = true
 		}
 	}
 
@@ -202,6 +224,12 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Conte
 		}
 		if !liveStaff[entry.StaffID] {
 			continue // offboarded since the apply — do not resurrect scope
+		}
+		if target := renames[strings.TrimSpace(entry.SchoolClass)]; target != "" {
+			pair := staffClass{entry.StaffID, schoolclass.Normalize(target)}
+			if ledgerCreated[pair] && !deletedCreated[pair] {
+				continue // the admin removed the renamed row after the apply
+			}
 		}
 		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
 		if _, taken := current[key]; taken {

--- a/backend/services/education/grade_transition_class_teachers.go
+++ b/backend/services/education/grade_transition_class_teachers.go
@@ -3,18 +3,28 @@ package education
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
 	"github.com/moto-nrw/project-phoenix/models/education"
 )
 
 // classTeacherRenames builds the rename map an apply implies for the
-// Klassenlehrer assignments: normalized from-class → to-class display form,
+// Klassenlehrer assignments: trimmed from-class → to-class display form,
 // where an empty target means the class graduates and its assignments are
-// dropped. There is deliberately no reverse variant — the revert replays the
-// recorded ledger instead, because a reverse rename cannot distinguish a row
-// the apply renamed into a class from a pre-existing assignment of that class
-// it never touched.
+// dropped.
+//
+// Keys are EXACT (trimmed) matches, deliberately NOT schoolclass.Normalize:
+// the student side promotes on exact school_class equality
+// (PromoteStudentsByIDs), so the teacher rows must move under precisely the
+// same condition. With normalized keys a teacher assigned "1A" would be
+// remapped while the "1A" children stay put, and two mappings normalizing
+// identically ("1a"→"2a" and "1A"→"2B") would collapse to one entry.
+//
+// There is deliberately no reverse variant — the revert replays the recorded
+// ledger instead, because a reverse rename cannot distinguish a row the apply
+// renamed into a class from a pre-existing assignment of that class it never
+// touched.
 func classTeacherRenames(mappings []*education.GradeTransitionMapping) map[string]string {
 	renames := make(map[string]string, len(mappings))
 	for _, mapping := range mappings {
@@ -22,10 +32,10 @@ func classTeacherRenames(mappings []*education.GradeTransitionMapping) map[strin
 			continue
 		}
 		if mapping.IsGraduating() {
-			renames[schoolclass.Normalize(mapping.FromClass)] = ""
+			renames[strings.TrimSpace(mapping.FromClass)] = ""
 			continue
 		}
-		renames[schoolclass.Normalize(mapping.FromClass)] = *mapping.ToClass
+		renames[strings.TrimSpace(mapping.FromClass)] = *mapping.ToClass
 	}
 	return renames
 }
@@ -66,11 +76,13 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(
 	}
 
 	// Normalized class names each staff member keeps untouched — renamed rows
-	// must not collide with these on re-insert.
+	// must not collide with these on re-insert. Affected-row matching is
+	// exact (trimmed), mirroring the student promotion; only the collision
+	// bookkeeping is normalized, because that is what the unique index sees.
 	kept := make(map[int64]map[string]bool, len(assignments))
 	var affected []*education.ClassTeacher
 	for _, assignment := range assignments {
-		if _, hit := renames[schoolclass.Normalize(assignment.SchoolClass)]; hit {
+		if _, hit := renames[strings.TrimSpace(assignment.SchoolClass)]; hit {
 			affected = append(affected, assignment)
 			continue
 		}
@@ -98,7 +110,7 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(
 	}
 
 	for _, assignment := range affected {
-		target := renames[schoolclass.Normalize(assignment.SchoolClass)]
+		target := renames[strings.TrimSpace(assignment.SchoolClass)]
 		if target == "" {
 			continue // graduated — assignment is dropped
 		}
@@ -135,7 +147,10 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(
 // ledger entry and stay untouched, which is exactly what the mapping-derived
 // reverse rename could not guarantee. Assignments the admin changed between
 // apply and revert win: a created row already deleted is skipped, a restore
-// colliding with a current assignment is skipped.
+// colliding with a current assignment is skipped, and a restore for a staff
+// member offboarded since the apply is skipped too (offboarding cleared
+// their assignments; the soft-deleted staff row would otherwise satisfy the
+// FK and resurrect scope for a person the normal write path 404s on).
 func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Context, transitionID int64) error {
 	if s.classTeacherRepo == nil {
 		return nil
@@ -147,6 +162,11 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Conte
 	}
 	if len(ledger) == 0 {
 		return nil
+	}
+
+	liveStaff, err := s.liveLedgerStaff(ctx, ledger)
+	if err != nil {
+		return err
 	}
 
 	assignments, err := s.classTeacherRepo.List(ctx, nil)
@@ -180,6 +200,9 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Conte
 		if entry.Action != education.ClassTeacherActionRemoved {
 			continue
 		}
+		if !liveStaff[entry.StaffID] {
+			continue // offboarded since the apply — do not resurrect scope
+		}
 		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
 		if _, taken := current[key]; taken {
 			continue
@@ -192,4 +215,32 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Conte
 	}
 
 	return nil
+}
+
+// liveLedgerStaff resolves which staff members named in the ledger still
+// exist as live (non-soft-deleted) rows. FindByIDs filters soft deletes, so
+// an offboarded staff member simply drops out of the map.
+func (s *GradeTransitionService) liveLedgerStaff(ctx context.Context, ledger []*education.GradeTransitionClassTeacher) (map[int64]bool, error) {
+	staffIDs := make([]int64, 0, len(ledger))
+	seen := make(map[int64]bool, len(ledger))
+	for _, entry := range ledger {
+		if entry.Action != education.ClassTeacherActionRemoved || seen[entry.StaffID] {
+			continue
+		}
+		seen[entry.StaffID] = true
+		staffIDs = append(staffIDs, entry.StaffID)
+	}
+	if len(staffIDs) == 0 {
+		return map[int64]bool{}, nil
+	}
+
+	staffRows, err := s.staffRepo.FindByIDs(ctx, staffIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve ledger staff: %w", err)
+	}
+	live := make(map[int64]bool, len(staffRows))
+	for id := range staffRows {
+		live[id] = true
+	}
+	return live, nil
 }

--- a/backend/services/education/grade_transition_class_teachers.go
+++ b/backend/services/education/grade_transition_class_teachers.go
@@ -154,6 +154,16 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(
 //     silently re-grant student-data scope (a removed entry whose rename
 //     target has no created ledger entry at all — merge dedupe, graduation —
 //     has no such pair and restores as before);
+//   - in a rename chain ("1a"→"2a" while "2a"→"3a") the middle class is
+//     dual-role: a created target (paired with the removed "1a") AND a
+//     restore source (its own removed entry). An admin removal of that name
+//     must suppress BOTH roles, so a removed entry whose OWN class is a
+//     created target the admin deleted is skipped too — otherwise the revert
+//     re-creates the very name the admin just removed, and any student still
+//     carrying that name (enrolled after the cohort lock, so never renamed by
+//     the replay) would land back in the teacher's scope. The teacher may
+//     lose sight of a cohort the admin left alone under its renamed name;
+//     that errs on the side of less scope, and the admin can re-assign;
 //   - a restore colliding with a current assignment is skipped;
 //   - a restore for a staff member offboarded since the apply is skipped too
 //     (offboarding cleared their assignments; the soft-deleted staff row
@@ -225,13 +235,21 @@ func (s *GradeTransitionService) revertClassTeacherAssignments(
 		if !liveStaff[entry.StaffID] {
 			continue // offboarded since the apply — do not resurrect scope
 		}
+		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
+		if ledgerCreated[key] && !deletedCreated[key] {
+			// Dual-role name in a rename chain (or a graduation whose class
+			// was simultaneously a rename target): the class this entry would
+			// restore is itself a row the apply created and the admin has
+			// deleted since. Re-creating that name would re-grant scope the
+			// admin explicitly removed.
+			continue
+		}
 		if target := renames[strings.TrimSpace(entry.SchoolClass)]; target != "" {
 			pair := staffClass{entry.StaffID, schoolclass.Normalize(target)}
 			if ledgerCreated[pair] && !deletedCreated[pair] {
 				continue // the admin removed the renamed row after the apply
 			}
 		}
-		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
 		if _, taken := current[key]; taken {
 			continue
 		}

--- a/backend/services/education/grade_transition_class_teachers.go
+++ b/backend/services/education/grade_transition_class_teachers.go
@@ -1,0 +1,108 @@
+package education
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
+	"github.com/moto-nrw/project-phoenix/models/education"
+)
+
+// classTeacherRenames builds the rename map a transition implies for the
+// Klassenlehrer assignments: normalized from-class → to-class display form,
+// where an empty target means the class graduates and its assignments are
+// dropped. reverse=true builds the revert direction (to → from, promotions
+// only — graduated assignments were deleted on apply and have no history to
+// restore from; the admin re-creates them if the revert brings the class
+// back).
+func classTeacherRenames(mappings []*education.GradeTransitionMapping, reverse bool) map[string]string {
+	renames := make(map[string]string, len(mappings))
+	for _, mapping := range mappings {
+		if mapping == nil {
+			continue
+		}
+		if mapping.IsGraduating() {
+			if !reverse {
+				renames[schoolclass.Normalize(mapping.FromClass)] = ""
+			}
+			continue
+		}
+		if reverse {
+			key := schoolclass.Normalize(*mapping.ToClass)
+			if _, taken := renames[key]; !taken {
+				renames[key] = mapping.FromClass
+			}
+			continue
+		}
+		renames[schoolclass.Normalize(mapping.FromClass)] = *mapping.ToClass
+	}
+	return renames
+}
+
+// remapClassTeacherAssignments follows the transition's class renames for
+// education.class_teachers (#1772): a promoted class carries its teachers
+// along, a graduating class loses them. Without this, an assignment string
+// like "1a" would survive the school-year rollover and silently point at the
+// NEXT incoming 1a cohort while the teacher's actual class ("2a") becomes
+// invisible to them.
+//
+// Affected rows are deleted and re-inserted instead of updated in place:
+// simultaneous renames ("1a"→"2a" while "2a"→"3a") would collide with the
+// unique (tenant, staff, normalized class) index mid-sequence, and merges
+// (two classes mapped onto one) need per-staff dedupe anyway. Losing row
+// identity is fine — it IS a new school year. Runs inside the apply/revert
+// transaction; a nil repo (pure unit tests) disables the step.
+func (s *GradeTransitionService) remapClassTeacherAssignments(ctx context.Context, renames map[string]string) error {
+	if s.classTeacherRepo == nil || len(renames) == 0 {
+		return nil
+	}
+
+	assignments, err := s.classTeacherRepo.List(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	// Normalized class names each staff member keeps untouched — renamed rows
+	// must not collide with these on re-insert.
+	kept := make(map[int64]map[string]bool, len(assignments))
+	var affected []*education.ClassTeacher
+	for _, assignment := range assignments {
+		if _, hit := renames[schoolclass.Normalize(assignment.SchoolClass)]; hit {
+			affected = append(affected, assignment)
+			continue
+		}
+		if kept[assignment.StaffID] == nil {
+			kept[assignment.StaffID] = make(map[string]bool)
+		}
+		kept[assignment.StaffID][schoolclass.Normalize(assignment.SchoolClass)] = true
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+
+	for _, assignment := range affected {
+		if err := s.classTeacherRepo.Delete(ctx, assignment.ID); err != nil {
+			return err
+		}
+	}
+
+	for _, assignment := range affected {
+		target := renames[schoolclass.Normalize(assignment.SchoolClass)]
+		if target == "" {
+			continue // graduated — assignment is dropped
+		}
+		key := schoolclass.Normalize(target)
+		if kept[assignment.StaffID][key] {
+			continue // staff already holds the target class
+		}
+		replacement := &education.ClassTeacher{StaffID: assignment.StaffID, SchoolClass: target}
+		if err := s.classTeacherRepo.Create(ctx, replacement); err != nil {
+			return err
+		}
+		if kept[assignment.StaffID] == nil {
+			kept[assignment.StaffID] = make(map[string]bool)
+		}
+		kept[assignment.StaffID][key] = true
+	}
+
+	return nil
+}

--- a/backend/services/education/grade_transition_class_teachers.go
+++ b/backend/services/education/grade_transition_class_teachers.go
@@ -2,35 +2,27 @@ package education
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
 	"github.com/moto-nrw/project-phoenix/models/education"
 )
 
-// classTeacherRenames builds the rename map a transition implies for the
+// classTeacherRenames builds the rename map an apply implies for the
 // Klassenlehrer assignments: normalized from-class → to-class display form,
 // where an empty target means the class graduates and its assignments are
-// dropped. reverse=true builds the revert direction (to → from, promotions
-// only — graduated assignments were deleted on apply and have no history to
-// restore from; the admin re-creates them if the revert brings the class
-// back).
-func classTeacherRenames(mappings []*education.GradeTransitionMapping, reverse bool) map[string]string {
+// dropped. There is deliberately no reverse variant — the revert replays the
+// recorded ledger instead, because a reverse rename cannot distinguish a row
+// the apply renamed into a class from a pre-existing assignment of that class
+// it never touched.
+func classTeacherRenames(mappings []*education.GradeTransitionMapping) map[string]string {
 	renames := make(map[string]string, len(mappings))
 	for _, mapping := range mappings {
 		if mapping == nil {
 			continue
 		}
 		if mapping.IsGraduating() {
-			if !reverse {
-				renames[schoolclass.Normalize(mapping.FromClass)] = ""
-			}
-			continue
-		}
-		if reverse {
-			key := schoolclass.Normalize(*mapping.ToClass)
-			if _, taken := renames[key]; !taken {
-				renames[key] = mapping.FromClass
-			}
+			renames[schoolclass.Normalize(mapping.FromClass)] = ""
 			continue
 		}
 		renames[schoolclass.Normalize(mapping.FromClass)] = *mapping.ToClass
@@ -49,16 +41,28 @@ func classTeacherRenames(mappings []*education.GradeTransitionMapping, reverse b
 // simultaneous renames ("1a"→"2a" while "2a"→"3a") would collide with the
 // unique (tenant, staff, normalized class) index mid-sequence, and merges
 // (two classes mapped onto one) need per-staff dedupe anyway. Losing row
-// identity is fine — it IS a new school year. Runs inside the apply/revert
-// transaction; a nil repo (pure unit tests) disables the step.
-func (s *GradeTransitionService) remapClassTeacherAssignments(ctx context.Context, renames map[string]string) error {
-	if s.classTeacherRepo == nil || len(renames) == 0 {
+// identity is fine — it IS a new school year.
+//
+// Every delete and insert is recorded in the transition's class-teacher
+// ledger so the revert can replay exactly what happened, mirroring the
+// student-side history. Runs inside the apply transaction; a nil repo (pure
+// unit tests) disables the step.
+func (s *GradeTransitionService) remapClassTeacherAssignments(
+	ctx context.Context,
+	transitionID int64,
+	mappings []*education.GradeTransitionMapping,
+) error {
+	if s.classTeacherRepo == nil {
+		return nil
+	}
+	renames := classTeacherRenames(mappings)
+	if len(renames) == 0 {
 		return nil
 	}
 
 	assignments, err := s.classTeacherRepo.List(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list class teacher assignments: %w", err)
 	}
 
 	// Normalized class names each staff member keeps untouched — renamed rows
@@ -79,10 +83,18 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(ctx context.Contex
 		return nil
 	}
 
+	var ledger []*education.GradeTransitionClassTeacher
+
 	for _, assignment := range affected {
 		if err := s.classTeacherRepo.Delete(ctx, assignment.ID); err != nil {
-			return err
+			return fmt.Errorf("failed to delete class teacher assignment: %w", err)
 		}
+		ledger = append(ledger, &education.GradeTransitionClassTeacher{
+			TransitionID: transitionID,
+			StaffID:      assignment.StaffID,
+			SchoolClass:  assignment.SchoolClass,
+			Action:       education.ClassTeacherActionRemoved,
+		})
 	}
 
 	for _, assignment := range affected {
@@ -96,12 +108,87 @@ func (s *GradeTransitionService) remapClassTeacherAssignments(ctx context.Contex
 		}
 		replacement := &education.ClassTeacher{StaffID: assignment.StaffID, SchoolClass: target}
 		if err := s.classTeacherRepo.Create(ctx, replacement); err != nil {
-			return err
+			return fmt.Errorf("failed to create class teacher assignment: %w", err)
 		}
+		ledger = append(ledger, &education.GradeTransitionClassTeacher{
+			TransitionID: transitionID,
+			StaffID:      assignment.StaffID,
+			SchoolClass:  target,
+			Action:       education.ClassTeacherActionCreated,
+		})
 		if kept[assignment.StaffID] == nil {
 			kept[assignment.StaffID] = make(map[string]bool)
 		}
 		kept[assignment.StaffID][key] = true
+	}
+
+	if err := s.transitionRepo.CreateClassTeacherHistoryBatch(ctx, ledger); err != nil {
+		return fmt.Errorf("failed to record class teacher ledger: %w", err)
+	}
+	return nil
+}
+
+// revertClassTeacherAssignments replays the transition's class-teacher ledger
+// backwards (#1772): rows the apply created are deleted again, rows it
+// removed are restored with their original display form. Rows the apply never
+// touched — a pre-existing assignment of a rename target, say — have no
+// ledger entry and stay untouched, which is exactly what the mapping-derived
+// reverse rename could not guarantee. Assignments the admin changed between
+// apply and revert win: a created row already deleted is skipped, a restore
+// colliding with a current assignment is skipped.
+func (s *GradeTransitionService) revertClassTeacherAssignments(ctx context.Context, transitionID int64) error {
+	if s.classTeacherRepo == nil {
+		return nil
+	}
+
+	ledger, err := s.transitionRepo.GetClassTeacherHistory(ctx, transitionID)
+	if err != nil {
+		return fmt.Errorf("failed to load class teacher ledger: %w", err)
+	}
+	if len(ledger) == 0 {
+		return nil
+	}
+
+	assignments, err := s.classTeacherRepo.List(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list class teacher assignments: %w", err)
+	}
+
+	type staffClass struct {
+		staffID int64
+		class   string
+	}
+	current := make(map[staffClass]*education.ClassTeacher, len(assignments))
+	for _, assignment := range assignments {
+		current[staffClass{assignment.StaffID, schoolclass.Normalize(assignment.SchoolClass)}] = assignment
+	}
+
+	for _, entry := range ledger {
+		if entry.Action != education.ClassTeacherActionCreated {
+			continue
+		}
+		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
+		if row, ok := current[key]; ok {
+			if err := s.classTeacherRepo.Delete(ctx, row.ID); err != nil {
+				return fmt.Errorf("failed to delete class teacher assignment: %w", err)
+			}
+			delete(current, key)
+		}
+	}
+
+	for _, entry := range ledger {
+		if entry.Action != education.ClassTeacherActionRemoved {
+			continue
+		}
+		key := staffClass{entry.StaffID, schoolclass.Normalize(entry.SchoolClass)}
+		if _, taken := current[key]; taken {
+			continue
+		}
+		restored := &education.ClassTeacher{StaffID: entry.StaffID, SchoolClass: entry.SchoolClass}
+		if err := s.classTeacherRepo.Create(ctx, restored); err != nil {
+			return fmt.Errorf("failed to restore class teacher assignment: %w", err)
+		}
+		current[key] = restored
 	}
 
 	return nil

--- a/backend/services/education/grade_transition_class_teachers_test.go
+++ b/backend/services/education/grade_transition_class_teachers_test.go
@@ -89,6 +89,65 @@ func TestGradeTransitionService_Apply_RemapsClassTeachers(t *testing.T) {
 
 	assert.Equal(t, []string{class1, class2}, staffClassNames(t, db, ctx, chainTeacher.ID),
 		"revert must carry the promoted assignments back")
-	assert.Empty(t, staffClassNames(t, db, ctx, graduateTeacher.ID),
-		"graduated assignments have no history and stay gone after revert")
+	assert.Equal(t, []string{class3}, staffClassNames(t, db, ctx, graduateTeacher.ID),
+		"revert must restore the graduated class assignment from the ledger, like it reactivates the students")
+}
+
+// The revert replays the recorded ledger, not a reverse rename — a
+// pre-existing assignment of a rename target that the apply never touched
+// must survive the revert untouched, and a merge (teacher held both the from-
+// and the to-class) must round-trip without losing the surviving assignment.
+func TestGradeTransitionService_Revert_TouchesOnlyLedgeredClassTeachers(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-ledger@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1a-%s", suffix)
+	class2 := fmt.Sprintf("2a-%s", suffix)
+
+	// Only 1a → 2a is mapped; 2a itself is NOT a from-class.
+	student := testpkg.CreateTestStudent(t, db, "Ledger", "Child", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	// mergeTeacher holds BOTH classes (apply drops 1a, keeps 2a);
+	// bystander holds only the pre-existing 2a the apply never touches.
+	mergeTeacher := testpkg.CreateTestStaff(t, db, "Ledger", "MergeTeacher")
+	bystander := testpkg.CreateTestStaff(t, db, "Ledger", "Bystander")
+	defer testpkg.CleanupStaffFixtures(t, db, mergeTeacher.ID, bystander.ID)
+	defer func() {
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").
+			Where("staff_id IN (?)", bun.List([]int64{mergeTeacher.ID, bystander.ID})).
+			Exec(tenantCtx)
+	}()
+
+	testpkg.CreateTestClassTeacher(t, db, mergeTeacher.ID, class1)
+	testpkg.CreateTestClassTeacher(t, db, mergeTeacher.ID, class2)
+	testpkg.CreateTestClassTeacher(t, db, bystander.ID, class2)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class2}, staffClassNames(t, db, ctx, mergeTeacher.ID),
+		"merge: the 1a assignment folds into the already-held 2a")
+	assert.Equal(t, []string{class2}, staffClassNames(t, db, ctx, bystander.ID),
+		"apply must not touch the bystander's pre-existing 2a")
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class1, class2}, staffClassNames(t, db, ctx, mergeTeacher.ID),
+		"round trip must restore 1a without losing the surviving 2a")
+	assert.Equal(t, []string{class2}, staffClassNames(t, db, ctx, bystander.ID),
+		"revert must not rewrite an assignment the apply never touched")
 }

--- a/backend/services/education/grade_transition_class_teachers_test.go
+++ b/backend/services/education/grade_transition_class_teachers_test.go
@@ -1,0 +1,94 @@
+package education_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// staffClassNames reads the current class assignments of one staff member
+// straight from the table, in normalized order.
+func staffClassNames(t *testing.T, db *bun.DB, ctx context.Context, staffID int64) []string {
+	t.Helper()
+	var classes []string
+	err := db.NewSelect().
+		TableExpr("education.class_teachers").
+		Column("school_class").
+		Where("staff_id = ?", staffID).
+		OrderExpr("LOWER(BTRIM(school_class)) ASC").
+		Scan(ctx, &classes)
+	require.NoError(t, err)
+	return classes
+}
+
+// The Klassenlehrer assignments must follow the school-year rollover (#1772):
+// promoted classes carry their teachers along — including chain renames that
+// would collide with the unique index if applied one by one — and graduating
+// classes lose theirs. Revert carries the promotions back.
+func TestGradeTransitionService_Apply_RemapsClassTeachers(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-classteacher@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1a-%s", suffix)
+	class2 := fmt.Sprintf("2a-%s", suffix)
+	class3 := fmt.Sprintf("3a-%s", suffix)
+
+	// One child per class so the transition has a locked cohort to move.
+	student1 := testpkg.CreateTestStudent(t, db, "Remap", "Child1", class1)
+	student2 := testpkg.CreateTestStudent(t, db, "Remap", "Child2", class2)
+	student3 := testpkg.CreateTestStudent(t, db, "Remap", "Child3", class3)
+	defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID, student3.ID)
+
+	// The teacher holds the chain's start AND middle class — the rename
+	// 1a→2a while 2a→3a must not trip the unique index. A second teacher
+	// holds the graduating class.
+	chainTeacher := testpkg.CreateTestStaff(t, db, "Remap", "ChainTeacher")
+	graduateTeacher := testpkg.CreateTestStaff(t, db, "Remap", "GraduateTeacher")
+	defer testpkg.CleanupStaffFixtures(t, db, chainTeacher.ID, graduateTeacher.ID)
+	defer func() {
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").
+			Where("staff_id IN (?)", bun.List([]int64{chainTeacher.ID, graduateTeacher.ID})).
+			Exec(tenantCtx)
+	}()
+
+	testpkg.CreateTestClassTeacher(t, db, chainTeacher.ID, class1)
+	testpkg.CreateTestClassTeacher(t, db, chainTeacher.ID, class2)
+	testpkg.CreateTestClassTeacher(t, db, graduateTeacher.ID, class3)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class2, testpkg.StrPtr(class3))
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class3, nil) // graduates
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class2, class3}, staffClassNames(t, db, ctx, chainTeacher.ID),
+		"chain rename must carry both assignments forward")
+	assert.Empty(t, staffClassNames(t, db, ctx, graduateTeacher.ID),
+		"graduating class must lose its teacher assignment")
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class1, class2}, staffClassNames(t, db, ctx, chainTeacher.ID),
+		"revert must carry the promoted assignments back")
+	assert.Empty(t, staffClassNames(t, db, ctx, graduateTeacher.ID),
+		"graduated assignments have no history and stay gone after revert")
+}

--- a/backend/services/education/grade_transition_class_teachers_test.go
+++ b/backend/services/education/grade_transition_class_teachers_test.go
@@ -190,6 +190,58 @@ func TestGradeTransitionService_Revert_SkipsOffboardedStaff(t *testing.T) {
 		"revert must not resurrect assignments for an offboarded staff member")
 }
 
+// An assignment the admin deliberately removed AFTER the apply must stay
+// removed on revert: the renamed row's disappearance means the admin took the
+// class away, and restoring the pre-apply name would silently re-grant
+// student-data scope.
+func TestGradeTransitionService_Revert_RespectsAdminRemovalAfterApply(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-adminremoval@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1a-%s", suffix)
+	class2 := fmt.Sprintf("2a-%s", suffix)
+	class3 := fmt.Sprintf("3b-%s", suffix)
+
+	student := testpkg.CreateTestStudent(t, db, "AdminRemoval", "Child", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	teacher := testpkg.CreateTestStaff(t, db, "AdminRemoval", "Teacher")
+	defer testpkg.CleanupStaffFixtures(t, db, teacher.ID)
+	defer func() {
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").
+			Where("staff_id = ?", teacher.ID).Exec(tenantCtx)
+	}()
+	testpkg.CreateTestClassTeacher(t, db, teacher.ID, class1)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{class2}, staffClassNames(t, db, ctx, teacher.ID))
+
+	// The admin re-scopes the teacher after the apply: 2a removed, 3b set.
+	_, err = db.NewDelete().TableExpr("education.class_teachers").
+		Where("staff_id = ?", teacher.ID).Exec(ctx)
+	require.NoError(t, err)
+	testpkg.CreateTestClassTeacher(t, db, teacher.ID, class3)
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class3}, staffClassNames(t, db, ctx, teacher.ID),
+		"revert must not restore a class the admin deliberately took away after the apply")
+}
+
 // The revert replays the recorded ledger, not a reverse rename — a
 // pre-existing assignment of a rename target that the apply never touched
 // must survive the revert untouched, and a merge (teacher held both the from-

--- a/backend/services/education/grade_transition_class_teachers_test.go
+++ b/backend/services/education/grade_transition_class_teachers_test.go
@@ -93,6 +93,103 @@ func TestGradeTransitionService_Apply_RemapsClassTeachers(t *testing.T) {
 		"revert must restore the graduated class assignment from the ledger, like it reactivates the students")
 }
 
+// Teacher rows move under exactly the same condition as the students: an
+// EXACT (trimmed) from-class match. A teacher assigned "1A" must stay put
+// when the mapping renames "1a" — the "1A" children do not move either, and
+// remapping the teacher would take away sight of their own class.
+func TestGradeTransitionService_Apply_MatchesClassTeachersExactlyLikeStudents(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-exactmatch@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	classLower := fmt.Sprintf("1a-%s", suffix)
+	classUpper := fmt.Sprintf("1A-%s", suffix)
+	classTarget := fmt.Sprintf("2a-%s", suffix)
+
+	// The moving cohort sits in the lower-case class; the teacher holds the
+	// case-variant the mapping does NOT name.
+	student := testpkg.CreateTestStudent(t, db, "Exact", "Child", classLower)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	teacher := testpkg.CreateTestStaff(t, db, "Exact", "CaseTeacher")
+	defer testpkg.CleanupStaffFixtures(t, db, teacher.ID)
+	defer func() {
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").
+			Where("staff_id = ?", teacher.ID).Exec(tenantCtx)
+	}()
+	testpkg.CreateTestClassTeacher(t, db, teacher.ID, classUpper)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, classLower, testpkg.StrPtr(classTarget))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{classUpper}, staffClassNames(t, db, ctx, teacher.ID),
+		"a case-variant assignment must stay put, exactly like its students do")
+}
+
+// A staff member offboarded between apply and revert must not get assignments
+// resurrected: offboarding cleared their class rows, and the soft-deleted
+// staff row would satisfy the FK even though the normal write path 404s on it.
+func TestGradeTransitionService_Revert_SkipsOffboardedStaff(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-offboard@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1a-%s", suffix)
+	class2 := fmt.Sprintf("2a-%s", suffix)
+
+	student := testpkg.CreateTestStudent(t, db, "Offboard", "Child", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	teacher := testpkg.CreateTestStaff(t, db, "Offboard", "Teacher")
+	defer testpkg.CleanupStaffFixtures(t, db, teacher.ID)
+	defer func() {
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").
+			Where("staff_id = ?", teacher.ID).Exec(tenantCtx)
+	}()
+	testpkg.CreateTestClassTeacher(t, db, teacher.ID, class1)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{class2}, staffClassNames(t, db, ctx, teacher.ID))
+
+	// Offboarding: assignments cleared, staff row soft-deleted.
+	_, err = db.NewDelete().TableExpr("education.class_teachers").
+		Where("staff_id = ?", teacher.ID).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewUpdate().TableExpr("users.staff").
+		Set("deleted_at = NOW()").
+		Where("id = ?", teacher.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Empty(t, staffClassNames(t, db, ctx, teacher.ID),
+		"revert must not resurrect assignments for an offboarded staff member")
+}
+
 // The revert replays the recorded ledger, not a reverse rename — a
 // pre-existing assignment of a rename target that the apply never touched
 // must survive the revert untouched, and a merge (teacher held both the from-

--- a/backend/services/education/grade_transition_class_teachers_test.go
+++ b/backend/services/education/grade_transition_class_teachers_test.go
@@ -242,6 +242,121 @@ func TestGradeTransitionService_Revert_RespectsAdminRemovalAfterApply(t *testing
 		"revert must not restore a class the admin deliberately took away after the apply")
 }
 
+// setupChainTeacherTransition builds the dual-role rename chain: one teacher
+// holds 1a AND 2a, the mappings rename 1a→2a and 2a→3a, so after the apply
+// the middle class name (2a) is both a created target (the renamed 1a) and a
+// restore source (the pre-apply 2a). Returns the teacher, the three class
+// names, and a fixture cleanup the caller MUST defer AFTER the setup cleanup
+// (defers run LIFO, and the fixture deletes need the still-open DB).
+func setupChainTeacherTransition(t *testing.T, db *bun.DB) (teacherID, transitionID, accountID int64, class1, class2, class3 string, cleanup func()) {
+	t.Helper()
+
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("transition-chain-%s@test.local", uuid.Must(uuid.NewV4()).String()[:8]))
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 = fmt.Sprintf("1a-%s", suffix)
+	class2 = fmt.Sprintf("2a-%s", suffix)
+	class3 = fmt.Sprintf("3a-%s", suffix)
+
+	student1 := testpkg.CreateTestStudent(t, db, "Chain", "Child1", class1)
+	student2 := testpkg.CreateTestStudent(t, db, "Chain", "Child2", class2)
+
+	teacher := testpkg.CreateTestStaff(t, db, "Chain", "DualRoleTeacher")
+	testpkg.CreateTestClassTeacher(t, db, teacher.ID, class1)
+	testpkg.CreateTestClassTeacher(t, db, teacher.ID, class2)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class2, testpkg.StrPtr(class3))
+
+	cleanup = func() {
+		testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").
+			Where("staff_id = ?", teacher.ID).Exec(tenantCtx)
+		testpkg.CleanupStaffFixtures(t, db, teacher.ID)
+		testpkg.CleanupActivityFixtures(t, db, student1.ID, student2.ID)
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+	}
+
+	return teacher.ID, transition.ID, account.ID, class1, class2, class3, cleanup
+}
+
+// deleteClassTeacherRow removes one specific assignment, the way an admin
+// edit between apply and revert would.
+func deleteClassTeacherRow(t *testing.T, db *bun.DB, ctx context.Context, staffID int64, class string) {
+	t.Helper()
+	res, err := db.NewDelete().TableExpr("education.class_teachers").
+		Where("staff_id = ?", staffID).
+		Where("LOWER(BTRIM(school_class)) = LOWER(BTRIM(?))", class).
+		Exec(ctx)
+	require.NoError(t, err)
+	affected, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, affected)
+}
+
+// Dual-role chain, admin removes the MIDDLE class after the apply: deleting
+// the renamed "2a" row must suppress BOTH ledger restores that involve that
+// name — the paired "1a" (its renamed row is gone) AND the removed "2a"
+// itself (re-creating the name the admin just deleted would re-grant scope
+// over any student still carrying it, e.g. one enrolled after the cohort
+// lock). The teacher deliberately ends with nothing; erring on the side of
+// less scope beats silently re-granting a removed class, and the admin can
+// re-assign.
+func TestGradeTransitionService_Revert_ChainAdminRemovedMiddleClass(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	teacherID, transitionID, accountID, _, class2, class3, fixtureCleanup := setupChainTeacherTransition(t, db)
+	defer fixtureCleanup()
+
+	_, err := service.Apply(ctx, transitionID, accountID)
+	require.NoError(t, err)
+	require.Equal(t, []string{class2, class3}, staffClassNames(t, db, ctx, teacherID))
+
+	deleteClassTeacherRow(t, db, ctx, teacherID, class2)
+
+	_, err = service.Revert(ctx, transitionID, accountID)
+	require.NoError(t, err)
+
+	assert.Empty(t, staffClassNames(t, db, ctx, teacherID),
+		"removing the dual-role middle class must suppress both restores that involve its name")
+}
+
+// Dual-role chain, admin removes the END class after the apply: the kept
+// "2a" row is the promoted 1a cohort and rolls back to its pre-apply name
+// ("1a") like in a clean revert, while the pre-apply "2a" stays gone — its
+// renamed row ("3a") is exactly what the admin deleted, and the students the
+// ledger replay renames back from 3a to 2a are the ones the admin revoked.
+// The class NAMES the admin saw ("kept 2a") shift because every class name
+// rolls back with the students; the SCOPE the admin curated is preserved.
+func TestGradeTransitionService_Revert_ChainAdminRemovedEndClass(t *testing.T) {
+	service, db, cleanup := setupGradeTransitionServiceTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 15*time.Second)
+	defer cancel()
+
+	teacherID, transitionID, accountID, class1, class2, class3, fixtureCleanup := setupChainTeacherTransition(t, db)
+	defer fixtureCleanup()
+
+	_, err := service.Apply(ctx, transitionID, accountID)
+	require.NoError(t, err)
+	require.Equal(t, []string{class2, class3}, staffClassNames(t, db, ctx, teacherID))
+
+	deleteClassTeacherRow(t, db, ctx, teacherID, class3)
+
+	_, err = service.Revert(ctx, transitionID, accountID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class1}, staffClassNames(t, db, ctx, teacherID),
+		"the kept cohort returns under its pre-apply name, the admin-removed cohort stays gone")
+}
+
 // The revert replays the recorded ledger, not a reverse rename — a
 // pre-existing assignment of a rename target that the apply never touched
 // must survive the revert untouched, and a merge (teacher held both the from-

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -192,6 +192,7 @@ type GradeTransitionService struct {
 	personRepo             users.PersonRepository
 	visitRepo              activeModels.VisitRepository
 	attendanceRepo         activeModels.AttendanceRepository
+	classTeacherRepo       education.ClassTeacherRepository
 	rosterReconciler       RosterReconciler
 	offeringSourceResyncer OfferingSourceResyncer
 	db                     *bun.DB
@@ -213,6 +214,11 @@ type GradeTransitionServiceDependencies struct {
 	// tests that don't exercise the check can leave them nil.
 	VisitRepo      activeModels.VisitRepository
 	AttendanceRepo activeModels.AttendanceRepository
+	// ClassTeacherRepo lets apply/revert follow the class renames for the
+	// Klassenlehrer assignments (#1772) — without it a "1a" assignment would
+	// silently point at next year's incoming cohort after 1a→2a. Optional;
+	// nil disables the remap for tests that don't exercise it.
+	ClassTeacherRepo education.ClassTeacherRepository
 	// RosterReconciler reconciles already-materialized future timetable rosters
 	// on apply (drop graduates) and revert (restore reactivated students).
 	// Optional; nil disables reconciliation for tests that don't exercise it.
@@ -228,6 +234,7 @@ func NewGradeTransitionService(deps GradeTransitionServiceDependencies) *GradeTr
 		personRepo:       deps.PersonRepo,
 		visitRepo:        deps.VisitRepo,
 		attendanceRepo:   deps.AttendanceRepo,
+		classTeacherRepo: deps.ClassTeacherRepo,
 		rosterReconciler: deps.RosterReconciler,
 		db:               deps.DB,
 	}
@@ -857,6 +864,14 @@ func (s *GradeTransitionService) executeApply(
 	}
 
 	if err := s.applyPromotions(ctx, transition.Mappings, promotions, result); err != nil {
+		return err
+	}
+
+	// The Klassenlehrer assignments (#1772) follow the same renames as the
+	// student rows: promoted classes keep their teachers, graduating classes
+	// lose them. Left untouched, a "1a" assignment would point at next
+	// year's incoming cohort after this apply.
+	if err := s.remapClassTeacherAssignments(ctx, classTeacherRenames(transition.Mappings, false)); err != nil {
 		return err
 	}
 
@@ -1498,6 +1513,13 @@ func (s *GradeTransitionService) executeRevert(
 	// rows are still capped at this point, so those instances are covered by
 	// the resync's own occurrence reconciliation right after.
 	if err := s.reconcileRestoredRosters(ctx, transition, reactivated); err != nil {
+		return err
+	}
+
+	// Mirror of the apply-side remap (#1772): promoted classes carry their
+	// teachers back (2a→1a). Assignments of graduated classes were deleted on
+	// apply and have no history — the admin re-creates them if needed.
+	if err := s.remapClassTeacherAssignments(ctx, classTeacherRenames(transition.Mappings, true)); err != nil {
 		return err
 	}
 

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -1526,8 +1526,9 @@ func (s *GradeTransitionService) executeRevert(
 	// Mirror of the apply-side remap (#1772): replay the recorded ledger
 	// backwards — created rows are deleted, removed rows (promotions AND
 	// graduations) are restored. Pre-existing assignments the apply never
-	// touched have no ledger entry and stay untouched.
-	if err := s.revertClassTeacherAssignments(ctx, transition.ID); err != nil {
+	// touched have no ledger entry and stay untouched, and rows the admin
+	// deliberately removed since the apply stay removed.
+	if err := s.revertClassTeacherAssignments(ctx, transition.ID, transition.Mappings); err != nil {
 		return err
 	}
 

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -190,6 +190,7 @@ type GradeTransitionService struct {
 	transitionRepo         education.GradeTransitionRepository
 	studentRepo            users.StudentRepository
 	personRepo             users.PersonRepository
+	staffRepo              users.StaffRepository
 	visitRepo              activeModels.VisitRepository
 	attendanceRepo         activeModels.AttendanceRepository
 	classTeacherRepo       education.ClassTeacherRepository
@@ -217,8 +218,12 @@ type GradeTransitionServiceDependencies struct {
 	// ClassTeacherRepo lets apply/revert follow the class renames for the
 	// Klassenlehrer assignments (#1772) — without it a "1a" assignment would
 	// silently point at next year's incoming cohort after 1a→2a. Optional;
-	// nil disables the remap for tests that don't exercise it.
+	// nil disables the remap for tests that don't exercise it. StaffRepo is
+	// its companion: the revert consults it (soft-delete-filtered) so a
+	// staff member offboarded since the apply gets no assignment
+	// resurrected. Wire both together.
 	ClassTeacherRepo education.ClassTeacherRepository
+	StaffRepo        users.StaffRepository
 	// RosterReconciler reconciles already-materialized future timetable rosters
 	// on apply (drop graduates) and revert (restore reactivated students).
 	// Optional; nil disables reconciliation for tests that don't exercise it.
@@ -232,6 +237,7 @@ func NewGradeTransitionService(deps GradeTransitionServiceDependencies) *GradeTr
 		transitionRepo:   deps.TransitionRepo,
 		studentRepo:      deps.StudentRepo,
 		personRepo:       deps.PersonRepo,
+		staffRepo:        deps.StaffRepo,
 		visitRepo:        deps.VisitRepo,
 		attendanceRepo:   deps.AttendanceRepo,
 		classTeacherRepo: deps.ClassTeacherRepo,

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -870,8 +870,9 @@ func (s *GradeTransitionService) executeApply(
 	// The Klassenlehrer assignments (#1772) follow the same renames as the
 	// student rows: promoted classes keep their teachers, graduating classes
 	// lose them. Left untouched, a "1a" assignment would point at next
-	// year's incoming cohort after this apply.
-	if err := s.remapClassTeacherAssignments(ctx, classTeacherRenames(transition.Mappings, false)); err != nil {
+	// year's incoming cohort after this apply. Every rewrite lands in the
+	// transition's class-teacher ledger so the revert can replay it exactly.
+	if err := s.remapClassTeacherAssignments(ctx, transition.ID, transition.Mappings); err != nil {
 		return err
 	}
 
@@ -1516,10 +1517,11 @@ func (s *GradeTransitionService) executeRevert(
 		return err
 	}
 
-	// Mirror of the apply-side remap (#1772): promoted classes carry their
-	// teachers back (2a→1a). Assignments of graduated classes were deleted on
-	// apply and have no history — the admin re-creates them if needed.
-	if err := s.remapClassTeacherAssignments(ctx, classTeacherRenames(transition.Mappings, true)); err != nil {
+	// Mirror of the apply-side remap (#1772): replay the recorded ledger
+	// backwards — created rows are deleted, removed rows (promotions AND
+	// graduations) are restored. Pre-existing assignments the apply never
+	// touched have no ledger entry and stay untouched.
+	if err := s.revertClassTeacherAssignments(ctx, transition.ID); err != nil {
 		return err
 	}
 

--- a/backend/services/education/grade_transition_service_test.go
+++ b/backend/services/education/grade_transition_service_test.go
@@ -31,10 +31,11 @@ func setupGradeTransitionServiceTest(t *testing.T) (*educationService.GradeTrans
 	personRepo := usersRepo.NewPersonRepository(db)
 
 	service := educationService.NewGradeTransitionService(educationService.GradeTransitionServiceDependencies{
-		TransitionRepo: transitionRepo,
-		StudentRepo:    studentRepo,
-		PersonRepo:     personRepo,
-		DB:             db,
+		TransitionRepo:   transitionRepo,
+		StudentRepo:      studentRepo,
+		PersonRepo:       personRepo,
+		ClassTeacherRepo: educationRepo.NewClassTeacherRepository(db),
+		DB:               db,
 	})
 
 	cleanup := func() {

--- a/backend/services/education/grade_transition_service_test.go
+++ b/backend/services/education/grade_transition_service_test.go
@@ -35,6 +35,7 @@ func setupGradeTransitionServiceTest(t *testing.T) (*educationService.GradeTrans
 		StudentRepo:      studentRepo,
 		PersonRepo:       personRepo,
 		ClassTeacherRepo: educationRepo.NewClassTeacherRepository(db),
+		StaffRepo:        usersRepo.NewStaffRepository(db),
 		DB:               db,
 	})
 

--- a/backend/services/education/interface.go
+++ b/backend/services/education/interface.go
@@ -34,9 +34,10 @@ type Service interface {
 
 	// Class-Teacher operations (#1772): staff-to-school-class assignments
 	// that scope the Lehrkraft day view. Classes are free-text strings
-	// matched via schoolclass.Normalize; there is no class entity.
+	// matched via schoolclass.Normalize; there is no class entity. changedBy
+	// is the authenticated account ID for the audit trail.
 	GetStaffSchoolClasses(ctx context.Context, staffID int64) ([]string, error)
-	SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string) error
+	SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string, changedBy int64) error
 
 	// Substitution operations
 	CreateSubstitution(ctx context.Context, substitution *education.GroupSubstitution) error

--- a/backend/services/education/interface.go
+++ b/backend/services/education/interface.go
@@ -32,6 +32,12 @@ type Service interface {
 	GetTeachersForGroups(ctx context.Context, groupIDs []int64) (map[int64][]*users.Teacher, error)
 	GetTeacherGroups(ctx context.Context, teacherID int64) ([]*education.Group, error)
 
+	// Class-Teacher operations (#1772): staff-to-school-class assignments
+	// that scope the Lehrkraft day view. Classes are free-text strings
+	// matched via schoolclass.Normalize; there is no class entity.
+	GetStaffSchoolClasses(ctx context.Context, staffID int64) ([]string, error)
+	SetStaffSchoolClasses(ctx context.Context, staffID int64, classes []string) error
+
 	// Substitution operations
 	CreateSubstitution(ctx context.Context, substitution *education.GroupSubstitution) error
 

--- a/backend/services/facilities/schulhof_service_test.go
+++ b/backend/services/facilities/schulhof_service_test.go
@@ -79,6 +79,7 @@ func setupSchulhofService(t *testing.T, db *bun.DB) facilitiesSvc.SchulhofServic
 	educationService := educationSvc.NewService(
 		repoFactory.Group,
 		repoFactory.GroupTeacher,
+		repoFactory.ClassTeacher,
 		repoFactory.GroupSubstitution,
 		repoFactory.Room,
 		repoFactory.Teacher,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -337,6 +337,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		PersonRepo:       repos.Person,
 		VisitRepo:        repos.ActiveVisit,
 		AttendanceRepo:   repos.Attendance,
+		ClassTeacherRepo: repos.ClassTeacher,
 		RosterReconciler: rosterReconciler,
 		DB:               db,
 	})

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -306,6 +306,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	educationService := education.NewService(
 		repos.Group,
 		repos.GroupTeacher,
+		repos.ClassTeacher,
 		repos.GroupSubstitution,
 		repos.Room,
 		repos.Teacher,
@@ -1253,6 +1254,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		TeacherRepo:            repos.Teacher,
 		GroupSupervisorRepo:    repos.GroupSupervisor,
 		GroupTeacherRepo:       repos.GroupTeacher,
+		ClassTeacherRepo:       repos.ClassTeacher,
 		GroupSubstitutionRepo:  repos.GroupSubstitution,
 		ActivitySupervisorRepo: repos.ActivitySupervisor,
 		InstanceStaffRepo:      repos.InstanceStaff,
@@ -1288,6 +1290,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		SupervisorRepo:     repos.GroupSupervisor,
 		ProfileRepo:        repos.Profile,
 		SubstitutionRepo:   repos.GroupSubstitution,
+		ClassTeacherRepo:   repos.ClassTeacher,
 		ActiveService:      activeService,
 		SSESettings:        settingsService,
 	}, usercontextLogger)

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -320,6 +320,13 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	}); ok {
 		broadcastAware.SetBroadcaster(realtimeHub)
 	}
+	// Class assignment rewrites scope the Lehrkraft student day view (#1772)
+	// and land in the Stammdaten audit trail.
+	if auditAware, ok := educationService.(interface {
+		SetMasterDataAudit(auditModels.StaffMasterDataChangeCreator)
+	}); ok {
+		auditAware.SetMasterDataAudit(repos.StaffMasterDataChange)
+	}
 
 	// Reconciles already-materialized future timetable rosters when a grade
 	// transition graduates or restores students (#405).
@@ -338,6 +345,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		VisitRepo:        repos.ActiveVisit,
 		AttendanceRepo:   repos.Attendance,
 		ClassTeacherRepo: repos.ClassTeacher,
+		StaffRepo:        repos.Staff,
 		RosterReconciler: rosterReconciler,
 		DB:               db,
 	})

--- a/backend/services/platform/operator_provisioning_service.go
+++ b/backend/services/platform/operator_provisioning_service.go
@@ -517,6 +517,13 @@ func (s *operatorProvisioningService) CreateSchoolAccount(ctx context.Context, s
 			if strings.EqualFold(role.Name, "teacher") {
 				return &InvalidDataError{Err: fmt.Errorf("legacy teacher role is no longer assignable; use the user role for caregiver accounts")}
 			}
+			// Same invariant the invitation flow enforces (#1772): the
+			// caregiver upgrade would hand a Lehrkraft the full user role
+			// plus a caregiver profile, defeating its class-scoped
+			// read-only design.
+			if req.CaregiverEnabled && authSvc.IsLehrkraftSystemRole(role) {
+				return &InvalidDataError{Err: fmt.Errorf("the lehrkraft role cannot be combined with caregiver capability")}
+			}
 			selectedRole = role
 		}
 

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -2093,6 +2093,74 @@ func TestCreateSchoolAccount_Success(t *testing.T) {
 	assert.Equal(t, int64(300), createdTeacher.StaffID)
 }
 
+// The operator API must refuse the same combination the invitation flow
+// refuses (#1772): lehrkraft plus caregiver_enabled would grant the full
+// user role and a caregiver profile, defeating the role's class-scoped
+// read-only design.
+func TestCreateSchoolAccount_RejectsLehrkraftCaregiverCombo(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	bunDB := bun.NewDB(sqlDB, pgdialect.New())
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, bunDB.Close())
+		require.NoError(t, sqlDB.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SET LOCAL ROLE phoenix_admin").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	roleID := int64(5)
+
+	service := platformSvc.NewOperatorProvisioningService(platformSvc.OperatorProvisioningServiceConfig{
+		SummariesRepo: &mockSummariesRepo{},
+		SchoolRepo: &testpkg.SchoolRepoMock{
+			FindByIDFn: func(context.Context, int64) (*platformModels.School, error) {
+				return &platformModels.School{
+					Model:          base.Model{ID: 9},
+					OrganizationID: 3,
+					Name:           "School",
+					Slug:           "school",
+					Subdomain:      "school",
+					Active:         true,
+				}, nil
+			},
+		},
+		RoleRepo: &mockRoleRepo{
+			findByIDFn: func(_ context.Context, id interface{}) (*authModels.Role, error) {
+				return &authModels.Role{
+					Model:    base.Model{ID: roleID},
+					Name:     "lehrkraft",
+					IsSystem: true,
+				}, nil
+			},
+		},
+		AuthService: &mockAuthService{
+			registerFn: func(_ context.Context, _, _, _ string, _ *int64, _ int64) (*authModels.Account, error) {
+				t.Fatal("no account must be created for a rejected lehrkraft+caregiver request")
+				return nil, nil
+			},
+		},
+		AuditLogRepo: &mockAuditLogRepoShared{},
+		DB:           bunDB,
+	})
+
+	_, err = service.CreateSchoolAccount(context.Background(), 9, 7, net.IPv4(127, 0, 0, 1), platformSvc.CreateSchoolAccountRequest{
+		Email:            "lehrkraft@example.com",
+		Password:         "SecureP@ss1",
+		FirstName:        "Jane",
+		LastName:         "Doe",
+		RoleID:           &roleID,
+		CaregiverEnabled: true,
+	})
+	require.Error(t, err)
+	var invalidErr *platformSvc.InvalidDataError
+	require.ErrorAs(t, err, &invalidErr)
+	assert.Contains(t, invalidErr.Error(), "lehrkraft")
+}
+
 func TestCreateSchoolAccount_DefaultsToAdminRole(t *testing.T) {
 	sqlDB, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/backend/services/usercontext/identity_request_cache.go
+++ b/backend/services/usercontext/identity_request_cache.go
@@ -68,6 +68,8 @@ type identityEntry struct {
 	groups        []*education.Group
 	subsLoaded    bool
 	subs          map[int64]bool
+	classesLoaded bool
+	classes       []string
 }
 
 // WithIdentityRequestCache attaches a request-scoped identity memo cache to
@@ -218,6 +220,26 @@ func (c *identityRequestCache) storeGroups(key identityCacheKey, groups []*educa
 	entry := c.entryLocked(key)
 	entry.groups = slices.Clone(groups)
 	entry.groupsLoaded = true
+}
+
+// schoolClassesFor clones for the same reason as groupsFor: a caller-visible
+// mutation must not reorder the memoized value.
+func (c *identityRequestCache) schoolClassesFor(key identityCacheKey) ([]string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || !entry.classesLoaded {
+		return nil, false
+	}
+	return slices.Clone(entry.classes), true
+}
+
+func (c *identityRequestCache) storeSchoolClasses(key identityCacheKey, classes []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entryLocked(key)
+	entry.classes = slices.Clone(classes)
+	entry.classesLoaded = true
 }
 
 // substitutedFor clones for the same reason as groupsFor: the returned map

--- a/backend/services/usercontext/interface.go
+++ b/backend/services/usercontext/interface.go
@@ -44,6 +44,13 @@ type UserContextService interface {
 	// by an equivalence test.
 	GetMyGroups(ctx context.Context) ([]*education.Group, error)
 
+	// GetMySchoolClasses returns the school classes assigned to the current
+	// staff member via education.class_teachers (#1772), as display strings
+	// in class order. Callers comparing against student rows must normalize
+	// both sides with schoolclass.Normalize. An account without a staff
+	// record cleanly resolves to an empty set, mirroring GetMyGroups.
+	GetMySchoolClasses(ctx context.Context) ([]string, error)
+
 	// GetSubstitutedGroupIDs returns the set of education group IDs the current
 	// staff member can access via an active substitution where the regular
 	// staff slot is unassigned. Returns an empty set when the user is not

--- a/backend/services/usercontext/school_classes.go
+++ b/backend/services/usercontext/school_classes.go
@@ -1,0 +1,53 @@
+package usercontext
+
+import (
+	"context"
+	"errors"
+)
+
+const opGetMySchoolClasses = "get my school classes"
+
+// GetMySchoolClasses retrieves the school classes assigned to the current
+// staff member (#1772). It mirrors GetMyGroups: an account that is cleanly
+// not linked to a person/staff resolves to an empty set (a guardian-only or
+// operator account simply has no classes), any other lookup failure is an
+// error. Results are request-memoized like the rest of the identity chain.
+func (s *userContextService) GetMySchoolClasses(ctx context.Context) ([]string, error) {
+	if !isAuthenticated(ctx) {
+		return nil, &UserContextError{Op: opGetMySchoolClasses, Err: ErrUserNotAuthenticated}
+	}
+
+	cache, key, memo := identityMemo(ctx)
+	if memo {
+		if classes, ok := cache.schoolClassesFor(key); ok {
+			return classes, nil
+		}
+	}
+
+	staff, err := s.GetCurrentStaff(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUserNotLinkedToStaff) || errors.Is(err, ErrUserNotLinkedToPerson) {
+			empty := []string{}
+			if memo {
+				cache.storeSchoolClasses(key, empty)
+			}
+			return empty, nil
+		}
+		return nil, &UserContextError{Op: opGetMySchoolClasses, Err: err}
+	}
+
+	assignments, err := s.classTeacherRepo.FindByStaff(ctx, staff.ID)
+	if err != nil {
+		return nil, &UserContextError{Op: opGetMySchoolClasses, Err: err}
+	}
+
+	classes := make([]string, 0, len(assignments))
+	for _, assignment := range assignments {
+		classes = append(classes, assignment.SchoolClass)
+	}
+
+	if memo {
+		cache.storeSchoolClasses(key, classes)
+	}
+	return classes, nil
+}

--- a/backend/services/usercontext/school_classes_test.go
+++ b/backend/services/usercontext/school_classes_test.go
@@ -1,0 +1,77 @@
+package usercontext_test
+
+import (
+	"context"
+	"testing"
+
+	usercontextSvc "github.com/moto-nrw/project-phoenix/services/usercontext"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserContextService_GetMySchoolClasses(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	service := setupUserContextService(t, db)
+
+	t.Run("returns error for unauthenticated context", func(t *testing.T) {
+		_, err := service.GetMySchoolClasses(context.Background())
+		require.Error(t, err)
+	})
+
+	t.Run("returns empty slice for non-staff user", func(t *testing.T) {
+		_, account := testpkg.CreateTestPersonWithAccount(t, db, "ClassesNonStaff", "User")
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		ctx := contextWithClaims(int(account.ID))
+
+		classes, err := service.GetMySchoolClasses(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, classes)
+	})
+
+	t.Run("returns assigned classes in class order", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "ClassesStaff", "Teacher")
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		ctB := testpkg.CreateTestClassTeacher(t, db, staff.ID, "2b")
+		ctA := testpkg.CreateTestClassTeacher(t, db, staff.ID, "1a")
+		defer testpkg.CleanupTableRecords(t, db, "education.class_teachers", ctA.ID, ctB.ID)
+
+		ctx := contextWithClaims(int(account.ID))
+
+		classes, err := service.GetMySchoolClasses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1a", "2b"}, classes)
+	})
+
+	t.Run("memoizes the result within one request", func(t *testing.T) {
+		staff, account := testpkg.CreateTestStaffWithAccount(t, db, "ClassesMemo", "Teacher")
+		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+		ctA := testpkg.CreateTestClassTeacher(t, db, staff.ID, "1a")
+		defer testpkg.CleanupTableRecords(t, db, "education.class_teachers", ctA.ID)
+
+		ctx := usercontextSvc.WithIdentityRequestCache(contextWithClaims(int(account.ID)))
+
+		first, err := service.GetMySchoolClasses(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"1a"}, first)
+
+		// A row added mid-request must not appear: the memoized value wins
+		// for the rest of the request span.
+		ctB := testpkg.CreateTestClassTeacher(t, db, staff.ID, "2b")
+		defer testpkg.CleanupTableRecords(t, db, "education.class_teachers", ctB.ID)
+
+		second, err := service.GetMySchoolClasses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1a"}, second)
+
+		// A fresh request context sees the new assignment.
+		fresh, err := service.GetMySchoolClasses(contextWithClaims(int(account.ID)))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1a", "2b"}, fresh)
+	})
+}

--- a/backend/services/usercontext/usercontext_service.go
+++ b/backend/services/usercontext/usercontext_service.go
@@ -45,6 +45,7 @@ type UserContextRepositories struct {
 	SupervisorRepo     active.GroupSupervisorRepository
 	ProfileRepo        users.ProfileRepository
 	SubstitutionRepo   education.GroupSubstitutionRepository
+	ClassTeacherRepo   education.ClassTeacherRepository
 
 	// SSE subscription dependencies (optional — nil-safe). Injected so the
 	// SSE handler can delegate staff-resolution + topic-building to this
@@ -67,6 +68,7 @@ type userContextService struct {
 	supervisorRepo     active.GroupSupervisorRepository
 	profileRepo        users.ProfileRepository
 	substitutionRepo   education.GroupSubstitutionRepository
+	classTeacherRepo   education.ClassTeacherRepository
 	sseActiveSvc       activeService.Service
 	sseSettings        SSESettingsResolver
 	logger             *slog.Logger
@@ -92,6 +94,7 @@ func NewUserContextServiceWithRepos(repos UserContextRepositories, logger *slog.
 		supervisorRepo:     repos.SupervisorRepo,
 		profileRepo:        repos.ProfileRepo,
 		substitutionRepo:   repos.SubstitutionRepo,
+		classTeacherRepo:   repos.ClassTeacherRepo,
 		sseActiveSvc:       repos.ActiveService,
 		sseSettings:        repos.SSESettings,
 		logger:             logger,

--- a/backend/services/usercontext/usercontext_service_test.go
+++ b/backend/services/usercontext/usercontext_service_test.go
@@ -36,6 +36,7 @@ func setupUserContextService(t *testing.T, db *bun.DB) usercontextSvc.UserContex
 		SupervisorRepo:     repoFactory.GroupSupervisor,
 		ProfileRepo:        repoFactory.Profile,
 		SubstitutionRepo:   repoFactory.GroupSubstitution,
+		ClassTeacherRepo:   repoFactory.ClassTeacher,
 	}
 
 	return usercontextSvc.NewUserContextServiceWithRepos(repos, slog.Default())

--- a/backend/services/users/staff_offboarding.go
+++ b/backend/services/users/staff_offboarding.go
@@ -35,6 +35,7 @@ type StaffOffboardingServiceDependencies struct {
 	TeacherRepo            userModels.TeacherRepository
 	GroupSupervisorRepo    activeModels.GroupSupervisorRepository
 	GroupTeacherRepo       educationModels.GroupTeacherRepository
+	ClassTeacherRepo       educationModels.ClassTeacherRepository
 	GroupSubstitutionRepo  educationModels.GroupSubstitutionRepository
 	ActivitySupervisorRepo activitiesModels.SupervisorPlannedRepository
 	InstanceStaffRepo      scheduleModels.InstanceStaffRepository
@@ -178,6 +179,12 @@ func (s *staffOffboardingService) cleanupAssignments(ctx context.Context, staffI
 			return nil, &UsersError{Op: opOffboardStaff, Err: fmt.Errorf("failed to delete teacher record: %w", err)}
 		}
 	}
+
+	classAssignments, err := s.ClassTeacherRepo.DeleteByStaffID(ctx, staffID)
+	if err != nil {
+		return nil, &UsersError{Op: opOffboardStaff, Err: err}
+	}
+	counts["class_teachers"] = classAssignments
 
 	supervisions, err := s.ActivitySupervisorRepo.DeleteByStaffID(ctx, staffID)
 	if err != nil {

--- a/backend/services/users/staff_offboarding_test.go
+++ b/backend/services/users/staff_offboarding_test.go
@@ -61,6 +61,7 @@ func newOffboardingScenario(t *testing.T) *offboardingScenario {
 		TeacherRepo:            repos.Teacher,
 		GroupSupervisorRepo:    repos.GroupSupervisor,
 		GroupTeacherRepo:       repos.GroupTeacher,
+		ClassTeacherRepo:       repos.ClassTeacher,
 		GroupSubstitutionRepo:  repos.GroupSubstitution,
 		ActivitySupervisorRepo: repos.ActivitySupervisor,
 		InstanceStaffRepo:      repos.InstanceStaff,

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -852,6 +852,28 @@ func CreateTestGroupTeacher(tb testing.TB, db *bun.DB, groupID, teacherID int64)
 	return gt
 }
 
+// CreateTestClassTeacher creates a staff-to-school-class assignment (#1772).
+func CreateTestClassTeacher(tb testing.TB, db *bun.DB, staffID int64, schoolClass string) *education.ClassTeacher {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ct := &education.ClassTeacher{
+		StaffID:     staffID,
+		SchoolClass: schoolClass,
+	}
+	ct.SetTenantID(1)
+
+	err := db.NewInsert().
+		Model(ct).
+		ModelTableExpr(`education.class_teachers`).
+		Scan(ctx)
+	require.NoError(tb, err, "Failed to create test class teacher assignment")
+
+	return ct
+}
+
 // ============================================================================
 // Active Domain Fixtures (Sessions and Visits)
 // ============================================================================

--- a/frontend/src/app/operator/provisioning/create-account-modal.test.tsx
+++ b/frontend/src/app/operator/provisioning/create-account-modal.test.tsx
@@ -37,9 +37,13 @@ vi.mock("~/lib/operator/provisioning-api", () => ({
   },
 }));
 
-vi.mock("~/lib/auth-helpers", () => ({
-  getRoleDisplayName: (name: string) => name,
-}));
+vi.mock("~/lib/auth-helpers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/lib/auth-helpers")>();
+  return {
+    ...actual,
+    getRoleDisplayName: (name: string) => name,
+  };
+});
 
 vi.mock("~/lib/hooks/use-scroll-to-error", () => ({
   useScrollToError: () => vi.fn(),
@@ -66,6 +70,7 @@ const defaultRoles = [
   { id: "2", name: "user" },
   { id: "3", name: "teacher" },
   { id: "4", name: "guardian" },
+  { id: "5", name: "lehrkraft" },
 ];
 
 function renderModal(
@@ -173,6 +178,9 @@ describe("CreateAccountModal", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: "guardian" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "lehrkraft" }),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/operator/provisioning/create-account-modal.tsx
+++ b/frontend/src/app/operator/provisioning/create-account-modal.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import { Modal } from "~/components/ui/modal";
 import { useScrollToError } from "~/lib/hooks/use-scroll-to-error";
 import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
-import { getRoleDisplayName } from "~/lib/auth-helpers";
+import { getRoleDisplayName, isAssignableStaffRole } from "~/lib/auth-helpers";
 import { createLogger } from "~/lib/logger";
 import { FormField, FormError, SelectWithChevron } from "./provisioning-shared";
 
@@ -59,12 +59,7 @@ export function CreateAccountModal({
         const roleList = await operatorProvisioningService.listSystemRoles();
         if (cancelled) return;
         const options = roleList
-          .filter((role) => {
-            const normalizedName = role.name.toLowerCase();
-            return (
-              normalizedName !== "guardian" && normalizedName !== "teacher"
-            );
-          })
+          .filter((role) => isAssignableStaffRole(role.name))
           .map<RoleOption>((role) => ({
             id: Number(role.id),
             label: role.name

--- a/frontend/src/components/operator/account-tenant-access-modal.test.tsx
+++ b/frontend/src/components/operator/account-tenant-access-modal.test.tsx
@@ -223,6 +223,9 @@ describe("AccountTenantAccessModal", () => {
     mockListAssignableRoles.mockResolvedValue([
       { id: "1", name: "admin" },
       { id: "2", name: "user" },
+      // The backend admits lehrkraft (#1772); the modal must hide it until
+      // the class day view ships.
+      { id: "9", name: "lehrkraft" },
     ]);
   });
 
@@ -284,7 +287,7 @@ describe("AccountTenantAccessModal", () => {
     expect(options).not.toContain("OGS Nord (Träger Köln)");
   });
 
-  it("never offers the guardian role", async () => {
+  it("never offers the guardian or lehrkraft role", async () => {
     renderModal();
 
     const schoolSelect = await screen.findByLabelText("account-access-school");
@@ -303,6 +306,7 @@ describe("AccountTenantAccessModal", () => {
     expect(options).toContain("Verwaltung");
     expect(options).toContain("Betreuung");
     expect(options).not.toContain("guardian");
+    expect(options).not.toContain("lehrkraft");
   });
 
   it("grants access with the selected school and role", async () => {

--- a/frontend/src/components/operator/account-tenant-access-modal.tsx
+++ b/frontend/src/components/operator/account-tenant-access-modal.tsx
@@ -11,6 +11,7 @@ import { Input } from "~/components/ui/input";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { StatusBadge } from "~/components/ui/status-badge";
 import { useToast } from "~/contexts/ToastContext";
+import { isAssignableStaffRole } from "~/lib/auth-helpers";
 import { createLogger } from "~/lib/logger";
 import {
   AccountTenantAccessApiError,
@@ -217,7 +218,12 @@ export function AccountTenantAccessModal({
   const needsName = !knowsName;
 
   function rolesForSchool(schoolId: string) {
-    return rolesBySchool[schoolId] ?? [];
+    // The backend admits lehrkraft (#1772) by policy; hide it here like every
+    // other role picker until the class day view ships — an account holding
+    // only that role would land in an app with zero accessible areas.
+    return (rolesBySchool[schoolId] ?? []).filter((role) =>
+      isAssignableStaffRole(role.name),
+    );
   }
 
   async function runMutation(

--- a/frontend/src/lib/auth-helpers.ts
+++ b/frontend/src/lib/auth-helpers.ts
@@ -232,6 +232,10 @@ const SYSTEM_ROLE_TRANSLATIONS: Record<
     name: "Erziehungsberechtigter",
     description: "Eingeschränkter Zugriff auf Daten der eigenen Kinder",
   },
+  lehrkraft: {
+    name: "Lehrkraft",
+    description: "Lesezugriff auf die Tagesansicht der zugewiesenen Klassen",
+  },
 };
 
 /**
@@ -261,8 +265,18 @@ export interface RoleOption {
   name: string;
 }
 
-/** System roles that are legacy/relationship-derived and not assignable to staff accounts. */
-const NON_ASSIGNABLE_STAFF_ROLE_NAMES = new Set(["guardian", "teacher"]);
+/**
+ * System roles that are legacy/relationship-derived and not assignable to
+ * staff accounts. "lehrkraft" (#1772) stays hidden until the class day view
+ * ships — the backend seeds the role with PR 1, but inviting someone into a
+ * role whose only permission gates a not-yet-existing page would strand them
+ * in an empty app. Remove it here in the PR that lands the day view.
+ */
+const NON_ASSIGNABLE_STAFF_ROLE_NAMES = new Set([
+  "guardian",
+  "teacher",
+  "lehrkraft",
+]);
 
 /**
  * Filters a role list down to staff-assignable roles and maps them to

--- a/frontend/src/lib/auth-helpers.ts
+++ b/frontend/src/lib/auth-helpers.ts
@@ -279,15 +279,22 @@ const NON_ASSIGNABLE_STAFF_ROLE_NAMES = new Set([
 ]);
 
 /**
+ * Whether a system role may be assigned to a staff account. Shared by every
+ * role picker (invitation form, teacher-creation form, role-management modal,
+ * operator account creation) so the exclusion list lives in one place.
+ */
+export function isAssignableStaffRole(roleName: string): boolean {
+  return !NON_ASSIGNABLE_STAFF_ROLE_NAMES.has(roleName.toLowerCase());
+}
+
+/**
  * Filters a role list down to staff-assignable roles and maps them to
  * display options. Shared by the invitation form, teacher-creation form,
  * and the staff role-management modal to avoid re-deriving this list.
  */
 export function toAssignableRoleOptions(roles: Role[]): RoleOption[] {
   return roles
-    .filter(
-      (role) => !NON_ASSIGNABLE_STAFF_ROLE_NAMES.has(role.name.toLowerCase()),
-    )
+    .filter((role) => isAssignableStaffRole(role.name))
     .map((role) => ({
       id: Number(role.id),
       name: role.name ? getRoleDisplayName(role.name) : `Rolle ${role.id}`,


### PR DESCRIPTION
Teil von #1772 (kein Auto-Close, das Issue bleibt offen).

## Was dieser PR ist

Das Scope-Fundament für die Lehreransicht aus #1772: die Rolle, die Klassen-Zuordnung und deren Absicherung. Die eigentliche Lehrer-UI (Tageslisten) ist bewusst NICHT enthalten, siehe unten.

### Enthalten

**Datenmodell (Migrationen 1.15.277 bis 1.15.279)**
- `education.class_teachers`: ein Staff-Mitglied wird einer Schulklasse zugeordnet. Klassen bleiben bewusst Freitext auf `users.students.school_class` (keine Klassen-Entität); Matching überall über `LOWER(BTRIM(...))` bzw. `schoolclass.Normalize`. Unique pro (tenant, staff, normalisierte Klasse), RLS wie bei allen Tenant-Tabellen.
- `class_teacher_transition_history` als exaktes Ledger für den Jahrgangswechsel.

**Systemrolle `lehrkraft`**
- Neue Rolle mit ausschließlich `class_day:read`, ein eng geschnittener Read-only-Zugang für externe Schullehrer (Antwort auf die Issue-Frage "Wie werden Lehrkräfte im System modelliert?").
- Einladung mit `lehrkraft` + `caregiver_enabled` wird abgelehnt (400): das Caregiver-Upgrade würde die volle `user`-Rolle verleihen und den Klassen-Scope aushebeln. Gleicher Guard im Operator-Provisioning, defense-in-depth in beiden Token-Acceptance-Zweigen.
- Operator-UI blendet `lehrkraft` aus der Rollenauswahl aus (das Konto würde dort in einer App ohne erreichbare Bereiche landen).

**Klassen-Zuweisung**
- Admin-Endpoint unter `/api/staff` zum Setzen der Klassen einer Lehrkraft, als Admin-Write mit Audit-Trail. Audit-Snapshot vor dem In-Place-Update, damit auch reine Case-Renames (`1a` zu `1A`) eine Audit-Zeile schreiben, denn die Schreibweise entscheidet beim Freitext-Matching, wen die Lehrkraft sieht.
- `usercontext` liefert die zugewiesenen Klassen des eingeloggten Kontos (mit Request-Cache): die Basis, auf der die spätere Lehreransicht nur "ihre" Klassen zeigt (Issue-Frage "welchen Klassen werden sie zugeordnet?").

**Jahrgangswechsel**
- Zuweisungen wandern beim Jahrgangswechsel mit (`1a` zu `2a`), Matching exakt.
- Revert spielt das Ledger exakt zurück statt eines Reverse-Renames, respektiert zwischenzeitliche Admin-Entfernungen (sonst stillschweigend neu verliehener Schüler-Scope) und stellt keine offboardeten Staff wieder her.

### Nicht enthalten (bleibt für #1772 offen)

- Die Lehreransicht selbst: Tagesansicht pro Klasse mit OGS/Randstunden-Status, Geh-/Abholweise, Abhol-/Endzeiten (das MVP aus dem Issue, Schritte 3 bis 5).
- Wochenansicht, Hinweise auf kurzfristige Änderungen.
- Die offenen Produktfragen aus dem Issue (Vertretungsklassen, Datenschutz-Umfang der sichtbaren Felder, eigener Lehrerbereich vs. Tenant-Portal).
- Kein Ersatz für den Klassenlisten-Export aus PR #1771.

Kurz: nach diesem PR kann ein Admin eine Lehrkraft einladen und ihr Klassen zuweisen, und das System weiß sicher und auditierbar, welche Klassen zu welcher Lehrkraft gehören. Sehen kann die Lehrkraft damit noch nichts, dafür fehlt die Ansicht aus dem Folgeschritt.

## Ausdrücklich unverändert

`users.students.school_class` bleibt Freitext. Keine Klassen-Entität, kein FK, keine Normalisierung der Bestandsdaten.

## Tests

- Backend: Service-, Repository- und API-Tests für Zuweisung, Jahrgangswechsel inkl. Revert-Szenarien, Einladungs- und Operator-Guards, Rollen-Matrix.
- Frontend: Tests für die Rollen-Filterung in beiden Operator-Modals.
