### PR TITLE
Restore scrolling in student class lists

### DIFF
--- a/frontend/src/components/students/students-master-detail.test.tsx
+++ b/frontend/src/components/students/students-master-detail.test.tsx
@@ -301,6 +301,25 @@ describe("StudentsMasterDetail", () => {
     expect(screen.getByText("Keine Kinder gefunden.")).toBeInTheDocument();
   });
 
+  it("keeps the student list constrained to the scrollable master pane", () => {
+    render(
+      <StudentsMasterDetail
+        {...baseProps}
+        students={[makeStudent("1"), makeStudent("2")]}
+        grouping="class"
+        studentsWithArrival={new Set(["1", "2"])}
+        arrivalSummaryById={new Map()}
+      />,
+    );
+
+    expect(screen.getByTestId("list").firstElementChild).toHaveClass(
+      "flex",
+      "min-h-0",
+      "flex-1",
+      "flex-col",
+    );
+  });
+
   it("renders a flat single-group list when grouping is 'none'", () => {
     render(
       <StudentsMasterDetail

--- a/frontend/src/components/students/students-master-detail.tsx
+++ b/frontend/src/components/students/students-master-detail.tsx
@@ -38,6 +38,7 @@ import { StudentEnrollmentsTab } from "./student-enrollments-tab";
 import { StudentStammdatenTab } from "./student-stammdaten-tab";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { getInitials } from "~/lib/format-utils";
+import { cn } from "~/lib/utils";
 import type { Student } from "~/lib/api";
 import type { BulkArrivalFilter } from "~/lib/student-arrival-api";
 
@@ -309,7 +310,12 @@ export function StudentsMasterDetail({
   };
 
   const listNode = (
-    <div className={selectionMode ? "pb-28 md:pb-0" : undefined}>
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col",
+        selectionMode && "pb-28 md:pb-0",
+      )}
+    >
       {selectionMode ? (
         <SelectionBar
           count={selectedStudentIds.size}


### PR DESCRIPTION
## Summary
- restore the flex sizing contract around the grouped student list
- keep the list constrained to the master pane so overflow remains scrollable
- add a regression test for the list wrapper layout contract

## Root cause
PR #2198 introduced a wrapper around GroupedList for the selection toolbar. Without flex sizing and min-h-0, the list expanded to its full content height and was clipped by the outer overflow-hidden master pane.

## Verification
- pnpm test:run src/components/students/students-master-detail.test.tsx (25 passed)
- pnpm run check
- pnpm test:run (987 files, 13,484 tests passed)
- pre-push dependency-cruise, knip, and frontend check passed
- browser repro with 40 children: list viewport stays bounded and scrollTop advances to the final child