### PR TITLE
Release 2026-08-09 (2): Scrollen in Kinder-Klassenlisten wiederhergestellt

### DIFF
--- a/frontend/src/components/students/students-master-detail.test.tsx
+++ b/frontend/src/components/students/students-master-detail.test.tsx
@@ -301,6 +301,25 @@ describe("StudentsMasterDetail", () => {
     expect(screen.getByText("Keine Kinder gefunden.")).toBeInTheDocument();
   });
 
+  it("keeps the student list constrained to the scrollable master pane", () => {
+    render(
+      <StudentsMasterDetail
+        {...baseProps}
+        students={[makeStudent("1"), makeStudent("2")]}
+        grouping="class"
+        studentsWithArrival={new Set(["1", "2"])}
+        arrivalSummaryById={new Map()}
+      />,
+    );
+
+    expect(screen.getByTestId("list").firstElementChild).toHaveClass(
+      "flex",
+      "min-h-0",
+      "flex-1",
+      "flex-col",
+    );
+  });
+
   it("renders a flat single-group list when grouping is 'none'", () => {
     render(
       <StudentsMasterDetail

--- a/frontend/src/components/students/students-master-detail.tsx
+++ b/frontend/src/components/students/students-master-detail.tsx
@@ -38,6 +38,7 @@ import { StudentEnrollmentsTab } from "./student-enrollments-tab";
 import { StudentStammdatenTab } from "./student-stammdaten-tab";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { getInitials } from "~/lib/format-utils";
+import { cn } from "~/lib/utils";
 import type { Student } from "~/lib/api";
 import type { BulkArrivalFilter } from "~/lib/student-arrival-api";
 
@@ -309,7 +310,12 @@ export function StudentsMasterDetail({
   };
 
   const listNode = (
-    <div className={selectionMode ? "pb-28 md:pb-0" : undefined}>
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col",
+        selectionMode && "pb-28 md:pb-0",
+      )}
+    >
       {selectionMode ? (
         <SelectionBar
           count={selectedStudentIds.size}


### PR DESCRIPTION
## Release-Zusammenfassung

Diese PR bringt den Hotfix aus #2202 von development nach main. Klassenlisten unter Datenverwaltung > Kinder bleiben wieder auf die sichtbare Master-Pane begrenzt und können vollständig gescrollt werden.

Diese PR ist release-only. Sie enthält keinen neuen Code über das hinaus, was bereits nach development gemergt wurde.

## Ursache und Korrektur

Der mit #2198 eingeführte Wrapper um die gruppierte Kinderliste war kein schrumpfbarer Flex-Container. Dadurch wuchs die Liste auf ihre volle Inhaltshöhe und wurde vom äußeren overflow-hidden-Panel abgeschnitten. Der Hotfix stellt den Flex- und min-h-0-Vertrag wieder her und ergänzt einen Regressionstest.

## Migration und Deploy-Hinweise

- keine Datenbankmigrationen
- keine neuen oder geänderten Environment-Variablen
- keine Änderungen an IoT-Endpunkten oder PyrePortal-Verträgen
- der Merge nach main startet den Produktionsdeploy mit Backup und Healthcheck

## Verifikation

- zielgerichtete Tests: 25/25 bestanden
- vollständige Frontend-Suite: 987 Dateien, 13.484 Tests bestanden
- pnpm run check bestanden
- Pre-Push: dependency-cruise, knip und Frontend-Check bestanden
- Browser-Repro mit 40 Kindern: Scrollcontainer bleibt begrenzt und das letzte Kind ist erreichbar

## Enthaltener PR

- #2202 Restore scrolling in student class lists