### PR TITLE
fix(students): improve bulk selection toolbar UX

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -37,6 +37,7 @@ import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
 import { hasPermission } from "~/lib/auth-utils";
 import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
 
 const logger = createLogger({ component: "DatabaseStudentsPage" });
 
@@ -468,10 +469,21 @@ function StudentsPageContent() {
                   </Link>
                 </>
               ) : null}
-              {canUpdateStudents && !selectionMode ? (
+              {canUpdateStudents ? (
                 <Button
+                  type="button"
                   variant="outline"
+                  size="md"
+                  aria-pressed={selectionMode}
+                  className={cn(
+                    "h-10 gap-2 px-3 shadow-none hover:ring-gray-300",
+                    selectionMode && "ring-gray-900 hover:ring-gray-900",
+                  )}
                   onClick={() => {
+                    if (selectionMode) {
+                      finishSelection();
+                      return;
+                    }
                     handleSelect(null);
                     setSelectionMode(true);
                   }}

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -448,7 +448,7 @@ export const setupChapters: readonly GuideChapter[] = [
           "Im Bereich `Ankunftsplan & Notizen` auf `Bearbeiten` klicken und die regelmäßigen Zeiten pro Wochentag im Format `HH:MM` eintragen.",
           "Für mehrere Kinder mit denselben Ankunftszeiten oben bei `Gruppieren` `Klasse` oder `Gruppe` wählen. Im Drei-Punkte-Menü der gewünschten Klasse oder OGS-Gruppe `Ankunftszeit bearbeiten` öffnen und die gemeinsamen Zeiten eintragen. Ausgefüllte Wochentage werden für alle Kinder des Filters gesetzt; leere Felder bleiben unverändert.",
           "Für einige frei zusammengestellte Kinder auf `Auswählen` klicken und die gewünschten Kinder einzeln anhaken. Suche und Gruppenfilter dürfen zwischendurch geändert werden; die Auswahl bleibt erhalten.",
-          "In der Auswahlleiste unter `Aktion` entweder `Ankunftszeiten ändern`, `Gehzeiten ändern` oder `Klassenfahrt planen` wählen. Bei den Wochenzeiten werden nur ausgefüllte Tage geändert; leere Tage und vorhandene Notizen bleiben unverändert.",
+          "Oben in der Auswahlleiste `Ankunftszeiten`, `Gehzeiten` oder `Klassenfahrt` wählen. Bei den Wochenzeiten werden nur ausgefüllte Tage geändert; leere Tage und vorhandene Notizen bleiben unverändert.",
           "Nach dem Speichern bleibt die Auswahl aktiv, damit bei Bedarf direkt eine weitere Aktion für dieselben Kinder ausgeführt werden kann. Mit `Fertig` wird sie beendet.",
           "Im Bereich `Gehplan & Notizen` auf `Bearbeiten` klicken und die regelmäßigen Gehzeiten, Abholer sowie Hinweise eintragen.",
           "Einzelne Abweichungen später über das Stift-Symbol am jeweiligen Wochentag pflegen.",

--- a/frontend/src/components/students/students-master-detail.test.tsx
+++ b/frontend/src/components/students/students-master-detail.test.tsx
@@ -802,21 +802,19 @@ describe("StudentsMasterDetail", () => {
     );
 
     expect(screen.getByText("2 ausgewählt")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Auswahl" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Aufheben" }));
     fireEvent.click(screen.getByRole("button", { name: "Fertig" }));
     expect(onClearSelection).toHaveBeenCalledOnce();
     expect(onFinishSelection).toHaveBeenCalledOnce();
 
-    fireEvent.click(screen.getByLabelText("Aktion für Auswahl"));
     expect(
-      screen.getByRole("menuitem", { name: "Gehzeiten ändern" }),
+      screen.getByRole("button", { name: "Gehzeiten" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "Klassenfahrt planen" }),
+      screen.getByRole("button", { name: "Klassenfahrt" }),
     ).toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("menuitem", { name: "Ankunftszeiten ändern" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Ankunftszeiten" }));
     expect(screen.getByTestId("bulk-modal")).toHaveAttribute(
       "data-filter-value",
       "1,3",
@@ -825,18 +823,14 @@ describe("StudentsMasterDetail", () => {
     expect(screen.getByText("2 ausgewählt")).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("bulk-close"));
 
-    fireEvent.click(screen.getByLabelText("Aktion für Auswahl"));
-    fireEvent.click(screen.getByRole("menuitem", { name: "Gehzeiten ändern" }));
+    fireEvent.click(screen.getByRole("button", { name: "Gehzeiten" }));
     expect(screen.getByTestId("pickup-selection-modal")).toHaveAttribute(
       "data-student-ids",
       "1,3",
     );
     fireEvent.click(screen.getByRole("button", { name: "close pickup" }));
 
-    fireEvent.click(screen.getByLabelText("Aktion für Auswahl"));
-    fireEvent.click(
-      screen.getByRole("menuitem", { name: "Klassenfahrt planen" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Klassenfahrt" }));
     expect(screen.getByTestId("class-trip-selection-modal")).toHaveAttribute(
       "data-student-ids",
       "1,3",

--- a/frontend/src/components/students/students-master-detail.tsx
+++ b/frontend/src/components/students/students-master-detail.tsx
@@ -29,7 +29,6 @@ import { FilteredBulkArrivalModal } from "./class-bulk-arrival-modal";
 import { ClassTripBulkStatusModal } from "./class-trip-bulk-status-modal";
 import { SelectionBulkPickupModal } from "./selection-bulk-pickup-modal";
 import { Button } from "~/components/ui/button";
-import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import { ArrivalScheduleManager } from "./arrival-schedule-manager";
 import { StudentAbholungTab } from "./student-abholung-tab";
 import { StudentGuardiansTab } from "./student-guardians-tab";
@@ -38,7 +37,6 @@ import { StudentEnrollmentsTab } from "./student-enrollments-tab";
 import { StudentStammdatenTab } from "./student-stammdaten-tab";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { getInitials } from "~/lib/format-utils";
-import { cn } from "~/lib/utils";
 import type { Student } from "~/lib/api";
 import type { BulkArrivalFilter } from "~/lib/student-arrival-api";
 
@@ -310,12 +308,7 @@ export function StudentsMasterDetail({
   };
 
   const listNode = (
-    <div
-      className={cn(
-        "flex min-h-0 flex-1 flex-col",
-        selectionMode && "pb-28 md:pb-0",
-      )}
-    >
+    <div className="flex min-h-0 flex-1 flex-col">
       {selectionMode ? (
         <SelectionBar
           count={selectedStudentIds.size}
@@ -463,36 +456,65 @@ function SelectionBar({
 }: SelectionBarProps) {
   const disabled = count === 0;
   return (
-    <div className="moto-content-surface border-moto-green/30 fixed right-3 bottom-[calc(5.5rem+env(safe-area-inset-bottom))] left-3 z-40 flex items-center gap-2 rounded-xl border p-2 shadow-lg md:sticky md:top-0 md:right-auto md:bottom-auto md:left-auto md:rounded-none md:border-x-0 md:shadow-sm">
-      <CheckSquare className="text-moto-green h-5 w-5 shrink-0" aria-hidden />
-      <span className="min-w-0 flex-1 text-sm font-semibold text-gray-900">
-        {count} ausgewählt
-      </span>
-      <Button
-        variant="ghost"
-        size="compact"
-        onClick={onClear}
-        disabled={disabled}
-      >
-        Aufheben
-      </Button>
-      <OverflowMenu
-        ariaLabel="Aktion für Auswahl"
-        triggerContent="Aktion"
-        triggerClassName="h-8 rounded-md bg-moto-green px-3 text-sm font-medium !text-gray-950 hover:bg-moto-green/90 disabled:opacity-40"
-        items={
-          disabled
-            ? []
-            : [
-                { label: "Ankunftszeiten ändern", onClick: onArrival },
-                { label: "Gehzeiten ändern", onClick: onPickup },
-                { label: "Klassenfahrt planen", onClick: onClassTrip },
-              ]
-        }
-      />
-      <Button variant="outline" size="compact" onClick={onFinish}>
-        Fertig
-      </Button>
+    <div
+      className="moto-content-surface border-moto-green/30 sticky top-0 z-20 shrink-0 border-x-0 border-b px-2 py-2 shadow-sm"
+      role="region"
+      aria-label="Auswahl"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <CheckSquare className="text-moto-green h-4 w-4 shrink-0" aria-hidden />
+        <span className="min-w-0 text-sm font-semibold text-gray-900">
+          {count} ausgewählt
+        </span>
+        <div className="ml-auto flex flex-wrap items-center gap-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            onClick={onClear}
+            disabled={disabled}
+          >
+            Aufheben
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="compact"
+            onClick={onFinish}
+          >
+            Fertig
+          </Button>
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="compact"
+          onClick={onArrival}
+          disabled={disabled}
+        >
+          Ankunftszeiten
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="compact"
+          onClick={onPickup}
+          disabled={disabled}
+        >
+          Gehzeiten
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="compact"
+          onClick={onClassTrip}
+          disabled={disabled}
+        >
+          Klassenfahrt
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Make **Auswählen** a persistent kit `Button` (`outline`/`md`) that toggles selection mode in place (`aria-pressed`, dark ring when active) so a double-click no longer lands on **Importieren**
- Move the selection chrome to a **sticky top** bar with flat kit actions (`Ankunftszeiten`, `Gehzeiten`, `Klassenfahrt`, `Aufheben`, `Fertig`) instead of a floating bottom bar + overflow **Aktion** menu
- Align all bulk actions as equal `outline` buttons; update help copy and tests

## Test plan

- [ ] Open `Datenverwaltung` → `Kinder` with `users:update`
- [ ] **Auswählen** matches neighbor toolbar height; hover does not strengthen the ring
- [ ] First click enters selection mode; button stays put with dark ring; second click exits
- [ ] Double-click does **not** open Importieren
- [ ] Selection bar is sticky at the top of the list (mobile + desktop), not floating bottom
- [ ] With 0 selected, action buttons disabled; with ≥1, Ankunftszeiten / Gehzeiten / Klassenfahrt open the right modals
- [ ] After save, selection remains until Fertig or toggle off
- [ ] `cd frontend && pnpm exec vitest run src/components/students/students-master-detail.test.tsx`
- [ ] `cd frontend && pnpm run check`