### PR TITLE
fix(ui): stop dropdown options jumping under the mouse

### DIFF
--- a/frontend/src/components/ui/custom-select.test.tsx
+++ b/frontend/src/components/ui/custom-select.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { FormEvent } from "react";
+import { flushSync } from "react-dom";
 import { describe, expect, it, vi } from "vitest";
 import { CustomSelect } from "./custom-select";
 
@@ -522,6 +523,7 @@ describe("CustomSelect", () => {
         fireEvent.click(screen.getByRole("combobox", { name: "Lange Liste" }));
 
         expect(screen.getByRole("listbox")).toBeInTheDocument();
+        expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
         expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
         expect(screen.getByRole("option", { name: "Option 31" })).toHaveFocus();
       } finally {
@@ -597,6 +599,11 @@ describe("CustomSelect", () => {
       const scrolledLabels: string[] = [];
       const scrollIntoViewMock = vi.fn(function scrollIntoView(this: Element) {
         scrolledLabels.push(this.textContent ?? "");
+        // scrollIntoView on a long list scrolls the listbox; that fires a
+        // capture-phase window scroll listener. Without ignoring menu-local
+        // scrolls, a new menuStyle re-scrolls the hovered focusIndex.
+        const menu = this.closest('[role="listbox"]');
+        menu?.dispatchEvent(new Event("scroll", { bubbles: true }));
       });
       Element.prototype.scrollIntoView = scrollIntoViewMock;
 
@@ -611,11 +618,29 @@ describe("CustomSelect", () => {
         );
 
         const trigger = screen.getByRole("combobox", { name: "Lange Liste" });
-        // Batch open + hover in one act so focus can move before open scroll.
-        fireEvent.click(trigger);
-        fireEvent.mouseEnter(screen.getByRole("option", { name: "Option 1" }));
+        // flushSync opens the menu (layout) without running passive effects;
+        // hover then moves focusIndex before the open-scroll effect. Native
+        // dispatch (not RTL fireEvent) avoids a per-event act flush that would
+        // run effects between the two steps.
+        act(() => {
+          flushSync(() => {
+            trigger.dispatchEvent(
+              new MouseEvent("click", { bubbles: true, cancelable: true }),
+            );
+          });
+          const hovered = screen.getByRole("option", { name: "Option 1" });
+          // React wires onMouseEnter from mouseover; fire both.
+          hovered.dispatchEvent(
+            new MouseEvent("mouseover", { bubbles: true, cancelable: true }),
+          );
+          hovered.dispatchEvent(
+            new MouseEvent("mouseenter", { bubbles: true, cancelable: true }),
+          );
+        });
 
         expect(scrolledLabels).toContain("Option 31");
+        // Hover must not get a follow-up layout re-scroll after open reveal.
+        expect(scrolledLabels).not.toContain("Option 1");
         expect(screen.getByRole("option", { name: "Option 1" })).toHaveFocus();
       } finally {
         Element.prototype.scrollIntoView = vi.fn();

--- a/frontend/src/components/ui/custom-select.test.tsx
+++ b/frontend/src/components/ui/custom-select.test.tsx
@@ -498,4 +498,96 @@ describe("CustomSelect", () => {
       widthSpy.mockRestore();
     }
   });
+
+  describe("scroll behaviour in long lists", () => {
+    const longOptions = Array.from({ length: 40 }, (_, index) => ({
+      value: `opt-${index}`,
+      label: `Option ${index + 1}`,
+    }));
+
+    it("scrolls the selected option into view once when the menu opens", () => {
+      const scrollIntoViewMock = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+      try {
+        render(
+          <CustomSelect
+            value="opt-30"
+            options={longOptions}
+            onChange={vi.fn()}
+            ariaLabel="Lange Liste"
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox", { name: "Lange Liste" }));
+
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+        expect(screen.getByRole("option", { name: "Option 31" })).toHaveFocus();
+      } finally {
+        Element.prototype.scrollIntoView = vi.fn();
+      }
+    });
+
+    it("does not scroll when the pointer enters an already-visible option", () => {
+      // Hover used to set focusIndex and scrollIntoView({ block: "center" }),
+      // which re-centred the list under the cursor and made options jump (#2212).
+      const scrollIntoViewMock = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+      try {
+        render(
+          <CustomSelect
+            value="opt-0"
+            options={longOptions}
+            onChange={vi.fn()}
+            ariaLabel="Lange Liste"
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox", { name: "Lange Liste" }));
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+        // Opening may scroll the selected value into view once; that is fine.
+        scrollIntoViewMock.mockClear();
+
+        fireEvent.mouseEnter(screen.getByRole("option", { name: "Option 8" }));
+
+        expect(scrollIntoViewMock).not.toHaveBeenCalled();
+        expect(screen.getByRole("option", { name: "Option 8" })).toHaveFocus();
+      } finally {
+        Element.prototype.scrollIntoView = vi.fn();
+      }
+    });
+
+    it("scrolls the focused option into view on keyboard navigation", () => {
+      const scrollIntoViewMock = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+      try {
+        render(
+          <CustomSelect
+            value="opt-0"
+            options={longOptions}
+            onChange={vi.fn()}
+            ariaLabel="Lange Liste"
+          />,
+        );
+
+        const trigger = screen.getByRole("combobox", { name: "Lange Liste" });
+        fireEvent.click(trigger);
+        scrollIntoViewMock.mockClear();
+
+        fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+        expect(scrollIntoViewMock).toHaveBeenCalled();
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          block: "nearest",
+        });
+        expect(screen.getByRole("option", { name: "Option 2" })).toHaveFocus();
+      } finally {
+        Element.prototype.scrollIntoView = vi.fn();
+      }
+    });
+  });
 });

--- a/frontend/src/components/ui/custom-select.test.tsx
+++ b/frontend/src/components/ui/custom-select.test.tsx
@@ -589,5 +589,66 @@ describe("CustomSelect", () => {
         Element.prototype.scrollIntoView = vi.fn();
       }
     });
+
+    it("scrolls the selected option on open even when hover moves focus first", () => {
+      // Open scroll must use the index captured at open time. If mouseEnter
+      // changes focusIndex before the open effect runs, scrolling focusIndex
+      // would reveal the hovered row and leave the selection off-screen.
+      const scrolledLabels: string[] = [];
+      const scrollIntoViewMock = vi.fn(function scrollIntoView(this: Element) {
+        scrolledLabels.push(this.textContent ?? "");
+      });
+      Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+      try {
+        render(
+          <CustomSelect
+            value="opt-30"
+            options={longOptions}
+            onChange={vi.fn()}
+            ariaLabel="Lange Liste"
+          />,
+        );
+
+        const trigger = screen.getByRole("combobox", { name: "Lange Liste" });
+        // Batch open + hover in one act so focus can move before open scroll.
+        fireEvent.click(trigger);
+        fireEvent.mouseEnter(screen.getByRole("option", { name: "Option 1" }));
+
+        expect(scrolledLabels).toContain("Option 31");
+        expect(screen.getByRole("option", { name: "Option 1" })).toHaveFocus();
+      } finally {
+        Element.prototype.scrollIntoView = vi.fn();
+      }
+    });
+
+    it("scrolls the focused option after layout updates even when hover suppressed scroll", () => {
+      const scrollIntoViewMock = vi.fn();
+      Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+      try {
+        render(
+          <CustomSelect
+            value="opt-0"
+            options={longOptions}
+            onChange={vi.fn()}
+            ariaLabel="Lange Liste"
+          />,
+        );
+
+        fireEvent.click(screen.getByRole("combobox", { name: "Lange Liste" }));
+        fireEvent.mouseEnter(screen.getByRole("option", { name: "Option 8" }));
+        scrollIntoViewMock.mockClear();
+
+        // Resize repositions the menu (new menuStyle). Hover suppress must not
+        // leave the focused option off-screen after the layout change.
+        fireEvent(window, new Event("resize"));
+
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+        expect(screen.getByRole("option", { name: "Option 8" })).toHaveFocus();
+      } finally {
+        Element.prototype.scrollIntoView = vi.fn();
+      }
+    });
   });
 });

--- a/frontend/src/components/ui/listbox-dropdown.tsx
+++ b/frontend/src/components/ui/listbox-dropdown.tsx
@@ -183,6 +183,14 @@ export function ListboxDropdown<K extends string>({
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const typeaheadBufferRef = useRef("");
   const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Pointer-driven focus (hover) must not scroll the menu — re-centering under
+  // the cursor makes long lists jump and options unclickable (#2212). Stays
+  // true until the next keyboard/open focus move; do not clear in the effect
+  // (React Strict Mode re-runs effects and would re-enable scroll).
+  const suppressFocusScrollRef = useRef(false);
+  // One-shot scroll when the menu opens so an early mouseEnter (pointer over
+  // the portaled list as it appears) cannot suppress revealing the selection.
+  const forceOpenScrollRef = useRef(false);
   const [open, setOpen] = useState(false);
   const [menuStyle, setMenuStyle] = useState<CSSProperties | null>(null);
   const selectedIndex = selectedIndexForValue(options, value);
@@ -300,16 +308,26 @@ export function ListboxDropdown<K extends string>({
   useEffect(() => {
     if (!open) return;
     const option = optionRefs.current[focusIndex];
-    option?.focus();
+    // preventScroll: native focus scrolling would still jump the list on hover
+    // even when we skip the explicit scrollIntoView below.
+    option?.focus({ preventScroll: true });
     // A long list (the calendar's 101 years) otherwise opens scrolled to the
     // top, with the current value off-screen. This waits for menuStyle, because
     // the maxHeight it carries is what makes the menu scrollable at all —
     // scrolling before that would move the page instead of the list.
-    if (menuStyle) {
-      // "center" puts the current value in the middle of the list, so the
-      // neighbouring options are reachable in both directions. A list
-      // short enough not to overflow has nothing to scroll and stays put.
-      option?.scrollIntoView({ block: "center" });
+    //
+    // "nearest" only moves when the option is outside the visible range — never
+    // re-centres an already-visible row under the pointer. Skip pointer hover
+    // so mouseEnter never changes scroll position (#2212), except the one-shot
+    // open scroll which still reveals the selection.
+    if (!menuStyle) return;
+    if (forceOpenScrollRef.current) {
+      forceOpenScrollRef.current = false;
+      option?.scrollIntoView({ block: "nearest" });
+      return;
+    }
+    if (!suppressFocusScrollRef.current) {
+      option?.scrollIntoView({ block: "nearest" });
     }
   }, [open, focusIndex, menuStyle]);
 
@@ -343,6 +361,8 @@ export function ListboxDropdown<K extends string>({
   );
 
   const openAtSelected = () => {
+    suppressFocusScrollRef.current = false;
+    forceOpenScrollRef.current = true;
     setFocusIndex(selectedIndex);
     setOpen(true);
   };
@@ -379,12 +399,16 @@ export function ListboxDropdown<K extends string>({
       open ? focusIndex : selectedIndex,
       hasAnchor,
     );
+    suppressFocusScrollRef.current = false;
     if (matchIndex >= 0) {
       setFocusIndex(matchIndex);
     } else if (!open) {
       setFocusIndex(selectedIndex);
     }
-    if (!open) setOpen(true);
+    if (!open) {
+      forceOpenScrollRef.current = true;
+      setOpen(true);
+    }
     return true;
   };
 
@@ -408,11 +432,13 @@ export function ListboxDropdown<K extends string>({
     if (open) {
       if (event.key === "ArrowDown") {
         event.preventDefault();
+        suppressFocusScrollRef.current = false;
         setFocusIndex((prev) => nextEnabledIndex(options, prev, 1));
         return;
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
+        suppressFocusScrollRef.current = false;
         setFocusIndex((prev) => nextEnabledIndex(options, prev, -1));
         return;
       }
@@ -438,18 +464,22 @@ export function ListboxDropdown<K extends string>({
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();
+        suppressFocusScrollRef.current = false;
         setFocusIndex((prev) => nextEnabledIndex(options, prev, 1));
         break;
       case "ArrowUp":
         event.preventDefault();
+        suppressFocusScrollRef.current = false;
         setFocusIndex((prev) => nextEnabledIndex(options, prev, -1));
         break;
       case "Home":
         event.preventDefault();
+        suppressFocusScrollRef.current = false;
         setFocusIndex(firstEnabledIndex(options));
         break;
       case "End":
         event.preventDefault();
+        suppressFocusScrollRef.current = false;
         for (let index = options.length - 1; index >= 0; index--) {
           if (!options[index]?.disabled) {
             setFocusIndex(index);
@@ -493,8 +523,13 @@ export function ListboxDropdown<K extends string>({
         type="button"
         onClick={(event) => {
           event.preventDefault();
+          suppressFocusScrollRef.current = false;
+          setOpen((prev) => {
+            const next = !prev;
+            if (next) forceOpenScrollRef.current = true;
+            return next;
+          });
           setFocusIndex(selectedIndex);
-          setOpen((prev) => !prev);
         }}
         onKeyDown={handleTriggerKeyDown}
         aria-haspopup="listbox"
@@ -587,7 +622,9 @@ export function ListboxDropdown<K extends string>({
                       onClick={() => selectAt(index)}
                       onKeyDown={handleOptionKeyDown}
                       onMouseEnter={() => {
-                        if (!option.disabled) setFocusIndex(index);
+                        if (option.disabled) return;
+                        suppressFocusScrollRef.current = true;
+                        setFocusIndex(index);
                       }}
                       className={
                         option.disabled

--- a/frontend/src/components/ui/listbox-dropdown.tsx
+++ b/frontend/src/components/ui/listbox-dropdown.tsx
@@ -300,17 +300,31 @@ export function ListboxDropdown<K extends string>({
   // Layout effect so the first visible frame is already positioned (the menu
   // renders hidden until menuStyle is set). Scroll listens in capture phase to
   // catch ancestor scroll containers (modal bodies), not just the window.
+  // Scrolls *inside* the option list are ignored: scrollIntoView on open/keyboard
+  // would otherwise re-fire updateMenuPosition → new menuStyle → a layout
+  // re-scroll of the (possibly hover-moved) focusIndex, undoing the open reveal.
   useLayoutEffect(() => {
     if (!open) {
       setMenuStyle(null);
       return;
     }
+    const handleScroll = (event: Event) => {
+      const target = event.target;
+      if (
+        menuRef.current &&
+        target instanceof Node &&
+        (target === menuRef.current || menuRef.current.contains(target))
+      ) {
+        return;
+      }
+      updateMenuPosition();
+    };
     updateMenuPosition();
     window.addEventListener("resize", updateMenuPosition);
-    window.addEventListener("scroll", updateMenuPosition, true);
+    window.addEventListener("scroll", handleScroll, true);
     return () => {
       window.removeEventListener("resize", updateMenuPosition);
-      window.removeEventListener("scroll", updateMenuPosition, true);
+      window.removeEventListener("scroll", handleScroll, true);
     };
   }, [open, options, updateMenuPosition]);
 

--- a/frontend/src/components/ui/listbox-dropdown.tsx
+++ b/frontend/src/components/ui/listbox-dropdown.tsx
@@ -524,11 +524,10 @@ export function ListboxDropdown<K extends string>({
         onClick={(event) => {
           event.preventDefault();
           suppressFocusScrollRef.current = false;
-          setOpen((prev) => {
-            const next = !prev;
-            if (next) forceOpenScrollRef.current = true;
-            return next;
-          });
+          // Ref write stays outside setOpen — React may re-run functional
+          // updaters, so side effects inside them are invalid (react-doctor).
+          if (!open) forceOpenScrollRef.current = true;
+          setOpen((prev) => !prev);
           setFocusIndex(selectedIndex);
         }}
         onKeyDown={handleTriggerKeyDown}

--- a/frontend/src/components/ui/listbox-dropdown.tsx
+++ b/frontend/src/components/ui/listbox-dropdown.tsx
@@ -184,13 +184,22 @@ export function ListboxDropdown<K extends string>({
   const typeaheadBufferRef = useRef("");
   const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Pointer-driven focus (hover) must not scroll the menu — re-centering under
-  // the cursor makes long lists jump and options unclickable (#2212). Stays
-  // true until the next keyboard/open focus move; do not clear in the effect
-  // (React Strict Mode re-runs effects and would re-enable scroll).
+  // the cursor makes long lists jump and options unclickable (#2212). Applies
+  // only to hover-driven focusIndex changes; layout (menuStyle) updates still
+  // keep the focused option in view. Do not clear in the effect on its own
+  // (React Strict Mode re-runs effects and would re-enable hover scroll).
   const suppressFocusScrollRef = useRef(false);
   // One-shot scroll when the menu opens so an early mouseEnter (pointer over
   // the portaled list as it appears) cannot suppress revealing the selection.
   const forceOpenScrollRef = useRef(false);
+  // Index captured at open time — open scroll must target this, not whatever
+  // hover may have moved focusIndex to before the effect runs.
+  const openScrollIndexRef = useRef<number | null>(null);
+  // Track last effect inputs so hover-suppression does not also block
+  // layout-only re-runs (resize/scroll reposition), and Strict Mode re-runs
+  // do not re-scroll after a suppressed hover focus move.
+  const lastScrollFocusIndexRef = useRef<number | null>(null);
+  const lastScrollMenuStyleRef = useRef<CSSProperties | null>(null);
   const [open, setOpen] = useState(false);
   const [menuStyle, setMenuStyle] = useState<CSSProperties | null>(null);
   const selectedIndex = selectedIndexForValue(options, value);
@@ -306,7 +315,11 @@ export function ListboxDropdown<K extends string>({
   }, [open, options, updateMenuPosition]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      lastScrollFocusIndexRef.current = null;
+      lastScrollMenuStyleRef.current = null;
+      return;
+    }
     const option = optionRefs.current[focusIndex];
     // preventScroll: native focus scrolling would still jump the list on hover
     // even when we skip the explicit scrollIntoView below.
@@ -317,18 +330,35 @@ export function ListboxDropdown<K extends string>({
     // scrolling before that would move the page instead of the list.
     //
     // "nearest" only moves when the option is outside the visible range — never
-    // re-centres an already-visible row under the pointer. Skip pointer hover
-    // so mouseEnter never changes scroll position (#2212), except the one-shot
-    // open scroll which still reveals the selection.
+    // re-centres an already-visible row under the pointer. Hover-driven focus
+    // changes skip scroll (#2212); layout-driven menuStyle updates still reveal
+    // the focused option after resize/reposition. Open uses a captured index so
+    // an early mouseEnter cannot steal the one-shot reveal of the selection.
     if (!menuStyle) return;
+
     if (forceOpenScrollRef.current) {
       forceOpenScrollRef.current = false;
-      option?.scrollIntoView({ block: "nearest" });
+      const openIndex = openScrollIndexRef.current ?? focusIndex;
+      openScrollIndexRef.current = null;
+      optionRefs.current[openIndex]?.scrollIntoView({ block: "nearest" });
+      lastScrollFocusIndexRef.current = focusIndex;
+      lastScrollMenuStyleRef.current = menuStyle;
       return;
     }
-    if (!suppressFocusScrollRef.current) {
-      option?.scrollIntoView({ block: "nearest" });
+
+    const focusChanged = lastScrollFocusIndexRef.current !== focusIndex;
+    const layoutChanged = lastScrollMenuStyleRef.current !== menuStyle;
+    lastScrollFocusIndexRef.current = focusIndex;
+    lastScrollMenuStyleRef.current = menuStyle;
+
+    // No real input change (e.g. Strict Mode re-run after a suppressed hover).
+    if (!focusChanged && !layoutChanged) return;
+    // Pure hover focus move: leave scroll position alone.
+    if (focusChanged && suppressFocusScrollRef.current && !layoutChanged) {
+      return;
     }
+
+    option?.scrollIntoView({ block: "nearest" });
   }, [open, focusIndex, menuStyle]);
 
   const resetTypeahead = useCallback(() => {
@@ -360,9 +390,14 @@ export function ListboxDropdown<K extends string>({
     [closeAndReturnFocus, onChange, options],
   );
 
+  const markOpenScrollTo = (index: number) => {
+    forceOpenScrollRef.current = true;
+    openScrollIndexRef.current = index;
+  };
+
   const openAtSelected = () => {
     suppressFocusScrollRef.current = false;
-    forceOpenScrollRef.current = true;
+    markOpenScrollTo(selectedIndex);
     setFocusIndex(selectedIndex);
     setOpen(true);
   };
@@ -406,7 +441,7 @@ export function ListboxDropdown<K extends string>({
       setFocusIndex(selectedIndex);
     }
     if (!open) {
-      forceOpenScrollRef.current = true;
+      markOpenScrollTo(matchIndex >= 0 ? matchIndex : selectedIndex);
       setOpen(true);
     }
     return true;
@@ -526,7 +561,7 @@ export function ListboxDropdown<K extends string>({
           suppressFocusScrollRef.current = false;
           // Ref write stays outside setOpen — React may re-run functional
           // updaters, so side effects inside them are invalid (react-doctor).
-          if (!open) forceOpenScrollRef.current = true;
+          if (!open) markOpenScrollTo(selectedIndex);
           setOpen((prev) => !prev);
           setFocusIndex(selectedIndex);
         }}


### PR DESCRIPTION
## Summary

- Long `CustomSelect` / `ListboxDropdown` lists no longer re-center on mouse hover, so options stay under the cursor and remain clickable.
- Opening reveals the selected or typeahead-matched option once with `block: "nearest"`.
- Keyboard navigation and typeahead still keep the focused option visible.
- Viewport and ancestor repositioning remain supported without re-scrolling on menu-local scroll events.

Closes #2212

## Test plan

- [x] `pnpm exec vitest run src/components/ui/custom-select.test.tsx`
- [x] `pnpm exec vitest run src/components/ui/date-picker.test.tsx`
- [x] Related timetable + enrollment suite green
- [x] `pnpm run check`
- [ ] Manually open a long room select in the Betreuungsplan, hover lower options, and click one
- [ ] Manually open a long status filter on an enrollment phase and verify options stay put
- [ ] Verify keyboard arrows and typeahead reveal off-screen options
