### PR TITLE
fix(ui): Lehrkraft-Rolle groß anzeigen statt roh aus der DB

### DIFF
--- a/backend/services/auth/invitation_service.go
+++ b/backend/services/auth/invitation_service.go
@@ -34,10 +34,11 @@ const (
 // systemRoleTranslations maps English system role names to German display names.
 // Used for user-facing content like emails.
 var systemRoleTranslations = map[string]string{
-	"admin":    "Administrator",
-	"user":     "Betreuer",
-	"guest":    "Gast",
-	"guardian": "Erziehungsberechtigter",
+	"admin":     "Administrator",
+	"user":      "Betreuer",
+	"guest":     "Gast",
+	"guardian":  "Erziehungsberechtigter",
+	"lehrkraft": "Lehrkraft",
 }
 
 // translateRoleNameToGerman translates system role names to German.

--- a/backend/services/auth/invitation_service_test.go
+++ b/backend/services/auth/invitation_service_test.go
@@ -524,6 +524,8 @@ func TestTranslateRoleNameToGerman(t *testing.T) {
 		{"Guest", "Gast"},
 		{"guardian", "Erziehungsberechtigter"},
 		{"Guardian", "Erziehungsberechtigter"},
+		{"lehrkraft", "Lehrkraft"},
+		{"Lehrkraft", "Lehrkraft"},
 		{"teacher", "teacher"},         // Not a system role, returns as-is
 		{"custom_role", "custom_role"}, // Unknown role, returns as-is
 		{"", ""},                       // Empty string

--- a/frontend/src/lib/staff-helpers.test.ts
+++ b/frontend/src/lib/staff-helpers.test.ts
@@ -187,6 +187,30 @@ describe("getStaffDisplayType", () => {
     expect(result).toBe("Gast");
   });
 
+  it("maps 'lehrkraft' accountRole to Lehrkraft", () => {
+    const staff = createSampleStaff({
+      role: undefined,
+      isTeacher: false,
+      specialization: undefined,
+      accountRole: "lehrkraft",
+    });
+    const result = getStaffDisplayType(staff);
+
+    expect(result).toBe("Lehrkraft");
+  });
+
+  it("maps an accountRole regardless of its stored casing", () => {
+    const staff = createSampleStaff({
+      role: undefined,
+      isTeacher: false,
+      specialization: undefined,
+      accountRole: "Lehrkraft",
+    });
+    const result = getStaffDisplayType(staff);
+
+    expect(result).toBe("Lehrkraft");
+  });
+
   it("maps 'user' accountRole to Betreuer", () => {
     const staff = createSampleStaff({
       role: undefined,

--- a/frontend/src/lib/staff-helpers.ts
+++ b/frontend/src/lib/staff-helpers.ts
@@ -93,10 +93,13 @@ const ROLE_DISPLAY_NAMES: Record<string, string> = {
   user: "Betreuer",
   guest: "Gast",
   guardian: "Erziehungsberechtigte/r",
+  lehrkraft: "Lehrkraft",
 };
 
+// Role names are stored lowercase in auth.roles; lowercase before the lookup so
+// a raw system role name never reaches the UI in its stored spelling.
 function formatAccountRole(role: string): string {
-  return ROLE_DISPLAY_NAMES[role] ?? role;
+  return ROLE_DISPLAY_NAMES[role.toLowerCase()] ?? role;
 }
 
 // Get a display-friendly role/type for staff


### PR DESCRIPTION
## Problem

Die Systemrolle heißt in `auth.roles` `lehrkraft` (klein, wie alle Systemrollen). Zwei Anzeigepfade haben diesen Rohwert ungefiltert an die Oberfläche gereicht, weil ihre jeweilige Label-Map den Eintrag nicht kannte und auf den Rohwert zurückfällt.

## Fix

- **OGS-Portal, Mitarbeiter-Liste und -Detail** (`frontend/src/lib/staff-helpers.ts`): `ROLE_DISPLAY_NAMES` kannte nur `admin/user/guest/guardian`. Greift genau dann, wenn keine Position hinterlegt ist, also bei einer per Einladung angelegten Lehrkraft. Der Lookup schlägt jetzt zusätzlich kleingeschrieben nach, damit keine Schreibweise mehr durchrutscht.
- **Einladungs-Mail** (`backend/services/auth/invitation_service.go`): `systemRoleTranslations` fehlte der Eintrag, in der Mail stand wörtlich "Rolle: lehrkraft".

## Tests

Zwei neue Fälle in `staff-helpers.test.ts` (Mapping + Schreibweise), zwei Zeilen in der Tabelle von `TestTranslateRoleNameToGerman`. Keine bestehende Erwartung geändert. `pnpm run check` grün.

## Bewusst nicht enthalten

- **Operator-Portal, Konten-Tabelle, Spalte "Rolle"** (`accounts-table.tsx`): rendert `role_name` komplett roh, dort steht jede Systemrolle klein (`admin`, `user`, `lehrkraft`). Der Fix bleibt dort nicht lehrkraft-lokal: die etablierte Operator-Vokabel aus dem Schulzugänge-Modal ist `admin -> Verwaltung`, `user -> Betreuung`, und ein bestehender Test erwartet wörtlich "Admin" im Badge. Separat zu entscheiden.
- **Konsolidierung der Label-Maps**: es existieren vier parallele Rollen-Label-Maps (`auth-helpers` "Administrator", `staff-helpers` "Admin", Operator "Verwaltung", Backend "Administrator"). Genau diese Duplikation hat den Bug erzeugt. Zusammenführen auf `getRoleDisplayName` würde in der Mitarbeiter-Liste "Admin" zu "Administrator" ändern und einen bestehenden Test brechen, gehört also in einen eigenen PR.