### PR TITLE
fix: Geburtsdatum von Mitarbeitenden direkt eingeben

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "@tailwindcss/postcss": "^4.3.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1

--- a/frontend/src/components/staff/stammdaten-section-modals.tsx
+++ b/frontend/src/components/staff/stammdaten-section-modals.tsx
@@ -5,10 +5,11 @@ import { Plus, Trash2 } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { CustomSelect } from "~/components/ui/custom-select";
-import { ISODatePicker } from "~/components/ui/date-picker";
+import { ISODateInput, ISODatePicker } from "~/components/ui/date-picker";
 import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
 import { createLogger } from "~/lib/logger";
+import { todayISO } from "~/lib/date-helpers";
 import {
   staffStammdatenService,
   type StammdatenArbeitsvertrag,
@@ -163,6 +164,7 @@ export function PersonEditModal({
   const [firstName, setFirstName] = useState(person.firstName);
   const [lastName, setLastName] = useState(person.lastName);
   const [birthday, setBirthday] = useState(person.birthday ?? "");
+  const [birthdayValid, setBirthdayValid] = useState(true);
   const [gender, setGender] = useState<string>(person.gender ?? "");
   const [note, setNote] = useState("");
   const { saving, error, run } = useSectionSave(onSaved);
@@ -187,11 +189,14 @@ export function PersonEditModal({
             value={lastName}
             onChange={(e) => setLastName(e.target.value)}
           />
-          <ISODatePicker
+          <ISODateInput
             label="Geburtsdatum"
             id="stammdaten-birthday"
             value={birthday}
             onChange={setBirthday}
+            onValidityChange={setBirthdayValid}
+            max={todayISO()}
+            maxDateError="Das Geburtsdatum darf nicht in der Zukunft liegen."
           />
           <SelectField
             id="stammdaten-gender"
@@ -206,7 +211,7 @@ export function PersonEditModal({
         <ModalFooter
           onClose={onClose}
           saving={saving}
-          disabled={!valid}
+          disabled={!valid || !birthdayValid}
           onSave={() =>
             void run("stammdaten_person_save_failed", () =>
               staffStammdatenService.updatePerson(

--- a/frontend/src/components/staff/stammdaten-section-modals.tsx
+++ b/frontend/src/components/staff/stammdaten-section-modals.tsx
@@ -9,7 +9,8 @@ import { ISODateInput, ISODatePicker } from "~/components/ui/date-picker";
 import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
 import { createLogger } from "~/lib/logger";
-import { todayISO } from "~/lib/date-helpers";
+import { isValidISODate } from "~/lib/date-helpers";
+import { useBerlinToday } from "~/lib/hooks/use-berlin-today";
 import {
   staffStammdatenService,
   type StammdatenArbeitsvertrag,
@@ -164,7 +165,13 @@ export function PersonEditModal({
   const [firstName, setFirstName] = useState(person.firstName);
   const [lastName, setLastName] = useState(person.lastName);
   const [birthday, setBirthday] = useState(person.birthday ?? "");
-  const [birthdayValid, setBirthdayValid] = useState(true);
+  const berlinToday = useBerlinToday();
+  const birthdayDay = birthday.slice(0, 10);
+  const [birthdayValid, setBirthdayValid] = useState(
+    () =>
+      birthday === "" ||
+      (isValidISODate(birthdayDay) && birthdayDay <= berlinToday),
+  );
   const [gender, setGender] = useState<string>(person.gender ?? "");
   const [note, setNote] = useState("");
   const { saving, error, run } = useSectionSave(onSaved);
@@ -195,7 +202,7 @@ export function PersonEditModal({
             value={birthday}
             onChange={setBirthday}
             onValidityChange={setBirthdayValid}
-            max={todayISO()}
+            max={berlinToday}
             maxDateError="Das Geburtsdatum darf nicht in der Zukunft liegen."
           />
           <SelectField

--- a/frontend/src/components/staff/stammdaten-sections.test.tsx
+++ b/frontend/src/components/staff/stammdaten-sections.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { StammdatenTab } from "./stammdaten-tab";
-import type { StaffStammdaten } from "~/lib/staff-api";
+import { staffStammdatenService, type StaffStammdaten } from "~/lib/staff-api";
 
 // Section rendering + permission gating of the Stammdaten tab (#1423). The
 // SWR mock switches on the cache key so the aggregate, payroll and financial
@@ -103,6 +103,7 @@ describe("StammdatenTab Sektionen (#1423)", () => {
   beforeEach(() => {
     mutate.mockReset();
     revealFinancial.mockReset();
+    vi.mocked(staffStammdatenService.updatePerson).mockReset();
     swrErrors.current = new Map();
   });
 
@@ -151,6 +152,34 @@ describe("StammdatenTab Sektionen (#1423)", () => {
     fireEvent.click(editButtons[0]!);
     expect(screen.getByText("Person bearbeiten")).toBeInTheDocument();
     expect(screen.getByLabelText("Vorname")).toHaveValue("Mila");
+  });
+
+  it("überschreibt ein vorhandenes Geburtsdatum und sendet den ISO-Wert", async () => {
+    seedSWR();
+    render(
+      <StammdatenTab
+        staffId="42"
+        canManagePayroll={false}
+        canManagePayrollSettings={false}
+        canViewSections
+        canEditSections
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Bearbeiten" })[0]!);
+    const birthdayInput = screen.getByLabelText("Geburtsdatum");
+    expect(birthdayInput).toHaveValue("12.04.1990");
+
+    fireEvent.change(birthdayInput, { target: { value: "17.04.1982" } });
+    fireEvent.click(screen.getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() =>
+      expect(staffStammdatenService.updatePerson).toHaveBeenCalledWith(
+        "42",
+        expect.objectContaining({ birthday: "1982-04-17" }),
+        "",
+      ),
+    );
   });
 
   it("zeigt ohne staff:financial die Sperre statt der Bank-Sektion", () => {

--- a/frontend/src/components/ui/calendar-panel-position.test.ts
+++ b/frontend/src/components/ui/calendar-panel-position.test.ts
@@ -18,6 +18,10 @@ describe("clampCalendarWidth", () => {
     expect(dayButton).toBeGreaterThanOrEqual(20);
   });
 
+  it("keeps the complete header visible under an icon-only trigger", () => {
+    expect(clampCalendarWidth(40, VIEWPORT.width)).toBe(304);
+  });
+
   it("still matches the trigger width when the trigger is wide enough", () => {
     expect(clampCalendarWidth(380, VIEWPORT.width)).toBe(380);
   });

--- a/frontend/src/components/ui/calendar-panel-position.test.ts
+++ b/frontend/src/components/ui/calendar-panel-position.test.ts
@@ -22,6 +22,10 @@ describe("clampCalendarWidth", () => {
     expect(clampCalendarWidth(40, VIEWPORT.width)).toBe(304);
   });
 
+  it("shrinks the panel to the available width below 320px", () => {
+    expect(clampCalendarWidth(40, 280)).toBe(264);
+  });
+
   it("still matches the trigger width when the trigger is wide enough", () => {
     expect(clampCalendarWidth(380, VIEWPORT.width)).toBe(380);
   });

--- a/frontend/src/components/ui/calendar-panel-position.ts
+++ b/frontend/src/components/ui/calendar-panel-position.ts
@@ -21,13 +21,13 @@
 export const CALENDAR_PANEL_MARGIN = 8;
 
 /**
- * Narrowest a stretchable calendar gets: 7 × (20px day button + 8px cell
- * gutter) + 12px compact card padding per side + the 1px border. The previous
- * 176px floor was derived from the 20px *cell*, forgetting that the px-1
- * gutter lives inside the cell — which left the clickable day button at ~13px,
- * too narrow for two-digit dates. 20px is what the BUTTON needs.
+ * Narrowest a stretchable calendar gets. The day grid itself fits into less,
+ * but the complete component also needs room for both navigation buttons and
+ * the month and year controls. Keeping that requirement in the shared geometry
+ * prevents icon-only triggers from collapsing the panel and clipping its
+ * header.
  */
-const CALENDAR_MIN_WIDTH = 222;
+const CALENDAR_MIN_WIDTH = 304;
 
 /**
  * Height used for the flip-up decision: the worst case, a six-week month.

--- a/frontend/src/components/ui/date-picker.test.tsx
+++ b/frontend/src/components/ui/date-picker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { DatePicker } from "./date-picker";
+import { DatePicker, ISODateInput } from "./date-picker";
 
 // Mock react-day-picker
 vi.mock("react-day-picker", () => ({
@@ -257,34 +257,13 @@ describe("DatePicker", () => {
     expect(mockOnChange).toHaveBeenCalledWith(null);
   });
 
-  it("clears date when Enter key is pressed on clear button", () => {
+  it("uses a native button for keyboard-accessible clearing", () => {
     const testDate = new Date("2024-01-15T00:00:00Z");
     render(<DatePicker value={testDate} onChange={mockOnChange} />);
 
     const clearButton = screen.getByRole("button", { name: /datum löschen/i });
-    fireEvent.keyDown(clearButton, { key: "Enter" });
-
-    expect(mockOnChange).toHaveBeenCalledWith(null);
-  });
-
-  it("clears date when Space key is pressed on clear button", () => {
-    const testDate = new Date("2024-01-15T00:00:00Z");
-    render(<DatePicker value={testDate} onChange={mockOnChange} />);
-
-    const clearButton = screen.getByRole("button", { name: /datum löschen/i });
-    fireEvent.keyDown(clearButton, { key: " " });
-
-    expect(mockOnChange).toHaveBeenCalledWith(null);
-  });
-
-  it("does not clear date on other key presses", () => {
-    const testDate = new Date("2024-01-15T00:00:00Z");
-    render(<DatePicker value={testDate} onChange={mockOnChange} />);
-
-    const clearButton = screen.getByRole("button", { name: /datum löschen/i });
-    fireEvent.keyDown(clearButton, { key: "Tab" });
-
-    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(clearButton.tagName).toBe("BUTTON");
+    expect(clearButton).toHaveAttribute("type", "button");
   });
 
   it("prevents calendar from opening when clear button is clicked", async () => {
@@ -322,6 +301,25 @@ describe("DatePicker", () => {
     await waitFor(() => {
       expect(screen.getByTestId("day-picker")).toBeInTheDocument();
     });
+  });
+
+  it("closes the calendar with Escape and restores trigger focus", () => {
+    const parentKeyDown = vi.fn();
+    render(
+      <div role="group" aria-label="Testgruppe" onKeyDown={parentKeyDown}>
+        <DatePicker value={null} onChange={mockOnChange} />
+      </div>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /datum auswählen/i });
+    fireEvent.click(trigger);
+    expect(screen.getByTestId("day-picker")).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByTestId("day-picker"), { key: "Escape" });
+
+    expect(screen.queryByTestId("day-picker")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(parentKeyDown).not.toHaveBeenCalled();
   });
 
   it("applies custom className", () => {
@@ -501,5 +499,113 @@ describe("DatePicker", () => {
 
     // Calendar should still be open
     expect(screen.getByTestId("day-picker")).toBeInTheDocument();
+  });
+});
+
+describe("ISODateInput", () => {
+  it("converts a valid German date to the ISO calendar format", () => {
+    const onChange = vi.fn();
+    render(
+      <ISODateInput
+        id="birthday"
+        label="Geburtsdatum"
+        value=""
+        onChange={onChange}
+        max="2026-08-12"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Geburtsdatum"), {
+      target: { value: "17.04.1982" },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith("1982-04-17");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("rejects an impossible calendar date", () => {
+    const onChange = vi.fn();
+    render(
+      <ISODateInput
+        id="birthday"
+        label="Geburtsdatum"
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByLabelText("Geburtsdatum");
+    fireEvent.change(input, { target: { value: "31.02.1982" } });
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Bitte geben Sie ein gültiges Datum im Format TT.MM.JJJJ ein.",
+    );
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("rejects a date after the configured maximum", () => {
+    const onChange = vi.fn();
+    render(
+      <ISODateInput
+        id="birthday"
+        label="Geburtsdatum"
+        value=""
+        onChange={onChange}
+        max="2026-08-12"
+        maxDateError="Das Geburtsdatum darf nicht in der Zukunft liegen."
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Geburtsdatum"), {
+      target: { value: "13.08.2026" },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Das Geburtsdatum darf nicht in der Zukunft liegen.",
+    );
+  });
+
+  it("shows and replaces an existing ISO date", () => {
+    const onChange = vi.fn();
+    render(
+      <ISODateInput
+        id="birthday"
+        label="Geburtsdatum"
+        value="1982-04-17"
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByLabelText("Geburtsdatum");
+    expect(input).toHaveValue("17.04.1982");
+
+    fireEvent.change(input, { target: { value: "18.04.1982" } });
+
+    expect(onChange).toHaveBeenLastCalledWith("1982-04-18");
+  });
+
+  it("keeps calendar selection on a labeled native button", () => {
+    const onChange = vi.fn();
+    render(
+      <ISODateInput
+        id="birthday"
+        label="Geburtsdatum"
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    const calendarButton = screen.getByRole("button", {
+      name: "Geburtsdatum im Kalender auswählen",
+    });
+    expect(calendarButton.tagName).toBe("BUTTON");
+    expect(calendarButton).toHaveAttribute("type", "button");
+    fireEvent.click(calendarButton);
+    fireEvent.click(screen.getByTestId("select-date"));
+
+    expect(onChange).toHaveBeenLastCalledWith("2024-01-15");
   });
 });

--- a/frontend/src/components/ui/date-picker.test.tsx
+++ b/frontend/src/components/ui/date-picker.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { DatePicker, ISODateInput } from "./date-picker";
 
 // Mock react-day-picker
@@ -266,6 +267,33 @@ describe("DatePicker", () => {
     expect(clearButton).toHaveAttribute("type", "button");
   });
 
+  it.each([
+    ["Enter", "{Enter}"],
+    ["Space", " "],
+  ])("clears the date when %s activates the button", async (_name, key) => {
+    const user = userEvent.setup();
+    const testDate = new Date("2024-01-15T00:00:00Z");
+    render(<DatePicker value={testDate} onChange={mockOnChange} />);
+
+    const clearButton = screen.getByRole("button", { name: /datum löschen/i });
+    clearButton.focus();
+    await user.keyboard(key);
+
+    expect(mockOnChange).toHaveBeenCalledOnce();
+    expect(mockOnChange).toHaveBeenCalledWith(null);
+  });
+
+  it("does not clear the date for an unrelated key", async () => {
+    const user = userEvent.setup();
+    const testDate = new Date("2024-01-15T00:00:00Z");
+    render(<DatePicker value={testDate} onChange={mockOnChange} />);
+
+    screen.getByRole("button", { name: /datum löschen/i }).focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
   it("prevents calendar from opening when clear button is clicked", async () => {
     const testDate = new Date("2024-01-15T00:00:00Z");
     render(<DatePicker value={testDate} onChange={mockOnChange} />);
@@ -320,6 +348,26 @@ describe("DatePicker", () => {
     expect(screen.queryByTestId("day-picker")).not.toBeInTheDocument();
     expect(trigger).toHaveFocus();
     expect(parentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("closes an open month listbox before closing the calendar", () => {
+    render(
+      <DatePicker
+        value={new Date("2024-01-15T00:00:00Z")}
+        onChange={mockOnChange}
+        monthYearNavigation
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /15\.01\.2024/i }));
+    const month = screen.getByRole("combobox", { name: "Monat" });
+    fireEvent.click(month);
+    expect(month).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.keyDown(month, { key: "Escape" });
+
+    expect(month).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByTestId("day-picker")).toBeInTheDocument();
   });
 
   it("applies custom className", () => {
@@ -503,6 +551,26 @@ describe("DatePicker", () => {
 });
 
 describe("ISODateInput", () => {
+  it("reports an existing date after the configured maximum as invalid", () => {
+    const onValidityChange = vi.fn();
+    render(
+      <ISODateInput
+        id="birthday"
+        label="Geburtsdatum"
+        value="2026-08-13"
+        onChange={vi.fn()}
+        onValidityChange={onValidityChange}
+        max="2026-08-12"
+        maxDateError="Das Geburtsdatum darf nicht in der Zukunft liegen."
+      />,
+    );
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Das Geburtsdatum darf nicht in der Zukunft liegen.",
+    );
+  });
+
   it("converts a valid German date to the ISO calendar format", () => {
     const onChange = vi.fn();
     render(

--- a/frontend/src/components/ui/date-picker.test.tsx
+++ b/frontend/src/components/ui/date-picker.test.tsx
@@ -201,7 +201,7 @@ describe("DatePicker", () => {
     expect(controls?.nextElementSibling).toBe(panel);
   });
 
-  it("lets an inline calendar shrink to a narrow modal", () => {
+  it("keeps compact sizing and legible day buttons in a narrow modal", () => {
     render(
       <DatePicker
         value={null}
@@ -215,8 +215,8 @@ describe("DatePicker", () => {
     const panel = screen
       .getByTestId("day-picker")
       .closest("[data-date-picker-panel]");
-    expect(panel).toHaveClass("w-full", "min-w-0", "max-w-full");
-    expect(panel).not.toHaveClass("min-w-[304px]");
+    expect(panel).toHaveClass("w-full", "min-w-[222px]", "max-w-full", "p-3");
+    expect(panel).not.toHaveClass("p-4", "min-w-[304px]");
   });
 
   it("calls onChange when a date is selected", async () => {

--- a/frontend/src/components/ui/date-picker.test.tsx
+++ b/frontend/src/components/ui/date-picker.test.tsx
@@ -175,6 +175,44 @@ describe("DatePicker", () => {
     expect(screen.getByTestId("day-picker")).toBeInTheDocument();
   });
 
+  it("renders an inline calendar below the trigger controls", () => {
+    render(
+      <DatePicker
+        value={null}
+        onChange={mockOnChange}
+        calendarLayout="inline"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /datum auswählen/i }));
+
+    const controls = screen
+      .getByRole("button", { name: /datum auswählen/i })
+      .closest("[data-date-picker-controls]");
+    const panel = screen
+      .getByTestId("day-picker")
+      .closest("[data-date-picker-panel]");
+    expect(controls?.nextElementSibling).toBe(panel);
+  });
+
+  it("lets an inline calendar shrink to a narrow modal", () => {
+    render(
+      <DatePicker
+        value={null}
+        onChange={mockOnChange}
+        calendarLayout="inline"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /datum auswählen/i }));
+
+    const panel = screen
+      .getByTestId("day-picker")
+      .closest("[data-date-picker-panel]");
+    expect(panel).toHaveClass("w-full", "min-w-0", "max-w-full");
+    expect(panel).not.toHaveClass("min-w-[304px]");
+  });
+
   it("calls onChange when a date is selected", async () => {
     render(<DatePicker value={null} onChange={mockOnChange} />);
 
@@ -450,7 +488,10 @@ describe("DatePicker", () => {
     const trigger = screen.getByRole("button", { name: /datum auswählen/i });
     // jsdom reports an all-zero rect by default, which would make a top-left
     // render indistinguishable from a correctly positioned one.
-    vi.spyOn(trigger.parentElement!, "getBoundingClientRect").mockReturnValue({
+    vi.spyOn(
+      trigger.parentElement!.parentElement!,
+      "getBoundingClientRect",
+    ).mockReturnValue({
       top: 200,
       bottom: 240,
       left: 120,

--- a/frontend/src/components/ui/date-picker.test.tsx
+++ b/frontend/src/components/ui/date-picker.test.tsx
@@ -9,12 +9,18 @@ vi.mock("react-day-picker", () => ({
     selected,
     onSelect,
     required,
+    month,
   }: {
     selected?: Date | Date[];
     onSelect: (date: Date | undefined) => void;
     required?: boolean;
+    month?: Date;
   }) => (
-    <div data-testid="day-picker" data-required={required}>
+    <div
+      data-testid="day-picker"
+      data-required={required}
+      data-month={month?.toISOString()}
+    >
       <button
         type="button"
         onClick={() => onSelect(new Date("2024-01-15T00:00:00Z"))}
@@ -406,6 +412,73 @@ describe("DatePicker", () => {
 
     expect(month).toHaveAttribute("aria-expanded", "false");
     expect(screen.getByTestId("day-picker")).toBeInTheDocument();
+  });
+
+  it("constrains a long month label inside a narrow header", () => {
+    render(
+      <DatePicker
+        value={new Date("2024-01-15T00:00:00Z")}
+        onChange={mockOnChange}
+        monthYearNavigation
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /15\.01\.2024/i }));
+
+    const month = screen.getByRole("combobox", { name: "Monat" });
+    expect(month).toHaveClass("min-w-0", "overflow-hidden");
+    expect(month.querySelector("span")).toHaveClass("min-w-0", "truncate");
+    expect(month.querySelector("svg")).toHaveClass("shrink-0");
+  });
+
+  it("synchronizes the displayed month when the controlled value changes", () => {
+    const { rerender } = render(
+      <DatePicker
+        value={new Date("2024-01-15T00:00:00Z")}
+        onChange={mockOnChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /15\.01\.2024/i }));
+    expect(screen.getByTestId("day-picker")).toHaveAttribute(
+      "data-month",
+      "2024-01-15T00:00:00.000Z",
+    );
+
+    rerender(
+      <DatePicker
+        value={new Date("1982-04-17T00:00:00Z")}
+        onChange={mockOnChange}
+      />,
+    );
+
+    expect(screen.getByTestId("day-picker")).toHaveAttribute(
+      "data-month",
+      "1982-04-17T00:00:00.000Z",
+    );
+  });
+
+  it("keeps manual navigation when the controlled day is unchanged", () => {
+    const value = new Date("2024-01-15T00:00:00Z");
+    const { rerender } = render(
+      <DatePicker value={value} onChange={mockOnChange} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /15\.01\.2024/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Nächster Monat" }));
+    expect(screen.getByTestId("day-picker")).toHaveAttribute(
+      "data-month",
+      "2024-02-15T00:00:00.000Z",
+    );
+
+    rerender(
+      <DatePicker value={new Date(value.getTime())} onChange={mockOnChange} />,
+    );
+
+    expect(screen.getByTestId("day-picker")).toHaveAttribute(
+      "data-month",
+      "2024-02-15T00:00:00.000Z",
+    );
   });
 
   it("applies custom className", () => {

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -211,6 +211,15 @@ export function DatePicker({
     if (!isOpen) return;
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(
+          '[role="combobox"][aria-expanded="true"], [role="listbox"]',
+        )
+      ) {
+        return;
+      }
       event.preventDefault();
       event.stopImmediatePropagation();
       setIsOpen(false);
@@ -352,7 +361,10 @@ export function DatePicker({
     containerRef.current?.closest("[data-date-picker-focus-trap]") !== null;
 
   return (
-    <div className={`relative ${className}`} ref={containerRef}>
+    <div
+      className={`relative flex items-center gap-1 ${className}`}
+      ref={containerRef}
+    >
       <button
         ref={triggerRef}
         type="button"
@@ -369,7 +381,7 @@ export function DatePicker({
         className={`flex items-center rounded-lg border transition-all ${
           iconOnly
             ? "h-10 w-10 shrink-0 justify-center"
-            : `w-full justify-between ${
+            : `min-w-0 flex-1 justify-between ${
                 TRIGGER_SIZE_CLASS[
                   (isMultiple ? undefined : props.controlSize) ?? "sm"
                 ]
@@ -390,7 +402,7 @@ export function DatePicker({
           </span>
         )}
         <svg
-          className={`h-4 w-4 text-gray-400 ${canClear ? "mr-6" : ""}`}
+          className="h-4 w-4 shrink-0 text-gray-400"
           aria-hidden="true"
           fill="none"
           viewBox="0 0 24 24"
@@ -414,7 +426,7 @@ export function DatePicker({
               props.onChange(null);
             }
           }}
-          className="absolute top-1/2 right-7 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
           aria-label={labels.clear}
         >
           <svg
@@ -756,12 +768,39 @@ export function ISODateInput({
   const [inputValue, setInputValue] = useState(() =>
     formatISODateInputValue(value),
   );
-  const [inputError, setInputError] = useState<string | null>(null);
+  const [inputError, setInputError] = useState<string | null>(() =>
+    validateStoredISODate(
+      value,
+      min,
+      max,
+      invalidDateError,
+      minDateError,
+      maxDateError,
+    ),
+  );
   const errorId = `${id}-error`;
 
   useEffect(() => {
     setInputValue(formatISODateInputValue(value));
-  }, [value]);
+    const nextError = validateStoredISODate(
+      value,
+      min,
+      max,
+      invalidDateError,
+      minDateError,
+      maxDateError,
+    );
+    setInputError(nextError);
+    onValidityChange?.(nextError === null);
+  }, [
+    value,
+    min,
+    max,
+    invalidDateError,
+    minDateError,
+    maxDateError,
+    onValidityChange,
+  ]);
 
   const validate = (nextValue: string, showIncompleteError: boolean) => {
     const trimmed = nextValue.trim();
@@ -855,6 +894,22 @@ function parseGermanDateInput(value: string): string | null {
   if (!match) return null;
   const isoDate = `${match[3]}-${match[2]}-${match[1]}`;
   return isValidISODate(isoDate) ? isoDate : null;
+}
+
+function validateStoredISODate(
+  value: string,
+  min: string | undefined,
+  max: string | undefined,
+  invalidDateError: string,
+  minDateError: string,
+  maxDateError: string,
+): string | null {
+  if (value === "") return null;
+  const isoDate = value.slice(0, 10);
+  if (!isValidISODate(isoDate)) return invalidDateError;
+  if (min && isoDate < min) return minDateError;
+  if (max && isoDate > max) return maxDateError;
+  return null;
 }
 
 function formatISODateInputValue(value: string): string {

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -177,7 +177,9 @@ export function DatePicker({
   // Known only after the trigger is measured; until then assume the roomy
   // variant, which is what every field wider than a filter chip gets.
   const isCompactPanel =
-    popoverPosition !== null && popoverPosition.width < COMPACT_CARD_MAX_WIDTH;
+    calendarLayout === "inline" ||
+    (popoverPosition !== null &&
+      popoverPosition.width < COMPACT_CARD_MAX_WIDTH);
   const locale = isMultiple ? de : (props.locale ?? de);
   const labels = resolveLabels(isMultiple ? undefined : props.labels);
   const displayValue = isMultiple
@@ -1138,9 +1140,10 @@ function getCalendarContainerClass(
     compact ? "p-3" : "p-4"
   }`;
   // The floating layouts get their width from the portal wrapper. Inline
-  // calendars belong to their container and must shrink with narrow modals.
+  // calendars belong to their container, but retain the minimum width needed
+  // for 20px day buttons with compact card padding.
   if (calendarLayout === "inline") {
-    return `${base} mt-2 w-full min-w-0 max-w-full`;
+    return `${base} mt-2 w-full min-w-[222px] max-w-full`;
   }
   return `${base} w-full`;
 }

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -450,7 +450,7 @@ export function DatePicker({
               <FocusScope asChild loop trapped>
                 <div
                   ref={popoverRef}
-                  className="fixed z-[10001] max-h-[calc(100dvh-1rem)] overflow-y-auto overscroll-contain"
+                  className="fixed z-[10001] max-h-[calc(100dvh-1rem)] overflow-x-hidden overflow-y-auto overscroll-contain"
                   style={{
                     top: popoverPosition.top,
                     left: popoverPosition.left,
@@ -464,7 +464,7 @@ export function DatePicker({
             ) : (
               <div
                 ref={popoverRef}
-                className="fixed z-[10001] max-h-[calc(100dvh-1rem)] overflow-y-auto overscroll-contain"
+                className="fixed z-[10001] max-h-[calc(100dvh-1rem)] overflow-x-hidden overflow-y-auto overscroll-contain"
                 style={{
                   top: popoverPosition.top,
                   left: popoverPosition.left,
@@ -902,7 +902,7 @@ const NAV_OPTION_ACTIVE_CLASS =
   "flex w-full cursor-pointer items-center gap-2 bg-gray-50 px-4 py-2 text-left text-sm font-medium text-gray-900 transition-colors";
 
 const NAV_SELECT_CLASS =
-  "inline-flex h-9 min-w-0 cursor-pointer items-center gap-2 rounded-lg border border-gray-200 bg-white px-2.5 text-sm leading-5 font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none";
+  "inline-flex h-9 w-full min-w-0 cursor-pointer items-center justify-between gap-1.5 rounded-lg border border-gray-200 bg-white px-2.5 text-sm leading-5 font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none";
 
 // The offered years always include the month currently on screen, so a value
 // outside the caller's bounds (legacy data) still shows its own year instead of
@@ -951,7 +951,7 @@ function CalendarNavHeader({
 
   return (
     <div
-      className={`flex items-center justify-between ${
+      className={`grid grid-cols-[2rem_minmax(0,1fr)_2rem] items-center ${
         compact ? "mb-3 gap-1" : "mb-4 gap-2"
       }`}
     >
@@ -980,7 +980,7 @@ function CalendarNavHeader({
         // OS-level popup, which cannot be styled to match the kit and does not
         // exist in the DOM (so it never appears in a screenshot or a test).
         // The menu z-index has to clear the calendar's own portal.
-        <div className="flex min-w-0 items-center gap-1">
+        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_5rem] items-center gap-1">
           <ListboxDropdown
             ariaLabel={labels.month}
             value={String(month.getMonth())}
@@ -991,6 +991,7 @@ function CalendarNavHeader({
             onChange={(next) =>
               onMonthChange(new Date(month.getFullYear(), Number(next), 1))
             }
+            containerClassName="relative min-w-0"
             className={NAV_SELECT_CLASS}
             menuClassName={NAV_MENU_CLASS}
             optionClassName={NAV_OPTION_CLASS}
@@ -1009,6 +1010,7 @@ function CalendarNavHeader({
             onChange={(next) =>
               onMonthChange(new Date(Number(next), month.getMonth(), 1))
             }
+            containerClassName="relative min-w-0"
             className={NAV_SELECT_CLASS}
             menuClassName={NAV_MENU_CLASS}
             optionClassName={NAV_OPTION_CLASS}
@@ -1062,7 +1064,7 @@ function buildSingleDisabledMatchers(
   return matchers;
 }
 
-// A panel narrower than this cannot afford the roomier padding: at the 222px
+// A panel narrower than this cannot afford the roomier padding: at a very small
 // minimum, p-4 would shave the day buttons below their 20px floor and truncate
 // the "Juli 2026" caption. Below the threshold the card falls back to p-3 and
 // spends the space on the grid instead.
@@ -1079,7 +1081,7 @@ function getCalendarContainerClass(
   // sized to the trigger; inline takes its parent's width and only needs the
   // legible-minimum floor.
   if (calendarLayout === "inline") {
-    return `${base} mt-2 w-full min-w-[222px]`;
+    return `${base} mt-2 w-full min-w-[304px]`;
   }
   return `${base} w-full`;
 }

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -9,6 +9,7 @@ import { de } from "date-fns/locale";
 import "react-day-picker/style.css";
 import { isValidISODate, parseISODate, toISODate } from "~/lib/date-helpers";
 import type { DatePickerLabels } from "~/lib/date-picker-labels";
+import { Input } from "~/components/ui/input";
 import { ListboxDropdown } from "~/components/ui/listbox-dropdown";
 import {
   clampCalendarWidth,
@@ -126,6 +127,7 @@ type DatePickerProps =
       // Overrides for the built-in German control labels, for those same
       // parent-facing surfaces.
       readonly labels?: DatePickerLabels;
+      readonly iconOnly?: boolean;
     }
   | {
       readonly mode: "multiple";
@@ -157,6 +159,7 @@ export function DatePicker({
 }: DatePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
   // null until the trigger rect has been measured. The portal renders only once
@@ -185,6 +188,12 @@ export function DatePicker({
         // everywhere. Switching it to "P" is a separate, test-pinned decision.
         format(props.value, "dd.MM.yyyy", { locale })
       : null;
+  const iconOnly = !isMultiple && props.iconOnly === true;
+  const canClear =
+    Boolean(displayValue) &&
+    !iconOnly &&
+    !isDisabled &&
+    !(!isMultiple && (props.hideClearButton || props.required));
 
   // Portals only exist client-side; render nothing on the server pass.
   useEffect(() => {
@@ -197,6 +206,19 @@ export function DatePicker({
   useEffect(() => {
     if (isDisabled) setIsOpen(false);
   }, [isDisabled]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      setIsOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("keydown", closeOnEscape, true);
+    return () => document.removeEventListener("keydown", closeOnEscape, true);
+  }, [isOpen]);
 
   const syncPopoverPosition = useCallback(() => {
     if (!containerRef.current) return;
@@ -332,24 +354,26 @@ export function DatePicker({
   return (
     <div className={`relative ${className}`} ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         id={isMultiple ? undefined : props.id}
-        aria-label={isMultiple ? undefined : props.ariaLabel}
-        // The trigger is a plain button, and ARIA does not allow aria-invalid /
-        // aria-required on that role (oxlint jsx-a11y enforces it). The invalid
-        // state is therefore carried visually plus by the caller's own error
-        // text, and `aria-describedby` links the two when the caller passes it.
+        aria-label={
+          isMultiple
+            ? undefined
+            : (props.ariaLabel ?? (iconOnly ? "Kalender öffnen" : undefined))
+        }
+        aria-expanded={isOpen}
         aria-describedby={isMultiple ? undefined : props.ariaDescribedBy}
         disabled={isDisabled}
         onClick={toggleOpen}
-        // The background is picked in exactly one place: a base `bg-white` plus
-        // a conditional `bg-gray-50` are two utilities of equal specificity, and
-        // which one wins depends on Tailwind's output order — the disabled state
-        // silently rendered white.
-        className={`flex w-full items-center justify-between rounded-lg border transition-all ${
-          TRIGGER_SIZE_CLASS[
-            (isMultiple ? undefined : props.controlSize) ?? "sm"
-          ]
+        className={`flex items-center rounded-lg border transition-all ${
+          iconOnly
+            ? "h-10 w-10 shrink-0 justify-center"
+            : `w-full justify-between ${
+                TRIGGER_SIZE_CLASS[
+                  (isMultiple ? undefined : props.controlSize) ?? "sm"
+                ]
+              }`
         } ${
           !isMultiple && props.invalid ? "border-moto-red" : "border-gray-200"
         } ${
@@ -360,54 +384,42 @@ export function DatePicker({
               : "bg-white hover:bg-gray-50"
         }`}
       >
-        <span className={displayValue ? "text-gray-900" : "text-gray-500"}>
-          {displayValue ?? placeholder}
-        </span>
-        <div className="flex items-center gap-1">
-          {displayValue &&
-            !isDisabled &&
-            !(!isMultiple && (props.hideClearButton || props.required)) && (
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (isMultiple) {
-                    props.onChangeDates([]);
-                  } else {
-                    props.onChange(null);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.stopPropagation();
-                    if (isMultiple) {
-                      props.onChangeDates([]);
-                    } else {
-                      props.onChange(null);
-                    }
-                  }
-                }}
-                className="rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                aria-label={labels.clear}
-              >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </span>
-            )}
+        {!iconOnly && (
+          <span className={displayValue ? "text-gray-900" : "text-gray-500"}>
+            {displayValue ?? placeholder}
+          </span>
+        )}
+        <svg
+          className={`h-4 w-4 text-gray-400 ${canClear ? "mr-6" : ""}`}
+          aria-hidden="true"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+      </button>
+      {canClear && (
+        <button
+          type="button"
+          onClick={() => {
+            if (isMultiple) {
+              props.onChangeDates([]);
+            } else {
+              props.onChange(null);
+            }
+          }}
+          className="absolute top-1/2 right-7 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          aria-label={labels.clear}
+        >
           <svg
-            className="h-4 w-4 text-gray-400"
+            className="h-4 w-4"
+            aria-hidden="true"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -416,11 +428,11 @@ export function DatePicker({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-        </div>
-      </button>
+        </button>
+      )}
 
       {/* The overlay/inline layouts render in place; the popover layout renders
           the calendar into document.body at a viewport-fixed position. Portals
@@ -712,6 +724,143 @@ export function ISODatePicker({
       )}
     </div>
   );
+}
+
+interface ISODateInputProps {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly onValidityChange?: (valid: boolean) => void;
+  readonly min?: string;
+  readonly max?: string;
+  readonly invalidDateError?: string;
+  readonly minDateError?: string;
+  readonly maxDateError?: string;
+  readonly disabled?: boolean;
+}
+
+export function ISODateInput({
+  id,
+  label,
+  value,
+  onChange,
+  onValidityChange,
+  min,
+  max,
+  invalidDateError = "Bitte geben Sie ein gültiges Datum im Format TT.MM.JJJJ ein.",
+  minDateError = "Das Datum liegt vor dem zulässigen Zeitraum.",
+  maxDateError = "Das Datum liegt nach dem zulässigen Zeitraum.",
+  disabled,
+}: ISODateInputProps) {
+  const [inputValue, setInputValue] = useState(() =>
+    formatISODateInputValue(value),
+  );
+  const [inputError, setInputError] = useState<string | null>(null);
+  const errorId = `${id}-error`;
+
+  useEffect(() => {
+    setInputValue(formatISODateInputValue(value));
+  }, [value]);
+
+  const validate = (nextValue: string, showIncompleteError: boolean) => {
+    const trimmed = nextValue.trim();
+    if (trimmed === "") {
+      setInputError(null);
+      onValidityChange?.(true);
+      onChange("");
+      return;
+    }
+
+    const isoDate = parseGermanDateInput(trimmed);
+    let nextError: string | null = null;
+    if (!isoDate) {
+      if (showIncompleteError || trimmed.length >= 10) {
+        nextError = invalidDateError;
+      }
+    } else if (min && isoDate < min) {
+      nextError = minDateError;
+    } else if (max && isoDate > max) {
+      nextError = maxDateError;
+    }
+
+    setInputError(nextError);
+    const valid = Boolean(isoDate) && nextError === null;
+    onValidityChange?.(valid);
+    if (valid && isoDate) onChange(isoDate);
+  };
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-2 block text-sm font-medium text-gray-700"
+      >
+        {label}
+      </label>
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <Input
+            id={id}
+            name={id}
+            type="text"
+            controlSize="compact"
+            inputMode="numeric"
+            autoComplete="bday"
+            placeholder="TT.MM.JJJJ"
+            maxLength={10}
+            value={inputValue}
+            disabled={disabled}
+            aria-invalid={inputError ? true : undefined}
+            aria-describedby={inputError ? errorId : undefined}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setInputValue(nextValue);
+              validate(nextValue, false);
+            }}
+            onBlur={() => validate(inputValue, true)}
+            className={inputError ? "ring-moto-red" : ""}
+          />
+        </div>
+        <DatePicker
+          value={toDateOrNull(value)}
+          minDate={toDateOrNull(min) ?? undefined}
+          maxDate={toDateOrNull(max) ?? undefined}
+          onChange={(date) => {
+            const isoDate = date ? toISODate(date) : "";
+            setInputValue(formatISODateInputValue(isoDate));
+            setInputError(null);
+            onValidityChange?.(true);
+            onChange(isoDate);
+          }}
+          iconOnly
+          hideClearButton
+          monthYearNavigation
+          disabled={disabled}
+          ariaLabel={`${label} im Kalender auswählen`}
+          invalid={Boolean(inputError)}
+        />
+      </div>
+      {inputError && (
+        <p id={errorId} role="alert" className="text-moto-red mt-1 text-xs">
+          {inputError}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function parseGermanDateInput(value: string): string | null {
+  const match = /^(\d{2})\.(\d{2})\.(\d{4})$/.exec(value);
+  if (!match) return null;
+  const isoDate = `${match[3]}-${match[2]}-${match[1]}`;
+  return isValidISODate(isoDate) ? isoDate : null;
+}
+
+function formatISODateInputValue(value: string): string {
+  const isoDate = value.slice(0, 10);
+  if (!isValidISODate(isoDate)) return value;
+  return `${isoDate.slice(8, 10)}.${isoDate.slice(5, 7)}.${isoDate.slice(0, 4)}`;
 }
 
 // Accepts both a bare "YYYY-MM-DD" and a full backend timestamp

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -532,6 +532,12 @@ function DatePickerCalendar({
   readonly onChange: (date: Date | null) => void;
 }) {
   const [month, setMonth] = useState(value ?? new Date());
+  const controlledMonthTime = value?.getTime();
+
+  useEffect(() => {
+    if (controlledMonthTime === undefined) return;
+    setMonth(new Date(controlledMonthTime));
+  }, [controlledMonthTime]);
 
   return (
     <div
@@ -956,7 +962,7 @@ const NAV_OPTION_ACTIVE_CLASS =
   "flex w-full cursor-pointer items-center gap-2 bg-gray-50 px-4 py-2 text-left text-sm font-medium text-gray-900 transition-colors";
 
 const NAV_SELECT_CLASS =
-  "inline-flex h-9 w-full min-w-0 cursor-pointer items-center justify-between gap-1.5 rounded-lg border border-gray-200 bg-white px-2.5 text-sm leading-5 font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none";
+  "inline-flex h-9 w-full min-w-0 cursor-pointer items-center justify-between gap-1.5 overflow-hidden rounded-lg border border-gray-200 bg-white px-2.5 text-sm leading-5 font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none";
 
 // The offered years always include the month currently on screen, so a value
 // outside the caller's bounds (legacy data) still shows its own year instead of

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -361,76 +361,46 @@ export function DatePicker({
     containerRef.current?.closest("[data-date-picker-focus-trap]") !== null;
 
   return (
-    <div
-      className={`relative flex items-center gap-1 ${className}`}
-      ref={containerRef}
-    >
-      <button
-        ref={triggerRef}
-        type="button"
-        id={isMultiple ? undefined : props.id}
-        aria-label={
-          isMultiple
-            ? undefined
-            : (props.ariaLabel ?? (iconOnly ? "Kalender öffnen" : undefined))
-        }
-        aria-expanded={isOpen}
-        aria-describedby={isMultiple ? undefined : props.ariaDescribedBy}
-        disabled={isDisabled}
-        onClick={toggleOpen}
-        className={`flex items-center rounded-lg border transition-all ${
-          iconOnly
-            ? "h-10 w-10 shrink-0 justify-center"
-            : `min-w-0 flex-1 justify-between ${
-                TRIGGER_SIZE_CLASS[
-                  (isMultiple ? undefined : props.controlSize) ?? "sm"
-                ]
-              }`
-        } ${
-          !isMultiple && props.invalid ? "border-moto-red" : "border-gray-200"
-        } ${
-          isDisabled
-            ? "cursor-not-allowed bg-gray-50 text-gray-400"
-            : isOpen
-              ? "border-gray-300 bg-gray-50"
-              : "bg-white hover:bg-gray-50"
-        }`}
-      >
-        {!iconOnly && (
-          <span className={displayValue ? "text-gray-900" : "text-gray-500"}>
-            {displayValue ?? placeholder}
-          </span>
-        )}
-        <svg
-          className="h-4 w-4 shrink-0 text-gray-400"
-          aria-hidden="true"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-          />
-        </svg>
-      </button>
-      {canClear && (
+    <div className={`relative ${className}`} ref={containerRef}>
+      <div className="flex items-center gap-1" data-date-picker-controls>
         <button
+          ref={triggerRef}
           type="button"
-          onClick={() => {
-            if (isMultiple) {
-              props.onChangeDates([]);
-            } else {
-              props.onChange(null);
-            }
-          }}
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
-          aria-label={labels.clear}
+          id={isMultiple ? undefined : props.id}
+          aria-label={
+            isMultiple
+              ? undefined
+              : (props.ariaLabel ?? (iconOnly ? "Kalender öffnen" : undefined))
+          }
+          aria-expanded={isOpen}
+          aria-describedby={isMultiple ? undefined : props.ariaDescribedBy}
+          disabled={isDisabled}
+          onClick={toggleOpen}
+          className={`flex items-center rounded-lg border transition-all ${
+            iconOnly
+              ? "h-10 w-10 shrink-0 justify-center"
+              : `min-w-0 flex-1 justify-between ${
+                  TRIGGER_SIZE_CLASS[
+                    (isMultiple ? undefined : props.controlSize) ?? "sm"
+                  ]
+                }`
+          } ${
+            !isMultiple && props.invalid ? "border-moto-red" : "border-gray-200"
+          } ${
+            isDisabled
+              ? "cursor-not-allowed bg-gray-50 text-gray-400"
+              : isOpen
+                ? "border-gray-300 bg-gray-50"
+                : "bg-white hover:bg-gray-50"
+          }`}
         >
+          {!iconOnly && (
+            <span className={displayValue ? "text-gray-900" : "text-gray-500"}>
+              {displayValue ?? placeholder}
+            </span>
+          )}
           <svg
-            className="h-4 w-4"
+            className="h-4 w-4 shrink-0 text-gray-400"
             aria-hidden="true"
             fill="none"
             viewBox="0 0 24 24"
@@ -440,11 +410,40 @@ export function DatePicker({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
             />
           </svg>
         </button>
-      )}
+        {canClear && (
+          <button
+            type="button"
+            onClick={() => {
+              if (isMultiple) {
+                props.onChangeDates([]);
+              } else {
+                props.onChange(null);
+              }
+            }}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+            aria-label={labels.clear}
+          >
+            <svg
+              className="h-4 w-4"
+              aria-hidden="true"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
 
       {/* The overlay/inline layouts render in place; the popover layout renders
           the calendar into document.body at a viewport-fixed position. Portals
@@ -1132,11 +1131,10 @@ function getCalendarContainerClass(
   const base = `rounded-xl border border-gray-200 bg-white shadow-lg ${
     compact ? "p-3" : "p-4"
   }`;
-  // The floating layouts get their width from the portal wrapper, which is
-  // sized to the trigger; inline takes its parent's width and only needs the
-  // legible-minimum floor.
+  // The floating layouts get their width from the portal wrapper. Inline
+  // calendars belong to their container and must shrink with narrow modals.
   if (calendarLayout === "inline") {
-    return `${base} mt-2 w-full min-w-[304px]`;
+    return `${base} mt-2 w-full min-w-0 max-w-full`;
   }
   return `${base} w-full`;
 }

--- a/frontend/src/components/ui/listbox-dropdown.tsx
+++ b/frontend/src/components/ui/listbox-dropdown.tsx
@@ -608,8 +608,11 @@ export function ListboxDropdown<K extends string>({
           renderTrigger({ selectedLabel, open })
         ) : (
           <>
-            <span>{selectedLabel}</span>
-            <ChevronDown className="h-4 w-4 text-gray-400" aria-hidden />
+            <span className="min-w-0 truncate">{selectedLabel}</span>
+            <ChevronDown
+              className="h-4 w-4 shrink-0 text-gray-400"
+              aria-hidden
+            />
           </>
         )}
       </button>


### PR DESCRIPTION
## Zusammenfassung

- ergänzt im Mitarbeiterprofil eine direkte Eingabe im Format `TT.MM.JJJJ`
- überträgt gültige Werte weiterhin als `YYYY-MM-DD`
- behält den Kalender als separate, vollständig per Tastatur bedienbare Auswahl bei
- zeigt verständliche Fehler für ungültige Kalenderdaten und zukünftige Geburtstage
- behebt im gemeinsamen DatePicker den verschachtelten Löschen-Button und ergänzt Escape mit Fokus-Rückgabe

Closes #2245

## Tests

- `pnpm exec vitest run src/components/ui/date-picker.test.tsx src/components/staff/stammdaten-sections.test.tsx`
- `pnpm run check`
- Pre-Push: Dependency-Cruise, Knip, Frontend-Check und Git-Secrets

## Manuelle QA

- vorhandenes Geburtsdatum direkt überschrieben
- gültige Eingabe `17.04.1982` geprüft
- unmögliches Datum `31.02.1982` geprüft
- zukünftiges Datum geprüft
- Tab-Reihenfolge, Kalenderöffnung per Enter und Schließen per Escape mit Fokus-Rückgabe geprüft
- Vorher-Nachher-Vergleich lokal erstellt; die Bilder können bei Bedarf über GitHubs native Anhangsfunktion ergänzt werden