### PR TITLE
fix: Teamstatus nach Antworten auf Elternnachrichten aktualisieren

### DIFF
--- a/backend/api/messaging/api.go
+++ b/backend/api/messaging/api.go
@@ -119,7 +119,8 @@ type StartThreadRequest struct {
 }
 
 type PostMessageRequest struct {
-	Body string `json:"body"`
+	Body                 string `json:"body"`
+	HandledUpToMessageID string `json:"handled_up_to_message_id,omitempty"`
 }
 
 type OpenThreadRequest struct {
@@ -252,7 +253,16 @@ func (rs *Resource) postMessage(w http.ResponseWriter, r *http.Request) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid request body")))
 		return
 	}
-	messages, err := rs.Service.PostMessage(r.Context(), threadID, req.Body)
+	var handledUpToMessageID int64
+	if req.HandledUpToMessageID != "" {
+		parsed, parseErr := strconv.ParseInt(req.HandledUpToMessageID, 10, 64)
+		if parseErr != nil || parsed <= 0 {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid handled message ID")))
+			return
+		}
+		handledUpToMessageID = parsed
+	}
+	messages, err := rs.Service.PostMessage(r.Context(), threadID, req.Body, handledUpToMessageID)
 	if err != nil {
 		renderMessagingError(w, r, err)
 		return
@@ -347,6 +357,8 @@ func renderMessagingError(w http.ResponseWriter, r *http.Request, err error) {
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 	case errors.Is(err, messagingService.ErrGuardianAccessRevoked):
 		common.RenderError(w, r, common.ErrorConflictMessage("Der Empfänger hat keinen Zugriff mehr auf dieses Kind."))
+	case errors.Is(err, messagingService.ErrHandledBoundaryRequired):
+		common.RenderError(w, r, common.ErrorConflictMessage("Der Nachrichtenverlauf hat sich geändert. Bitte laden Sie die Seite neu."))
 	default:
 		common.RenderError(w, r, common.ErrorInternalServerWrap("messaging request failed", err))
 	}

--- a/backend/database/migrations/001015287_parent_message_team_handled.go
+++ b/backend/database/migrations/001015287_parent_message_team_handled.go
@@ -1,0 +1,58 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	parentMessageTeamHandledVersion     = "1.15.287"
+	parentMessageTeamHandledDescription = "Track guardian messages covered by a staff reply (#2246)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     parentMessageTeamHandledVersion,
+		Description: parentMessageTeamHandledDescription,
+		DependsOn:   []string{parentMessagingVersion},
+	})
+	Migrations.MustRegister(parentMessageTeamHandledUp, parentMessageTeamHandledDown)
+}
+
+func parentMessageTeamHandledUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.287: Adding the parent-message team handled cursor...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE users.parent_message_threads
+			ADD COLUMN IF NOT EXISTS staff_handled_up_to_at TIMESTAMPTZ,
+			ADD COLUMN IF NOT EXISTS staff_handled_up_to_message_id BIGINT;
+
+		ALTER TABLE users.parent_message_threads
+			DROP CONSTRAINT IF EXISTS chk_parent_message_threads_staff_handled_cursor,
+			ADD CONSTRAINT chk_parent_message_threads_staff_handled_cursor CHECK (
+				(staff_handled_up_to_at IS NULL) = (staff_handled_up_to_message_id IS NULL)
+			) NOT VALID;
+
+		ALTER TABLE users.parent_message_threads
+			VALIDATE CONSTRAINT chk_parent_message_threads_staff_handled_cursor;
+	`)
+	if err != nil {
+		return fmt.Errorf("add parent-message team handled cursor: %w", err)
+	}
+	return nil
+}
+
+func parentMessageTeamHandledDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.287: Removing the parent-message team handled cursor...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE users.parent_message_threads
+			DROP CONSTRAINT IF EXISTS chk_parent_message_threads_staff_handled_cursor,
+			DROP COLUMN IF EXISTS staff_handled_up_to_message_id,
+			DROP COLUMN IF EXISTS staff_handled_up_to_at;
+	`)
+	if err != nil {
+		return fmt.Errorf("remove parent-message team handled cursor: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015287_parent_message_team_handled_test.go
+++ b/backend/database/migrations/001015287_parent_message_team_handled_test.go
@@ -1,0 +1,73 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	usersRepo "github.com/moto-nrw/project-phoenix/database/repositories/users"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParentMessageTeamHandledMigrationLeavesExistingHistoryOpen(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+	require.NoError(t, parentMessageTeamHandledDown(ctx, db))
+	t.Cleanup(func() { require.NoError(t, parentMessageTeamHandledUp(ctx, db)) })
+
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	t.Cleanup(func() { testpkg.CleanupParentGuardianChain(t, db, chain) })
+	staff, staffAccount := testpkg.CreateTestStaffWithAccount(t, db, "Olivia", "Berg")
+	t.Cleanup(func() { testpkg.CleanupStaffFixtures(t, db, staff.ID) })
+	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, staffAccount.ID) })
+	t.Cleanup(func() { testpkg.CleanupParentMessagingForAccount(t, db, staffAccount.ID) })
+
+	tenantCtx := tenant.WithTenantID(ctx, chain.TenantID)
+	var threadID int64
+	require.NoError(t, db.NewRaw(`
+		INSERT INTO users.parent_message_threads (tenant_id, student_id, guardian_account_id)
+		VALUES (?, ?, ?)
+		RETURNING id
+	`, chain.TenantID, chain.StudentID, chain.AccountID).Scan(ctx, &threadID))
+
+	base := time.Now().Add(-time.Minute).Truncate(time.Microsecond)
+	insert := func(senderID int64, senderKind, body string, at time.Time) *usersModels.ParentMessage {
+		t.Helper()
+		message := &usersModels.ParentMessage{
+			ThreadID:        threadID,
+			StudentID:       chain.StudentID,
+			SenderAccountID: senderID,
+			SenderKind:      senderKind,
+			SenderName:      "Test",
+			Body:            body,
+			Kind:            usersModels.ParentMessageKindMessage,
+		}
+		message.SetTenantID(chain.TenantID)
+		message.CreatedAt, message.UpdatedAt = at, at
+		require.NoError(t, usersRepo.NewParentMessageRepository(db).Create(tenantCtx, message))
+		return message
+	}
+
+	insert(chain.AccountID, usersModels.ParentMessageSenderGuardian, "Frage", base)
+	insert(staffAccount.ID, usersModels.ParentMessageSenderStaff, "Antwort", base.Add(time.Second))
+
+	require.NoError(t, parentMessageTeamHandledUp(ctx, db))
+
+	var handledMessageID *int64
+	require.NoError(t, db.NewRaw(`
+		SELECT staff_handled_up_to_message_id
+		FROM users.parent_message_threads
+		WHERE id = ?
+	`, threadID).Scan(ctx, &handledMessageID))
+	assert.Nil(t, handledMessageID, "the migration must not guess which existing messages were visible before a reply")
+
+	count, err := usersRepo.NewParentMessageReadRepository(db).
+		UnreadMessageCountForStaff(tenantCtx, staffAccount.ID, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "existing guardian activity stays open until a new snapshot-bounded team reply")
+}

--- a/backend/database/repositories/users/parent_message_read.go
+++ b/backend/database/repositories/users/parent_message_read.go
@@ -73,6 +73,25 @@ func (r *ParentMessageReadRepository) MarkReadUpTo(ctx context.Context, tenantID
 	return affected > 0, nil
 }
 
+// MarkStaffHandledUpTo advances the shared staff boundary atomically. The
+// composite guard keeps stale or concurrent replies from moving it backward.
+func (r *ParentMessageReadRepository) MarkStaffHandledUpTo(ctx context.Context, tenantID, threadID int64, handledAt time.Time, handledMessageID int64) error {
+	query := base.GetDB(ctx, r.db).NewUpdate().
+		Model((*users.ParentMessageThread)(nil)).
+		ModelTableExpr(`users.parent_message_threads AS "thread"`).
+		Set("staff_handled_up_to_at = ?", handledAt).
+		Set("staff_handled_up_to_message_id = ?", handledMessageID).
+		Where(`"thread".id = ?`, threadID).
+		Where(`"thread".tenant_id = ?`, tenantID).
+		Where(`("thread".staff_handled_up_to_at IS NULL OR
+			("thread".staff_handled_up_to_at, "thread".staff_handled_up_to_message_id) < (?, ?))`, handledAt, handledMessageID)
+	query = base.WithTenantFilter(ctx, query, "thread")
+	if _, err := query.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "mark parent message thread handled for staff", Err: err}
+	}
+	return nil
+}
+
 // counterpartUnread builds the SQL boolean for "a message from the OTHER party
 // relative to the reader", on the given message alias: a staff reader counts
 // unread guardian-side activity, a guardian reader counts unread staff-side
@@ -122,6 +141,15 @@ func afterReadCursor(alias string) string {
 	)
 }
 
+// afterStaffHandledCursor keeps only guardian activity not yet covered by a
+// team reply. It supplements, rather than replaces, each account's read cursor.
+func afterStaffHandledCursor(alias string) string {
+	return fmt.Sprintf(
+		`(%[1]s.created_at, %[1]s.id) > (COALESCE(t.staff_handled_up_to_at, '1970-01-01'::timestamptz), COALESCE(t.staff_handled_up_to_message_id, 0))`,
+		alias,
+	)
+}
+
 // notReaderAuthored excludes the reader's OWN plain messages from their unread
 // set, keyed on sender_account_id (a real column). It is the third leg of every
 // unread predicate, and carries a single `?` bound to the reader's account id at
@@ -163,13 +191,17 @@ func inboxSelect(q *bun.SelectQuery, accountID int64, staffReader bool) *bun.Sel
 	// predicate, so a thread_id-only correlated filter cannot use the index and
 	// seq-scans parent_messages per thread row. Binding the leading column makes it
 	// an index scan. Redundant-but-correct under RLS-scoped staff queries.
+	unreadPredicates := fmt.Sprintf(`
+		  AND %s
+		  AND %s
+		  AND %s`, counterpartUnread("cm", staffReader), afterReadCursor("cm"), notReaderAuthored("cm"))
+	if staffReader {
+		unreadPredicates += fmt.Sprintf("\n\t\t  AND %s", afterStaffHandledCursor("cm"))
+	}
 	unreadSub := fmt.Sprintf(`(
 		SELECT COUNT(*) FROM users.parent_messages cm
-		WHERE cm.thread_id = t.id AND cm.tenant_id = t.tenant_id
-		  AND %s
-		  AND %s
-		  AND %s
-	) AS unread_count`, counterpartUnread("cm", staffReader), afterReadCursor("cm"), notReaderAuthored("cm"))
+		WHERE cm.thread_id = t.id AND cm.tenant_id = t.tenant_id%s
+	) AS unread_count`, unreadPredicates)
 
 	return q.
 		TableExpr("users.parent_message_threads AS t").
@@ -280,7 +312,8 @@ var guardianUnreadExists = fmt.Sprintf(`EXISTS (
 	  AND %s
 	  AND %s
 	  AND %s
-)`, counterpartUnread("um", true), afterReadCursor("um"), notReaderAuthored("um"))
+	  AND %s
+)`, counterpartUnread("um", true), afterReadCursor("um"), notReaderAuthored("um"), afterStaffHandledCursor("um"))
 
 // unreadMessageCountSelect builds a query whose ROWS are the unread MESSAGES for
 // the given reader: counterpart-authored messages strictly after the reader's
@@ -303,7 +336,7 @@ var guardianUnreadExists = fmt.Sprintf(`EXISTS (
 // unique per (thread, account), so no row fans out and COUNT(*) is an exact
 // message count.
 func unreadMessageCountSelect(q *bun.SelectQuery, accountID int64, staffReader bool) *bun.SelectQuery {
-	return q.
+	query := q.
 		TableExpr("users.parent_messages AS um").
 		Join("JOIN users.parent_message_threads AS t ON t.id = um.thread_id AND t.tenant_id = um.tenant_id").
 		Join("JOIN users.students AS s ON s.id = t.student_id").
@@ -313,6 +346,10 @@ func unreadMessageCountSelect(q *bun.SelectQuery, accountID int64, staffReader b
 		Where(counterpartUnread("um", staffReader)).
 		Where(afterReadCursor("um")).
 		Where(notReaderAuthored("um"), accountID)
+	if staffReader {
+		query = query.Where(afterStaffHandledCursor("um"))
+	}
+	return query
 }
 
 // applyStaffScope narrows a thread query to the students a staff member may

--- a/backend/database/repositories/users/parent_message_thread.go
+++ b/backend/database/repositories/users/parent_message_thread.go
@@ -96,27 +96,31 @@ func (r *ParentMessageThreadRepository) GetOrCreate(ctx context.Context, tenantI
 	return existing, nil
 }
 
+// LockForMessageAppend serializes inserts into a thread within the caller's
+// transaction, keeping message tuple order aligned with commit order.
+func (r *ParentMessageThreadRepository) LockForMessageAppend(ctx context.Context, threadID int64) error {
+	var id int64
+	query := base.GetDB(ctx, r.DB).NewSelect().
+		TableExpr(tableExprParentMessageThreadsAsThread).
+		ColumnExpr(`"parent_message_thread".id`).
+		Where(`"parent_message_thread".id = ?`, threadID).
+		For("UPDATE")
+	query = base.WithTenantFilter(ctx, query, "parent_message_thread")
+	if err := query.Scan(ctx, &id); err != nil {
+		return &modelBase.DatabaseError{Op: "lock parent message thread for append", Err: err}
+	}
+	return nil
+}
+
 // TouchLastMessage atomically advances the thread's denormalized last-activity
 // fields (last_message_at, last_sender_kind, last_message_body) — the columns the
 // inbox projection sorts and previews by — but ONLY when `at` is newer than the
 // stored last_message_at. This is the single write path for those fields on both
 // portals.
 //
-// The `(last_message_at, last_message_id)` guard is what makes concurrent sends
-// correct. Without it, a staff reply and a guardian message to the SAME thread
-// each load the thread, stamp their own captured instant, and race on a full-row
-// Update: whichever transaction COMMITS last wins, even when its message is
-// actually the OLDER of the two. That leaves /api/messages and the parent thread
-// list sorted by — and previewing — the wrong message, showing the wrong last
-// sender. Folding every update into this one guarded statement makes the
-// denormalized fields monotonic in the SAME (created_at, id) order the message
-// log uses, so a later-committing-but-older writer is a no-op and the
-// genuinely-latest message always owns the preview. The id tie-breaker matters
-// because clock_timestamp() can hand two messages the same created_at (the unread
-// cursor already tie-breaks on id for exactly this reason): on an equal instant
-// the higher-id message still wins, so the preview can never lag behind
-// ListByThread. A fresh thread (NULL last_message_at) always loses to its first
-// real message.
+// The composite guard also protects repair and legacy call sites from moving the
+// preview backward. The append path separately locks the thread before insert,
+// aligning message order with commit order.
 func (r *ParentMessageThreadRepository) TouchLastMessage(ctx context.Context, threadID int64, at time.Time, messageID int64, senderKind, body string) error {
 	query := base.GetDB(ctx, r.DB).NewUpdate().
 		Model((*users.ParentMessageThread)(nil)).

--- a/backend/database/repositories/users/parent_messaging_repository_test.go
+++ b/backend/database/repositories/users/parent_messaging_repository_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	usersRepo "github.com/moto-nrw/project-phoenix/database/repositories/users"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -206,6 +207,83 @@ func TestParentMessaging_UnreadCreatedAtTie(t *testing.T) {
 	count, err = readRepo.UnreadMessageCountForStaff(ctx, reader, true, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+// TestParentMessaging_TeamHandledCursorDoesNotSkipTiedNewMessage pins the
+// reply/message race: handling a snapshot up to one guardian row must leave a
+// later row with the same timestamp and a higher id unread for every colleague.
+func TestParentMessaging_TeamHandledCursorDoesNotSkipTiedNewMessage(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+	staff, staffAccount := testpkg.CreateTestStaffWithAccount(t, db, "Miriam", "Klein")
+	defer testpkg.CleanupStaffFixtures(t, db, staff.ID)
+	defer testpkg.CleanupAuthFixtures(t, db, staffAccount.ID)
+	defer testpkg.CleanupParentMessagingForAccount(t, db, staffAccount.ID)
+
+	threadRepo := usersRepo.NewParentMessageThreadRepository(db)
+	msgRepo := usersRepo.NewParentMessageRepository(db)
+	readRepo := usersRepo.NewParentMessageReadRepository(db)
+	ctx := tenantCtx()
+	thread := newThread(chain.StudentID, chain.AccountID)
+	require.NoError(t, threadRepo.Create(ctx, thread))
+
+	tie := time.Now().Truncate(time.Microsecond)
+	first := newMessage(thread.ID, chain.StudentID, chain.AccountID, usersModels.ParentMessageSenderGuardian, "erste")
+	first.CreatedAt, first.UpdatedAt = tie, tie
+	require.NoError(t, msgRepo.Create(ctx, first))
+	require.NoError(t, readRepo.MarkStaffHandledUpTo(ctx, 1, thread.ID, first.CreatedAt, first.ID))
+
+	concurrent := newMessage(thread.ID, chain.StudentID, chain.AccountID, usersModels.ParentMessageSenderGuardian, "gleichzeitig")
+	concurrent.CreatedAt, concurrent.UpdatedAt = tie, tie
+	require.NoError(t, msgRepo.Create(ctx, concurrent))
+	require.Greater(t, concurrent.ID, first.ID)
+
+	count, err := readRepo.UnreadMessageCountForStaff(ctx, staffAccount.ID, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "a tied higher-id message outside the handled snapshot must remain unread")
+
+	require.NoError(t, readRepo.MarkStaffHandledUpTo(ctx, 1, thread.ID, concurrent.CreatedAt, concurrent.ID))
+	count, err = readRepo.UnreadMessageCountForStaff(ctx, staffAccount.ID, true, nil)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+}
+
+func TestParentMessaging_MessageAppendLockSerializesThreadWrites(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	repo := usersRepo.NewParentMessageThreadRepository(db)
+	ctx := tenantCtx()
+	thread := newThread(chain.StudentID, chain.AccountID)
+	require.NoError(t, repo.Create(ctx, thread))
+
+	holder, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = holder.Rollback() }()
+	holderCtx := modelBase.ContextWithTx(ctx, &holder)
+	require.NoError(t, repo.LockForMessageAppend(holderCtx, thread.ID))
+
+	contender, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = contender.Rollback() }()
+	_, err = contender.ExecContext(ctx, "SET LOCAL lock_timeout = ?", "200ms")
+	require.NoError(t, err)
+	contenderCtx := modelBase.ContextWithTx(ctx, &contender)
+	err = repo.LockForMessageAppend(contenderCtx, thread.ID)
+	require.Error(t, err, "a second append must wait for the first transaction")
+	assert.True(t, isLockTimeoutError(err), "expected lock_timeout, got: %v", err)
+	require.NoError(t, contender.Rollback())
+
+	require.NoError(t, holder.Commit())
+	followUp, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = followUp.Rollback() }()
+	followUpCtx := modelBase.ContextWithTx(ctx, &followUp)
+	require.NoError(t, repo.LockForMessageAppend(followUpCtx, thread.ID))
 }
 
 // newRequestCreatedPill builds a "request created" event pill as the emitter

--- a/backend/models/users/parent_message_read.go
+++ b/backend/models/users/parent_message_read.go
@@ -103,6 +103,9 @@ type ParentMessageReadRepository interface {
 	// advanced, so the read-receipt SSE push can fire only on a real move and not
 	// ping-pong with the refetch it triggers on the counterpart.
 	MarkReadUpTo(ctx context.Context, tenantID, threadID, accountID int64, readAt time.Time, readMessageID int64) (bool, error)
+	// MarkStaffHandledUpTo advances the team-wide handled boundary to the newest
+	// guardian activity covered by a staff reply. It never moves backward.
+	MarkStaffHandledUpTo(ctx context.Context, tenantID, threadID int64, handledAt time.Time, handledMessageID int64) error
 	// UnreadMessageCountForStaff counts unread guardian MESSAGES the staff reader
 	// has not seen (sent by the other side), within the given student scope — the
 	// sidebar badge source. Counts messages, not threads, so the badge matches the

--- a/backend/models/users/parent_message_thread.go
+++ b/backend/models/users/parent_message_thread.go
@@ -40,6 +40,10 @@ type ParentMessageThread struct {
 	// per thread row. Every code path that updates LastMessageAt MUST also set
 	// this in the same UPDATE.
 	LastMessageBody string `bun:"last_message_body" json:"last_message_body,omitempty"`
+	// StaffHandledUpTo is the team-wide boundary for guardian activity already
+	// covered by a staff reply. Personal read cursors remain account-specific.
+	StaffHandledUpToAt        *time.Time `bun:"staff_handled_up_to_at" json:"-"`
+	StaffHandledUpToMessageID *int64     `bun:"staff_handled_up_to_message_id" json:"-"`
 }
 
 // ParentMessageThreadRepository is the tenant-scoped data-access contract for
@@ -47,16 +51,16 @@ type ParentMessageThread struct {
 type ParentMessageThreadRepository interface {
 	Create(ctx context.Context, thread *ParentMessageThread) error
 	Update(ctx context.Context, thread *ParentMessageThread) error
+	// LockForMessageAppend serializes message inserts for one thread. The lock
+	// must be acquired before inserting so message order also reflects commit order.
+	LockForMessageAppend(ctx context.Context, threadID int64) error
 	// TouchLastMessage atomically advances the denormalized last-activity fields
 	// (last_message_at, last_message_id, last_sender_kind, last_message_body) that
 	// drive the inbox preview/order, but ONLY when the message's (at, messageID)
 	// composite is newer than the stored (last_message_at, last_message_id). This
-	// is the single, concurrency-safe write path for those fields: it makes them
-	// monotonic in the SAME (created_at, id) order the message log uses, so two
-	// near-simultaneous sends (staff + guardian) to the same thread can't have the
-	// later-committing-but-older one clobber the newer preview/order — including
-	// when both messages share a created_at, where the higher id wins. Callers
-	// must still insert the message row separately.
+	// is the single monotonic write path for those fields, including when two
+	// messages share a timestamp and the higher id wins. Callers must still insert
+	// the message row separately.
 	TouchLastMessage(ctx context.Context, threadID int64, at time.Time, messageID int64, senderKind, body string) error
 	// FindByID returns the thread by id (tenant-scoped), or nil when absent.
 	FindByID(ctx context.Context, id int64) (*ParentMessageThread, error)

--- a/backend/services/messaging/service.go
+++ b/backend/services/messaging/service.go
@@ -44,6 +44,9 @@ var (
 	ErrEmptyBody = errors.New("messaging: message body must not be empty")
 	// ErrBodyTooLong means the message exceeded maxMessageLen.
 	ErrBodyTooLong = errors.New("messaging: message body too long")
+	// ErrHandledBoundaryRequired means the replying client did not identify the
+	// message snapshot its team reply covers.
+	ErrHandledBoundaryRequired = errors.New("messaging: handled message boundary required")
 	// ErrInvalidGuardian means the chosen recipient is not an account-holding
 	// guardian of the child.
 	ErrInvalidGuardian = errors.New("messaging: recipient is not a guardian of this child")
@@ -333,7 +336,7 @@ func (s *Service) GetThread(ctx context.Context, threadID int64) (*ThreadDetail,
 }
 
 // PostMessage appends a staff reply and returns the refreshed thread messages.
-func (s *Service) PostMessage(ctx context.Context, threadID int64, body string) ([]*usersModels.ParentMessage, error) {
+func (s *Service) PostMessage(ctx context.Context, threadID int64, body string, handledUpToMessageID int64) ([]*usersModels.ParentMessage, error) {
 	body = strings.TrimSpace(body)
 	if body == "" {
 		return nil, ErrEmptyBody
@@ -354,6 +357,26 @@ func (s *Service) PostMessage(ctx context.Context, threadID int64, body string) 
 	if err := s.requireLinkedGuardian(ctx, thread); err != nil {
 		return nil, err
 	}
+	visibleMessages, err := s.MessageRepo.ListByThread(ctx, thread.ID, 0)
+	if err != nil {
+		return nil, fmt.Errorf("messaging: list visible messages: %w", err)
+	}
+	boundaryFound := handledUpToMessageID <= 0
+	for _, message := range visibleMessages {
+		if message.ID == handledUpToMessageID {
+			boundaryFound = true
+		}
+	}
+	if !boundaryFound {
+		return nil, ErrHandledBoundaryRequired
+	}
+	if handledUpToMessageID <= 0 {
+		for _, message := range visibleMessages {
+			if usersModels.IsCounterpartMessage(message, true) {
+				return nil, ErrHandledBoundaryRequired
+			}
+		}
+	}
 
 	accountID := accountIDFromCtx(ctx)
 	if err := s.appendStaffMessage(ctx, thread, accountID, body); err != nil {
@@ -363,6 +386,9 @@ func (s *Service) PostMessage(ctx context.Context, threadID int64, body string) 
 	messages, err := s.MessageRepo.ListByThread(ctx, thread.ID, 0)
 	if err != nil {
 		return nil, fmt.Errorf("messaging: list messages: %w", err)
+	}
+	if err := parentmessaging.MarkStaffHandledToVisible(ctx, s.ReadRepo, thread.TenantID, thread.ID, handledUpToMessageID, visibleMessages); err != nil {
+		return nil, fmt.Errorf("messaging: mark handled: %w", err)
 	}
 	// Advance the staff reader's cursor over this returned snapshot, exactly as the
 	// GET path (markReadAndBuild) does. The client applies this list with
@@ -432,6 +458,10 @@ func (s *Service) StartThread(ctx context.Context, studentID, guardianAccountID 
 	if err := s.appendStaffMessage(ctx, thread, accountID, body); err != nil {
 		return nil, err
 	}
+	messages, err := s.MessageRepo.ListByThread(ctx, thread.ID, 0)
+	if err != nil {
+		return nil, fmt.Errorf("messaging: list messages: %w", err)
+	}
 	s.broadcastAfterCommit(ctx, thread)
 	s.notifyGuardianDevice(ctx, thread)
 	s.Logger.Info("staff sent parent message",
@@ -447,7 +477,10 @@ func (s *Service) StartThread(ctx context.Context, studentID, guardianAccountID 
 	// refetch. Snapshot-bounded (never NOW()) via markReadAndBuild. The advance flag
 	// is ignored: this is a SEND path, and broadcastAfterCommit above already wakes
 	// the guardian with the new message (which refreshes receipts too).
-	detail, _, err := s.markReadAndBuild(ctx, thread)
+	if _, err := parentmessaging.MarkReadToNewest(ctx, s.ReadRepo, thread.TenantID, thread.ID, accountID, true, messages); err != nil {
+		return nil, fmt.Errorf("messaging: mark read: %w", err)
+	}
+	detail, err := s.buildDetailFromMessages(ctx, thread, messages)
 	return detail, err
 }
 

--- a/backend/services/messaging/service_error_test.go
+++ b/backend/services/messaging/service_error_test.go
@@ -36,6 +36,8 @@ type fakeThreadRepo struct {
 	getOrCreateErr   error
 }
 
+func (f *fakeThreadRepo) LockForMessageAppend(context.Context, int64) error { return nil }
+
 func (f *fakeThreadRepo) FindByID(context.Context, int64) (*usersModels.ParentMessageThread, error) {
 	return f.thread, f.findErr
 }
@@ -205,7 +207,7 @@ func TestPostMessage_NoBroadcastOnAppendFailure(t *testing.T) {
 		ThreadRepo: tr, MessageRepo: &fakeMessageRepo{createErr: errBoom}, ReadRepo: &fakeReadRepo{},
 		Persons: fakePersons{}, Settings: stubSettings{messagingEnabled: true}, Broadcaster: bc, Logger: slog.Default(),
 	})
-	_, err := svc.PostMessage(errCtx(), 5, "Hallo")
+	_, err := svc.PostMessage(errCtx(), 5, "Hallo", 0)
 	require.Error(t, err)
 	assert.Equal(t, 0, parentEventCount(bc, realtime.EventParentMessage), "a failed append must not broadcast")
 }

--- a/backend/services/messaging/service_test.go
+++ b/backend/services/messaging/service_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/realtime"
 	configService "github.com/moto-nrw/project-phoenix/services/config"
 	"github.com/moto-nrw/project-phoenix/services/messaging"
+	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	usersService "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
@@ -166,7 +167,7 @@ func newFixtureWithSettings(t *testing.T, settings stubSettings) *fixture {
 
 // createGuardianMessage inserts a guardian-authored message straight through the
 // repo, simulating the parent side so a staff-facing unread exists.
-func createGuardianMessage(t *testing.T, db *bun.DB, chain testpkg.ParentChain, threadID int64, body string) {
+func createGuardianMessage(t *testing.T, db *bun.DB, chain testpkg.ParentChain, threadID int64, body string) *usersModels.ParentMessage {
 	t.Helper()
 	gm := &usersModels.ParentMessage{
 		ThreadID:        threadID,
@@ -178,6 +179,7 @@ func createGuardianMessage(t *testing.T, db *bun.DB, chain testpkg.ParentChain, 
 	}
 	gm.SetTenantID(chain.TenantID)
 	require.NoError(t, repositories.NewFactory(db).ParentMessage.Create(tenant.WithTenantID(context.Background(), 1), gm))
+	return gm
 }
 
 // --- StartThread / PostMessage / GetThread ------------------------------
@@ -255,11 +257,108 @@ func TestPostMessage_AppendsAndBroadcasts(t *testing.T) {
 	require.NoError(t, err)
 	f.bc.Reset() // reset to isolate the reply's broadcast
 
-	msgs, err := f.svc.PostMessage(ctx, started.ThreadID, "Noch eine Info")
+	msgs, err := f.svc.PostMessage(ctx, started.ThreadID, "Noch eine Info", 0)
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "Noch eine Info", msgs[1].Body)
 	assert.Equal(t, 1, parentEventCount(f.bc, realtime.EventParentMessage))
+}
+
+// TestPostMessage_ClearsTeamUnreadForColleagues covers the shared-inbox contract:
+// a reply handles the guardian activity for every authorized staff member without
+// forging a personal read cursor for colleagues. Later guardian activity becomes
+// unread for the whole team again.
+func TestPostMessage_ClearsTeamUnreadForColleagues(t *testing.T) {
+	f := newFixture(t, true)
+	accessibleGroup := testpkg.CreateTestEducationGroup(t, f.db, "Nachrichten Zugriff")
+	otherGroup := testpkg.CreateTestEducationGroup(t, f.db, "Nachrichten Kein Zugriff")
+	t.Cleanup(func() {
+		_, _ = f.db.NewUpdate().TableExpr("users.students").Set("group_id = NULL").Where("id = ?", f.chain.StudentID).Exec(context.Background())
+		_, _ = f.db.NewDelete().TableExpr("education.groups").Where("id IN (?)", bun.List([]int64{accessibleGroup.ID, otherGroup.ID})).Exec(context.Background())
+	})
+	_, err := f.db.NewUpdate().TableExpr("users.students").Set("group_id = ?", accessibleGroup.ID).Where("id = ?", f.chain.StudentID).Exec(context.Background())
+	require.NoError(t, err)
+	colleague, colleagueAccount := testpkg.CreateTestStaffWithAccount(t, f.db, "Miriam", "Klein")
+	t.Cleanup(func() { testpkg.CleanupStaffFixtures(t, f.db, colleague.ID) })
+	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, f.db, colleagueAccount.ID) })
+	t.Cleanup(func() { testpkg.CleanupParentMessagingForAccount(t, f.db, colleagueAccount.ID) })
+
+	started, err := f.svc.StartThread(adminCtx(f.staffAccount), f.chain.StudentID, f.chain.AccountID, "Hallo")
+	require.NoError(t, err)
+	firstGuardianMessage := createGuardianMessage(t, f.db, f.chain, started.ThreadID, "Erste Frage")
+
+	assertStaffUnread := func(accountID int64, expected int) {
+		t.Helper()
+		count, countErr := f.svc.UnreadMessageCount(adminCtx(accountID))
+		require.NoError(t, countErr)
+		assert.Equal(t, expected, count)
+
+		inbox, inboxErr := f.svc.ListInbox(adminCtx(accountID), true)
+		require.NoError(t, inboxErr)
+		if expected == 0 {
+			assert.Empty(t, inbox)
+		} else {
+			require.Len(t, inbox, 1)
+			assert.Equal(t, expected, inbox[0].UnreadCount)
+		}
+
+		threads, threadsErr := f.svc.ListStudentThreads(adminCtx(accountID), f.chain.StudentID)
+		require.NoError(t, threadsErr)
+		require.Len(t, threads, 1)
+		assert.Equal(t, expected, threads[0].UnreadCount)
+	}
+
+	assertStaffUnread(f.staffAccount, 1)
+	assertStaffUnread(colleagueAccount.ID, 1)
+
+	_, err = f.svc.PostMessage(adminCtx(f.staffAccount), started.ThreadID, "Team-Antwort", firstGuardianMessage.ID)
+	require.NoError(t, err)
+	assertStaffUnread(f.staffAccount, 0)
+	assertStaffUnread(colleagueAccount.ID, 0)
+
+	var colleagueReadRows int
+	require.NoError(t, f.db.NewRaw(`
+		SELECT COUNT(*) FROM users.parent_message_reads
+		WHERE thread_id = ? AND account_id = ?
+	`, started.ThreadID, colleagueAccount.ID).Scan(context.Background(), &colleagueReadRows))
+	assert.Zero(t, colleagueReadRows, "team handling must not forge a colleague's personal read receipt")
+
+	allMessages, err := repositories.NewFactory(f.db).ParentMessage.ListByThread(adminCtx(f.staffAccount), started.ThreadID, 0)
+	require.NoError(t, err)
+	parentmessaging.DecorateReadReceipts(adminCtx(f.chain.AccountID), repositories.NewFactory(f.db).ParentMessageRead, nil, started.ThreadID, f.chain.AccountID, allMessages)
+	assert.True(t, allMessages[1].ReadByStaff, "the guardian receipt remains tied to the responding staff account's personal cursor")
+
+	createGuardianMessage(t, f.db, f.chain, started.ThreadID, "Neue Frage")
+	assertStaffUnread(f.staffAccount, 1)
+	assertStaffUnread(colleagueAccount.ID, 1)
+
+	readRepo := repositories.NewFactory(f.db).ParentMessageRead
+	count, err := readRepo.UnreadMessageCountForStaff(adminCtx(colleagueAccount.ID), colleagueAccount.ID, false, []int64{accessibleGroup.ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "authorized group staff must see the new open message")
+	count, err = readRepo.UnreadMessageCountForStaff(adminCtx(colleagueAccount.ID), colleagueAccount.ID, false, []int64{otherGroup.ID})
+	require.NoError(t, err)
+	assert.Zero(t, count, "the team boundary must not broaden student access")
+}
+
+func TestPostMessage_RejectsLegacyReplyWithoutVisibleBoundary(t *testing.T) {
+	f := newFixture(t, true)
+	started, err := f.svc.StartThread(adminCtx(f.staffAccount), f.chain.StudentID, f.chain.AccountID, "Hallo")
+	require.NoError(t, err)
+	createGuardianMessage(t, f.db, f.chain, started.ThreadID, "Frage")
+
+	_, err = f.svc.PostMessage(adminCtx(f.staffAccount), started.ThreadID, "Antwort", 0)
+	require.ErrorIs(t, err, messaging.ErrHandledBoundaryRequired)
+
+	messages, err := repositories.NewFactory(f.db).ParentMessage.ListByThread(adminCtx(f.staffAccount), started.ThreadID, 0)
+	require.NoError(t, err)
+	assert.Len(t, messages, 2, "the rejected legacy reply must not be inserted")
+
+	_, err = f.svc.PostMessage(adminCtx(f.staffAccount), started.ThreadID, "Antwort", 999999999)
+	require.ErrorIs(t, err, messaging.ErrHandledBoundaryRequired)
+	messages, err = repositories.NewFactory(f.db).ParentMessage.ListByThread(adminCtx(f.staffAccount), started.ThreadID, 0)
+	require.NoError(t, err)
+	assert.Len(t, messages, 2, "a reply with a foreign boundary must not be inserted")
 }
 
 // TestPostMessage_EmptyAndTooLong pins the body guards: blank → ErrEmptyBody,
@@ -270,10 +369,10 @@ func TestPostMessage_EmptyAndTooLong(t *testing.T) {
 	started, err := f.svc.StartThread(ctx, f.chain.StudentID, f.chain.AccountID, "Hallo")
 	require.NoError(t, err)
 
-	_, err = f.svc.PostMessage(ctx, started.ThreadID, "   \n\t ")
+	_, err = f.svc.PostMessage(ctx, started.ThreadID, "   \n\t ", 0)
 	require.ErrorIs(t, err, messaging.ErrEmptyBody)
 
-	_, err = f.svc.PostMessage(ctx, started.ThreadID, strings.Repeat("x", 2001))
+	_, err = f.svc.PostMessage(ctx, started.ThreadID, strings.Repeat("x", 2001), 0)
 	require.ErrorIs(t, err, messaging.ErrBodyTooLong)
 }
 
@@ -483,7 +582,7 @@ func TestMessaging_GraduatedStudentIsForbidden(t *testing.T) {
 
 	_, err = f.svc.GetThread(ctx, started.ThreadID)
 	require.ErrorIs(t, err, messaging.ErrForbidden)
-	_, err = f.svc.PostMessage(ctx, started.ThreadID, "Reply")
+	_, err = f.svc.PostMessage(ctx, started.ThreadID, "Reply", 0)
 	require.ErrorIs(t, err, messaging.ErrForbidden)
 	_, err = f.svc.ListStudentThreads(ctx, f.chain.StudentID)
 	require.ErrorIs(t, err, messaging.ErrForbidden)
@@ -510,7 +609,7 @@ func TestPostMessage_GuardianAccessRevoked(t *testing.T) {
 	`, f.chain.TenantID, f.chain.StudentID, f.chain.GuardianProfileID)
 	require.NoError(t, err)
 
-	_, err = f.svc.PostMessage(ctx, started.ThreadID, "Reply")
+	_, err = f.svc.PostMessage(ctx, started.ThreadID, "Reply", 0)
 	require.ErrorIs(t, err, messaging.ErrGuardianAccessRevoked)
 
 	// Read still works — history stays visible.
@@ -538,7 +637,7 @@ func TestMessaging_DisabledFeature(t *testing.T) {
 		Broadcaster: f.bc, DB: f.db, Logger: slog.Default(),
 	})
 
-	_, err = disabled.PostMessage(ctx, started.ThreadID, "Reply")
+	_, err = disabled.PostMessage(ctx, started.ThreadID, "Reply", 0)
 	require.ErrorIs(t, err, messaging.ErrMessagingDisabled)
 
 	count, err := disabled.UnreadMessageCount(ctx)

--- a/backend/services/parentmessaging/emitter.go
+++ b/backend/services/parentmessaging/emitter.go
@@ -248,6 +248,9 @@ func (e *Emitter) EmitChildEvent(tenantID, studentID, guardianAccountID int64, e
 			RefID:           ev.RefID,
 		}
 		msg.SetTenantID(thread.TenantID)
+		if err := e.threadRepo.LockForMessageAppend(txCtx, thread.ID); err != nil {
+			return err
+		}
 		if err := e.messageRepo.Create(txCtx, msg); err != nil {
 			return err
 		}

--- a/backend/services/parentmessaging/parentmessaging.go
+++ b/backend/services/parentmessaging/parentmessaging.go
@@ -74,9 +74,9 @@ func loggerOr(logger *slog.Logger) *slog.Logger {
 	return cmp.Or(logger, slog.Default())
 }
 
-// AppendMessage persists an already-built ParentMessage, then updates the
-// thread's last-activity preview. The caller has already authorized/validated the
-// body and stamped SenderKind / SenderName / tenant on msg.
+// AppendMessage serializes the thread, persists an already-built message, then
+// updates the last-activity preview. The caller has already authorized and
+// stamped the sender and tenant fields.
 //
 // The thread touch is driven off the inserted row's DB-stamped created_at
 // (msg.CreatedAt), NOT a Go time.Now(): messages.created_at defaults to the
@@ -85,24 +85,18 @@ func loggerOr(logger *slog.Logger) *slog.Logger {
 // preview guard (TouchLastMessage) could then keep the older message. Using the
 // row's own created_at keeps every comparison on one clock.
 //
-// It deliberately does NOT advance the sender's read cursor. Advancing the cursor
-// to the just-sent message leaps it past an EARLIER counterpart message that
-// committed AFTER this send: created_at defaults to the transaction's start
-// instant, so a counterpart whose tx began first (lower created_at) but committed
-// later sits below the sent message's timestamp, and a cursor moved to the send
-// would mark that never-seen message read once it commits. Instead the unread
-// predicates exclude a reader's OWN messages by sender_account_id
-// (notReaderAuthored in database/repositories/users/parent_message_read.go), which
-// is what keeps a dual-role (staff+guardian) sender from counting their own
-// just-sent message as unread to themselves — without any cursor move. The
-// legitimate "I have now seen everything" advance happens on the read path
-// (MarkReadToNewest), bounded to the snapshot actually returned to the client.
+// It deliberately does not advance the sender's read cursor. Own messages are
+// excluded by sender_account_id, while read paths advance only to a snapshot the
+// client actually received.
 func AppendMessage(
 	ctx context.Context,
 	msgRepo usersModels.ParentMessageRepository,
 	threadRepo usersModels.ParentMessageThreadRepository,
 	msg *usersModels.ParentMessage,
 ) error {
+	if err := threadRepo.LockForMessageAppend(ctx, msg.ThreadID); err != nil {
+		return err
+	}
 	if err := msgRepo.Create(ctx, msg); err != nil {
 		return err
 	}
@@ -189,6 +183,37 @@ func MarkReadToNewest(
 		return false, nil
 	}
 	return readRepo.MarkReadUpTo(ctx, tenantID, threadID, accountID, newest.CreatedAt, newest.ID)
+}
+
+// MarkStaffHandledToVisible advances the shared team boundary only through the
+// last timeline row the replying client displayed. Missing or stale boundaries
+// are safe no-ops, so a concurrent message can stay open but is never skipped.
+func MarkStaffHandledToVisible(
+	ctx context.Context,
+	readRepo usersModels.ParentMessageReadRepository,
+	tenantID, threadID int64,
+	handledUpToMessageID int64,
+	messages []*usersModels.ParentMessage,
+) error {
+	if handledUpToMessageID <= 0 {
+		return nil
+	}
+	var newest *usersModels.ParentMessage
+	for _, msg := range messages {
+		if msg == nil {
+			continue
+		}
+		if usersModels.IsCounterpartMessage(msg, true) {
+			newest = msg
+		}
+		if msg.ID == handledUpToMessageID {
+			if newest == nil {
+				return nil
+			}
+			return readRepo.MarkStaffHandledUpTo(ctx, tenantID, threadID, newest.CreatedAt, newest.ID)
+		}
+	}
+	return nil
 }
 
 // DecorateReadReceipts stamps the "OGS hat gelesen" indicator (ReadByStaff) on

--- a/backend/services/parentmessaging/parentmessaging_test.go
+++ b/backend/services/parentmessaging/parentmessaging_test.go
@@ -40,13 +40,17 @@ func (f fakeTenantSettings) ResolveBoolForTenant(context.Context, int64, string)
 
 type fakeMsgRepo struct {
 	usersModels.ParentMessageRepository
-	createErr error
-	nextID    int64
-	stampAt   time.Time
-	created   []*usersModels.ParentMessage
+	createErr    error
+	nextID       int64
+	stampAt      time.Time
+	created      []*usersModels.ParentMessage
+	beforeCreate func()
 }
 
 func (f *fakeMsgRepo) Create(_ context.Context, m *usersModels.ParentMessage) error {
+	if f.beforeCreate != nil {
+		f.beforeCreate()
+	}
 	if f.createErr != nil {
 		return f.createErr
 	}
@@ -72,6 +76,13 @@ type fakeThreadRepo struct {
 	touched      *touchCall
 	guardians    []*usersModels.MessageableGuardian
 	guardiansErr error
+	locked       bool
+	lockErr      error
+}
+
+func (f *fakeThreadRepo) LockForMessageAppend(context.Context, int64) error {
+	f.locked = true
+	return f.lockErr
 }
 
 func (f *fakeThreadRepo) ListGuardiansForStudent(context.Context, int64) ([]*usersModels.MessageableGuardian, error) {
@@ -100,11 +111,18 @@ type fakeReadRepo struct {
 	staffCursorErr    error
 	guardianCursor    *usersModels.ReadCursor
 	guardianCursorErr error
+	handled           []markCall
+	handledErr        error
 }
 
 func (f *fakeReadRepo) MarkReadUpTo(_ context.Context, tenantID, threadID, accountID int64, readAt time.Time, messageID int64) (bool, error) {
 	f.marks = append(f.marks, markCall{tenantID, threadID, accountID, messageID, readAt})
 	return f.markAdvanced, f.markErr
+}
+
+func (f *fakeReadRepo) MarkStaffHandledUpTo(_ context.Context, tenantID, threadID int64, handledAt time.Time, messageID int64) error {
+	f.handled = append(f.handled, markCall{tenantID: tenantID, threadID: threadID, messageID: messageID, readAt: handledAt})
+	return f.handledErr
 }
 
 func (f *fakeReadRepo) LatestReadCursorByOther(context.Context, int64, int64) (*usersModels.ReadCursor, error) {
@@ -177,8 +195,10 @@ func TestGuardianHasChildAccess(t *testing.T) {
 
 func TestAppendMessage_PersistsThenTouchesOffDBStampedRow(t *testing.T) {
 	stamp := time.Now().Add(-time.Minute).Truncate(time.Microsecond)
-	mr := &fakeMsgRepo{stampAt: stamp}
 	tr := &fakeThreadRepo{}
+	mr := &fakeMsgRepo{stampAt: stamp, beforeCreate: func() {
+		assert.True(t, tr.locked, "the thread must be locked before the message insert")
+	}}
 	m := &usersModels.ParentMessage{ThreadID: 42, SenderKind: usersModels.ParentMessageSenderStaff, Body: "Hallo"}
 
 	require.NoError(t, AppendMessage(context.Background(), mr, tr, m))
@@ -190,6 +210,14 @@ func TestAppendMessage_PersistsThenTouchesOffDBStampedRow(t *testing.T) {
 	assert.Equal(t, m.ID, tr.touched.messageID)
 	assert.Equal(t, usersModels.ParentMessageSenderStaff, tr.touched.kind)
 	assert.Equal(t, "Hallo", tr.touched.body)
+}
+
+func TestAppendMessage_LockErrorSkipsInsert(t *testing.T) {
+	mr := &fakeMsgRepo{}
+	tr := &fakeThreadRepo{lockErr: errors.New("lock failed")}
+	err := AppendMessage(context.Background(), mr, tr, &usersModels.ParentMessage{ThreadID: 42})
+	require.Error(t, err)
+	assert.Empty(t, mr.created)
 }
 
 func TestAppendMessage_CreateErrorSkipsTouch(t *testing.T) {
@@ -375,6 +403,29 @@ func TestMarkReadToNewest_PropagatesRepoError(t *testing.T) {
 	rr := &fakeReadRepo{markErr: errors.New("upsert failed")}
 	messages := []*usersModels.ParentMessage{msg(1, 200, usersModels.ParentMessageSenderGuardian)}
 	_, err := MarkReadToNewest(context.Background(), rr, 1, 42, 100, true, messages)
+	require.Error(t, err)
+}
+
+func TestMarkStaffHandledToVisible_BoundsToVisibleGuardianActivity(t *testing.T) {
+	guardian := msg(1, 200, usersModels.ParentMessageSenderGuardian)
+	staffReply := msg(2, 100, usersModels.ParentMessageSenderStaff)
+	concurrentGuardian := msg(3, 200, usersModels.ParentMessageSenderGuardian)
+	requestCreated := msg(4, 200, usersModels.ParentMessageSenderSystem)
+	requestCreated.EventActorKind = usersModels.ParentMessageSenderGuardian
+	requestCreated.EventType = usersModels.ParentMessageEventRequestCreated
+
+	rr := &fakeReadRepo{}
+	err := MarkStaffHandledToVisible(context.Background(), rr, 1, 42, staffReply.ID, []*usersModels.ParentMessage{guardian, staffReply, concurrentGuardian, requestCreated})
+	require.NoError(t, err)
+	require.Len(t, rr.handled, 1)
+	assert.Equal(t, guardian.ID, rr.handled[0].messageID, "the team boundary must stop at the client snapshot and leave concurrent guardian activity open")
+}
+
+func TestMarkStaffHandledToVisible_PropagatesRepoError(t *testing.T) {
+	rr := &fakeReadRepo{handledErr: errors.New("update failed")}
+	err := MarkStaffHandledToVisible(context.Background(), rr, 1, 42, 1, []*usersModels.ParentMessage{
+		msg(1, 200, usersModels.ParentMessageSenderGuardian),
+	})
 	require.Error(t, err)
 }
 

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.test.ts
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isMessageSnapshotUnavailable } from "./page";
+
+describe("isMessageSnapshotUnavailable", () => {
+  it("blocks replies until the seeded thread history has loaded", () => {
+    expect(isMessageSnapshotUnavailable(false, true, 0, undefined)).toBe(true);
+  });
+
+  it("blocks replies after the history request failed", () => {
+    expect(
+      isMessageSnapshotUnavailable(false, false, 0, new Error("failed")),
+    ).toBe(true);
+  });
+
+  it("allows replies after an empty or populated snapshot loaded", () => {
+    expect(isMessageSnapshotUnavailable(false, false, 0, undefined)).toBe(
+      false,
+    );
+    expect(isMessageSnapshotUnavailable(false, false, 2, undefined)).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
@@ -33,6 +33,17 @@ import { ThreadSkeleton } from "./page-skeleton";
 
 const logger = createLogger({ component: "MessageThreadPage" });
 
+export function isMessageSnapshotUnavailable(
+  isLoading: boolean,
+  isValidating: boolean,
+  messageCount: number,
+  loadError: unknown,
+): boolean {
+  return (
+    Boolean(loadError) || ((isLoading || isValidating) && messageCount === 0)
+  );
+}
+
 function MessageThreadContent() {
   const params = useParams();
   const threadId = params.threadId as string;
@@ -112,6 +123,12 @@ function MessageThreadContent() {
   // Nachrichten…" until the GET resolves. A background revalidation of a thread
   // that already has messages keeps messages.length > 0, so this stays false.
   const messagesLoading = (isLoading || isValidating) && messages.length === 0;
+  const snapshotUnavailable = isMessageSnapshotUnavailable(
+    isLoading,
+    isValidating,
+    messages.length,
+    loadError,
+  );
 
   // Per-ROW open/closed tracking for "request_created" pills. A pill offers the
   // "Anfrage bearbeiten" action only while its request is still open; once
@@ -186,10 +203,14 @@ function MessageThreadContent() {
   const handleSend = async () => {
     const body = draft.trim();
     if (!body || isSending) return;
+    if (snapshotUnavailable) {
+      setSendError("Bitte warten Sie, bis der Nachrichtenverlauf geladen ist.");
+      return;
+    }
     setIsSending(true);
     setSendError(null);
     try {
-      const updated = await postMessage(threadId, body);
+      const updated = await postMessage(threadId, body, messages.at(-1)?.id);
       // Show the sent message immediately. The postMessage response now carries
       // the rebuilt "current → requested" diff inline on every still-open request
       // (like the GET path), so the optimistic replace keeps the review card's
@@ -346,6 +367,7 @@ function MessageThreadContent() {
               onChange={setDraft}
               onSend={() => void handleSend()}
               sending={isSending}
+              disabled={snapshotUnavailable}
               placeholder="Nachricht an die Eltern schreiben..."
             />
           ) : (

--- a/frontend/src/lib/parent-messages-api.test.ts
+++ b/frontend/src/lib/parent-messages-api.test.ts
@@ -321,10 +321,11 @@ describe("postMessage", () => {
       seenMethod = init?.method ?? "";
       return jsonOk({ data: [] });
     });
-    const msgs = await postMessage("t1", "Guten Morgen!");
+    const msgs = await postMessage("t1", "Guten Morgen!", "17");
     expect(seenURL).toBe("/api/messages/threads/t1");
     expect(seenMethod).toBe("POST");
     expect(seenBody).toContain('"body":"Guten Morgen!"');
+    expect(seenBody).toContain('"handled_up_to_message_id":"17"');
     expect(Array.isArray(msgs)).toBe(true);
   });
 

--- a/frontend/src/lib/parent-messages-api.ts
+++ b/frontend/src/lib/parent-messages-api.ts
@@ -169,10 +169,16 @@ export async function fetchThread(threadId: string): Promise<ThreadDetail> {
 export async function postMessage(
   threadId: string,
   body: string,
+  handledUpToMessageId?: string,
 ): Promise<Message[]> {
   const result = await postEnvelope<Message[]>(
     `/api/messages/threads/${threadId}`,
-    { body },
+    {
+      body,
+      ...(handledUpToMessageId
+        ? { handled_up_to_message_id: handledUpToMessageId }
+        : {}),
+    },
     "Nachricht konnte nicht gesendet werden",
   );
   return result.data ?? [];


### PR DESCRIPTION
## Zusammenfassung

- trennt persönliche Lesecursor von einem gemeinsamen Bearbeitungsstatus der Team-Inbox
- markiert nur Elternaktivität aus dem tatsächlich sichtbaren Antwort-Snapshot als bearbeitet
- aktualisiert Posteingang, Seitenleisten-Zähler und Nachrichtenkarte im Kinderprofil über dieselbe Repository-Logik
- lässt spätere Elternnachrichten für alle weiterhin berechtigten Mitarbeitenden wieder als offen erscheinen
- belässt die Lesebestätigung im Elternportal ausschließlich auf den persönlichen Lesecursorn

## Parallelität und Rollout

- serialisiert Nachrichten-Inserts pro Unterhaltung vor dem Insert
- verwendet weiterhin `(created_at, id)` als stabile Grenze bei identischen Zeitstempeln
- lehnt Antworten ohne gültige sichtbare Grenze vor dem Insert ab, damit alte oder fehlerhafte Clients keinen unvollständigen Teamstatus erzeugen
- migriert bestehende Verläufe konservativ ohne rückwirkend Sichtbarkeit zu erraten

## Tests

- zwei Mitarbeiterkonten, Team-Antwort und neue Elternnachricht
- Posteingang, Seitenleiste und Kinderprofil
- Gruppen-Zugriff und ausgeschlossene Gruppe
- persönliche Lesebestätigung im Elternportal
- parallele Thread-Sperre und identische Zeitstempel
- fehlende und fremde Snapshot-Grenzen ohne Nachrichten-Insert
- Migration auf leerem Teamstatus
- Frontend-Snapshot-Sperre und API-Payload

Ausgeführt:

- `go test -p 1 ./test ./database/migrations ./database/repositories/users ./services/parentmessaging ./services/messaging ./api/messaging -count=1`
- `golangci-lint run --timeout 10m`
- `pnpm exec vitest run src/app/[tenant]/(protected)/messages/[threadId]/page.test.ts src/lib/parent-messages-api.test.ts`
- `pnpm run check`
- vollständige Pre-Push-Hooks

Closes #2246
