### PR TITLE
fix(students): Heimweg-Editor bei Renderfehlern bedienbar halten

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx
@@ -17,6 +17,8 @@ vi.mock("next-auth/react", () => ({
 // the detail panel to show, and assert on `mockReplace` for click-driven
 // navigations (which in the real page flow would update the URL).
 let currentSearch: URLSearchParams = new URLSearchParams();
+let suspendSearchParams = false;
+const pendingSearchParams = new Promise<never>(() => undefined);
 const mockReplace = vi.fn((url: string) => {
   const q = url.includes("?") ? (url.split("?")[1] ?? "") : "";
   currentSearch = new URLSearchParams(q);
@@ -30,7 +32,16 @@ vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
   useRouter: vi.fn(() => ({ push: vi.fn(), replace: mockReplace })),
   usePathname: vi.fn(() => "/tenant/database/students"),
-  useSearchParams: () => currentSearch,
+  useSearchParams: () => {
+    if (suspendSearchParams) throw pendingSearchParams;
+    return currentSearch;
+  },
+}));
+
+vi.mock("../section-skeleton", () => ({
+  DatabaseSectionSkeleton: () => (
+    <div data-testid="database-section-skeleton">Loading</div>
+  ),
 }));
 
 // Mock SWR hooks
@@ -345,6 +356,7 @@ const mockStudents = [
 
 describe("StudentsPage", () => {
   beforeEach(() => {
+    suspendSearchParams = false;
     vi.clearAllMocks();
     setSelectedStudent(null);
     mockSessionWithPermissions(["config:manage", "users:delete"]);
@@ -377,6 +389,14 @@ describe("StudentsPage", () => {
     mockGetOne.mockImplementation((id: string) =>
       Promise.resolve(mockStudents.find((s) => s.id === id)),
     );
+  });
+
+  it("shows the database skeleton while the route suspends", () => {
+    suspendSearchParams = true;
+
+    render(<StudentsPage />);
+
+    expect(screen.getByTestId("database-section-skeleton")).toBeVisible();
   });
 
   it("renders the page with students data", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -38,6 +38,7 @@ import { createLogger } from "~/lib/logger";
 import { hasPermission } from "~/lib/auth-utils";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils";
+import { DatabaseSectionSkeleton } from "../section-skeleton";
 
 const logger = createLogger({ component: "DatabaseStudentsPage" });
 
@@ -56,7 +57,7 @@ function parseGrouping(value: string | null): GroupingMode {
 
 export default function StudentsPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<DatabaseSectionSkeleton />}>
       <StudentsPageContent />
     </Suspense>
   );

--- a/frontend/src/components/students/student-departure-error-boundary.test.tsx
+++ b/frontend/src/components/students/student-departure-error-boundary.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: captureExceptionMock,
+}));
+
+import { StudentDepartureErrorBoundary } from "./student-departure-error-boundary";
+
+let departureEditorBroken = true;
+
+function DepartureEditor() {
+  if (departureEditorBroken) throw new Error("picker render failed");
+  return <div>Erlaubte Heimwege</div>;
+}
+
+describe("StudentDepartureErrorBoundary", () => {
+  beforeEach(() => {
+    departureEditorBroken = true;
+    vi.clearAllMocks();
+  });
+
+  it("keeps a recoverable error visible and reports the render failure", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <StudentDepartureErrorBoundary>
+        <DepartureEditor />
+      </StudentDepartureErrorBoundary>,
+    );
+
+    expect(
+      screen.getByText(
+        "Die erlaubten Heimwege konnten nicht angezeigt werden. Bitte versuchen Sie es erneut.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Erneut versuchen" }),
+    ).toBeVisible();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "picker render failed" }),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "student_departure_render_failed",
+      { error: "picker render failed", error_name: "Error" },
+    );
+
+    departureEditorBroken = false;
+    fireEvent.click(screen.getByRole("button", { name: "Erneut versuchen" }));
+    expect(screen.getByText("Erlaubte Heimwege")).toBeVisible();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/components/students/student-departure-error-boundary.tsx
+++ b/frontend/src/components/students/student-departure-error-boundary.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import React, { type ErrorInfo, type ReactNode } from "react";
+
+import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "StudentDepartureErrorBoundary" });
+
+interface StudentDepartureErrorBoundaryProps {
+  readonly children: ReactNode;
+}
+
+interface StudentDepartureErrorBoundaryState {
+  readonly error: Error | null;
+}
+
+export class StudentDepartureErrorBoundary extends React.Component<
+  StudentDepartureErrorBoundaryProps,
+  StudentDepartureErrorBoundaryState
+> {
+  state: StudentDepartureErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(
+    error: unknown,
+  ): StudentDepartureErrorBoundaryState {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  componentDidCatch(error: unknown, _errorInfo: ErrorInfo): void {
+    const normalized =
+      error instanceof Error ? error : new Error(String(error));
+    Sentry.captureException(normalized);
+    logger.error("student_departure_render_failed", {
+      error: normalized.message,
+      error_name: normalized.name,
+    });
+  }
+
+  private retry = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <Alert
+          type="error"
+          message="Die erlaubten Heimwege konnten nicht angezeigt werden. Bitte versuchen Sie es erneut."
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              size="compact"
+              onClick={this.retry}
+            >
+              Erneut versuchen
+            </Button>
+          }
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/students/student-stammdaten-tab.departure-integration.test.tsx
+++ b/frontend/src/components/students/student-stammdaten-tab.departure-integration.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createElement, type ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Student } from "~/lib/api";
+import type { AllowedDepartureModes } from "~/lib/student-helpers";
+
+const { pickerShouldThrow, captureExceptionMock } = vi.hoisted(() => ({
+  pickerShouldThrow: { current: false },
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: captureExceptionMock }));
+
+vi.mock("./companion-picker", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./companion-picker")>();
+  return {
+    ...original,
+    CompanionPicker: (
+      props: ComponentProps<typeof original.CompanionPicker>,
+    ) => {
+      if (pickerShouldThrow.current) throw new Error("picker render failed");
+      return createElement(original.CompanionPicker, props);
+    },
+  };
+});
+
+vi.mock("~/lib/hooks/use-student-photos-enabled", () => ({
+  useStudentPhotosEnabled: () => ({ enabled: false, isLoading: false }),
+}));
+
+vi.mock("~/lib/hooks/use-student-enrollment-extra-fields", () => ({
+  useStudentEnrollmentExtraFields: () => ({
+    groups: [],
+    loading: false,
+    hasError: false,
+  }),
+}));
+
+vi.mock("~/lib/hooks/use-companion-remote-refresh", () => ({
+  useCompanionRemoteRefresh: () => ({
+    companionsStale: false,
+    refreshFromRemote: vi.fn(),
+    withOwnWrite: <T,>(write: () => Promise<T>) => write(),
+    markStale: vi.fn(),
+  }),
+}));
+
+vi.mock("~/lib/student-companion-api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/student-companion-api")>()),
+  fetchStudentCompanions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("~/lib/student-api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/student-api")>()),
+  fetchStudentPrivacyConsent: vi.fn().mockResolvedValue(null),
+  uploadStudentPhoto: vi.fn(),
+  deleteStudentPhoto: vi.fn(),
+}));
+
+vi.mock("./student-photo-section", () => ({
+  StudentPhotoSection: () => null,
+}));
+
+vi.mock("./student-common-form-sections", () => ({
+  StudentCommonFormSections: () => <div data-testid="common-form-sections" />,
+}));
+
+import { StudentStammdatenTab } from "./student-stammdaten-tab";
+
+const busEveryDay = {
+  mon: ["bus"],
+  tue: ["bus"],
+  wed: ["bus"],
+  thu: ["bus"],
+  fri: ["bus"],
+} satisfies AllowedDepartureModes;
+
+function productionShapedStudent(): Student {
+  return {
+    id: "564",
+    name: "Test Kind",
+    first_name: "Test",
+    second_name: "Kind",
+    school_class: "3a",
+    current_location: "class",
+    allowed_departure_modes: busEveryDay,
+    departure_days: {
+      mon: "bus",
+      tue: "bus",
+      wed: "bus",
+      thu: "bus",
+      fri: "bus",
+    },
+    bus: true,
+    bus_days: { mon: true, tue: true, wed: true, thu: true, fri: true },
+    pickup_days: {},
+    departure_companion_note: undefined,
+  } as Student;
+}
+
+describe("StudentStammdatenTab departure integration", () => {
+  beforeEach(() => {
+    pickerShouldThrow.current = false;
+    vi.clearAllMocks();
+  });
+
+  it("keeps the real form usable when accompanied is added beside bus", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <StudentStammdatenTab
+        student={productionShapedStudent()}
+        groups={[]}
+        onSave={onSave}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Montag: Bus")).toBeChecked(),
+    );
+    fireEvent.click(screen.getByLabelText("Montag: Anderes Kind"));
+
+    expect(screen.getByLabelText("Montag: Anderes Kind")).toBeChecked();
+    expect(
+      screen.getByRole("button", { name: "Kind hinzufügen" }),
+    ).toBeVisible();
+    expect(onSave).not.toHaveBeenCalled();
+    const note = screen.getByLabelText("Oder mit welcher Person?");
+    fireEvent.change(note, { target: { value: "Nachbarin" } });
+    fireEvent.click(screen.getByRole("button", { name: /Speichern/ }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowed_departure_modes: expect.objectContaining({
+          mon: ["bus", "accompanied"],
+        }),
+        departure_companion_note: "Nachbarin",
+      }),
+    );
+  });
+
+  it("shows a rejected save without unmounting the departure editor", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Keine Berechtigung"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    render(
+      <StudentStammdatenTab
+        student={productionShapedStudent()}
+        groups={[]}
+        onSave={onSave}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Montag: Bus")).toBeChecked(),
+    );
+
+    fireEvent.click(screen.getByLabelText("Montag: Anderes Kind"));
+    fireEvent.change(screen.getByLabelText("Oder mit welcher Person?"), {
+      target: { value: "Nachbarin" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Speichern/ }));
+
+    expect(
+      await screen.findByText(
+        "Fehler beim Speichern. Bitte versuchen Sie es erneut.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Montag: Anderes Kind")).toBeChecked();
+    expect(
+      screen.getByRole("button", { name: "Kind hinzufügen" }),
+    ).toBeVisible();
+    expect(consoleError).toHaveBeenCalledWith("error saving student", {
+      error: "Keine Berechtigung",
+    });
+    consoleError.mockRestore();
+  });
+
+  it("contains a picker render failure inside the composed student editor", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    render(
+      <StudentStammdatenTab
+        student={productionShapedStudent()}
+        groups={[]}
+        onSave={vi.fn()}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Montag: Bus")).toBeChecked(),
+    );
+
+    pickerShouldThrow.current = true;
+    fireEvent.click(screen.getByLabelText("Montag: Anderes Kind"));
+
+    expect(screen.getByRole("button", { name: /Speichern/ })).toBeVisible();
+    expect(
+      screen.getByText(
+        "Die erlaubten Heimwege konnten nicht angezeigt werden. Bitte versuchen Sie es erneut.",
+      ),
+    ).toBeVisible();
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "picker render failed" }),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "student_departure_render_failed",
+      { error: "picker render failed", error_name: "Error" },
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/components/students/student-stammdaten-tab.tsx
+++ b/frontend/src/components/students/student-stammdaten-tab.tsx
@@ -18,6 +18,7 @@ import {
 } from "./student-form-fields";
 import { StudentCommonFormSections } from "./student-common-form-sections";
 import { StudentPhotoSection } from "./student-photo-section";
+import { StudentDepartureErrorBoundary } from "./student-departure-error-boundary";
 import { validateStudentForm } from "~/lib/student-form-validation";
 import { useStudentPhotosEnabled } from "~/lib/hooks/use-student-photos-enabled";
 import { useStudentEnrollmentExtraFields } from "~/lib/hooks/use-student-enrollment-extra-fields";
@@ -1154,50 +1155,52 @@ export function StudentStammdatenTab({
         hasError={enrollmentExtraLoadError}
       />
 
-      <DepartureSection
-        days={formData.allowed_departure_modes}
-        onChange={(value) => {
-          const allowed = normalizeAllowedDepartureModes(value);
-          const departure = allowedDepartureToDepartureDays(allowed);
-          const busDays = allowedDepartureToBusDays(allowed);
-          const pickupDays = allowedDepartureToPickupDays(allowed);
-          setFormData((prev) => ({
-            ...prev,
-            allowed_departure_modes: allowed,
-            departure_days: departure,
-            // Keep the derived legacy fields consistent for any reader.
-            bus_days: busDays,
-            bus: busDaysHaveAny(busDays),
-            pickup_days: pickupDays,
-            pickup_status: pickupDaysHaveAny(pickupDays)
-              ? "Wird abgeholt"
-              : "Geht alleine nach Hause",
-          }));
-        }}
-        companionNote={formData.departure_companion_note}
-        onCompanionNoteChange={(value) =>
-          setFormData((prev) => ({
-            ...prev,
-            departure_companion_note: value,
-          }))
-        }
-        companionNoteError={errors.departure_companion_note}
-        companions={companions}
-        // Hidden until the stored links are known (the section drops the picker
-        // without a change handler): an edit made against a pending or failed
-        // load would be silently discarded on save, since the list only travels
-        // when it is the stored one.
-        onCompanionsChange={
-          companionsStatus === "ready" ? setCompanions : undefined
-        }
-        companionStudentId={String(student.id)}
-        onCompanionExtensionConfirmed={(confirmation) => {
-          setExtendCompanionPlans(true);
-          setConfirmedExtensions((current) =>
-            mergeCompanionConfirmations(current, [confirmation]),
-          );
-        }}
-      />
+      <StudentDepartureErrorBoundary key={String(student.id)}>
+        <DepartureSection
+          days={formData.allowed_departure_modes}
+          onChange={(value) => {
+            const allowed = normalizeAllowedDepartureModes(value);
+            const departure = allowedDepartureToDepartureDays(allowed);
+            const busDays = allowedDepartureToBusDays(allowed);
+            const pickupDays = allowedDepartureToPickupDays(allowed);
+            setFormData((prev) => ({
+              ...prev,
+              allowed_departure_modes: allowed,
+              departure_days: departure,
+              // Keep the derived legacy fields consistent for any reader.
+              bus_days: busDays,
+              bus: busDaysHaveAny(busDays),
+              pickup_days: pickupDays,
+              pickup_status: pickupDaysHaveAny(pickupDays)
+                ? "Wird abgeholt"
+                : "Geht alleine nach Hause",
+            }));
+          }}
+          companionNote={formData.departure_companion_note}
+          onCompanionNoteChange={(value) =>
+            setFormData((prev) => ({
+              ...prev,
+              departure_companion_note: value,
+            }))
+          }
+          companionNoteError={errors.departure_companion_note}
+          companions={companions}
+          // Hidden until the stored links are known (the section drops the picker
+          // without a change handler): an edit made against a pending or failed
+          // load would be silently discarded on save, since the list only travels
+          // when it is the stored one.
+          onCompanionsChange={
+            companionsStatus === "ready" ? setCompanions : undefined
+          }
+          companionStudentId={String(student.id)}
+          onCompanionExtensionConfirmed={(confirmation) => {
+            setExtendCompanionPlans(true);
+            setConfirmedExtensions((current) =>
+              mergeCompanionConfirmations(current, [confirmation]),
+            );
+          }}
+        />
+      </StudentDepartureErrorBoundary>
 
       <EnrollmentConsentsSection
         agbAcceptedAt={student.agb_accepted_at}


### PR DESCRIPTION
## Zusammenfassung

- zeigt bei einer Suspense-Unterbrechung der Kinderverwaltung das bestehende Master-Detail-Skeleton statt einer leeren Inhaltsfläche
- begrenzt Renderfehler im Heimweg-Bereich auf eine sichtbare Fehlermeldung mit „Erneut versuchen“; der übrige Stammdaten-Editor bleibt verfügbar
- meldet Renderfehler an Sentry und den strukturierten Client-Logger, ohne Schülerdaten zu protokollieren
- sichert den Bus-→-„Anderes Kind“-Pfad sowie Render-, Speicher- und Suspense-Fehler mit Regressionstests ab

## Tests

- `pnpm exec vitest run frontend/src/app/[tenant]/(protected)/database/students/page.test.tsx frontend/src/components/students/student-departure-error-boundary.test.tsx frontend/src/components/students/student-stammdaten-tab.departure-integration.test.tsx`
- `pnpm run test:run`
- `pnpm run check`
- `pnpm run depcruise`
- `pnpm run knip`

Closes #2244
