### PR TITLE
style(auth): use fingerprint icon for passkey login buttons

### DIFF
--- a/frontend/src/app/[tenant]/page.tsx
+++ b/frontend/src/app/[tenant]/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef, Suspense } from "react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import Image from "next/image";
-import { KeyRound } from "lucide-react";
+import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
 import { Alert } from "~/components/ui/alert";
 import { refreshToken } from "~/lib/auth-api";
 import { trackTenantEvent } from "~/lib/analytics";
@@ -579,7 +579,7 @@ function LoginForm() {
                   onClick={handlePasskeyLogin}
                   className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
                 >
-                  <KeyRound className="h-4 w-4" aria-hidden="true" />
+                  <MotoConceptIcon concept="passkeys" size={16} />
                   <span>Mit Passkey anmelden</span>
                 </button>
               )}

--- a/frontend/src/app/operator/login/page.tsx
+++ b/frontend/src/app/operator/login/page.tsx
@@ -346,7 +346,7 @@ export default function OperatorLoginPage() {
               onClick={handlePasskeyLogin}
               className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-900 shadow-sm transition-colors hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
             >
-              <MotoConceptIcon concept="permissions" size={16} />
+              <MotoConceptIcon concept="passkeys" size={16} />
               <span>Mit Passkey anmelden</span>
             </button>
           )}

--- a/frontend/src/lib/moto-concepts.ts
+++ b/frontend/src/lib/moto-concepts.ts
@@ -29,6 +29,7 @@ import {
   EnvelopeIcon,
   EyeIcon,
   FileArrowDownIcon,
+  FingerprintSimpleIcon,
   FirstAidKitIcon,
   ForkKnifeIcon,
   GearIcon,
@@ -350,6 +351,13 @@ export const MOTO_CONCEPTS = {
   permissions: concept(
     "Berechtigungen",
     LockKeyIcon,
+    "purple",
+    "function",
+    "system",
+  ),
+  passkeys: concept(
+    "Passkeys",
+    FingerprintSimpleIcon,
     "purple",
     "function",
     "system",


### PR DESCRIPTION
## Summary

Replaces the passkey login button icons with a fingerprint icon, the symbol users know from their devices' passkey prompts (Touch ID / Android fingerprint).

- New `passkeys` concept in `lib/moto-concepts.ts`: Phosphor `FingerprintSimpleIcon`, purple tone, section `system`. The Simple variant stays legible at the button's 16px render size.
- Tenant login (`app/[tenant]/page.tsx`): lucide `KeyRound` replaced with `<MotoConceptIcon concept="passkeys" />`, dropping the lucide import.
- Operator login: `concept="permissions"` (LockKey) switched to `concept="passkeys"`.

No behavior change; `pnpm run check` and the full Vitest suite pass.