### PR TITLE
Audit refresh token revocations

### DIFF
--- a/backend/auth/rotation/policy.go
+++ b/backend/auth/rotation/policy.go
@@ -6,8 +6,16 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"time"
 )
+
+// FamilyFingerprint returns a stable, non-reversible identifier suitable for
+// correlating revocation audit rows without persisting the session family ID.
+func FamilyFingerprint(familyID string) string {
+	sum := sha256.Sum256([]byte(familyID))
+	return hex.EncodeToString(sum[:])
+}
 
 const (
 	// RecoveryProofHeader carries an independent, high-entropy secret that is

--- a/backend/auth/rotation/policy_fingerprint_test.go
+++ b/backend/auth/rotation/policy_fingerprint_test.go
@@ -1,0 +1,16 @@
+package rotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFamilyFingerprintUsesStableSHA256(t *testing.T) {
+	const familyID = "family-123"
+
+	fingerprint := FamilyFingerprint(familyID)
+
+	assert.Equal(t, "4e8c93922ccdfb7d6a6550a756e980d0616ba222cbda421b329b550e80cf3d57", fingerprint)
+	assert.NotContains(t, fingerprint, familyID)
+}

--- a/backend/database/migrations/001015289_auth_token_portal_scope.go
+++ b/backend/database/migrations/001015289_auth_token_portal_scope.go
@@ -1,0 +1,49 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	authTokenPortalScopeVersion     = "1.15.289"
+	authTokenPortalScopeDescription = "Persist the portal scope that minted each refresh-token session"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     authTokenPortalScopeVersion,
+		Description: authTokenPortalScopeDescription,
+		DependsOn:   []string{"1.15.288"},
+	})
+	Migrations.MustRegister(authTokenPortalScopeUp, authTokenPortalScopeDown)
+}
+
+func authTokenPortalScopeUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.289: Adding portal scope to refresh-token sessions...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE auth.tokens
+			ADD COLUMN IF NOT EXISTS portal_scope VARCHAR(16) NOT NULL DEFAULT 'unknown';
+		ALTER TABLE auth.tokens
+			DROP CONSTRAINT IF EXISTS chk_tokens_portal_scope;
+		ALTER TABLE auth.tokens
+			ADD CONSTRAINT chk_tokens_portal_scope
+			CHECK (portal_scope IN ('tenant', 'org', 'parent', 'school', 'unknown'));
+		COMMENT ON COLUMN auth.tokens.portal_scope IS
+			'Isolated portal that minted the session; unknown identifies pre-1.15.289 tokens';
+	`)
+	if err != nil {
+		return fmt.Errorf("add auth token portal scope: %w", err)
+	}
+	return nil
+}
+
+func authTokenPortalScopeDown(ctx context.Context, db *bun.DB) error {
+	_, err := db.ExecContext(ctx, `ALTER TABLE auth.tokens DROP COLUMN IF EXISTS portal_scope;`)
+	if err != nil {
+		return fmt.Errorf("drop auth token portal scope: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/auth/token.go
+++ b/backend/database/repositories/auth/token.go
@@ -159,55 +159,46 @@ func (r *TokenRepository) DeleteExpiredTokens(ctx context.Context) (int, error) 
 	return int(deleted), err
 }
 
-// DeleteByAccountID removes all tokens for an account
-func (r *TokenRepository) DeleteByAccountID(ctx context.Context, accountID int64) error {
+// DeleteByAccountIDReturning atomically deletes and returns every affected
+// token so the service can persist a complete revocation audit in the same
+// transaction; the generic repository cannot express DELETE ... RETURNING.
+func (r *TokenRepository) DeleteByAccountIDReturning(ctx context.Context, accountID int64) ([]*auth.Token, error) {
+	var deleted []*auth.Token
 	query := base.GetDB(ctx, r.db).NewDelete().
 		Model((*auth.Token)(nil)).
 		ModelTableExpr(`auth.tokens AS "token"`).
-		Where(`"token".account_id = ?`, accountID)
-
+		Where(`"token".account_id = ?`, accountID).
+		Returning("*")
 	query = base.WithTenantFilter(ctx, query, "token")
-
-	_, err := query.Exec(ctx)
-
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  "delete by account ID",
-			Err: err,
-		}
+	if err := query.Scan(ctx, &deleted); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "delete and return by account ID", Err: err}
 	}
-
-	return nil
+	return deleted, nil
 }
 
-// DeleteByTenantID removes all tokens for a given tenant (school).
-// Used during soft-delete to immediately revoke all refresh tokens.
-func (r *TokenRepository) DeleteByTenantID(ctx context.Context, tenantID int64) (int, error) {
-	res, err := base.GetDB(ctx, r.db).NewDelete().
+// DeleteByTenantIDReturning uses DELETE ... RETURNING so tenant revocation and
+// its per-family audit evidence can commit atomically; generic CRUD cannot.
+func (r *TokenRepository) DeleteByTenantIDReturning(ctx context.Context, tenantID int64) ([]*auth.Token, error) {
+	var deleted []*auth.Token
+	err := base.GetDB(ctx, r.db).NewDelete().
 		Model((*auth.Token)(nil)).
 		ModelTableExpr(`auth.tokens AS "token"`).
 		Where(`"token".tenant_id = ?`, tenantID).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx, &deleted)
 	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "delete tokens by tenant ID",
-			Err: err,
-		}
+		return nil, &modelBase.DatabaseError{Op: "delete and return tokens by tenant ID", Err: err}
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, &modelBase.DatabaseError{
-			Op:  "count affected rows",
-			Err: err,
-		}
-	}
-	return int(n), nil
+	return deleted, nil
 }
 
 // Create overrides the base Create method to handle validation
 func (r *TokenRepository) Create(ctx context.Context, token *auth.Token) error {
 	if token == nil {
 		return fmt.Errorf("token cannot be nil")
+	}
+	if token.PortalScope == "" {
+		token.PortalScope = auth.PortalScopeUnknown
 	}
 
 	// Validate token
@@ -309,11 +300,10 @@ func (r *TokenRepository) applyExpiredTokenFilter(query *bun.SelectQuery, value 
 	return query
 }
 
-// CleanupOldTokensForAccount keeps only the most recent N active, unexpired
-// sessions for an account. Rotated predecessor rows are recovery metadata and
-// are cleaned separately after their refresh JWTs expire.
-func (r *TokenRepository) CleanupOldTokensForAccount(ctx context.Context, accountID int64, keepCount int) error {
-	// First, get all active sessions for the account ordered newest first.
+// CleanupOldTokensForAccountReturning enforces the active-session cap and
+// returns only sessions that were actually revoked for same-transaction audit;
+// generic CRUD cannot combine the ordered cap policy with DELETE ... RETURNING.
+func (r *TokenRepository) CleanupOldTokensForAccountReturning(ctx context.Context, accountID int64, keepCount int) ([]*auth.Token, error) {
 	var tokens []*auth.Token
 	selectQuery := base.GetDB(ctx, r.db).NewSelect().
 		Model(&tokens).
@@ -321,69 +311,45 @@ func (r *TokenRepository) CleanupOldTokensForAccount(ctx context.Context, accoun
 		Where(`"token".account_id = ?`, accountID).
 		Where(`"token".rotated_at IS NULL`).
 		Where(`"token".expiry > ?`, time.Now()).
-		OrderExpr(`"token".id DESC`) // Assuming ID is auto-incrementing, so higher ID = newer
-
+		OrderExpr(`"token".id DESC`)
 	selectQuery = base.WithTenantFilter(ctx, selectQuery, "token")
-
-	err := selectQuery.Scan(ctx)
-
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  "find tokens for cleanup",
-			Err: err,
-		}
+	if err := selectQuery.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "find tokens for audited cleanup", Err: err}
 	}
-
-	// If we have more tokens than we want to keep, delete the old ones
-	if len(tokens) > keepCount {
-		// Get the IDs of tokens to delete (all except the most recent keepCount)
-		var idsToDelete []int64
-		for i := keepCount; i < len(tokens); i++ {
-			idsToDelete = append(idsToDelete, tokens[i].ID)
-		}
-
-		// Delete the old tokens
-		if len(idsToDelete) > 0 {
-			delQuery := base.GetDB(ctx, r.db).NewDelete().
-				Model((*auth.Token)(nil)).
-				ModelTableExpr(`auth.tokens AS "token"`).
-				Where(`"token".id IN (?)`, bun.List(idsToDelete))
-
-			delQuery = base.WithTenantFilter(ctx, delQuery, "token")
-
-			_, err = delQuery.Exec(ctx)
-
-			if err != nil {
-				return &modelBase.DatabaseError{
-					Op:  "delete old tokens",
-					Err: err,
-				}
-			}
-		}
+	if len(tokens) <= keepCount {
+		return nil, nil
 	}
-
-	return nil
-}
-
-// DeleteByFamilyID deletes all tokens in a specific family
-func (r *TokenRepository) DeleteByFamilyID(ctx context.Context, familyID string) error {
+	ids := make([]int64, 0, len(tokens)-keepCount)
+	for _, token := range tokens[keepCount:] {
+		ids = append(ids, token.ID)
+	}
+	var deleted []*auth.Token
 	query := base.GetDB(ctx, r.db).NewDelete().
 		Model((*auth.Token)(nil)).
 		ModelTableExpr(`auth.tokens AS "token"`).
-		Where(`"token".family_id = ?`, familyID)
-
+		Where(`"token".id IN (?)`, bun.List(ids)).
+		Returning("*")
 	query = base.WithTenantFilter(ctx, query, "token")
-
-	_, err := query.Exec(ctx)
-
-	if err != nil {
-		return &modelBase.DatabaseError{
-			Op:  "delete tokens by family ID",
-			Err: err,
-		}
+	if err := query.Scan(ctx, &deleted); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "delete and return old tokens", Err: err}
 	}
+	return deleted, nil
+}
 
-	return nil
+// DeleteByFamilyIDReturning uses DELETE ... RETURNING so family revocation and
+// its audit evidence share one transaction; generic CRUD cannot express it.
+func (r *TokenRepository) DeleteByFamilyIDReturning(ctx context.Context, familyID string) ([]*auth.Token, error) {
+	var deleted []*auth.Token
+	query := base.GetDB(ctx, r.db).NewDelete().
+		Model((*auth.Token)(nil)).
+		ModelTableExpr(`auth.tokens AS "token"`).
+		Where(`"token".family_id = ?`, familyID).
+		Returning("*")
+	query = base.WithTenantFilter(ctx, query, "token")
+	if err := query.Scan(ctx, &deleted); err != nil {
+		return nil, &modelBase.DatabaseError{Op: "delete and return tokens by family ID", Err: err}
+	}
+	return deleted, nil
 }
 
 // GetLatestTokenInFamily gets the token with the highest generation in a family

--- a/backend/database/repositories/auth/token_repository_test.go
+++ b/backend/database/repositories/auth/token_repository_test.go
@@ -318,8 +318,9 @@ func TestTokenRepository_DeleteByAccountID(t *testing.T) {
 		token2 := testpkg.CreateTestToken(t, db, account.ID, "access")
 		defer cleanupAccountRecords(t, db, account.ID)
 
-		err := repo.DeleteByAccountID(ctx, account.ID)
+		deleted, err := repo.DeleteByAccountIDReturning(ctx, account.ID)
 		require.NoError(t, err)
+		require.Len(t, deleted, 2)
 
 		// Verify tokens are gone
 		_, err = repo.FindByID(ctx, token1.ID)
@@ -407,8 +408,9 @@ func TestTokenRepository_DeleteByFamilyID(t *testing.T) {
 		require.NoError(t, err)
 
 		// Delete family
-		err = repo.DeleteByFamilyID(ctx, familyID)
+		deleted, err := repo.DeleteByFamilyIDReturning(ctx, familyID)
 		require.NoError(t, err)
+		require.Len(t, deleted, 2)
 
 		// Verify tokens are gone
 		tokens, err := repo.FindByFamilyID(ctx, familyID)
@@ -453,7 +455,9 @@ func TestTokenRepository_CleanupOldTokensForAccount(t *testing.T) {
 	}
 	require.NoError(t, repo.Create(ctx, expired))
 
-	require.NoError(t, repo.CleanupOldTokensForAccount(ctx, account.ID, 5))
+	deleted, err := repo.CleanupOldTokensForAccountReturning(ctx, account.ID, 5)
+	require.NoError(t, err)
+	require.Empty(t, deleted)
 	for _, token := range activeTokens {
 		_, err := repo.FindByID(ctx, token.ID)
 		require.NoError(t, err, "rotated and expired rows must not displace active sessions")
@@ -465,10 +469,12 @@ func TestTokenRepository_CleanupOldTokensForAccount(t *testing.T) {
 		Expiry:    time.Now().Add(time.Hour),
 	}
 	require.NoError(t, repo.Create(ctx, newest))
-	require.NoError(t, repo.CleanupOldTokensForAccount(ctx, account.ID, 5))
+	deleted, err = repo.CleanupOldTokensForAccountReturning(ctx, account.ID, 5)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
 
 	var currentIDs []int64
-	err := db.NewSelect().
+	err = db.NewSelect().
 		TableExpr("auth.tokens").
 		Column("id").
 		Where("account_id = ?", account.ID).
@@ -682,11 +688,11 @@ func TestTokenRepository_DeleteByTenantID(t *testing.T) {
 
 		// ACT
 		ctx := testpkg.TenantContext(tenantID)
-		count, err := repo.DeleteByTenantID(ctx, tenantID)
+		deleted, err := repo.DeleteByTenantIDReturning(ctx, tenantID)
 
 		// ASSERT
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Len(t, deleted, 1)
 
 		// Verify the token is actually gone
 		_, findErr := repo.FindByID(ctx, token.ID)
@@ -699,8 +705,8 @@ func TestTokenRepository_DeleteByTenantID(t *testing.T) {
 		testpkg.EnsureTestTenant(t, db, tenantID)
 		ctx := testpkg.TenantContext(tenantID)
 
-		count, err := repo.DeleteByTenantID(ctx, tenantID)
+		deleted, err := repo.DeleteByTenantIDReturning(ctx, tenantID)
 		require.NoError(t, err)
-		assert.Equal(t, 0, count)
+		assert.Empty(t, deleted)
 	})
 }

--- a/backend/database/repositories/platform/operator_refresh_token.go
+++ b/backend/database/repositories/platform/operator_refresh_token.go
@@ -105,32 +105,36 @@ func (r *OperatorRefreshTokenRepository) Delete(ctx context.Context, id any) err
 	return nil
 }
 
-func (r *OperatorRefreshTokenRepository) DeleteByOperatorID(ctx context.Context, operatorID int64) (int, error) {
-	res, err := base.GetDB(ctx, r.db).NewDelete().
+// DeleteByOperatorIDReturning uses DELETE ... RETURNING so operator revocation
+// and its per-family audit evidence commit atomically; generic CRUD cannot.
+func (r *OperatorRefreshTokenRepository) DeleteByOperatorIDReturning(ctx context.Context, operatorID int64) ([]*platform.OperatorRefreshToken, error) {
+	var deleted []*platform.OperatorRefreshToken
+	err := base.GetDB(ctx, r.db).NewDelete().
 		Model((*platform.OperatorRefreshToken)(nil)).
 		ModelTableExpr(operatorRefreshTokenTableAlias).
 		Where(`"operator_refresh_token".operator_id = ?`, operatorID).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx, &deleted)
 	if err != nil {
-		return 0, &modelBase.DatabaseError{Op: "delete operator refresh tokens by operator ID", Err: err}
+		return nil, &modelBase.DatabaseError{Op: "delete and return operator refresh tokens", Err: err}
 	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return 0, &modelBase.DatabaseError{Op: "count deleted operator refresh tokens", Err: err}
-	}
-	return int(affected), nil
+	return deleted, nil
 }
 
-func (r *OperatorRefreshTokenRepository) DeleteByFamilyID(ctx context.Context, familyID string) error {
-	_, err := base.GetDB(ctx, r.db).NewDelete().
+// DeleteByFamilyIDReturning uses DELETE ... RETURNING so operator-family
+// revocation and audit evidence share one transaction; generic CRUD cannot.
+func (r *OperatorRefreshTokenRepository) DeleteByFamilyIDReturning(ctx context.Context, familyID string) ([]*platform.OperatorRefreshToken, error) {
+	var deleted []*platform.OperatorRefreshToken
+	err := base.GetDB(ctx, r.db).NewDelete().
 		Model((*platform.OperatorRefreshToken)(nil)).
 		ModelTableExpr(operatorRefreshTokenTableAlias).
 		Where(`"operator_refresh_token".family_id = ?`, familyID).
-		Exec(ctx)
+		Returning("*").
+		Scan(ctx, &deleted)
 	if err != nil {
-		return &modelBase.DatabaseError{Op: "delete operator refresh token family", Err: err}
+		return nil, &modelBase.DatabaseError{Op: "delete and return operator refresh-token family", Err: err}
 	}
-	return nil
+	return deleted, nil
 }
 
 func (r *OperatorRefreshTokenRepository) GetLatestTokenInFamily(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {

--- a/backend/database/repositories/platform/operator_refresh_token_repository_test.go
+++ b/backend/database/repositories/platform/operator_refresh_token_repository_test.go
@@ -58,9 +58,9 @@ func TestOperatorRefreshTokenRepository_DeleteByOperatorID(t *testing.T) {
 		}))
 	}
 
-	deleted, err := repo.DeleteByOperatorID(ctx, operatorID)
+	deleted, err := repo.DeleteByOperatorIDReturning(ctx, operatorID)
 	require.NoError(t, err)
-	assert.Equal(t, 2, deleted)
+	assert.Len(t, deleted, 2)
 
 	remaining, err := db.NewSelect().
 		TableExpr("platform.operator_refresh_tokens").
@@ -94,7 +94,9 @@ func TestOperatorRefreshTokenRepository_DeleteByFamilyIDAndLatest(t *testing.T) 
 	require.NotNil(t, latest)
 	assert.Equal(t, 2, latest.Generation)
 
-	require.NoError(t, repo.DeleteByFamilyID(ctx, familyID))
+	deleted, err := repo.DeleteByFamilyIDReturning(ctx, familyID)
+	require.NoError(t, err)
+	require.Len(t, deleted, 3)
 	latest, err = repo.GetLatestTokenInFamily(ctx, familyID)
 	require.NoError(t, err)
 	assert.Nil(t, latest)

--- a/backend/models/audit/auth_event.go
+++ b/backend/models/audit/auth_event.go
@@ -27,6 +27,7 @@ const (
 	EventTypeLogout                      = "logout"
 	EventTypeTokenRefresh                = "token_refresh"
 	EventTypeTokenExpired                = "token_expired"
+	EventTypeTokenRevoked                = "token_revoked"
 	EventTypePasswordReset               = "password_reset"
 	EventTypeAccountLocked               = "account_locked"
 	EventTypeTenantSwitch                = "tenant_switch"
@@ -63,7 +64,7 @@ func (ae *AuthEvent) Validate() error {
 
 	// Validate event type
 	switch ae.EventType {
-	case EventTypeLogin, EventTypeLogout, EventTypeTokenRefresh,
+	case EventTypeLogin, EventTypeLogout, EventTypeTokenRefresh, EventTypeTokenRevoked,
 		EventTypeTokenExpired, EventTypePasswordReset, EventTypeAccountLocked,
 		EventTypeTenantSwitch, EventTypeCaregiverCapabilityEnabled,
 		EventTypeCaregiverCapabilityDisabled,

--- a/backend/models/auth/repository.go
+++ b/backend/models/auth/repository.go
@@ -169,13 +169,13 @@ type TokenRepository interface {
 	DeleteExpiredRotatedForAccount(ctx context.Context, accountID int64, now time.Time) error
 	FindByAccountID(ctx context.Context, accountID int64) ([]*Token, error)
 	DeleteExpiredTokens(ctx context.Context) (int, error)
-	DeleteByAccountID(ctx context.Context, accountID int64) error
-	CleanupOldTokensForAccount(ctx context.Context, accountID int64, keepCount int) error
+	DeleteByAccountIDReturning(ctx context.Context, accountID int64) ([]*Token, error)
+	CleanupOldTokensForAccountReturning(ctx context.Context, accountID int64, keepCount int) ([]*Token, error)
 
 	// Bulk deletion
-	DeleteByTenantID(ctx context.Context, tenantID int64) (int, error)
+	DeleteByTenantIDReturning(ctx context.Context, tenantID int64) ([]*Token, error)
 
-	DeleteByFamilyID(ctx context.Context, familyID string) error
+	DeleteByFamilyIDReturning(ctx context.Context, familyID string) ([]*Token, error)
 	GetLatestTokenInFamily(ctx context.Context, familyID string) (*Token, error)
 
 	// Token family tracking methods

--- a/backend/models/auth/token.go
+++ b/backend/models/auth/token.go
@@ -11,11 +11,12 @@ import (
 type Token struct {
 	base.Model `bun:"schema:auth,table:tokens"`
 	base.TenantModel
-	AccountID  int64     `bun:"account_id,notnull" json:"account_id"`
-	Token      string    `bun:"token,notnull" json:"token"`
-	Expiry     time.Time `bun:"expiry,notnull" json:"expiry"`
-	Mobile     bool      `bun:"mobile,notnull,default:false" json:"mobile"`
-	Identifier *string   `bun:"identifier" json:"identifier,omitempty"`
+	AccountID   int64     `bun:"account_id,notnull" json:"account_id"`
+	Token       string    `bun:"token,notnull" json:"token"`
+	Expiry      time.Time `bun:"expiry,notnull" json:"expiry"`
+	Mobile      bool      `bun:"mobile,notnull,default:false" json:"mobile"`
+	Identifier  *string   `bun:"identifier" json:"identifier,omitempty"`
+	PortalScope string    `bun:"portal_scope,notnull,default:'unknown'" json:"portal_scope"`
 
 	// Token family tracking for detecting token theft
 	FamilyID          string     `bun:"family_id" json:"family_id,omitempty"`
@@ -28,6 +29,14 @@ type Token struct {
 	Account *Account `bun:"rel:belongs-to,join:account_id=id" json:"account,omitempty"`
 }
 
+const (
+	PortalScopeTenant  = "tenant"
+	PortalScopeOrg     = "org"
+	PortalScopeParent  = "parent"
+	PortalScopeSchool  = "school"
+	PortalScopeUnknown = "unknown"
+)
+
 // Validate ensures token data is valid. It performs pure field validation only.
 // The expiry/validity decision is wall-clock policy enforced by the read paths'
 // SQL expiry filters, per issue #586 (Rule 12: models hold data, not
@@ -39,6 +48,13 @@ func (t *Token) Validate() error {
 
 	if t.Token == "" {
 		return errors.New("token value is required")
+	}
+	if t.PortalScope != "" {
+		switch t.PortalScope {
+		case PortalScopeTenant, PortalScopeOrg, PortalScopeParent, PortalScopeSchool, PortalScopeUnknown:
+		default:
+			return errors.New("invalid portal scope")
+		}
 	}
 	if (t.RotatedAt == nil) != (t.ReplacementToken == nil) {
 		return errors.New("rotation handoff must include both timestamp and replacement token")

--- a/backend/models/platform/operator_audit_log.go
+++ b/backend/models/platform/operator_audit_log.go
@@ -14,6 +14,7 @@ const (
 	ActionStatusChange         = "status_change"
 	ActionPublish              = "publish"
 	ActionLogin                = "login"
+	ActionTokenRevoked         = "token_revoked"
 	ActionAddComment           = "add_comment"
 	ActionDeleteComment        = "delete_comment"
 	ActionRotateAPIKey         = "rotate_api_key"

--- a/backend/models/platform/repository.go
+++ b/backend/models/platform/repository.go
@@ -128,8 +128,8 @@ type OperatorRefreshTokenRepository interface {
 	MarkRotated(ctx context.Context, id int64, replacementToken string, recoveryProofHash []byte, rotatedAt time.Time) error
 	DeleteExpiredRotated(ctx context.Context, familyID string, now time.Time) error
 	Delete(ctx context.Context, id any) error
-	DeleteByOperatorID(ctx context.Context, operatorID int64) (int, error)
-	DeleteByFamilyID(ctx context.Context, familyID string) error
+	DeleteByOperatorIDReturning(ctx context.Context, operatorID int64) ([]*OperatorRefreshToken, error)
+	DeleteByFamilyIDReturning(ctx context.Context, familyID string) ([]*OperatorRefreshToken, error)
 	GetLatestTokenInFamily(ctx context.Context, familyID string) (*OperatorRefreshToken, error)
 	DeleteExpired(ctx context.Context, now time.Time) (int, error)
 }

--- a/backend/services/auth/account_management.go
+++ b/backend/services/auth/account_management.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/moto-nrw/project-phoenix/models/auth"
 )
@@ -26,26 +25,20 @@ func (s *Service) ActivateAccount(ctx context.Context, accountID int) error {
 
 // DeactivateAccount deactivates a user account
 func (s *Service) DeactivateAccount(ctx context.Context, accountID int) error {
-	account, err := s.repos.Account.FindByID(ctx, int64(accountID))
-	if err != nil {
-		return &AuthError{Op: "deactivate account", Err: ErrAccountNotFound}
-	}
-
-	account.Active = false
-	if err := s.repos.Account.Update(ctx, account); err != nil {
-		return &AuthError{Op: "deactivate account", Err: err}
-	}
-
-	// Also invalidate all tokens for this account
-	if err := s.repos.Token.DeleteByAccountID(ctx, int64(accountID)); err != nil {
-		// Log error but don't fail the deactivation
-		s.getLogger().Warn("failed to delete tokens during account deactivation",
-			slog.Int("account_id", accountID),
-			slog.Any("error", err),
-		)
-	}
-
-	return nil
+	return s.runInTx(ctx, func(txCtx context.Context) error {
+		account, err := s.repos.Account.FindByID(txCtx, int64(accountID))
+		if err != nil {
+			return &AuthError{Op: "deactivate account", Err: ErrAccountNotFound}
+		}
+		account.Active = false
+		if err := s.repos.Account.Update(txCtx, account); err != nil {
+			return &AuthError{Op: "deactivate account", Err: err}
+		}
+		if _, err := s.deleteAccountTokensWithAudit(txCtx, int64(accountID), "account_deactivated", "", ""); err != nil {
+			return &AuthError{Op: "revoke tokens during account deactivation", Err: err}
+		}
+		return nil
+	})
 }
 
 // UpdateAccount updates account information

--- a/backend/services/auth/auth_login.go
+++ b/backend/services/auth/auth_login.go
@@ -58,7 +58,7 @@ func (s *Service) LoginWithAudit(ctx context.Context, email, password, ipAddress
 	}
 
 	// Create refresh token with resolved tenant ID
-	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID)
+	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID, metadata.scope)
 	if err != nil {
 		return "", "", err
 	}
@@ -224,7 +224,7 @@ func (s *Service) LoginWithMFAGate(
 	}
 
 	// Token-pair issuance (regular login or MFA-skipped via trusted device).
-	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID)
+	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID, metadata.scope)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func (s *Service) IssueTokensForAuthenticatedAccount(
 		return "", "", &AuthError{Op: "issue tokens", Err: ErrParentMustUseParentPortal}
 	}
 
-	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID)
+	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID, metadata.scope)
 	if err != nil {
 		return "", "", err
 	}
@@ -375,8 +375,8 @@ func (e *mintGuardError) Error() string { return e.err.Error() }
 func (e *mintGuardError) Unwrap() error { return e.err }
 
 // createRefreshTokenWithRetry creates a refresh token with retry logic for concurrent logins
-func (s *Service) createRefreshTokenWithRetry(ctx context.Context, account *auth.Account, tenantID int64) (*auth.Token, error) {
-	return s.createRefreshTokenWithRetryGuarded(ctx, account, tenantID, nil)
+func (s *Service) createRefreshTokenWithRetry(ctx context.Context, account *auth.Account, tenantID int64, scope string) (*auth.Token, error) {
+	return s.createRefreshTokenWithRetryGuarded(ctx, account, tenantID, scope, nil)
 }
 
 // createRefreshTokenWithRetryGuarded is createRefreshTokenWithRetry with an
@@ -387,9 +387,10 @@ func (s *Service) createRefreshTokenWithRetryGuarded(
 	ctx context.Context,
 	account *auth.Account,
 	tenantID int64,
+	scope string,
 	guard mintGuard,
 ) (*auth.Token, error) {
-	token := s.newRefreshToken(account.ID)
+	token := s.newRefreshToken(account.ID, scope)
 
 	maxRetries := 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
@@ -420,16 +421,17 @@ func (s *Service) createRefreshTokenWithRetryGuarded(
 }
 
 // newRefreshToken creates a new refresh token for the given account
-func (s *Service) newRefreshToken(accountID int64) *auth.Token {
+func (s *Service) newRefreshToken(accountID int64, scope string) *auth.Token {
 	identifier := "Service login"
 	return &auth.Token{
-		Token:      uuid.Must(uuid.NewV4()).String(),
-		AccountID:  accountID,
-		Expiry:     time.Now().Add(s.jwtRefreshExpiry),
-		Mobile:     false,
-		Identifier: &identifier,
-		FamilyID:   uuid.Must(uuid.NewV4()).String(),
-		Generation: 0,
+		Token:       uuid.Must(uuid.NewV4()).String(),
+		AccountID:   accountID,
+		Expiry:      time.Now().Add(s.jwtRefreshExpiry),
+		Mobile:      false,
+		Identifier:  &identifier,
+		FamilyID:    uuid.Must(uuid.NewV4()).String(),
+		Generation:  0,
+		PortalScope: persistedPortalScope(scope),
 	}
 }
 
@@ -479,8 +481,12 @@ func (s *Service) persistTokenInTransaction(ctx context.Context, account *auth.A
 
 		// Enforce the cap after insertion so at most five active sessions remain.
 		const maxTokensPerAccount = 5
-		if err := s.repos.Token.CleanupOldTokensForAccount(ctx, account.ID, maxTokensPerAccount); err != nil {
+		deleted, err := s.repos.Token.CleanupOldTokensForAccountReturning(ctx, account.ID, maxTokensPerAccount)
+		if err != nil {
 			return fmt.Errorf("enforce active session cap: %w", err)
+		}
+		if err := s.auditRevokedTokens(ctx, deleted, "session_cap", "", ""); err != nil {
+			return err
 		}
 
 		return nil
@@ -1372,7 +1378,7 @@ func (s *Service) refreshTokenInTransaction(ctx context.Context, refreshClaims *
 		}
 
 		if dbToken.AccountID != int64(refreshClaims.ID) || (refreshClaims.TenantID > 0 && dbToken.TenantID != refreshClaims.TenantID) {
-			if err := s.revokeRefreshTokenFamily(ctx, dbToken); err != nil {
+			if err := s.deleteFamilyWithAudit(ctx, dbToken, "claim_mismatch", ipAddress, userAgent); err != nil {
 				return fmt.Errorf("revoke mismatched refresh-token family: %w", err)
 			}
 			rejectAfterCommit = ErrInvalidToken
@@ -1381,7 +1387,7 @@ func (s *Service) refreshTokenInTransaction(ctx context.Context, refreshClaims *
 		}
 
 		if now.After(dbToken.Expiry) {
-			if err := s.revokeRefreshTokenFamily(ctx, dbToken); err != nil {
+			if err := s.deleteFamilyWithAudit(ctx, dbToken, "token_expired", ipAddress, userAgent); err != nil {
 				return fmt.Errorf("delete expired refresh-token family: %w", err)
 			}
 			rejectAfterCommit = ErrTokenExpired
@@ -1392,7 +1398,7 @@ func (s *Service) refreshTokenInTransaction(ctx context.Context, refreshClaims *
 		dbToken, recovered, err = s.resolveRefreshHandoff(ctx, dbToken, now)
 		if err != nil {
 			if errors.Is(err, ErrInvalidToken) {
-				if revokeErr := s.revokeRefreshTokenFamily(ctx, dbToken); revokeErr != nil {
+				if revokeErr := s.deleteFamilyWithAudit(ctx, dbToken, "replay_detected", ipAddress, userAgent); revokeErr != nil {
 					return fmt.Errorf("revoke replayed refresh-token family: %w", revokeErr)
 				}
 				rejectAfterCommit = ErrInvalidToken
@@ -1407,7 +1413,7 @@ func (s *Service) refreshTokenInTransaction(ctx context.Context, refreshClaims *
 				return fmt.Errorf("inspect refresh-token family: %w", latestErr)
 			}
 			if latestToken != nil && latestToken.Generation > dbToken.Generation {
-				if revokeErr := s.revokeRefreshTokenFamily(ctx, dbToken); revokeErr != nil {
+				if revokeErr := s.deleteFamilyWithAudit(ctx, dbToken, "lineage_mismatch", ipAddress, userAgent); revokeErr != nil {
 					return fmt.Errorf("revoke inconsistent refresh-token family: %w", revokeErr)
 				}
 				rejectAfterCommit = ErrInvalidToken
@@ -1431,7 +1437,7 @@ func (s *Service) refreshTokenInTransaction(ctx context.Context, refreshClaims *
 			newToken = dbToken
 		} else {
 			// Create and persist new token with resolved tenant.
-			newToken, err = s.createAndPersistNewToken(ctx, dbToken, account.ID, effectiveTenantID, now)
+			newToken, err = s.createAndPersistNewToken(ctx, dbToken, account.ID, effectiveTenantID, refreshClaims.Scope, now)
 			if err != nil {
 				return err
 			}
@@ -1538,15 +1544,16 @@ func (s *Service) fetchAndValidateAccount(ctx context.Context, accountID int64, 
 
 // createAndPersistNewToken creates a successor and persists the bounded
 // predecessor handoff atomically.
-func (s *Service) createAndPersistNewToken(ctx context.Context, oldToken *auth.Token, accountID int64, tenantID int64, now time.Time) (*auth.Token, error) {
+func (s *Service) createAndPersistNewToken(ctx context.Context, oldToken *auth.Token, accountID int64, tenantID int64, scope string, now time.Time) (*auth.Token, error) {
 	newToken := &auth.Token{
-		Token:      uuid.Must(uuid.NewV4()).String(),
-		AccountID:  accountID,
-		Expiry:     now.Add(s.jwtRefreshExpiry),
-		Mobile:     oldToken.Mobile,
-		Identifier: oldToken.Identifier,
-		FamilyID:   oldToken.FamilyID,
-		Generation: oldToken.Generation + 1,
+		Token:       uuid.Must(uuid.NewV4()).String(),
+		AccountID:   accountID,
+		Expiry:      now.Add(s.jwtRefreshExpiry),
+		Mobile:      oldToken.Mobile,
+		Identifier:  oldToken.Identifier,
+		FamilyID:    oldToken.FamilyID,
+		Generation:  oldToken.Generation + 1,
+		PortalScope: persistedPortalScope(scope),
 	}
 
 	// Set tenant ID from refresh claims (not from context — refresh is a public route)
@@ -1563,15 +1570,6 @@ func (s *Service) createAndPersistNewToken(ctx context.Context, oldToken *auth.T
 	}
 
 	return newToken, nil
-}
-
-func (s *Service) revokeRefreshTokenFamily(ctx context.Context, token *auth.Token) error {
-	if token.FamilyID == "" {
-		// Legacy pre-family rows must never turn an empty family identifier into
-		// a cross-account bulk delete.
-		return s.repos.Token.Delete(ctx, token.ID)
-	}
-	return s.repos.Token.DeleteByFamilyID(ctx, token.FamilyID)
 }
 
 func (s *Service) logRefreshDecision(event, reason string, accountID int, tenantID int64) {
@@ -1882,17 +1880,13 @@ func (s *Service) LogoutWithAudit(ctx context.Context, refreshTokenStr, ipAddres
 
 		// Delete ALL tokens for this account to ensure complete logout
 		// This ensures that all sessions (access and refresh tokens) are invalidated
-		err = s.repos.Token.DeleteByAccountID(ctx, dbToken.AccountID)
+		_, err = s.deleteAccountTokensWithAudit(ctx, dbToken.AccountID, "logout", ipAddress, userAgent)
 		if err != nil {
-			// Log the error but don't fail the logout
 			s.getLogger().Warn("failed to delete all tokens during logout",
 				slog.Int64("account_id", dbToken.AccountID),
 				slog.Any("error", err),
 			)
-			// Still try to delete the specific token
-			if deleteErr := s.repos.Token.Delete(ctx, dbToken.ID); deleteErr != nil {
-				return &AuthError{Op: "delete token", Err: deleteErr}
-			}
+			return &AuthError{Op: "delete tokens with audit", Err: err}
 		}
 
 		// Log successful logout against the school the session actually

--- a/backend/services/auth/auth_login_parent.go
+++ b/backend/services/auth/auth_login_parent.go
@@ -53,7 +53,7 @@ func (s *Service) LoginParentWithAudit(
 	// Pin the refresh token row to the first guardian tenant for the
 	// FK + RLS. The token's purpose is parent-scope (cross-tenant on
 	// read), but the row needs a real tenant_id to satisfy the schema.
-	token, err := s.createRefreshTokenWithRetry(ctx, account, firstGuardianTenantID)
+	token, err := s.createRefreshTokenWithRetry(ctx, account, firstGuardianTenantID, tenant.ScopeParent)
 	if err != nil {
 		return "", "", err
 	}

--- a/backend/services/auth/auth_login_school.go
+++ b/backend/services/auth/auth_login_school.go
@@ -127,7 +127,7 @@ func (s *Service) LoginSchoolWithMFAGate(
 		guardOpts = append(guardOpts, withMFAGateRecheck(s.freshSchoolMFAPolicy(account.ID, portalTenantID)))
 	}
 	var metadata *accountMetadata
-	token, err := s.createRefreshTokenWithRetryGuarded(ctx, account, portalTenantID, s.schoolMintGuard(account.ID, portalTenantID, &metadata, guardOpts...))
+	token, err := s.createRefreshTokenWithRetryGuarded(ctx, account, portalTenantID, tenant.ScopeSchool, s.schoolMintGuard(account.ID, portalTenantID, &metadata, guardOpts...))
 	if errors.Is(err, errSchoolMFARequiredAtMint) {
 		// Nothing was written — the guard aborted its own transaction. Send
 		// the login down the branch it would have taken had the role been
@@ -195,7 +195,7 @@ func (s *Service) IssueSchoolTokensForAuthenticatedAccount(
 	}
 
 	var metadata *accountMetadata
-	token, err := s.createRefreshTokenWithRetryGuarded(ctx, account, tenantID, s.schoolMintGuard(account.ID, tenantID, &metadata))
+	token, err := s.createRefreshTokenWithRetryGuarded(ctx, account, tenantID, tenant.ScopeSchool, s.schoolMintGuard(account.ID, tenantID, &metadata))
 	if err != nil {
 		return "", "", wrapSchoolMintError("issue school tokens", err)
 	}
@@ -263,7 +263,7 @@ func (s *Service) SwitchSchool(ctx context.Context, accountID int64, tenantSlug,
 	}
 
 	var metadata *accountMetadata
-	token, err := s.createRefreshTokenWithRetryGuarded(ctx, account, targetTenantID, s.schoolMintGuard(accountID, targetTenantID, &metadata))
+	token, err := s.createRefreshTokenWithRetryGuarded(ctx, account, targetTenantID, tenant.ScopeSchool, s.schoolMintGuard(accountID, targetTenantID, &metadata))
 	if err != nil {
 		return "", "", wrapSchoolMintError("switch school", err)
 	}

--- a/backend/services/auth/auth_login_school_internal_test.go
+++ b/backend/services/auth/auth_login_school_internal_test.go
@@ -452,7 +452,7 @@ func TestCreateRefreshTokenWithRetryGuarded_GuardRefusalWritesNoToken(t *testing
 	before := countAccountTokens(t, db, account.ID)
 
 	token, err := service.createRefreshTokenWithRetryGuarded(
-		context.Background(), account, tenantID, service.schoolMintGuard(account.ID, tenantID, new(*accountMetadata)))
+		context.Background(), account, tenantID, tenant.ScopeSchool, service.schoolMintGuard(account.ID, tenantID, new(*accountMetadata)))
 
 	require.Error(t, err)
 	assert.Nil(t, token)

--- a/backend/services/auth/auth_switch_tenant.go
+++ b/backend/services/auth/auth_switch_tenant.go
@@ -37,7 +37,7 @@ func (s *Service) SwitchTenant(ctx context.Context, accountID int64, tenantSlug 
 	}
 
 	// 3. Create refresh token with resolved tenant ID
-	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID)
+	token, err := s.createRefreshTokenWithRetry(ctx, account, metadata.tenantID, metadata.scope)
 	if err != nil {
 		return "", "", err
 	}

--- a/backend/services/auth/interface.go
+++ b/backend/services/auth/interface.go
@@ -114,6 +114,7 @@ type AuthService interface {
 	CleanupExpiredTokens(ctx context.Context) (int, error)
 	CleanupExpiredPasswordResetTokens(ctx context.Context) (int, error)
 	RevokeAllTokens(ctx context.Context, accountID int) error
+	RevokeAllTokensWithReason(ctx context.Context, accountID int, reason string) error
 	RevokeTokensByTenantID(ctx context.Context, tenantID int64) (int, error)
 	GetActiveTokens(ctx context.Context, accountID int) ([]*auth.Token, error)
 

--- a/backend/services/auth/password_reset.go
+++ b/backend/services/auth/password_reset.go
@@ -259,12 +259,8 @@ func (s *Service) ResetPassword(ctx context.Context, token, newPassword string) 
 		}
 
 		// Invalidate all existing auth tokens for security
-		if err := s.repos.Token.DeleteByAccountID(ctx, resetToken.AccountID); err != nil {
-			// Log error but don't fail the password reset
-			s.getLogger().Warn("failed to delete tokens during password reset",
-				slog.Int64("account_id", resetToken.AccountID),
-				slog.Any("error", err),
-			)
+		if _, err := s.deleteAccountTokensWithAudit(ctx, resetToken.AccountID, "password_reset", "", ""); err != nil {
+			return fmt.Errorf("revoke tokens during password reset: %w", err)
 		}
 
 		return nil

--- a/backend/services/auth/role_management.go
+++ b/backend/services/auth/role_management.go
@@ -197,7 +197,7 @@ func (s *Service) AssignRoleToAccount(ctx context.Context, accountID, roleID int
 			return &AuthError{Op: "assign role to account", Err: err}
 		}
 
-		if err := s.repos.Token.DeleteByAccountID(txCtx, int64(accountID)); err != nil {
+		if _, err := s.deleteAccountTokensWithAudit(txCtx, int64(accountID), "role_changed", "", ""); err != nil {
 			return &AuthError{Op: "revoke tokens after role assignment", Err: err}
 		}
 
@@ -238,7 +238,7 @@ func (s *Service) RemoveRoleFromAccount(ctx context.Context, accountID, roleID i
 			return &AuthError{Op: "remove role from account", Err: err}
 		}
 
-		if err := s.repos.Token.DeleteByAccountID(txCtx, int64(accountID)); err != nil {
+		if _, err := s.deleteAccountTokensWithAudit(txCtx, int64(accountID), "role_changed", "", ""); err != nil {
 			return &AuthError{Op: "revoke tokens after role removal", Err: err}
 		}
 

--- a/backend/services/auth/role_management_internal_test.go
+++ b/backend/services/auth/role_management_internal_test.go
@@ -203,11 +203,11 @@ type roleManagementTokenRepo struct {
 	deleteByAccountIDFn func(context.Context, int64) error
 }
 
-func (r roleManagementTokenRepo) DeleteByAccountID(ctx context.Context, accountID int64) error {
+func (r roleManagementTokenRepo) DeleteByAccountIDReturning(ctx context.Context, accountID int64) ([]*authModel.Token, error) {
 	if r.deleteByAccountIDFn != nil {
-		return r.deleteByAccountIDFn(ctx, accountID)
+		return nil, r.deleteByAccountIDFn(ctx, accountID)
 	}
-	return nil
+	return nil, nil
 }
 
 func newRoleManagementService(

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -1131,8 +1131,8 @@ func (noopTokenRepository) DeleteExpiredTokens(context.Context) (int, error) {
 	panic("DeleteExpiredTokens not implemented")
 }
 
-func (noopTokenRepository) DeleteByAccountID(context.Context, int64) error {
-	panic("DeleteByAccountID not implemented")
+func (noopTokenRepository) DeleteByAccountIDReturning(context.Context, int64) ([]*authModel.Token, error) {
+	panic("DeleteByAccountIDReturning not implemented")
 }
 
 func (noopTokenRepository) DeleteByAccountIDAndIdentifier(context.Context, int64, string) error {
@@ -1143,24 +1143,24 @@ func (noopTokenRepository) FindValidTokens(context.Context, map[string]interface
 	panic("FindValidTokens not implemented")
 }
 
-func (noopTokenRepository) CleanupOldTokensForAccount(context.Context, int64, int) error {
-	panic("CleanupOldTokensForAccount not implemented")
+func (noopTokenRepository) CleanupOldTokensForAccountReturning(context.Context, int64, int) ([]*authModel.Token, error) {
+	panic("CleanupOldTokensForAccountReturning not implemented")
 }
 
 func (noopTokenRepository) FindByFamilyID(context.Context, string) ([]*authModel.Token, error) {
 	panic("FindByFamilyID not implemented")
 }
 
-func (noopTokenRepository) DeleteByFamilyID(context.Context, string) error {
-	panic("DeleteByFamilyID not implemented")
+func (noopTokenRepository) DeleteByFamilyIDReturning(context.Context, string) ([]*authModel.Token, error) {
+	panic("DeleteByFamilyIDReturning not implemented")
 }
 
 func (noopTokenRepository) GetLatestTokenInFamily(context.Context, string) (*authModel.Token, error) {
 	panic("GetLatestTokenInFamily not implemented")
 }
 
-func (noopTokenRepository) DeleteByTenantID(context.Context, int64) (int, error) {
-	panic("DeleteByTenantID not implemented")
+func (noopTokenRepository) DeleteByTenantIDReturning(context.Context, int64) ([]*authModel.Token, error) {
+	panic("DeleteByTenantIDReturning not implemented")
 }
 
 // stubTokenRepository tracks delete operations for verification.
@@ -1277,11 +1277,11 @@ func (r *stubAccountTenantRepository) ListTenantAccessByAccountID(context.Contex
 	return nil, nil
 }
 
-func (r *stubTokenRepository) DeleteByAccountID(_ context.Context, accountID int64) error {
+func (r *stubTokenRepository) DeleteByAccountIDReturning(_ context.Context, accountID int64) ([]*authModel.Token, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.deletedAccountIDs = append(r.deletedAccountIDs, accountID)
-	return nil
+	return nil, nil
 }
 
 func (r *stubTokenRepository) DeletedAccountIDs() []int64 {

--- a/backend/services/auth/token_cleanup.go
+++ b/backend/services/auth/token_cleanup.go
@@ -51,16 +51,33 @@ func (s *Service) CleanupExpiredRateLimits(ctx context.Context) (int, error) {
 
 // RevokeAllTokens revokes all tokens for an account
 func (s *Service) RevokeAllTokens(ctx context.Context, accountID int) error {
-	if err := s.repos.Token.DeleteByAccountID(ctx, int64(accountID)); err != nil {
-		return &AuthError{Op: "revoke all tokens", Err: err}
-	}
-	return nil
+	return s.RevokeAllTokensWithReason(ctx, accountID, "administrative_revoke")
+}
+
+func (s *Service) RevokeAllTokensWithReason(ctx context.Context, accountID int, reason string) error {
+	return s.runInTx(ctx, func(txCtx context.Context) error {
+		if _, err := s.deleteAccountTokensWithAudit(txCtx, int64(accountID), reason, "", ""); err != nil {
+			return &AuthError{Op: "revoke all tokens", Err: err}
+		}
+		return nil
+	})
 }
 
 // RevokeTokensByTenantID deletes all refresh tokens for a given tenant.
 // Used during soft-delete to immediately cut off session refresh for all users of the school.
 func (s *Service) RevokeTokensByTenantID(ctx context.Context, tenantID int64) (int, error) {
-	count, err := s.repos.Token.DeleteByTenantID(ctx, tenantID)
+	count := 0
+	err := s.runInTx(ctx, func(txCtx context.Context) error {
+		deleted, err := s.repos.Token.DeleteByTenantIDReturning(txCtx, tenantID)
+		if err != nil {
+			return err
+		}
+		if err := s.auditRevokedTokens(txCtx, deleted, "tenant_deleted", "", ""); err != nil {
+			return err
+		}
+		count = len(deleted)
+		return nil
+	})
 	if err != nil {
 		return 0, &AuthError{Op: "revoke tokens by tenant", Err: err}
 	}

--- a/backend/services/auth/token_revocation_audit.go
+++ b/backend/services/auth/token_revocation_audit.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/moto-nrw/project-phoenix/auth/rotation"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+)
+
+const internalRevocationAuditIP = "0.0.0.0"
+
+type revocationGroup struct {
+	accountID int64
+	tenantID  int64
+	scope     string
+	familyID  string
+	count     int
+}
+
+func persistedPortalScope(jwtScope string) string {
+	switch jwtScope {
+	case "", authModels.PortalScopeTenant:
+		return authModels.PortalScopeTenant
+	case authModels.PortalScopeOrg, authModels.PortalScopeParent, authModels.PortalScopeSchool:
+		return jwtScope
+	default:
+		return authModels.PortalScopeUnknown
+	}
+}
+
+func (s *Service) auditRevokedTokens(ctx context.Context, tokens []*authModels.Token, reason, ipAddress, userAgent string) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	if ipAddress == "" {
+		ipAddress = internalRevocationAuditIP
+	}
+	groups := make(map[string]*revocationGroup)
+	for _, token := range tokens {
+		familyID := token.FamilyID
+		if familyID == "" {
+			familyID = "legacy:" + token.Token
+		}
+		key := fmt.Sprintf("%d:%d:%s:%s", token.AccountID, token.TenantID, token.PortalScope, familyID)
+		group := groups[key]
+		if group == nil {
+			scope := token.PortalScope
+			if scope == "" {
+				scope = authModels.PortalScopeUnknown
+			}
+			group = &revocationGroup{accountID: token.AccountID, tenantID: token.TenantID, scope: scope, familyID: familyID}
+			groups[key] = group
+		}
+		group.count++
+	}
+	keys := make([]string, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		group := groups[key]
+		event := auditModels.NewAuthEvent(group.accountID, auditModels.EventTypeTokenRevoked, true, ipAddress)
+		event.SetTenantID(group.tenantID)
+		event.UserAgent = userAgent
+		event.SetMetadata("portal_scope", group.scope)
+		event.SetMetadata("family_fingerprint", rotation.FamilyFingerprint(group.familyID))
+		event.SetMetadata("reason", reason)
+		event.SetMetadata("revoked_token_count", group.count)
+		if err := s.repos.AuthEvent.Create(ctx, event); err != nil {
+			return fmt.Errorf("audit token revocation: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) deleteAccountTokensWithAudit(ctx context.Context, accountID int64, reason, ipAddress, userAgent string) ([]*authModels.Token, error) {
+	tokens, err := s.repos.Token.DeleteByAccountIDReturning(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	return tokens, s.auditRevokedTokens(ctx, tokens, reason, ipAddress, userAgent)
+}
+
+func (s *Service) deleteFamilyWithAudit(ctx context.Context, token *authModels.Token, reason, ipAddress, userAgent string) error {
+	if token.FamilyID == "" {
+		if err := s.repos.Token.Delete(ctx, token.ID); err != nil {
+			return err
+		}
+		return s.auditRevokedTokens(ctx, []*authModels.Token{token}, reason, ipAddress, userAgent)
+	}
+	tokens, err := s.repos.Token.DeleteByFamilyIDReturning(ctx, token.FamilyID)
+	if err != nil {
+		return err
+	}
+	return s.auditRevokedTokens(ctx, tokens, reason, ipAddress, userAgent)
+}

--- a/backend/services/auth/token_revocation_audit_internal_test.go
+++ b/backend/services/auth/token_revocation_audit_internal_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"testing"
+
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPersistedPortalScope(t *testing.T) {
+	tests := map[string]string{
+		"":                     authModels.PortalScopeTenant,
+		tenant.ScopeOrg:        authModels.PortalScopeOrg,
+		tenant.ScopeParent:     authModels.PortalScopeParent,
+		tenant.ScopeSchool:     authModels.PortalScopeSchool,
+		"unexpected-new-scope": authModels.PortalScopeUnknown,
+	}
+
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			assert.Equal(t, want, persistedPortalScope(input))
+		})
+	}
+}

--- a/backend/services/auth/token_revocation_audit_test.go
+++ b/backend/services/auth/token_revocation_audit_test.go
@@ -1,0 +1,129 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/auth/rotation"
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	"github.com/moto-nrw/project-phoenix/services"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingAuthEventRepository struct {
+	auditModels.AuthEventRepository
+}
+
+func (failingAuthEventRepository) Create(context.Context, *auditModels.AuthEvent) error {
+	return errors.New("forced audit failure")
+}
+
+func TestLogoutPersistsRevocationAuditWithoutRawFamilyID(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	service := setupAuthService(t, db)
+	tenantID, _ := testpkg.CreateTestTenant(t, db)
+	ctx := testpkg.TenantContext(tenantID)
+	email, username := uniqueTestCredentials("revocation-audit")
+	account, err := service.Register(ctx, email, username, testPassword, nil, 0)
+	require.NoError(t, err)
+	testpkg.EnsureAccountTenant(t, db, account.ID, tenantID)
+	t.Cleanup(func() {
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.CleanupTestTenant(t, db, tenantID)
+	})
+
+	_, refreshToken, err := service.Login(ctx, email, testPassword)
+	require.NoError(t, err)
+	var persisted authModels.Token
+	require.NoError(t, db.NewSelect().Model(&persisted).ModelTableExpr(`auth.tokens AS "token"`).
+		Where(`"token".account_id = ?`, account.ID).Scan(ctx))
+	require.Equal(t, authModels.PortalScopeTenant, persisted.PortalScope)
+
+	require.NoError(t, service.LogoutWithAudit(ctx, refreshToken, "192.0.2.10", "revocation-test"))
+
+	var event auditModels.AuthEvent
+	require.NoError(t, db.NewSelect().Model(&event).ModelTableExpr(`audit.auth_events AS "auth_event"`).
+		Where(`"auth_event".account_id = ?`, account.ID).
+		Where(`"auth_event".event_type = ?`, auditModels.EventTypeTokenRevoked).
+		OrderExpr(`"auth_event".id DESC`).Limit(1).Scan(ctx))
+	assert.Equal(t, tenantID, event.TenantID)
+	assert.Equal(t, "192.0.2.10", event.IPAddress)
+	assert.Equal(t, "revocation-test", event.UserAgent)
+	assert.Equal(t, authModels.PortalScopeTenant, event.Metadata["portal_scope"])
+	assert.Equal(t, "logout", event.Metadata["reason"])
+	assert.Equal(t, float64(1), event.Metadata["revoked_token_count"])
+	assert.Equal(t, rotation.FamilyFingerprint(persisted.FamilyID), event.Metadata["family_fingerprint"])
+	assert.NotContains(t, event.Metadata["family_fingerprint"], persisted.FamilyID)
+}
+
+func TestRevocationRollsBackWhenAuditInsertFails(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	tenantID, _ := testpkg.CreateTestTenant(t, db)
+	ctx := testpkg.TenantContext(tenantID)
+	workingService := setupAuthService(t, db)
+	email, username := uniqueTestCredentials("revocation-rollback")
+	account, err := workingService.Register(ctx, email, username, testPassword, nil, 0)
+	require.NoError(t, err)
+	testpkg.EnsureAccountTenant(t, db, account.ID, tenantID)
+	t.Cleanup(func() {
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.CleanupTestTenant(t, db, tenantID)
+	})
+	_, _, err = workingService.Login(ctx, email, testPassword)
+	require.NoError(t, err)
+
+	repoFactory := repositories.NewFactory(db)
+	repoFactory.AuthEvent = failingAuthEventRepository{AuthEventRepository: repoFactory.AuthEvent}
+	serviceFactory, err := services.NewFactory(repoFactory, db, slog.Default())
+	require.NoError(t, err)
+
+	err = serviceFactory.Auth.RevokeAllTokensWithReason(tenant.WithTenantID(context.Background(), tenantID), int(account.ID), "password_reset")
+	require.ErrorContains(t, err, "forced audit failure")
+
+	count, err := db.NewSelect().TableExpr("auth.tokens").Where("account_id = ?", account.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "token deletion must roll back with the failed audit insert")
+}
+
+func TestSessionCapAuditsEvictedTokenFamily(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	service := setupAuthService(t, db)
+	tenantID, _ := testpkg.CreateTestTenant(t, db)
+	ctx := testpkg.TenantContext(tenantID)
+	email, username := uniqueTestCredentials("session-cap-audit")
+	account, err := service.Register(ctx, email, username, testPassword, nil, 0)
+	require.NoError(t, err)
+	testpkg.EnsureAccountTenant(t, db, account.ID, tenantID)
+	t.Cleanup(func() {
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.CleanupTestTenant(t, db, tenantID)
+	})
+
+	for range 6 {
+		_, _, err = service.Login(ctx, email, testPassword)
+		require.NoError(t, err)
+	}
+
+	tokenCount, err := db.NewSelect().TableExpr("auth.tokens").Where("account_id = ?", account.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 5, tokenCount)
+
+	var event auditModels.AuthEvent
+	require.NoError(t, db.NewSelect().Model(&event).ModelTableExpr(`audit.auth_events AS "auth_event"`).
+		Where(`"auth_event".account_id = ?`, account.ID).
+		Where(`"auth_event".event_type = ?`, auditModels.EventTypeTokenRevoked).
+		Where(`"auth_event".metadata->>'reason' = 'session_cap'`).
+		OrderExpr(`"auth_event".id DESC`).Limit(1).Scan(ctx))
+	assert.Equal(t, authModels.PortalScopeTenant, event.Metadata["portal_scope"])
+	assert.Equal(t, float64(1), event.Metadata["revoked_token_count"])
+}

--- a/backend/services/platform/operator_account_access.go
+++ b/backend/services/platform/operator_account_access.go
@@ -291,7 +291,7 @@ func (s *operatorProvisioningService) UpdateAccountTenantRole(
 			}
 			removed = append(removed, existing.Name)
 		}
-		if err := s.AuthService.RevokeAllTokens(adminCtx, int(accountID)); err != nil {
+		if err := s.AuthService.RevokeAllTokensWithReason(adminCtx, int(accountID), "role_changed"); err != nil {
 			return fmt.Errorf("revoke tokens after role change: %w", err)
 		}
 
@@ -375,7 +375,7 @@ func (s *operatorProvisioningService) RevokeAccountTenantAccess(
 		if _, err := s.AccountPermissionRepo.DeleteByAccountID(tenant.WithTenantID(adminCtx, schoolID), accountID); err != nil {
 			return fmt.Errorf("delete direct account permissions: %w", err)
 		}
-		if err := s.AuthService.RevokeAllTokens(adminCtx, int(accountID)); err != nil {
+		if err := s.AuthService.RevokeAllTokensWithReason(adminCtx, int(accountID), "tenant_access_revoked"); err != nil {
 			return fmt.Errorf("revoke tokens after access revocation: %w", err)
 		}
 

--- a/backend/services/platform/operator_auth_service.go
+++ b/backend/services/platform/operator_auth_service.go
@@ -458,7 +458,7 @@ func (s *operatorAuthService) RefreshToken(ctx context.Context, operatorID int64
 
 		now := time.Now()
 		if now.After(dbToken.Expiry) {
-			if err := s.RefreshTokenRepo.DeleteByFamilyID(txCtx, dbToken.FamilyID); err != nil {
+			if err := s.deleteOperatorFamilyWithAudit(txCtx, dbToken, "token_expired"); err != nil {
 				return fmt.Errorf("failed to delete expired operator refresh-token family: %w", err)
 			}
 			rejectAfterCommit = true
@@ -472,7 +472,7 @@ func (s *operatorAuthService) RefreshToken(ctx context.Context, operatorID int64
 			if !errors.As(err, &invalidRefresh) {
 				return err
 			}
-			if err := s.RefreshTokenRepo.DeleteByFamilyID(txCtx, dbToken.FamilyID); err != nil {
+			if err := s.deleteOperatorFamilyWithAudit(txCtx, dbToken, "replay_detected"); err != nil {
 				return fmt.Errorf("failed to revoke replayed operator refresh-token family: %w", err)
 			}
 			rejectAfterCommit = true
@@ -485,7 +485,7 @@ func (s *operatorAuthService) RefreshToken(ctx context.Context, operatorID int64
 			return fmt.Errorf("failed to inspect operator refresh token family: %w", err)
 		}
 		if latestToken != nil && latestToken.Generation > dbToken.Generation {
-			if err := s.RefreshTokenRepo.DeleteByFamilyID(txCtx, dbToken.FamilyID); err != nil {
+			if err := s.deleteOperatorFamilyWithAudit(txCtx, dbToken, "lineage_mismatch"); err != nil {
 				return fmt.Errorf("failed to revoke operator refresh token family: %w", err)
 			}
 			rejectAfterCommit = true
@@ -695,7 +695,7 @@ func (s *operatorAuthService) ChangePassword(ctx context.Context, operatorID int
 				return fmt.Errorf("failed to invalidate email change tokens after password change: %w", err)
 			}
 		}
-		if _, err := s.RefreshTokenRepo.DeleteByOperatorID(txCtx, operatorID); err != nil {
+		if err := s.deleteAllOperatorTokensWithAudit(txCtx, operatorID, "password_change"); err != nil {
 			return fmt.Errorf("failed to revoke refresh tokens after password change: %w", err)
 		}
 		return nil

--- a/backend/services/platform/operator_auth_service_test.go
+++ b/backend/services/platform/operator_auth_service_test.go
@@ -711,10 +711,12 @@ func TestOperatorAuthService_ChangePassword_Success(t *testing.T) {
 
 	email := fmt.Sprintf("chpw-ok-%d@test.local", time.Now().UnixNano())
 	operatorID, _ := createEmailChangeTestOperator(t, db, email)
+	_, _, _, err := service.Login(ctx, email, testPassword, net.ParseIP("192.0.2.20"))
+	require.NoError(t, err)
 
 	// Read old hash for comparison
 	var oldHash string
-	err := db.NewSelect().
+	err = db.NewSelect().
 		TableExpr("platform.operators").
 		Column("password_hash").
 		Where("id = ?", operatorID).
@@ -734,6 +736,18 @@ func TestOperatorAuthService_ChangePassword_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, oldHash, newHash, "password hash should be updated")
 	assert.NotEmpty(t, newHash)
+
+	var auditEntry platform.OperatorAuditLog
+	err = db.NewSelect().Model(&auditEntry).
+		ModelTableExpr(`platform.operator_audit_log AS "operator_audit_log"`).
+		Where(`"operator_audit_log".operator_id = ?`, operatorID).
+		Where(`"operator_audit_log".action = ?`, platform.ActionTokenRevoked).
+		OrderExpr(`"operator_audit_log".id DESC`).Limit(1).Scan(ctx)
+	require.NoError(t, err)
+	changes, err := auditEntry.GetChanges()
+	require.NoError(t, err)
+	assert.Equal(t, "operator", changes["portal_scope"])
+	assert.Equal(t, "password_change", changes["reason"])
 }
 
 func TestOperatorAuthService_ChangePassword_WrongCurrentPassword(t *testing.T) {
@@ -1308,9 +1322,9 @@ func TestOperatorAuthService_RefreshToken_HandoffLookupErrorDoesNotRevokeFamily(
 				RecoveryProofHash: recoveryProofHash,
 			}, nil
 		},
-		deleteByFamilyIDFn: func(context.Context, string) error {
+		deleteByFamilyIDFn: func(context.Context, string) ([]*platform.OperatorRefreshToken, error) {
 			familyRevoked = true
-			return nil
+			return nil, nil
 		},
 	}
 

--- a/backend/services/platform/operator_provisioning_service_test.go
+++ b/backend/services/platform/operator_provisioning_service_test.go
@@ -409,8 +409,9 @@ func (m *mockAuthService) CleanupExpiredTokens(context.Context) (int, error) { r
 func (m *mockAuthService) CleanupExpiredPasswordResetTokens(context.Context) (int, error) {
 	return 0, nil
 }
-func (m *mockAuthService) RevokeAllTokens(context.Context, int) error                 { return nil }
-func (m *mockAuthService) RevokeTokensByTenantID(context.Context, int64) (int, error) { return 0, nil }
+func (m *mockAuthService) RevokeAllTokens(context.Context, int) error                   { return nil }
+func (m *mockAuthService) RevokeAllTokensWithReason(context.Context, int, string) error { return nil }
+func (m *mockAuthService) RevokeTokensByTenantID(context.Context, int64) (int, error)   { return 0, nil }
 func (m *mockAuthService) GetActiveTokens(context.Context, int) ([]*authModels.Token, error) {
 	return nil, nil
 }

--- a/backend/services/platform/operator_token_revocation_audit.go
+++ b/backend/services/platform/operator_token_revocation_audit.go
@@ -1,0 +1,55 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/auth/rotation"
+	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
+)
+
+func (s *operatorAuthService) auditOperatorRevocation(ctx context.Context, operatorID int64, familyID, reason string, count int) error {
+	entry := &platformModels.OperatorAuditLog{
+		OperatorID:   operatorID,
+		Action:       platformModels.ActionTokenRevoked,
+		ResourceType: platformModels.ResourceOperator,
+		ResourceID:   &operatorID,
+	}
+	if err := entry.SetChanges(map[string]any{
+		"portal_scope":        "operator",
+		"family_fingerprint":  rotation.FamilyFingerprint(familyID),
+		"reason":              reason,
+		"revoked_token_count": count,
+	}); err != nil {
+		return fmt.Errorf("encode operator token revocation audit: %w", err)
+	}
+	if err := s.AuditLogRepo.Create(ctx, entry); err != nil {
+		return fmt.Errorf("audit operator token revocation: %w", err)
+	}
+	return nil
+}
+
+func (s *operatorAuthService) deleteOperatorFamilyWithAudit(ctx context.Context, token *platformModels.OperatorRefreshToken, reason string) error {
+	deleted, err := s.RefreshTokenRepo.DeleteByFamilyIDReturning(ctx, token.FamilyID)
+	if err != nil {
+		return err
+	}
+	return s.auditOperatorRevocation(ctx, token.OperatorID, token.FamilyID, reason, len(deleted))
+}
+
+func (s *operatorAuthService) deleteAllOperatorTokensWithAudit(ctx context.Context, operatorID int64, reason string) error {
+	deleted, err := s.RefreshTokenRepo.DeleteByOperatorIDReturning(ctx, operatorID)
+	if err != nil {
+		return err
+	}
+	counts := make(map[string]int)
+	for _, token := range deleted {
+		counts[token.FamilyID]++
+	}
+	for familyID, count := range counts {
+		if err := s.auditOperatorRevocation(ctx, operatorID, familyID, reason, count); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/services/platform/test_mocks_test.go
+++ b/backend/services/platform/test_mocks_test.go
@@ -118,8 +118,8 @@ type mockOperatorRefreshTokenRepo struct {
 	markRotatedFn            func(ctx context.Context, id int64, replacementToken string, recoveryProofHash []byte, rotatedAt time.Time) error
 	deleteExpiredRotatedFn   func(ctx context.Context, familyID string, now time.Time) error
 	deleteFn                 func(ctx context.Context, id any) error
-	deleteByOperatorIDFn     func(ctx context.Context, operatorID int64) (int, error)
-	deleteByFamilyIDFn       func(ctx context.Context, familyID string) error
+	deleteByOperatorIDFn     func(ctx context.Context, operatorID int64) ([]*platform.OperatorRefreshToken, error)
+	deleteByFamilyIDFn       func(ctx context.Context, familyID string) ([]*platform.OperatorRefreshToken, error)
 	getLatestTokenInFamilyFn func(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error)
 	deleteExpiredFn          func(ctx context.Context, now time.Time) (int, error)
 	created                  []*platform.OperatorRefreshToken
@@ -161,18 +161,18 @@ func (m *mockOperatorRefreshTokenRepo) Delete(ctx context.Context, id any) error
 	return nil
 }
 
-func (m *mockOperatorRefreshTokenRepo) DeleteByOperatorID(ctx context.Context, operatorID int64) (int, error) {
+func (m *mockOperatorRefreshTokenRepo) DeleteByOperatorIDReturning(ctx context.Context, operatorID int64) ([]*platform.OperatorRefreshToken, error) {
 	if m.deleteByOperatorIDFn != nil {
 		return m.deleteByOperatorIDFn(ctx, operatorID)
 	}
-	return 0, nil
+	return nil, nil
 }
 
-func (m *mockOperatorRefreshTokenRepo) DeleteByFamilyID(ctx context.Context, familyID string) error {
+func (m *mockOperatorRefreshTokenRepo) DeleteByFamilyIDReturning(ctx context.Context, familyID string) ([]*platform.OperatorRefreshToken, error) {
 	if m.deleteByFamilyIDFn != nil {
 		return m.deleteByFamilyIDFn(ctx, familyID)
 	}
-	return nil
+	return nil, nil
 }
 
 func (m *mockOperatorRefreshTokenRepo) GetLatestTokenInFamily(ctx context.Context, familyID string) (*platform.OperatorRefreshToken, error) {


### PR DESCRIPTION
# Pull Request

## Description

Records refresh-token revocations after the token rows are deleted, so security-relevant invalidations remain auditable.

Each revoked token family records:

- affected account and tenant
- portal scope
- SHA-256 fingerprint of the token-family ID, never the raw ID or token
- revocation reason and deleted-token count

Tenant, organization, parent, and school sessions write `token_revoked` events to `audit.auth_events`. Operator sessions write equivalent entries to `platform.operator_audit_log`.

Token deletion and audit insertion run in one transaction. An audit failure rolls back the deletion and the surrounding security action.

The migration adds `portal_scope` to `auth.tokens`. Existing sessions are marked `unknown`; newly issued and rotated tenant, org, parent, and school sessions store their scope.

### Audited reasons

- `logout`, `session_cap`, and `administrative_revoke`
- `password_reset` and operator `password_change`
- `role_changed`, `account_deactivated`, `tenant_access_revoked`, and `tenant_deleted`
- `claim_mismatch`, `token_expired`, `replay_detected`, and `lineage_mismatch`

Normal expiry cleanup and successful rotation-handoff cleanup remain unaudited.

## Testing

- Added revocation-audit coverage for logout, session-cap eviction, fingerprinting, portal-scope persistence, and rollback on audit failure.
- Updated token repository and operator password-change tests.

```bash
docker compose --profile test up -d postgres-test
cd backend && APP_ENV=test go test ./...
```

## Screenshots or Examples

Not applicable; backend-only security and audit change.

## Additional Notes

Logout still revokes all refresh sessions for the account; this change adds audit evidence without narrowing that behavior.
