### PR TITLE
NFC-Hinweise bei deaktivierter NFC-Anwesenheit ausblenden

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part6.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part6.test.tsx
@@ -273,6 +273,7 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { useNFCEnabled } from "~/lib/tenant-context";
 import MeinRaumPage from "./page";
 
 describe("MeinRaumPage (Active Supervisions) (5/5)", () => {
@@ -280,6 +281,7 @@ describe("MeinRaumPage (Active Supervisions) (5/5)", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
     navigationMockState.roomParam = null;
     global.fetch = vi.fn();
     // Default mock: loading state
@@ -660,6 +662,33 @@ describe("MeinRaumPage (Active Supervisions) (5/5)", () => {
       expect(
         screen.getByText("Keine aktive Raum-Aufsicht"),
       ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Starte eine Aktivität an einem Terminal, um Live-Raumdaten einzusehen.",
+        ),
+      ).toBeInTheDocument();
     });
+  });
+
+  it("points NFC-free tenants to the web app when no supervision is active", async () => {
+    vi.mocked(useNFCEnabled).mockReturnValue(false);
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("BFF request failed: 403"),
+      mutate: mockMutate,
+      isValidating: false,
+    } as never);
+
+    render(<MeinRaumPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Starte eine Aktivität in der Web-App, um Live-Raumdaten einzusehen.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Terminal/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.test.tsx
@@ -9,6 +9,7 @@ import {
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import StudentDetailPage from "./page";
 import { useSession } from "next-auth/react";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 const {
   mockSWRMutate,
@@ -587,6 +588,7 @@ const mockStudentAtHome = {
 describe("StudentDetailPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
     mockSearchParams.delete("from");
     mockSearchParams.delete("tab");
     mockActionType = "none";
@@ -1202,7 +1204,7 @@ describe("StudentDetailPage", () => {
       });
     });
 
-    it("shows message when no active rooms available", async () => {
+    it("shows the NFC instruction when no active rooms are available for an NFC tenant", async () => {
       mockGetActiveGroups.mockResolvedValue([]);
 
       render(<StudentDetailPage />);
@@ -1212,9 +1214,29 @@ describe("StudentDetailPage", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(/Keine aktiven Räume verfügbar/i),
+          screen.getByText(
+            "Keine aktiven Räume verfügbar. Bitte starten Sie zuerst eine aktive Aufsicht in einem Raum über ein NFC-Tablet.",
+          ),
         ).toBeInTheDocument();
       });
+    });
+
+    it("shows a web instruction when no active rooms are available without NFC", async () => {
+      vi.mocked(useNFCEnabled).mockReturnValue(false);
+      mockGetActiveGroups.mockResolvedValue([]);
+
+      render(<StudentDetailPage />);
+
+      fireEvent.click(screen.getByTestId("checkin-button"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Keine aktiven Räume verfügbar. Bitte starten Sie zuerst eine aktive Aufsicht in einem Raum über die Web-App.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/NFC-Tablet/i)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 import { useSession } from "next-auth/react";
 import { useSWRConfig } from "swr";
 import { useTenantRouter } from "~/lib/tenant-router";
+import { useNFCEnabled } from "~/lib/tenant-context";
 import { hasPermission } from "~/lib/auth-utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
@@ -313,6 +314,7 @@ export default function StudentDetailPage() {
 }
 
 function StudentDetailPageContent() {
+  const nfcEnabled = useNFCEnabled();
   const { mutate } = useSWRConfig();
   const router = useTenantRouter();
   const params = useParams();
@@ -1096,7 +1098,8 @@ function StudentDetailPageContent() {
       return (
         <p className="text-moto-amber-strong text-sm">
           Keine aktiven Räume verfügbar. Bitte starten Sie zuerst eine aktive
-          Aufsicht in einem Raum über ein NFC-Tablet.
+          Aufsicht in einem Raum über{" "}
+          {nfcEnabled ? "ein NFC-Tablet" : "die Web-App"}.
         </p>
       );
     }

--- a/frontend/src/components/active-supervisions/states.tsx
+++ b/frontend/src/components/active-supervisions/states.tsx
@@ -12,6 +12,7 @@ import { UnclaimedRooms } from "~/components/active/unclaimed-rooms";
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
 import { MotoDuotoneIcon } from "~/components/ui/moto-duotone-icon";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 interface MinimalActiveGroup {
   id: string;
@@ -49,6 +50,8 @@ export function ActiveSupervisionLoadingView() {
 }
 
 export function NoActiveSupervisionAccessView() {
+  const nfcEnabled = useNFCEnabled();
+
   useSetBreadcrumb({
     pageTitle: "Aktuelle Aufsicht",
   });
@@ -68,8 +71,9 @@ export function NoActiveSupervisionAccessView() {
               Du bist aktuell in keinem Raum als Live-Aktivität registriert.
             </p>
             <p className="mt-4 text-sm text-gray-500">
-              Starte eine Aktivität an einem Terminal, um Live-Raumdaten
-              einzusehen.
+              Starte eine Aktivität{" "}
+              {nfcEnabled ? "an einem Terminal" : "in der Web-App"}, um
+              Live-Raumdaten einzusehen.
             </p>
           </div>
         </div>

--- a/frontend/src/components/students/arrival-day-edit-modal.test.tsx
+++ b/frontend/src/components/students/arrival-day-edit-modal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import type { ArrivalDayData } from "~/lib/arrival-schedule-helpers";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 vi.mock("~/components/ui/form-modal", () => ({
   FormModal: ({
@@ -60,7 +61,22 @@ describe("ArrivalDayEditModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
     Object.values(callbacks).forEach((fn) => fn.mockReset?.());
+  });
+
+  it("shows the NFC tablet note only for NFC tenants", () => {
+    const props = { isOpen: true, day: makeDay(), ...callbacks };
+    const { rerender } = render(<ArrivalDayEditModal {...props} />);
+
+    expect(
+      screen.getByText("Notizen werden auch auf den NFC-Tablets angezeigt."),
+    ).toBeInTheDocument();
+
+    vi.mocked(useNFCEnabled).mockReturnValue(false);
+    rerender(<ArrivalDayEditModal {...props} />);
+
+    expect(screen.queryByText(/NFC-Tablets/i)).not.toBeInTheDocument();
   });
 
   it("returns null (no dialog) when day is null", () => {

--- a/frontend/src/components/students/arrival-day-edit-modal.tsx
+++ b/frontend/src/components/students/arrival-day-edit-modal.tsx
@@ -5,6 +5,7 @@ import { Loader2, Pencil, Plus, StickyNote, Trash2, X } from "lucide-react";
 import { FormModal } from "~/components/ui/form-modal";
 import { Alert } from "~/components/ui/alert";
 import { createLogger } from "~/lib/logger";
+import { useNFCEnabled } from "~/lib/tenant-context";
 import type { ArrivalNote } from "~/lib/student-arrival-api";
 import {
   type ArrivalDayData,
@@ -38,6 +39,7 @@ export function ArrivalDayEditModal({
   onUpdateNote,
   onDeleteNote,
 }: ArrivalDayEditModalProps) {
+  const nfcEnabled = useNFCEnabled();
   const [arrivalTime, setArrivalTime] = useState("");
   const [hasTimeOverride, setHasTimeOverride] = useState(false);
   const [markAbsent, setMarkAbsent] = useState(false);
@@ -350,12 +352,14 @@ export function ArrivalDayEditModal({
             ) : null}
           </div>
 
-          <div className="mb-3">
-            <Alert
-              type="info"
-              message="Notizen werden auch auf den NFC-Tablets angezeigt."
-            />
-          </div>
+          {nfcEnabled ? (
+            <div className="mb-3">
+              <Alert
+                type="info"
+                message="Notizen werden auch auf den NFC-Tablets angezeigt."
+              />
+            </div>
+          ) : null}
 
           {day.notes.length > 0 ? (
             <div className="space-y-2">

--- a/frontend/src/components/students/pickup-day-edit-modal.test.tsx
+++ b/frontend/src/components/students/pickup-day-edit-modal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { PickupDayEditModal } from "./pickup-day-edit-modal";
 import type { DayData, PickupNote } from "@/lib/pickup-schedule-helpers";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 // Mock lucide-react icons
 vi.mock("lucide-react", () => ({
@@ -89,11 +90,32 @@ describe("PickupDayEditModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
     mockOnSaveException.mockResolvedValue(undefined);
     mockOnDeleteException.mockResolvedValue(undefined);
     mockOnCreateNote.mockResolvedValue(undefined);
     mockOnUpdateNote.mockResolvedValue(undefined);
     mockOnDeleteNote.mockResolvedValue(undefined);
+  });
+
+  it("shows the NFC tablet note only for NFC tenants", () => {
+    const props = {
+      isOpen: true,
+      day: createMockDayData(),
+      ...defaultProps,
+    };
+    const { rerender } = render(<PickupDayEditModal {...props} />);
+
+    expect(
+      screen.getByText(
+        "Diese Notiz wird auch auf den NFC-Tablets angezeigt und ist für Kinder einsehbar.",
+      ),
+    ).toBeInTheDocument();
+
+    vi.mocked(useNFCEnabled).mockReturnValue(false);
+    rerender(<PickupDayEditModal {...props} />);
+
+    expect(screen.queryByText(/NFC-Tablets/i)).not.toBeInTheDocument();
   });
 
   describe("Rendering", () => {

--- a/frontend/src/components/students/pickup-day-edit-modal.tsx
+++ b/frontend/src/components/students/pickup-day-edit-modal.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/pickup-schedule-helpers";
 import { Alert } from "~/components/ui/alert";
 import { createLogger } from "~/lib/logger";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 const logger = createLogger({ component: "PickupDayEdit" });
 
@@ -39,6 +40,7 @@ export function PickupDayEditModal({
   onUpdateNote,
   onDeleteNote,
 }: PickupDayEditModalProps) {
+  const nfcEnabled = useNFCEnabled();
   // Exception section state
   const [pickupTime, setPickupTime] = useState("");
   const [hasTimeOverride, setHasTimeOverride] = useState(false);
@@ -317,12 +319,14 @@ export function PickupDayEditModal({
             )}
           </div>
 
-          <div className="mb-3">
-            <Alert
-              type="info"
-              message="Diese Notiz wird auch auf den NFC-Tablets angezeigt und ist für Kinder einsehbar."
-            />
-          </div>
+          {nfcEnabled ? (
+            <div className="mb-3">
+              <Alert
+                type="info"
+                message="Diese Notiz wird auch auf den NFC-Tablets angezeigt und ist für Kinder einsehbar."
+              />
+            </div>
+          ) : null}
 
           {/* Existing notes */}
           {day.notes.length > 0 ? (

--- a/frontend/src/components/students/pickup-schedule-form-modal.test.tsx
+++ b/frontend/src/components/students/pickup-schedule-form-modal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { PickupScheduleFormModal } from "./pickup-schedule-form-modal";
 import type { PickupScheduleFormData } from "@/lib/pickup-schedule-helpers";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 // Mock FormModal
 vi.mock("~/components/ui/form-modal", () => ({
@@ -64,6 +65,29 @@ describe("PickupScheduleFormModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNFCEnabled).mockReturnValue(true);
+  });
+
+  it("shows the NFC tablet note only for NFC tenants", () => {
+    const props = {
+      isOpen: true,
+      onClose: mockOnClose,
+      onSubmit: mockOnSubmit,
+      initialSchedules: emptySchedules,
+    };
+
+    const { rerender } = render(<PickupScheduleFormModal {...props} />);
+
+    expect(
+      screen.getByText(
+        "Abholzeiten und Notizen werden auch auf den NFC-Tablets angezeigt und sind für Kinder einsehbar.",
+      ),
+    ).toBeInTheDocument();
+
+    vi.mocked(useNFCEnabled).mockReturnValue(false);
+    rerender(<PickupScheduleFormModal {...props} />);
+
+    expect(screen.queryByText(/NFC-Tablets/i)).not.toBeInTheDocument();
   });
 
   describe("Modal open/close behavior", () => {

--- a/frontend/src/components/students/pickup-schedule-form-modal.tsx
+++ b/frontend/src/components/students/pickup-schedule-form-modal.tsx
@@ -11,6 +11,7 @@ import type {
 import { WEEKDAYS } from "@/lib/pickup-schedule-helpers";
 import { Alert } from "~/components/ui/alert";
 import { createLogger } from "~/lib/logger";
+import { useNFCEnabled } from "~/lib/tenant-context";
 
 const logger = createLogger({ component: "PickupScheduleForm" });
 
@@ -27,6 +28,7 @@ export function PickupScheduleFormModal({
   onSubmit,
   initialSchedules,
 }: PickupScheduleFormModalProps) {
+  const nfcEnabled = useNFCEnabled();
   const [schedules, setSchedules] =
     useState<PickupScheduleFormData[]>(initialSchedules);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -131,12 +133,14 @@ export function PickupScheduleFormModal({
           Zeiten und Notizen gelten wöchentlich wiederkehrend für jeden
           Wochentag.
         </p>
-        <div className="mb-4">
-          <Alert
-            type="info"
-            message="Abholzeiten und Notizen werden auch auf den NFC-Tablets angezeigt und sind für Kinder einsehbar."
-          />
-        </div>
+        {nfcEnabled ? (
+          <div className="mb-4">
+            <Alert
+              type="info"
+              message="Abholzeiten und Notizen werden auch auf den NFC-Tablets angezeigt und sind für Kinder einsehbar."
+            />
+          </div>
+        ) : null}
         {error && (
           <div
             ref={errorRef}


### PR DESCRIPTION
## Beschreibung

Blendet NFC-spezifische Anwesenheits-Hinweise für Schulen mit deaktivierter NFC-Anwesenheit aus oder verweist auf die Web-App:

- Der manuelle Check-in bei fehlenden aktiven Räumen verweist auf die Web-App.
- Die leere Ansicht „Aktuelle Aufsicht“ verweist auf die Web-App statt auf ein Terminal.
- NFC-Hinweise in Ankunfts-, Abhol- und wöchentlichen Gehplan-Dialogen erscheinen nur bei aktivierter NFC-Anwesenheit.
- Für Schulen mit aktivierter NFC-Anwesenheit bleiben die bisherigen Hinweise unverändert.

## Related Issues

Closes #2268

## Tests

Erweiterte Vitest-Tests prüfen die NFC-aktivierte und NFC-deaktivierte Konfiguration einschließlich der angezeigten Texte.

```bash
cd frontend && pnpm run check
```
