### PR TITLE
Passkey-Icons vereinheitlichen

### DIFF
--- a/frontend/src/components/settings/passkey-settings-section.tsx
+++ b/frontend/src/components/settings/passkey-settings-section.tsx
@@ -131,7 +131,7 @@ export function PasskeySettingsSection({
         // als h2 wuerde TrustedDevicesSection darunter einsortiert.
         level={3}
         title="Passkeys"
-        concept="permissions"
+        concept="passkeys"
         actions={
           supported &&
           !confirmingEnrollment &&

--- a/frontend/src/components/ui/moto-concept-icon.tsx
+++ b/frontend/src/components/ui/moto-concept-icon.tsx
@@ -12,6 +12,11 @@ interface MotoConceptIconProps extends Omit<
 export function MotoConceptIcon({ concept, ...props }: MotoConceptIconProps) {
   const definition = MOTO_CONCEPTS[concept];
   return (
-    <MotoDuotoneIcon icon={definition.icon} tone={definition.tone} {...props} />
+    <MotoDuotoneIcon
+      icon={definition.icon}
+      tone={definition.tone}
+      weight={definition.weight}
+      {...props}
+    />
   );
 }

--- a/frontend/src/components/ui/moto-duotone-icon.test.tsx
+++ b/frontend/src/components/ui/moto-duotone-icon.test.tsx
@@ -77,4 +77,13 @@ describe("MotoDuotoneIcon", () => {
 
     expect(screen.getByRole("img", { name: "Räume" })).toBeInTheDocument();
   });
+
+  it("can render a compact icon without the duotone background fill", () => {
+    const { container } = render(
+      <MotoDuotoneIcon icon={BuildingsIcon} tone="blue" weight="regular" />,
+    );
+    const icon = container.querySelector("svg");
+
+    expect(icon?.querySelector('[opacity="0.2"]')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/moto-duotone-icon.tsx
+++ b/frontend/src/components/ui/moto-duotone-icon.tsx
@@ -96,6 +96,7 @@ export interface MotoDuotoneIconProps {
   readonly icon: PhosphorIcon;
   readonly tone: MotoDuotoneTone;
   readonly size?: IconProps["size"];
+  readonly weight?: IconProps["weight"];
   readonly className?: string;
   readonly label?: string;
 }
@@ -104,6 +105,7 @@ export function MotoDuotoneIcon({
   icon: Icon,
   tone,
   size = 32,
+  weight = "duotone",
   className,
   label,
 }: MotoDuotoneIconProps) {
@@ -112,7 +114,7 @@ export function MotoDuotoneIcon({
   return (
     <Icon
       size={size}
-      weight="duotone"
+      weight={weight}
       className={cn("moto-duotone-icon shrink-0", className)}
       data-moto-duotone-tone={tone}
       style={

--- a/frontend/src/lib/moto-concepts.test.ts
+++ b/frontend/src/lib/moto-concepts.test.ts
@@ -36,4 +36,8 @@ describe("MOTO_CONCEPTS", () => {
     expect(MOTO_CONCEPTS.schoolyard.tone).toBe("orange");
     expect(MOTO_CONCEPTS.utilization.tone).toBe("gold");
   });
+
+  it("renders passkeys as a clean outline without a duotone fill", () => {
+    expect(MOTO_CONCEPTS.passkeys.weight).toBe("regular");
+  });
 });

--- a/frontend/src/lib/moto-concepts.ts
+++ b/frontend/src/lib/moto-concepts.ts
@@ -61,7 +61,7 @@ import {
   UsersThreeIcon,
   VanIcon,
 } from "@phosphor-icons/react/ssr";
-import type { Icon as PhosphorIcon } from "@phosphor-icons/react";
+import type { Icon as PhosphorIcon, IconProps } from "@phosphor-icons/react";
 import type { MotoDuotoneTone } from "~/lib/location-helper";
 
 export type MotoConceptKind = "core" | "status" | "function";
@@ -79,6 +79,7 @@ export interface MotoConceptDefinition {
   readonly tone: MotoDuotoneTone;
   readonly kind: MotoConceptKind;
   readonly section: MotoConceptSection;
+  readonly weight: IconProps["weight"];
 }
 
 export const MOTO_CONCEPTS = {
@@ -361,6 +362,7 @@ export const MOTO_CONCEPTS = {
     "purple",
     "function",
     "system",
+    "regular",
   ),
   exports: concept(
     "Exporte",
@@ -412,6 +414,7 @@ function concept(
   tone: MotoDuotoneTone,
   kind: MotoConceptKind,
   section: MotoConceptSection,
+  weight: IconProps["weight"] = "duotone",
 ): MotoConceptDefinition {
-  return { label, icon, tone, kind, section };
+  return { label, icon, tone, kind, section, weight };
 }


### PR DESCRIPTION
## Zusammenfassung
- verwendet das Fingerabdruck-Icon zentral für das Passkey-Konzept
- rendert Passkey-Icons als klare Outline ohne Duotone-Hintergrundfläche
- ersetzt das Berechtigungs-Icon in den Passkey-Einstellungen

## Tests
- `pnpm exec vitest run src/components/ui/moto-duotone-icon.test.tsx src/lib/moto-concepts.test.ts src/components/settings/passkey-settings-section.test.tsx`
- `pnpm run check`
- Sichtprüfung im laufenden Docker-Frontend