### PR TITLE
fix(parents): mobile refactoring of the parent portal

### DIFF
--- a/frontend/src/app/parents/calendar/page.tsx
+++ b/frontend/src/app/parents/calendar/page.tsx
@@ -151,6 +151,7 @@ export default function ParentCalendarPage() {
       <PersonalCalendar
         title="Familienkalender"
         subtitle="Termine, Einladungen und Betreuungsangebote Ihrer Kinder."
+        cardHeader
         events={data?.events ?? []}
         referenceDate={referenceDate}
         viewMode={viewMode}

--- a/frontend/src/components/calendar/personal-calendar.tsx
+++ b/frontend/src/components/calendar/personal-calendar.tsx
@@ -39,6 +39,8 @@ interface PersonalCalendarProps {
    */
   readonly title: string;
   readonly subtitle?: string;
+  /** Titel/Untertitel als Karte rendern (Elternportal-Konvention). */
+  readonly cardHeader?: boolean;
   readonly events: readonly CalendarEvent[];
   readonly referenceDate?: Date;
   readonly weekStart?: Date;
@@ -383,6 +385,7 @@ function nextLabel(viewMode: CalendarViewMode): string {
 export function PersonalCalendar({
   title,
   subtitle,
+  cardHeader = false,
   events,
   referenceDate: rawReferenceDate,
   weekStart,
@@ -456,15 +459,26 @@ export function PersonalCalendar({
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
-        {subtitle ? (
-          <p className="mt-1 text-sm leading-6 text-gray-600">{subtitle}</p>
-        ) : null}
-      </div>
+      {cardHeader ? (
+        <header className="moto-content-surface rounded-2xl border p-5 shadow-sm backdrop-blur-md">
+          <h1 className="text-xl font-semibold text-gray-900 sm:text-2xl">
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className="mt-1 text-sm leading-6 text-gray-600">{subtitle}</p>
+          ) : null}
+        </header>
+      ) : (
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+          {subtitle ? (
+            <p className="mt-1 text-sm leading-6 text-gray-600">{subtitle}</p>
+          ) : null}
+        </div>
+      )}
       <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="flex shrink-0 items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
+        <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm sm:flex-none">
             <Button
               type="button"
               variant="ghost"
@@ -476,7 +490,7 @@ export function PersonalCalendar({
             >
               <ChevronLeft className="h-4 w-4" aria-hidden />
             </Button>
-            <div className="flex-1 px-2 text-center text-sm font-semibold text-gray-900 sm:min-w-52">
+            <div className="min-w-0 flex-1 truncate px-2 text-center text-sm font-semibold text-gray-900 sm:min-w-52">
               {label}
             </div>
             <Button
@@ -495,7 +509,7 @@ export function PersonalCalendar({
             type="button"
             variant="outline"
             size="compact"
-            className="flex-1 justify-center bg-white sm:flex-none"
+            className="shrink-0 justify-center bg-white"
             onClick={() => handleDateChange(new Date())}
           >
             Heute
@@ -503,7 +517,7 @@ export function PersonalCalendar({
         </div>
 
         <div className="flex flex-wrap items-center gap-2 xl:flex-nowrap xl:justify-end">
-          <div className="flex w-full items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm sm:w-auto">
+          <div className="flex flex-1 items-center gap-1 rounded-lg border border-gray-200 bg-white p-1 shadow-sm sm:flex-none">
             {viewOptions.map((option) => {
               const selected = option.mode === viewMode;
               return (

--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -99,6 +99,15 @@ export function Header() {
       return tParentNav("settings");
     if (pathname === "/parents/meal-plan" || pathname === "/meal-plan")
       return tParentNav("mealPlan");
+    if (pathname === "/parents/calendar" || pathname === "/calendar")
+      return tParentNav("calendar");
+    if (pathname === "/parents/feedback" || pathname === "/feedback")
+      return tParentNav("feedback");
+    if (
+      matchesPathPrefix(pathname, "/parents/enroll") ||
+      matchesPathPrefix(pathname, "/enroll")
+    )
+      return tParentNav("enroll");
     return null;
   })();
   const displayedPageTitle = parentPageTitle ?? pageTitle;
@@ -205,9 +214,18 @@ export function Header() {
                 isScrolled={isScrolled}
                 href={homeUrl}
                 label={brandLabel}
+                hideLabelOnMobile={mode === "parent"}
               />
             )}
             <BreadcrumbDivider />
+            {/* Elternportal: Seitentitel auch auf Mobilgeräten anzeigen —
+                die Breadcrumb-Komponenten sind hidden md:flex, ohne diesen
+                Titel fehlt unterhalb md jede Ortsangabe (#Elternapp-Audit). */}
+            {mode === "parent" && (
+              <span className="min-w-0 truncate text-sm font-semibold text-gray-900 md:hidden">
+                {displayedPageTitle}
+              </span>
+            )}
             <HeaderBreadcrumb
               pathname={pathname}
               pageTitle={displayedPageTitle}

--- a/frontend/src/components/dashboard/header/brand-link.tsx
+++ b/frontend/src/components/dashboard/header/brand-link.tsx
@@ -49,12 +49,15 @@ interface BrandLinkProps {
   readonly isScrolled?: boolean;
   readonly href?: string;
   readonly label?: string | null;
+  /** Unterhalb md nur das Logo zeigen (Elternportal: Platz für den Seitentitel). */
+  readonly hideLabelOnMobile?: boolean;
 }
 
 export function BrandLink({
   isScrolled = false,
   href = "/dashboard",
   label,
+  hideLabelOnMobile = false,
 }: BrandLinkProps) {
   const displayLabel = label?.trim() || "moto";
   const usesTenantLabel = Boolean(label?.trim());
@@ -66,7 +69,11 @@ export function BrandLink({
     >
       <BrandLogo />
 
-      <div className="flex min-w-0 items-center space-x-3">
+      <div
+        className={`min-w-0 items-center space-x-3 ${
+          hideLabelOnMobile ? "hidden md:flex" : "flex"
+        }`}
+      >
         <span className={brandLabelClass(isScrolled, usesTenantLabel)}>
           {displayLabel}
         </span>

--- a/frontend/src/components/parent/child-detail.tsx
+++ b/frontend/src/components/parent/child-detail.tsx
@@ -286,7 +286,7 @@ function ChildDetailContent({ child }: Readonly<{ child: Child }>) {
         description={t("today.description")}
         bodyClassName="mt-4 space-y-4"
       >
-        <div className="grid gap-2 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
           <ParentStatusRow icon={HeartPulse} label={t("today.sickLabel")}>
             <SickStatusSummary
               sickDays={care.sickDays}

--- a/frontend/src/components/parent/child-master-data.tsx
+++ b/frontend/src/components/parent/child-master-data.tsx
@@ -212,7 +212,7 @@ function ChildMasterDataContent({
           disabled={!contactEditEnabled}
           onSave={(v) => saveField("guardian_phone", "primary", v)}
         />
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <AutoSaveSelect
             label={t("fields.contactMethod")}
             value={data.preferred_contact_method}
@@ -244,7 +244,7 @@ function ChildMasterDataContent({
           disabled={!contactEditEnabled}
           onSave={(v) => saveField("guardian_profile", "address_street", v)}
         />
-        <div className="grid gap-4 sm:grid-cols-[8rem_minmax(0,1fr)]">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[8rem_minmax(0,1fr)]">
           <AutoSaveField
             label={t("fields.addressPostalCode")}
             value={data.address_postal_code ?? ""}

--- a/frontend/src/components/parent/child-row.tsx
+++ b/frontend/src/components/parent/child-row.tsx
@@ -52,11 +52,10 @@ export function ChildRow({
         <p className="truncate text-sm font-semibold text-gray-900">
           {item.name}
         </p>
-        <p className="truncate text-sm text-gray-600">
-          {item.detail
-            ? `${item.schoolName} · ${item.detail}`
-            : item.schoolName}
-        </p>
+        {item.detail && (
+          <p className="truncate text-sm text-gray-600">{item.detail}</p>
+        )}
+        <p className="truncate text-xs text-gray-500">{item.schoolName}</p>
       </div>
       {item.badgeLabel ? (
         <span className="shrink-0">

--- a/frontend/src/components/parent/guardians-panel.tsx
+++ b/frontend/src/components/parent/guardians-panel.tsx
@@ -521,7 +521,7 @@ function ContactModal({
             {error}
           </div>
         )}
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Input
             label={t("guardians.firstName")}
             value={firstName}
@@ -544,7 +544,7 @@ function ContactModal({
           value={street}
           onChange={(e) => setStreet(e.target.value)}
         />
-        <div className="grid gap-4 sm:grid-cols-[8rem_1fr]">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[8rem_minmax(0,1fr)]">
           <Input
             label={t("guardians.postalCode")}
             value={postal}

--- a/frontend/src/components/parent/language-switcher.tsx
+++ b/frontend/src/components/parent/language-switcher.tsx
@@ -68,7 +68,11 @@ export function LanguageSwitcher({
           <span className={compact ? "sr-only" : "text-gray-600"}>
             {t("label")}
           </span>
-          <span className="min-w-0 truncate text-sm font-semibold text-gray-900">
+          <span
+            className={`min-w-0 truncate text-sm font-semibold text-gray-900 ${
+              compact ? "hidden md:inline" : ""
+            }`}
+          >
             {selectedLabel}
           </span>
           <ChevronDown

--- a/frontend/src/components/parent/parent-children-page.tsx
+++ b/frontend/src/components/parent/parent-children-page.tsx
@@ -72,17 +72,18 @@ export function ParentChildrenPage() {
   const items: ChildRowItem[] = children.map((child) => ({
     key: child.student_id,
     name: `${child.first_name} ${child.last_name}`,
-    schoolName: child.school_class
-      ? `${child.school_name}, ${child.school_class}`
-      : child.school_name,
-    detail: t("careRange", {
-      range: formatServiceRange(
-        child,
-        locale,
-        t("openRange"),
-        t("dateRangeConnector"),
-      ),
-    }),
+    schoolName: child.school_name,
+    detail: `${child.school_class ? `${child.school_class} · ` : ""}${t(
+      "careRange",
+      {
+        range: formatServiceRange(
+          child,
+          locale,
+          t("openRange"),
+          t("dateRangeConnector"),
+        ),
+      },
+    )}`,
     href: `/parents/children/${child.student_id}`,
   }));
 
@@ -104,7 +105,7 @@ export function ParentChildrenPage() {
           />
         </div>
       ) : (
-        <div className="grid gap-3 lg:grid-cols-2">
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           {items.map((item) => (
             <ChildRow key={item.key} item={item} variant="card" />
           ))}

--- a/frontend/src/components/parent/parent-dashboard.tsx
+++ b/frontend/src/components/parent/parent-dashboard.tsx
@@ -206,7 +206,7 @@ export function ParentDashboard() {
             {t("emptyChildren")}
           </p>
         ) : (
-          <div className="grid gap-2 sm:grid-cols-2">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {previewItems.map((item) => (
               <ChildRow key={item.key} item={item} />
             ))}

--- a/frontend/src/components/parent/parent-page.tsx
+++ b/frontend/src/components/parent/parent-page.tsx
@@ -168,7 +168,9 @@ export function ParentFieldGrid({
   className = "",
 }: Readonly<{ children: React.ReactNode; className?: string }>) {
   return (
-    <dl className={`grid gap-4 sm:grid-cols-2 ${className}`}>{children}</dl>
+    <dl className={`grid grid-cols-1 gap-4 sm:grid-cols-2 ${className}`}>
+      {children}
+    </dl>
   );
 }
 

--- a/frontend/src/i18n/messages/de.json
+++ b/frontend/src/i18n/messages/de.json
@@ -1,7 +1,7 @@
 {
   "language": {
     "label": "Sprache",
-    "saveError": "Sprache konnte nicht in deinem Konto gespeichert werden. Die Auswahl gilt auf diesem Gerät."
+    "saveError": "Sprache konnte nicht in Ihrem Konto gespeichert werden. Die Auswahl gilt auf diesem Gerät."
   },
   "datePicker": {
     "placeholder": "Datum auswählen",
@@ -63,7 +63,8 @@
     "childProfile": "Kinderprofil",
     "loading": "Lädt...",
     "feedback": "Feedback",
-    "settings": "Einstellungen"
+    "settings": "Einstellungen",
+    "enroll": "Neue Anmeldung"
   },
   "parentMealPlan": {
     "title": "Essensplan",
@@ -485,9 +486,9 @@
   "guardianInvite": {
     "eyebrow": "Eltern-Portal",
     "title": "Willkommen",
-    "fallbackSchool": "deiner Schule",
-    "subtitle": "Bestätige deine Einladung für {school} und lege dein persönliches Passwort fest.",
-    "errorHelpBefore": "Du kannst eine neue Einladung bei der Schule anfordern oder dich über",
+    "fallbackSchool": "Ihrer Schule",
+    "subtitle": "Bestätigen Sie Ihre Einladung für {school} und legen Sie Ihr persönliches Passwort fest.",
+    "errorHelpBefore": "Sie können eine neue Einladung bei der Schule anfordern oder sich über",
     "startPage": "die Startseite",
     "errorHelpAfter": "anmelden.",
     "contactOgs": "Kontaktieren Sie bitte Ihre OGS.",
@@ -501,15 +502,15 @@
     "formErrors": {
       "expired": "Diese Einladung ist nicht mehr gültig.",
       "notFound": "Einladung wurde nicht gefunden.",
-      "conflict": "Für diese E-Mail existiert bereits ein Konto. Bitte melde dich direkt an oder kontaktiere den Support.",
+      "conflict": "Für diese E-Mail existiert bereits ein Konto. Bitte melden Sie sich direkt an oder kontaktieren Sie den Support.",
       "invalid": "Ungültige Eingaben. Bitte überprüfe das Formular.",
       "generic": "Beim Annehmen der Einladung ist ein Fehler aufgetreten.",
       "passwordRules": "Das Passwort erfüllt noch nicht alle Sicherheitsanforderungen.",
       "passwordMismatch": "Die Passwörter stimmen nicht überein.",
-      "offline": "Keine Netzwerkverbindung. Bitte überprüfe deine Internetverbindung und versuche es erneut."
+      "offline": "Keine Netzwerkverbindung. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."
     },
     "acceptedTitle": "Konto erstellt",
-    "acceptedText": "Bitte melde dich mit deinen neuen Zugangsdaten an.",
+    "acceptedText": "Bitte melden Sie sich mit Ihren neuen Zugangsdaten an.",
     "invitationFor": "Einladung für",
     "passwordLabel": "Passwort",
     "confirmPasswordLabel": "Passwort bestätigen",
@@ -1157,8 +1158,8 @@
   "parentFeedback": {
     "kicker": "Rückmeldung",
     "title": "Feedback",
-    "productTeamNotice": "Dein Feedback geht direkt an das Produktteam von moto, das die App entwickelt. Die OGS deines Kindes sieht diese Beiträge nicht.",
-    "pseudonymNotice": "Du erscheinst für alle nur als „Elternteil“, auch für das Produktteam.",
+    "productTeamNotice": "Ihr Feedback geht direkt an das Produktteam von moto, das die App entwickelt. Die OGS Ihres Kindes sieht diese Beiträge nicht.",
+    "pseudonymNotice": "Sie erscheinen für alle nur als „Elternteil“, auch für das Produktteam.",
     "schoolLabel": "Schule",
     "sortLabel": "Sortierung",
     "sortPopular": "Beliebteste",
@@ -1168,12 +1169,12 @@
     "delete": "Löschen",
     "actions": "Aktionen",
     "emptyTitle": "Noch keine Beiträge",
-    "emptyDescription": "Teile Ideen, melde Probleme oder schlage Verbesserungen an der App vor.",
+    "emptyDescription": "Teilen Sie Ideen, melden Sie Probleme oder schlagen Sie Verbesserungen an der App vor.",
     "noSchoolsTitle": "Noch keine Schule verknüpft",
-    "noSchoolsDescription": "Sobald dein Kind an einer Schule angemeldet ist, kannst du hier Feedback geben.",
+    "noSchoolsDescription": "Sobald Ihr Kind an einer Schule angemeldet ist, können Sie hier Feedback geben.",
     "loadError": "Das Feedback konnte nicht geladen werden.",
     "retry": "Erneut laden",
-    "formHint": "Dieser Beitrag geht an das Produktteam von moto, nicht an die OGS. Andere Eltern deiner Schule können ihn lesen und bewerten.",
+    "formHint": "Dieser Beitrag geht an das Produktteam von moto, nicht an die OGS. Andere Eltern Ihrer Schule können ihn lesen und bewerten.",
     "deleteTitle": "Beitrag löschen?",
     "deleteBody": "Dieser Beitrag und alle Stimmen werden unwiderruflich gelöscht.",
     "deleteSuccess": "Beitrag wurde gelöscht.",
@@ -1185,6 +1186,6 @@
     "statusRejected": "Abgelehnt",
     "statusNeedInfo": "Rückfrage",
     "titlePlaceholder": "z.B. „Erinnerung vor der Abholzeit“",
-    "descriptionPlaceholder": "Beschreibe deine Rückmeldung..."
+    "descriptionPlaceholder": "Beschreiben Sie Ihre Rückmeldung..."
   }
 }

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -63,7 +63,8 @@
     "childProfile": "Child profile",
     "loading": "Loading...",
     "feedback": "Feedback",
-    "settings": "Settings"
+    "settings": "Settings",
+    "enroll": "New enrollment"
   },
   "parentMealPlan": {
     "title": "Meal plan",

--- a/frontend/src/i18n/messages/ru.json
+++ b/frontend/src/i18n/messages/ru.json
@@ -63,7 +63,8 @@
     "childProfile": "Профиль ребенка",
     "loading": "Загрузка...",
     "feedback": "Обратная связь",
-    "settings": "Настройки"
+    "settings": "Настройки",
+    "enroll": "Новая заявка"
   },
   "parentMealPlan": {
     "title": "Меню питания",

--- a/frontend/src/i18n/messages/sq.json
+++ b/frontend/src/i18n/messages/sq.json
@@ -63,7 +63,8 @@
     "childProfile": "Profili i fëmijës",
     "loading": "Po ngarkohet...",
     "feedback": "Reagime",
-    "settings": "Cilësimet"
+    "settings": "Cilësimet",
+    "enroll": "Regjistrim i ri"
   },
   "parentMealPlan": {
     "title": "Plani i ushqimit",


### PR DESCRIPTION
## Zusammenfassung

Mobile-Refactoring des Elternportals nach visuellem Audit auf 375 px, 390 px und 430 px.

### Änderungen

- Elternansichten verwenden auf Mobilgeräten explizit einspaltige Grids; Kind-Karten, Formulare und Statusbereiche bleiben innerhalb des Viewports.
- Der Header zeigt im Elternportal unterhalb von `md` einen gekürzten Seitentitel. Wortmarke und Sprachbezeichnung weichen dort den Icons; Kalender, Feedback und neue Anmeldung haben eigene Seitentitel.
- Kind-Karten priorisieren Klasse und Betreuungszeitraum; der Schulname steht als ruhige dritte Zeile.
- Der Familienkalender erhält einen Karten-Header und kompaktere Steuerelemente. Der Tenant-Kalender bleibt unverändert.
- Deutsche Eltern-Texte für Feedback, Einladungen und Sprachspeicherfehler verwenden durchgehend die Sie-Form.

## Verifikation

```bash
cd frontend && pnpm run check
cd frontend && pnpm run test:run
```

Zusätzlich auf 375 px, 390 px und 430 px prüfen: keine horizontale Scrollbar, lesbarer Seitentitel und bedienbare Kalender-Steuerung. Den Tenant-Kalender auf Desktop gegenprüfen.

## Screenshots

Screenshots folgen im Kommentar.
