### PR TITLE
Profilseite: Bearbeiten in die Datenkarte integriert und entschlackt

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
@@ -142,6 +142,9 @@ vi.mock("lucide-react", () => ({
   Camera: (props: Record<string, unknown>) => (
     <svg data-testid="camera-icon" {...props} />
   ),
+  Pencil: (props: Record<string, unknown>) => (
+    <svg data-testid="pencil-icon" {...props} />
+  ),
   // Used by the PushNotificationSection mounted on the profile page (#2003).
   BellRing: (props: Record<string, unknown>) => (
     <svg data-testid="bell-ring-icon" {...props} />
@@ -243,26 +246,24 @@ describe("ProfilePage", () => {
   });
 
   describe("Profile Form", () => {
-    it("should render profile form fields", async () => {
+    it("should render profile fields in read mode", async () => {
       render(<ProfilePage />);
 
       await waitFor(() => {
-        expect(screen.getByLabelText("Vorname")).toBeInTheDocument();
-        expect(screen.getByLabelText("Nachname")).toBeInTheDocument();
-        expect(screen.getByLabelText("E-Mail")).toBeInTheDocument();
+        expect(screen.getByText("Vorname")).toBeInTheDocument();
+        expect(screen.getByText("Nachname")).toBeInTheDocument();
+        expect(screen.getByText("E-Mail")).toBeInTheDocument();
       });
     });
 
-    it("should display profile data in form fields", async () => {
+    it("should display profile data as text in read mode", async () => {
       render(<ProfilePage />);
 
       await waitFor(() => {
-        expect(screen.getByLabelText("Vorname")).toHaveValue("John");
-        expect(screen.getByLabelText("Nachname")).toHaveValue("Doe");
-        expect(screen.getByLabelText("E-Mail")).toHaveValue(
-          "john.doe@example.com",
-        );
-        expect(screen.getByLabelText("E-Mail")).toBeDisabled();
+        expect(screen.getByText("John")).toBeInTheDocument();
+        expect(screen.getByText("Doe")).toBeInTheDocument();
+        expect(screen.getByText("john.doe@example.com")).toBeInTheDocument();
+        expect(screen.queryByLabelText("Vorname")).not.toBeInTheDocument();
       });
     });
 
@@ -305,7 +306,7 @@ describe("ProfilePage", () => {
       fireEvent.click(screen.getByRole("button", { name: /bearbeiten/i }));
 
       await waitFor(() => {
-        expect(screen.getByLabelText("Vorname")).not.toBeDisabled();
+        expect(screen.getByLabelText("Vorname")).toBeInTheDocument();
         expect(
           screen.getByRole("button", { name: /abbrechen/i }),
         ).toBeInTheDocument();
@@ -327,8 +328,8 @@ describe("ProfilePage", () => {
       fireEvent.click(screen.getByRole("button", { name: /abbrechen/i }));
 
       await waitFor(() => {
-        expect(screen.getByLabelText("Vorname")).toHaveValue("John");
-        expect(screen.getByLabelText("Vorname")).toBeDisabled();
+        expect(screen.queryByLabelText("Vorname")).not.toBeInTheDocument();
+        expect(screen.getByText("John")).toBeInTheDocument();
       });
     });
 
@@ -388,7 +389,7 @@ describe("ProfilePage", () => {
       render(<ProfilePage />);
 
       await waitFor(() => {
-        expect(screen.getByLabelText("Vorname")).toBeInTheDocument();
+        expect(screen.getByText("Vorname")).toBeInTheDocument();
       });
 
       const fileInput = document.querySelector("#avatar-upload")!;
@@ -415,7 +416,7 @@ describe("ProfilePage", () => {
     it("should open password change modal", async () => {
       render(<ProfilePage />);
 
-      fireEvent.click(screen.getByRole("button", { name: /passwort ändern/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^ändern$/i }));
 
       await waitFor(() => {
         expect(screen.getByTestId("password-modal")).toBeInTheDocument();
@@ -425,7 +426,7 @@ describe("ProfilePage", () => {
     it("should close password modal and show success toast on success", async () => {
       render(<ProfilePage />);
 
-      fireEvent.click(screen.getByRole("button", { name: /passwort ändern/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^ändern$/i }));
 
       fireEvent.click(await screen.findByRole("button", { name: "Success" }));
 

--- a/frontend/src/app/[tenant]/(protected)/profile/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 import Image from "next/image";
-import { Camera } from "lucide-react";
+import { Camera, Pencil } from "lucide-react";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
 import { updateProfile, uploadAvatar } from "~/lib/profile-api";
@@ -169,106 +169,123 @@ function ProfileContent() {
               }}
               className="hidden"
             />
-          </div>
-          <button
-            type="button"
-            onClick={() => document.getElementById("avatar-upload")?.click()}
-            className="mt-3 text-xs font-medium text-gray-500 transition-colors hover:text-gray-900"
-          >
-            Profilbild ändern
-          </button>
-        </div>
-
-        {/* Profile Form */}
-        <div className="moto-content-surface rounded-2xl border p-4 backdrop-blur-sm md:p-6">
-          <div className="space-y-4">
-            <Input
-              label="Vorname"
-              name="profile-firstname"
-              type="text"
-              value={formData.firstName}
-              onChange={(e) =>
-                setFormData({ ...formData, firstName: e.target.value })
-              }
-              disabled={!isEditing}
-              maxLength={255}
-            />
-            <Input
-              label="Nachname"
-              name="profile-lastname"
-              type="text"
-              value={formData.lastName}
-              onChange={(e) =>
-                setFormData({ ...formData, lastName: e.target.value })
-              }
-              disabled={!isEditing}
-              maxLength={255}
-            />
-            <Input
-              label="E-Mail"
-              name="profile-email"
-              type="email"
-              value={formData.email}
-              disabled
-              maxLength={255}
-            />
-          </div>
-        </div>
-
-        {/* Action Buttons */}
-        <div className="flex gap-3">
-          {isEditing ? (
-            <>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setIsEditing(false);
-                  resetFormFromProfile();
-                }}
-              >
-                Abbrechen
-              </Button>
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                isLoading={isSaving}
-                loadingText="Speichern..."
-                onClick={() => void handleSaveProfile()}
-              >
-                Speichern
-              </Button>
-            </>
-          ) : (
-            <Button
+            <button
               type="button"
-              variant="primary"
-              size="sm"
-              onClick={() => setIsEditing(true)}
+              aria-label="Profilbild ändern"
+              onClick={() => document.getElementById("avatar-upload")?.click()}
+              className="absolute -right-1 -bottom-1 flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-600 shadow-sm transition-colors hover:text-gray-900"
             >
-              Bearbeiten
-            </Button>
+              <Camera className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Profile Data */}
+        <div className="moto-content-surface rounded-2xl border p-4 backdrop-blur-sm md:p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className="text-base font-semibold text-gray-900">
+              Persönliche Daten
+            </h3>
+            {!isEditing && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="compact"
+                onClick={() => setIsEditing(true)}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                Bearbeiten
+              </Button>
+            )}
+          </div>
+          {isEditing ? (
+            <div className="space-y-4">
+              <Input
+                label="Vorname"
+                name="profile-firstname"
+                type="text"
+                value={formData.firstName}
+                onChange={(e) =>
+                  setFormData({ ...formData, firstName: e.target.value })
+                }
+                maxLength={255}
+              />
+              <Input
+                label="Nachname"
+                name="profile-lastname"
+                type="text"
+                value={formData.lastName}
+                onChange={(e) =>
+                  setFormData({ ...formData, lastName: e.target.value })
+                }
+                maxLength={255}
+              />
+              <div>
+                <span className="text-xs font-medium text-gray-500">
+                  E-Mail
+                </span>
+                <p className="text-sm font-medium text-gray-900">
+                  {formData.email}
+                </p>
+              </div>
+              <div className="flex justify-end gap-3 pt-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="md"
+                  onClick={() => {
+                    setIsEditing(false);
+                    resetFormFromProfile();
+                  }}
+                >
+                  Abbrechen
+                </Button>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="md"
+                  isLoading={isSaving}
+                  loadingText="Speichern..."
+                  onClick={() => void handleSaveProfile()}
+                >
+                  Speichern
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <dl className="space-y-3">
+              <div>
+                <dt className="text-xs font-medium text-gray-500">Vorname</dt>
+                <dd className="text-sm font-medium text-gray-900">
+                  {formData.firstName || "–"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium text-gray-500">Nachname</dt>
+                <dd className="text-sm font-medium text-gray-900">
+                  {formData.lastName || "–"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium text-gray-500">E-Mail</dt>
+                <dd className="text-sm font-medium text-gray-900">
+                  {formData.email || "–"}
+                </dd>
+              </div>
+            </dl>
           )}
         </div>
 
         {/* Security Section */}
-        <div className="moto-content-surface rounded-2xl border p-4 backdrop-blur-sm md:p-6">
-          <h3 className="mb-3 text-base font-semibold text-gray-900">
-            Passwort ändern
-          </h3>
-          <p className="mb-4 text-sm text-gray-600">
-            Aktualisieren Sie Ihr Passwort regelmäßig für zusätzliche
-            Sicherheit.
-          </p>
+        <div className="moto-content-surface flex items-center justify-between rounded-2xl border p-4 backdrop-blur-sm md:p-6">
+          <h3 className="text-base font-semibold text-gray-900">Passwort</h3>
           <Button
             type="button"
-            variant="primary"
-            size="sm"
+            variant="outline"
+            size="md"
             onClick={() => setShowPasswordModal(true)}
           >
-            Passwort ändern
+            Ändern
           </Button>
         </div>
 

--- a/frontend/src/components/settings/birthday-visibility-section.tsx
+++ b/frontend/src/components/settings/birthday-visibility-section.tsx
@@ -76,9 +76,8 @@ export function BirthdayVisibilitySection() {
       </div>
 
       <p className="mb-4 text-sm text-gray-600">
-        Wenn Ihre Schule die Geburtstagsanzeige für das Team eingeschaltet hat,
-        erscheint Ihr Name an Ihrem Geburtstag auf der Startseite. Ihr
-        Geburtsjahr wird dabei nie angezeigt.
+        Ihr Name erscheint an Ihrem Geburtstag auf der Startseite, ohne
+        Geburtsjahr.
       </p>
 
       {error && (

--- a/frontend/src/components/settings/notification-preferences-section.tsx
+++ b/frontend/src/components/settings/notification-preferences-section.tsx
@@ -161,8 +161,7 @@ export function NotificationPreferencesSection({
       />
 
       <p className="mb-4 text-sm text-gray-600">
-        Wählen Sie, worüber moto Sie informieren soll. Es wird nur verschickt,
-        was Sie hier einschalten.
+        Wählen Sie, worüber moto Sie informieren soll.
       </p>
 
       {error && (

--- a/frontend/src/components/settings/push-notification-section.test.tsx
+++ b/frontend/src/components/settings/push-notification-section.test.tsx
@@ -35,10 +35,10 @@ describe("PushNotificationSection", () => {
   it("shows the enable button when push is supported and not subscribed", async () => {
     render(<PushNotificationSection />);
     expect(
-      await screen.findByRole("button", { name: "Aktivieren" }),
+      await screen.findByRole("button", { name: "Einschalten" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Erhalten Sie Erinnerungen als Systembenachrichtigung/),
+      screen.getByText(/Bekommen Sie Erinnerungen direkt auf dieses Gerät/),
     ).toBeInTheDocument();
   });
 
@@ -47,7 +47,7 @@ describe("PushNotificationSection", () => {
     render(<PushNotificationSection />);
     expect(await screen.findByText(/Zum Home-Bildschirm/)).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Aktivieren" }),
+      screen.queryByRole("button", { name: "Einschalten" }),
     ).not.toBeInTheDocument();
   });
 
@@ -56,7 +56,7 @@ describe("PushNotificationSection", () => {
     render(<PushNotificationSection />);
     expect(
       await screen.findByText(
-        "Dieser Browser unterstützt keine Push-Benachrichtigungen.",
+        "Dieser Browser kann leider keine Benachrichtigungen anzeigen.",
       ),
     ).toBeInTheDocument();
   });
@@ -75,16 +75,14 @@ describe("PushNotificationSection", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Aktivieren" }),
+      screen.queryByRole("button", { name: "Einschalten" }),
     ).not.toBeInTheDocument();
   });
 
   it("shows the blocked message when permission is denied", async () => {
     stubNotificationPermission("denied");
     render(<PushNotificationSection />);
-    expect(
-      await screen.findByText(/für diese Seite blockiert/),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/für moto blockiert/)).toBeInTheDocument();
   });
 
   it("subscribes via the push API and flips to the active state", async () => {
@@ -96,24 +94,24 @@ describe("PushNotificationSection", () => {
     });
 
     render(<PushNotificationSection portal="tenant" />);
-    fireEvent.click(await screen.findByRole("button", { name: "Aktivieren" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Einschalten" }));
 
     await waitFor(() =>
       expect(pushApi.subscribePush).toHaveBeenCalledWith("tenant"),
     );
     expect(
       await screen.findByText(
-        "Benachrichtigungen sind auf diesem Gerät aktiviert.",
+        "Benachrichtigungen sind auf diesem Gerät eingeschaltet.",
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Deaktivieren" }),
+      screen.getByRole("button", { name: "Ausschalten" }),
     ).toBeInTheDocument();
   });
 
   it("passes the parent portal through to the push API", async () => {
     render(<PushNotificationSection portal="parent" />);
-    fireEvent.click(await screen.findByRole("button", { name: "Aktivieren" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Einschalten" }));
     await waitFor(() =>
       expect(pushApi.subscribePush).toHaveBeenCalledWith("parent"),
     );
@@ -124,7 +122,7 @@ describe("PushNotificationSection", () => {
       new Error("Benachrichtigungen wurden nicht erlaubt."),
     );
     render(<PushNotificationSection />);
-    fireEvent.click(await screen.findByRole("button", { name: "Aktivieren" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Einschalten" }));
     expect(
       await screen.findByText("Benachrichtigungen wurden nicht erlaubt."),
     ).toBeInTheDocument();
@@ -140,15 +138,13 @@ describe("PushNotificationSection", () => {
     });
 
     render(<PushNotificationSection />);
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Deaktivieren" }),
-    );
+    fireEvent.click(await screen.findByRole("button", { name: "Ausschalten" }));
 
     await waitFor(() =>
       expect(pushApi.unsubscribePush).toHaveBeenCalledWith("tenant"),
     );
     expect(
-      await screen.findByRole("button", { name: "Aktivieren" }),
+      await screen.findByRole("button", { name: "Einschalten" }),
     ).toBeInTheDocument();
   });
 
@@ -216,7 +212,7 @@ describe("PushNotificationSection", () => {
     expect(
       await screen.findByRole("button", { name: "Wird gesendet…" }),
     ).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Deaktivieren" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Ausschalten" })).toBeDisabled();
 
     finishRequest?.();
     await screen.findByText("Testbenachrichtigung wurde gesendet.");

--- a/frontend/src/components/settings/push-notification-section.test.tsx
+++ b/frontend/src/components/settings/push-notification-section.test.tsx
@@ -71,7 +71,7 @@ describe("PushNotificationSection", () => {
 
     expect(
       await screen.findByText(
-        "Push-Benachrichtigungen sind auf diesem Server nicht eingerichtet.",
+        "Benachrichtigungen sind hier zurzeit nicht verfügbar.",
       ),
     ).toBeInTheDocument();
     expect(

--- a/frontend/src/components/settings/push-notification-section.tsx
+++ b/frontend/src/components/settings/push-notification-section.tsx
@@ -86,7 +86,7 @@ export function PushNotificationSection({
         disabled={busy}
         onClick={() => void enable()}
       >
-        Aktivieren
+        Einschalten
       </Button>
     ) : state === "subscribed" ? (
       <Button
@@ -96,7 +96,7 @@ export function PushNotificationSection({
         disabled={busy}
         onClick={() => void disable()}
       >
-        Deaktivieren
+        Ausschalten
       </Button>
     ) : null;
 
@@ -106,7 +106,7 @@ export function PushNotificationSection({
     setMessage(null);
     try {
       await subscribePush(portal);
-      setMessage("Benachrichtigungen sind auf diesem Gerät aktiviert.");
+      setMessage("Benachrichtigungen sind auf diesem Gerät eingeschaltet.");
       await refresh();
     } catch (err) {
       logger.error("push_subscribe_failed", {
@@ -115,7 +115,7 @@ export function PushNotificationSection({
       setError(
         err instanceof Error
           ? err.message
-          : "Benachrichtigungen konnten nicht aktiviert werden.",
+          : "Das hat leider nicht geklappt. Bitte versuchen Sie es noch einmal.",
       );
       await refresh();
     } finally {
@@ -129,7 +129,7 @@ export function PushNotificationSection({
     setMessage(null);
     try {
       await unsubscribePush(portal);
-      setMessage("Benachrichtigungen sind auf diesem Gerät deaktiviert.");
+      setMessage("Benachrichtigungen sind auf diesem Gerät ausgeschaltet.");
       await refresh();
     } catch (err) {
       logger.error("push_unsubscribe_failed", {
@@ -138,7 +138,7 @@ export function PushNotificationSection({
       setError(
         err instanceof Error
           ? err.message
-          : "Benachrichtigungen konnten nicht deaktiviert werden.",
+          : "Das hat leider nicht geklappt. Bitte versuchen Sie es noch einmal.",
       );
     } finally {
       setBusy(false);
@@ -160,7 +160,7 @@ export function PushNotificationSection({
       setError(
         err instanceof Error
           ? err.message
-          : "Testbenachrichtigung konnte nicht gesendet werden. Prüfen Sie die Verbindung und versuchen Sie es erneut.",
+          : "Das Senden hat nicht geklappt. Bitte versuchen Sie es noch einmal.",
       );
     } finally {
       setTesting(false);
@@ -194,17 +194,16 @@ export function PushNotificationSection({
 
       {state === "needs-install" && (
         <p className="text-sm text-gray-600">
-          Auf iPhone und iPad funktionieren Benachrichtigungen nur, wenn die App
-          zuerst zum Home-Bildschirm hinzugefügt wurde: In Safari das
-          Teilen-Symbol antippen und {"„"}Zum Home-Bildschirm{"“"} wählen.
-          Danach die App vom Home-Bildschirm aus öffnen und Benachrichtigungen
-          hier aktivieren.
+          Auf iPhone und iPad geht das nur, wenn moto auf dem Home-Bildschirm
+          liegt. So geht es: In Safari unten auf das Teilen-Symbol tippen, dann
+          {" „"}Zum Home-Bildschirm{"“"} wählen. Danach moto von dort öffnen und
+          die Benachrichtigungen hier einschalten.
         </p>
       )}
 
       {state === "unsupported" && (
         <p className="text-sm text-gray-600">
-          Dieser Browser unterstützt keine Push-Benachrichtigungen.
+          Dieser Browser kann leider keine Benachrichtigungen anzeigen.
         </p>
       )}
 
@@ -216,23 +215,23 @@ export function PushNotificationSection({
 
       {state === "denied" && (
         <p className="text-sm text-gray-600">
-          Benachrichtigungen wurden für diese Seite blockiert. Bitte in den
-          Browser-Einstellungen wieder erlauben, um sie zu aktivieren.
+          Benachrichtigungen sind für moto blockiert. Sie können sie in den
+          Einstellungen Ihres Browsers wieder erlauben.
         </p>
       )}
 
       {state === "unsubscribed" && (
         <p className="text-sm text-gray-600">
-          Erhalten Sie Erinnerungen als Systembenachrichtigung auf diesem Gerät,
-          auch wenn die App geschlossen ist.
+          Bekommen Sie Erinnerungen direkt auf dieses Gerät, auch wenn moto
+          gerade geschlossen ist.
         </p>
       )}
 
       {state === "subscribed" && (
         <div>
           <p className="text-sm text-gray-600">
-            Benachrichtigungen sind auf diesem Gerät aktiv. Erinnerungen kommen
-            auch bei geschlossener App an.
+            Benachrichtigungen sind auf diesem Gerät eingeschaltet. Erinnerungen
+            kommen auch an, wenn moto geschlossen ist.
           </p>
           {portal === "tenant" && (
             <Button

--- a/frontend/src/components/settings/push-notification-section.tsx
+++ b/frontend/src/components/settings/push-notification-section.tsx
@@ -210,7 +210,7 @@ export function PushNotificationSection({
 
       {state === "disabled" && (
         <p className="text-sm text-gray-600">
-          Push-Benachrichtigungen sind auf diesem Server nicht eingerichtet.
+          Benachrichtigungen sind hier zurzeit nicht verfügbar.
         </p>
       )}
 

--- a/frontend/src/components/settings/trusted-devices-section.tsx
+++ b/frontend/src/components/settings/trusted-devices-section.tsx
@@ -106,9 +106,8 @@ export function TrustedDevicesSection({
           Meine vertrauten Geräte
         </h3>
         <p className="mt-1 text-sm text-gray-600">
-          Geräte, auf denen Sie sich gemerkt haben, müssen den 2FA-Code nicht
-          erneut eingeben. Entfernen Sie hier Geräte, die Sie nicht mehr
-          besitzen oder verloren haben.
+          Gemerkte Geräte überspringen den 2FA-Code. Entfernen Sie Geräte, die
+          Sie nicht mehr nutzen.
         </p>
       </div>
 


### PR DESCRIPTION
## Zusammenfassung

- **Persönliche-Daten-Karte**: Der "Bearbeiten"-Button sitzt jetzt als Ghost-Button mit Stift-Icon oben rechts in der Karte statt als verlorener Block darunter. Im Lesemodus werden Vorname/Nachname/E-Mail als kompakte Label/Wert-Paare gezeigt statt drei ausgegrauter Inputs; erst im Editmodus erscheinen die Inputs mit Abbrechen/Speichern rechtsbündig in der Karte.
- **Avatar**: Der redundante Textbutton "Profilbild ändern" ist entfernt; stattdessen ein sichtbarer Camera-Badge an der Avatar-Ecke (Touch-Geräte haben keinen Hover).
- **Passwort-Karte**: Auf eine Zeile reduziert ("Passwort" + "Ändern"), Erklär-Absatz entfernt.
- **Copy gekürzt**: Geburtstags-, Vertraute-Geräte- und Benachrichtigungs-Sektion auf je einen knappen Satz. Push/Passkey-Sektionen unverändert (zustandsabhängige Texte).

Speicher-/Upload-Logik, Toasts und Kontexte sind unverändert; nur die Darstellung wurde umgebaut.

## Tests

- `pnpm run test:run` grün (13698 Tests, `page.test.tsx` an den neuen Lesemodus angepasst)
- `pnpm run check` exit 0
- Visuell gegen den lokalen Stack verifiziert (Read- und Editmodus, Screenshots folgen im Kommentar)