### PR TITLE
feat: add responsive-screenshots skill for device-size sweeps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,12 @@ If native upload is not available from the current tool context, provide the
 local screenshot paths and ask the user to attach them manually. Do not use
 releases, prereleases, tags, or Gists as an asset host.
 
+**Sanctioned exception — screenshot orphan branches (`pr-<NR>-screenshots`)**:
+responsive sweeps and other agent-produced QA imagery MAY be hosted on a
+dedicated orphan branch and linked by commit SHA in a `gh pr comment`, as
+prescribed by the `responsive-screenshots` skill. One branch per PR, named
+`pr-<NR>-screenshots`, deleted after merge once the links are no longer needed.
+
 ## Database Schemas
 
 `platform` · `auth` · `users` · `education` · `facilities` · `activities` · `active` · `schedule` · `iot` · `feedback` · `config` · `enrollment` · `suggestions` · `meta` · `audit`

--- a/frontend/.claude/skills/responsive-screenshots/SKILL.md
+++ b/frontend/.claude/skills/responsive-screenshots/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: responsive-screenshots
+description: Use when a frontend change needs a responsiveness check across device sizes. Captures every relevant view on iPhone SE, iPhone 12, iPhone 16 Pro Max, iPad Air, iPad Pro and desktop with agent-browser. Triggers on "responsiveness", "mobile check", "alle Auflösungen", "device sweep", or before merging UI work that touches layout.
+metadata:
+  author: moto-nrw
+  version: "1.0.0"
+---
+
+# Responsive Screenshot Sweep
+
+Capture every relevant view of a portal at the six canonical viewports so
+layout breaks (overflow, truncation, stacked controls, hidden context) become
+visible before review. Output: one PNG per route × viewport plus an overflow
+report.
+
+## Viewports (logical CSS pixels)
+
+| Tag    | Device            | Size      |
+|--------|-------------------|-----------|
+| `se`   | iPhone SE         | 375×667   |
+| `12p`  | iPhone 12 / Pro   | 390×844   |
+| `16pm` | iPhone 16 Pro Max | 430×932   |
+| `air`  | iPad Air          | 820×1180  |
+| `pro`  | iPad Pro 12.9"    | 1024×1366 |
+| `dt`   | Desktop           | 1440×900  |
+
+375 is the floor: what survives `se` survives everything. Tablets catch the
+`md:`/`lg:` breakpoint seams (sidebar vs bottom nav, grid column switches).
+
+## Prerequisites
+
+- Stack running (`docker compose up -d`); logins come from
+  `backend/.seed-state.json` (parents portal: guardian accounts are in the DB,
+  seed password `ParentSeed1234%` unless `--staff-password` was set).
+- Log in once via the UI, keep the agent-browser daemon alive. JWTs expire
+  after 15 min — a long sweep can silently land on the login page (see gotchas).
+- Build the route list from the portal's nav (snapshot the bottom nav / sidebar
+  / "Mehr" menu and collect hrefs), including detail pages (`/children/1`),
+  not just top-level tabs.
+
+## Sweep script pattern
+
+```bash
+S=<scratchpad>/shots; mkdir -p $S
+routes="/parents:dash /parents/children:children /parents/children/1:child ..."
+for vp in "375 667 se" "390 844 12p" "430 932 16pm" "820 1180 air" "1024 1366 pro" "1440 900 dt"; do
+  read w h tag <<< "$vp"
+  agent-browser set viewport $w $h >/dev/null
+  for r in $routes; do
+    path=${r%%:*}; name=${r##*:}
+    agent-browser open "http://<host>$path" >/dev/null 2>&1
+    agent-browser wait --load networkidle >/dev/null 2>&1; sleep 1
+    agent-browser screenshot --full "$S/$name-$tag.png" >/dev/null 2>&1
+    ow=$(agent-browser eval "document.documentElement.scrollWidth" | tr -d '"')
+    [ "$ow" -gt "$w" ] 2>/dev/null && echo "OVERFLOW $name-$tag: $ow > $w"
+  done
+done
+```
+
+The `scrollWidth > viewport` probe is the payoff: it catches horizontal
+overflow objectively, even when the screenshot "looks fine" at a glance.
+To find the offending element, iterate `querySelectorAll('*')` and report
+nodes whose `getBoundingClientRect().right` exceeds the viewport width.
+
+## Gotchas (all hit in practice)
+
+- **Session expiry mid-sweep**: after ~15 min every screenshot is the login
+  page. Detect it via identical file sizes across routes (`ls -la` — same
+  byte count for different routes = same page). Re-login and retake only
+  those files.
+- **Fullpage screenshots lie about fixed elements**: `screenshot --full`
+  renders `position: fixed` chrome (bottom nav) at its viewport position,
+  mid-page. An apparent overlap there is an artifact — verify live by
+  scrolling to the element and checking `getBoundingClientRect()` against the
+  nav before filing a bug.
+- **Dockerized `next dev` crash-loops** compiling `[tenant]` pages; if pages
+   500/refuse mid-sweep, check `docker compose ps frontend` and retake with
+  retries. Prefer local `pnpm dev` for long sweeps (see `ui-before-after`).
+- **Dedicated session for parallel work**: `agent-browser --session <name>`;
+  the default session is shared across concurrent Claude sessions, which can
+  swap your login or tab out from under you.
+- **A `grid gap-* lg:grid-cols-2` without `grid-cols-1`** is the classic
+  overflow root cause the probe finds: below the breakpoint the implicit auto
+  column grows to max-content and `truncate` stops working.
+
+## Delivery
+
+Read the worst-viewport (`se`) shots yourself and fix what they show; attach
+pairs/sweeps to the PR per the PR-screenshots rule in the root `CLAUDE.md`.
+For before/after pairs of a specific change use the `ui-before-after` skill —
+this skill is the breadth sweep, that one is the depth comparison.

--- a/frontend/.claude/skills/responsive-screenshots/SKILL.md
+++ b/frontend/.claude/skills/responsive-screenshots/SKILL.md
@@ -83,9 +83,40 @@ nodes whose `getBoundingClientRect().right` exceeds the viewport width.
   overflow root cause the probe finds: below the breakpoint the implicit auto
   column grows to max-content and `truncate` stops working.
 
-## Delivery
+## Delivery: ALWAYS post the sweep as a PR comment via gh
 
-Read the worst-viewport (`se`) shots yourself and fix what they show; attach
-pairs/sweeps to the PR per the PR-screenshots rule in the root `CLAUDE.md`.
+Read the worst-viewport (`se`) shots yourself and fix what they show. Then
+publish the sweep on the PR — do not stop at local file paths. GitHub has no
+API for comment image uploads, so host the PNGs on an orphan branch and link
+them by commit SHA (public repo, raw URLs render fine):
+
+```bash
+git checkout --orphan pr-<NR>-screenshots
+git rm -rf --cached . -q
+mkdir -p screenshots-pr<NR> && cp <shots>/*.png screenshots-pr<NR>/
+git add screenshots-pr<NR>
+git commit -m "docs: Screenshots für PR #<NR>" --no-verify
+git push -u origin pr-<NR>-screenshots
+git checkout -f <feature-branch>   # -f: the orphan switch untracks the old tree
+SHA=$(git rev-parse pr-<NR>-screenshots)
+BASE="https://raw.githubusercontent.com/<owner>/<repo>/$SHA/screenshots-pr<NR>"
+gh pr comment <NR> --body-file <comment.md>   # ![…]($BASE/<name>.png) per shot
+```
+
+Structure the comment: before/after pairs first (if any), then one collapsed
+`<details>` block per viewport with all views. Short caption above every image.
+
+**Re-running the sweep? UPDATE, don't stack comments**: commit the new PNGs to
+the same orphan branch, take the new SHA, then edit the existing comment:
+
+```bash
+gh api repos/<owner>/<repo>/issues/comments/<comment-id> -X PATCH -F body=@<comment.md>
+```
+
+(Find the comment id via `gh api repos/<owner>/<repo>/issues/<NR>/comments`.)
+Leave the orphan branch alive while the PR needs the links; link via SHA, not
+branch name. This flow is the sanctioned exception to the root `CLAUDE.md`
+no-screenshot-branches rule for sweep deliveries.
+
 For before/after pairs of a specific change use the `ui-before-after` skill —
 this skill is the breadth sweep, that one is the depth comparison.


### PR DESCRIPTION
## Summary

Neuer Frontend-Skill `responsive-screenshots` (`frontend/.claude/skills/`): ein wiederholbarer Screenshot-Sweep über alle relevanten Views eines Portals auf sechs kanonischen Viewports, damit Responsiveness-Brüche vor dem Review sichtbar werden.

### Viewports

iPhone SE (375×667), iPhone 12 (390×844), iPhone 16 Pro Max (430×932), iPad Air (820×1180), iPad Pro 12.9" (1024×1366), Desktop (1440×900).

### Inhalt

- Sweep-Script-Pattern mit agent-browser (Route-Liste × Viewports, Fullpage-Screenshots)
- Objektiver Overflow-Check per `document.documentElement.scrollWidth > viewport` inkl. Element-Lokalisierung — findet horizontale Overflows auch dann, wenn der Screenshot harmlos aussieht
- Gotchas aus der Praxis (Elternapp-Refactoring PR #2279): JWT-Ablauf mitten im Sweep (identische Dateigrößen als Erkennungssignal), Fullpage-Screenshot-Artefakte bei `position: fixed`, Docker-`next dev`-Crash-Loop, geteilte agent-browser-Default-Session, `grid` ohne `grid-cols-1` als klassische Overflow-Ursache
- Abgrenzung zu `ui-before-after` (Breiten-Sweep vs. Vorher/Nachher-Vergleich)

Frontend-scoped wie die übrigen Skills dort; lädt nur, wenn unter `frontend/` gearbeitet wird.