### PR TITLE
fix: Migrationskollision 1.15.292 auflösen

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,3 +18,62 @@ Eine **Rücknahme** öffnet eine gerade beendete Aktivität innerhalb von fünf
 Minuten kontrolliert wieder. Sie stellt die aktive Raumaufsicht und die beim
 Beenden noch anwesenden Kinder wieder her; eine Aktivität zu einem späteren
 Zeitpunkt neu anzulegen ist keine Rücknahme.
+
+## Elternänderung
+
+Eine **Elternänderung** ist eine von einer sorgeberechtigten Person gewünschte
+Änderung an den Betreuungsdaten eines Kindes. Welche Arten von Elternänderungen
+eingereicht werden dürfen, legt die OGS je Änderungsart fest.
+
+## Elternanfrage
+
+Eine **Elternanfrage** ist eine eingereichte Elternänderung, über die ein
+OGS-Admin noch entscheiden muss. Sie verändert die wirksamen Betreuungsdaten
+erst nach der Bestätigung.
+
+## Elternmitteilung
+
+Eine **Elternmitteilung** informiert die OGS über einen Sachverhalt, den sie
+nicht genehmigen oder ablehnen kann, etwa eine Krankmeldung. Sie gilt sofort
+und kann von der OGS als gelesen markiert werden.
+
+## Freigabeansicht
+
+Die **Freigabeansicht** ist die gemeinsame Arbeitsliste der OGS für alle
+Elternanfragen. Sie macht Änderungsart, betroffenes Kind und gewünschte Änderung
+in einfacher Sprache erkennbar und fasst offene Vorgänge pro Kind zusammen.
+
+## Abgelaufene Elternanfrage
+
+Eine **abgelaufene Elternanfrage** betrifft ausschließlich vergangene
+Betreuungsdaten. Sie verändert diese Daten nicht mehr und kann von der OGS nur
+noch als erledigt markiert werden.
+
+## Anfragekonflikt
+
+Ein **Anfragekonflikt** liegt vor, wenn offene Elternanfragen für denselben
+Betreuungswert unterschiedliche Ergebnisse verlangen. Die OGS legt für den Wert
+ein einziges Ergebnis fest; sie bestätigt niemals widersprüchliche Ergebnisse
+nebeneinander.
+
+## Entscheidungskorrektur
+
+Eine **Entscheidungskorrektur** ersetzt das Ergebnis einer früheren Entscheidung,
+ohne diese aus der Historie zu entfernen. Eltern werden über das neue Ergebnis
+informiert.
+
+## Gemeinsamer Betreuungsstand
+
+Der **gemeinsame Betreuungsstand** umfasst die wirksamen Betreuungsdaten eines
+Kindes, die allen dafür berechtigten Sorgeberechtigten angezeigt werden.
+
+## Private Anfrageangaben
+
+**Private Anfrageangaben** sind Urheber und Begründung einer Elternanfrage. Sie
+sind nur für die einreichende Person und die OGS sichtbar, solange die Person
+sie nicht ausdrücklich mit anderen Sorgeberechtigten teilt.
+
+## Familienschutz
+
+Der **Familienschutz** ist eine von der OGS verwaltete Regel für ein Kind, die
+das Teilen privater Anfrageangaben zwischen Sorgeberechtigten verhindert.

--- a/backend/database/migrations/001015294_add_users_absence_permission.go
+++ b/backend/database/migrations/001015294_add_users_absence_permission.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	addUsersAbsencePermissionVersion     = "1.15.292"
+	addUsersAbsencePermissionVersion     = "1.15.294"
 	addUsersAbsencePermissionDescription = "Add users:absence permission for managing student absence statuses without fixed groups"
 )
 
@@ -33,7 +33,7 @@ func init() {
 }
 
 func addUsersAbsencePermissionUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.292: Adding users:absence permission and granting to user role...")
+	fmt.Println("Migration 1.15.294: Adding users:absence permission and granting to user role...")
 
 	// Mirrors 1.15.49 (users:checkin): auth.permissions requires resource+action
 	// and is unique on both (resource, action) and name. Admin wildcards
@@ -68,7 +68,7 @@ func addUsersAbsencePermissionUp(ctx context.Context, db *bun.DB) error {
 }
 
 func addUsersAbsencePermissionDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.292: Removing users:absence permission...")
+	fmt.Println("Rolling back migration 1.15.294: Removing users:absence permission...")
 
 	// role_permissions rows cascade on permission delete.
 	_, err := db.NewRaw(`DELETE FROM auth.permissions WHERE name = 'users:absence';`).Exec(ctx)


### PR DESCRIPTION
PRs #2238 und #2228 haben beide die Migrationsversion 1.15.292 registriert; seit dem Merge beider paniced der Registry-Init auf development (validate-migrations, test-backend und lint rot).

Fix: die unabhängige users:absence-Migration (#2238) zieht auf die nächste freie Version **1.15.294** um (Datei umbenannt, Konstante + Log-Strings angepasst). 1.15.293 bleibt beim School-Identity-Repair, das per Konstante vom base_role-Backfill (1.15.292) abhängt — Abhängigkeitskette unverändert.

`go run main.go migrate validate` läuft lokal wieder durch. Blockiert Release-PR #2285.