### PR TITLE
fix(enrollment): Anschlussphase übernimmt vollständige Betreuungsbuchungen und Wochentage

### DIFF
--- a/backend/api/students/list_projection_test.go
+++ b/backend/api/students/list_projection_test.go
@@ -82,6 +82,10 @@ func listStudentIDs(t *testing.T, body []byte) []int64 {
 // full record separately.
 func TestListStudents_SlimProjection(t *testing.T) {
 	tc := setupTestContext(t)
+	// Pin the clock to a fixed Monday: departure_modes exist for mon-fri only
+	// (departureDayKey has no weekend mapping), so a real-today run fails on
+	// every Saturday/Sunday CI run.
+	tc.resource.Now = func() time.Time { return time.Date(2026, time.June, 1, 10, 0, 0, 0, time.UTC) }
 
 	student := testpkg.CreateTestStudent(t, tc.db, "Slim", "Kind", "SL1")
 	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID)

--- a/backend/api/students/partial_absence_test.go
+++ b/backend/api/students/partial_absence_test.go
@@ -162,9 +162,13 @@ func TestFullDayStatusDoesNotOverwritePartialAbsence(t *testing.T) {
 
 func TestPartialAbsenceIsAPlannedPickupTimeWithoutAFullDayStatus(t *testing.T) {
 	tc := setupTestContext(t)
+	// Pin the clock to a fixed Monday: the effective-time resolver skips
+	// Saturday/Sunday entirely (weekday > WeekdayFriday), so a real-today
+	// date makes this test fail on every weekend CI run.
+	tc.resource.Now = func() time.Time { return time.Date(2026, time.June, 1, 10, 0, 0, 0, time.UTC) }
 	student := testpkg.CreateTestStudent(t, tc.db, "Planning", "Partial", "PA4")
 	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Planning", "Teacher")
-	date := timezone.TodayDate()
+	date := timezone.NewDate(2026, 6, 1)
 	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, tc.db, student.ID, teacher.ID) })
 
 	partialReq := testutil.NewAuthenticatedRequest(t, http.MethodPost, fmt.Sprintf("/%d/partial-absences", student.ID), map[string]any{

--- a/backend/database/repositories/enrollment/care_offering_repository.go
+++ b/backend/database/repositories/enrollment/care_offering_repository.go
@@ -205,8 +205,9 @@ func (r *CareOfferingRepository) ListByPhase(ctx context.Context, phaseID int64)
 }
 
 // ListByIDs returns the exact care offerings referenced by ids. It is not
-// phase-scoped because rollover request children can intentionally carry
-// source-phase offering IDs into the target phase.
+// phase-scoped: callers like the decision path resolve whatever IDs are
+// persisted on a request child, and legacy pre-#2249 rollover rows may
+// still carry source-phase offering IDs.
 func (r *CareOfferingRepository) ListByIDs(ctx context.Context, ids []int64) ([]*enrollment.CareOffering, error) {
 	if len(ids) == 0 {
 		return []*enrollment.CareOffering{}, nil

--- a/backend/services/enrollment/care_offering_service.go
+++ b/backend/services/enrollment/care_offering_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
@@ -68,9 +69,10 @@ type CareOfferingService interface {
 // CareOfferingSeriesValidator — so HTTP-layer mocks never implement an
 // operation that is not an enrollment endpoint.
 //
-// CloneCatalogForRollover copies EVERY care offering of the source phase
-// into the target phase and returns the source→target offering ID
-// mapping. Unlike the admin Clone it keeps the linked timetable template
+// CloneCatalogForRollover copies EVERY care offering of the source phase,
+// plus effective legacy bookings that reference an earlier phase, into the
+// target phase and returns the source→target offering ID mapping. Unlike the
+// admin Clone it keeps the linked timetable template
 // (activity_group_id): the link resolution is split-series-aware, so a
 // template whose recurrence covers the target phase keeps feeding
 // materialization, and one that does not fails validation here —
@@ -80,7 +82,7 @@ type CareOfferingService interface {
 // are deliberately NOT rewritten — re-pointing period-bound templates at
 // the new phase's offerings is planning work the admin owns.
 type RolloverOfferingCatalogCloner interface {
-	CloneCatalogForRollover(ctx context.Context, sourcePhaseID int64, targetPhaseID int64) (map[int64]int64, error)
+	CloneCatalogForRollover(ctx context.Context, sourcePhaseID int64, targetPhaseID int64, carriedOfferingIDs []int64) (map[int64]int64, error)
 }
 
 // CareOfferingSeriesValidator is the narrow cross-domain contract used by the
@@ -756,6 +758,16 @@ func (s *careOfferingService) validateLinkedTemplate(ctx context.Context, offeri
 	if err != nil {
 		return err
 	}
+	return s.validateLinkedTemplateForMaterialization(ctx, offering, phase, deps, requiresMaterialization)
+}
+
+func (s *careOfferingService) validateLinkedTemplateForMaterialization(
+	ctx context.Context,
+	offering *enrollmentModels.CareOffering,
+	phase *enrollmentModels.Phase,
+	deps careOfferingTemplateDeps,
+	requiresMaterialization bool,
+) error {
 	segments, err := resolveCareOfferingLinkedGroupsForPhase(ctx, deps, *offering.ActivityGroupID, phase)
 	if err != nil {
 		return err
@@ -1124,6 +1136,8 @@ func (s *careOfferingService) Clone(ctx context.Context, sourceID int64, targetP
 
 	clone := *source
 	clone.ID = 0 // BIGSERIAL - let the DB assign
+	clone.CreatedAt = time.Time{}
+	clone.UpdatedAt = time.Time{}
 	clone.PhaseID = targetPhaseID
 	if source.PhaseID != targetPhaseID && clone.ActivityGroupID != nil {
 		clone.ActivityGroupID = nil
@@ -1152,7 +1166,7 @@ func (s *careOfferingService) Clone(ctx context.Context, sourceID int64, targetP
 // See the interface doc for the contract. Callers run it inside the
 // rollover's tenant transaction, so a validation failure on any single
 // offering rolls back the whole follow-up phase.
-func (s *careOfferingService) CloneCatalogForRollover(ctx context.Context, sourcePhaseID int64, targetPhaseID int64) (map[int64]int64, error) {
+func (s *careOfferingService) CloneCatalogForRollover(ctx context.Context, sourcePhaseID int64, targetPhaseID int64, carriedOfferingIDs []int64) (map[int64]int64, error) {
 	if sourcePhaseID <= 0 {
 		return nil, careOfferingInvalidf("source phase id must be positive")
 	}
@@ -1170,11 +1184,36 @@ func (s *careOfferingService) CloneCatalogForRollover(ctx context.Context, sourc
 	if err != nil {
 		return nil, fmt.Errorf("rollover catalog clone: list source offerings: %w", err)
 	}
+	sourceByID := make(map[int64]*enrollmentModels.CareOffering, len(sources)+len(carriedOfferingIDs))
+	carriedByID := make(map[int64]bool, len(carriedOfferingIDs))
+	for _, offeringID := range carriedOfferingIDs {
+		carriedByID[offeringID] = true
+	}
+	for _, source := range sources {
+		sourceByID[source.ID] = source
+	}
+	for _, offeringID := range carriedOfferingIDs {
+		if _, ok := sourceByID[offeringID]; ok {
+			continue
+		}
+		source, findErr := s.Repo.FindByID(ctx, offeringID)
+		if findErr != nil {
+			return nil, fmt.Errorf("rollover catalog clone: load carried offering %d: %w", offeringID, findErr)
+		}
+		sources = append(sources, source)
+		sourceByID[offeringID] = source
+	}
+	if err := validateCatalogGroupRuleConsistency(sources); err != nil {
+		return nil, fmt.Errorf("rollover catalog clone: %w", err)
+	}
 
 	mapping := make(map[int64]int64, len(sources))
 	for _, source := range sources {
+		requiresMaterialization := source.IsActive || carriedByID[source.ID]
 		clone := *source
 		clone.ID = 0 // BIGSERIAL — let the DB assign
+		clone.CreatedAt = time.Time{}
+		clone.UpdatedAt = time.Time{}
 		clone.PhaseID = targetPhaseID
 		// Triggers reference offering IDs; they are remapped and written
 		// in the second pass once every clone has its ID.
@@ -1182,11 +1221,11 @@ func (s *careOfferingService) CloneCatalogForRollover(ctx context.Context, sourc
 		if err := s.validateAvailabilityRule(ctx, &clone); err != nil {
 			return nil, fmt.Errorf("rollover catalog clone: offering %q (%d): %w", source.Name, source.ID, err)
 		}
-		if err := s.validateRolloverCloneLinkedGroup(ctx, &clone); err != nil {
+		if err := s.validateRolloverCloneLinkedGroup(ctx, &clone, requiresMaterialization); err != nil {
 			return nil, fmt.Errorf("rollover catalog clone: offering %q (%d): %w", source.Name, source.ID, err)
 		}
-		// Group-rule consistency holds by construction: the catalog is
-		// copied verbatim, so a consistent source group stays consistent.
+		// Group-rule consistency was checked across the complete clone set
+		// before the first row was inserted.
 		if err := s.Repo.Create(ctx, &clone); err != nil {
 			return nil, fmt.Errorf("rollover catalog clone: offering %q (%d): %w", source.Name, source.ID, err)
 		}
@@ -1233,7 +1272,7 @@ func (s *careOfferingService) CloneCatalogForRollover(ctx context.Context, sourc
 // a historical non-template link — which the admin catalog no longer allows
 // but Decide still materializes — is carried verbatim. Rejecting those would
 // wedge every rollover of a phase carrying pre-template-era links.
-func (s *careOfferingService) validateRolloverCloneLinkedGroup(ctx context.Context, clone *enrollmentModels.CareOffering) error {
+func (s *careOfferingService) validateRolloverCloneLinkedGroup(ctx context.Context, clone *enrollmentModels.CareOffering, requiresMaterialization bool) error {
 	if clone == nil || clone.ActivityGroupID == nil {
 		return nil
 	}
@@ -1255,5 +1294,34 @@ func (s *careOfferingService) validateRolloverCloneLinkedGroup(ctx context.Conte
 	if group == nil || !group.IsTemplate {
 		return nil
 	}
-	return s.validateLinkedTemplate(ctx, clone)
+	if s.PhaseRepo == nil {
+		return errors.New("phase validation dependency is not configured")
+	}
+	phase, err := s.PhaseRepo.FindByID(ctx, clone.PhaseID)
+	if err != nil {
+		if modelBase.IsNoRows(err) {
+			return careOfferingInvalidf("phase_id does not reference a phase in this tenant")
+		}
+		return fmt.Errorf("load care offering phase: %w", err)
+	}
+	if phase == nil {
+		return careOfferingInvalidf("phase_id does not reference a phase in this tenant")
+	}
+	return s.validateLinkedTemplateForMaterialization(ctx, clone, phase, deps, requiresMaterialization)
+}
+
+func validateCatalogGroupRuleConsistency(offerings []*enrollmentModels.CareOffering) error {
+	rules := make(map[string]string)
+	for _, offering := range offerings {
+		group := strings.TrimSpace(offering.SelectionGroup)
+		if group == "" {
+			continue
+		}
+		rule := normalizeSelectionRule(offering.SelectionRule)
+		if existing, ok := rules[group]; ok && existing != rule {
+			return fmt.Errorf("%w: group %q uses both %q and %q", ErrCareOfferingGroupRuleConflict, group, existing, rule)
+		}
+		rules[group] = rule
+	}
+	return nil
 }

--- a/backend/services/enrollment/care_offering_service.go
+++ b/backend/services/enrollment/care_offering_service.go
@@ -63,6 +63,26 @@ type CareOfferingService interface {
 	Clone(ctx context.Context, sourceID int64, targetPhaseID int64) (*enrollmentModels.CareOffering, error)
 }
 
+// RolloverOfferingCatalogCloner is the narrow contract the rollover
+// service consumes (#2249). Kept separate from CareOfferingService — like
+// CareOfferingSeriesValidator — so HTTP-layer mocks never implement an
+// operation that is not an enrollment endpoint.
+//
+// CloneCatalogForRollover copies EVERY care offering of the source phase
+// into the target phase and returns the source→target offering ID
+// mapping. Unlike the admin Clone it keeps the linked timetable template
+// (activity_group_id): the link resolution is split-series-aware, so a
+// template whose recurrence covers the target phase keeps feeding
+// materialization, and one that does not fails validation here —
+// aborting the rollover atomically instead of producing a booking that
+// only breaks at Freigabe. Auto-add triggers are remapped inside the
+// cloned catalog. Sourced templates (source_care_offering_ids, #2137)
+// are deliberately NOT rewritten — re-pointing period-bound templates at
+// the new phase's offerings is planning work the admin owns.
+type RolloverOfferingCatalogCloner interface {
+	CloneCatalogForRollover(ctx context.Context, sourcePhaseID int64, targetPhaseID int64) (map[int64]int64, error)
+}
+
 // CareOfferingSeriesValidator is the narrow cross-domain contract used by the
 // timetable split service. Keeping it separate from CareOfferingService avoids
 // making HTTP-layer mocks implement an operation that is never exposed as an
@@ -1126,4 +1146,114 @@ func (s *careOfferingService) Clone(ctx context.Context, sourceID int64, targetP
 		slog.Int64("clone_id", clone.ID),
 		slog.Int64("target_phase_id", targetPhaseID))
 	return &clone, nil
+}
+
+// CloneCatalogForRollover implements the rollover-facing catalog copy.
+// See the interface doc for the contract. Callers run it inside the
+// rollover's tenant transaction, so a validation failure on any single
+// offering rolls back the whole follow-up phase.
+func (s *careOfferingService) CloneCatalogForRollover(ctx context.Context, sourcePhaseID int64, targetPhaseID int64) (map[int64]int64, error) {
+	if sourcePhaseID <= 0 {
+		return nil, careOfferingInvalidf("source phase id must be positive")
+	}
+	if targetPhaseID <= 0 {
+		return nil, careOfferingInvalidf("target phase id must be positive")
+	}
+	if sourcePhaseID == targetPhaseID {
+		return nil, careOfferingInvalidf("source and target phase must differ")
+	}
+	if err := s.lockTemplateRecurrence(ctx); err != nil {
+		return nil, err
+	}
+
+	sources, err := s.Repo.ListByPhase(ctx, sourcePhaseID)
+	if err != nil {
+		return nil, fmt.Errorf("rollover catalog clone: list source offerings: %w", err)
+	}
+
+	mapping := make(map[int64]int64, len(sources))
+	for _, source := range sources {
+		clone := *source
+		clone.ID = 0 // BIGSERIAL — let the DB assign
+		clone.PhaseID = targetPhaseID
+		// Triggers reference offering IDs; they are remapped and written
+		// in the second pass once every clone has its ID.
+		clone.AutoAddTriggerOfferingIDs = nil
+		if err := s.validateAvailabilityRule(ctx, &clone); err != nil {
+			return nil, fmt.Errorf("rollover catalog clone: offering %q (%d): %w", source.Name, source.ID, err)
+		}
+		if err := s.validateRolloverCloneLinkedGroup(ctx, &clone); err != nil {
+			return nil, fmt.Errorf("rollover catalog clone: offering %q (%d): %w", source.Name, source.ID, err)
+		}
+		// Group-rule consistency holds by construction: the catalog is
+		// copied verbatim, so a consistent source group stays consistent.
+		if err := s.Repo.Create(ctx, &clone); err != nil {
+			return nil, fmt.Errorf("rollover catalog clone: offering %q (%d): %w", source.Name, source.ID, err)
+		}
+		mapping[source.ID] = clone.ID
+	}
+
+	for _, source := range sources {
+		if len(source.AutoAddTriggerOfferingIDs) == 0 {
+			continue
+		}
+		remapped := make([]int64, 0, len(source.AutoAddTriggerOfferingIDs))
+		for _, triggerID := range source.AutoAddTriggerOfferingIDs {
+			cloneTriggerID, ok := mapping[triggerID]
+			if !ok {
+				// Save-path validation pins triggers to the same phase,
+				// so this only fires for legacy rows. Carrying a
+				// cross-phase trigger forward would create exactly the
+				// mixed-phase state the rollover exists to prevent.
+				s.Logger.Warn("rollover catalog clone: dropping trigger outside the source phase",
+					slog.Int64("offering_id", source.ID),
+					slog.Int64("trigger_offering_id", triggerID))
+				continue
+			}
+			remapped = append(remapped, cloneTriggerID)
+		}
+		if len(remapped) == 0 {
+			continue
+		}
+		if err := s.Repo.ReplaceAutoAddTriggers(ctx, mapping[source.ID], remapped); err != nil {
+			return nil, fmt.Errorf("rollover catalog clone: remap triggers for offering %d: %w", source.ID, err)
+		}
+	}
+
+	s.Logger.Info("care offering catalog cloned for rollover",
+		slog.Int64("source_phase_id", sourcePhaseID),
+		slog.Int64("target_phase_id", targetPhaseID),
+		slog.Int("offering_count", len(mapping)))
+	return mapping, nil
+}
+
+// validateRolloverCloneLinkedGroup validates a clone's activity-group link
+// with the same tolerance the decision materialization applies: a linked
+// TEMPLATE must cover the target phase (full validateLinkedTemplate), while
+// a historical non-template link — which the admin catalog no longer allows
+// but Decide still materializes — is carried verbatim. Rejecting those would
+// wedge every rollover of a phase carrying pre-template-era links.
+func (s *careOfferingService) validateRolloverCloneLinkedGroup(ctx context.Context, clone *enrollmentModels.CareOffering) error {
+	if clone == nil || clone.ActivityGroupID == nil {
+		return nil
+	}
+	deps := careOfferingTemplateDeps{
+		activityGroupRepo:    s.ActivityGroupRepo,
+		activityScheduleRepo: s.ActivityScheduleRepo,
+		calendarPeriodRepo:   s.CalendarPeriodRepo,
+	}
+	if err := deps.validateActivityGroupLookup(); err != nil {
+		return err
+	}
+	group, err := s.ActivityGroupRepo.FindByID(ctx, *clone.ActivityGroupID)
+	if err != nil {
+		if modelBase.IsNoRows(err) {
+			return careOfferingInvalidf("activity_group_id does not reference a group in this tenant")
+		}
+		return fmt.Errorf("load linked activity group: %w", err)
+	}
+	if group == nil || !group.IsTemplate {
+		return nil
+	}
+	return s.validateLinkedTemplate(ctx, clone)
 }

--- a/backend/services/enrollment/decision_service_test.go
+++ b/backend/services/enrollment/decision_service_test.go
@@ -3238,7 +3238,11 @@ func TestDecisionService_Decide_ApprovedPreservesLegacyNonTemplateLinkedOffering
 	assert.Empty(t, rows[0].SelectedWeekdays)
 }
 
-func TestDecisionService_Decide_RolloverApprovalMaterializesSourcePhaseOffering(t *testing.T) {
+// Since #2249 the rollover clones the offering catalog into the target
+// phase and remaps the carried booking onto the clone — including a
+// historical non-template activity-group link, which the clone carries
+// verbatim so Decide keeps materializing it for the target window.
+func TestDecisionService_Decide_RolloverApprovalMaterializesClonedOffering(t *testing.T) {
 	env, cleanup := setupDecisionTest(t)
 	defer cleanup()
 	ctx := testpkg.TenantContext(1)
@@ -3318,11 +3322,20 @@ func TestDecisionService_Decide_RolloverApprovalMaterializesSourcePhaseOffering(
 	require.NotNil(t, rolled.RolloverSourceChildID)
 	assert.Equal(t, submitted.Children[0].ID, *rolled.RolloverSourceChildID)
 
+	clones, err := env.repos.CareOffering.ListByPhase(ctx, result.Phase.ID)
+	require.NoError(t, err)
+	require.Len(t, clones, 1)
+	clone := clones[0]
+	assert.NotEqual(t, offering.ID, clone.ID)
+	require.NotNil(t, clone.ActivityGroupID)
+	assert.Equal(t, group.ID, *clone.ActivityGroupID,
+		"a historical non-template link is carried verbatim onto the clone")
+
 	rolledLinks, err := env.repos.RequestChildOffering.ListByRequestChildID(ctx, rolled.ID)
 	require.NoError(t, err)
 	require.Len(t, rolledLinks, 1)
-	assert.Equal(t, offering.ID, rolledLinks[0].CareOfferingID,
-		"rollover intentionally copies the source-phase offering id")
+	assert.Equal(t, clone.ID, rolledLinks[0].CareOfferingID,
+		"the carried booking must reference the target-phase clone (#2249)")
 
 	rolloverOutcome, err := env.decision.Decide(ctx, enrollmentService.DecideInput{
 		RequestID:  rolled.RequestID,
@@ -3353,15 +3366,15 @@ func TestDecisionService_Decide_RolloverApprovalMaterializesSourcePhaseOffering(
 		ActorRole:      "admin",
 		Reason:         "Rollover-Angebot unverändert gespeichert",
 		Offerings: []enrollmentService.OfferingAdjustmentSelection{
-			{OfferingID: offering.ID},
+			{OfferingID: clone.ID},
 		},
 	})
 	require.NoError(t, err)
 	rolledLinks, err = env.repos.RequestChildOffering.ListByRequestChildID(ctx, rolled.ID)
 	require.NoError(t, err)
 	require.Len(t, rolledLinks, 1)
-	assert.Equal(t, offering.ID, rolledLinks[0].CareOfferingID,
-		"adjustment save must preserve existing source-phase offering ids")
+	assert.Equal(t, clone.ID, rolledLinks[0].CareOfferingID,
+		"adjustment save must keep the target-phase clone reference")
 }
 
 func TestDecisionService_Decide_ApprovedRejectsEmptyDaysForTemplateOffering(t *testing.T) {

--- a/backend/services/enrollment/rollover_autoapprove_integration_test.go
+++ b/backend/services/enrollment/rollover_autoapprove_integration_test.go
@@ -83,6 +83,7 @@ func setupAutoApproveIntegrationEnvWithSettings(
 		RequestRepo:              env.repos.Request,
 		RequestChildRepo:         env.repos.RequestChild,
 		RequestChildOfferingRepo: env.repos.RequestChildOffering,
+		OfferingCatalogCloner:    env.offeringCloner,
 		OutboxEnqueuer:           env.outbox,
 		Settings:                 env.settings,
 		DecisionService:          decision,
@@ -480,9 +481,11 @@ func TestRolloverService_AutoApprove_ValidationFailureRollsBackStudentUpdate(t *
 	originalFrom := *existing.EnrolledFrom
 	originalUntil := *existing.EnrolledUntil
 
-	// Persist a legacy-invalid template offering. The schedule resolves for the
-	// target phase, but the fixed offering has no days, so Decide fails in care
-	// recurrence validation only after applyApprovalRollover updates the student.
+	// A valid template-linked source offering; the rollover clones it into
+	// the target phase (#2249). After the rollover we corrupt the CLONE the
+	// way legacy rows looked before #1885 made available_days mandatory:
+	// Decide then fails in care recurrence validation only after
+	// applyApprovalRollover updates the student — the rollback under test.
 	group := createCareOfferingTemplateGroup(t, env.db, "rollover-savepoint")
 	period := createCareOfferingTestPeriod(
 		t,
@@ -495,22 +498,13 @@ func TestRolloverService_AutoApprove_ValidationFailureRollsBackStudentUpdate(t *
 	offering := &enrollmentModels.CareOffering{
 		PhaseID:         env.sourcePhase.ID,
 		ActivityGroupID: &group.ID,
-		Name:            "Invalid empty-day rollover offering",
+		Name:            "Rollover savepoint offering",
 		DaysOfWeekMode:  enrollmentModels.DaysOfWeekModeFixed,
 		AvailableDays:   []string{"tue"},
 		IsActive:        true,
 	}
 	offering.SetTenantID(1)
 	require.NoError(t, env.repos.CareOffering.Create(ctx, offering))
-	// Simulate a legacy row saved before #1885 made available_days
-	// mandatory: clear the days directly, bypassing Validate. The rollback
-	// behavior under test targets exactly such legacy-invalid rows.
-	_, updErr := env.db.NewUpdate().
-		TableExpr("enrollment.care_offerings").
-		Set("available_days = '[]'::jsonb").
-		Where("id = ?", offering.ID).
-		Exec(ctx)
-	require.NoError(t, updErr)
 	link := &enrollmentModels.RequestChildOffering{
 		RequestChildID: source.ID,
 		CareOfferingID: offering.ID,
@@ -524,6 +518,16 @@ func TestRolloverService_AutoApprove_ValidationFailureRollsBackStudentUpdate(t *
 	req.Name = "auto-approve-savepoint-rollback-target"
 	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx, req)
 	require.NoError(t, err)
+	require.Equal(t, 1, result.ClonedOfferingCount)
+
+	// Blank the target-phase clone's days directly, bypassing Validate —
+	// simulating a legacy-invalid row in the phase Decide will materialize.
+	_, updErr := env.db.NewUpdate().
+		TableExpr("enrollment.care_offerings").
+		Set("available_days = '[]'::jsonb").
+		Where("phase_id = ?", result.Phase.ID).
+		Exec(ctx)
+	require.NoError(t, updErr)
 
 	rolled, err := env.repos.RequestChild.ListByPhaseAndStatuses(
 		ctx,

--- a/backend/services/enrollment/rollover_offering_carryover_test.go
+++ b/backend/services/enrollment/rollover_offering_carryover_test.go
@@ -288,6 +288,98 @@ func TestRolloverService_CreatePhaseFromSource_FailsWhenBookingHasNoClone(t *tes
 	assert.False(t, exists)
 }
 
+// The parent-status page must be able to reopen the rolled request: before
+// #2249 the carried booking pointed at a source-phase offering, which the
+// edit-draft loader rejects with ErrEditNotAllowed.
+func TestRolloverService_CreatePhaseFromSource_RolledRequestIsEditableInParentStatus(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Elena", "Edit", "elena.edit@example.com",
+		"Emil", "Edit", int16(2))
+	offering := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Editierbar",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeParentChoice,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IsActive:       true,
+	})
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: offering.ID,
+		SelectedDays:   []string{"tue"},
+	})
+
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx,
+		validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+	require.NoError(t, err)
+
+	rolled, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, result.Phase.ID, []string{enrollmentModels.ChildStatusAutoRenewed})
+	require.NoError(t, err)
+	require.Len(t, rolled, 1)
+	newRequest, err := env.repos.Request.FindByID(ctx, rolled[0].RequestID)
+	require.NoError(t, err)
+
+	draft, err := env.requestSvc.GetEditDraft(ctx, newRequest.StatusToken)
+	require.NoError(t, err,
+		"the rolled request must open in the parent status page without a phase-foreign rejection")
+	require.NotNil(t, draft)
+	links := draft.OfferingsByChild[rolled[0].ID]
+	require.Len(t, links, 1)
+	assert.NotEqual(t, offering.ID, links[0].CareOfferingID)
+	assert.Equal(t, []string{"tue"}, links[0].SelectedDays)
+	offeredIDs := make(map[int64]bool, len(draft.OpenOfferings))
+	for _, open := range draft.OpenOfferings {
+		offeredIDs[open.ID] = true
+	}
+	assert.True(t, offeredIDs[links[0].CareOfferingID],
+		"the carried clone must be part of the target phase's offered catalog")
+}
+
+// Re-running the rollover must not duplicate target requests, bookings, or
+// cloned offerings — the second execution fails up front and atomically.
+func TestRolloverService_CreatePhaseFromSource_RepeatedExecutionCreatesNoDuplicates(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Rita", "Repeat", "rita.repeat@example.com",
+		"Rio", "Repeat", int16(2))
+	offering := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Wiederholung",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon"},
+		IsActive:       true,
+	})
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: offering.ID,
+	})
+
+	first, err := env.rolloverSvc.CreatePhaseFromSource(ctx,
+		validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+	require.NoError(t, err)
+
+	secondReq := validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true)
+	secondReq.Name = "rollover-target-second-run"
+	_, err = env.rolloverSvc.CreatePhaseFromSource(ctx, secondReq)
+	require.ErrorIs(t, err, enrollmentService.ErrRolloverSourceAlreadyRolled)
+
+	rolled, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, first.Phase.ID, []string{enrollmentModels.ChildStatusAutoRenewed})
+	require.NoError(t, err)
+	require.Len(t, rolled, 1, "repeated execution must not duplicate target enrollments")
+	links, err := env.repos.RequestChildOffering.ListByRequestChildID(ctx, rolled[0].ID)
+	require.NoError(t, err)
+	assert.Len(t, links, 1, "repeated execution must not duplicate bookings")
+	clones, err := env.repos.CareOffering.ListByPhase(ctx, first.Phase.ID)
+	require.NoError(t, err)
+	assert.Len(t, clones, 1, "repeated execution must not duplicate cloned offerings")
+}
+
 // TestRolloverService_AutoApprove_MaterializesCarriedDaysIntoLinkedTemplate is
 // the #2249 acceptance test: a parent-choice offering with several selected
 // weekdays and a linked timetable template travels from rollover through

--- a/backend/services/enrollment/rollover_offering_carryover_test.go
+++ b/backend/services/enrollment/rollover_offering_carryover_test.go
@@ -1,0 +1,392 @@
+package enrollment_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// This file pins the #2249 contract: a follow-up phase (Anschlussphase)
+// carries the FULL care booking effective at the end of the source phase
+// — the offering catalog is cloned into the target phase, booking rows
+// are remapped onto the clones, weekday selections travel verbatim, and
+// historical validity intervals are reset to the new service period.
+
+// sourceOffering creates one care offering on the rollover source phase
+// via the repository (no service-side template validation, matching how
+// production rows exist before a rollover runs).
+func sourceOffering(t *testing.T, env *rolloverTestEnv, offering *enrollmentModels.CareOffering) *enrollmentModels.CareOffering {
+	t.Helper()
+	offering.PhaseID = env.sourcePhase.ID
+	offering.SetTenantID(1)
+	require.NoError(t, env.repos.CareOffering.Create(testpkg.TenantContext(1), offering))
+	return offering
+}
+
+func linkChildOffering(t *testing.T, env *rolloverTestEnv, link *enrollmentModels.RequestChildOffering) *enrollmentModels.RequestChildOffering {
+	t.Helper()
+	link.SetTenantID(1)
+	require.NoError(t, env.repos.RequestChildOffering.Create(testpkg.TenantContext(1), link))
+	return link
+}
+
+func TestRolloverService_CreatePhaseFromSource_ClonesCatalogAndRemapsBookings(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	// Seed the child before the exactly_one group exists — the Submit
+	// path validates selection rules against the live catalog.
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Carla", "Carry", "carla.carry@example.com",
+		"Kim", "Carry", int16(2))
+
+	capacity := 20
+	price := 4200
+	kurz := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Betreuung kurz",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeParentChoice,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IsActive:       true,
+		Capacity:       &capacity,
+		PriceCents:     &price,
+		SelectionGroup: "kernzeit",
+		SelectionRule:  enrollmentModels.SelectionRuleExactlyOne,
+	})
+	lang := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Betreuung lang",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeParentChoice,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IsActive:       true,
+		SelectionGroup: "kernzeit",
+		SelectionRule:  enrollmentModels.SelectionRuleExactlyOne,
+	})
+	mittag := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Mittagessen",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IncludesLunch:  true,
+		IsActive:       true,
+		IsRequired:     true,
+	})
+	frueh := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Frühbetreuung",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeParentChoice,
+		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
+		IsActive:       false,
+	})
+	// Frühbetreuung is auto-added whenever Betreuung kurz is selected.
+	require.NoError(t, env.repos.CareOffering.ReplaceAutoAddTriggers(ctx, frueh.ID, []int64{kurz.ID}))
+
+	// A replaced historical booking (kurz, first months only) plus the
+	// booking effective at the end of the source phase (kurz with a
+	// mid-phase weekday change, and the required lunch).
+	historyEnd := timezone.NewDate(2027, 1, 1)
+	notes := "Oma holt ab"
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: kurz.ID,
+		SelectedDays:   []string{"mon", "wed"},
+		ValidUntil:     &historyEnd,
+	})
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID:        child.ID,
+		CareOfferingID:        kurz.ID,
+		SelectedDays:          []string{"tue", "thu"},
+		ManualSelectedDays:    []string{"tue"},
+		AutomaticSelectedDays: []string{"thu"},
+		Notes:                 &notes,
+		ValidFrom:             &historyEnd,
+	})
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: mittag.ID,
+	})
+
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx,
+		validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+	require.NoError(t, err)
+	require.Equal(t, 4, result.ClonedOfferingCount)
+
+	// The target phase owns a full clone of the catalog.
+	clones, err := env.repos.CareOffering.ListByPhase(ctx, result.Phase.ID)
+	require.NoError(t, err)
+	require.Len(t, clones, 4)
+	cloneByName := make(map[string]*enrollmentModels.CareOffering, len(clones))
+	sourceIDs := map[int64]bool{kurz.ID: true, lang.ID: true, mittag.ID: true, frueh.ID: true}
+	for _, clone := range clones {
+		cloneByName[clone.Name] = clone
+		assert.False(t, sourceIDs[clone.ID], "clone %q must be a new row", clone.Name)
+		assert.Equal(t, result.Phase.ID, clone.PhaseID)
+	}
+	kurzClone := cloneByName["Betreuung kurz"]
+	require.NotNil(t, kurzClone)
+	assert.Equal(t, enrollmentModels.DaysOfWeekModeParentChoice, kurzClone.DaysOfWeekMode)
+	assert.Equal(t, []string{"mon", "tue", "wed", "thu", "fri"}, kurzClone.AvailableDays)
+	require.NotNil(t, kurzClone.Capacity)
+	assert.Equal(t, capacity, *kurzClone.Capacity)
+	require.NotNil(t, kurzClone.PriceCents)
+	assert.Equal(t, price, *kurzClone.PriceCents)
+	assert.Equal(t, "kernzeit", kurzClone.SelectionGroup)
+	assert.Equal(t, enrollmentModels.SelectionRuleExactlyOne, kurzClone.SelectionRule)
+	langClone := cloneByName["Betreuung lang"]
+	require.NotNil(t, langClone)
+	assert.Equal(t, enrollmentModels.SelectionRuleExactlyOne, langClone.SelectionRule)
+	mittagClone := cloneByName["Mittagessen"]
+	require.NotNil(t, mittagClone)
+	assert.True(t, mittagClone.IsRequired)
+	assert.True(t, mittagClone.IncludesLunch)
+	fruehClone := cloneByName["Frühbetreuung"]
+	require.NotNil(t, fruehClone)
+	assert.False(t, fruehClone.IsActive, "inactive offerings clone as inactive")
+	assert.Equal(t, []int64{kurzClone.ID}, fruehClone.AutoAddTriggerOfferingIDs,
+		"auto-add triggers must be remapped onto the cloned catalog")
+
+	// The rolled child's booking is the selection effective at the END of
+	// the source phase, remapped onto the clones, days carried, validity
+	// reset to the new service period.
+	rolled, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, result.Phase.ID, []string{enrollmentModels.ChildStatusAutoRenewed})
+	require.NoError(t, err)
+	require.Len(t, rolled, 1)
+	copied, err := env.repos.RequestChildOffering.ListByRequestChildID(ctx, rolled[0].ID)
+	require.NoError(t, err)
+	require.Len(t, copied, 2, "only the effective booking is carried, not history rows")
+	copiedByOffering := make(map[int64]*enrollmentModels.RequestChildOffering, len(copied))
+	for _, row := range copied {
+		copiedByOffering[row.CareOfferingID] = row
+	}
+	kurzCopy := copiedByOffering[kurzClone.ID]
+	require.NotNil(t, kurzCopy, "booking must reference the target-phase clone")
+	assert.Equal(t, []string{"tue", "thu"}, kurzCopy.SelectedDays)
+	assert.Equal(t, []string{"tue"}, kurzCopy.ManualSelectedDays)
+	assert.Equal(t, []string{"thu"}, kurzCopy.AutomaticSelectedDays)
+	require.NotNil(t, kurzCopy.Notes)
+	assert.Equal(t, notes, *kurzCopy.Notes)
+	// Historical source-phase intervals are NOT carried: the repository
+	// pins the copy to the target phase's service window (end exclusive).
+	require.NotNil(t, kurzCopy.ValidFrom)
+	assert.Equal(t, result.Phase.ServiceStartDate, *kurzCopy.ValidFrom,
+		"historical validity must not carry into the target phase")
+	require.NotNil(t, kurzCopy.ValidUntil)
+	assert.Equal(t, result.Phase.ServiceEndDate.AddDays(1), *kurzCopy.ValidUntil)
+	mittagCopy := copiedByOffering[mittagClone.ID]
+	require.NotNil(t, mittagCopy)
+	assert.Nil(t, mittagCopy.SelectedDays)
+
+	// Source data is untouched: same offering rows, same booking history.
+	sourceOfferings, err := env.repos.CareOffering.ListByPhase(ctx, env.sourcePhase.ID)
+	require.NoError(t, err)
+	assert.Len(t, sourceOfferings, 4)
+	sourceHistory, err := env.repos.RequestChildOffering.ListHistoryByRequestChildID(ctx, child.ID)
+	require.NoError(t, err)
+	require.Len(t, sourceHistory, 3)
+	for _, row := range sourceHistory {
+		assert.True(t, sourceIDs[row.CareOfferingID], "source bookings keep source offerings")
+	}
+}
+
+func TestRolloverService_CreatePhaseFromSource_FailsAtomicallyOnInvalidSourceOffering(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	offering := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Legacy ohne Tage",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon"},
+		IsActive:       true,
+	})
+	// Simulate a legacy row saved before #1885 made available_days
+	// mandatory: cloning it into the target phase must fail validation.
+	_, updErr := env.db.NewUpdate().
+		TableExpr("enrollment.care_offerings").
+		Set("available_days = '[]'::jsonb").
+		Where("id = ?", offering.ID).
+		Exec(ctx)
+	require.NoError(t, updErr)
+
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Frank", "Fail", "frank.fail@example.com",
+		"Fritz", "Fail", int16(2))
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: offering.ID,
+	})
+
+	// Production wraps the rollover in the handler's tenant transaction —
+	// that is where the atomicity contract comes from.
+	err := tenant.WithTenantTx(context.Background(), env.db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		_, createErr := env.rolloverSvc.CreatePhaseFromSource(txCtx,
+			validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+		return createErr
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "rollover: clone offering catalog")
+
+	// Atomic: no follow-up phase, no rolled rows, no parent emails.
+	exists, err := env.repos.Phase.ExistsByRolloverSourcePhaseID(ctx, env.sourcePhase.ID)
+	require.NoError(t, err)
+	assert.False(t, exists, "failed rollover must not leave the follow-up phase behind")
+	assert.Empty(t, env.outbox.ByKind("enrollment_rollover_opt_out"),
+		"failed rollover must not enqueue parent emails")
+	assert.Empty(t, env.outbox.ByKind("enrollment_rollover_opt_in"))
+}
+
+func TestRolloverService_CreatePhaseFromSource_FailsWhenBookingHasNoClone(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	offering := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Ohne Cloner",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon"},
+		IsActive:       true,
+	})
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Nora", "NoClone", "nora.noclone@example.com",
+		"Nils", "NoClone", int16(2))
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: offering.ID,
+	})
+
+	// A mis-wired service (nil cloner) must fail the rollover instead of
+	// silently persisting a source-phase offering reference.
+	svcNoCloner := enrollmentService.NewRolloverService(enrollmentService.RolloverServiceConfig{
+		PhaseRepo:                env.repos.Phase,
+		RequestRepo:              env.repos.Request,
+		RequestChildRepo:         env.repos.RequestChild,
+		RequestChildOfferingRepo: env.repos.RequestChildOffering,
+		OutboxEnqueuer:           env.outbox,
+		Settings:                 env.settings,
+		ParentsURL:               "http://parents.localhost:3000",
+		DB:                       env.db,
+	})
+	err := tenant.WithTenantTx(context.Background(), env.db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		_, createErr := svcNoCloner.CreatePhaseFromSource(txCtx,
+			validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+		return createErr
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "has no clone in the target phase")
+
+	exists, err := env.repos.Phase.ExistsByRolloverSourcePhaseID(ctx, env.sourcePhase.ID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// TestRolloverService_AutoApprove_MaterializesCarriedDaysIntoLinkedTemplate is
+// the #2249 acceptance test: a parent-choice offering with several selected
+// weekdays and a linked timetable template travels from rollover through
+// Freigabe, and the approval materializes the carried weekdays into the
+// template roster.
+func TestRolloverService_AutoApprove_MaterializesCarriedDaysIntoLinkedTemplate(t *testing.T) {
+	env, cleanup := setupAutoApproveIntegrationEnv(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	// Template + period spanning source AND target phase (the half-year
+	// rollover case: one planning period, two enrollment phases).
+	group := createCareOfferingTemplateGroup(t, env.db, "rollover-carryover")
+	period := createCareOfferingTestPeriod(
+		t, env.db, "rollover-carryover",
+		timezone.NewDate(2026, 8, 1),
+		timezone.NewDate(2028, 8, 31),
+	)
+	createCareOfferingTemplateSchedule(t, env.db, group.ID, activitiesModels.WeekdayTuesday, &period.ID)
+	createCareOfferingTemplateSchedule(t, env.db, group.ID, activitiesModels.WeekdayThursday, &period.ID)
+
+	offering := &enrollmentModels.CareOffering{
+		PhaseID:         env.sourcePhase.ID,
+		ActivityGroupID: &group.ID,
+		Name:            "Wochentagswahl mit Vorlage",
+		DaysOfWeekMode:  enrollmentModels.DaysOfWeekModeParentChoice,
+		AvailableDays:   []string{"tue", "thu"},
+		IsActive:        true,
+	}
+	offering.SetTenantID(1)
+	require.NoError(t, env.repos.CareOffering.Create(ctx, offering))
+
+	source, existing := seedApprovedChildWithStudent(
+		t, env,
+		"Vera", "Vorlage", "vera.vorlage@example.com",
+		"Vito", "Vorlage",
+		int16(1),
+	)
+	link := &enrollmentModels.RequestChildOffering{
+		RequestChildID:     source.ID,
+		CareOfferingID:     offering.ID,
+		SelectedDays:       []string{"tue", "thu"},
+		ManualSelectedDays: []string{"tue", "thu"},
+	}
+	link.SetTenantID(1)
+	require.NoError(t, env.repos.RequestChildOffering.Create(ctx, link))
+
+	req := validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true)
+	req.RolloverAutoApprove = true
+	req.RolloverDeadline = time.Now().Add(-time.Hour)
+	req.Name = "carryover-materialization-target"
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.ClonedOfferingCount)
+
+	// The clone keeps the timetable-template link — the series covers the
+	// target phase, so approval materialization keeps working (#2249).
+	clones, err := env.repos.CareOffering.ListByPhase(ctx, result.Phase.ID)
+	require.NoError(t, err)
+	require.Len(t, clones, 1)
+	require.NotNil(t, clones[0].ActivityGroupID)
+	assert.Equal(t, group.ID, *clones[0].ActivityGroupID)
+
+	rolled, err := env.repos.RequestChild.ListByPhaseAndStatuses(
+		ctx, result.Phase.ID, []string{enrollmentModels.ChildStatusAutoRenewed})
+	require.NoError(t, err)
+	require.Len(t, rolled, 1)
+	rolledChildID := rolled[0].ID
+
+	t.Cleanup(func() {
+		_, _ = env.db.NewDelete().
+			TableExpr("activities.student_enrollments").
+			Where("student_id = ?", existing.ID).
+			Exec(context.Background())
+	})
+
+	err = tenant.WithTenantTx(context.Background(), env.db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		summary, workerErr := env.rolloverSvc.RunDeadlineWorker(txCtx, time.Now())
+		if workerErr != nil {
+			return workerErr
+		}
+		require.Equal(t, 1, summary.AutoRenewedToApproved)
+		require.Equal(t, 0, summary.AutoApproveErrors)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Freigabe materialized the carried weekdays into the linked template.
+	var rows []activitiesModels.StudentEnrollment
+	require.NoError(t, env.db.NewSelect().
+		Model(&rows).
+		ModelTableExpr(`activities.student_enrollments AS "student_enrollment"`).
+		Where(`"student_enrollment".tenant_id = ?`, 1).
+		Where(`"student_enrollment".student_id = ?`, existing.ID).
+		Where(`"student_enrollment".activity_group_id = ?`, group.ID).
+		Scan(ctx))
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].EnrollmentRequestChildID)
+	assert.Equal(t, rolledChildID, *rows[0].EnrollmentRequestChildID)
+	assert.Equal(t, []int{activitiesModels.WeekdayTuesday, activitiesModels.WeekdayThursday}, rows[0].SelectedWeekdays,
+		"the carried weekday selection must reach the template roster")
+}

--- a/backend/services/enrollment/rollover_offering_carryover_test.go
+++ b/backend/services/enrollment/rollover_offering_carryover_test.go
@@ -86,6 +86,14 @@ func TestRolloverService_CreatePhaseFromSource_ClonesCatalogAndRemapsBookings(t 
 		AvailableDays:  []string{"mon", "tue", "wed", "thu", "fri"},
 		IsActive:       false,
 	})
+	oldTimestamp := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	_, err := env.db.NewUpdate().
+		TableExpr("enrollment.care_offerings").
+		Set("created_at = ?", oldTimestamp).
+		Set("updated_at = ?", oldTimestamp).
+		Where("id = ?", kurz.ID).
+		Exec(ctx)
+	require.NoError(t, err)
 	// Frühbetreuung is auto-added whenever Betreuung kurz is selected.
 	require.NoError(t, env.repos.CareOffering.ReplaceAutoAddTriggers(ctx, frueh.ID, []int64{kurz.ID}))
 
@@ -132,6 +140,8 @@ func TestRolloverService_CreatePhaseFromSource_ClonesCatalogAndRemapsBookings(t 
 	}
 	kurzClone := cloneByName["Betreuung kurz"]
 	require.NotNil(t, kurzClone)
+	assert.True(t, kurzClone.CreatedAt.After(oldTimestamp), "clone must receive a fresh creation timestamp")
+	assert.True(t, kurzClone.UpdatedAt.After(oldTimestamp), "clone must receive a fresh update timestamp")
 	assert.Equal(t, enrollmentModels.DaysOfWeekModeParentChoice, kurzClone.DaysOfWeekMode)
 	assert.Equal(t, []string{"mon", "tue", "wed", "thu", "fri"}, kurzClone.AvailableDays)
 	require.NotNil(t, kurzClone.Capacity)
@@ -197,6 +207,87 @@ func TestRolloverService_CreatePhaseFromSource_ClonesCatalogAndRemapsBookings(t 
 	}
 }
 
+func TestRolloverService_CreatePhaseFromSource_ClonesLegacyCrossPhaseBooking(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	offering := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:           "Legacy-Phasenreferenz",
+		DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:  []string{"mon"},
+		IsActive:       true,
+	})
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Lena", "Legacy", "lena.legacy@example.com",
+		"Luis", "Legacy", int16(2))
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: offering.ID,
+	})
+
+	legacyPhase := *env.sourcePhase
+	legacyPhase.ID = 0
+	legacyPhase.Name = "legacy-owner-" + t.Name()
+	legacyPhase.RolloverSourcePhaseID = nil
+	require.NoError(t, env.repos.Phase.Create(ctx, &legacyPhase))
+	_, err := env.db.NewUpdate().TableExpr("enrollment.care_offerings").
+		Set("phase_id = ?", legacyPhase.ID).
+		Where("id = ?", offering.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = env.db.NewUpdate().TableExpr("enrollment.care_offerings").
+			Set("phase_id = ?", env.sourcePhase.ID).
+			Where("id = ?", offering.ID).
+			Exec(context.Background())
+		_, _ = env.db.NewDelete().TableExpr("enrollment.phases").Where("id = ?", legacyPhase.ID).Exec(context.Background())
+	}()
+
+	result, err := env.rolloverSvc.CreatePhaseFromSource(ctx,
+		validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+	require.NoError(t, err)
+	require.Equal(t, 1, result.ClonedOfferingCount)
+
+	clones, err := env.repos.CareOffering.ListByPhase(ctx, result.Phase.ID)
+	require.NoError(t, err)
+	require.Len(t, clones, 1)
+	rolled, err := env.repos.RequestChild.ListByPhaseAndStatuses(ctx, result.Phase.ID, []string{enrollmentModels.ChildStatusAutoRenewed})
+	require.NoError(t, err)
+	require.Len(t, rolled, 1)
+	bookings, err := env.repos.RequestChildOffering.ListByRequestChildID(ctx, rolled[0].ID)
+	require.NoError(t, err)
+	require.Len(t, bookings, 1)
+	assert.Equal(t, clones[0].ID, bookings[0].CareOfferingID)
+}
+
+func TestRolloverService_CreatePhaseFromSource_RejectsConflictingLegacyGroupRules(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	for _, rule := range []string{enrollmentModels.SelectionRuleExactlyOne, enrollmentModels.SelectionRuleAtLeastOne} {
+		sourceOffering(t, env, &enrollmentModels.CareOffering{
+			Name:           "Legacy-Regel " + rule,
+			DaysOfWeekMode: enrollmentModels.DaysOfWeekModeFixed,
+			AvailableDays:  []string{"mon"},
+			IsActive:       true,
+			SelectionGroup: "umfang",
+			SelectionRule:  rule,
+		})
+	}
+
+	err := tenant.WithTenantTx(context.Background(), env.db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		_, createErr := env.rolloverSvc.CreatePhaseFromSource(txCtx,
+			validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+		return createErr
+	})
+	require.ErrorIs(t, err, enrollmentService.ErrCareOfferingGroupRuleConflict)
+	exists, findErr := env.repos.Phase.ExistsByRolloverSourcePhaseID(ctx, env.sourcePhase.ID)
+	require.NoError(t, findErr)
+	assert.False(t, exists)
+}
+
 func TestRolloverService_CreatePhaseFromSource_FailsAtomicallyOnInvalidSourceOffering(t *testing.T) {
 	env, cleanup := setupRolloverTest(t)
 	defer cleanup()
@@ -242,6 +333,45 @@ func TestRolloverService_CreatePhaseFromSource_FailsAtomicallyOnInvalidSourceOff
 	assert.Empty(t, env.outbox.ByKind("enrollment_rollover_opt_out"),
 		"failed rollover must not enqueue parent emails")
 	assert.Empty(t, env.outbox.ByKind("enrollment_rollover_opt_in"))
+}
+
+func TestRolloverService_CreatePhaseFromSource_ValidatesInactiveSelectedTemplateOffering(t *testing.T) {
+	env, cleanup := setupRolloverTest(t)
+	defer cleanup()
+	ctx := testpkg.TenantContext(1)
+
+	period := createCareOfferingTestPeriod(t, env.db, "rollover-inactive-selected",
+		timezone.NewDate(2026, 8, 1), timezone.NewDate(2028, 8, 31))
+	group := createCareOfferingTemplateGroup(t, env.db, "rollover-inactive-selected")
+	schedule := &activitiesModels.Schedule{
+		Weekday: activitiesModels.WeekdayMonday, ActivityGroupID: group.ID,
+		CalendarPeriodID: &period.ID,
+	}
+	schedule.SetTenantID(1)
+	require.NoError(t, env.repos.ActivitySchedule.Create(ctx, schedule))
+
+	offering := sourceOffering(t, env, &enrollmentModels.CareOffering{
+		Name:            "Inaktive Auswahl ohne Zeitfenster",
+		ActivityGroupID: &group.ID,
+		DaysOfWeekMode:  enrollmentModels.DaysOfWeekModeFixed,
+		AvailableDays:   []string{"mon"},
+		IsActive:        false,
+	})
+	child := seedApprovedChild(t, env, env.sourcePhase.ID,
+		"Ines", "Inaktiv", "ines.inaktiv@example.com",
+		"Ida", "Inaktiv", int16(2))
+	linkChildOffering(t, env, &enrollmentModels.RequestChildOffering{
+		RequestChildID: child.ID,
+		CareOfferingID: offering.ID,
+	})
+
+	err := tenant.WithTenantTx(context.Background(), env.db, 1, func(txCtx context.Context, _ bun.Tx) error {
+		_, createErr := env.rolloverSvc.CreatePhaseFromSource(txCtx,
+			validRolloverRequest(env, enrollmentModels.PhaseRolloverModeOptOut, true))
+		return createErr
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no complete timeframe")
 }
 
 func TestRolloverService_CreatePhaseFromSource_FailsWhenBookingHasNoClone(t *testing.T) {

--- a/backend/services/enrollment/rollover_service.go
+++ b/backend/services/enrollment/rollover_service.go
@@ -148,14 +148,15 @@ type CreatePhaseFromSourceRequest struct {
 // RolloverResult summarises what the rollover did so the admin UI can
 // confirm "you carried 27 children forward, 2 need review".
 type RolloverResult struct {
-	Phase             *enrollmentModels.Phase
-	SourceChildCount  int            // approved children scanned in the source phase
-	RolledCount       int            // child rows created in renewal state
-	ReviewCount       int            // child rows created in pending_admin_review
-	ReviewByReason    map[string]int // per-reason breakdown for the UI
-	RequestCount      int            // distinct parent requests created in the new phase
-	EnqueuedEmails    int
-	SkippedEmptyEmail int // rows whose parent had no email (no enqueue)
+	Phase               *enrollmentModels.Phase
+	SourceChildCount    int            // approved children scanned in the source phase
+	RolledCount         int            // child rows created in renewal state
+	ClonedOfferingCount int            // care offerings cloned into the new phase (#2249)
+	ReviewCount         int            // child rows created in pending_admin_review
+	ReviewByReason      map[string]int // per-reason breakdown for the UI
+	RequestCount        int            // distinct parent requests created in the new phase
+	EnqueuedEmails      int
+	SkippedEmptyEmail   int // rows whose parent had no email (no enqueue)
 }
 
 // ReviewQueueItem is one row in the admin review UI. SourceChild is
@@ -200,7 +201,12 @@ type rolloverRequestInput struct {
 	sourceChildren    []*enrollmentModels.RequestChild
 	maxGrade          int
 	collectGradeLevel bool
-	result            *RolloverResult
+	// offeringIDMap translates source-phase care offering IDs to their
+	// target-phase clones (built by OfferingCatalogCloner). Every carried
+	// booking MUST resolve through it — a source-phase reference in the
+	// target phase is exactly the mixed-phase state #2249 forbids.
+	offeringIDMap map[int64]int64
+	result        *RolloverResult
 }
 
 type rolloverChildAttributes struct {
@@ -216,9 +222,15 @@ type RolloverServiceConfig struct {
 	RequestRepo              enrollmentModels.RequestRepository
 	RequestChildRepo         enrollmentModels.RequestChildRepository
 	RequestChildOfferingRepo enrollmentModels.RequestChildOfferingRepository
-	SchoolRepo               platformModels.SchoolRepository
-	OutboxEnqueuer           platformModels.OutboxEnqueuer
-	Settings                 RequestSettingsResolver
+	// OfferingCatalogCloner clones the source phase's care-offering
+	// catalog into the follow-up phase (#2249). Production always wires
+	// the care-offering service; when nil (lightweight tests without
+	// offerings) the catalog is not cloned and any carried booking fails
+	// the rollover instead of persisting a source-phase reference.
+	OfferingCatalogCloner RolloverOfferingCatalogCloner
+	SchoolRepo            platformModels.SchoolRepository
+	OutboxEnqueuer        platformModels.OutboxEnqueuer
+	Settings              RequestSettingsResolver
 	// DecisionService is consumed by RunDeadlineWorker only when a
 	// phase carries rollover_auto_approve = true. Optional — leave
 	// nil to disable auto-approve regardless of the phase flag
@@ -241,11 +253,14 @@ func NewRolloverService(cfg RolloverServiceConfig) RolloverService {
 // CreatePhaseFromSource is the workhorse. Pseudocode:
 //  1. Load + validate source phase
 //  2. Build the new Phase (Validate(), Insert)
-//  3. List approved source children + skip ones already rolled
-//  4. Group by source request_id and create one new request per group
-//  5. Per child: compute new grade, decide status, create row
-//  6. Copy care offerings (request_child_offerings) verbatim
-//  7. Enqueue one email per new request via the outbox
+//  3. Clone the source phase's care-offering catalog into the new phase
+//     (source→target ID map, see RolloverOfferingCatalogCloner)
+//  4. List approved source children + skip ones already rolled
+//  5. Group by source request_id and create one new request per group
+//  6. Per child: compute new grade, decide status, create row
+//  7. Copy the effective care-offering booking (request_child_offerings),
+//     remapped to the cloned offerings, days carried, validity reset
+//  8. Enqueue one email per new request via the outbox
 func (s *rolloverService) CreatePhaseFromSource(ctx context.Context, req CreatePhaseFromSourceRequest) (*RolloverResult, error) {
 	if err := s.validateCreateRequest(req); err != nil {
 		return nil, err
@@ -299,6 +314,11 @@ func (s *rolloverService) runCreate(ctx context.Context, tenantID int64, req Cre
 		return err
 	}
 	result.SourceChildCount = len(sourceChildren)
+	offeringIDMap, err := s.cloneOfferingCatalog(ctx, source.ID, newPhase.ID)
+	if err != nil {
+		return err
+	}
+	result.ClonedOfferingCount = len(offeringIDMap)
 	return s.rollSourceRequests(ctx, rolloverRequestInput{
 		tenantID:          tenantID,
 		sourcePhase:       source,
@@ -306,8 +326,24 @@ func (s *rolloverService) runCreate(ctx context.Context, tenantID int64, req Cre
 		sourceChildren:    sourceChildren,
 		maxGrade:          maxGrade,
 		collectGradeLevel: collectGradeLevel,
+		offeringIDMap:     offeringIDMap,
 		result:            result,
 	})
+}
+
+// cloneOfferingCatalog delegates to the injected cloner. A nil cloner
+// yields an empty map — copyRolloverOfferings then rejects any booking
+// it cannot remap, so a mis-wired production setup fails loudly instead
+// of carrying source-phase offering references (#2249).
+func (s *rolloverService) cloneOfferingCatalog(ctx context.Context, sourcePhaseID, targetPhaseID int64) (map[int64]int64, error) {
+	if s.OfferingCatalogCloner == nil {
+		return map[int64]int64{}, nil
+	}
+	mapping, err := s.OfferingCatalogCloner.CloneCatalogForRollover(ctx, sourcePhaseID, targetPhaseID)
+	if err != nil {
+		return nil, fmt.Errorf("rollover: clone offering catalog: %w", err)
+	}
+	return mapping, nil
 }
 
 func (s *rolloverService) loadRolloverSourcePhase(ctx context.Context, tenantID, sourcePhaseID int64) (*enrollmentModels.Phase, error) {
@@ -503,7 +539,7 @@ func (s *rolloverService) rollSourceChild(ctx context.Context, input rolloverReq
 		}
 		return "", fmt.Errorf("rollover: create request_child: %w", err)
 	}
-	if err := s.copyRolloverOfferings(ctx, input.tenantID, source.ID, child.ID, input.sourcePhase.ServiceEndDate); err != nil {
+	if err := s.copyRolloverOfferings(ctx, input, source.ID, child.ID); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%s %s", source.FirstName, source.LastName), nil
@@ -531,14 +567,35 @@ func rolloverAttributesForSource(input rolloverRequestInput, source *enrollmentM
 	return attributes
 }
 
-func (s *rolloverService) copyRolloverOfferings(ctx context.Context, tenantID, sourceChildID, newChildID int64, sourcePeriodEnd timezone.Date) error {
-	offerings, err := s.RequestChildOfferingRepo.ListByRequestChildIDAtDate(ctx, sourceChildID, sourcePeriodEnd)
+// copyRolloverOfferings carries the booking effective at the END of the
+// source phase into the new child: the offering reference is remapped to
+// the target phase's clone, the effective weekday selection (parent-
+// selected, manual, and automatically derived days) plus notes travel
+// verbatim, and the validity interval is deliberately left nil — the
+// repository pins it to the NEW phase's service window on insert, so
+// historical source-phase intervals never carry over (#2249).
+func (s *rolloverService) copyRolloverOfferings(ctx context.Context, input rolloverRequestInput, sourceChildID, newChildID int64) error {
+	offerings, err := s.RequestChildOfferingRepo.ListByRequestChildIDAtDate(ctx, sourceChildID, input.sourcePhase.ServiceEndDate)
 	if err != nil {
 		return fmt.Errorf("rollover: list source offerings: %w", err)
 	}
 	for _, offering := range offerings {
-		copyRow := &enrollmentModels.RequestChildOffering{RequestChildID: newChildID, CareOfferingID: offering.CareOfferingID}
-		copyRow.SetTenantID(tenantID)
+		targetOfferingID, ok := input.offeringIDMap[offering.CareOfferingID]
+		if !ok {
+			return fmt.Errorf(
+				"rollover: source care offering %d of child %d has no clone in the target phase",
+				offering.CareOfferingID, sourceChildID,
+			)
+		}
+		copyRow := &enrollmentModels.RequestChildOffering{
+			RequestChildID:        newChildID,
+			CareOfferingID:        targetOfferingID,
+			SelectedDays:          offering.SelectedDays,
+			ManualSelectedDays:    offering.ManualSelectedDays,
+			AutomaticSelectedDays: offering.AutomaticSelectedDays,
+			Notes:                 offering.Notes,
+		}
+		copyRow.SetTenantID(input.tenantID)
 		if err := s.RequestChildOfferingRepo.Create(ctx, copyRow); err != nil {
 			return fmt.Errorf("rollover: copy offering: %w", err)
 		}

--- a/backend/services/enrollment/rollover_service.go
+++ b/backend/services/enrollment/rollover_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -314,7 +315,11 @@ func (s *rolloverService) runCreate(ctx context.Context, tenantID int64, req Cre
 		return err
 	}
 	result.SourceChildCount = len(sourceChildren)
-	offeringIDMap, err := s.cloneOfferingCatalog(ctx, source.ID, newPhase.ID)
+	carriedOfferingIDs, err := s.listCarriedOfferingIDs(ctx, source, sourceChildren)
+	if err != nil {
+		return err
+	}
+	offeringIDMap, err := s.cloneOfferingCatalog(ctx, source.ID, newPhase.ID, carriedOfferingIDs)
 	if err != nil {
 		return err
 	}
@@ -335,15 +340,34 @@ func (s *rolloverService) runCreate(ctx context.Context, tenantID int64, req Cre
 // yields an empty map — copyRolloverOfferings then rejects any booking
 // it cannot remap, so a mis-wired production setup fails loudly instead
 // of carrying source-phase offering references (#2249).
-func (s *rolloverService) cloneOfferingCatalog(ctx context.Context, sourcePhaseID, targetPhaseID int64) (map[int64]int64, error) {
+func (s *rolloverService) cloneOfferingCatalog(ctx context.Context, sourcePhaseID, targetPhaseID int64, carriedOfferingIDs []int64) (map[int64]int64, error) {
 	if s.OfferingCatalogCloner == nil {
 		return map[int64]int64{}, nil
 	}
-	mapping, err := s.OfferingCatalogCloner.CloneCatalogForRollover(ctx, sourcePhaseID, targetPhaseID)
+	mapping, err := s.OfferingCatalogCloner.CloneCatalogForRollover(ctx, sourcePhaseID, targetPhaseID, carriedOfferingIDs)
 	if err != nil {
 		return nil, fmt.Errorf("rollover: clone offering catalog: %w", err)
 	}
 	return mapping, nil
+}
+
+func (s *rolloverService) listCarriedOfferingIDs(ctx context.Context, sourcePhase *enrollmentModels.Phase, children []*enrollmentModels.RequestChild) ([]int64, error) {
+	ids := make(map[int64]struct{})
+	for _, child := range children {
+		offerings, err := s.RequestChildOfferingRepo.ListByRequestChildIDAtDate(ctx, child.ID, sourcePhase.ServiceEndDate)
+		if err != nil {
+			return nil, fmt.Errorf("rollover: list source offerings for child %d: %w", child.ID, err)
+		}
+		for _, offering := range offerings {
+			ids[offering.CareOfferingID] = struct{}{}
+		}
+	}
+	result := make([]int64, 0, len(ids))
+	for id := range ids {
+		result = append(result, id)
+	}
+	slices.Sort(result)
+	return result, nil
 }
 
 func (s *rolloverService) loadRolloverSourcePhase(ctx context.Context, tenantID, sourcePhaseID int64) (*enrollmentModels.Phase, error) {

--- a/backend/services/enrollment/rollover_service_test.go
+++ b/backend/services/enrollment/rollover_service_test.go
@@ -25,14 +25,15 @@ import (
 // in request_service_test.go so we get tenant + form schema + base
 // phase out of the box.
 type rolloverTestEnv struct {
-	db          *bun.DB
-	repos       *repositories.Factory
-	rolloverSvc enrollmentService.RolloverService
-	requestSvc  enrollmentService.RequestService
-	settings    *stubRequestSettings
-	outbox      *recordingOutbox
-	sourcePhase *enrollmentModels.Phase
-	creatorID   int64
+	db             *bun.DB
+	repos          *repositories.Factory
+	rolloverSvc    enrollmentService.RolloverService
+	requestSvc     enrollmentService.RequestService
+	offeringCloner enrollmentService.RolloverOfferingCatalogCloner
+	settings       *stubRequestSettings
+	outbox         *recordingOutbox
+	sourcePhase    *enrollmentModels.Phase
+	creatorID      int64
 }
 
 func setupRolloverTest(t *testing.T) (*rolloverTestEnv, func()) {
@@ -86,11 +87,27 @@ func setupRolloverTest(t *testing.T) (*rolloverTestEnv, func()) {
 		Logger:                   slog.Default(),
 	})
 
+	careOfferingSvc := enrollmentService.NewCareOfferingService(enrollmentService.CareOfferingServiceConfig{
+		Repo:                     repoFactory.CareOffering,
+		RequestChildOfferingRepo: repoFactory.RequestChildOffering,
+		ActivityGroupRepo:        repoFactory.ActivityGroup,
+		ActivityScheduleRepo:     repoFactory.ActivitySchedule,
+		CalendarPeriodRepo:       repoFactory.CalendarPeriod,
+		TimeframeRepo:            repoFactory.Timeframe,
+		ActivityExceptionRepo:    repoFactory.ActivityException,
+		PhaseRepo:                repoFactory.Phase,
+		Settings:                 settings,
+		Logger:                   slog.Default(),
+	})
+	offeringCloner, ok := careOfferingSvc.(enrollmentService.RolloverOfferingCatalogCloner)
+	require.True(t, ok, "care offering service must implement RolloverOfferingCatalogCloner")
+
 	rolloverSvc := enrollmentService.NewRolloverService(enrollmentService.RolloverServiceConfig{
 		PhaseRepo:                repoFactory.Phase,
 		RequestRepo:              repoFactory.Request,
 		RequestChildRepo:         repoFactory.RequestChild,
 		RequestChildOfferingRepo: repoFactory.RequestChildOffering,
+		OfferingCatalogCloner:    offeringCloner,
 		OutboxEnqueuer:           outbox,
 		Settings:                 settings,
 		ParentsURL:               "http://parents.localhost:3000",
@@ -123,14 +140,15 @@ func setupRolloverTest(t *testing.T) (*rolloverTestEnv, func()) {
 	require.NoError(t, repoFactory.Phase.Create(ctx, sourcePhase))
 
 	env := &rolloverTestEnv{
-		db:          db,
-		repos:       repoFactory,
-		rolloverSvc: rolloverSvc,
-		requestSvc:  requestSvc,
-		settings:    settings,
-		outbox:      outbox,
-		sourcePhase: sourcePhase,
-		creatorID:   account.ID,
+		db:             db,
+		repos:          repoFactory,
+		rolloverSvc:    rolloverSvc,
+		requestSvc:     requestSvc,
+		offeringCloner: offeringCloner,
+		settings:       settings,
+		outbox:         outbox,
+		sourcePhase:    sourcePhase,
+		creatorID:      account.ID,
 	}
 
 	cleanup := func() {
@@ -251,6 +269,7 @@ func rolloverServiceWithSettings(
 		RequestRepo:              env.repos.Request,
 		RequestChildRepo:         env.repos.RequestChild,
 		RequestChildOfferingRepo: env.repos.RequestChildOffering,
+		OfferingCatalogCloner:    env.offeringCloner,
 		OutboxEnqueuer:           env.outbox,
 		Settings:                 settings,
 		ParentsURL:               "http://parents.localhost:3000",

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1751,11 +1751,16 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 
 	// Rollover service depends on DecisionService for the
 	// rollover_auto_approve=true deadline path.
+	enrollmentRolloverCatalogCloner, ok := enrollmentCareOfferingService.(enrollment.RolloverOfferingCatalogCloner)
+	if !ok {
+		return nil, fmt.Errorf("enrollment care offering service does not implement rollover catalog cloning")
+	}
 	enrollmentRolloverService := enrollment.NewRolloverService(enrollment.RolloverServiceConfig{
 		PhaseRepo:                repos.Phase,
 		RequestRepo:              repos.Request,
 		RequestChildRepo:         repos.RequestChild,
 		RequestChildOfferingRepo: repos.RequestChildOffering,
+		OfferingCatalogCloner:    enrollmentRolloverCatalogCloner,
 		SchoolRepo:               repos.School,
 		OutboxEnqueuer:           emailOutboxService,
 		Settings:                 settingsService,


### PR DESCRIPTION
Closes #2249

## Problem

Der Rollover einer Anschlussphase übernahm Betreuungsbuchungen mit Angebotsreferenzen aus der Quellphase. Dadurch waren sie in der Zielphase nicht bearbeitbar; außerdem gingen Wochentage, Notizen und die Gültigkeit der aktuellen Auswahl verloren.

## Lösung

Der Rollover erstellt jetzt innerhalb derselben Tenant-Transaktion einen vollständigen Klon des Angebotskatalogs der Quellphase und ordnet übernommene Buchungen den Zielangeboten zu.

- Übernommen werden die am Ende der Quellphase wirksamen Buchungen, einschließlich `selected_days`, manueller und automatischer Wochentage sowie Notizen.
- Die Buchungen erhalten das Betreuungsfenster der neuen Phase; historische Intervalle werden nicht übernommen.
- Auswahlgruppen, Pflichtangebote, Preise, Kapazitäten und Auto-Add-Trigger bleiben im Klonkatalog erhalten; Trigger verweisen auf die jeweiligen Klone.
- Auch wirksame Legacy-Buchungen mit phasenfremder Angebotsreferenz werden für den Rollover geklont und korrekt zugeordnet.
- Verknüpfte Stundenplanvorlagen bleiben erhalten, wenn ihre Serie die Zielphase abdeckt. Andernfalls bricht der Rollover vor dem Anlegen einer unbrauchbaren Anschlussphase ab.
- `source_care_offering_ids` verknüpfter Vorlagen (#2137) werden nicht angepasst.
- Fehlt die Klon-Zuordnung oder schlägt die Validierung fehl, wird der gesamte Rollover ohne Anschlussphase, Buchungen oder Rollover-E-Mails zurückgerollt.

Damit können Eltern übernommene Anmeldungen in der Anschlussphase wieder bearbeiten, und eine automatische Freigabe materialisiert die übernommenen Wochentage weiterhin in verknüpfte Stundenplanvorlagen.

## Ablauf

Beim Erstellen einer Anschlussphase übernimmt das System bestätigte Kinder in den Verlängerungsstatus, klont den Angebotskatalog und übernimmt deren aktuelle Betreuungswahl. Die Quellphase und ihre Buchungshistorie bleiben unverändert.

## Tests

- Katalog-Klon, Remapping, Trigger-Remapping und unveränderte Quelldaten
- Übernahme von Wochentagen, Notizen und Zielphasen-Gültigkeit
- Legacy-Referenzen, Elternstatus-Bearbeitung und Wiederholungsschutz
- atomarer Abbruch bei ungültigem Angebot oder fehlendem Kloner
- Auto-Freigabe mit Di/Do-Auswahl und Materialisierung in einer Stundenplanvorlage
- Zwei bestehende Student-API-Tests verwenden einen festen Montag und sind damit nicht mehr am Wochenende instabil

```bash
cd backend && go test ./services/enrollment
cd backend && go test ./...
```
