### PR TITLE
Aufsichten rückwirkend einsehbar: Tagesrückblick auf beendete und abgelaufene Blöcke

### DIFF
--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -74,18 +74,23 @@ func (rs *Resource) operationsPlannedNow(w http.ResponseWriter, r *http.Request)
 		common.RenderError(w, r, common.ErrorInternalServer(errors.New("timetable operations service not wired")))
 		return
 	}
-	date := timezone.TodayDate()
+	opts, ok := parsePlannedNowOptions(w, r)
+	if !ok {
+		return
+	}
+	today := timezone.TodayDate()
+	date := today
 	if raw := r.URL.Query().Get("date"); raw != "" {
 		parsed, err := timezone.ParseDate(raw)
 		if err != nil {
 			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid date")))
 			return
 		}
+		if opts.Scope == scheduleSvc.PlannedNowScopePast && parsed != today {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("past scope only supports today's date")))
+			return
+		}
 		date = parsed
-	}
-	opts, ok := parsePlannedNowOptions(w, r)
-	if !ok {
-		return
 	}
 	claims := jwt.ClaimsFromCtx(r.Context())
 	result, err := rs.OperationsService.PlannedNow(r.Context(), int64(claims.ID), claims.IsAdmin, date, timezone.Now(), opts)

--- a/backend/api/timetable/operations.go
+++ b/backend/api/timetable/operations.go
@@ -115,6 +115,13 @@ func parsePlannedNowOptions(w http.ResponseWriter, r *http.Request) (scheduleSvc
 		}
 		opts.Limit = value
 	}
+	if raw := query.Get("scope"); raw != "" {
+		if raw != scheduleSvc.PlannedNowScopePast {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid scope")))
+			return opts, false
+		}
+		opts.Scope = raw
+	}
 	if raw := query.Get("include_roster"); raw != "" {
 		value, err := strconv.ParseBool(raw)
 		if err != nil {

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -57,6 +57,11 @@ func TestOperationsPlannedNow(t *testing.T) {
 	assert.Equal(t, 480, service.lastPlannedOptions.HorizonMinutes)
 	assert.Equal(t, 5, service.lastPlannedOptions.Limit)
 	assert.True(t, service.lastPlannedOptions.IncludeRoster)
+
+	rr = executeOperationRequest(router, http.MethodGet, "/planned-now?scope=past", nil)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, scheduleSvc.PlannedNowScopePast, service.lastPlannedOptions.Scope)
 }
 
 func testWorkdayNow() time.Time {
@@ -78,6 +83,9 @@ func TestOperationsPlannedNowValidationAndWiring(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
 	rr = executeOperationRequest(router, http.MethodGet, "/planned-now?include_roster=maybe", nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	rr = executeOperationRequest(router, http.MethodGet, "/planned-now?scope=future", nil)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 

--- a/backend/api/timetable/operations_unit_test.go
+++ b/backend/api/timetable/operations_unit_test.go
@@ -87,6 +87,9 @@ func TestOperationsPlannedNowValidationAndWiring(t *testing.T) {
 
 	rr = executeOperationRequest(router, http.MethodGet, "/planned-now?scope=future", nil)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	rr = executeOperationRequest(router, http.MethodGet, "/planned-now?scope=past&date=2000-01-01", nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestOperationsInstanceEndpoints(t *testing.T) {

--- a/backend/services/schedule/timetable_operations_service.go
+++ b/backend/services/schedule/timetable_operations_service.go
@@ -79,10 +79,18 @@ type TimetableOperationsService interface {
 	PatchAttendance(ctx context.Context, accountID int64, isAdmin bool, instanceID, studentID int64, patch scheduleModel.AttendanceFieldPatch) (*OperationRosterRow, error)
 }
 
+// PlannedNowScopePast flips PlannedNow to the complement of its default
+// window (#2335): today's finished blocks — completed ones, and planned ones
+// whose end time has passed without ever being started (no job moves them out
+// of "planned", so a status filter alone would miss them).
+const PlannedNowScopePast = "past"
+
 type PlannedNowOptions struct {
 	HorizonMinutes int
 	Limit          int
 	IncludeRoster  bool
+	// Scope is "" for the default upcoming window or PlannedNowScopePast.
+	Scope string
 }
 
 type TimetableOperationsDependencies struct {
@@ -270,9 +278,14 @@ func (s *timetableOperationsService) PlannedNow(ctx context.Context, accountID i
 	if startLead > horizon {
 		horizon = startLead
 	}
+	past := opts.Scope == PlannedNowScopePast
 	candidates := make([]plannedNowCandidate, 0, len(instances))
 	for _, inst := range instances {
-		if inst.Status != scheduleModel.InstanceStatusPlanned || !plannedNowWindow(inst, now, horizon) {
+		if past {
+			if !plannedPastToday(inst, now) {
+				continue
+			}
+		} else if inst.Status != scheduleModel.InstanceStatusPlanned || !plannedNowWindow(inst, now, horizon) {
 			continue
 		}
 		roomName := roomNames[inst.RoomID]
@@ -306,11 +319,15 @@ func (s *timetableOperationsService) PlannedNow(ctx context.Context, accountID i
 	out := make([]OperationPlannedInstance, 0, len(candidates))
 	for _, candidate := range candidates {
 		mapped := mapPlannedInstance(candidate.instance, candidate.staffRows, candidate.studentRows, now, staffID, candidate.roomName, careDay)
-		availability := EvaluateLifecycleAvailability(candidate.instance, now, startLead, true)
-		mapped.CanStart = availability.CanStart
-		mapped.StartAvailableAt = availability.StartAvailableAt.Format(time.RFC3339)
-		if !candidate.instance.IsSpontaneous {
-			mapped.StartExpiresAt = availability.CompleteAvailableAt.Format(time.RFC3339)
+		// Past blocks are read-only: no start lifecycle, the zero-value
+		// CanStart/StartAvailableAt/StartExpiresAt say so.
+		if !past {
+			availability := EvaluateLifecycleAvailability(candidate.instance, now, startLead, true)
+			mapped.CanStart = availability.CanStart
+			mapped.StartAvailableAt = availability.StartAvailableAt.Format(time.RFC3339)
+			if !candidate.instance.IsSpontaneous {
+				mapped.StartExpiresAt = availability.CompleteAvailableAt.Format(time.RFC3339)
+			}
 		}
 		if opts.IncludeRoster {
 			roster, err := s.buildRosterWithCareDay(ctx, candidate.instance.ID, careDay)
@@ -1207,6 +1224,23 @@ func plannedNowWindow(inst *scheduleModel.ActivityInstance, now time.Time, horiz
 		return false
 	}
 	return (start.After(now.Add(-15*time.Minute)) && start.Before(now.Add(time.Duration(horizonMinutes)*time.Minute))) || start.Before(now)
+}
+
+// plannedPastToday is the scope=past complement of plannedNowWindow (#2335):
+// completed blocks, plus non-spontaneous planned blocks whose end time has
+// passed — those never started and stay "planned" forever, so a pure status
+// filter would hide them. Spontaneous planned instances stay in the default
+// scope (plannedNowWindow keeps them startable past their end), and cancelled
+// and running instances belong to neither list.
+func plannedPastToday(inst *scheduleModel.ActivityInstance, now time.Time) bool {
+	switch inst.Status {
+	case scheduleModel.InstanceStatusCompleted:
+		return true
+	case scheduleModel.InstanceStatusPlanned:
+		return !inst.IsSpontaneous && !now.Before(instanceEndAt(inst, now.Location()))
+	default:
+		return false
+	}
 }
 
 func instanceEndAt(inst *scheduleModel.ActivityInstance, loc *time.Location) time.Time {

--- a/backend/services/schedule/timetable_operations_service_test.go
+++ b/backend/services/schedule/timetable_operations_service_test.go
@@ -302,6 +302,64 @@ func TestTimetableOperationsPlannedNowSupportsUpcomingOptions(t *testing.T) {
 	assert.Equal(t, "Lina Lang", result[0].RosterPreview[0].StudentName)
 }
 
+// scope=past is the complement of the default window (#2335): completed
+// blocks and never-started planned blocks whose end has passed. Running,
+// cancelled, still-open planned, and spontaneous planned instances stay out.
+func TestTimetableOperationsPlannedNowPastScopeSelectsFinishedBlocks(t *testing.T) {
+	now := time.Date(2026, time.May, 10, 15, 0, 0, 0, time.UTC)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 632, 438, 231, 360)
+	completed := instanceWithTimes(361, scheduleModel.InstanceStatusCompleted, now.Add(-3*time.Hour), now.Add(-2*time.Hour))
+	expiredSpontaneous := instanceWithTimes(364, scheduleModel.InstanceStatusPlanned, now.Add(-3*time.Hour), now.Add(-2*time.Hour))
+	expiredSpontaneous.IsSpontaneous = true
+	deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+		instanceWithTimes(360, scheduleModel.InstanceStatusPlanned, now.Add(-135*time.Minute), now.Add(-30*time.Minute)),
+		completed,
+		instanceWithTimes(362, scheduleModel.InstanceStatusPlanned, now.Add(-time.Hour), now.Add(time.Hour)),
+		instanceWithTimes(363, scheduleModel.InstanceStatusCancelled, now.Add(-3*time.Hour), now.Add(-2*time.Hour)),
+		expiredSpontaneous,
+		instanceWithTimes(365, scheduleModel.InstanceStatusActive, now.Add(-time.Hour), now.Add(-30*time.Minute)),
+	}
+	for _, inst := range deps.instanceRepo.byDate {
+		deps.staffRepo.byInstance[inst.ID] = []*scheduleModel.InstanceStaff{{StaffID: 231}}
+	}
+
+	result, err := deps.service.PlannedNow(context.Background(), 632, false, timezone.DateFromTime(now), now, PlannedNowOptions{Scope: PlannedNowScopePast})
+
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	ids := []int64{result[0].ID, result[1].ID}
+	assert.ElementsMatch(t, []int64{360, 361}, ids)
+	for _, inst := range result {
+		assert.False(t, inst.CanStart)
+		assert.Empty(t, inst.StartExpiresAt)
+	}
+}
+
+// Past-scope visibility mirrors the default scope: unassigned staff see
+// nothing, the admin overview sees everything (#2335).
+func TestTimetableOperationsPlannedNowPastScopeKeepsVisibilityRules(t *testing.T) {
+	now := time.Date(2026, time.May, 10, 15, 0, 0, 0, time.UTC)
+	deps := newTimetableOpsDeps()
+	wireAssignedStaff(deps, 633, 439, 232, 370)
+	deps.instanceRepo.byDate = []*scheduleModel.ActivityInstance{
+		instanceWithTimes(370, scheduleModel.InstanceStatusCompleted, now.Add(-3*time.Hour), now.Add(-2*time.Hour)),
+		instanceWithTimes(371, scheduleModel.InstanceStatusCompleted, now.Add(-3*time.Hour), now.Add(-2*time.Hour)),
+	}
+	deps.staffRepo.byInstance[370] = []*scheduleModel.InstanceStaff{{StaffID: 232}}
+	deps.staffRepo.byInstance[371] = []*scheduleModel.InstanceStaff{{StaffID: 999}}
+
+	result, err := deps.service.PlannedNow(context.Background(), 633, false, timezone.DateFromTime(now), now, PlannedNowOptions{Scope: PlannedNowScopePast})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, int64(370), result[0].ID)
+
+	deps.settings.enabled = true
+	result, err = deps.service.PlannedNow(context.Background(), 633, true, timezone.DateFromTime(now), now, PlannedNowOptions{Scope: PlannedNowScopePast})
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+}
+
 func TestTimetableOperationsStartRequiresAStaffIdentity(t *testing.T) {
 	deps := newTimetableOpsDeps()
 	deps.settings.enabled = true

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -84,6 +84,7 @@ import {
   ReleaseSupervisionModal,
   SchulhofNotSupervisingView,
 } from "~/components/active-supervisions/states";
+import { PastBlocksSection } from "~/components/active-supervisions/past-blocks-section";
 import { PlannedNowSection } from "~/components/active-supervisions/planned-now-section";
 import {
   SpontaneousActivityStart,
@@ -2684,6 +2685,9 @@ function MeinRaumPageContent() {
       {/* Student Grid - Mobile Optimized */}
       {(!isSchulhofTabSelected || schulhofStatus?.isUserSupervising) &&
         renderStudentContent()}
+
+      {/* Read-only end-of-day review of finished and expired blocks (#2335) */}
+      <PastBlocksSection />
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -2251,6 +2251,9 @@ function MeinRaumPageContent() {
           filterConfigs={filterConfigs}
           activeFilters={activeFilters}
         />
+        {/* The day review must survive the empty state: after the last block
+            ends, supervisors land exactly here (#2335). */}
+        <PastBlocksSection />
       </div>
     );
   }

--- a/frontend/src/components/active-supervisions/past-blocks-section.test.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.test.tsx
@@ -1,0 +1,237 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PastBlocksSection } from "./past-blocks-section";
+import type {
+  PlannedTimetableInstance,
+  TimetableRoster,
+} from "~/lib/timetable-operations-types";
+
+const { plannedNowMock, rosterMock } = vi.hoisted(() => ({
+  plannedNowMock: vi.fn(),
+  rosterMock: vi.fn(),
+}));
+
+vi.mock("~/lib/timetable-operations-api", () => ({
+  timetableOperationsApi: {
+    plannedNow: plannedNowMock,
+    roster: rosterMock,
+  },
+}));
+
+function pastBlock(
+  overrides: Partial<PlannedTimetableInstance>,
+): PlannedTimetableInstance {
+  return {
+    id: "instance-1",
+    date: "2026-08-16",
+    title: "Aufsicht 2B",
+    roomId: "room-1",
+    roomName: "Raum 2B",
+    startTime: "12:45",
+    endTime: "14:30",
+    status: "completed",
+    expectedStudentsCount: 8,
+    notScheduledStudentsCount: 0,
+    presentStudentsCount: 6,
+    minutesUntilStart: -180,
+    assignedStaffIds: ["staff-1", "staff-2"],
+    isAssigned: true,
+    isPrimary: false,
+    isSubstitute: false,
+    isAbsent: false,
+    rosterPreview: [],
+    isOverdue: false,
+    ...overrides,
+  };
+}
+
+const completedRoster: TimetableRoster = {
+  instance: {
+    id: "instance-1",
+    title: "Aufsicht 2B",
+    status: "completed",
+    isSpontaneous: false,
+    activeGroupId: null,
+    roomId: "room-1",
+    roomName: "Raum 2B",
+    date: "2026-08-16",
+    startTime: "12:45",
+    endTime: "14:30",
+    canComplete: false,
+    completeAvailableAt: "",
+  },
+  rows: [
+    {
+      studentId: "student-1",
+      studentName: "Mia Bauer",
+      schoolClass: "2a",
+      groupName: "Sternengruppe",
+      planned: true,
+      isUnplanned: false,
+      currentlyPresent: false,
+      visitId: "visit-1",
+      status: "present",
+      substatus: null,
+      note: null,
+      checkedInAt: "2026-08-16T12:50:00Z",
+      checkedOutAt: "2026-08-16T14:25:00Z",
+      visitEntryTime: null,
+      warnings: [],
+      careDayStatus: "scheduled",
+      parallelPresentIn: null,
+    },
+    {
+      studentId: "student-2",
+      studentName: "Tom Weber",
+      schoolClass: "2b",
+      groupName: "Sternengruppe",
+      planned: true,
+      isUnplanned: false,
+      currentlyPresent: false,
+      visitId: null,
+      status: "expected",
+      substatus: null,
+      note: null,
+      checkedInAt: null,
+      checkedOutAt: null,
+      visitEntryTime: null,
+      warnings: [],
+      careDayStatus: "scheduled",
+      parallelPresentIn: null,
+    },
+  ],
+};
+
+describe("PastBlocksSection", () => {
+  beforeEach(() => {
+    plannedNowMock.mockReset();
+    rosterMock.mockReset();
+  });
+
+  it("stays collapsed and does not fetch until opened", () => {
+    render(<PastBlocksSection />);
+
+    expect(
+      screen.getByText("Beendete und abgelaufene Blöcke"),
+    ).toBeInTheDocument();
+    expect(plannedNowMock).not.toHaveBeenCalled();
+  });
+
+  it("loads past blocks on expand and labels completed and never-started ones", async () => {
+    plannedNowMock.mockResolvedValue([
+      pastBlock({}),
+      pastBlock({
+        id: "instance-2",
+        title: "Lernzeit",
+        status: "planned",
+        startTime: "10:00",
+        endTime: "11:00",
+      }),
+    ]);
+
+    render(<PastBlocksSection />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Beendete und abgelaufene Blöcke/ }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Aufsicht 2B")).toBeInTheDocument(),
+    );
+    expect(plannedNowMock).toHaveBeenCalledWith({ scope: "past" });
+    expect(screen.getByText("Beendet")).toBeInTheDocument();
+    expect(screen.getByText("Nicht gestartet")).toBeInTheDocument();
+    // Sorted chronologically: the 10:00 block renders before the 12:45 one.
+    const titles = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((el) => el.textContent);
+    expect(titles).toEqual(["Lernzeit", "Aufsicht 2B"]);
+  });
+
+  it("shows an empty state when nothing has finished yet", async () => {
+    plannedNowMock.mockResolvedValue([]);
+
+    render(<PastBlocksSection />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Beendete und abgelaufene Blöcke/ }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Heute sind noch keine Blöcke beendet oder abgelaufen.",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("lazy-loads the roster with final statuses for a completed block", async () => {
+    plannedNowMock.mockResolvedValue([pastBlock({})]);
+    rosterMock.mockResolvedValue(completedRoster);
+
+    render(<PastBlocksSection />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Beendete und abgelaufene Blöcke/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Aufsicht 2B")).toBeInTheDocument(),
+    );
+    expect(rosterMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Kinder" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Mia Bauer")).toBeInTheDocument(),
+    );
+    expect(rosterMock).toHaveBeenCalledWith("instance-1");
+    expect(screen.getByText("Gegangen")).toBeInTheDocument();
+    expect(screen.getByText("Nicht erschienen")).toBeInTheDocument();
+  });
+
+  it("shows the never-started hint instead of per-child statuses", async () => {
+    plannedNowMock.mockResolvedValue([
+      pastBlock({ status: "planned", title: "Lernzeit" }),
+    ]);
+    rosterMock.mockResolvedValue({
+      ...completedRoster,
+      instance: { ...completedRoster.instance, status: "planned" },
+    });
+
+    render(<PastBlocksSection />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Beendete und abgelaufene Blöcke/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Lernzeit")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Kinder" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Keine Anwesenheit erfasst: Der Block wurde nicht gestartet.",
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Mia Bauer")).toBeInTheDocument();
+    expect(screen.queryByText("Gegangen")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a load error", async () => {
+    plannedNowMock.mockRejectedValue(new Error("kaputt"));
+
+    render(<PastBlocksSection />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Beendete und abgelaufene Blöcke/ }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Vergangene Blöcke konnten nicht geladen werden. Bitte später erneut versuchen.",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/active-supervisions/past-blocks-section.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, History } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { Loading } from "~/components/ui/loading";
+import { SectionCard } from "~/components/ui/section-card";
 import { StatusBadge } from "~/components/ui/status-badge";
 import { StatusDotBadge } from "~/components/ui/status-dot-badge";
 import { LOCATION_COLORS } from "~/lib/location-helper";
@@ -87,50 +88,32 @@ export function PastBlocksSection() {
   }, [expanded]);
 
   return (
-    <section className="moto-content-surface mt-5 overflow-hidden rounded-2xl border shadow-sm backdrop-blur-md">
-      <button
-        type="button"
-        onClick={() => setExpanded((current) => !current)}
-        className="group focus-visible:ring-moto-blue/30 flex w-full items-center gap-3 p-4 text-left focus-visible:ring-2 focus-visible:outline-none sm:p-5"
-        aria-expanded={expanded}
-      >
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gray-100">
-          <History className="h-5 w-5 text-gray-600" aria-hidden="true" />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="text-moto-blue block text-xs font-semibold tracking-wide uppercase">
-            Rückblick
-          </span>
-          <span className="block text-base font-semibold text-gray-900">
-            Beendete und abgelaufene Blöcke
-          </span>
-        </span>
-        <ChevronDown
-          className={`h-4 w-4 shrink-0 text-gray-400 transition-transform group-hover:text-gray-600 ${expanded ? "rotate-180" : ""}`}
-          aria-hidden="true"
-        />
-      </button>
-
-      {expanded ? (
-        <div className="border-t border-gray-100 bg-gray-50/50 p-4 sm:p-5">
-          {isLoading && blocks === null ? (
-            <Loading fullPage={false} />
-          ) : loadError ? (
-            <Alert type="error" message={loadError} />
-          ) : blocks !== null && blocks.length === 0 ? (
-            <p className="text-sm text-gray-600">
-              Heute sind noch keine Blöcke beendet oder abgelaufen.
-            </p>
-          ) : blocks !== null ? (
-            <div className="grid gap-3 xl:grid-cols-2">
-              {blocks.map((block) => (
-                <PastBlockCard key={block.id} block={block} />
-              ))}
-            </div>
-          ) : null}
+    <SectionCard
+      kicker="Rückblick"
+      title="Beendete und abgelaufene Blöcke"
+      icon={History}
+      collapsible
+      defaultCollapsed
+      onCollapsedChange={(collapsed) => setExpanded(!collapsed)}
+      className="mt-5"
+      bodyClassName="-mx-5 -mb-5 mt-5 border-t border-gray-100 bg-gray-50/50 p-5"
+    >
+      {isLoading && blocks === null ? (
+        <Loading fullPage={false} />
+      ) : loadError ? (
+        <Alert type="error" message={loadError} />
+      ) : blocks !== null && blocks.length === 0 ? (
+        <p className="text-sm text-gray-600">
+          Heute sind noch keine Blöcke beendet oder abgelaufen.
+        </p>
+      ) : blocks !== null ? (
+        <div className="grid gap-3 xl:grid-cols-2">
+          {blocks.map((block) => (
+            <PastBlockCard key={block.id} block={block} />
+          ))}
         </div>
       ) : null}
-    </section>
+    </SectionCard>
   );
 }
 

--- a/frontend/src/components/active-supervisions/past-blocks-section.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.tsx
@@ -41,7 +41,11 @@ function pastRosterDotColor(row: TimetableRosterRow): string {
   if (row.currentlyPresent) return LOCATION_COLORS.GROUP_ROOM;
   if (row.status === "present") return LOCATION_COLORS.HOME;
   if (!isCareDayExpected(row.careDayStatus)) return LOCATION_COLORS.UNKNOWN;
-  return LOCATION_COLORS.DANGER;
+  if (row.status === "absent") return LOCATION_COLORS.DANGER;
+  // "Nicht erschienen" must not share the hex with "Abwesend" (two states on
+  // one list, see the color rule); the never-arrived case wears the
+  // "Kommt heute nicht" navy.
+  return LOCATION_COLORS.NOT_ARRIVAL;
 }
 
 export function PastBlocksSection() {

--- a/frontend/src/components/active-supervisions/past-blocks-section.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, History } from "lucide-react";
+import { Alert } from "~/components/ui/alert";
+import { Loading } from "~/components/ui/loading";
+import { LOCATION_COLORS } from "~/lib/location-helper";
+import { createLogger } from "~/lib/logger";
+import { isCareDayExpected } from "~/lib/timetable-types";
+import { timetableOperationsApi } from "~/lib/timetable-operations-api";
+import type {
+  PlannedTimetableInstance,
+  TimetableRoster,
+  TimetableRosterRow,
+} from "~/lib/timetable-operations-types";
+
+const logger = createLogger({ component: "PastBlocksSection" });
+
+// Read-only end-of-day review (#2335): today's completed blocks plus planned
+// blocks whose end time passed without a start. Everything here is display
+// only — no start button, no attendance actions.
+
+function isPastBlockCompleted(instance: PlannedTimetableInstance): boolean {
+  return instance.status === "completed";
+}
+
+function pastRosterStatusLabel(row: TimetableRosterRow): string {
+  if (row.currentlyPresent) return "Anwesend";
+  if (row.status === "present") return "Gegangen";
+  if (!isCareDayExpected(row.careDayStatus)) {
+    return row.careDayStatus === "cancelled"
+      ? "Abgemeldet"
+      : "Nicht eingeplant";
+  }
+  if (row.status === "absent") return "Abwesend";
+  return "Nicht erschienen";
+}
+
+function pastRosterDotColor(row: TimetableRosterRow): string {
+  if (row.currentlyPresent) return LOCATION_COLORS.GROUP_ROOM;
+  if (row.status === "present") return LOCATION_COLORS.HOME;
+  if (!isCareDayExpected(row.careDayStatus)) return LOCATION_COLORS.UNKNOWN;
+  return LOCATION_COLORS.DANGER;
+}
+
+export function PastBlocksSection() {
+  const [expanded, setExpanded] = useState(false);
+  const [blocks, setBlocks] = useState<PlannedTimetableInstance[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Lazy: the list loads when the section opens, and reloads on every open so
+  // a block that ended in the meantime shows up without a page refresh.
+  useEffect(() => {
+    if (!expanded) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setLoadError(null);
+    timetableOperationsApi
+      .plannedNow({ scope: "past" })
+      .then((instances) => {
+        if (cancelled) return;
+        setBlocks(
+          [...instances].sort((a, b) => a.startTime.localeCompare(b.startTime)),
+        );
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        logger.error("past_blocks_load_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setLoadError(
+          "Vergangene Blöcke konnten nicht geladen werden. Bitte später erneut versuchen.",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [expanded]);
+
+  return (
+    <section className="moto-content-surface mt-5 overflow-hidden rounded-2xl border shadow-sm backdrop-blur-md">
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        className="group focus-visible:ring-moto-blue/30 flex w-full items-center gap-3 p-4 text-left focus-visible:ring-2 focus-visible:outline-none sm:p-5"
+        aria-expanded={expanded}
+      >
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gray-100">
+          <History className="h-5 w-5 text-gray-600" aria-hidden="true" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="text-moto-blue block text-xs font-semibold tracking-wide uppercase">
+            Rückblick
+          </span>
+          <span className="block text-base font-semibold text-gray-900">
+            Beendete und abgelaufene Blöcke
+          </span>
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-gray-400 transition-transform group-hover:text-gray-600 ${expanded ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {expanded ? (
+        <div className="border-t border-gray-100 bg-gray-50/50 p-4 sm:p-5">
+          {isLoading && blocks === null ? (
+            <Loading fullPage={false} />
+          ) : loadError ? (
+            <Alert type="error" message={loadError} />
+          ) : blocks !== null && blocks.length === 0 ? (
+            <p className="text-sm text-gray-600">
+              Heute sind noch keine Blöcke beendet oder abgelaufen.
+            </p>
+          ) : blocks !== null ? (
+            <div className="grid gap-3 xl:grid-cols-2">
+              {blocks.map((block) => (
+                <PastBlockCard key={block.id} block={block} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function PastBlockCard({
+  block,
+}: Readonly<{ block: PlannedTimetableInstance }>) {
+  const [expanded, setExpanded] = useState(false);
+  const [roster, setRoster] = useState<TimetableRoster | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const completed = isPastBlockCompleted(block);
+
+  const loadRoster = useCallback(() => {
+    setIsLoading(true);
+    setLoadError(null);
+    timetableOperationsApi
+      .roster(block.id)
+      .then(setRoster)
+      .catch((err: unknown) => {
+        logger.error("past_block_roster_load_failed", {
+          instance_id: block.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setLoadError("Kinderliste konnte nicht geladen werden.");
+      })
+      .finally(() => setIsLoading(false));
+  }, [block.id]);
+
+  const toggleRoster = () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && roster === null && !isLoading) loadRoster();
+  };
+
+  return (
+    <article className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div className="p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="truncate text-sm font-semibold text-gray-900">
+            {block.title}
+          </h3>
+          {completed ? (
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+              Beendet
+            </span>
+          ) : (
+            <span className="bg-moto-amber/20 text-moto-amber-strong rounded-full px-2 py-0.5 text-xs font-medium">
+              Nicht gestartet
+            </span>
+          )}
+        </div>
+        <div className="mt-2 flex flex-wrap gap-3 text-sm text-gray-600">
+          <span>
+            {block.startTime}-{block.endTime}
+          </span>
+          <span>{block.roomName ?? `Raum ${block.roomId}`}</span>
+          <span>
+            {block.assignedStaffIds.length}{" "}
+            {block.assignedStaffIds.length === 1 ? "Betreuer" : "Betreuende"}
+          </span>
+        </div>
+      </div>
+
+      <div className="border-t border-gray-100 bg-gray-50/70 px-4 py-3">
+        <button
+          type="button"
+          onClick={toggleRoster}
+          className="flex w-full items-center justify-between gap-3 text-left text-sm font-medium text-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          aria-expanded={expanded}
+        >
+          <span>Kinder</span>
+          <ChevronDown
+            className={`h-4 w-4 text-gray-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+            aria-hidden="true"
+          />
+        </button>
+
+        {expanded ? (
+          <div className="mt-3">
+            {isLoading ? (
+              <Loading fullPage={false} />
+            ) : loadError ? (
+              <Alert type="error" message={loadError} />
+            ) : roster !== null ? (
+              <div className="space-y-2">
+                {!completed ? (
+                  <p className="text-moto-amber-strong text-xs">
+                    Keine Anwesenheit erfasst: Der Block wurde nicht gestartet.
+                  </p>
+                ) : null}
+                {roster.rows.length === 0 ? (
+                  <p className="text-sm text-gray-600">
+                    Keine Kinder eingeplant.
+                  </p>
+                ) : (
+                  roster.rows.map((row) => (
+                    <PastRosterRow
+                      key={row.studentId}
+                      row={row}
+                      showStatus={completed}
+                    />
+                  ))
+                )}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function PastRosterRow({
+  row,
+  showStatus,
+}: Readonly<{ row: TimetableRosterRow; showStatus: boolean }>) {
+  return (
+    <div className="rounded-lg bg-white px-3 py-2 text-sm shadow-[0_1px_0_rgba(17,24,39,0.04)]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate font-medium text-gray-900">
+            {row.studentName || `Kind ${row.studentId}`}
+          </p>
+          <p className="mt-0.5 truncate text-xs text-gray-500">
+            {[row.schoolClass, row.groupName].filter(Boolean).join(" · ") ||
+              "Ohne Klassengruppe"}
+          </p>
+        </div>
+        {showStatus ? (
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600">
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: pastRosterDotColor(row) }}
+              aria-hidden="true"
+            />
+            {pastRosterStatusLabel(row)}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/active-supervisions/past-blocks-section.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, History } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
 import { Loading } from "~/components/ui/loading";
 import { SectionCard } from "~/components/ui/section-card";
 import { StatusBadge } from "~/components/ui/status-badge";
@@ -149,35 +150,36 @@ function PastBlockCard({
   };
 
   return (
-    <article className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-      <div className="p-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <h3 className="truncate text-sm font-semibold text-gray-900">
-            {block.title}
-          </h3>
-          {completed ? (
-            <StatusBadge label="Beendet" tone="gray" />
-          ) : (
-            <StatusBadge label="Nicht gestartet" tone="orange" />
-          )}
-        </div>
-        <div className="mt-2 flex flex-wrap gap-3 text-sm text-gray-600">
-          <span>
-            {block.startTime}-{block.endTime}
-          </span>
-          <span>{block.roomName ?? `Raum ${block.roomId}`}</span>
-          <span>
-            {block.assignedStaffIds.length}{" "}
-            {block.assignedStaffIds.length === 1 ? "Betreuer" : "Betreuende"}
-          </span>
-        </div>
+    <SectionCard
+      title={block.title}
+      headingLevel={3}
+      action={
+        completed ? (
+          <StatusBadge label="Beendet" tone="gray" />
+        ) : (
+          <StatusBadge label="Nicht gestartet" tone="orange" />
+        )
+      }
+      bodyClassName="mt-2"
+    >
+      <div className="flex flex-wrap gap-3 text-sm text-gray-600">
+        <span>
+          {block.startTime}-{block.endTime}
+        </span>
+        <span>{block.roomName ?? `Raum ${block.roomId}`}</span>
+        <span>
+          {block.assignedStaffIds.length}{" "}
+          {block.assignedStaffIds.length === 1 ? "Betreuer" : "Betreuende"}
+        </span>
       </div>
 
-      <div className="border-t border-gray-100 bg-gray-50/70 px-4 py-3">
-        <button
+      <div className="-mx-5 mt-4 -mb-5 border-t border-gray-100 bg-gray-50/70 px-5 py-3">
+        <Button
           type="button"
+          variant="ghost"
+          size="compact"
           onClick={toggleRoster}
-          className="flex w-full items-center justify-between gap-3 text-left text-sm font-medium text-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none"
+          className="w-full justify-between text-sm"
           aria-expanded={expanded}
         >
           <span>Kinder</span>
@@ -185,7 +187,7 @@ function PastBlockCard({
             className={`h-4 w-4 text-gray-400 transition-transform ${expanded ? "rotate-180" : ""}`}
             aria-hidden="true"
           />
-        </button>
+        </Button>
 
         {expanded ? (
           <div className="mt-3">
@@ -218,7 +220,7 @@ function PastBlockCard({
           </div>
         ) : null}
       </div>
-    </article>
+    </SectionCard>
   );
 }
 

--- a/frontend/src/components/active-supervisions/past-blocks-section.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, History } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { Loading } from "~/components/ui/loading";
+import { StatusBadge } from "~/components/ui/status-badge";
+import { StatusDotBadge } from "~/components/ui/status-dot-badge";
 import { LOCATION_COLORS } from "~/lib/location-helper";
 import { createLogger } from "~/lib/logger";
 import { isCareDayExpected } from "~/lib/timetable-types";
@@ -20,10 +22,9 @@ const logger = createLogger({ component: "PastBlocksSection" });
 // blocks whose end time passed without a start. Everything here is display
 // only — no start button, no attendance actions.
 
-function isPastBlockCompleted(instance: PlannedTimetableInstance): boolean {
-  return instance.status === "completed";
-}
-
+// Deliberately local, not shared with planned-now-section's rosterStatusLabel:
+// that one describes the LIVE state of an upcoming block ("Erwartet"), these
+// describe the FINAL state of a finished one ("Gegangen", "Nicht erschienen").
 function pastRosterStatusLabel(row: TimetableRosterRow): string {
   if (row.currentlyPresent) return "Anwesend";
   if (row.status === "present") return "Gegangen";
@@ -136,7 +137,7 @@ function PastBlockCard({
   const [roster, setRoster] = useState<TimetableRoster | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const completed = isPastBlockCompleted(block);
+  const completed = block.status === "completed";
 
   const loadRoster = useCallback(() => {
     setIsLoading(true);
@@ -168,13 +169,9 @@ function PastBlockCard({
             {block.title}
           </h3>
           {completed ? (
-            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-              Beendet
-            </span>
+            <StatusBadge label="Beendet" tone="gray" />
           ) : (
-            <span className="bg-moto-amber/20 text-moto-amber-strong rounded-full px-2 py-0.5 text-xs font-medium">
-              Nicht gestartet
-            </span>
+            <StatusBadge label="Nicht gestartet" tone="orange" />
           )}
         </div>
         <div className="mt-2 flex flex-wrap gap-3 text-sm text-gray-600">
@@ -255,14 +252,10 @@ function PastRosterRow({
           </p>
         </div>
         {showStatus ? (
-          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600">
-            <span
-              className="h-2.5 w-2.5 rounded-full"
-              style={{ backgroundColor: pastRosterDotColor(row) }}
-              aria-hidden="true"
-            />
-            {pastRosterStatusLabel(row)}
-          </span>
+          <StatusDotBadge
+            label={pastRosterStatusLabel(row)}
+            color={pastRosterDotColor(row)}
+          />
         ) : null}
       </div>
     </div>

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -701,6 +701,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Den Schulhof über den Schulhof-Tab und `Beaufsichtigen` führen. Läuft dort bereits eine Aufsicht oder ein gestarteter Termin, treten Sie als weitere Aufsicht bei; sonst startet eine spontane Schulhof-Aufsicht. Im Dialog für eine spontane Aktivität lässt sich der Raum `Schulhof` wie jeder andere Raum wählen.",
           "Für ein neues Angebot `Spontane Aktivität starten`.",
           "Erfasst Ihre Einrichtung Anwesenheit ohne Raum- oder Aktivitätszuordnung, erscheinen weder dieser Bereich noch `Räume` und `Aktivitäten` in der Seitenleiste. Ist die Schulhof-Funktion aktiviert, kann der Schulhof trotzdem zusätzlich erfasst werden. Diesen Modus stellt das moto-Team ein.",
+          "Ganz unten zeigt der Bereich `Beendete und abgelaufene Blöcke` zur Kontrolle die heutigen Blöcke, die bereits vorbei sind. Beim Aufklappen erscheint pro Block die Kinderliste zum Nachlesen: bei beendeten Blöcken mit dem letzten Stand (Anwesend, Gegangen, Abwesend), bei nie gestarteten Blöcken die geplante Liste mit dem Hinweis, dass keine Anwesenheit erfasst wurde. Ändern lässt sich hier nichts.",
         ],
         callout: {
           title: "Warum steht ein Kind auf `Nicht eingeplant`?",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -701,7 +701,10 @@ export const appChapters: readonly GuideChapter[] = [
           "Den Schulhof über den Schulhof-Tab und `Beaufsichtigen` führen. Läuft dort bereits eine Aufsicht oder ein gestarteter Termin, treten Sie als weitere Aufsicht bei; sonst startet eine spontane Schulhof-Aufsicht. Im Dialog für eine spontane Aktivität lässt sich der Raum `Schulhof` wie jeder andere Raum wählen.",
           "Für ein neues Angebot `Spontane Aktivität starten`.",
           "Erfasst Ihre Einrichtung Anwesenheit ohne Raum- oder Aktivitätszuordnung, erscheinen weder dieser Bereich noch `Räume` und `Aktivitäten` in der Seitenleiste. Ist die Schulhof-Funktion aktiviert, kann der Schulhof trotzdem zusätzlich erfasst werden. Diesen Modus stellt das moto-Team ein.",
-          "Ganz unten zeigt der Bereich `Beendete und abgelaufene Blöcke` zur Kontrolle die heutigen Blöcke, die bereits vorbei sind. Beim Aufklappen erscheint pro Block die Kinderliste zum Nachlesen: bei beendeten Blöcken mit dem letzten Stand (Anwesend, Gegangen, Abwesend), bei nie gestarteten Blöcken die geplante Liste mit dem Hinweis, dass keine Anwesenheit erfasst wurde. Ändern lässt sich hier nichts.",
+          "Ganz unten `Beendete und abgelaufene Blöcke` aufklappen.",
+          "Bei beendeten Blöcken den letzten Stand der Kinder nachlesen.",
+          "Bei nicht gestarteten Blöcken die geplante Kinderliste ansehen.",
+          "Die Angaben in diesem Bereich lassen sich nicht ändern.",
         ],
         callout: {
           title: "Warum steht ein Kind auf `Nicht eingeplant`?",

--- a/frontend/src/components/ui/section-card.tsx
+++ b/frontend/src/components/ui/section-card.tsx
@@ -102,13 +102,11 @@ export function SectionCard({
                   collapsed ? `${title} ausklappen` : `${title} einklappen`
                 }
                 aria-expanded={!collapsed}
-                onClick={() =>
-                  setCollapsed((previous) => {
-                    const next = !previous;
-                    onCollapsedChange?.(next);
-                    return next;
-                  })
-                }
+                onClick={() => {
+                  const next = !collapsed;
+                  setCollapsed(next);
+                  onCollapsedChange?.(next);
+                }}
               >
                 <ChevronDown
                   className={`h-4 w-4 transition-transform ${collapsed ? "-rotate-90" : ""}`}

--- a/frontend/src/components/ui/section-card.tsx
+++ b/frontend/src/components/ui/section-card.tsx
@@ -29,6 +29,8 @@ export function SectionCard({
   action,
   actions,
   collapsible = false,
+  defaultCollapsed = false,
+  onCollapsedChange,
   headingLevel = 2,
   bodyClassName,
   className = "",
@@ -43,6 +45,8 @@ export function SectionCard({
   action?: ReactNode;
   actions?: ReactNode;
   collapsible?: boolean;
+  defaultCollapsed?: boolean;
+  onCollapsedChange?: (collapsed: boolean) => void;
   /** 1 for a page's primary section, 2 (default) for the rest. */
   headingLevel?: 1 | 2 | 3;
   /** Overrides the default `mt-4` spacing above the body. */
@@ -51,7 +55,7 @@ export function SectionCard({
   children?: ReactNode;
   id?: string;
 }>) {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const Heading = `h${headingLevel}` as "h1" | "h2" | "h3";
   const headerActions = actions ?? action;
   const showBody = children != null && !(collapsible && collapsed);
@@ -98,7 +102,13 @@ export function SectionCard({
                   collapsed ? `${title} ausklappen` : `${title} einklappen`
                 }
                 aria-expanded={!collapsed}
-                onClick={() => setCollapsed((prev) => !prev)}
+                onClick={() =>
+                  setCollapsed((previous) => {
+                    const next = !previous;
+                    onCollapsedChange?.(next);
+                    return next;
+                  })
+                }
               >
                 <ChevronDown
                   className={`h-4 w-4 transition-transform ${collapsed ? "-rotate-90" : ""}`}

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -59,7 +59,7 @@ export function StatusBadge({
   return (
     <span
       title={title}
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
+      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium whitespace-nowrap"
       style={{ backgroundColor: styles.bg, color: styles.text }}
     >
       <span

--- a/frontend/src/components/ui/status-dot-badge.tsx
+++ b/frontend/src/components/ui/status-dot-badge.tsx
@@ -24,7 +24,7 @@ export function StatusDotBadge({
 
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium"
+      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium whitespace-nowrap"
       style={{
         backgroundColor: tone.backgroundColor,
         color: tone.textColor,

--- a/frontend/src/lib/timetable-operations-api.test.ts
+++ b/frontend/src/lib/timetable-operations-api.test.ts
@@ -85,6 +85,25 @@ describe("timetableOperationsApi", () => {
     );
   });
 
+  it("fetches past blocks with the scope query (#2335)", async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: { instances: [] },
+      }),
+    );
+
+    await timetableOperationsApi.plannedNow({ scope: "past" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/timetable/operations/planned-now?scope=past",
+      {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      },
+    );
+  });
+
   it("fetches planned instances without a date query", async () => {
     const mockFetch = vi.mocked(globalThis.fetch);
     mockFetch.mockResolvedValueOnce(

--- a/frontend/src/lib/timetable-operations-api.ts
+++ b/frontend/src/lib/timetable-operations-api.ts
@@ -22,6 +22,8 @@ interface PlannedNowOptions {
   horizonMinutes?: number;
   limit?: number;
   includeRoster?: boolean;
+  /** "past" lists today's finished blocks instead of the upcoming window (#2335). */
+  scope?: "past";
 }
 
 export class TimetableOperationsApiError extends Error {
@@ -87,6 +89,7 @@ export const timetableOperationsApi = {
     if (options?.includeRoster !== undefined) {
       params.set("include_roster", String(options.includeRoster));
     }
+    if (options?.scope) params.set("scope", options.scope);
     const suffix = params.size > 0 ? `?${params.toString()}` : "";
     const raw = await unwrap<{
       instances: Parameters<typeof mapPlannedInstance>[0][];


### PR DESCRIPTION
Closes #2335

## Tagesrückblick für Aufsichten

Auf `/active-supervisions` steht unter den bestehenden Bereichen eine standardmäßig eingeklappte, rein lesende Sektion **„Beendete und abgelaufene Blöcke“** zur Verfügung – auch wenn keine aktive Aufsicht mehr angezeigt wird.

Sie lädt beim Aufklappen die heutigen:

- beendeten Blöcke,
- nie gestarteten, nicht spontanen Blöcke nach Ablauf ihrer Endzeit.

Laufende, abgebrochene und spontane, noch geplante Blöcke bleiben ausgeschlossen. Die bestehenden Sichtbarkeitsregeln gelten unverändert: Zugewiesene Betreuende sehen ihre Blöcke; die Admin-Übersicht bzw. Open-Care-Modus sieht alle.

## Anzeige und Kinderlisten

- Blöcke zeigen Uhrzeit, Raum, Anzahl der Betreuenden sowie **Beendet** oder **Nicht gestartet**.
- Die Kinderliste wird pro Block erst beim Aufklappen geladen.
- Beendete Blöcke zeigen den letzten Anwesenheitsstatus, z. B. Anwesend, Gegangen, Abwesend, Nicht erschienen, Abgemeldet oder Nicht eingeplant.
- Nie gestartete Blöcke zeigen die geplante Kinderliste mit dem Hinweis, dass keine Anwesenheit erfasst wurde.
- Der Rückblick enthält keine Start- oder Anwesenheitsaktionen.

## API

`GET /api/timetable/operations/planned-now?scope=past` liefert den heutigen Rückblick. Andere `scope`-Werte sowie ein Datum außerhalb des heutigen Tages werden mit `400` abgelehnt.

## Hilfe

Das Kapitel **„Aktuelle Aufsicht“** beschreibt den neuen Rückblick und seine read-only-Nutzung.

## Tests

- Backend: Auswahl, Sichtbarkeit und Validierung des `past`-Scopes.
- Frontend: Lazy Loading, Sortierung, Empty State, Kinderlisten, Statusanzeige und Fehlerfall.
