### PR TITLE
Realistic loading skeletons: colocation + real chrome across all portals

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/absences/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/absences/page.tsx
@@ -16,7 +16,6 @@ import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
 import { DateRangePicker } from "~/components/ui/date-range-picker";
 import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
-import { Skeleton } from "~/components/ui/skeleton";
 import { StatusDotBadge } from "~/components/ui/status-dot-badge";
 import {
   berlinTodayISO,
@@ -300,23 +299,21 @@ export default function AbsencesPage() {
           </div>
         )}
 
-        {isLoading && entries === null && (
-          <div className="mt-4 space-y-3">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-64 w-full" />
-          </div>
-        )}
-
-        {error === null && entries !== null && (
+        {error === null && (
           <div className="mt-4">
             <DataTable
               columns={COLUMNS}
-              rows={entries}
+              rows={entries ?? []}
+              isLoading={isLoading && entries === null}
               getRowKey={(row) => row.id}
               onRowClick={(row) =>
                 router.push(`/students/${row.student_id}?from=/absences`)
               }
-              caption={`${entries.length} ${entries.length === 1 ? "Eintrag" : "Einträge"} auf Seite ${displayedPage}`}
+              caption={
+                entries
+                  ? `${entries.length} ${entries.length === 1 ? "Eintrag" : "Einträge"} auf Seite ${displayedPage}`
+                  : undefined
+              }
               emptyState={
                 <EmptyState
                   title="Keine Abwesenheiten eingetragen"
@@ -328,7 +325,7 @@ export default function AbsencesPage() {
                 />
               }
             />
-            {(displayedPage > 1 || hasMore) && (
+            {entries && (displayedPage > 1 || hasMore) && (
               <div className="mt-3 flex justify-end gap-2">
                 <Button
                   type="button"

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
@@ -65,11 +65,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock PageHeaderWithSearch (vi.fn wrapper enables mockImplementation in enhanced tests)
 vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   PageHeaderWithSearch: vi.fn(
@@ -978,7 +973,9 @@ describe("RoleGuard integration", () => {
 
     render(<MeinRaumPage />);
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Aktuelle Aufsicht wird geladen…"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part2.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part2.test.tsx
@@ -59,11 +59,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock PageHeaderWithSearch (vi.fn wrapper enables mockImplementation in enhanced tests)
 vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   PageHeaderWithSearch: vi.fn(
@@ -295,7 +290,9 @@ describe("MeinRaumPage (Active Supervisions) (1/5)", () => {
   it("shows loading state initially", async () => {
     render(<MeinRaumPage />);
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Aktuelle Aufsicht wird geladen…"),
+    ).toBeInTheDocument();
   });
 
   it("renders with SSE error boundary wrapper", () => {

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part4.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part4.test.tsx
@@ -65,11 +65,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock PageHeaderWithSearch (vi.fn wrapper enables mockImplementation in enhanced tests)
 vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   PageHeaderWithSearch: vi.fn(
@@ -541,6 +536,8 @@ describe("MeinRaumPage (Active Supervisions) (3/5)", () => {
     render(<MeinRaumPage />);
 
     // Should show loading state while SWR is loading
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Aktuelle Aufsicht wird geladen…"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part5.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part5.test.tsx
@@ -59,11 +59,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock PageHeaderWithSearch (vi.fn wrapper enables mockImplementation in enhanced tests)
 vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   PageHeaderWithSearch: vi.fn(
@@ -408,7 +403,9 @@ describe("MeinRaumPage (Active Supervisions) (4/5)", () => {
     render(<MeinRaumPage />);
 
     await waitFor(() => {
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Aktuelle Aufsicht wird geladen…"),
+      ).toBeInTheDocument();
       expect(screen.queryByTestId("student-card")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -31,7 +31,11 @@ import type {
   FilterConfig,
   ActiveFilter,
 } from "~/components/ui/page-header/types";
-import { Loading } from "~/components/ui/loading";
+import {
+  CardGridSkeleton,
+  PageHeaderSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { StudentPresenceBadge } from "@/components/ui/student-presence-badge";
 import { EmptyStudentResults } from "~/components/ui/empty-student-results";
 import {
@@ -2261,7 +2265,7 @@ function MeinRaumPageContent() {
   // Render helper for student grid content
   const renderStudentContent = () => {
     if (isWaitingForUrlRoomSelection || isWaitingForTimetableRoster) {
-      return <ActiveSupervisionLoadingView />;
+      return <ActiveSupervisionLoadingView withHeader={false} />;
     }
 
     if (currentTimetableRoster) {
@@ -2710,7 +2714,7 @@ function ActiveSupervisionGate({
     useOptionalSupervision();
 
   if (status === "loading" || isLoadingSupervision) {
-    return <Loading fullPage={false} />;
+    return <ActiveSupervisionLoadingView />;
   }
 
   // Caregivers (user/teacher role) always have access
@@ -2735,7 +2739,18 @@ function ActiveSupervisionGate({
 export default function MeinRaumPage() {
   return (
     <BinaryModeGuard>
-      <Suspense fallback={<Loading fullPage={false} />}>
+      <Suspense
+        fallback={
+          <SkeletonRegion label="Mein Raum wird geladen">
+            <PageHeaderSkeleton actions={1} />
+            <CardGridSkeleton
+              cards={6}
+              rowsPerCard={2}
+              className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3"
+            />
+          </SkeletonRegion>
+        }
+      >
         <ActiveSupervisionGate>
           <SSEErrorBoundary>
             <MeinRaumPageContent />

--- a/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.test.tsx
@@ -34,10 +34,6 @@ vi.mock("~/components/students/excused-request-review-list", () => ({
   ExcusedRequestReviewList: () => <div>excused-request-review-list</div>,
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div>loading</div>,
-}));
-
 const mockUseRequirePermission = vi.mocked(useRequirePermission);
 
 /** Sitzung mit den angegebenen Rechten, ohne Admin-Rolle. */
@@ -62,7 +58,9 @@ describe("AdminChangeRequestsPage", () => {
 
     render(<AdminChangeRequestsPage />);
 
-    expect(screen.getByText("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Änderungsanfragen werden geladen…"),
+    ).toBeInTheDocument();
   });
 
   it("renders both review queues once access is ready", () => {

--- a/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
@@ -6,8 +6,8 @@ import { CareRequestReviewList } from "~/components/students/care-request-review
 import { ExcusedRequestReviewList } from "~/components/students/excused-request-review-list";
 import { MasterDataReviewList } from "~/components/students/master-data-review-list";
 import { OfferingRequestReviewList } from "~/components/students/offering-request-review-list";
-import { Loading } from "~/components/ui/loading";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { SkeletonRegion, ListSkeleton } from "~/components/ui/page-skeletons";
 import {
   canReviewChangeRequests,
   canReviewStudentDataRequests,
@@ -27,7 +27,16 @@ export default function AdminChangeRequestsPage() {
   // that permission gets a 403 on the three Stammdaten-side queues, so they are
   // not rendered at all instead of showing three error cards (#2232).
   const showStudentDataQueues = canReviewStudentDataRequests(session);
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady) {
+    return (
+      <div className="-mt-1.5 w-full">
+        <PageHeaderWithSearch title="Änderungsanfragen" />
+        <SkeletonRegion label="Änderungsanfragen werden geladen…">
+          <ListSkeleton rows={4} avatar={false} />
+        </SkeletonRegion>
+      </div>
+    );
+  }
 
   // Stacked sections instead of tabs: both queues are short, and tabs
   // would hide the pending count of the inactive one. Unlike the enrollment

--- a/frontend/src/app/[tenant]/(protected)/admin/enrollments/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/enrollments/[id]/page.tsx
@@ -2,8 +2,9 @@
 
 import { use } from "react";
 import { AdminEnrollmentDetail } from "~/components/enrollment/admin-enrollment-detail";
-import { Loading } from "~/components/ui/loading";
 import { MobileBackButton } from "~/components/ui/mobile-back-button";
+import { DetailSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
+import { Skeleton } from "~/components/ui/skeleton";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 interface PageProps {
@@ -13,7 +14,13 @@ interface PageProps {
 export default function AdminEnrollmentDetailPage({ params }: PageProps) {
   const { id } = use(params);
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Anmeldung wird geladen" className="space-y-4">
+        <Skeleton className="h-6 w-56 rounded" />
+        <DetailSkeleton sections={3} fieldsPerSection={4} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="w-full">

--- a/frontend/src/app/[tenant]/(protected)/admin/enrollments/change-requests/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/enrollments/change-requests/[id]/page.tsx
@@ -2,8 +2,9 @@
 
 import { use } from "react";
 import { AdminEnrollmentChangeRequestDetail } from "~/components/enrollment/admin-enrollment-change-requests";
-import { Loading } from "~/components/ui/loading";
 import { MobileBackButton } from "~/components/ui/mobile-back-button";
+import { DetailSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
+import { Skeleton } from "~/components/ui/skeleton";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 interface PageProps {
@@ -15,7 +16,16 @@ export default function AdminEnrollmentChangeRequestDetailPage({
 }: PageProps) {
   const { id } = use(params);
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion
+        label="Änderungsanfrage wird geladen"
+        className="space-y-4"
+      >
+        <Skeleton className="h-6 w-56 rounded" />
+        <DetailSkeleton sections={2} fieldsPerSection={4} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="w-full">

--- a/frontend/src/app/[tenant]/(protected)/admin/enrollments/change-requests/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/enrollments/change-requests/page.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 import { AdminEnrollmentChangeRequestsList } from "~/components/enrollment/admin-enrollment-change-requests";
-import { Loading } from "~/components/ui/loading";
 import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 export default function AdminEnrollmentChangeRequestsPage() {
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Änderungsanfragen werden geladen">
+        <ListSkeleton rows={6} avatar={false} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="-mt-1.5 w-full">

--- a/frontend/src/app/[tenant]/(protected)/admin/enrollments/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/enrollments/page.tsx
@@ -2,13 +2,18 @@
 
 import { AdminEnrollmentsList } from "~/components/enrollment/admin-enrollments-list";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
-import { Loading } from "~/components/ui/loading";
 import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 export default function AdminEnrollmentsPage() {
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Anmeldungen werden geladen">
+        <ListSkeleton rows={6} avatar={false} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="-mt-1.5 w-full">

--- a/frontend/src/app/[tenant]/(protected)/admin/enrollments/phases/[phaseId]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/enrollments/phases/[phaseId]/page.tsx
@@ -2,8 +2,9 @@
 
 import { use } from "react";
 import { AdminEnrollmentPhaseDetail } from "~/components/enrollment/admin-enrollment-phase-detail";
-import { Loading } from "~/components/ui/loading";
 import { MobileBackButton } from "~/components/ui/mobile-back-button";
+import { DetailSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
+import { Skeleton } from "~/components/ui/skeleton";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 interface PageProps {
@@ -13,7 +14,13 @@ interface PageProps {
 export default function AdminEnrollmentPhasePage({ params }: PageProps) {
   const { phaseId } = use(params);
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Anmeldephase wird geladen" className="space-y-4">
+        <Skeleton className="h-6 w-56 rounded" />
+        <DetailSkeleton sections={2} fieldsPerSection={4} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="w-full">

--- a/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/guardian-approvals/page.tsx
@@ -5,7 +5,7 @@ import GuardianApprovalQueue, {
   type GuardianInviteModeState,
 } from "~/components/admin/guardian-approval-queue";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 import { useSettingsSchema } from "~/lib/hooks/use-settings-schema";
 import { getSettingValue } from "~/lib/settings-api";
@@ -45,7 +45,12 @@ export default function GuardianApprovalsPage() {
     getSettingValue(settingsSchema, "guardians.parent_invite_mode"),
   );
 
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Konto-Anfragen werden geladen">
+        <ListSkeleton rows={5} />
+      </SkeletonRegion>
+    );
 
   const inviteModeState: GuardianInviteModeState = isSettingsLoading
     ? { status: "loading" }

--- a/frontend/src/app/[tenant]/(protected)/calendar-periods/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar-periods/page.tsx
@@ -2,7 +2,7 @@
 
 import { CalendarPeriodsEditor } from "~/components/planning/calendar-periods-editor";
 import { ClosingDaysEditor } from "~/components/planning/closing-days-editor";
-import { Loading } from "~/components/ui/loading";
+import { SkeletonRegion, TableSkeleton } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 /**
@@ -19,7 +19,18 @@ import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 export default function CalendarPeriodsPage() {
   const { isReady } = useRequireAdmin();
 
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady) {
+    return (
+      <SkeletonRegion
+        label="Kalenderzeiträume werden geladen"
+        testId="loading"
+        className="-mt-1.5 w-full space-y-8"
+      >
+        <TableSkeleton rows={5} columns={3} />
+        <TableSkeleton rows={4} columns={3} />
+      </SkeletonRegion>
+    );
+  }
 
   return (
     <div className="-mt-1.5 w-full space-y-8">

--- a/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/calendar/page.tsx
@@ -17,8 +17,8 @@ import { CustomSelect } from "~/components/ui/custom-select";
 import { ISODatePicker } from "~/components/ui/date-picker";
 import { Input } from "~/components/ui/input";
 import { Modal } from "~/components/ui/modal";
-import { Loading } from "~/components/ui/loading";
 import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
+import { SkeletonRegion, TableSkeleton } from "~/components/ui/page-skeletons";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useToast } from "~/contexts/ToastContext";
 import { hasPermission, isAdmin } from "~/lib/auth-utils";
@@ -276,7 +276,14 @@ const SchoolPlanReadView = dynamic(
     import("~/components/timetable/betreuungsplan-view").then(
       (mod) => mod.BetreuungsplanView,
     ),
-  { ssr: false, loading: () => <Loading /> },
+  {
+    ssr: false,
+    loading: () => (
+      <SkeletonRegion label="Betreuungsplan wird geladen…">
+        <TableSkeleton rows={7} columns={5} />
+      </SkeletonRegion>
+    ),
+  },
 );
 
 export default function StaffCalendarPage() {

--- a/frontend/src/app/[tenant]/(protected)/care-offerings/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/care-offerings/page.tsx
@@ -1,13 +1,22 @@
 "use client";
 
 import { CareOfferingsEditor } from "~/components/enrollment/care-offerings-editor";
-import { Loading } from "~/components/ui/loading";
+import { SkeletonRegion, TableSkeleton } from "~/components/ui/page-skeletons";
 import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 export default function CareOfferingsPage() {
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady) {
+    return (
+      <SkeletonRegion
+        label="Betreuungsangebote werden geladen"
+        className="-mt-1.5 w-full"
+      >
+        <TableSkeleton rows={5} columns={4} />
+      </SkeletonRegion>
+    );
+  }
 
   return (
     <div className="-mt-1.5 w-full">

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page-skeleton.tsx
@@ -1,11 +1,84 @@
 "use client";
 
+import type { Icon as PhosphorIcon } from "@phosphor-icons/react";
 import { Skeleton } from "~/components/ui/skeleton";
+import { MotoDuotoneIcon } from "~/components/ui/moto-duotone-icon";
+import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
+import { MOTO_CONCEPTS, type MotoConceptKey } from "~/lib/moto-concepts";
+import type { MotoDuotoneTone } from "~/lib/location-helper";
+import {
+  useNFCEnabled,
+  useOpenCareGroupMode,
+  usePresenceMode,
+} from "~/lib/tenant-context";
 
-// Content-shaped placeholder for the auth-session loading gate — mirrors the
-// real shell (greeting, stat-card grid, info-card grid) so there is no layout
-// shift once data arrives.
+// Mirrors a StatCard tile: real icon + real title render immediately, only
+// the data-bound value skeletonizes.
+function StatTileSkeleton({
+  title,
+  icon,
+  tone,
+}: Readonly<{
+  title: string;
+  icon: PhosphorIcon;
+  tone: MotoDuotoneTone;
+}>) {
+  return (
+    <div className="moto-content-surface relative overflow-hidden rounded-3xl border p-4 shadow-sm backdrop-blur-md md:p-6">
+      <div className="mb-3 flex items-start justify-between">
+        <div className="p-0.5">
+          <MotoDuotoneIcon icon={icon} tone={tone} />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-gray-600 md:text-sm">{title}</p>
+        <Skeleton className="h-7 w-16 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
+// Mirrors an InfoCard tile: real icon + real title render immediately, only
+// the data-bound list body skeletonizes.
+function InfoTileSkeleton({
+  title,
+  concept,
+  rows = 3,
+}: Readonly<{ title: string; concept: MotoConceptKey; rows?: number }>) {
+  return (
+    <div className="moto-content-surface relative h-full overflow-hidden rounded-3xl border p-4 shadow-sm backdrop-blur-md md:p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <div className="rounded-xl bg-gray-100 p-2">
+          <MotoConceptIcon concept={concept} size={20} />
+        </div>
+        <h3 className="text-base font-semibold text-gray-900 md:text-lg">
+          {title}
+        </h3>
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: rows }, (_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Real-chrome loading state for the dashboard (RoleGuard fallback + route
+ * loading.tsx): static tile titles/icons render immediately — the same
+ * visibility rules as DashboardContent, driven by tenant presence-mode
+ * settings that are already resolved via TenantProvider before the
+ * session/role check completes — and only the data-bound values / list rows
+ * skeletonize. Keep the tile visibility conditions in sync with page.tsx.
+ */
 export function DashboardSkeleton() {
+  const nfcEnabled = useNFCEnabled();
+  const openCareGroupMode = useOpenCareGroupMode();
+  const presenceMode = usePresenceMode();
+  const showActivitySurfaces = nfcEnabled && presenceMode !== "binary";
+  const showRoomSurfaces = presenceMode !== "binary";
+
   return (
     <div
       role="status"
@@ -17,44 +90,79 @@ export function DashboardSkeleton() {
       <div className="mb-6 md:mb-8">
         <div className="ml-6 space-y-2">
           <Skeleton className="h-8 w-64 rounded-full" />
-          <Skeleton className="h-4 w-48 rounded-full" />
+          <p className="mt-2 text-sm text-gray-600 md:text-base">
+            Hier ist die aktuelle Übersicht
+          </p>
         </div>
       </div>
 
       <div className="mb-6 grid grid-cols-2 gap-3 md:mb-8 md:grid-cols-3 md:gap-4 xl:grid-cols-4">
-        {[0, 1, 2, 3, 4, 5, 6, 7].map((item) => (
-          <div
-            key={item}
-            className="moto-content-surface rounded-3xl border p-4 shadow-sm md:p-6"
-          >
-            <div className="mb-3 flex items-start justify-between">
-              <Skeleton className="h-10 w-10 rounded-2xl md:h-12 md:w-12" />
-            </div>
-            <div className="space-y-2">
-              <Skeleton className="h-3 w-2/3 rounded-full" />
-              <Skeleton className="h-7 w-1/2 rounded-full" />
-            </div>
-          </div>
-        ))}
+        <StatTileSkeleton
+          title="Kinder anwesend"
+          icon={MOTO_CONCEPTS.present.icon}
+          tone={MOTO_CONCEPTS.present.tone}
+        />
+        {showRoomSurfaces ? (
+          <>
+            <StatTileSkeleton
+              title="In Räumen"
+              icon={MOTO_CONCEPTS.rooms.icon}
+              tone={MOTO_CONCEPTS.rooms.tone}
+            />
+            <StatTileSkeleton
+              title="Unterwegs"
+              icon={MOTO_CONCEPTS.transit.icon}
+              tone={MOTO_CONCEPTS.transit.tone}
+            />
+          </>
+        ) : null}
+        <StatTileSkeleton
+          title="Schulhof"
+          icon={MOTO_CONCEPTS.schoolyard.icon}
+          tone={MOTO_CONCEPTS.schoolyard.tone}
+        />
+        <StatTileSkeleton
+          title="Krank"
+          icon={MOTO_CONCEPTS.sick.icon}
+          tone={MOTO_CONCEPTS.sick.tone}
+        />
+        <StatTileSkeleton
+          title="Entschuldigt"
+          icon={MOTO_CONCEPTS.excused.icon}
+          tone={MOTO_CONCEPTS.excused.tone}
+        />
+        <StatTileSkeleton
+          title="Zuhause"
+          icon={MOTO_CONCEPTS.home.icon}
+          tone={MOTO_CONCEPTS.home.tone}
+        />
+        {showActivitySurfaces ? (
+          <StatTileSkeleton
+            title="Aktive Aktivitäten"
+            icon={MOTO_CONCEPTS.activities.icon}
+            tone={MOTO_CONCEPTS.activities.tone}
+          />
+        ) : null}
+        {showRoomSurfaces ? (
+          <StatTileSkeleton
+            title="Auslastung"
+            icon={MOTO_CONCEPTS.utilization.icon}
+            tone={MOTO_CONCEPTS.utilization.tone}
+          />
+        ) : null}
       </div>
 
       <div className="grid grid-cols-1 items-stretch gap-4 md:gap-6 lg:grid-cols-2 xl:grid-cols-3">
-        {[0, 1, 2].map((item) => (
-          <div
-            key={item}
-            className="moto-content-surface rounded-3xl border p-4 shadow-sm md:p-6"
-          >
-            <div className="mb-4 flex items-center gap-2">
-              <Skeleton className="h-8 w-8 rounded-xl" />
-              <Skeleton className="h-5 w-32 rounded-full" />
-            </div>
-            <div className="space-y-2">
-              <Skeleton className="h-12 w-full rounded-xl" />
-              <Skeleton className="h-12 w-full rounded-xl" />
-              <Skeleton className="h-12 w-full rounded-xl" />
-            </div>
-          </div>
-        ))}
+        {showRoomSurfaces ? (
+          <InfoTileSkeleton title="Letzte Bewegungen" concept="changeHistory" />
+        ) : null}
+        {showActivitySurfaces ? (
+          <InfoTileSkeleton title="Laufende Aktivitäten" concept="activities" />
+        ) : null}
+        {!openCareGroupMode ? (
+          <InfoTileSkeleton title="Aktive Gruppen" concept="groups" />
+        ) : null}
+        <InfoTileSkeleton title="Personal heute" concept="staff" rows={2} />
       </div>
     </div>
   );

--- a/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/dashboard/page.tsx
@@ -366,13 +366,21 @@ function DashboardContent() {
           <InfoCard title="Letzte Bewegungen" concept="changeHistory">
             {(() => {
               if (isLoading) {
+                // Mirrors the loaded activity row below: same rounded-xl
+                // p-3 surface, two text lines left, badge right.
                 return (
-                  <div className="space-y-3">
+                  <div className="space-y-2" aria-hidden="true">
                     {[1, 2, 3].map((i) => (
                       <div
                         key={i}
-                        className="h-12 animate-pulse rounded-lg bg-gray-100"
-                      ></div>
+                        className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3"
+                      >
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <div className="h-4 w-2/5 animate-pulse rounded bg-gray-200"></div>
+                          <div className="h-3 w-1/4 animate-pulse rounded bg-gray-200"></div>
+                        </div>
+                        <div className="h-6 w-16 animate-pulse rounded-full bg-gray-200"></div>
+                      </div>
                     ))}
                   </div>
                 );
@@ -443,13 +451,21 @@ function DashboardContent() {
           >
             {(() => {
               if (isLoading) {
+                // Mirrors the loaded row: rounded-xl p-3, name + meta line
+                // left, status dot right.
                 return (
-                  <div className="space-y-3">
+                  <div className="space-y-2" aria-hidden="true">
                     {[1, 2, 3].map((i) => (
                       <div
                         key={i}
-                        className="h-14 animate-pulse rounded-lg bg-gray-100"
-                      ></div>
+                        className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3"
+                      >
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <div className="h-4 w-1/2 animate-pulse rounded bg-gray-200"></div>
+                          <div className="h-3 w-2/3 animate-pulse rounded bg-gray-200"></div>
+                        </div>
+                        <div className="ml-2 h-2.5 w-2.5 flex-shrink-0 animate-pulse rounded-full bg-gray-200"></div>
+                      </div>
                     ))}
                   </div>
                 );
@@ -496,13 +512,21 @@ function DashboardContent() {
           <InfoCard title="Aktive Gruppen" concept="groups" href="/ogs-groups">
             {(() => {
               if (isLoading) {
+                // Mirrors the loaded row: rounded-xl p-3, name + meta line
+                // left, status dot right.
                 return (
-                  <div className="space-y-3">
+                  <div className="space-y-2" aria-hidden="true">
                     {[1, 2, 3].map((i) => (
                       <div
                         key={i}
-                        className="h-14 animate-pulse rounded-lg bg-gray-100"
-                      ></div>
+                        className="flex items-center justify-between rounded-xl bg-gray-50/50 p-3"
+                      >
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <div className="h-4 w-1/2 animate-pulse rounded bg-gray-200"></div>
+                          <div className="h-3 w-2/3 animate-pulse rounded bg-gray-200"></div>
+                        </div>
+                        <div className="ml-2 h-2.5 w-2.5 flex-shrink-0 animate-pulse rounded-full bg-gray-200"></div>
+                      </div>
                     ))}
                   </div>
                 );
@@ -549,7 +573,19 @@ function DashboardContent() {
         >
           <InfoCard title="Personal heute" concept="staff" href="/staff">
             {isLoading ? (
-              <div className="h-32 animate-pulse rounded-lg bg-gray-100"></div>
+              // Mirrors the loaded 2-column stat grid: same tile surface,
+              // label line over a large value line.
+              <div className="grid grid-cols-2 gap-4" aria-hidden="true">
+                {[1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="rounded-xl border border-gray-200/50 bg-gray-50/50 p-4"
+                  >
+                    <div className="mb-2 h-3 w-24 animate-pulse rounded bg-gray-200"></div>
+                    <div className="h-7 w-12 animate-pulse rounded bg-gray-200"></div>
+                  </div>
+                ))}
+              </div>
             ) : (
               <div className="grid grid-cols-2 gap-4">
                 <div className="rounded-xl border border-gray-200/50 bg-gray-50/50 p-4 transition-colors hover:bg-gray-100/50">

--- a/frontend/src/app/[tenant]/(protected)/database/personal/import/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/import/page.test.tsx
@@ -53,11 +53,6 @@ vi.mock("~/lib/auth-helpers", () => ({
   getRoleDisplayName: (name: string) => name,
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock Button component
 vi.mock("~/components/ui/button", () => ({
   Button: ({
@@ -699,7 +694,9 @@ describe("StaffImportPage", () => {
     });
 
     render(<StaffImportPage />);
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Mitarbeiter-Import wird geladen…"),
+    ).toBeInTheDocument();
   });
 
   it("handles a missing token gracefully", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/personal/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/import/page.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 import { Download, Info, ListChecks, X } from "lucide-react";
-import { Loading } from "~/components/ui/loading";
+import { SkeletonRegion, FormSkeleton } from "~/components/ui/page-skeletons";
 import { Button } from "~/components/ui/button";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Alert } from "~/components/ui/alert";
@@ -355,7 +355,11 @@ export default function StaffImportPage() {
   };
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return (
+      <SkeletonRegion label="Mitarbeiter-Import wird geladen…">
+        <FormSkeleton fields={2} />
+      </SkeletonRegion>
+    );
   }
 
   return (

--- a/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/personal/opening-balances/page.tsx
@@ -12,7 +12,11 @@ import { ISODatePicker } from "~/components/ui/date-picker";
 import { EmptyState } from "~/components/ui/empty-state";
 import { ForbiddenPage } from "~/components/ui/forbidden-page";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
+import {
+  FormSkeleton,
+  SkeletonRegion,
+  TableSkeleton,
+} from "~/components/ui/page-skeletons";
 import { StatusBadge } from "~/components/ui/status-badge";
 import { UploadSection } from "~/components/import/upload-section";
 import { useToast } from "~/contexts/ToastContext";
@@ -446,7 +450,15 @@ export default function OpeningBalanceImportPage() {
   );
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return (
+      <SkeletonRegion
+        label="Eröffnungssalden-Import wird geladen"
+        className="mx-auto max-w-5xl space-y-5 px-4 py-6 sm:px-6 lg:px-8"
+      >
+        <FormSkeleton fields={4} />
+        <TableSkeleton rows={5} columns={4} />
+      </SkeletonRegion>
+    );
   }
 
   // Die Datenverwaltung ist bereits adminOnly (database/layout.tsx); die

--- a/frontend/src/app/[tenant]/(protected)/database/students/import/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/import/page.test.tsx
@@ -41,11 +41,6 @@ vi.mock("~/lib/breadcrumb-context", () => ({
   ),
 }));
 
-// Mock Loading component
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div data-testid="loading">Loading...</div>,
-}));
-
 // Mock Button component
 vi.mock("~/components/ui/button", () => ({
   Button: ({
@@ -811,7 +806,9 @@ describe("StudentImportPage", () => {
 
     render(<StudentImportPage />);
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Kinder-Import wird geladen…"),
+    ).toBeInTheDocument();
   });
 
   it("handles missing token gracefully", async () => {

--- a/frontend/src/app/[tenant]/(protected)/database/students/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/import/page.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 import { Download, Info, ListChecks, X } from "lucide-react";
-import { Loading } from "~/components/ui/loading";
+import { SkeletonRegion, FormSkeleton } from "~/components/ui/page-skeletons";
 import { Button } from "~/components/ui/button";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Alert } from "~/components/ui/alert";
@@ -398,7 +398,11 @@ export default function StudentImportPage() {
   };
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return (
+      <SkeletonRegion label="Kinder-Import wird geladen…">
+        <FormSkeleton fields={2} />
+      </SkeletonRegion>
+    );
   }
 
   return (

--- a/frontend/src/app/[tenant]/(protected)/eltern/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/eltern/page.tsx
@@ -5,7 +5,10 @@ import { useSession } from "next-auth/react";
 
 import { EntryPointCard } from "~/components/help/guide-components";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
-import { Loading } from "~/components/ui/loading";
+import {
+  SkeletonRegion,
+  CardGridSkeleton,
+} from "~/components/ui/page-skeletons";
 import { useIsMobile } from "~/components/ui/hooks/useIsMobile";
 import { hasPermission, hasRole } from "~/lib/auth-utils";
 import { canReviewChangeRequests } from "~/lib/change-request-access";
@@ -49,9 +52,10 @@ function ElternContent() {
   // every /api/parent-announcements route). Same rule as the sidebar entry.
   const canAnnounce = hasPermission(session, "admin:*");
 
-  if (status === "loading") {
-    return <Loading fullPage={false} />;
-  }
+  // Auth-loading joins the showSkeleton flag instead of an early return
+  // before the header, so the real PageHeaderWithSearch and intro copy
+  // render immediately and only the card grid skeletonizes.
+  const showSkeleton = status === "loading";
 
   const cards: readonly ElternCard[] = [
     {
@@ -117,27 +121,45 @@ function ElternContent() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {visibleCards.map((card) => (
-            <EntryPointCard
-              key={card.href}
-              href={tenantPath(card.href)}
-              title={card.title}
-              body={card.body}
-              concept={card.concept}
-              iconTone="blue"
-              points={card.points}
-            />
-          ))}
-        </div>
+        {showSkeleton ? (
+          <ElternCardsSkeleton />
+        ) : (
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {visibleCards.map((card) => (
+              <EntryPointCard
+                key={card.href}
+                href={tenantPath(card.href)}
+                title={card.title}
+                body={card.body}
+                concept={card.concept}
+                iconTone="blue"
+                points={card.points}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
+/**
+ * Data-region skeleton: just the entry-point card grid. The real header
+ * (PageHeaderWithSearch on mobile, intro copy on desktop) renders
+ * immediately regardless of loading state — only this data-bound region
+ * skeletonizes while the session/settings load.
+ */
+function ElternCardsSkeleton() {
+  return (
+    <SkeletonRegion label="Elternbereich wird geladen…">
+      <CardGridSkeleton cards={4} rowsPerCard={2} />
+    </SkeletonRegion>
+  );
+}
+
 export default function ElternPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<ElternCardsSkeleton />}>
       <ElternContent />
     </Suspense>
   );

--- a/frontend/src/app/[tenant]/(protected)/emergency/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/emergency/page.test.tsx
@@ -13,14 +13,6 @@ vi.mock("~/lib/emergency-export-api", () => ({
   exportEmergencySnapshot: (mode: string) => mockExportEmergencySnapshot(mode),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-full-page={fullPage}>
-      Loading
-    </div>
-  ),
-}));
-
 vi.mock("~/components/ui/moto-concept-icon", () => ({
   MotoConceptIcon: ({ concept }: { concept: string }) => (
     <svg data-testid="concept-icon" data-concept={concept} />
@@ -124,9 +116,8 @@ describe("EmergencyPage", () => {
 
     render(<EmergencyPage />);
 
-    expect(screen.getByTestId("loading")).toHaveAttribute(
-      "data-full-page",
-      "false",
-    );
+    expect(
+      screen.getByLabelText("Notfallliste wird geladen…"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/emergency/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/emergency/page.tsx
@@ -9,7 +9,7 @@ import {
   exportEmergencySnapshot,
   type EmergencySnapshotExportMode,
 } from "~/lib/emergency-export-api";
-import { Loading } from "~/components/ui/loading";
+import { SkeletonRegion, CardSkeleton } from "~/components/ui/page-skeletons";
 
 export default function EmergencyPage() {
   const { status } = useSession({ required: true });
@@ -40,7 +40,16 @@ export default function EmergencyPage() {
   }, [handleExport]);
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return (
+      <main className="flex w-full items-center justify-center px-4 py-6 sm:min-h-[calc(100dvh-11rem)] sm:px-6 sm:py-10 lg:px-8">
+        <SkeletonRegion
+          label="Notfallliste wird geladen…"
+          className="w-full max-w-3xl"
+        >
+          <CardSkeleton rows={2} />
+        </SkeletonRegion>
+      </main>
+    );
   }
 
   return (

--- a/frontend/src/app/[tenant]/(protected)/enrollment-form/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/enrollment-form/page.tsx
@@ -1,14 +1,19 @@
 "use client";
 
 import { EnrollmentFormEditor } from "~/components/enrollment/enrollment-form-editor";
-import { Loading } from "~/components/ui/loading";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
+import { FormSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 export default function EnrollmentFormPage() {
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Anmeldeformular wird geladen">
+        <FormSkeleton fields={6} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="-mt-1.5 w-full">

--- a/frontend/src/app/[tenant]/(protected)/enrollment-phases/[id]/review/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/enrollment-phases/[id]/review/page.tsx
@@ -3,9 +3,9 @@
 import { use } from "react";
 import Link from "next/link";
 import { RolloverReviewQueue } from "~/components/enrollment/rollover-review-queue";
-import { Loading } from "~/components/ui/loading";
 import { MobileBackButton } from "~/components/ui/mobile-back-button";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
 
 interface PageProps {
@@ -19,7 +19,12 @@ interface PageProps {
 export default function RolloverReviewPage({ params }: PageProps) {
   const { id } = use(params);
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  if (!isReady)
+    return (
+      <SkeletonRegion label="Prüfliste wird geladen">
+        <ListSkeleton rows={5} avatar={false} />
+      </SkeletonRegion>
+    );
 
   return (
     <div className="-mt-1.5 w-full">

--- a/frontend/src/app/[tenant]/(protected)/enrollment-phases/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/enrollment-phases/page.tsx
@@ -2,21 +2,33 @@
 
 import { Suspense } from "react";
 import { PhasesEditor } from "~/components/enrollment/phases-editor";
-import { Loading } from "~/components/ui/loading";
 import { DesktopOnlyNotice } from "~/components/ui/desktop-only-notice";
+import { SkeletonRegion, TableSkeleton } from "~/components/ui/page-skeletons";
 import { useRequireAdmin } from "~/lib/hooks/use-require-admin";
+
+function PhasesEditorSkeleton() {
+  return (
+    <SkeletonRegion label="Anmeldephasen werden geladen">
+      <TableSkeleton columns={6} rows={5} />
+    </SkeletonRegion>
+  );
+}
 
 export default function EnrollmentPhasesPage() {
   const { isReady } = useRequireAdmin();
-  if (!isReady) return <Loading fullPage={false} />;
+  const showSkeleton = !isReady;
 
   return (
     <div className="-mt-1.5 w-full">
       <DesktopOnlyNotice />
       <div className="hidden lg:block">
-        <Suspense fallback={<Loading fullPage={false} />}>
-          <PhasesEditor />
-        </Suspense>
+        {showSkeleton ? (
+          <PhasesEditorSkeleton />
+        ) : (
+          <Suspense fallback={<PhasesEditorSkeleton />}>
+            <PhasesEditor />
+          </Suspense>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/[tenant]/(protected)/info-displays/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/info-displays/page.tsx
@@ -15,7 +15,6 @@ import { Input } from "~/components/ui/input";
 import { FormModal } from "~/components/ui/form-modal";
 import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
 import { DisplayModeGuard } from "~/components/tenant/display-mode-guard";
 import { useRequirePermission } from "~/lib/hooks/use-require-permission";
 import { hasPermission, isAdmin } from "~/lib/auth-utils";
@@ -54,7 +53,7 @@ export default function InfoDisplaysPage() {
 function InfoDisplaysPageContent() {
   // Viewing needs display:read OR display:manage (matching the backend list
   // route); mutating actions are additionally gated on display:manage below.
-  const { isReady, isLoading: permissionLoading } = useRequirePermission([
+  const { isLoading: permissionLoading } = useRequirePermission([
     "display:read",
     "display:manage",
   ]);
@@ -235,10 +234,6 @@ function InfoDisplaysPageContent() {
       : []),
   ];
 
-  if (permissionLoading || !isReady) {
-    return <Loading />;
-  }
-
   return (
     <div className="space-y-6">
       <PageHeaderWithSearch
@@ -276,7 +271,7 @@ function InfoDisplaysPageContent() {
         columns={columns}
         rows={filtered}
         getRowKey={(row) => row.id}
-        isLoading={isLoading}
+        isLoading={permissionLoading || isLoading}
         defaultSortKey="name"
         emptyState={
           loadError ? (

--- a/frontend/src/app/[tenant]/(protected)/lists/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/lists/page.tsx
@@ -29,7 +29,6 @@ import { BackButton } from "~/components/ui/back-button";
 import { Button } from "~/components/ui/button";
 import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
 import { DatePicker } from "~/components/ui/date-picker";
-import { Loading } from "~/components/ui/loading";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { DesktopFilters } from "~/components/ui/page-header/DesktopFilters";
 import { ActiveFilterChips } from "~/components/ui/page-header/ActiveFilterChips";
@@ -711,11 +710,13 @@ export default function SlotListsPage() {
   // timetable.enabled=false hides the page just like the Betreuungsplan/Vertretung
   // guards and the sidebar (#1565 review). getSettingValue returns undefined when
   // the user cannot read settings, so the page renders normally by default.
-  const { data: settingsSchema, isLoading: settingsSchemaLoading } =
-    useSettingsSchema(authStatus === "authenticated", {
+  const { data: settingsSchema } = useSettingsSchema(
+    authStatus === "authenticated",
+    {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-    });
+    },
+  );
   const timetableDisabled =
     getSettingValue(settingsSchema, "timetable.enabled") === false;
   const initialState = useMemo(
@@ -2046,10 +2047,6 @@ export default function SlotListsPage() {
     });
     return cols;
   }, [isPickupBased, source]);
-
-  if (authStatus === "loading" || settingsSchemaLoading) {
-    return <Loading fullPage={false} />;
-  }
 
   if (timetableDisabled) {
     return (

--- a/frontend/src/app/[tenant]/(protected)/loading.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/loading.test.tsx
@@ -1,29 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import ProtectedLoadingPage from "./loading";
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({
-    message,
-    fullPage,
-  }: {
-    message?: string;
-    fullPage?: boolean;
-  }) => (
-    <div data-testid="loading" data-full-page={String(fullPage)}>
-      {message}
-    </div>
-  ),
-}));
-
 describe("ProtectedLoadingPage", () => {
-  it("renders Loading component with correct props", () => {
+  it("renders the generic list-page skeleton", () => {
     render(<ProtectedLoadingPage />);
 
-    const loading = screen.getByTestId("loading");
-    expect(loading).toBeInTheDocument();
-    expect(loading).toHaveAttribute("data-full-page", "false");
-    expect(loading).toHaveTextContent("Laden...");
+    expect(screen.getByLabelText("Laden...")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/loading.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Loading } from "~/components/ui/loading";
+import { ListPageSkeleton } from "~/components/ui/page-skeletons";
 
 /**
  * Content-area-only loading skeleton for the (protected) route group.
  * Renders inline within the persistent shell (Header/Sidebar stay mounted).
- * Uses fullPage=false so there's no fixed overlay or z-50.
+ * Generic list-page silhouette (header + table) since the actual route
+ * being navigated to is not known here.
  */
 export default function ProtectedLoadingPage() {
-  return <Loading message="Laden..." fullPage={false} />;
+  return <ListPageSkeleton label="Laden..." chips={3} rows={7} columns={5} />;
 }

--- a/frontend/src/app/[tenant]/(protected)/meal-plan/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/meal-plan/page.tsx
@@ -13,10 +13,13 @@ import {
 } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
-import { Loading } from "~/components/ui/loading";
 import { ConfirmationModal } from "~/components/ui/modal";
 import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import {
+  CardGridSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { hasPermission, isAdmin } from "~/lib/auth-utils";
 import { useToast } from "~/contexts/ToastContext";
 import { parseISODate, toISODate } from "~/lib/date-helpers";
@@ -528,7 +531,13 @@ export default function MealPlanPage() {
         </section>
 
         {loading && !hasLoaded ? (
-          <Loading fullPage={false} />
+          <SkeletonRegion label="Essensplan wird geladen">
+            <CardGridSkeleton
+              cards={5}
+              rowsPerCard={2}
+              className="grid grid-cols-1 gap-4 md:grid-cols-5"
+            />
+          </SkeletonRegion>
         ) : loadError ? (
           <section className="moto-content-surface flex flex-col items-center gap-4 rounded-2xl border p-8 text-center shadow-sm">
             <p className="text-sm text-gray-500">

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/loading.tsx
@@ -1,7 +1,33 @@
 "use client";
 
-import { ThreadSkeleton } from "./page-skeleton";
+import { ArrowLeft } from "lucide-react";
+import { BackButton } from "~/components/ui/back-button";
+import { ThreadSkeleton, ThreadComposerSkeleton } from "./page-skeleton";
 
+/**
+ * Route-level loading UI: the back navigation and card frame are real,
+ * static chrome (Polaris: real chrome first, skeletonize only the data
+ * region) — only the header/message-list/composer regions skeletonize.
+ * Mirrors MessagesBackNav in ./page.tsx (kept inline here rather than
+ * imported, matching the staff/rooms loading.tsx convention of
+ * reconstructing static chrome directly instead of importing from page.tsx).
+ */
 export default function MessageThreadLoading() {
-  return <ThreadSkeleton />;
+  return (
+    <div className="-mt-1.5 flex min-h-[20rem] w-full flex-col overflow-hidden">
+      <BackButton referrer="/messages" />
+      <button
+        type="button"
+        disabled
+        className="mb-4 hidden items-center gap-1 text-sm text-gray-500 md:flex"
+      >
+        <ArrowLeft className="h-4 w-4" /> Zurück zu den Nachrichten
+      </button>
+
+      <div className="moto-content-surface flex min-h-0 flex-1 flex-col rounded-2xl border p-4 backdrop-blur-sm sm:p-6">
+        <ThreadSkeleton />
+        <ThreadComposerSkeleton />
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page-skeleton.tsx
@@ -2,9 +2,14 @@
 
 import { Skeleton } from "~/components/ui/skeleton";
 
-// Mirrors the real thread layout: back-nav, header row (guardian name +
-// subtitle vs. "Zum Kinderprofil" button), the scrollable chat bubble list,
-// and the composer bar, so the loaded page swaps in without layout shift.
+/**
+ * Data-region skeleton: header row (guardian name + subtitle vs. "Zum
+ * Kinderprofil" button — both resolved from the loaded thread, so hidden
+ * behind a placeholder while loading) and the message-bubble list. Renders
+ * inside the real card frame (back nav + moto-content-surface wrapper are
+ * static chrome and render immediately), so this covers only the data-bound
+ * regions.
+ */
 export function ThreadSkeleton() {
   return (
     <div
@@ -12,34 +17,40 @@ export function ThreadSkeleton() {
       aria-busy="true"
       aria-label="Unterhaltung wird geladen"
       data-testid="thread-skeleton"
-      className="-mt-1.5 flex min-h-[20rem] w-full flex-col overflow-hidden"
+      className="flex min-h-0 flex-1 flex-col"
     >
-      <Skeleton className="mb-4 h-5 w-40 rounded" />
-
-      <div className="moto-content-surface flex min-h-0 flex-1 flex-col rounded-2xl border p-4 backdrop-blur-sm sm:p-6">
-        <div className="mb-4 flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1 space-y-2">
-            <Skeleton className="h-6 w-40 rounded" />
-            <Skeleton className="h-4 w-56 rounded" />
-          </div>
-          <Skeleton className="h-9 w-36 flex-shrink-0 rounded-lg" />
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-6 w-40 rounded" />
+          <Skeleton className="h-4 w-56 rounded" />
         </div>
-
-        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
-          {Array.from({ length: 5 }, (_, i) => (
-            <Skeleton
-              key={i}
-              className={`h-12 rounded-2xl ${
-                i % 2 === 0 ? "w-2/3" : "ml-auto w-1/2"
-              }`}
-            />
-          ))}
-        </div>
-
-        <div className="mt-4">
-          <Skeleton className="h-12 w-full rounded-full" />
-        </div>
+        <Skeleton className="h-9 w-36 flex-shrink-0 rounded-lg" />
       </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton
+            key={i}
+            className={`h-12 rounded-2xl ${
+              i % 2 === 0 ? "w-2/3" : "ml-auto w-1/2"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Composer-bar placeholder for the route-level loading fallback, which
+ * mounts before the page component (and its draft/send state) exists — the
+ * real, interactive composer isn't available yet. `page.tsx` itself keeps the
+ * real composer mounted (disabled while loading) once the component is live.
+ */
+export function ThreadComposerSkeleton() {
+  return (
+    <div className="mt-4">
+      <Skeleton className="h-12 w-full rounded-full" />
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
@@ -244,12 +244,15 @@ function MessageThreadContent() {
     Boolean(thread) && !isLoading,
   );
 
-  // Full-page skeleton only for a direct deep-link with no cached seed.
-  if (!thread && isLoading) {
-    return <ThreadSkeleton />;
-  }
+  // Skeleton only for a direct deep-link with no cached seed. The back nav
+  // and card frame are real chrome and render immediately regardless; only
+  // the header (guardian name, "Zum Kinderprofil") and message list are
+  // data-bound and skeletonize. The composer stays real — its structural
+  // frame doesn't depend on thread data, and `disabled` already covers the
+  // loading window via `snapshotUnavailable`.
+  const showSkeleton = !thread && isLoading;
 
-  if (!thread) {
+  if (!showSkeleton && !thread) {
     return (
       <div className="-mt-1.5 w-full">
         <MessagesBackNav />
@@ -273,86 +276,99 @@ function MessageThreadContent() {
       <MessagesBackNav />
 
       <div className="moto-content-surface flex min-h-0 flex-1 flex-col rounded-2xl border p-4 backdrop-blur-sm sm:p-6">
-        <div className="mb-4 flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <h1 className="truncate text-lg font-semibold text-gray-900 sm:text-xl">
-              {thread.guardian_name}
-            </h1>
-            <p className="mt-0.5 truncate text-sm text-gray-500">
-              {relationshipLabel(thread.relationship_type)} von{" "}
-              {thread.student_name}
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="md"
-            onClick={() =>
-              router.push(`/students/${thread.student_id}?from=/messages`)
-            }
-            className="flex-shrink-0"
-          >
-            <MotoConceptIcon concept="children" size={18} className="mr-1.5" />
-            Zum Kinderprofil
-          </Button>
-        </div>
+        {showSkeleton ? (
+          <ThreadSkeleton />
+        ) : (
+          <>
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h1 className="truncate text-lg font-semibold text-gray-900 sm:text-xl">
+                  {thread?.guardian_name}
+                </h1>
+                <p className="mt-0.5 truncate text-sm text-gray-500">
+                  {thread ? relationshipLabel(thread.relationship_type) : ""}{" "}
+                  von {thread?.student_name}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                onClick={() =>
+                  thread &&
+                  router.push(`/students/${thread.student_id}?from=/messages`)
+                }
+                className="flex-shrink-0"
+              >
+                <MotoConceptIcon
+                  concept="children"
+                  size={18}
+                  className="mr-1.5"
+                />
+                Zum Kinderprofil
+              </Button>
+            </div>
 
-        <div
-          ref={scrollRef}
-          className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
-        >
-          {messagesLoading ? (
-            <p className="py-6 text-center text-sm text-gray-400">
-              Verlauf wird geladen...
-            </p>
-          ) : messages.length > 0 ? (
-            messages.map((message) =>
-              message.kind === "request" ? (
-                <RequestHistoryCard key={message.id} message={message} />
-              ) : message.kind === "event" ? (
-                <ChatEventCard
-                  key={message.id}
-                  body={message.body}
-                  createdAt={message.created_at}
-                  action={
-                    canReviewRequests && requestStillOpen(message)
-                      ? {
-                          label: "Anfrage bearbeiten",
-                          onClick: () => router.push("/admin/change-requests"),
-                        }
-                      : undefined
-                  }
+            <div
+              ref={scrollRef}
+              className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+            >
+              {messagesLoading ? (
+                <p className="py-6 text-center text-sm text-gray-400">
+                  Verlauf wird geladen...
+                </p>
+              ) : messages.length > 0 ? (
+                messages.map((message) =>
+                  message.kind === "request" ? (
+                    <RequestHistoryCard key={message.id} message={message} />
+                  ) : message.kind === "event" ? (
+                    <ChatEventCard
+                      key={message.id}
+                      body={message.body}
+                      createdAt={message.created_at}
+                      action={
+                        canReviewRequests && requestStillOpen(message)
+                          ? {
+                              label: "Anfrage bearbeiten",
+                              onClick: () =>
+                                router.push("/admin/change-requests"),
+                            }
+                          : undefined
+                      }
+                    />
+                  ) : (
+                    <ChatBubble
+                      key={message.id}
+                      body={message.body}
+                      own={message.sender_kind === "staff"}
+                      senderName={message.sender_name}
+                      createdAt={message.created_at}
+                      readReceiptLabel={
+                        message.sender_kind === "staff" &&
+                        message.read_by_guardian
+                          ? "Gelesen"
+                          : undefined
+                      }
+                    />
+                  ),
+                )
+              ) : loadError ? (
+                // The header seed (fallbackData) keeps `thread` truthy with an empty
+                // messages array, so a failed history fetch would otherwise render the
+                // "no messages" empty state for a thread that actually has history.
+                // Surface the load failure instead of a misleading empty conversation.
+                <Alert
+                  type="error"
+                  message="Nachrichtenverlauf konnte nicht geladen werden."
                 />
               ) : (
-                <ChatBubble
-                  key={message.id}
-                  body={message.body}
-                  own={message.sender_kind === "staff"}
-                  senderName={message.sender_name}
-                  createdAt={message.created_at}
-                  readReceiptLabel={
-                    message.sender_kind === "staff" && message.read_by_guardian
-                      ? "Gelesen"
-                      : undefined
-                  }
-                />
-              ),
-            )
-          ) : loadError ? (
-            // The header seed (fallbackData) keeps `thread` truthy with an empty
-            // messages array, so a failed history fetch would otherwise render the
-            // "no messages" empty state for a thread that actually has history.
-            // Surface the load failure instead of a misleading empty conversation.
-            <Alert
-              type="error"
-              message="Nachrichtenverlauf konnte nicht geladen werden."
-            />
-          ) : (
-            <p className="py-6 text-center text-sm text-gray-500">
-              Noch keine Nachrichten in dieser Unterhaltung.
-            </p>
-          )}
-        </div>
+                <p className="py-6 text-center text-sm text-gray-500">
+                  Noch keine Nachrichten in dieser Unterhaltung.
+                </p>
+              )}
+            </div>
+          </>
+        )}
 
         {sendError && (
           <div className="mt-3">

--- a/frontend/src/app/[tenant]/(protected)/messages/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/loading.tsx
@@ -1,12 +1,22 @@
 "use client";
 
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { MessagesSkeleton } from "./page-skeleton";
 
 /**
- * Route-level loading UI: renders the same skeleton the page shows while its
- * data loads, so navigation shows one continuous skeleton instead of the
- * generic group-level Loading followed by the page skeleton.
+ * Route-level loading UI: renders the real header immediately (Polaris: real
+ * chrome first, skeletonize only the data region) with a disabled no-op
+ * search field — this component has no page state yet — followed by the
+ * thread-list skeleton.
  */
 export default function MessagesLoading() {
-  return <MessagesSkeleton />;
+  return (
+    <div className="-mt-1.5 w-full">
+      <PageHeaderWithSearch
+        title="Nachrichten"
+        search={{ value: "", onChange: () => {} }}
+      />
+      <MessagesSkeleton />
+    </div>
+  );
 }

--- a/frontend/src/app/[tenant]/(protected)/messages/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/loading.tsx
@@ -14,7 +14,11 @@ export default function MessagesLoading() {
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch
         title="Nachrichten"
-        search={{ value: "", onChange: () => {} }}
+        search={{
+          value: "",
+          onChange: () => {},
+          inputProps: { disabled: true },
+        }}
       />
       <MessagesSkeleton />
     </div>

--- a/frontend/src/app/[tenant]/(protected)/messages/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/page-skeleton.tsx
@@ -2,35 +2,37 @@
 
 import { Skeleton } from "~/components/ui/skeleton";
 
-// Content-shaped placeholder mirroring the thread-list rows, so there is no
-// layout shift once the inbox loads.
+/**
+ * Data-region skeleton: just the thread-list rows. The real header
+ * (PageHeaderWithSearch) and filter/compose bar render immediately
+ * regardless of loading state — only this data-bound region skeletonizes
+ * while the inbox loads.
+ */
 export function MessagesSkeleton() {
   return (
-    <div
+    <ul
       role="status"
       aria-busy="true"
       aria-label="Nachrichten werden geladen"
       data-testid="messages-skeleton"
-      className="-mt-1.5 w-full"
+      className="space-y-3"
     >
-      <ul className="space-y-3">
-        {[0, 1, 2, 3, 4].map((item) => (
-          <li key={item}>
-            <div className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 sm:p-5">
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex min-w-0 flex-1 items-start gap-3">
-                  <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <Skeleton className="h-4 w-2/5 rounded-full" />
-                    <Skeleton className="h-3.5 w-3/5 rounded-full" />
-                  </div>
+      {[0, 1, 2, 3, 4].map((item) => (
+        <li key={item}>
+          <div className="moto-content-surface rounded-2xl border border-gray-200 bg-white p-4 sm:p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 flex-1 items-start gap-3">
+                <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <Skeleton className="h-4 w-2/5 rounded-full" />
+                  <Skeleton className="h-3.5 w-3/5 rounded-full" />
                 </div>
-                <Skeleton className="h-3 w-10 flex-shrink-0 rounded-full" />
               </div>
+              <Skeleton className="h-3 w-10 flex-shrink-0 rounded-full" />
             </div>
-          </li>
-        ))}
-      </ul>
-    </div>
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/messages/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/page.tsx
@@ -84,19 +84,25 @@ function MessagesInboxContent() {
     );
   }, [threads, searchTerm]);
 
-  // Skeleton only on the very first load (no cached data yet).
-  if (isLoading && !threads) {
-    return <MessagesSkeleton />;
-  }
+  // Skeleton only on the very first load (no cached data yet). The header,
+  // filter bar, and compose entry point are real chrome and render
+  // immediately regardless — only the thread list skeletonizes.
+  const showSkeleton = isLoading && !threads;
 
   return (
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch
         title="Nachrichten"
-        badge={{
-          icon: <MotoConceptIcon concept="parentConversations" size={20} />,
-          count: filteredThreads.length,
-        }}
+        badge={
+          showSkeleton
+            ? undefined
+            : {
+                icon: (
+                  <MotoConceptIcon concept="parentConversations" size={20} />
+                ),
+                count: filteredThreads.length,
+              }
+        }
         search={{
           value: searchTerm,
           onChange: setSearchTerm,
@@ -129,93 +135,100 @@ function MessagesInboxContent() {
         )}
       </div>
 
-      {error && (
-        <div className="mb-4">
-          <Alert
-            type="error"
-            message="Nachrichten konnten nicht geladen werden."
-          />
-        </div>
-      )}
-
-      {filteredThreads.length === 0 ? (
-        <div className="py-12 text-center">
-          <div className="flex flex-col items-center gap-4">
-            <MotoConceptIcon concept="parentConversations" size={48} />
-            <div>
-              <h3 className="text-lg font-medium text-gray-900">
-                Noch keine Nachrichten
-              </h3>
-              <p className="text-gray-600">
-                {messagingEnabled ? (
-                  <>
-                    Hier erscheinen Unterhaltungen mit den Eltern. Über{" "}
-                    <span className="font-medium text-gray-700">
-                      Neue Nachricht
-                    </span>{" "}
-                    können Sie selbst eine beginnen.
-                  </>
-                ) : (
-                  "Der Nachrichtenaustausch mit den Eltern ist für diese Schule deaktiviert."
-                )}
-              </p>
-            </div>
-            {messagingEnabled && (
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                onClick={() => setComposeOpen(true)}
-              >
-                Neue Nachricht
-              </Button>
-            )}
-          </div>
-        </div>
+      {showSkeleton ? (
+        <MessagesSkeleton />
       ) : (
-        <ul className="space-y-3">
-          {filteredThreads.map((thread) => {
-            const navigate = () => router.push(`/messages/${thread.thread_id}`);
+        <>
+          {error && (
+            <div className="mb-4">
+              <Alert
+                type="error"
+                message="Nachrichten konnten nicht geladen werden."
+              />
+            </div>
+          )}
 
-            return (
-              <li key={thread.thread_id}>
-                <button
-                  type="button"
-                  onClick={navigate}
-                  className="moto-content-surface moto-hover-elevated block w-full cursor-pointer rounded-2xl border border-gray-200 bg-white p-4 text-left shadow-sm focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 focus-visible:outline-none sm:p-5"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                        <h3 className="truncate text-base font-semibold text-gray-900">
-                          {thread.guardian_name}
-                        </h3>
-                        <span className="truncate text-sm text-gray-500">
-                          {relationshipLabel(thread.relationship_type)} von{" "}
-                          {thread.student_name}
-                        </span>
-                        <UnreadBadge count={thread.unread_count} />
-                      </div>
-                      {thread.last_message_body && (
-                        <p className="mt-1 truncate text-sm text-gray-600">
-                          {thread.last_sender_kind === "staff" && (
-                            <span className="text-gray-500">Sie: </span>
-                          )}
-                          {thread.last_message_body}
-                        </p>
-                      )}
-                    </div>
-                    {thread.last_message_at && (
-                      <span className="flex-shrink-0 text-xs whitespace-nowrap text-gray-400">
-                        {formatChatDateTime(thread.last_message_at)}
-                      </span>
+          {filteredThreads.length === 0 ? (
+            <div className="py-12 text-center">
+              <div className="flex flex-col items-center gap-4">
+                <MotoConceptIcon concept="parentConversations" size={48} />
+                <div>
+                  <h3 className="text-lg font-medium text-gray-900">
+                    Noch keine Nachrichten
+                  </h3>
+                  <p className="text-gray-600">
+                    {messagingEnabled ? (
+                      <>
+                        Hier erscheinen Unterhaltungen mit den Eltern. Über{" "}
+                        <span className="font-medium text-gray-700">
+                          Neue Nachricht
+                        </span>{" "}
+                        können Sie selbst eine beginnen.
+                      </>
+                    ) : (
+                      "Der Nachrichtenaustausch mit den Eltern ist für diese Schule deaktiviert."
                     )}
-                  </div>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+                  </p>
+                </div>
+                {messagingEnabled && (
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="md"
+                    onClick={() => setComposeOpen(true)}
+                  >
+                    Neue Nachricht
+                  </Button>
+                )}
+              </div>
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {filteredThreads.map((thread) => {
+                const navigate = () =>
+                  router.push(`/messages/${thread.thread_id}`);
+
+                return (
+                  <li key={thread.thread_id}>
+                    <button
+                      type="button"
+                      onClick={navigate}
+                      className="moto-content-surface moto-hover-elevated block w-full cursor-pointer rounded-2xl border border-gray-200 bg-white p-4 text-left shadow-sm focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 focus-visible:outline-none sm:p-5"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                            <h3 className="truncate text-base font-semibold text-gray-900">
+                              {thread.guardian_name}
+                            </h3>
+                            <span className="truncate text-sm text-gray-500">
+                              {relationshipLabel(thread.relationship_type)} von{" "}
+                              {thread.student_name}
+                            </span>
+                            <UnreadBadge count={thread.unread_count} />
+                          </div>
+                          {thread.last_message_body && (
+                            <p className="mt-1 truncate text-sm text-gray-600">
+                              {thread.last_sender_kind === "staff" && (
+                                <span className="text-gray-500">Sie: </span>
+                              )}
+                              {thread.last_message_body}
+                            </p>
+                          )}
+                        </div>
+                        {thread.last_message_at && (
+                          <span className="flex-shrink-0 text-xs whitespace-nowrap text-gray-400">
+                            {formatChatDateTime(thread.last_message_at)}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </>
       )}
 
       {composeOpen && (

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -509,8 +509,12 @@ describe("OGSGroupPage", () => {
   it("shows loading state initially", async () => {
     render(<OGSGroupPage />);
 
-    // Initial loading state should show the page-shell skeleton
-    expect(screen.getByTestId("ogs-groups-skeleton")).toBeInTheDocument();
+    // Real chrome (header) renders immediately; only the student-grid data
+    // region skeletonizes while access/data resolve (showSkeleton pattern).
+    expect(screen.getByTestId("page-header")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("student-card-grid-skeleton"),
+    ).toBeInTheDocument();
   });
 
   it("renders with SSE error boundary wrapper", () => {
@@ -586,8 +590,12 @@ describe("OGSGroupPage", () => {
 
     render(<OGSGroupPage />);
 
-    // Should show the page-shell skeleton while SWR is loading
-    expect(screen.getByTestId("ogs-groups-skeleton")).toBeInTheDocument();
+    // Header renders immediately; the student-grid data region shows the
+    // skeleton while SWR is loading (showSkeleton pattern).
+    expect(screen.getByTestId("page-header")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("student-card-grid-skeleton"),
+    ).toBeInTheDocument();
   });
 
   it("displays group data when available", async () => {

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -837,12 +837,15 @@ function OGSGroupPageContent() {
     return filters;
   }, [sortMode, searchTerm, attendanceFilter]);
 
-  if (isLoading || hasAccess === null) {
-    return <OgsGroupsPageSkeleton />;
-  }
+  // Loading joins the access-unknown state below instead of an early return
+  // before the header, so the real PageHeaderWithSearch (title, tabs,
+  // actions) renders immediately and only the student-grid area
+  // skeletonizes. Permission/access early-returns below only run once
+  // showSkeleton clears.
+  const showSkeleton = isLoading || hasAccess === null;
 
   // If user doesn't have access, show empty state
-  if (!hasAccess) {
+  if (!showSkeleton && !hasAccess) {
     return (
       <div className="-mt-1.5 w-full">
         <PageHeaderWithSearch title="Meine Gruppe" />
@@ -905,7 +908,7 @@ function OGSGroupPageContent() {
 
   // Render helper for student grid content
   const renderStudentContent = () => {
-    if (isLoading) {
+    if (showSkeleton) {
       return <StudentCardGridSkeleton />;
     }
     if (students.length === 0) {
@@ -1166,7 +1169,7 @@ function OGSGroupPageContent() {
           </div>
         )}
 
-        {currentGroup ? (
+        {currentGroup && !showSkeleton ? (
           <GroupAbsenceOverview
             totalStudents={groupAbsenceOverview.totalStudents}
             sickCount={groupAbsenceOverview.sickCount}

--- a/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/parent-announcements/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   BarChart3,
   BellRing,
@@ -32,7 +32,7 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Checkbox } from "~/components/ui/checkbox";
 import { DatePicker } from "~/components/ui/date-picker";
-import { Loading } from "~/components/ui/loading";
+import { SkeletonRegion, ListSkeleton } from "~/components/ui/page-skeletons";
 import { MultiCheckboxSelect } from "~/components/ui/multi-checkbox-select";
 import { WizardStepper } from "~/components/ui/wizard-stepper";
 import { SegmentedControl } from "~/components/ui/segmented-control";
@@ -214,11 +214,7 @@ function StatusPill({ status }: { status: AnnouncementStatus }) {
 }
 
 export default function ParentAnnouncementsPage() {
-  return (
-    <Suspense fallback={<Loading fullPage={false} />}>
-      <ParentAnnouncementsContent />
-    </Suspense>
-  );
+  return <ParentAnnouncementsContent />;
 }
 
 function ParentAnnouncementsContent() {
@@ -633,7 +629,30 @@ function ParentAnnouncementsContent() {
       )}
 
       {isLoading ? (
-        <Loading fullPage={false} />
+        <>
+          {/* Mobile: skeleton cards, matching the real card list below. */}
+          <div className="md:hidden">
+            <SkeletonRegion
+              label={
+                kind === "poll"
+                  ? "Umfragen werden geladen…"
+                  : "Elternmitteilungen werden geladen…"
+              }
+            >
+              <ListSkeleton rows={5} avatar={false} />
+            </SkeletonRegion>
+          </div>
+          <div className="hidden md:block">
+            <DataTable
+              columns={columns}
+              rows={[]}
+              isLoading
+              loadingRowCount={6}
+              getRowKey={(row) => row.id}
+              defaultSortKey="title"
+            />
+          </div>
+        </>
       ) : filtered.length === 0 ? (
         <div className="py-12 text-center">
           <div className="flex flex-col items-center gap-4">
@@ -2021,7 +2040,9 @@ function PollResultsPanel({
 
       {results === null || children === null ? (
         error ? null : (
-          <Loading fullPage={false} />
+          <SkeletonRegion label="Umfrageergebnisse werden geladen…">
+            <ListSkeleton rows={4} avatar={false} />
+          </SkeletonRegion>
         )
       ) : (
         <>
@@ -2298,7 +2319,9 @@ function DetailModal({
             {error ? (
               <p className="text-sm text-[#CC2626]">{error}</p>
             ) : stats === null || recipients === null ? (
-              <Loading fullPage={false} />
+              <SkeletonRegion label="Statistik wird geladen…">
+                <ListSkeleton rows={4} avatar={false} />
+              </SkeletonRegion>
             ) : (
               <>
                 <p className="text-sm text-gray-700">

--- a/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/payroll/page.tsx
@@ -5,7 +5,11 @@ import useSWR from "swr";
 import { Alert } from "~/components/ui/alert";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
+import {
+  SkeletonRegion,
+  CardSkeleton,
+  TableSkeleton,
+} from "~/components/ui/page-skeletons";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { useRequirePermission } from "~/lib/hooks/use-require-permission";
 import {
@@ -31,6 +35,19 @@ const UNIT_OPTIONS = [
   { value: "stunden", label: "Stunden" },
   { value: "tage", label: "Tage" },
 ];
+
+/** Data-region-only skeleton: header/chrome renders immediately, only this swaps in. */
+function PayrollDataSkeleton() {
+  return (
+    <SkeletonRegion label="Abrechnung wird geladen">
+      <div className="space-y-5">
+        <CardSkeleton rows={3} />
+        <TableSkeleton rows={4} columns={3} />
+        <CardSkeleton rows={2} />
+      </div>
+    </SkeletonRegion>
+  );
+}
 
 export default function PayrollPage() {
   const { isReady, isLoading: permissionLoading } = useRequirePermission([
@@ -73,25 +90,12 @@ export default function PayrollPage() {
     [mutate],
   );
 
-  if (permissionLoading || !isReady) {
-    return <Loading fullPage />;
-  }
-  if (error) {
-    return (
-      <div className="-mt-1.5 w-full">
-        <PageHeaderWithSearch title="Abrechnung" />
-        <Alert
-          type="error"
-          message="Die Abrechnungs-Konfiguration konnte nicht geladen werden."
-        />
-      </div>
-    );
-  }
-  if (!status) {
-    return <Loading fullPage />;
-  }
+  // Permission-loading joins the data-loading condition below instead of an
+  // early return before the header, so the real PageHeaderWithSearch renders
+  // immediately and only the data region skeletonizes.
+  const showSkeleton = permissionLoading || !isReady || (!error && !status);
 
-  const duplicates = duplicateLohnartNumbers(status);
+  const duplicates = status ? duplicateLohnartNumbers(status) : [];
 
   return (
     // Volle Inhaltsbreite und Abstände wie auf den übrigen Seiten: die eigene
@@ -100,26 +104,37 @@ export default function PayrollPage() {
     // Desktop in der Breadcrumb, PageHeaderWithSearch zeigt ihn nur mobil.
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch title="Abrechnung" />
-      <div className="space-y-5">
-        <p className="max-w-3xl text-sm text-gray-600">
-          Zuordnung der Zeiterfassungs-Kategorien zu den Lohnarten des
-          Lohnsystems und DATEV-Mandantendaten. Grundlage für den späteren
-          DATEV-Export (LODAS und Lohn und Gehalt).
-        </p>
+      {showSkeleton ? (
+        <PayrollDataSkeleton />
+      ) : error ? (
+        <Alert
+          type="error"
+          message="Die Abrechnungs-Konfiguration konnte nicht geladen werden."
+        />
+      ) : (
+        status && (
+          <div className="space-y-5">
+            <p className="max-w-3xl text-sm text-gray-600">
+              Zuordnung der Zeiterfassungs-Kategorien zu den Lohnarten des
+              Lohnsystems und DATEV-Mandantendaten. Grundlage für den späteren
+              DATEV-Export (LODAS und Lohn und Gehalt).
+            </p>
 
-        <ReadinessCard status={status} />
+            <ReadinessCard status={status} />
 
-        {saveError && <Alert type="error" message={saveError} />}
-        {duplicates.length > 0 && (
-          <Alert
-            type="warning"
-            message={`Lohnartnummer ${duplicates.join(", ")} ist mehreren Kategorien zugeordnet. Das ist zulässig, führt aber meist zu doppelt gebuchten Stunden — bitte prüfen.`}
-          />
-        )}
+            {saveError && <Alert type="error" message={saveError} />}
+            {duplicates.length > 0 && (
+              <Alert
+                type="warning"
+                message={`Lohnartnummer ${duplicates.join(", ")} ist mehreren Kategorien zugeordnet. Das ist zulässig, führt aber meist zu doppelt gebuchten Stunden — bitte prüfen.`}
+              />
+            )}
 
-        <LohnartenCard status={status} onSave={save} />
-        <DatevCard status={status} onSave={save} />
-      </div>
+            <LohnartenCard status={status} onSave={save} />
+            <DatevCard status={status} onSave={save} />
+          </div>
+        )
+      )}
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
@@ -81,14 +81,6 @@ vi.mock("~/components/ui/password-change-modal", () => ({
   ),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-full-page={fullPage}>
-      Loading...
-    </div>
-  ),
-}));
-
 vi.mock("~/components/settings/passkey-settings-section", () => ({
   PasskeySettingsSection: () => <div data-testid="passkey-settings" />,
 }));
@@ -228,7 +220,7 @@ describe("ProfilePage", () => {
 
       render(<ProfilePage />);
 
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(screen.getByLabelText("Profil wird geladen…")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/[tenant]/(protected)/profile/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.tsx
@@ -9,7 +9,11 @@ import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
 import { updateProfile, uploadAvatar } from "~/lib/profile-api";
 import type { ProfileUpdateRequest } from "~/lib/profile-helpers";
-import { Loading } from "~/components/ui/loading";
+import {
+  SkeletonRegion,
+  PageHeaderSkeleton,
+  DetailSkeleton,
+} from "~/components/ui/page-skeletons";
 import { useProfile } from "~/lib/profile-context";
 import { compressAvatar } from "~/lib/image-utils";
 import { Button } from "~/components/ui/button";
@@ -24,6 +28,13 @@ import { PushNotificationSection } from "~/components/settings/push-notification
 import { getInitials } from "~/lib/format-utils";
 
 const logger = createLogger({ component: "ProfilePage" });
+
+const profileLoadingFallback = (
+  <SkeletonRegion label="Profil wird geladen…">
+    <PageHeaderSkeleton search={false} />
+    <DetailSkeleton sections={3} fieldsPerSection={3} />
+  </SkeletonRegion>
+);
 
 function ProfileContent() {
   const {
@@ -118,7 +129,7 @@ function ProfileContent() {
   }, []);
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return profileLoadingFallback;
   }
 
   if (!session?.user) {
@@ -317,7 +328,7 @@ function ProfileContent() {
 
 export default function ProfilePage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={profileLoadingFallback}>
       <ProfileContent />
     </Suspense>
   );

--- a/frontend/src/app/[tenant]/(protected)/reminders/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/reminders/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useReminders } from "~/lib/hooks/use-reminders";
 import type { Reminder } from "~/lib/reminders-api";
 import {
@@ -52,7 +52,9 @@ export default function RemindersPage() {
       )}
 
       {isLoading && !reminders.length ? (
-        <Loading message="Erinnerungen werden geladen…" fullPage={false} />
+        <SkeletonRegion label="Erinnerungen werden geladen…">
+          <ListSkeleton rows={5} avatar={false} />
+        </SkeletonRegion>
       ) : error && !data ? null : count === 0 ? (
         data?.enabled === false ? (
           <div className="rounded-2xl border border-gray-200 bg-white p-10 text-center shadow-sm">

--- a/frontend/src/app/[tenant]/(protected)/rooms/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/loading.tsx
@@ -14,7 +14,11 @@ export default function RoomsLoading() {
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch
         title="Räume"
-        search={{ value: "", onChange: () => {} }}
+        search={{
+          value: "",
+          onChange: () => {},
+          inputProps: { disabled: true },
+        }}
       />
       <RoomsGridSkeleton />
     </div>

--- a/frontend/src/app/[tenant]/(protected)/rooms/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/loading.tsx
@@ -1,12 +1,22 @@
 "use client";
 
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { RoomsGridSkeleton } from "./page-skeleton";
 
 /**
- * Route-level loading UI: renders the same skeleton the page shows while its
- * data loads, so navigation shows one continuous skeleton instead of the
- * generic group-level Loading followed by the page skeleton.
+ * Route-level loading UI: renders the real header immediately (Polaris: real
+ * chrome first, skeletonize only the data region) with a disabled no-op
+ * search field — this component has no page state yet — followed by the
+ * room-card grid skeleton.
  */
 export default function RoomsLoading() {
-  return <RoomsGridSkeleton />;
+  return (
+    <div className="-mt-1.5 w-full">
+      <PageHeaderWithSearch
+        title="Räume"
+        search={{ value: "", onChange: () => {} }}
+      />
+      <RoomsGridSkeleton />
+    </div>
+  );
 }

--- a/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/rooms/page.tsx
@@ -501,24 +501,27 @@ function RoomsPageContent() {
     [exportTargetCount, handleExport, isExporting, loading],
   );
 
-  // Auth-loading: show the same skeleton as the Suspense fallback and the
-  // data-loading branch, so the cold-load sequence stays skeleton -> content
-  // without a spinner flash in between. The `useSession({ required: true })`
-  // callback redirects on unauthenticated.
-  if (status === "loading") {
-    return <RoomsGridSkeleton />;
-  }
+  // Auth-loading joins the data-loading condition below instead of an early
+  // return before the header, so the real PageHeaderWithSearch (title,
+  // search field, static tabs) renders immediately and only the room-card
+  // grid skeletonizes. The `useSession({ required: true })` callback
+  // redirects on unauthenticated.
+  const showSkeleton = status === "loading" || loading;
 
   return (
     <div className="-mt-1.5 w-full">
       {/* PageHeaderWithSearch - Title only on mobile */}
       <PageHeaderWithSearch
         title={isMobile ? "Räume" : ""}
-        badge={{
-          icon: <MotoConceptIcon concept="rooms" size={20} />,
-          count: filteredRooms.length,
-          label: "Räume",
-        }}
+        badge={
+          showSkeleton
+            ? undefined
+            : {
+                icon: <MotoConceptIcon concept="rooms" size={20} />,
+                count: filteredRooms.length,
+                label: "Räume",
+              }
+        }
         search={{
           value: searchTerm,
           onChange: setSearchTerm,
@@ -553,7 +556,7 @@ function RoomsPageContent() {
           data arrives. Review feedback (#1323): a generic spinner
           collapsed the header row into a tiny payload, then the layout
           jumped open when rooms loaded. */}
-      {loading ? (
+      {showSkeleton ? (
         <RoomsGridSkeleton />
       ) : (
         <>

--- a/frontend/src/app/[tenant]/(protected)/settings/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/settings/page.test.tsx
@@ -16,14 +16,6 @@ vi.mock("next/navigation", () => ({
   redirect: (url: string) => mockRedirect(url),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-full-page={fullPage}>
-      Loading...
-    </div>
-  ),
-}));
-
 // Mock useSettingsTabs — returns null by default (no access)
 const mockUseSettingsTabs = vi.fn();
 vi.mock("~/components/settings/settings-page", () => ({
@@ -64,7 +56,9 @@ describe("SettingsPage", () => {
 
     render(<SettingsPage />);
 
-    expect(screen.getByTestId("loading")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Einstellungen werden geladen…"),
+    ).toBeInTheDocument();
   });
 
   it("should redirect when unauthenticated", () => {

--- a/frontend/src/app/[tenant]/(protected)/settings/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/settings/page.tsx
@@ -3,9 +3,20 @@
 import { Suspense } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
-import { Loading } from "~/components/ui/loading";
+import {
+  SkeletonRegion,
+  PageHeaderSkeleton,
+  FormSkeleton,
+} from "~/components/ui/page-skeletons";
 import { SettingsLayout } from "~/components/shared/settings-layout";
 import { useSettingsTabs } from "~/components/settings/settings-page";
+
+const settingsLoadingFallback = (
+  <SkeletonRegion label="Einstellungen werden geladen…">
+    <PageHeaderSkeleton search={false} />
+    <FormSkeleton />
+  </SkeletonRegion>
+);
 
 function SettingsContent() {
   const { data: session, status } = useSession({
@@ -15,7 +26,7 @@ function SettingsContent() {
   const settingsTabs = useSettingsTabs();
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return settingsLoadingFallback;
   }
 
   if (!session?.user) {
@@ -31,7 +42,7 @@ function SettingsContent() {
   }
 
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={settingsLoadingFallback}>
       <SettingsLayout
         tabs={settingsTabs.tabs}
         renderTab={settingsTabs.renderTab}
@@ -42,7 +53,7 @@ function SettingsContent() {
 
 export default function SettingsPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={settingsLoadingFallback}>
       <SettingsContent />
     </Suspense>
   );

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page-skeleton.tsx
@@ -5,10 +5,39 @@ import { UebersichtTabSkeleton } from "~/components/staff/uebersicht-tab-skeleto
 
 // ─── Route-level loading skeleton ────────────────────────────────────────────
 
+/**
+ * Mirrors StaffHeader (avatar + name block + status badge + kebab trigger).
+ * Used both standalone (route-level loading, permission still unknown) and
+ * as the placeholder for the real StaffHeader while the staff fetch is in
+ * flight — the name/status/menu are all data-bound, so they stay skeletons
+ * until `staff` loads.
+ */
+export function StaffHeaderSkeleton() {
+  return (
+    <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 flex-1 items-start gap-4">
+        <Skeleton className="h-16 w-16 flex-shrink-0 rounded-full" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-3 w-32 rounded" />
+          <Skeleton className="h-7 w-48 rounded" />
+          <Skeleton className="h-4 w-40 rounded" />
+        </div>
+      </div>
+      <div className="flex flex-shrink-0 items-center gap-2">
+        <Skeleton className="h-7 w-24 rounded-full" />
+        <Skeleton className="h-10 w-10 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
 export function StaffDetailSkeleton() {
   // Mirrors StaffHeader (avatar + name block + status badge) and the
   // TabsList line, then the Übersicht tab body, so the loaded page swaps in
-  // without layout shift.
+  // without layout shift. Used only while the session (and therefore
+  // permissions/tab set) is still unknown — once permissions are known the
+  // page renders the real tab bar and StaffHeaderSkeleton instead (see
+  // page.tsx), since the tab set itself doesn't need the staff fetch.
   return (
     <div
       role="status"
@@ -17,20 +46,7 @@ export function StaffDetailSkeleton() {
       data-testid="staff-detail-skeleton"
       className="-mt-1.5 w-full"
     >
-      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex min-w-0 flex-1 items-start gap-4">
-          <Skeleton className="h-16 w-16 flex-shrink-0 rounded-full" />
-          <div className="min-w-0 flex-1 space-y-2">
-            <Skeleton className="h-3 w-32 rounded" />
-            <Skeleton className="h-7 w-48 rounded" />
-            <Skeleton className="h-4 w-40 rounded" />
-          </div>
-        </div>
-        <div className="flex flex-shrink-0 items-center gap-2">
-          <Skeleton className="h-7 w-24 rounded-full" />
-          <Skeleton className="h-10 w-10 rounded-full" />
-        </div>
-      </div>
+      <StaffHeaderSkeleton />
 
       <div className="mb-6 flex gap-6 border-b border-gray-200 pb-px">
         {Array.from({ length: 4 }, (_, i) => (

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -34,7 +34,8 @@ import { UebersichtTab } from "~/components/staff/uebersicht-tab";
 import { ZeiterfassungTab } from "~/components/staff/zeiterfassung-tab";
 import { staffAbsenceService } from "~/lib/staff-api";
 import { MOTO_CONCEPTS } from "~/lib/moto-concepts";
-import { StaffDetailSkeleton } from "./page-skeleton";
+import { DetailSkeleton } from "~/components/ui/page-skeletons";
+import { StaffDetailSkeleton, StaffHeaderSkeleton } from "./page-skeleton";
 
 // ─── Labels & constants ──────────────────────────────────────────────────────
 
@@ -207,7 +208,13 @@ export default function StaffDetailContent() {
     window.scrollTo({ top: 0, behavior: "instant" });
   }, [staffId]);
 
-  if (sessionStatus === "loading" || isLoading) {
+  // The tab set is permission-gated, and permissions come from the session,
+  // not from the staff fetch below — so until the session resolves we don't
+  // know which tabs to render at all and fall back to the full-page
+  // skeleton. Once it resolves, the real tab bar renders immediately; only
+  // the header (name/status, data-bound) and the active tab's content
+  // (needs the fetched `staff`) stay skeletons while `isLoading`.
+  if (sessionStatus === "loading") {
     return <StaffDetailSkeleton />;
   }
 
@@ -216,7 +223,7 @@ export default function StaffDetailContent() {
     return <StaffDetailSkeleton />;
   }
 
-  if (error || !staff) {
+  if (!isLoading && (error || !staff)) {
     return (
       <EmptyState
         title="Mitarbeiter konnte nicht geladen werden."
@@ -239,13 +246,22 @@ export default function StaffDetailContent() {
 
   return (
     <div className="-mt-1.5 w-full">
-      {/* Rich Header with kebab trigger */}
-      <StaffHeader
-        staff={staff}
-        menu={<OverflowMenu items={menuItems} ariaLabel="Weitere Aktionen" />}
-      />
+      {/* Rich Header with kebab trigger. Name/status are data-bound (they
+          come from `staff`), so this stays a skeleton until the fetch
+          resolves — the tab bar right below doesn't need to wait. */}
+      {staff ? (
+        <StaffHeader
+          staff={staff}
+          menu={<OverflowMenu items={menuItems} ariaLabel="Weitere Aktionen" />}
+        />
+      ) : (
+        <StaffHeaderSkeleton />
+      )}
 
-      {/* Tabs */}
+      {/* Tabs — permission-gated, not data-gated: the canView/canEdit/canManage
+          flags all derive from the session, which is already resolved here,
+          so the real tab bar renders immediately even while `staff` is
+          still loading. */}
       <Tabs
         defaultValue={
           requestedTab === "dokumente" && canViewDocuments
@@ -299,62 +315,73 @@ export default function StaffDetailContent() {
           ) : null}
         </TabsList>
 
-        {canViewTimeTracking ? (
-          <TabsPrimitive.Content value="uebersicht">
-            <UebersichtTab staffId={staffId} />
-          </TabsPrimitive.Content>
-        ) : null}
+        {staff ? (
+          <>
+            {canViewTimeTracking ? (
+              <TabsPrimitive.Content value="uebersicht">
+                <UebersichtTab staffId={staffId} />
+              </TabsPrimitive.Content>
+            ) : null}
 
-        {canViewTimeTracking ? (
-          <TabsPrimitive.Content value="zeiterfassung">
-            <ZeiterfassungTab staffId={staffId} />
-          </TabsPrimitive.Content>
-        ) : null}
+            {canViewTimeTracking ? (
+              <TabsPrimitive.Content value="zeiterfassung">
+                <ZeiterfassungTab staffId={staffId} />
+              </TabsPrimitive.Content>
+            ) : null}
 
-        {canEdit ? (
-          <TabsPrimitive.Content value="arbeitszeitmodell">
-            <ArbeitszeitmodellTab staffId={staffId} canEdit={canEdit} />
-          </TabsPrimitive.Content>
-        ) : null}
+            {canEdit ? (
+              <TabsPrimitive.Content value="arbeitszeitmodell">
+                <ArbeitszeitmodellTab staffId={staffId} canEdit={canEdit} />
+              </TabsPrimitive.Content>
+            ) : null}
 
-        {canManageAbsences ? (
-          <TabsPrimitive.Content value="abwesenheiten">
-            <AbwesenheitenTab
-              staffId={staffId}
-              canEdit={canEdit}
-              canManageSickReports={canManageTimeTracking}
-              staff={staff}
-            />
-          </TabsPrimitive.Content>
-        ) : null}
+            {canManageAbsences ? (
+              <TabsPrimitive.Content value="abwesenheiten">
+                <AbwesenheitenTab
+                  staffId={staffId}
+                  canEdit={canEdit}
+                  canManageSickReports={canManageTimeTracking}
+                  staff={staff}
+                />
+              </TabsPrimitive.Content>
+            ) : null}
 
-        {canViewStammdaten ? (
-          <TabsPrimitive.Content value="stammdaten">
-            <StammdatenTab
-              staffId={staffId}
-              canManagePayroll={canManageTimeTracking}
-              canManagePayrollSettings={canManagePayrollSettings}
-              canViewSections={canViewStammdatenSections}
-              canEditSections={canEditStammdaten}
-              canViewFinancial={canViewFinancial}
-            />
-          </TabsPrimitive.Content>
-        ) : null}
+            {canViewStammdaten ? (
+              <TabsPrimitive.Content value="stammdaten">
+                <StammdatenTab
+                  staffId={staffId}
+                  canManagePayroll={canManageTimeTracking}
+                  canManagePayrollSettings={canManagePayrollSettings}
+                  canViewSections={canViewStammdatenSections}
+                  canEditSections={canEditStammdaten}
+                  canViewFinancial={canViewFinancial}
+                />
+              </TabsPrimitive.Content>
+            ) : null}
 
-        {canViewDocuments ? (
-          <TabsPrimitive.Content value="dokumente">
-            <DokumenteTab staffId={staffId} />
-          </TabsPrimitive.Content>
-        ) : null}
+            {canViewDocuments ? (
+              <TabsPrimitive.Content value="dokumente">
+                <DokumenteTab staffId={staffId} />
+              </TabsPrimitive.Content>
+            ) : null}
 
-        {/* Klassen-Zuweisung (#1772): scopt die Lehrkraft-Klassenansicht.
-            Lesen mit users:read (wie die übrigen Staff-Detail-Reads),
-            Ersetzen mit users:manage — beides erzwingt das Backend. */}
-        {canViewKlassen ? (
-          <TabsPrimitive.Content value="klassen">
-            <KlassenTab staffId={staffId} canEdit={canEditKlassen} />
-          </TabsPrimitive.Content>
-        ) : null}
+            {/* Klassen-Zuweisung (#1772): scopt die Lehrkraft-Klassenansicht.
+                Lesen mit users:read (wie die übrigen Staff-Detail-Reads),
+                Ersetzen mit users:manage — beides erzwingt das Backend. */}
+            {canViewKlassen ? (
+              <TabsPrimitive.Content value="klassen">
+                <KlassenTab staffId={staffId} canEdit={canEditKlassen} />
+              </TabsPrimitive.Content>
+            ) : null}
+          </>
+        ) : (
+          // The active tab's content needs the fetched `staff` (e.g.
+          // AbwesenheitenTab takes it as a prop directly), so it skeletonizes
+          // as a unit instead of rendering per-tab while data is missing.
+          <div className="mt-6">
+            <DetailSkeleton sections={2} fieldsPerSection={4} />
+          </div>
+        )}
       </Tabs>
     </div>
   );

--- a/frontend/src/app/[tenant]/(protected)/staff/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/loading.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { StaffPageSkeleton } from "./page-skeleton";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { StaffCardsSkeleton } from "./page-skeleton";
 
 /**
- * Route-level loading UI: renders the same skeleton the page shows while its
- * data loads, so navigation shows one continuous skeleton instead of the
- * generic group-level Loading followed by the page skeleton.
+ * Route-level loading UI: renders the real header immediately (Polaris: real
+ * chrome first, skeletonize only the data region) with a disabled no-op
+ * search field — this component has no page state yet — followed by the
+ * card-grid skeleton for the data region.
  */
 export default function StaffLoading() {
-  return <StaffPageSkeleton />;
+  return (
+    <div className="-mt-1.5 w-full">
+      <PageHeaderWithSearch
+        title="Mitarbeiter"
+        search={{ value: "", onChange: () => {} }}
+      />
+      <StaffCardsSkeleton />
+    </div>
+  );
 }

--- a/frontend/src/app/[tenant]/(protected)/staff/loading.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/loading.tsx
@@ -14,7 +14,11 @@ export default function StaffLoading() {
     <div className="-mt-1.5 w-full">
       <PageHeaderWithSearch
         title="Mitarbeiter"
-        search={{ value: "", onChange: () => {} }}
+        search={{
+          value: "",
+          onChange: () => {},
+          inputProps: { disabled: true },
+        }}
       />
       <StaffCardsSkeleton />
     </div>

--- a/frontend/src/app/[tenant]/(protected)/staff/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page-skeleton.tsx
@@ -28,33 +28,23 @@ function StaffCardSkeleton() {
   );
 }
 
-export function StaffPageSkeleton() {
+/**
+ * Data-region skeleton: just the staff-card grid. The real header
+ * (PageHeaderWithSearch) renders immediately regardless of loading state —
+ * only this data-bound region skeletonizes while staff data loads.
+ */
+export function StaffCardsSkeleton() {
   return (
     <div
       role="status"
       aria-busy="true"
       aria-label="Mitarbeitende werden geladen"
       data-testid="staff-page-skeleton"
-      className="-mt-1.5 w-full"
+      className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3"
     >
-      {/* PageHeaderWithSearch placeholder: title + search field + filter chips */}
-      <div className="mb-4 flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <Skeleton className="h-6 w-32 rounded" />
-          <Skeleton className="h-10 w-full max-w-sm flex-1 rounded-lg sm:max-w-md" />
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {Array.from({ length: 5 }, (_, i) => (
-            <Skeleton key={i} className="h-8 w-24 rounded-full" />
-          ))}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
-        {Array.from({ length: 6 }, (_, i) => (
-          <StaffCardSkeleton key={i} />
-        ))}
-      </div>
+      {Array.from({ length: 6 }, (_, i) => (
+        <StaffCardSkeleton key={i} />
+      ))}
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/staff/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/page.tsx
@@ -48,7 +48,7 @@ import { useSWRConfig } from "swr";
 import { ForbiddenPage } from "~/components/ui/forbidden-page";
 import { staffOverviewService } from "~/lib/staff-overview-api";
 import { employmentTypeLabels } from "~/lib/staff-helpers";
-import { StaffPageSkeleton } from "./page-skeleton";
+import { StaffCardsSkeleton } from "./page-skeleton";
 
 function DocumentDirectory({
   entries,
@@ -573,22 +573,23 @@ function StaffPageContent() {
     view,
   ]);
 
-  if (status === "loading" || isLoading || isDocumentDirectoryLoading) {
-    return <StaffPageSkeleton />;
-  }
+  const showSkeleton =
+    status === "loading" || isLoading || isDocumentDirectoryLoading;
 
-  if (!canReadUsers && !canManageTimeTracking && !canAccessDocuments) {
-    return <ForbiddenPage />;
-  }
+  if (!showSkeleton) {
+    if (!canReadUsers && !canManageTimeTracking && !canAccessDocuments) {
+      return <ForbiddenPage />;
+    }
 
-  if (documentDirectoryOnly) {
-    return (
-      <DocumentDirectory
-        entries={documentDirectory ?? []}
-        error={documentDirectoryError}
-        onRetry={() => void mutateDocumentDirectory()}
-      />
-    );
+    if (documentDirectoryOnly) {
+      return (
+        <DocumentDirectory
+          entries={documentDirectory ?? []}
+          error={documentDirectoryError}
+          onRetry={() => void mutateDocumentDirectory()}
+        />
+      );
+    }
   }
 
   return (
@@ -596,15 +597,19 @@ function StaffPageContent() {
       {/* PageHeaderWithSearch - Title only on mobile */}
       <PageHeaderWithSearch
         title={isMobile ? "Mitarbeiter" : ""}
-        badge={{
-          icon: <MotoConceptIcon concept="staff" size={20} />,
-          count:
-            view === "accounts"
-              ? accountRows.length
-              : view === "documents"
-                ? (documentDirectory?.length ?? 0)
-                : filteredStaff.length,
-        }}
+        badge={
+          showSkeleton
+            ? undefined
+            : {
+                icon: <MotoConceptIcon concept="staff" size={20} />,
+                count:
+                  view === "accounts"
+                    ? accountRows.length
+                    : view === "documents"
+                      ? (documentDirectory?.length ?? 0)
+                      : filteredStaff.length,
+              }
+        }
         search={
           // Im Änderungsprotokoll filtert die Komponente selbst; ein
           // wirkungsloses Suchfeld wäre irreführend.
@@ -628,303 +633,320 @@ function StaffPageContent() {
         }}
       />
 
-      {/* Sektion 1 — Eingehende Anfragen (#1419), nur für Genehmigende. Die
-          Inbox trägt die offenen Anträge samt Detail; das aggregierte
-          pending_requests_count aus dem Dashboard-Endpoint wäre daneben eine
-          zweite, ärmere Anzeige derselben Zahl und bleibt deshalb ungenutzt. */}
-      {canReviewAbsences && (
-        <StaffPendingInbox rows={pendingAbsences} staffList={staff} />
-      )}
+      {showSkeleton ? (
+        <StaffCardsSkeleton />
+      ) : (
+        <>
+          {/* Sektion 1 — Eingehende Anfragen (#1419), nur für Genehmigende. Die
+              Inbox trägt die offenen Anträge samt Detail; das aggregierte
+              pending_requests_count aus dem Dashboard-Endpoint wäre daneben eine
+              zweite, ärmere Anzeige derselben Zahl und bleibt deshalb ungenutzt. */}
+          {canReviewAbsences && (
+            <StaffPendingInbox rows={pendingAbsences} staffList={staff} />
+          )}
 
-      {/* Sektion 2 — Einrichtungs-Übersicht (#1417 Tranche 2a), läuft mit users:read */}
-      {canReadUsers && <SchoolOverviewSection />}
+          {/* Sektion 2 — Einrichtungs-Übersicht (#1417 Tranche 2a), läuft mit users:read */}
+          {canReadUsers && <SchoolOverviewSection />}
 
-      {/* Sektion 3 — Mitarbeitende. Status (Karten) und Zeitkonten (Tabelle)
-          beantworten verschiedene Fragen; der Umschalter erscheint nur mit
-          time_tracking:manage. */}
-      {canManageTimeTracking && (
-        <Tabs
-          value={view}
-          onValueChange={(value) =>
-            setSelectedView(
-              value as "status" | "accounts" | "audit" | "documents",
-            )
-          }
-          className="mb-4"
-        >
-          <TabsList variant="line">
-            {canReadUsers && <TabsTrigger value="status">Status</TabsTrigger>}
-            <TabsTrigger value="accounts">Zeitkonten</TabsTrigger>
-            <TabsTrigger value="audit">Änderungsprotokoll</TabsTrigger>
-            {canAccessDocuments && (
-              <TabsTrigger value="documents">Personalunterlagen</TabsTrigger>
+          {/* Sektion 3 — Mitarbeitende. Status (Karten) und Zeitkonten (Tabelle)
+              beantworten verschiedene Fragen; der Umschalter erscheint nur mit
+              time_tracking:manage. */}
+          {canManageTimeTracking && (
+            <Tabs
+              value={view}
+              onValueChange={(value) =>
+                setSelectedView(
+                  value as "status" | "accounts" | "audit" | "documents",
+                )
+              }
+              className="mb-4"
+            >
+              <TabsList variant="line">
+                {canReadUsers && (
+                  <TabsTrigger value="status">Status</TabsTrigger>
+                )}
+                <TabsTrigger value="accounts">Zeitkonten</TabsTrigger>
+                <TabsTrigger value="audit">Änderungsprotokoll</TabsTrigger>
+                {canAccessDocuments && (
+                  <TabsTrigger value="documents">
+                    Personalunterlagen
+                  </TabsTrigger>
+                )}
+              </TabsList>
+            </Tabs>
+          )}
+
+          {/* Änderungsprotokoll (#1417): cross-MA audit feed, eigene Filter in der
+              Komponente. Nur mit time_tracking:manage erreichbar (Tab-Gate oben). */}
+          {view === "audit" && canManageTimeTracking && (
+            <StaffAuditLog staffOptions={auditStaffOptions} />
+          )}
+
+          {view === "documents" &&
+            canManageTimeTracking &&
+            canAccessDocuments && (
+              <DocumentDirectory
+                entries={documentDirectory ?? []}
+                error={documentDirectoryError}
+                onRetry={() => void mutateDocumentDirectory()}
+                embedded
+              />
             )}
-          </TabsList>
-        </Tabs>
-      )}
 
-      {/* Änderungsprotokoll (#1417): cross-MA audit feed, eigene Filter in der
-          Komponente. Nur mit time_tracking:manage erreichbar (Tab-Gate oben). */}
-      {view === "audit" && canManageTimeTracking && (
-        <StaffAuditLog staffOptions={auditStaffOptions} />
-      )}
+          {view === "accounts" && (
+            <StaffTimeAccountsTable
+              rows={accountRows}
+              year={accounts?.year ?? monthAnchor.year}
+              month={accounts?.month ?? monthAnchor.month}
+              onPrevMonth={() => shiftMonth(-1)}
+              onNextMonth={() => shiftMonth(1)}
+              canGoNextMonth={!isCurrentOrFutureMonth}
+              monthClose={monthClose}
+              monthCloseError={
+                monthCloseStatusError
+                  ? "Der Abschlussstatus konnte nicht geladen werden. Abschließen und erneutes Abschließen sind bis zur erfolgreichen Aktualisierung nicht verfügbar."
+                  : null
+              }
+              onRetryMonthClose={() => void mutateMonthClose()}
+              monthIsOver={!isCurrentOrFutureMonth}
+              onCloseMonth={() => setShowCloseModal(true)}
+              onExport={() => setShowExportModal(true)}
+              onOpeningBalances={
+                userIsAdmin
+                  ? () => router.push("/database/personal/opening-balances")
+                  : undefined
+              }
+              isLoading={accountsLoading && !accounts}
+              error={
+                accountsError
+                  ? "Zeitkonten konnten nicht geladen werden."
+                  : null
+              }
+              onRowClick={(row) =>
+                router.push(
+                  `/staff/${row.staffId}${canAccessDocuments && !userIsAdmin ? "?tab=dokumente" : ""}`,
+                )
+              }
+              saldoPreset={saldoPreset}
+              onSaldoPresetChange={setSaldoPreset}
+              customSaldoHours={customSaldoHours}
+              onCustomSaldoHoursChange={setCustomSaldoHours}
+              showCustomSaldo={showCustomSaldo}
+              onShowCustomSaldoChange={setShowCustomSaldo}
+              paginationResetKey={`${accountsKey ?? "inactive"}:${searchTerm}`}
+            />
+          )}
 
-      {view === "documents" && canManageTimeTracking && canAccessDocuments && (
-        <DocumentDirectory
-          entries={documentDirectory ?? []}
-          error={documentDirectoryError}
-          onRetry={() => void mutateDocumentDirectory()}
-          embedded
-        />
-      )}
+          {showCloseModal && (
+            <MonthCloseReasonModal
+              title={`Monat abschließen — ${String(monthAnchor.month).padStart(2, "0")}/${monthAnchor.year}`}
+              description={
+                <>
+                  <p>
+                    Der Abschluss friert den Saldo zum Monatsende für{" "}
+                    <strong>alle Mitarbeitenden</strong> ein. Spätere Monate
+                    rechnen ab dann mit diesem eingefrorenen Übertrag weiter.
+                  </p>
+                  <p>
+                    Werden danach noch Zeiten in diesem Monat geändert, bleibt
+                    der Übertrag stehen; die Abweichung wird auf der Monatskarte
+                    der Person angezeigt.
+                  </p>
+                  <p>
+                    Bereits abgeschlossene Konten bleiben unverändert; nur
+                    offene Konten werden eingefroren.
+                  </p>
+                </>
+              }
+              submitLabel="Monat abschließen"
+              successMessage="Monat abgeschlossen."
+              onSubmit={handleCloseMonth}
+              onClose={() => setShowCloseModal(false)}
+            />
+          )}
 
-      {view === "accounts" && (
-        <StaffTimeAccountsTable
-          rows={accountRows}
-          year={accounts?.year ?? monthAnchor.year}
-          month={accounts?.month ?? monthAnchor.month}
-          onPrevMonth={() => shiftMonth(-1)}
-          onNextMonth={() => shiftMonth(1)}
-          canGoNextMonth={!isCurrentOrFutureMonth}
-          monthClose={monthClose}
-          monthCloseError={
-            monthCloseStatusError
-              ? "Der Abschlussstatus konnte nicht geladen werden. Abschließen und erneutes Abschließen sind bis zur erfolgreichen Aktualisierung nicht verfügbar."
-              : null
-          }
-          onRetryMonthClose={() => void mutateMonthClose()}
-          monthIsOver={!isCurrentOrFutureMonth}
-          onCloseMonth={() => setShowCloseModal(true)}
-          onExport={() => setShowExportModal(true)}
-          onOpeningBalances={
-            userIsAdmin
-              ? () => router.push("/database/personal/opening-balances")
-              : undefined
-          }
-          isLoading={accountsLoading && !accounts}
-          error={
-            accountsError ? "Zeitkonten konnten nicht geladen werden." : null
-          }
-          onRowClick={(row) =>
-            router.push(
-              `/staff/${row.staffId}${canAccessDocuments && !userIsAdmin ? "?tab=dokumente" : ""}`,
-            )
-          }
-          saldoPreset={saldoPreset}
-          onSaldoPresetChange={setSaldoPreset}
-          customSaldoHours={customSaldoHours}
-          onCustomSaldoHoursChange={setCustomSaldoHours}
-          showCustomSaldo={showCustomSaldo}
-          onShowCustomSaldoChange={setShowCustomSaldo}
-          paginationResetKey={`${accountsKey ?? "inactive"}:${searchTerm}`}
-        />
-      )}
+          {/* Cross-MA-Export (#1417 2b): Query-Bau im Dialog, Zahlen und Datei
+              komplett aus dem Backend. */}
+          <StaffTimeExportModal
+            isOpen={showExportModal}
+            onClose={() => setShowExportModal(false)}
+            year={accounts?.year ?? monthAnchor.year}
+            month={accounts?.month ?? monthAnchor.month}
+          />
 
-      {showCloseModal && (
-        <MonthCloseReasonModal
-          title={`Monat abschließen — ${String(monthAnchor.month).padStart(2, "0")}/${monthAnchor.year}`}
-          description={
-            <>
-              <p>
-                Der Abschluss friert den Saldo zum Monatsende für{" "}
-                <strong>alle Mitarbeitenden</strong> ein. Spätere Monate rechnen
-                ab dann mit diesem eingefrorenen Übertrag weiter.
-              </p>
-              <p>
-                Werden danach noch Zeiten in diesem Monat geändert, bleibt der
-                Übertrag stehen; die Abweichung wird auf der Monatskarte der
-                Person angezeigt.
-              </p>
-              <p>
-                Bereits abgeschlossene Konten bleiben unverändert; nur offene
-                Konten werden eingefroren.
-              </p>
-            </>
-          }
-          submitLabel="Monat abschließen"
-          successMessage="Monat abgeschlossen."
-          onSubmit={handleCloseMonth}
-          onClose={() => setShowCloseModal(false)}
-        />
-      )}
-
-      {/* Cross-MA-Export (#1417 2b): Query-Bau im Dialog, Zahlen und Datei
-          komplett aus dem Backend. */}
-      <StaffTimeExportModal
-        isOpen={showExportModal}
-        onClose={() => setShowExportModal(false)}
-        year={accounts?.year ?? monthAnchor.year}
-        month={accounts?.month ?? monthAnchor.month}
-      />
-
-      {/* Error Display */}
-      {view === "status" && error && (
-        <div className="border-moto-red/20 bg-moto-red-soft text-moto-red-strong mb-4 rounded-lg border p-4">
-          {error}
-        </div>
-      )}
-
-      {/* Staff Grid */}
-      {view === "status" &&
-        (filteredStaff.length === 0 ? (
-          <div className="py-12 text-center">
-            <div className="flex flex-col items-center gap-4">
-              <MotoConceptIcon concept="staff" size={48} />
-              <div>
-                <h3 className="text-lg font-medium text-gray-900">
-                  Kein Personal gefunden
-                </h3>
-                <p className="text-gray-600">
-                  Versuchen Sie Ihre Suchkriterien anzupassen.
-                </p>
-              </div>
+          {/* Error Display */}
+          {view === "status" && error && (
+            <div className="border-moto-red/20 bg-moto-red-soft text-moto-red-strong mb-4 rounded-lg border p-4">
+              {error}
             </div>
-          </div>
-        ) : (
-          <div>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
-              {filteredStaff.map((staffMember) => {
-                const locationStatus = getStaffLocationStatus(staffMember);
-                const displayType = getStaffDisplayType(staffMember);
-                const cardInfo = getStaffCardInfo(staffMember);
-                const notes = formatStaffNotes(staffMember.staffNotes, 80);
-                const supervisions = staffMember.supervisions ?? [];
-                const pendingRequestCount =
-                  pendingByStaff.get(Number(staffMember.id)) ?? 0;
+          )}
 
-                const canNavigateToStaff = userIsAdmin || canAccessDocuments;
-                const cardClassName = `group moto-content-surface moto-hover-elevated relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-[0_1px_2px_rgba(15,23,42,0.04),0_0_0_1px_rgba(15,23,42,0.02)] focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 focus-visible:outline-none active:shadow-[0_10px_26px_rgba(15,23,42,0.1)] ${canNavigateToStaff ? "cursor-pointer" : ""}`;
-                const navigateToStaff = () =>
-                  router.push(
-                    `/staff/${staffMember.id}${canAccessDocuments && !userIsAdmin ? "?tab=dokumente" : ""}`,
-                  );
+          {/* Staff Grid */}
+          {view === "status" &&
+            (filteredStaff.length === 0 ? (
+              <div className="py-12 text-center">
+                <div className="flex flex-col items-center gap-4">
+                  <MotoConceptIcon concept="staff" size={48} />
+                  <div>
+                    <h3 className="text-lg font-medium text-gray-900">
+                      Kein Personal gefunden
+                    </h3>
+                    <p className="text-gray-600">
+                      Versuchen Sie Ihre Suchkriterien anzupassen.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3">
+                  {filteredStaff.map((staffMember) => {
+                    const locationStatus = getStaffLocationStatus(staffMember);
+                    const displayType = getStaffDisplayType(staffMember);
+                    const cardInfo = getStaffCardInfo(staffMember);
+                    const notes = formatStaffNotes(staffMember.staffNotes, 80);
+                    const supervisions = staffMember.supervisions ?? [];
+                    const pendingRequestCount =
+                      pendingByStaff.get(Number(staffMember.id)) ?? 0;
 
-                return (
-                  <div
-                    key={staffMember.id}
-                    {...(canNavigateToStaff
-                      ? {
-                          role: "button" as const,
-                          tabIndex: 0,
-                          onClick: navigateToStaff,
-                          onKeyDown: (e: React.KeyboardEvent) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              navigateToStaff();
+                    const canNavigateToStaff =
+                      userIsAdmin || canAccessDocuments;
+                    const cardClassName = `group moto-content-surface moto-hover-elevated relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-[0_1px_2px_rgba(15,23,42,0.04),0_0_0_1px_rgba(15,23,42,0.02)] focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 focus-visible:outline-none active:shadow-[0_10px_26px_rgba(15,23,42,0.1)] ${canNavigateToStaff ? "cursor-pointer" : ""}`;
+                    const navigateToStaff = () =>
+                      router.push(
+                        `/staff/${staffMember.id}${canAccessDocuments && !userIsAdmin ? "?tab=dokumente" : ""}`,
+                      );
+
+                    return (
+                      <div
+                        key={staffMember.id}
+                        {...(canNavigateToStaff
+                          ? {
+                              role: "button" as const,
+                              tabIndex: 0,
+                              onClick: navigateToStaff,
+                              onKeyDown: (e: React.KeyboardEvent) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  navigateToStaff();
+                                }
+                              },
                             }
-                          },
-                        }
-                      : {})}
-                    className={cardClassName}
-                  >
-                    <div className="relative p-4">
-                      <div className="relative flex min-h-[104px] flex-col">
-                        <div className="mb-3 flex items-start justify-between gap-3">
-                          <div className="min-w-0 flex-1">
-                            {/* Ein Name, eine Zeile: der Umbruch zwischen Vor-
+                          : {})}
+                        className={cardClassName}
+                      >
+                        <div className="relative p-4">
+                          <div className="relative flex min-h-[104px] flex-col">
+                            <div className="mb-3 flex items-start justify-between gap-3">
+                              <div className="min-w-0 flex-1">
+                                {/* Ein Name, eine Zeile: der Umbruch zwischen Vor-
                                 und Nachname ließ jede Karte wie zwei Personen
                                 aussehen. */}
-                            <div className="flex min-w-0 items-center gap-1.5">
-                              <h3 className="truncate text-base font-bold text-gray-900">
-                                {staffMember.firstName} {staffMember.lastName}
-                              </h3>
-                              {canNavigateToStaff && (
-                                <CaretRightIcon
-                                  className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-200 md:group-hover:text-gray-500"
-                                  aria-hidden="true"
-                                />
+                                <div className="flex min-w-0 items-center gap-1.5">
+                                  <h3 className="truncate text-base font-bold text-gray-900">
+                                    {staffMember.firstName}{" "}
+                                    {staffMember.lastName}
+                                  </h3>
+                                  {canNavigateToStaff && (
+                                    <CaretRightIcon
+                                      className="h-4 w-4 flex-shrink-0 text-gray-300 transition-colors duration-200 md:group-hover:text-gray-500"
+                                      aria-hidden="true"
+                                    />
+                                  )}
+                                </div>
+                                <p className="mt-0.5 truncate text-xs text-gray-500">
+                                  {staffMember.specialization ?? displayType}
+                                </p>
+                              </div>
+
+                              <span className="flex flex-shrink-0 flex-col items-end gap-1.5">
+                                {/* Kein Glow, kein Pulsieren: 20 gleichzeitig
+                                leuchtende Badges sind Lärm, kein Status. */}
+                                <span
+                                  className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${locationStatus.badgeColor}`}
+                                  style={{
+                                    backgroundColor:
+                                      locationStatus.customBgColor,
+                                  }}
+                                >
+                                  <span className="h-1.5 w-1.5 rounded-full bg-white/80"></span>
+                                  {locationStatus.label}
+                                </span>
+                              </span>
+                            </div>
+
+                            <div className="flex-1 space-y-2">
+                              {pendingRequestCount > 0 && (
+                                <div className="text-moto-orange-strong flex items-center gap-1.5 text-xs font-medium">
+                                  <BellSimpleRingingIcon
+                                    className="text-moto-orange h-[18px] w-[18px] shrink-0"
+                                    aria-hidden="true"
+                                  />
+                                  <span>
+                                    <span className="font-semibold">
+                                      {pendingRequestCount}
+                                    </span>{" "}
+                                    {pendingRequestCount === 1
+                                      ? "offener Abwesenheitsantrag"
+                                      : "offene Abwesenheitsanträge"}
+                                  </span>
+                                </div>
+                              )}
+
+                              {supervisions.length > 0 && (
+                                <div className="text-sm text-gray-600">
+                                  <span className="font-medium">
+                                    Aktuelle Aufsicht:
+                                  </span>
+                                  <ul className="mt-0.5 list-inside">
+                                    {supervisions.map((supervision) => (
+                                      <li
+                                        key={`${supervision.roomId}-${supervision.activeGroupId}`}
+                                      >
+                                        • {supervision.roomName}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                </div>
+                              )}
+
+                              {cardInfo.length > 0 && (
+                                <div className="flex flex-wrap gap-2">
+                                  {cardInfo.map((info) => (
+                                    <span
+                                      key={info}
+                                      className="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700"
+                                    >
+                                      {info}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+
+                              {notes && (
+                                <p className="text-xs text-gray-500 italic transition-colors duration-300 md:group-hover:text-gray-600">
+                                  {notes}
+                                </p>
                               )}
                             </div>
-                            <p className="mt-0.5 truncate text-xs text-gray-500">
-                              {staffMember.specialization ?? displayType}
-                            </p>
+
+                            {canNavigateToStaff && (
+                              <p className="mt-2 text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-gray-500">
+                                {userIsAdmin
+                                  ? "Tippen für mehr Infos"
+                                  : "Tippen für Personalunterlagen"}
+                              </p>
+                            )}
                           </div>
-
-                          <span className="flex flex-shrink-0 flex-col items-end gap-1.5">
-                            {/* Kein Glow, kein Pulsieren: 20 gleichzeitig
-                                leuchtende Badges sind Lärm, kein Status. */}
-                            <span
-                              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${locationStatus.badgeColor}`}
-                              style={{
-                                backgroundColor: locationStatus.customBgColor,
-                              }}
-                            >
-                              <span className="h-1.5 w-1.5 rounded-full bg-white/80"></span>
-                              {locationStatus.label}
-                            </span>
-                          </span>
                         </div>
-
-                        <div className="flex-1 space-y-2">
-                          {pendingRequestCount > 0 && (
-                            <div className="text-moto-orange-strong flex items-center gap-1.5 text-xs font-medium">
-                              <BellSimpleRingingIcon
-                                className="text-moto-orange h-[18px] w-[18px] shrink-0"
-                                aria-hidden="true"
-                              />
-                              <span>
-                                <span className="font-semibold">
-                                  {pendingRequestCount}
-                                </span>{" "}
-                                {pendingRequestCount === 1
-                                  ? "offener Abwesenheitsantrag"
-                                  : "offene Abwesenheitsanträge"}
-                              </span>
-                            </div>
-                          )}
-
-                          {supervisions.length > 0 && (
-                            <div className="text-sm text-gray-600">
-                              <span className="font-medium">
-                                Aktuelle Aufsicht:
-                              </span>
-                              <ul className="mt-0.5 list-inside">
-                                {supervisions.map((supervision) => (
-                                  <li
-                                    key={`${supervision.roomId}-${supervision.activeGroupId}`}
-                                  >
-                                    • {supervision.roomName}
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-
-                          {cardInfo.length > 0 && (
-                            <div className="flex flex-wrap gap-2">
-                              {cardInfo.map((info) => (
-                                <span
-                                  key={info}
-                                  className="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700"
-                                >
-                                  {info}
-                                </span>
-                              ))}
-                            </div>
-                          )}
-
-                          {notes && (
-                            <p className="text-xs text-gray-500 italic transition-colors duration-300 md:group-hover:text-gray-600">
-                              {notes}
-                            </p>
-                          )}
-                        </div>
-
-                        {canNavigateToStaff && (
-                          <p className="mt-2 text-xs text-gray-400 transition-colors duration-150 md:group-hover:text-gray-500">
-                            {userIsAdmin
-                              ? "Tippen für mehr Infos"
-                              : "Tippen für Personalunterlagen"}
-                          </p>
-                        )}
                       </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        ))}
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/change-history/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/change-history/page.tsx
@@ -6,11 +6,11 @@ import { useTenantRouter } from "~/lib/tenant-router";
 import { BackButton } from "~/components/ui/back-button";
 import { Button } from "~/components/ui/button";
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
 import {
   ConceptPageHeader,
   ConceptSectionHeader,
 } from "~/components/ui/concept-section-header";
+import { SkeletonRegion, TableSkeleton } from "~/components/ui/page-skeletons";
 import { useStudentHistoryBreadcrumb } from "~/lib/breadcrumb-context";
 import { useScrollToTop } from "~/lib/hooks/use-scroll-to-top";
 import { createLogger } from "~/lib/logger";
@@ -83,9 +83,17 @@ function ValueText({ value }: { readonly value: string }) {
 
 // ─── Page ────────────────────────────────────────────────────────────────────
 
+function ChangeHistorySkeleton() {
+  return (
+    <SkeletonRegion label="Änderungsverlauf wird geladen">
+      <TableSkeleton rows={8} columns={5} />
+    </SkeletonRegion>
+  );
+}
+
 export default function StudentChangeHistoryPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<ChangeHistorySkeleton />}>
       <StudentChangeHistoryPageContent />
     </Suspense>
   );
@@ -166,7 +174,7 @@ function StudentChangeHistoryPageContent() {
   }, [fetchStudent, fetchHistory]);
 
   if (loading) {
-    return <Loading fullPage={false} />;
+    return <ChangeHistorySkeleton />;
   }
 
   if (errorCode !== null) {

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page-skeleton.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page-skeleton.tsx
@@ -1,11 +1,20 @@
 "use client";
 
+import { BackButton } from "~/components/ui/back-button";
 import { Skeleton } from "~/components/ui/skeleton";
 
 // Mirrors StudentDetailHeader (avatar + name + meta rows + location badge),
 // the checkout/checkin action-card row, the tab bar, and a Stammdaten-shaped
 // field section, so the loaded page swaps in without layout shift.
-export function StudentDetailSkeleton() {
+//
+// `referrer` is real chrome, not data-bound (it comes straight off the
+// `?from=` query param) — when the caller already knows it, render the real
+// BackButton instead of a placeholder so it's clickable immediately. The
+// route-level loading.tsx renders this with no `referrer` (it has no access
+// to the page's search params), so that placeholder path stays.
+export function StudentDetailSkeleton({
+  referrer,
+}: Readonly<{ referrer?: string }>) {
   return (
     <div
       role="status"
@@ -14,7 +23,11 @@ export function StudentDetailSkeleton() {
       data-testid="student-detail-skeleton"
       className="mx-auto max-w-7xl"
     >
-      <Skeleton className="mb-4 h-9 w-24 rounded-lg" />
+      {referrer ? (
+        <BackButton referrer={referrer} />
+      ) : (
+        <Skeleton className="mb-4 h-9 w-24 rounded-lg" />
+      )}
 
       <div className="mb-6 flex items-end justify-between gap-4">
         <div className="ml-6 flex flex-1 items-center gap-4">

--- a/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/[id]/page.tsx
@@ -669,9 +669,14 @@ function StudentDetailPageContent() {
     }
   }, [loading, student, sessionStatus, urlTab, activeTab, handleTabChange]);
 
-  // Show loading state
+  // Show loading state. `referrer` needs no fetched data (it's derived from
+  // the `?from=` query param above), so the BackButton renders for real here
+  // instead of a placeholder — see page-skeleton.tsx. The rest of the body
+  // stays skeletonized: `visibleTabs` and the FullAccessView/LimitedAccessView
+  // split both depend on `hasFullAccess`, a field on the student object that
+  // isn't known until this fetch resolves.
   if (loading) {
-    return <StudentDetailSkeleton />;
+    return <StudentDetailSkeleton referrer={referrer} />;
   }
 
   // Show error state

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.test.tsx
@@ -1317,8 +1317,11 @@ describe("StudentSearchPage", () => {
 
       render(<StudentSearchPage />);
 
+      // Real chrome (page header) renders immediately; only the results
+      // region skeletonizes while the session resolves (colocation pattern).
+      expect(screen.getByTestId("page-header")).toBeInTheDocument();
       expect(
-        screen.getByTestId("students-search-skeleton"),
+        screen.getByTestId("student-card-grid-skeleton"),
       ).toBeInTheDocument();
     });
 
@@ -1821,9 +1824,12 @@ describe("StudentSearchPage", () => {
 
       render(<StudentSearchPage />);
 
-      // Should show loading, NOT empty state
+      // Should show loading, NOT empty state. Real chrome (page header)
+      // renders immediately; only the results region skeletonizes
+      // (colocation pattern).
+      expect(screen.getByTestId("page-header")).toBeInTheDocument();
       expect(
-        screen.getByTestId("students-search-skeleton"),
+        screen.getByTestId("student-card-grid-skeleton"),
       ).toBeInTheDocument();
       expect(
         screen.queryByText("Keine Kinder gefunden"),

--- a/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/students/search/page.tsx
@@ -2564,11 +2564,10 @@ function SearchPageContent() {
     [sortedStudents, effectiveGroupMode],
   );
 
-  // Fix P2: Show loading during initialization (prevents empty state flash)
-  // Note: With required: true, unauthenticated users are auto-redirected to login
-  if (isInitializing || isAuthError) {
-    return <StudentSearchPageSkeleton />;
-  }
+  // Fix P2: Session initialization / auth-gate loading no longer replaces the
+  // whole page — real chrome (header, filters) renders immediately below;
+  // only the results region skeletonizes while the session resolves. Note:
+  // with required: true, unauthenticated users are auto-redirected to login.
 
   return (
     <div className="-mt-1.5 w-full">
@@ -2689,17 +2688,20 @@ function SearchPageContent() {
           bar / tablet floating FAB; desktop has neither. */}
       <div className={checkinModeAvailable ? "pb-24 lg:pb-0" : undefined}>
         {(() => {
-          // Fix P2: Show loading while first fetch is in progress (not yet hasFetchedOnce)
-          // or while a date switch is in flight — keepPreviousData still holds
-          // the previous day's rows, so show the skeleton instead of presenting
+          // Fix P2: Show loading while the session is still resolving, while
+          // the first fetch is in progress (not yet hasFetchedOnce), or while
+          // a date switch is in flight — keepPreviousData still holds the
+          // previous day's rows, so show the skeleton instead of presenting
           // them under the newly selected date (#1939). Handle a fetch error
           // FIRST, though: when the new date's request fails, keepPreviousData
           // keeps the stale response so isDateTransition stays true — without
           // this guard the page would show the skeleton indefinitely instead of
           // the error and its recovery guidance (#1939).
           if (
-            !errorMessage &&
-            ((isSearching && !hasFetchedOnce) || isDateTransition)
+            isInitializing ||
+            isAuthError ||
+            (!errorMessage &&
+              ((isSearching && !hasFetchedOnce) || isDateTransition))
           ) {
             return <StudentCardGridSkeleton />;
           }

--- a/frontend/src/app/[tenant]/(protected)/substitutions/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/substitutions/page.test.tsx
@@ -181,11 +181,6 @@ vi.mock("~/components/ui/alert", () => ({
 
 // Note: substitution-helpers are not mocked - using actual implementations
 
-// Mock Loading
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div aria-label="Lädt...">Loading...</div>,
-}));
-
 import { useSession } from "next-auth/react";
 // eslint-disable-next-line no-restricted-imports -- test mock
 import { useRouter } from "next/navigation";
@@ -339,6 +334,10 @@ describe("SubstitutionsPage", () => {
 
       render(<SubstitutionsPage />);
 
+      // RoleGuard (not touched by this migration) gates on session status
+      // itself and renders its own (unmocked) Loading fallback before
+      // SubstitutionPageContent's own status==="loading" branch is ever
+      // reached — so this asserts RoleGuard's real loading output.
       expect(screen.getByLabelText("Lädt...")).toBeInTheDocument();
     });
 
@@ -362,7 +361,9 @@ describe("SubstitutionsPage", () => {
 
       render(<SubstitutionsPage />);
 
-      expect(screen.getByLabelText("Lädt...")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Fachkräfte werden geladen…"),
+      ).toBeInTheDocument();
     });
 
     it("shows error message when data fetch fails", () => {

--- a/frontend/src/app/[tenant]/(protected)/substitutions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/substitutions/page.tsx
@@ -12,9 +12,13 @@ import { Button } from "~/components/ui/button";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
 import { ConfirmationModal, Modal } from "~/components/ui/modal";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import {
+  SkeletonRegion,
+  PageHeaderSkeleton,
+  ListSkeleton,
+} from "~/components/ui/page-skeletons";
 import type {
   ActiveFilter,
   FilterConfig,
@@ -428,7 +432,7 @@ function SubstitutionPageContent() {
   }, [searchTerm, statusFilter]);
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return <SubstitutionPageSkeleton />;
   }
 
   if (openCareGroupMode) {
@@ -452,7 +456,11 @@ function SubstitutionPageContent() {
 
   const renderTeacherList = () => {
     if (isLoading) {
-      return <Loading fullPage={false} />;
+      return (
+        <SkeletonRegion label="Fachkräfte werden geladen…">
+          <ListSkeleton rows={6} />
+        </SkeletonRegion>
+      );
     }
 
     if (filteredTeachers.length === 0) {
@@ -793,10 +801,19 @@ function SubstitutionPageContent() {
   );
 }
 
+function SubstitutionPageSkeleton() {
+  return (
+    <SkeletonRegion label="Gruppenzugriff wird geladen">
+      <PageHeaderSkeleton />
+      <ListSkeleton rows={6} />
+    </SkeletonRegion>
+  );
+}
+
 export default function SubstitutionPage() {
   return (
     <RoleGuard variant="adminOnly">
-      <Suspense fallback={<Loading fullPage={false} />}>
+      <Suspense fallback={<SubstitutionPageSkeleton />}>
         <SubstitutionPageContent />
       </Suspense>
     </RoleGuard>

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -221,12 +221,6 @@ vi.mock("~/components/staff/staff-session-table", () => ({
   },
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: ({ fullPage }: { fullPage?: boolean }) => (
-    <div data-testid="loading" data-fullpage={fullPage} aria-label="Laden..." />
-  ),
-}));
-
 vi.mock("~/components/ui/modal", () => ({
   Modal: ({
     isOpen,
@@ -714,7 +708,9 @@ describe("TimeTrackingPage", () => {
       } as never);
 
       render(<TimeTrackingPage />);
-      expect(screen.getByTestId("loading")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Zeiterfassung wird geladen"),
+      ).toBeInTheDocument();
     });
 
     it("renders main content when authenticated", () => {

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -11,7 +11,11 @@ import React, {
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
-import { Loading } from "~/components/ui/loading";
+import {
+  SkeletonRegion,
+  CardSkeleton,
+  TableSkeleton,
+} from "~/components/ui/page-skeletons";
 import { Button } from "~/components/ui/button";
 import {
   Drawer,
@@ -3729,7 +3733,7 @@ function TimeTrackingContent() {
   );
 
   if (authStatus === "loading") {
-    return <Loading fullPage={false} />;
+    return <TimeTrackingPageSkeleton />;
   }
 
   return (
@@ -4037,9 +4041,27 @@ function TimeTrackingContent() {
 
 // ─── Page Export ───────────────────────────────────────────────────────────────
 
+function TimeTrackingPageSkeleton() {
+  return (
+    <SkeletonRegion label="Zeiterfassung wird geladen">
+      <div className="mb-4 grid grid-cols-1 gap-4 md:mb-6 md:grid-cols-2 md:gap-6">
+        <CardSkeleton rows={4} />
+        <CardSkeleton rows={4} />
+      </div>
+      <div className="mb-4 md:mb-6">
+        <CardSkeleton rows={2} />
+      </div>
+      <div className="mb-4 md:mb-6">
+        <CardSkeleton rows={2} />
+      </div>
+      <TableSkeleton rows={7} columns={5} />
+    </SkeletonRegion>
+  );
+}
+
 export default function TimeTrackingPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={<TimeTrackingPageSkeleton />}>
       <TimeTrackingContent />
     </Suspense>
   );

--- a/frontend/src/app/operator/accounts/page.tsx
+++ b/frontend/src/app/operator/accounts/page.tsx
@@ -10,10 +10,7 @@ import type {
   OrgAccount,
   SchoolAccount,
 } from "~/lib/operator/provisioning-helpers";
-import {
-  CardSkeletons,
-  SimpleEmptyState,
-} from "../provisioning/provisioning-shared";
+import { SimpleEmptyState } from "../provisioning/provisioning-shared";
 import { CaregiverCapabilityModal } from "~/components/teachers/caregiver-capability-modal";
 import { MFAAdminOverrideModal } from "~/components/auth/mfa-admin-override-modal";
 import { useSession } from "next-auth/react";
@@ -100,12 +97,6 @@ function OperatorAccountsPageContent() {
     },
   );
 
-  const accountsLoading = selectedSchool
-    ? schoolAccountsLoading
-    : filterOrgId
-      ? orgAccountsLoading
-      : allAccountsLoading;
-
   const refreshAccounts = useCallback(() => {
     return globalMutate(
       (key: unknown) =>
@@ -180,20 +171,18 @@ function OperatorAccountsPageContent() {
         onSchoolChange={handleSchoolFilterChange}
       />
 
-      {accountsLoading && <CardSkeletons />}
-
-      {!selectedSchool && filterOrgId && !orgAccountsLoading && (
+      {!selectedSchool && filterOrgId && (
         <>
-          {orgAccounts?.length === 0 && (
+          {!orgAccountsLoading && orgAccounts?.length === 0 ? (
             <SimpleEmptyState
               title="Keine Konten"
               description="Für diesen Träger gibt es noch keine zugewiesenen Konten."
             />
-          )}
-          {orgAccounts && orgAccounts.length > 0 && (
+          ) : (
             <AccountsTable
-              accounts={orgAccounts}
+              accounts={orgAccounts ?? []}
               showSchool
+              isLoading={orgAccountsLoading}
               onManageCaregiver={openCaregiverModal}
               onManageMFA={openMFAModal}
               onManageTenantAccess={openTenantAccessModal}
@@ -202,18 +191,18 @@ function OperatorAccountsPageContent() {
         </>
       )}
 
-      {!selectedSchool && !filterOrgId && !allAccountsLoading && (
+      {!selectedSchool && !filterOrgId && (
         <>
-          {allAccounts?.length === 0 && (
+          {!allAccountsLoading && allAccounts?.length === 0 ? (
             <SimpleEmptyState
               title="Keine Konten"
               description="Es gibt noch keine Konten im System."
             />
-          )}
-          {allAccounts && allAccounts.length > 0 && (
+          ) : (
             <AccountsTable
-              accounts={allAccounts}
+              accounts={allAccounts ?? []}
               showSchool
+              isLoading={allAccountsLoading}
               onManageCaregiver={openCaregiverModal}
               onManageMFA={openMFAModal}
               onManageTenantAccess={openTenantAccessModal}
@@ -222,7 +211,7 @@ function OperatorAccountsPageContent() {
         </>
       )}
 
-      {selectedSchool && !schoolAccountsLoading && (
+      {selectedSchool && (
         <>
           <div className="mb-3 flex items-center gap-2">
             <h3 className="text-sm font-semibold text-gray-900">
@@ -240,16 +229,16 @@ function OperatorAccountsPageContent() {
               </span>
             )}
           </div>
-          {schoolAccounts?.length === 0 && (
+          {!schoolAccountsLoading && schoolAccounts?.length === 0 ? (
             <SimpleEmptyState
               title="Keine Konten"
               description="Für diese Schule gibt es noch keine zugewiesenen Konten."
             />
-          )}
-          {schoolAccounts && schoolAccounts.length > 0 && (
+          ) : (
             <AccountsTable
-              accounts={schoolAccounts}
+              accounts={schoolAccounts ?? []}
               selectedSchool={selectedSchool}
+              isLoading={schoolAccountsLoading}
               onManageCaregiver={openCaregiverModal}
               onManageMFA={openMFAModal}
               onManageTenantAccess={openTenantAccessModal}

--- a/frontend/src/app/operator/announcements/page.tsx
+++ b/frontend/src/app/operator/announcements/page.tsx
@@ -10,6 +10,7 @@ import { OverflowMenu } from "~/components/ui/page-header/OverflowMenu";
 import type { FilterConfig } from "~/components/ui/page-header/types";
 import { Modal, ConfirmationModal } from "~/components/ui/modal";
 import { Skeleton } from "~/components/ui/skeleton";
+import { SkeletonRegion } from "~/components/ui/page-skeletons";
 import { DatePicker } from "~/components/ui/date-picker";
 import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { operatorAnnouncementsService } from "~/lib/operator/announcements-api";
@@ -437,7 +438,11 @@ export default function OperatorAnnouncementsPage() {
         }
       />
 
-      {isLoading && <AnnouncementSkeletons />}
+      {isLoading && (
+        <SkeletonRegion label="Ankündigungen werden geladen">
+          <AnnouncementSkeletons />
+        </SkeletonRegion>
+      )}
       {!isLoading && filteredAnnouncements.length === 0 && (
         <div className="flex flex-col items-center gap-3 py-12 text-center">
           <svg

--- a/frontend/src/app/operator/devices/page.tsx
+++ b/frontend/src/app/operator/devices/page.tsx
@@ -8,7 +8,6 @@ import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
 import type { OperatorDevice } from "~/lib/operator/provisioning-helpers";
 import {
-  CardSkeletons,
   PlusIcon,
   SimpleEmptyState,
 } from "../provisioning/provisioning-shared";
@@ -85,12 +84,6 @@ function OperatorDevicesPageContent() {
     },
   );
 
-  const devicesLoading = selectedSchool
-    ? schoolDevicesLoading
-    : filterOrgId
-      ? orgDevicesLoading
-      : allDevicesLoading;
-
   const refreshDevices = useCallback(() => {
     return globalMutate(
       (key: unknown) =>
@@ -165,20 +158,18 @@ function OperatorDevicesPageContent() {
         onSchoolChange={handleSchoolFilterChange}
       />
 
-      {devicesLoading && <CardSkeletons />}
-
-      {!selectedSchool && filterOrgId && !orgDevicesLoading && (
+      {!selectedSchool && filterOrgId && (
         <>
-          {orgDevices?.length === 0 && (
+          {!orgDevicesLoading && orgDevices?.length === 0 ? (
             <SimpleEmptyState
               title="Keine Geräte"
               description="Für diesen Träger gibt es noch keine registrierten Geräte."
             />
-          )}
-          {orgDevices && orgDevices.length > 0 && (
+          ) : (
             <DevicesTable
-              devices={orgDevices}
+              devices={orgDevices ?? []}
               showSchool
+              isLoading={orgDevicesLoading}
               onSetKey={setSetKeyDevice}
               onTransfer={setTransferDevice}
               onDelete={setDeleteDevice}
@@ -187,18 +178,18 @@ function OperatorDevicesPageContent() {
         </>
       )}
 
-      {!selectedSchool && !filterOrgId && !allDevicesLoading && (
+      {!selectedSchool && !filterOrgId && (
         <>
-          {allDevices?.length === 0 && (
+          {!allDevicesLoading && allDevices?.length === 0 ? (
             <SimpleEmptyState
               title="Keine Geräte"
               description="Es gibt noch keine registrierten Geräte im System."
             />
-          )}
-          {allDevices && allDevices.length > 0 && (
+          ) : (
             <DevicesTable
-              devices={allDevices}
+              devices={allDevices ?? []}
               showSchool
+              isLoading={allDevicesLoading}
               onSetKey={setSetKeyDevice}
               onTransfer={setTransferDevice}
               onDelete={setDeleteDevice}
@@ -207,7 +198,7 @@ function OperatorDevicesPageContent() {
         </>
       )}
 
-      {selectedSchool && !schoolDevicesLoading && (
+      {selectedSchool && (
         <>
           <div className="mb-3 flex items-center gap-2">
             <h3 className="text-sm font-semibold text-gray-900">
@@ -225,15 +216,15 @@ function OperatorDevicesPageContent() {
               </span>
             )}
           </div>
-          {schoolDevices?.length === 0 && (
+          {!schoolDevicesLoading && schoolDevices?.length === 0 ? (
             <SimpleEmptyState
               title="Keine Geräte"
               description="Für diese Schule gibt es noch keine registrierten Geräte."
             />
-          )}
-          {schoolDevices && schoolDevices.length > 0 && (
+          ) : (
             <DevicesTable
-              devices={schoolDevices}
+              devices={schoolDevices ?? []}
+              isLoading={schoolDevicesLoading}
               onSetKey={setSetKeyDevice}
               onTransfer={setTransferDevice}
               onDelete={setDeleteDevice}

--- a/frontend/src/app/operator/operators/page.test.tsx
+++ b/frontend/src/app/operator/operators/page.test.tsx
@@ -132,12 +132,13 @@ describe("OperatorOperatorsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows loading spinner when loading", () => {
+  it("shows loading skeleton when loading", () => {
     setupSWR(undefined, { isLoading: true });
     render(<OperatorOperatorsPage />);
 
-    const spinner = document.querySelector(".animate-spin");
-    expect(spinner).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Operatoren werden geladen"),
+    ).toBeInTheDocument();
   });
 
   it("displays pending invitations and operators", () => {

--- a/frontend/src/app/operator/operators/page.tsx
+++ b/frontend/src/app/operator/operators/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "~/components/ui/concept-section-header";
 import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
 import { DataTableStatusBadge } from "~/components/ui/data-table";
+import { SkeletonRegion, ListSkeleton } from "~/components/ui/page-skeletons";
 
 const logger = createLogger({ component: "OperatorOperatorsPage" });
 
@@ -61,9 +62,9 @@ export default function OperatorOperatorsPage() {
       )}
 
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-gray-900" />
-        </div>
+        <SkeletonRegion label="Operatoren werden geladen">
+          <ListSkeleton rows={4} avatar={false} />
+        </SkeletonRegion>
       )}
 
       {data && (

--- a/frontend/src/app/operator/organizations/[slug]/page.tsx
+++ b/frontend/src/app/operator/organizations/[slug]/page.tsx
@@ -36,10 +36,10 @@ import { useSetBreadcrumb } from "~/lib/breadcrumb-context";
 import { formatCount } from "~/lib/format-utils";
 import { createLogger } from "~/lib/logger";
 import {
-  CardSkeletons,
   EmptyState,
   PlusIcon,
 } from "~/app/operator/provisioning/provisioning-shared";
+import { SkeletonRegion, DetailSkeleton } from "~/components/ui/page-skeletons";
 import { CreateSchoolModal } from "~/app/operator/provisioning/create-school-modal";
 import { EditOrganizationModal } from "~/app/operator/provisioning/edit-organization-modal";
 import { CreateDeviceModal } from "~/app/operator/provisioning/create-device-modal";
@@ -440,8 +440,17 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
 
   if (isLoading && !organization) {
     return (
-      <div className="w-full py-10 text-center text-gray-500">
-        Wird geladen…
+      <div className="w-full">
+        <Link
+          href="/operator/organizations"
+          className="mb-4 inline-flex items-center gap-2 text-sm text-gray-600 transition-colors hover:text-gray-900"
+        >
+          <span aria-hidden>←</span>
+          <span>Zurück zur Träger-Übersicht</span>
+        </Link>
+        <SkeletonRegion label="Träger wird geladen">
+          <DetailSkeleton sections={1} fieldsPerSection={4} />
+        </SkeletonRegion>
       </div>
     );
   }
@@ -505,9 +514,7 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
           </div>
 
           <TabsPrimitive.Content value="schulen" className="mt-4">
-            {schoolsLoading ? (
-              <CardSkeletons />
-            ) : schoolDelete.showTrash ? (
+            {schoolDelete.showTrash ? (
               <div className="space-y-4">
                 {deletedSchools.map((school) => (
                   <DeletedEntityCard
@@ -526,7 +533,7 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
                   />
                 ))}
               </div>
-            ) : activeSchools.length === 0 ? (
+            ) : !schoolsLoading && activeSchools.length === 0 ? (
               <EmptyState
                 title="Keine Schulen"
                 description="Erstellen Sie eine neue Schule unter diesem Träger."
@@ -540,59 +547,54 @@ function OperatorOrganizationDetailPageContent({ params }: PageProps) {
                 getRowKey={(row) => row.id}
                 onRowClick={handleSchoolClick}
                 defaultSortKey="name"
+                isLoading={schoolsLoading}
               />
             )}
           </TabsPrimitive.Content>
 
           <TabsPrimitive.Content value="konten" className="mt-4">
-            {accountsLoading ? (
-              <div className="py-10 text-center text-gray-500">
-                Wird geladen…
-              </div>
-            ) : orgAccounts && orgAccounts.length > 0 ? (
-              <AccountsTable
-                accounts={orgAccounts}
-                showSchool
-                onManageCaregiver={openCaregiverModal}
-              />
-            ) : (
+            {!accountsLoading && (!orgAccounts || orgAccounts.length === 0) ? (
               <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
                 Keine Konten für diesen Träger.
               </div>
+            ) : (
+              <AccountsTable
+                accounts={orgAccounts ?? []}
+                showSchool
+                isLoading={accountsLoading}
+                onManageCaregiver={openCaregiverModal}
+              />
             )}
           </TabsPrimitive.Content>
 
           <TabsPrimitive.Content value="geraete" className="mt-4">
-            {devicesLoading ? (
-              <div className="py-10 text-center text-gray-500">
-                Wird geladen…
+            {!devicesLoading && (!orgDevices || orgDevices.length === 0) ? (
+              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
+                Keine Geräte für diesen Träger.
               </div>
-            ) : orgDevices && orgDevices.length > 0 ? (
+            ) : (
               <DevicesTable
-                devices={orgDevices}
+                devices={orgDevices ?? []}
                 showSchool
+                isLoading={devicesLoading}
                 onSetKey={setSetKeyDevice}
                 onTransfer={setTransferDevice}
                 onDelete={setDeleteDevice}
               />
-            ) : (
-              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
-                Keine Geräte für diesen Träger.
-              </div>
             )}
           </TabsPrimitive.Content>
 
           <TabsPrimitive.Content value="personen" className="mt-4">
-            {personsLoading ? (
-              <div className="py-10 text-center text-gray-500">
-                Wird geladen…
-              </div>
-            ) : orgPersons && orgPersons.length > 0 ? (
-              <PersonsTable persons={orgPersons} showSchool />
-            ) : (
+            {!personsLoading && (!orgPersons || orgPersons.length === 0) ? (
               <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
                 Keine Personen für diesen Träger.
               </div>
+            ) : (
+              <PersonsTable
+                persons={orgPersons ?? []}
+                showSchool
+                isLoading={personsLoading}
+              />
             )}
           </TabsPrimitive.Content>
         </Tabs>

--- a/frontend/src/app/operator/organizations/[slug]/schools/[schoolSlug]/page.tsx
+++ b/frontend/src/app/operator/organizations/[slug]/schools/[schoolSlug]/page.tsx
@@ -45,6 +45,7 @@ import { CreateDeviceModal } from "~/app/operator/provisioning/create-device-mod
 import { SetApiKeyModal } from "~/app/operator/provisioning/set-api-key-modal";
 import { useSoftDeletable } from "~/app/operator/provisioning/soft-delete-shared";
 import { SchoolSoftDeleteModal } from "~/app/operator/provisioning/operator-entity-modals";
+import { SkeletonRegion, DetailSkeleton } from "~/components/ui/page-skeletons";
 
 const logger = createLogger({ component: "OperatorSchoolDetailPage" });
 
@@ -410,9 +411,9 @@ function OperatorSchoolDetailPageContent({ params }: PageProps) {
 
   if ((!organizations || schoolsLoading) && !school) {
     return (
-      <div className="w-full py-10 text-center text-gray-500">
-        Wird geladen…
-      </div>
+      <SkeletonRegion label="Schule wird geladen">
+        <DetailSkeleton sections={1} fieldsPerSection={3} />
+      </SkeletonRegion>
     );
   }
 
@@ -507,57 +508,51 @@ function OperatorSchoolDetailPageContent({ params }: PageProps) {
           </div>
 
           <TabsPrimitive.Content value="konten" className="mt-4">
-            {accountsLoading ? (
-              <div className="py-10 text-center text-gray-500">
-                Wird geladen…
+            {!accountsLoading &&
+            (!schoolAccounts || schoolAccounts.length === 0) ? (
+              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
+                Keine Konten für diese Schule.
               </div>
-            ) : schoolAccounts && schoolAccounts.length > 0 ? (
+            ) : (
               <AccountsTable
-                accounts={schoolAccounts}
+                accounts={schoolAccounts ?? []}
+                isLoading={accountsLoading}
                 selectedSchool={selectedSchoolForTable}
                 onManageCaregiver={openCaregiverModal}
                 onManageMFA={openMFAModal}
               />
-            ) : (
-              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
-                Keine Konten für diese Schule.
-              </div>
             )}
           </TabsPrimitive.Content>
 
           <TabsPrimitive.Content value="geraete" className="mt-4">
-            {devicesLoading ? (
-              <div className="py-10 text-center text-gray-500">
-                Wird geladen…
+            {!devicesLoading &&
+            (!schoolDevices || schoolDevices.length === 0) ? (
+              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
+                Keine Geräte für diese Schule.
               </div>
-            ) : schoolDevices && schoolDevices.length > 0 ? (
+            ) : (
               <DevicesTable
-                devices={schoolDevices}
+                devices={schoolDevices ?? []}
+                isLoading={devicesLoading}
                 onSetKey={setSetKeyDevice}
                 onTransfer={setTransferDevice}
                 onDelete={setDeleteDevice}
               />
-            ) : (
-              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
-                Keine Geräte für diese Schule.
-              </div>
             )}
           </TabsPrimitive.Content>
 
           <TabsPrimitive.Content value="personen" className="mt-4">
-            {personsLoading ? (
-              <div className="py-10 text-center text-gray-500">
-                Wird geladen…
-              </div>
-            ) : schoolPersons && schoolPersons.length > 0 ? (
-              <PersonsTable
-                persons={schoolPersons}
-                onDelete={setDeletePersonTarget}
-              />
-            ) : (
+            {!personsLoading &&
+            (!schoolPersons || schoolPersons.length === 0) ? (
               <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-500">
                 Keine Personen für diese Schule.
               </div>
+            ) : (
+              <PersonsTable
+                persons={schoolPersons ?? []}
+                isLoading={personsLoading}
+                onDelete={setDeletePersonTarget}
+              />
             )}
           </TabsPrimitive.Content>
         </Tabs>

--- a/frontend/src/app/operator/organizations/page.tsx
+++ b/frontend/src/app/operator/organizations/page.tsx
@@ -12,11 +12,7 @@ import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
 import type { OrganizationSummary } from "~/lib/operator/provisioning-helpers";
 import { DataTable, DataTableStatusBadge } from "~/components/ui/data-table";
 import type { DataTableColumn } from "~/components/ui/data-table";
-import {
-  EmptyState,
-  PlusIcon,
-  CardSkeletons,
-} from "../provisioning/provisioning-shared";
+import { EmptyState, PlusIcon } from "../provisioning/provisioning-shared";
 import { CreateOrganizationModal } from "../provisioning/create-organization-modal";
 import {
   useSoftDeletable,
@@ -218,56 +214,53 @@ export default function OperatorOrganizationsPage() {
         </div>
       ) : null}
 
-      {orgsLoading && <CardSkeletons />}
+      <div className="mt-6">
+        {deletedOrganizations.length > 0 && (
+          <div className="mb-4 flex justify-end">
+            <button
+              type="button"
+              onClick={() => orgDelete.setShowTrash(!orgDelete.showTrash)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                orgDelete.showTrash
+                  ? "bg-moto-red/15 text-moto-red-strong hover:bg-moto-red/20"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              Papierkorb ({deletedOrganizations.length})
+            </button>
+          </div>
+        )}
 
-      {!orgsLoading && (
-        <div className="mt-6">
-          {deletedOrganizations.length > 0 && (
-            <div className="mb-4 flex justify-end">
-              <button
-                type="button"
-                onClick={() => orgDelete.setShowTrash(!orgDelete.showTrash)}
-                className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-                  orgDelete.showTrash
-                    ? "bg-moto-red/15 text-moto-red-strong hover:bg-moto-red/20"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
-              >
-                Papierkorb ({deletedOrganizations.length})
-              </button>
-            </div>
-          )}
-
-          {orgDelete.showTrash ? (
-            <div className="mt-4 space-y-4">
-              {deletedOrganizations.map((org) => (
-                <DeletedEntityCard
-                  key={org.id}
-                  name={org.name}
-                  subtitle={org.slug}
-                  deletedAt={org.deletedAt}
-                  onRestore={() => orgDelete.setRestoreTarget(org)}
-                />
-              ))}
-            </div>
-          ) : activeOrganizations.length === 0 ? (
-            <EmptyState
-              title="Keine Träger"
-              description="Erstellen Sie einen neuen Träger, um Schulen zu verwalten."
-              buttonLabel="Neuer Träger"
-              onAction={() => setCreateOrgOpen(true)}
-            />
-          ) : (
-            <DataTable
-              columns={columns}
-              rows={activeOrganizations}
-              getRowKey={(row) => row.id}
-              onRowClick={handleRowClick}
-              defaultSortKey="name"
-            />
-          )}
-        </div>
-      )}
+        {orgDelete.showTrash ? (
+          <div className="mt-4 space-y-4">
+            {deletedOrganizations.map((org) => (
+              <DeletedEntityCard
+                key={org.id}
+                name={org.name}
+                subtitle={org.slug}
+                deletedAt={org.deletedAt}
+                onRestore={() => orgDelete.setRestoreTarget(org)}
+              />
+            ))}
+          </div>
+        ) : !orgsLoading && activeOrganizations.length === 0 ? (
+          <EmptyState
+            title="Keine Träger"
+            description="Erstellen Sie einen neuen Träger, um Schulen zu verwalten."
+            buttonLabel="Neuer Träger"
+            onAction={() => setCreateOrgOpen(true)}
+          />
+        ) : (
+          <DataTable
+            columns={columns}
+            rows={activeOrganizations}
+            getRowKey={(row) => row.id}
+            onRowClick={handleRowClick}
+            defaultSortKey="name"
+            isLoading={orgsLoading}
+          />
+        )}
+      </div>
 
       {orgDelete.deleteTarget && (
         <OrgSoftDeleteModal

--- a/frontend/src/app/operator/persons/page.tsx
+++ b/frontend/src/app/operator/persons/page.tsx
@@ -9,10 +9,11 @@ import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
 import type { OperatorPerson } from "~/lib/operator/provisioning-helpers";
 import { createLogger } from "~/lib/logger";
 import { PersonTags } from "~/components/operator/persons-table";
+import { SimpleEmptyState } from "../provisioning/provisioning-shared";
 import {
-  CardSkeletons,
-  SimpleEmptyState,
-} from "../provisioning/provisioning-shared";
+  SkeletonRegion,
+  CardGridSkeleton,
+} from "~/components/ui/page-skeletons";
 import { OrgSchoolFilter } from "../provisioning/provisioning-tables-shared";
 import { useOrgSchoolFilter } from "../provisioning/use-org-school-filter";
 
@@ -114,7 +115,13 @@ function OperatorPersonsPageContent() {
           description="Wählen Sie eine Schule aus, um deren Personen anzuzeigen."
         />
       ) : schoolPersonsLoading ? (
-        <CardSkeletons />
+        <SkeletonRegion label="Personen werden geladen">
+          <CardGridSkeleton
+            cards={6}
+            rowsPerCard={2}
+            className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+          />
+        </SkeletonRegion>
       ) : !schoolPersons || schoolPersons.length === 0 ? (
         <SimpleEmptyState
           title="Keine Personen"

--- a/frontend/src/app/operator/schools/page.tsx
+++ b/frontend/src/app/operator/schools/page.tsx
@@ -14,11 +14,7 @@ import {
 import type { SchoolSummary } from "~/lib/operator/provisioning-helpers";
 import { buildSchoolColumns } from "~/components/operator/school-table-columns";
 import { DataTable } from "~/components/ui/data-table";
-import {
-  EmptyState,
-  PlusIcon,
-  CardSkeletons,
-} from "../provisioning/provisioning-shared";
+import { EmptyState, PlusIcon } from "../provisioning/provisioning-shared";
 import { CreateSchoolModal } from "../provisioning/create-school-modal";
 import {
   useSoftDeletable,
@@ -188,93 +184,88 @@ export default function OperatorSchoolsPage() {
         mobileActionButton={mobileActionButton}
       />
 
-      {summariesLoading && <CardSkeletons />}
+      <div className="mt-6">
+        {deletedSummaries.length > 0 && (
+          <div className="mb-4 flex justify-end">
+            <button
+              type="button"
+              onClick={() => schoolDelete.setShowTrash(!schoolDelete.showTrash)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                schoolDelete.showTrash
+                  ? "bg-red-100 text-red-700 hover:bg-red-200"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+              }`}
+            >
+              Papierkorb ({deletedSummaries.length})
+            </button>
+          </div>
+        )}
 
-      {!summariesLoading && (
-        <div className="mt-6">
-          {deletedSummaries.length > 0 && (
-            <div className="mb-4 flex justify-end">
-              <button
-                type="button"
-                onClick={() =>
-                  schoolDelete.setShowTrash(!schoolDelete.showTrash)
-                }
-                className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-                  schoolDelete.showTrash
-                    ? "bg-red-100 text-red-700 hover:bg-red-200"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
-              >
-                Papierkorb ({deletedSummaries.length})
-              </button>
-            </div>
-          )}
-
-          {schoolDelete.showTrash ? (
-            <div className="mt-4 space-y-4">
-              {deletedSummaries.map((summary) => {
-                const parentOrgDeleted = deletedOrgIds.has(
-                  summary.organizationId,
-                );
-                return (
-                  <DeletedEntityCard
-                    key={summary.id}
-                    name={summary.name}
-                    subtitle={summary.subdomain}
-                    extraSubtitle={summary.organizationName}
-                    deletedAt={summary.deletedAt}
-                    onRestore={() => requestRestore(summary)}
-                    restoreDisabled={parentOrgDeleted}
-                    restoreDisabledReason={
-                      parentOrgDeleted
-                        ? "Träger ist gelöscht. Bitte zuerst den Träger wiederherstellen."
-                        : undefined
-                    }
-                  />
-                );
-              })}
-            </div>
-          ) : activeSummaries.length === 0 ? (
-            <EmptyState
-              title="Keine Schulen"
-              description="Erstellen Sie eine neue Schule unter einem Träger."
-              buttonLabel="Neue Schule"
-              onAction={() => setCreateSchoolOpen(true)}
-            />
-          ) : (
-            <DataTable
-              columns={columns}
-              rows={activeSummaries}
-              getRowKey={(row) => row.id}
-              onRowClick={handleRowClick}
-              defaultSortKey="name"
-            />
-          )}
-
-          {schoolDelete.deleteTarget && (
-            <SchoolSoftDeleteModal
-              target={schoolDelete.deleteTarget}
-              inputId="delete-school-confirm"
-              confirmInput={schoolDelete.deleteConfirmInput}
-              onConfirmInputChange={schoolDelete.setDeleteConfirmInput}
-              errorMessage={schoolDelete.softDeleteError}
-              isProcessing={schoolDelete.isProcessing}
-              onCancel={() => schoolDelete.setDeleteTarget(null)}
-              onConfirm={() => void schoolDelete.handleSoftDelete()}
-            />
-          )}
-
-          <SchoolRestoreModal
-            target={schoolDelete.restoreTarget}
-            setTarget={schoolDelete.setRestoreTarget}
-            onConfirm={() => void schoolDelete.handleRestore()}
-            isProcessing={schoolDelete.isProcessing}
-            errorMessage={schoolDelete.softDeleteError}
-            confirmDisabled={schoolRestoreParentDeleted}
-            confirmDisabledReason="Der Träger dieser Schule ist gelöscht. Bitte zuerst den Träger wiederherstellen."
+        {schoolDelete.showTrash ? (
+          <div className="mt-4 space-y-4">
+            {deletedSummaries.map((summary) => {
+              const parentOrgDeleted = deletedOrgIds.has(
+                summary.organizationId,
+              );
+              return (
+                <DeletedEntityCard
+                  key={summary.id}
+                  name={summary.name}
+                  subtitle={summary.subdomain}
+                  extraSubtitle={summary.organizationName}
+                  deletedAt={summary.deletedAt}
+                  onRestore={() => requestRestore(summary)}
+                  restoreDisabled={parentOrgDeleted}
+                  restoreDisabledReason={
+                    parentOrgDeleted
+                      ? "Träger ist gelöscht. Bitte zuerst den Träger wiederherstellen."
+                      : undefined
+                  }
+                />
+              );
+            })}
+          </div>
+        ) : !summariesLoading && activeSummaries.length === 0 ? (
+          <EmptyState
+            title="Keine Schulen"
+            description="Erstellen Sie eine neue Schule unter einem Träger."
+            buttonLabel="Neue Schule"
+            onAction={() => setCreateSchoolOpen(true)}
           />
-        </div>
-      )}
+        ) : (
+          <DataTable
+            columns={columns}
+            rows={activeSummaries}
+            getRowKey={(row) => row.id}
+            onRowClick={handleRowClick}
+            defaultSortKey="name"
+            isLoading={summariesLoading}
+          />
+        )}
+
+        {schoolDelete.deleteTarget && (
+          <SchoolSoftDeleteModal
+            target={schoolDelete.deleteTarget}
+            inputId="delete-school-confirm"
+            confirmInput={schoolDelete.deleteConfirmInput}
+            onConfirmInputChange={schoolDelete.setDeleteConfirmInput}
+            errorMessage={schoolDelete.softDeleteError}
+            isProcessing={schoolDelete.isProcessing}
+            onCancel={() => schoolDelete.setDeleteTarget(null)}
+            onConfirm={() => void schoolDelete.handleSoftDelete()}
+          />
+        )}
+
+        <SchoolRestoreModal
+          target={schoolDelete.restoreTarget}
+          setTarget={schoolDelete.setRestoreTarget}
+          onConfirm={() => void schoolDelete.handleRestore()}
+          isProcessing={schoolDelete.isProcessing}
+          errorMessage={schoolDelete.softDeleteError}
+          confirmDisabled={schoolRestoreParentDeleted}
+          confirmDisabledReason="Der Träger dieser Schule ist gelöscht. Bitte zuerst den Träger wiederherstellen."
+        />
+      </div>
 
       <CreateSchoolModal
         isOpen={createSchoolOpen}

--- a/frontend/src/app/operator/settings/page.test.tsx
+++ b/frontend/src/app/operator/settings/page.test.tsx
@@ -30,10 +30,6 @@ vi.mock("~/contexts/ToastContext", () => ({
   }),
 }));
 
-vi.mock("~/components/ui/loading", () => ({
-  Loading: () => <div>Loading...</div>,
-}));
-
 vi.mock("~/components/ui/page-header/PageHeaderWithSearch", () => ({
   PageHeaderWithSearch: ({ title }: { title: string }) => (
     <div data-testid="page-header">{title}</div>
@@ -116,7 +112,9 @@ describe("OperatorSettingsPage", () => {
     render(<OperatorSettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Loading...")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Profileinstellungen werden geladen"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/operator/settings/page.tsx
+++ b/frontend/src/app/operator/settings/page.tsx
@@ -2,9 +2,13 @@
 
 import { Suspense, useState, useEffect, useCallback, useRef } from "react";
 import { useSession } from "next-auth/react";
-import { Loading } from "~/components/ui/loading";
 import { PasswordChangeModal } from "~/components/ui/password-change-modal";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import {
+  FormSkeleton,
+  PageHeaderSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { useToast } from "~/contexts/ToastContext";
 import { sessionFetch } from "~/lib/session-cache";
 import { TrustedDevicesSection } from "~/components/settings/trusted-devices-section";
@@ -19,6 +23,18 @@ interface OperatorProfile {
 function isEmail(value: string | null | undefined): value is string {
   return typeof value === "string" && value.includes("@");
 }
+
+const operatorSettingsLoadingFallback = (
+  <SkeletonRegion
+    label="Profileinstellungen werden geladen"
+    className="-mt-1.5 w-full"
+  >
+    <PageHeaderSkeleton search={false} />
+    <div className="mx-auto max-w-2xl px-4 pb-8 md:px-6">
+      <FormSkeleton fields={2} />
+    </div>
+  </SkeletonRegion>
+);
 
 function OperatorSettingsContent() {
   const { data: session, status, update: updateSession } = useSession();
@@ -198,7 +214,7 @@ function OperatorSettingsContent() {
   };
 
   if (status === "loading") {
-    return <Loading fullPage={false} />;
+    return operatorSettingsLoadingFallback;
   }
 
   const initials = formData.displayName
@@ -456,7 +472,7 @@ function OperatorSettingsContent() {
 
 export default function OperatorSettingsPage() {
   return (
-    <Suspense fallback={<Loading fullPage={false} />}>
+    <Suspense fallback={operatorSettingsLoadingFallback}>
       <OperatorSettingsContent />
     </Suspense>
   );

--- a/frontend/src/app/operator/suggestions/page.tsx
+++ b/frontend/src/app/operator/suggestions/page.tsx
@@ -9,6 +9,7 @@ import useSWR from "swr";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import type { FilterConfig } from "~/components/ui/page-header/types";
 import { Skeleton } from "~/components/ui/skeleton";
+import { SkeletonRegion } from "~/components/ui/page-skeletons";
 import { StatusDropdown } from "~/components/operator/status-dropdown";
 import { OperatorCommentAccordion } from "~/components/operator/operator-comment-accordion";
 import { useSession } from "next-auth/react";
@@ -225,7 +226,11 @@ export default function OperatorSuggestionsPage() {
         }}
       />
 
-      {isLoading && <SuggestionSkeletons />}
+      {isLoading && (
+        <SkeletonRegion label="Feedback wird geladen">
+          <SuggestionSkeletons />
+        </SkeletonRegion>
+      )}
       {!isLoading && filteredSuggestions.length === 0 && (
         <div className="flex flex-col items-center gap-3 py-12 text-center">
           <svg

--- a/frontend/src/app/operator/unregistered-tags/page.tsx
+++ b/frontend/src/app/operator/unregistered-tags/page.tsx
@@ -10,12 +10,12 @@ import { getRelativeTime } from "~/lib/format-utils";
 import { createLogger } from "~/lib/logger";
 import { operatorProvisioningService } from "~/lib/operator/provisioning-api";
 import type { UnregisteredTagScan } from "~/lib/operator/provisioning-helpers";
-import {
-  CardSkeletons,
-  SimpleEmptyState,
-} from "../provisioning/provisioning-shared";
+import { SimpleEmptyState } from "../provisioning/provisioning-shared";
 import { OrgSchoolFilter } from "../provisioning/provisioning-tables-shared";
 import { useOrgSchoolFilter } from "../provisioning/use-org-school-filter";
+import { DataTable } from "~/components/ui/data-table";
+import type { DataTableColumn } from "~/components/ui/data-table";
+import { ListPageSkeleton } from "~/components/ui/page-skeletons";
 
 const logger = createLogger({ component: "OperatorUnregisteredTagsPage" });
 
@@ -159,17 +159,17 @@ function OperatorUnregisteredTagsPageContent() {
         onSchoolChange={handleSchoolFilterChange}
       />
 
-      {isLoading && <CardSkeletons />}
-
-      {!isLoading && (!scans || scans.length === 0) && (
+      {!isLoading && (!scans || scans.length === 0) ? (
         <SimpleEmptyState
           title="Keine unbekannten RFID-Scans"
           description="Es liegen keine passenden Scanversuche vor."
         />
-      )}
-
-      {!isLoading && scans && scans.length > 0 && (
-        <UnregisteredTagsTable scans={scans} onResolve={openResolveModal} />
+      ) : (
+        <UnregisteredTagsTable
+          scans={scans ?? []}
+          isLoading={isLoading}
+          onResolve={openResolveModal}
+        />
       )}
 
       {resolveTarget && (
@@ -189,79 +189,99 @@ function OperatorUnregisteredTagsPageContent() {
 
 function UnregisteredTagsTable({
   scans,
+  isLoading,
   onResolve,
 }: Readonly<{
   scans: UnregisteredTagScan[];
+  isLoading: boolean;
   onResolve: (scan: UnregisteredTagScan) => void;
 }>) {
+  const columns: DataTableColumn<UnregisteredTagScan>[] = useMemo(
+    () => [
+      {
+        key: "tagUid",
+        header: "RFID",
+        render: (row) => row.tagUid,
+        sortValue: (row) => row.tagUid.toLowerCase(),
+        className: "font-mono text-xs font-medium text-gray-900",
+      },
+      {
+        key: "schoolName",
+        header: "Schule",
+        render: (row) => (
+          <div>
+            <div className="font-medium text-gray-900">{row.schoolName}</div>
+            <div className="text-xs text-gray-500">{row.organizationName}</div>
+          </div>
+        ),
+        sortValue: (row) => row.schoolName.toLowerCase(),
+      },
+      {
+        key: "device",
+        header: "Gerät",
+        render: (row) => row.deviceName || row.deviceIdentifier || "—",
+        sortValue: (row) =>
+          (row.deviceName || row.deviceIdentifier || "").toLowerCase(),
+        className: "text-gray-600",
+      },
+      {
+        key: "scannedAt",
+        header: "Zeitpunkt",
+        render: (row) => (
+          <span
+            title={new Date(row.scannedAt).toLocaleString("de-DE", {
+              timeZone: "Europe/Berlin",
+            })}
+          >
+            {getRelativeTime(row.scannedAt)}
+          </span>
+        ),
+        sortValue: (row) => row.scannedAt,
+        className: "text-gray-600",
+      },
+      {
+        key: "status",
+        header: "Status",
+        render: (row) =>
+          row.resolvedAt ? (
+            <span className="bg-moto-green/15 text-moto-green-strong inline-flex rounded-full px-2 py-0.5 text-xs font-medium">
+              Erledigt
+            </span>
+          ) : (
+            <span className="bg-moto-amber/15 text-moto-amber-strong inline-flex rounded-full px-2 py-0.5 text-xs font-medium">
+              Offen
+            </span>
+          ),
+        sortValue: (row) => (row.resolvedAt ? 1 : 0),
+      },
+      {
+        key: "action",
+        header: "Aktion",
+        align: "right",
+        render: (row) =>
+          !row.resolvedAt && (
+            <button
+              type="button"
+              onClick={() => onResolve(row)}
+              className="rounded-lg border border-gray-200 px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
+            >
+              Erledigen
+            </button>
+          ),
+      },
+    ],
+    [onResolve],
+  );
+
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-100 bg-white shadow-sm">
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-100 text-sm">
-          <thead className="bg-gray-50">
-            <tr className="text-left text-xs font-semibold tracking-wide text-gray-500 uppercase">
-              <th className="px-4 py-3">RFID</th>
-              <th className="px-4 py-3">Schule</th>
-              <th className="px-4 py-3">Gerät</th>
-              <th className="px-4 py-3">Zeitpunkt</th>
-              <th className="px-4 py-3">Status</th>
-              <th className="px-4 py-3 text-right">Aktion</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {scans.map((scan) => (
-              <tr key={scan.id}>
-                <td className="px-4 py-3 font-mono text-xs font-medium text-gray-900">
-                  {scan.tagUid}
-                </td>
-                <td className="px-4 py-3">
-                  <div className="font-medium text-gray-900">
-                    {scan.schoolName}
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {scan.organizationName}
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-gray-600">
-                  {scan.deviceName || scan.deviceIdentifier || "—"}
-                </td>
-                <td className="px-4 py-3 text-gray-600">
-                  <span
-                    title={new Date(scan.scannedAt).toLocaleString("de-DE", {
-                      timeZone: "Europe/Berlin",
-                    })}
-                  >
-                    {getRelativeTime(scan.scannedAt)}
-                  </span>
-                </td>
-                <td className="px-4 py-3">
-                  {scan.resolvedAt ? (
-                    <span className="bg-moto-green/15 text-moto-green-strong inline-flex rounded-full px-2 py-0.5 text-xs font-medium">
-                      Erledigt
-                    </span>
-                  ) : (
-                    <span className="bg-moto-amber/15 text-moto-amber-strong inline-flex rounded-full px-2 py-0.5 text-xs font-medium">
-                      Offen
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  {!scan.resolvedAt && (
-                    <button
-                      type="button"
-                      onClick={() => onResolve(scan)}
-                      className="rounded-lg border border-gray-200 px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
-                    >
-                      Erledigen
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <DataTable
+      columns={columns}
+      rows={scans}
+      getRowKey={(row) => row.id}
+      defaultSortKey="scannedAt"
+      defaultSortDirection="desc"
+      isLoading={isLoading}
+    />
   );
 }
 
@@ -328,7 +348,9 @@ function ResolveScanModal({
 
 export default function OperatorUnregisteredTagsPage() {
   return (
-    <Suspense fallback={<CardSkeletons />}>
+    <Suspense
+      fallback={<ListPageSkeleton label="Unbekannte RFID werden geladen" />}
+    >
       <OperatorUnregisteredTagsPageContent />
     </Suspense>
   );

--- a/frontend/src/components/active-supervisions/past-blocks-section.tsx
+++ b/frontend/src/components/active-supervisions/past-blocks-section.tsx
@@ -4,7 +4,11 @@ import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, History } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
-import { Loading } from "~/components/ui/loading";
+import {
+  CardGridSkeleton,
+  ListSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { SectionCard } from "~/components/ui/section-card";
 import { StatusBadge } from "~/components/ui/status-badge";
 import { StatusDotBadge } from "~/components/ui/status-dot-badge";
@@ -100,7 +104,13 @@ export function PastBlocksSection() {
       bodyClassName="-mx-5 -mb-5 mt-5 border-t border-gray-100 bg-gray-50/50 p-5"
     >
       {isLoading && blocks === null ? (
-        <Loading fullPage={false} />
+        <SkeletonRegion label="Vergangene Blöcke werden geladen">
+          <CardGridSkeleton
+            cards={4}
+            rowsPerCard={2}
+            className="grid gap-3 xl:grid-cols-2"
+          />
+        </SkeletonRegion>
       ) : loadError ? (
         <Alert type="error" message={loadError} />
       ) : blocks !== null && blocks.length === 0 ? (
@@ -192,7 +202,9 @@ function PastBlockCard({
         {expanded ? (
           <div className="mt-3">
             {isLoading ? (
-              <Loading fullPage={false} />
+              <SkeletonRegion label="Kinderliste wird geladen">
+                <ListSkeleton rows={4} avatar={false} />
+              </SkeletonRegion>
             ) : loadError ? (
               <Alert type="error" message={loadError} />
             ) : roster !== null ? (

--- a/frontend/src/components/active-supervisions/states.tsx
+++ b/frontend/src/components/active-supervisions/states.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { WarningCircleIcon } from "@phosphor-icons/react";
-import { Loading } from "~/components/ui/loading";
+import {
+  SkeletonRegion,
+  PageHeaderSkeleton,
+  CardGridSkeleton,
+} from "~/components/ui/page-skeletons";
 import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import type {
   ActiveFilter,
@@ -45,8 +49,22 @@ interface ReleaseSupervisionModalProps {
   readonly onConfirm: () => void;
 }
 
-export function ActiveSupervisionLoadingView() {
-  return <Loading fullPage={false} />;
+// withHeader is false when the real PageHeaderWithSearch chrome is already
+// on screen (e.g. re-loading only the student grid) — showing a second
+// header skeleton underneath it would duplicate the page's own chrome.
+export function ActiveSupervisionLoadingView({
+  withHeader = true,
+}: Readonly<{ withHeader?: boolean }> = {}) {
+  return (
+    <SkeletonRegion label="Aktuelle Aufsicht wird geladen…">
+      {withHeader && <PageHeaderSkeleton actions={1} />}
+      <CardGridSkeleton
+        cards={6}
+        rowsPerCard={2}
+        className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3"
+      />
+    </SkeletonRegion>
+  );
 }
 
 export function NoActiveSupervisionAccessView() {

--- a/frontend/src/components/admin/guardian-approval-queue.tsx
+++ b/frontend/src/components/admin/guardian-approval-queue.tsx
@@ -12,8 +12,8 @@ import {
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { EmptyState } from "~/components/ui/empty-state";
-import { Loading } from "~/components/ui/loading";
 import { ConfirmationModal } from "~/components/ui/modal";
+import { CardSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
 import { useTenantRouter } from "~/lib/tenant-router";
@@ -117,10 +117,9 @@ function InviteModeDependentEmptyState({
 }) {
   if (state.status === "loading") {
     return (
-      <Loading
-        message="Einladungs-Einstellung wird geladen…"
-        fullPage={false}
-      />
+      <SkeletonRegion label="Einladungs-Einstellung wird geladen…">
+        <CardSkeleton rows={2} />
+      </SkeletonRegion>
     );
   }
 

--- a/frontend/src/components/database/grade-transitions/graduates-modal.tsx
+++ b/frontend/src/components/database/grade-transitions/graduates-modal.tsx
@@ -14,7 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { ConfirmationModal, Modal } from "~/components/ui/modal";
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useToast } from "~/contexts/ToastContext";
 import { createLogger } from "~/lib/logger";
 import { LOCATION_COLORS } from "~/lib/location-helper";
@@ -210,7 +210,11 @@ export function GraduatesModal({
             sich zurückholen, solange sie hier nicht endgültig gelöscht wurden.
           </p>
 
-          {entries === null && <Loading />}
+          {entries === null && (
+            <SkeletonRegion label="Abgänge werden geladen">
+              <ListSkeleton rows={4} avatar={false} />
+            </SkeletonRegion>
+          )}
 
           {loadFailed && (
             <p className="text-moto-red rounded-lg border border-gray-200 p-4 text-sm">

--- a/frontend/src/components/database/grade-transitions/transition-editor.tsx
+++ b/frontend/src/components/database/grade-transitions/transition-editor.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { Modal } from "~/components/ui/modal";
 import { createLogger } from "~/lib/logger";
 import {
@@ -286,7 +286,11 @@ export function TransitionEditor({
         </p>
 
         {loadError && <p className="text-moto-red text-sm">{loadError}</p>}
-        {rows === null && !loadError && <Loading fullPage={false} />}
+        {rows === null && !loadError && (
+          <SkeletonRegion label="Klassenvorschläge werden geladen">
+            <ListSkeleton rows={5} avatar={false} />
+          </SkeletonRegion>
+        )}
 
         {rows !== null && (
           <ul className="divide-y divide-gray-100 rounded-xl border border-gray-200">

--- a/frontend/src/components/database/grade-transitions/transition-preview-modal.tsx
+++ b/frontend/src/components/database/grade-transitions/transition-preview-modal.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { Modal, ConfirmationModal } from "~/components/ui/modal";
 import { createLogger } from "~/lib/logger";
 import {
@@ -180,7 +180,11 @@ export function TransitionPreviewModal({
           </div>
         }
       >
-        {!preview && !loadError && <Loading fullPage={false} />}
+        {!preview && !loadError && (
+          <SkeletonRegion label="Vorschau wird geladen">
+            <ListSkeleton rows={4} avatar={false} />
+          </SkeletonRegion>
+        )}
         {loadError && <p className="text-moto-red text-sm">{loadError}</p>}
 
         {preview && (

--- a/frontend/src/components/enrollment/admin-enrollment-phase-detail.tsx
+++ b/frontend/src/components/enrollment/admin-enrollment-phase-detail.tsx
@@ -49,8 +49,11 @@ import {
 import {
   DataTable,
   type DataTableColumn,
+  DataTableSkeleton,
   DataTableStatusBadge,
 } from "~/components/ui/data-table";
+import { SkeletonRegion } from "~/components/ui/page-skeletons";
+import { Skeleton } from "~/components/ui/skeleton";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { MultiCheckboxSelect } from "~/components/ui/multi-checkbox-select";
 import { useTenantSlugSafe } from "~/lib/tenant-context";
@@ -500,7 +503,21 @@ export function AdminEnrollmentPhaseDetail({ phaseId }: Props) {
 
   if (loading) {
     return (
-      <p className="text-sm text-gray-500">Anmeldungen werden geladen...</p>
+      <SkeletonRegion label="Anmeldungen werden geladen">
+        <div className="space-y-4">
+          <div className="moto-content-surface rounded-2xl border p-5 shadow-sm backdrop-blur-md sm:p-6">
+            <Skeleton className="h-3 w-28 rounded" />
+            <Skeleton className="mt-2 h-6 w-64 rounded" />
+            <Skeleton className="mt-2 h-4 w-48 rounded" />
+            <div className="mt-4 grid gap-3 md:grid-cols-4">
+              {Array.from({ length: 4 }, (_, i) => (
+                <Skeleton key={i} className="h-16 rounded-2xl" />
+              ))}
+            </div>
+          </div>
+          <DataTableSkeleton rows={8} columns={8} />
+        </div>
+      </SkeletonRegion>
     );
   }
 

--- a/frontend/src/components/enrollment/admin-enrollments-list.tsx
+++ b/frontend/src/components/enrollment/admin-enrollments-list.tsx
@@ -33,6 +33,10 @@ import {
 import { fetchSettingsSchema } from "~/lib/settings-api";
 import { Alert } from "~/components/ui/alert";
 import { DataTableStatusBadge } from "~/components/ui/data-table";
+import {
+  CardGridSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { useTenantSlugSafe } from "~/lib/tenant-context";
 import { useEnrollmentPublicUrl } from "~/lib/enrollment-public-url";
 import { useTenantAwarePath } from "~/lib/tenant-path";
@@ -156,7 +160,13 @@ export function AdminEnrollmentsList() {
 
   if (loading) {
     return (
-      <p className="text-sm text-gray-500">Anmeldungen werden geladen...</p>
+      <SkeletonRegion label="Anmeldungen werden geladen" className="mt-4">
+        <CardGridSkeleton
+          cards={3}
+          rowsPerCard={2}
+          className="grid grid-cols-1 gap-4"
+        />
+      </SkeletonRegion>
     );
   }
 

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -792,14 +792,6 @@ export function CareOfferingsEditor() {
     [deletingId, handleDelete, saving],
   );
 
-  if (loading) {
-    return (
-      <div className="moto-content-surface rounded-2xl border px-5 py-10 text-center text-sm text-gray-500 shadow-sm">
-        Betreuungsangebote werden geladen...
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
       {error && (
@@ -816,7 +808,15 @@ export function CareOfferingsEditor() {
         <PlannerMetadataNotice onRetry={() => void loadPlannerMetadata()} />
       ) : null}
 
-      {catalogError ? (
+      {loading ? (
+        <DataTable
+          columns={columns}
+          rows={[]}
+          isLoading
+          loadingRowCount={6}
+          getRowKey={(offering) => offering.id}
+        />
+      ) : catalogError ? (
         <CareOfferingCatalogError
           message={catalogError}
           onRetry={() => void loadAll(selectedPhaseIdRef.current)}

--- a/frontend/src/components/enrollment/phases-editor.tsx
+++ b/frontend/src/components/enrollment/phases-editor.tsx
@@ -708,14 +708,6 @@ export function PhasesEditor() {
     ],
   );
 
-  if (loading) {
-    return (
-      <div className="moto-content-surface rounded-2xl border px-5 py-10 text-center text-sm text-gray-500 shadow-sm">
-        Anmeldephasen werden geladen...
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
       {error && (
@@ -783,7 +775,15 @@ export function PhasesEditor() {
         />
       )}
 
-      {phases.length === 0 && !editingId && !rolloverSource ? (
+      {loading && !editingId && !rolloverSource ? (
+        <DataTable
+          columns={columns}
+          rows={[]}
+          isLoading
+          loadingRowCount={5}
+          getRowKey={(phase) => phase.id}
+        />
+      ) : phases.length === 0 && !editingId && !rolloverSource ? (
         <EmptyPhasesState onCreate={startCreate} />
       ) : phases.length > 0 && !editingId && !rolloverSource ? (
         <DataTable

--- a/frontend/src/components/operator/accounts-table.tsx
+++ b/frontend/src/components/operator/accounts-table.tsx
@@ -85,6 +85,7 @@ function getNameSortValue(account: AccountRow): string {
 interface AccountsTableProps {
   accounts: SchoolAccount[] | OrgAccount[];
   showSchool?: boolean;
+  isLoading?: boolean;
   selectedSchool?: School | null;
   onManageCaregiver?: (
     account: AccountRow,
@@ -101,6 +102,7 @@ interface AccountsTableProps {
 export function AccountsTable({
   accounts,
   showSchool = false,
+  isLoading = false,
   selectedSchool,
   onManageCaregiver,
   onManageMFA,
@@ -265,6 +267,7 @@ export function AccountsTable({
       }}
       defaultSortKey={showSchool ? "schoolName" : "name"}
       pageSize={50}
+      isLoading={isLoading}
     />
   );
 }

--- a/frontend/src/components/operator/devices-table.tsx
+++ b/frontend/src/components/operator/devices-table.tsx
@@ -87,6 +87,7 @@ function CheckIcon() {
 interface DevicesTableProps {
   devices: OperatorDevice[];
   showSchool?: boolean;
+  isLoading?: boolean;
   onSetKey?: (device: OperatorDevice) => void;
   onTransfer?: (device: OperatorDevice) => void;
   onDelete?: (device: OperatorDevice) => void;
@@ -95,6 +96,7 @@ interface DevicesTableProps {
 export function DevicesTable({
   devices,
   showSchool = false,
+  isLoading = false,
   onSetKey,
   onTransfer,
   onDelete,
@@ -246,6 +248,7 @@ export function DevicesTable({
       rows={devices}
       getRowKey={(row) => row.id}
       defaultSortKey={showSchool ? "schoolName" : "deviceId"}
+      isLoading={isLoading}
     />
   );
 }

--- a/frontend/src/components/operator/persons-table.tsx
+++ b/frontend/src/components/operator/persons-table.tsx
@@ -8,6 +8,7 @@ import type { DataTableColumn } from "~/components/ui/data-table";
 interface PersonsTableProps {
   persons: OperatorPerson[];
   showSchool?: boolean;
+  isLoading?: boolean;
   onDelete?: (person: OperatorPerson) => void;
 }
 
@@ -65,6 +66,7 @@ function getPersonTagSortValue(person: OperatorPerson): string {
 export function PersonsTable({
   persons,
   showSchool = false,
+  isLoading = false,
   onDelete,
 }: Readonly<PersonsTableProps>) {
   const columns: DataTableColumn<OperatorPerson>[] = useMemo(() => {
@@ -145,6 +147,7 @@ export function PersonsTable({
       emptyState="Keine Personen vorhanden."
       defaultSortKey="name"
       pageSize={50}
+      isLoading={isLoading}
     />
   );
 }

--- a/frontend/src/components/parent/child-master-data.tsx
+++ b/frontend/src/components/parent/child-master-data.tsx
@@ -20,7 +20,7 @@ import { Checkbox } from "~/components/ui/checkbox";
 import {
   ParentPage,
   ParentPageHeader,
-  ParentPageSkeleton,
+  ParentSectionSkeletons,
 } from "~/components/parent/parent-page";
 import { todayISO } from "~/lib/date-helpers";
 import { useLocalizedDatePicker } from "~/lib/hooks/use-localized-date-picker";
@@ -91,37 +91,42 @@ export function ChildMasterDataView({ studentId }: Props) {
     void load();
   }, [load]);
 
-  if (loading) {
-    return <ParentPageSkeleton rows={3} />;
-  }
-
-  if (error || !data || !features) {
-    return (
-      <ParentPage>
-        <ParentPageHeader
-          backHref={`/parents/children/${studentId}`}
-          backLabel={t("back")}
-          title={t("title")}
-        />
-        <Alert type="error" message={t("loadError")} />
-      </ParentPage>
-    );
-  }
+  // Rendered once, in the same tree position, across loading/error/success —
+  // the header content never depends on the fetch outcome, and identity here
+  // keeps it a single stable DOM node instead of one that gets torn down and
+  // rebuilt when the body swaps in underneath it.
+  const header = (
+    <ParentPageHeader
+      backHref={`/parents/children/${studentId}`}
+      backLabel={t("back")}
+      title={t("title")}
+      description={t("subtitle")}
+    />
+  );
 
   return (
-    <ChildMasterDataContent
-      studentId={studentId}
-      data={data}
-      features={features}
-      onApplied={setData}
-      onDirectApplied={(target, field, next) =>
-        setData((current) =>
-          current
-            ? mergeDirectMasterDataField(current, next, target, field)
-            : next,
-        )
-      }
-    />
+    <ParentPage>
+      {header}
+      {loading ? (
+        <ParentSectionSkeletons rows={3} />
+      ) : error || !data || !features ? (
+        <Alert type="error" message={t("loadError")} />
+      ) : (
+        <ChildMasterDataContent
+          studentId={studentId}
+          data={data}
+          features={features}
+          onApplied={setData}
+          onDirectApplied={(target, field, next) =>
+            setData((current) =>
+              current
+                ? mergeDirectMasterDataField(current, next, target, field)
+                : next,
+            )
+          }
+        />
+      )}
+    </ParentPage>
   );
 }
 
@@ -162,14 +167,7 @@ function ChildMasterDataContent({
   );
 
   return (
-    <ParentPage>
-      <ParentPageHeader
-        backHref={`/parents/children/${studentId}`}
-        backLabel={t("back")}
-        title={t("title")}
-        description={t("subtitle")}
-      />
-
+    <>
       {/* Track B — child identity (approval required) */}
       <IdentitySection
         studentId={studentId}
@@ -276,7 +274,7 @@ function ChildMasterDataContent({
       <ChildCareScheduleSection studentId={studentId} />
 
       <ChildCareOfferingsSection studentId={studentId} />
-    </ParentPage>
+    </>
   );
 }
 

--- a/frontend/src/components/parent/parent-children-page.tsx
+++ b/frontend/src/components/parent/parent-children-page.tsx
@@ -12,7 +12,7 @@ import {
   ParentLoadError,
   ParentPage,
   ParentPageHeader,
-  ParentPageSkeleton,
+  ParentSectionSkeletons,
 } from "~/components/parent/parent-page";
 
 const logger = createLogger({ component: "ParentChildrenPage" });
@@ -61,8 +61,21 @@ export function ParentChildrenPage() {
     void load();
   }, [load]);
 
+  const header = (
+    <ParentPageHeader
+      kicker={t("eyebrow")}
+      title={t("title")}
+      description={t("description")}
+    />
+  );
+
   if (loading) {
-    return <ParentPageSkeleton rows={1} />;
+    return (
+      <ParentPage>
+        {header}
+        <ParentSectionSkeletons rows={1} />
+      </ParentPage>
+    );
   }
 
   if (error) {
@@ -89,11 +102,7 @@ export function ParentChildrenPage() {
 
   return (
     <ParentPage>
-      <ParentPageHeader
-        kicker={t("eyebrow")}
-        title={t("title")}
-        description={t("description")}
-      />
+      {header}
 
       {items.length === 0 ? (
         <div className="moto-content-surface rounded-2xl border p-5 shadow-sm backdrop-blur-md">

--- a/frontend/src/components/parent/parent-dashboard.tsx
+++ b/frontend/src/components/parent/parent-dashboard.tsx
@@ -30,7 +30,7 @@ import {
   ParentLoadError,
   ParentPage,
   ParentPageHeader,
-  ParentPageSkeleton,
+  ParentSectionSkeletons,
 } from "~/components/parent/parent-page";
 
 const logger = createLogger({ component: "ParentDashboard" });
@@ -163,8 +163,27 @@ export function ParentDashboard() {
     [children, requests, locale, t],
   );
 
+  const header = (
+    <ParentPageHeader
+      kicker={t("eyebrow")}
+      title={t("title")}
+      description={t("description")}
+      actions={
+        <ParentLinkAction href="/parents/enroll">
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          {t("newEnrollment")}
+        </ParentLinkAction>
+      }
+    />
+  );
+
   if (loading) {
-    return <ParentPageSkeleton rows={2} />;
+    return (
+      <ParentPage>
+        {header}
+        <ParentSectionSkeletons rows={2} />
+      </ParentPage>
+    );
   }
 
   if (error) {
@@ -176,17 +195,7 @@ export function ParentDashboard() {
 
   return (
     <ParentPage>
-      <ParentPageHeader
-        kicker={t("eyebrow")}
-        title={t("title")}
-        description={t("description")}
-        actions={
-          <ParentLinkAction href="/parents/enroll">
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            {t("newEnrollment")}
-          </ParentLinkAction>
-        }
-      />
+      {header}
 
       <SectionCard
         icon={Users}

--- a/frontend/src/components/parent/parent-enroll-picker.tsx
+++ b/frontend/src/components/parent/parent-enroll-picker.tsx
@@ -255,14 +255,27 @@ function EmptyPhases() {
 }
 
 function ParentEnrollSkeleton() {
+  // Mirrors SchoolCard above: icon-tile header row over a divide-y list of
+  // PhaseRow-shaped lines, instead of two blank blocks.
   return (
-    <div className="space-y-4">
-      {[0, 1].map((item) => (
-        <div
-          key={item}
-          className="h-40 animate-pulse rounded-2xl border border-gray-200 bg-white shadow-sm"
-        />
-      ))}
+    <div className="space-y-4" aria-hidden="true">
+      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+        <div className="flex items-center gap-3 border-b border-gray-100 p-4 sm:px-6">
+          <span className="h-11 w-11 shrink-0 animate-pulse rounded-xl bg-gray-100" />
+          <span className="h-5 w-48 animate-pulse rounded bg-gray-200" />
+        </div>
+        <ul className="divide-y divide-gray-100">
+          {[0, 1, 2].map((row) => (
+            <li key={row} className="flex items-center gap-4 p-4 sm:px-6">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="h-4 w-2/5 animate-pulse rounded bg-gray-200" />
+                <div className="h-3 w-3/5 animate-pulse rounded bg-gray-200" />
+              </div>
+              <div className="h-4 w-4 shrink-0 animate-pulse rounded bg-gray-200" />
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/parent/parent-meal-plan-page.tsx
+++ b/frontend/src/components/parent/parent-meal-plan-page.tsx
@@ -4,8 +4,11 @@ import { useEffect, useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { CustomSelect } from "~/components/ui/custom-select";
-import { Loading } from "~/components/ui/loading";
 import { Alert } from "~/components/ui/alert";
+import {
+  CardGridSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import {
   ParentPage,
   ParentPageHeader,
@@ -289,7 +292,13 @@ export function ParentMealPlanPage() {
           </section>
 
           {!weekReady ? (
-            <Loading fullPage={false} />
+            <SkeletonRegion label="Essensplan wird geladen">
+              <CardGridSkeleton
+                cards={5}
+                rowsPerCard={1}
+                className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-5"
+              />
+            </SkeletonRegion>
           ) : weekError ? (
             <Alert type="error" message={t("loadError")} />
           ) : weekIsEmpty ? (

--- a/frontend/src/components/parent/parent-page.tsx
+++ b/frontend/src/components/parent/parent-page.tsx
@@ -215,17 +215,36 @@ export function ParentLoadError({ message }: Readonly<{ message: string }>) {
 }
 
 /**
- * Shared page skeleton. `rows` controls how many section placeholders follow
- * the header so a page can approximate its own shape without redefining the
- * whole block.
+ * Section placeholders only — no header skeleton. Use this when the page's
+ * `ParentPageHeader` is static (title/description don't depend on the
+ * fetched data): render the real header immediately and reserve the
+ * skeleton for the data-dependent region below it, so navigation never
+ * flashes a placeholder over chrome that was already known.
+ */
+export function ParentSectionSkeletons({
+  rows = 2,
+}: Readonly<{ rows?: number }>) {
+  return (
+    <>
+      {Array.from({ length: rows }, (_, index) => (
+        <Skeleton key={index} className="h-40 w-full rounded-2xl" />
+      ))}
+    </>
+  );
+}
+
+/**
+ * Shared page skeleton, header included. `rows` controls how many section
+ * placeholders follow the header so a page can approximate its own shape
+ * without redefining the whole block. Reserve this for pages whose header
+ * itself depends on the fetched data (e.g. a child's name) — when the header
+ * is static, render it directly and use `ParentSectionSkeletons` instead.
  */
 export function ParentPageSkeleton({ rows = 2 }: Readonly<{ rows?: number }>) {
   return (
     <ParentPage>
       <Skeleton className="h-28 w-full rounded-2xl" />
-      {Array.from({ length: rows }, (_, index) => (
-        <Skeleton key={index} className="h-40 w-full rounded-2xl" />
-      ))}
+      <ParentSectionSkeletons rows={rows} />
     </ParentPage>
   );
 }

--- a/frontend/src/components/planning/calendar-periods-editor.tsx
+++ b/frontend/src/components/planning/calendar-periods-editor.tsx
@@ -332,14 +332,6 @@ export function CalendarPeriodsEditor() {
     [beginEdit, usageTotal],
   );
 
-  if (loading) {
-    return (
-      <div className="moto-content-surface rounded-2xl border px-5 py-10 text-center text-sm text-gray-500 shadow-sm">
-        Kalenderzeiträume werden geladen...
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
       {error && (
@@ -386,7 +378,7 @@ export function CalendarPeriodsEditor() {
         </div>
       </section>
 
-      {periods.length === 0 ? (
+      {!loading && periods.length === 0 ? (
         <section className="moto-content-surface rounded-2xl border px-6 py-12 text-center shadow-sm backdrop-blur-md">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-gray-100">
             <MotoConceptIcon concept="calendarPeriods" size={28} />
@@ -416,6 +408,7 @@ export function CalendarPeriodsEditor() {
           getRowKey={(period) => period.id}
           defaultSortKey="range"
           defaultSortDirection="asc"
+          isLoading={loading}
         />
       )}
 

--- a/frontend/src/components/planning/closing-days-editor.tsx
+++ b/frontend/src/components/planning/closing-days-editor.tsx
@@ -171,14 +171,6 @@ export function ClosingDaysEditor() {
     [beginEdit],
   );
 
-  if (loading) {
-    return (
-      <div className="moto-content-surface rounded-2xl border px-5 py-10 text-center text-sm text-gray-500 shadow-sm">
-        Schließtage werden geladen...
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
       {error && (
@@ -211,7 +203,7 @@ export function ClosingDaysEditor() {
         </div>
       </section>
 
-      {closingDays.length === 0 ? (
+      {!loading && closingDays.length === 0 ? (
         <section className="moto-content-surface rounded-2xl border px-6 py-12 text-center shadow-sm backdrop-blur-md">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-gray-100">
             <MotoConceptIcon concept="closingDays" size={28} />
@@ -241,6 +233,7 @@ export function ClosingDaysEditor() {
           getRowKey={(day) => day.id}
           defaultSortKey="range"
           defaultSortDirection="asc"
+          isLoading={loading}
         />
       )}
 

--- a/frontend/src/components/rooms/room-detail-content.tsx
+++ b/frontend/src/components/rooms/room-detail-content.tsx
@@ -653,7 +653,9 @@ function SkeletonStudentRow({ withAvatar }: { withAvatar: boolean }) {
   );
 }
 
-function RoomDetailSkeleton() {
+function RoomDetailSkeleton({
+  headerAction,
+}: Readonly<{ headerAction?: React.ReactNode }>) {
   // Read the per-tenant photo flag once at the top of the skeleton so the
   // child-rows below match the populated CompactStudentCard shape exactly
   // (avatar slot reserved when the tenant has photos on; original tighter
@@ -665,13 +667,36 @@ function RoomDetailSkeleton() {
       data-testid="room-detail-skeleton"
       className="block"
     >
-      {/* Header row , name + status pill, same line as the loaded view. */}
-      <div className="mb-6 flex items-center gap-2">
-        <SkeletonLine className="h-7 w-48 md:h-8 md:w-64" />
-        <SkeletonLine className="h-6 w-16 rounded-full" />
+      {/* Header row mirrors RoomDetailContent's real header (icon + name +
+          status pill placeholders), but renders the real headerAction so
+          the close control (modal/drawer X) stays available while the
+          fetch is in flight instead of disappearing behind the skeleton. */}
+      <div
+        className={`flex items-center gap-2 ${
+          headerAction
+            ? "sticky top-0 z-20 border-b border-gray-200/70 bg-gray-50/95 px-5 pt-5 pb-4 backdrop-blur supports-[backdrop-filter]:bg-gray-50/85 sm:px-6"
+            : "mb-5"
+        }`}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <MotoDuotoneIcon
+            icon={MOTO_CONCEPTS.rooms.icon}
+            tone={MOTO_CONCEPTS.rooms.tone}
+            size={32}
+          />
+          <SkeletonLine className="h-7 w-48 md:h-8 md:w-64" />
+          <SkeletonLine className="h-6 w-16 flex-shrink-0 rounded-full" />
+        </div>
+        {headerAction && (
+          <div className="ml-auto flex-shrink-0">{headerAction}</div>
+        )}
       </div>
 
-      <div className="space-y-4 sm:space-y-6">
+      <div
+        className={`space-y-4 sm:space-y-6 ${
+          headerAction ? "px-5 pt-5 sm:px-6" : ""
+        }`}
+      >
         <SkeletonCardShell heading="Rauminformationen">
           <div className="space-y-1">
             <SkeletonIconRow />
@@ -735,9 +760,10 @@ export function RoomDetailLoader({
 }: RoomDetailLoaderProps) {
   const { room, history, loading, error, historyDisabled } =
     useRoomDetail(roomId);
+  const showSkeleton = loading;
 
-  if (loading) {
-    return <RoomDetailSkeleton />;
+  if (showSkeleton) {
+    return <RoomDetailSkeleton headerAction={headerAction} />;
   }
 
   if (error || !room) {

--- a/frontend/src/components/rooms/students-in-room-section.tsx
+++ b/frontend/src/components/rooms/students-in-room-section.tsx
@@ -25,6 +25,7 @@ import { ROOM_LIST_CACHE_KEYS } from "~/lib/swr/room-derived-caches";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { DatabaseSelect } from "~/components/ui/database/database-select";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { useToast } from "~/contexts/ToastContext";
 import { roomService, studentService } from "~/lib/api";
 import type { Student } from "~/lib/api";
@@ -551,28 +552,6 @@ interface StudentsInRoomBodyProps {
   readonly router: ReturnType<typeof useTenantRouter>;
 }
 
-// Single student-row skeleton matching CompactStudentCard's outer shell
-// (rounded-xl border, px-4 py-3, name line + meta line). The skeleton
-// list lives inside the same `flex flex-col gap-2` wrapper the populated
-// list uses, so swapping skeleton → real cards causes zero layout shift
-// (review feedback #1323). When the per-tenant photo feature is on we
-// also reserve the avatar slot (sm = 32px) so the row height + horizontal
-// content origin match the populated card; opt-out tenants keep the
-// original tighter shape.
-function StudentRowSkeleton({ withAvatar }: { withAvatar: boolean }) {
-  return (
-    <div className="moto-content-surface flex items-center gap-3 rounded-xl border px-4 py-3">
-      {withAvatar ? (
-        <div className="h-8 w-8 flex-shrink-0 animate-pulse rounded-full bg-gray-200" />
-      ) : null}
-      <div className="min-w-0 flex-1">
-        <div className="h-4 w-40 animate-pulse rounded bg-gray-200" />
-        <div className="mt-2 h-3 w-24 animate-pulse rounded bg-gray-200" />
-      </div>
-    </div>
-  );
-}
-
 function StudentsInRoomBody({
   fromReferrer,
   loading,
@@ -593,23 +572,19 @@ function StudentsInRoomBody({
     );
   }
 
-  // All three states (loading / empty / loaded) live inside the same
-  // `flex flex-col gap-2` wrapper so the section's vertical footprint
-  // stays stable across them. Without this, the loading placeholder
-  // (was: <Loading> with pt-24 pb-12) was a different shape than the
-  // populated list, and the section visibly resized when data arrived.
+  // All three states (loading / empty / loaded) occupy similar vertical
+  // space so the section's footprint stays roughly stable across them and
+  // doesn't visibly jump when real data arrives (#1323 review). Shared kit
+  // primitive: SkeletonRegion is the one announcing wrapper per region, its
+  // testid/label are the AT + test contract other code queries.
   if (loading && students.length === 0) {
     return (
-      <output
-        aria-label="Kinderliste wird geladen"
-        data-testid="students-in-room-skeleton"
-        className="flex flex-col gap-2"
+      <SkeletonRegion
+        label="Kinderliste wird geladen"
+        testId="students-in-room-skeleton"
       >
-        <StudentRowSkeleton withAvatar={photosEnabled} />
-        <StudentRowSkeleton withAvatar={photosEnabled} />
-        <StudentRowSkeleton withAvatar={photosEnabled} />
-        <StudentRowSkeleton withAvatar={photosEnabled} />
-      </output>
+        <ListSkeleton rows={4} avatar={photosEnabled} />
+      </SkeletonRegion>
     );
   }
 

--- a/frontend/src/components/staff/abwesenheiten-tab.tsx
+++ b/frontend/src/components/staff/abwesenheiten-tab.tsx
@@ -41,8 +41,12 @@ import { Button } from "~/components/ui/button";
 import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
 import { ISODatePicker } from "~/components/ui/date-picker";
 import { EmptyState } from "~/components/ui/empty-state";
-import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
+import {
+  CardGridSkeleton,
+  ListSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { SectionCard } from "~/components/ui/section-card";
 import { StatCard, type StatCardTone } from "~/components/ui/stat-card";
 import { StatusBadge } from "~/components/ui/status-badge";
@@ -151,7 +155,21 @@ function TabLoadingBoundary({
   readonly loading: boolean;
   readonly children: ReactNode;
 }) {
-  if (loading) return <Loading fullPage={false} />;
+  if (loading) {
+    return (
+      <SkeletonRegion
+        label="Abwesenheiten werden geladen"
+        className="space-y-5"
+      >
+        <CardGridSkeleton
+          cards={4}
+          rowsPerCard={1}
+          className="grid grid-cols-2 gap-4 sm:grid-cols-4"
+        />
+        <ListSkeleton rows={5} avatar={false} />
+      </SkeletonRegion>
+    );
+  }
   return children;
 }
 

--- a/frontend/src/components/staff/arbeitszeitmodell-tab.tsx
+++ b/frontend/src/components/staff/arbeitszeitmodell-tab.tsx
@@ -6,8 +6,11 @@ import { useSWRConfig } from "swr";
 import { Button } from "~/components/ui/button";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
+import {
+  CardGridSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { SectionCard } from "~/components/ui/section-card";
 import { SegmentedControl } from "~/components/ui/segmented-control";
 import { useToast } from "~/contexts/ToastContext";
@@ -134,7 +137,23 @@ export function ArbeitszeitmodellTab({
   const { mutate } = useSWRConfig();
 
   if (isLoading || !schedule) {
-    return <Loading fullPage={false} />;
+    return (
+      <SkeletonRegion
+        label="Arbeitszeitmodell wird geladen"
+        className="space-y-5"
+      >
+        <CardGridSkeleton
+          cards={2}
+          rowsPerCard={2}
+          className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+        />
+        <CardGridSkeleton
+          cards={4}
+          rowsPerCard={1}
+          className="grid grid-cols-1 gap-2"
+        />
+      </SkeletonRegion>
+    );
   }
 
   const today = new Date();

--- a/frontend/src/components/staff/dienstplan-skeleton.tsx
+++ b/frontend/src/components/staff/dienstplan-skeleton.tsx
@@ -19,30 +19,6 @@ const DAY_COLUMN_INDEXES = Array.from(
   (_, index) => index,
 );
 
-// The PlanningContextBar header placeholder mirrors its mobile title,
-// navigation, view switcher, action, and context row. Only used by the
-// full-page skeleton — once the session is ready the real PlanningContextBar
-// renders and only the grid area falls back to a skeleton on cold data
-// (docs/05 Abschnitt 5).
-function HeaderSkeleton() {
-  return (
-    <div className="moto-content-surface flex flex-col gap-2 rounded-2xl border px-4 py-3">
-      <Skeleton className="h-7 w-28 md:hidden" />
-      <div className="flex min-h-9 flex-wrap items-center gap-3">
-        <Skeleton className="h-8 w-28 rounded-lg" />
-        <Skeleton className="h-6 w-44 rounded" />
-        <Skeleton className="h-8 w-40 rounded-lg" />
-        <Skeleton className="ml-auto h-9 w-48 rounded-lg" />
-      </div>
-      <div className="border-t border-gray-100 pt-2">
-        <div className="min-h-8">
-          <Skeleton className="h-5 w-32" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 // The grid surface card: staff column + 5 weekday columns, 6 rows, plus the
 // CapacityStrip footer row (label + 5 cells). Shared by both the full-page
 // skeleton and the standalone grid skeleton — no status role here so it can be
@@ -109,9 +85,10 @@ function GridSkeletonBody() {
   );
 }
 
-// Grid-only skeleton for the content area while the schedule data loads on a
-// cold SWR key. The PlanningContextBar stays mounted above it, so week/view
-// navigation never disappears mid-click (docs/05 Abschnitt 5).
+// Grid-only skeleton for the content area while the schedule data loads —
+// including the initial session/settings-schema load, so the real
+// PlanningContextBar (title, week navigation) renders immediately and only
+// this grid area falls back to a skeleton (docs/05 Abschnitt 5).
 export function DienstplanGridSkeleton() {
   return (
     <div
@@ -120,23 +97,6 @@ export function DienstplanGridSkeleton() {
       aria-label="Dienstplan wird geladen"
       data-testid="dienstplan-grid-skeleton"
     >
-      <GridSkeletonBody />
-    </div>
-  );
-}
-
-// Full-page skeleton (header + grid) for the session/permission loading state,
-// before the real PlanningContextBar can render.
-export function DienstplanPageSkeleton() {
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      aria-label="Dienstplan wird geladen"
-      data-testid="dienstplan-skeleton"
-      className="space-y-4"
-    >
-      <HeaderSkeleton />
       <GridSkeletonBody />
     </div>
   );

--- a/frontend/src/components/staff/dienstplan-view.tsx
+++ b/frontend/src/components/staff/dienstplan-view.tsx
@@ -44,10 +44,7 @@ import {
 } from "~/lib/timetable-helpers";
 import { userContextService } from "~/lib/usercontext-api";
 
-import {
-  DienstplanGridSkeleton,
-  DienstplanPageSkeleton,
-} from "./dienstplan-skeleton";
+import { DienstplanGridSkeleton } from "./dienstplan-skeleton";
 
 const logger = createLogger({ component: "DienstplanView" });
 
@@ -264,13 +261,15 @@ function DienstplanContent() {
     redirect(tenantPath("/staff"));
   }
 
-  // Solange das Settings-Schema lädt, ist noch nicht entscheidbar, ob das
-  // Feature aktiv ist — Skeleton statt kurz aufblitzender Seite.
-  if (sessionStatus === "loading" || settingsSchemaLoading) {
-    return <DienstplanPageSkeleton />;
-  }
+  // Solange die Session oder das Settings-Schema lädt, ist noch nicht
+  // entscheidbar, ob das Feature aktiv ist und welche Aktionen erlaubt sind.
+  // Die PlanningContextBar (Titel, Wochen-Navigation) rendert trotzdem sofort
+  // — nur der Inhaltsbereich unten fällt auf das Grid-Skeleton zurück, und
+  // datenabhängige Toolbar-Teile (Ansichts-Umschalter, Export-Knopf) bleiben
+  // aus, bis die Berechtigungen feststehen.
+  const showSkeleton = sessionStatus === "loading" || settingsSchemaLoading;
 
-  if (timetableDisabled) {
+  if (!showSkeleton && timetableDisabled) {
     return <DienstplanDisabledState />;
   }
 
@@ -322,7 +321,7 @@ function DienstplanContent() {
         </div>
       </div>
     );
-  } else if (scheduleLoading) {
+  } else if (showSkeleton || scheduleLoading) {
     content = <DienstplanGridSkeleton />;
   } else if (sortedStaff.length === 0) {
     content = (
@@ -469,7 +468,7 @@ function DienstplanContent() {
         <PeriodSwitcherDropdown
           periods={periods ?? []}
           weekDays={weekDayDates}
-          isLoading={periodsLoading}
+          isLoading={showSkeleton || periodsLoading}
           onCreate={() => {
             setEditingPeriod(null);
             setPeriodModalOpen(true);

--- a/frontend/src/components/staff/dokumente-tab.tsx
+++ b/frontend/src/components/staff/dokumente-tab.tsx
@@ -8,7 +8,6 @@ import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
 import { EmptyState } from "~/components/ui/empty-state";
-import { Loading } from "~/components/ui/loading";
 import {
   OverflowMenu,
   type OverflowMenuEntry,
@@ -270,11 +269,7 @@ export function DokumenteTab({ staffId }: { readonly staffId: string }) {
     },
   ];
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  if (error || !data) {
+  if (error) {
     return (
       <Alert type="error" message="Dokumente konnten nicht geladen werden." />
     );
@@ -383,6 +378,7 @@ export function DokumenteTab({ staffId }: { readonly staffId: string }) {
           columns={columns}
           rows={filtered}
           getRowKey={(doc) => doc.id}
+          isLoading={isLoading}
           defaultSortKey="uploaded"
           defaultSortDirection="desc"
           paginationResetKey={filter}

--- a/frontend/src/components/staff/stammdaten-section-modals.tsx
+++ b/frontend/src/components/staff/stammdaten-section-modals.tsx
@@ -6,8 +6,8 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { ISODateInput, ISODatePicker } from "~/components/ui/date-picker";
-import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
+import { FormSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { createLogger } from "~/lib/logger";
 import { isValidISODate } from "~/lib/date-helpers";
 import { useBerlinToday } from "~/lib/hooks/use-berlin-today";
@@ -642,7 +642,9 @@ export function FinancialEditModal({
   return (
     <Modal isOpen onClose={onClose} title="Bank & Steuer bearbeiten">
       {loading ? (
-        <Loading fullPage={false} />
+        <SkeletonRegion label="Bank- und Steuerdaten werden geladen">
+          <FormSkeleton fields={3} />
+        </SkeletonRegion>
       ) : loadError ? (
         <p className="text-sm text-[#FF3130]">{loadError}</p>
       ) : (

--- a/frontend/src/components/staff/stammdaten-tab.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.tsx
@@ -6,8 +6,8 @@ import { Eye, EyeOff, Lock } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
 import { Modal } from "~/components/ui/modal";
+import { DataFieldSkeleton } from "~/components/ui/detail-modal-components";
 import { StatusBadge } from "~/components/ui/status-badge";
 import { SectionCard } from "~/components/ui/section-card";
 import { formatDate, todayISO } from "~/lib/date-helpers";
@@ -136,19 +136,11 @@ export function StammdatenTab({
   const {
     data: stammdaten,
     error: stammdatenError,
-    isLoading: stammdatenLoading,
     isValidating: stammdatenValidating,
     mutate: mutateStammdaten,
   } = useSWRAuth(canViewSections ? `staff-stammdaten-${staffId}` : null, () =>
     staffStammdatenService.get(staffId),
   );
-
-  if (
-    (canManagePayroll && payrollLoading) ||
-    (canViewSections && stammdatenLoading)
-  ) {
-    return <Loading fullPage={false} />;
-  }
 
   if (canManagePayroll && payrollError) {
     return (
@@ -201,7 +193,7 @@ export function StammdatenTab({
 
   return (
     <div className="space-y-5">
-      {stammdaten && (
+      {canViewSections && (
         <>
           <SectionCard
             collapsible
@@ -209,30 +201,41 @@ export function StammdatenTab({
             title="Person"
             action={
               <EditAction
-                visible={canEditSections}
+                visible={canEditSections && Boolean(stammdaten)}
                 onClick={() => setOpenModal("person")}
               />
             }
           >
             <FieldGrid>
-              <Field label="Vorname" value={stammdaten.person.firstName} />
-              <Field label="Nachname" value={stammdaten.person.lastName} />
-              <Field
-                label="Geburtsdatum"
-                value={
-                  stammdaten.person.birthday
-                    ? formatDate(stammdaten.person.birthday)
-                    : null
-                }
-              />
-              <Field
-                label="Geschlecht"
-                value={
-                  stammdaten.person.gender
-                    ? (genderLabels[stammdaten.person.gender] ?? null)
-                    : null
-                }
-              />
+              {stammdaten ? (
+                <>
+                  <Field label="Vorname" value={stammdaten.person.firstName} />
+                  <Field label="Nachname" value={stammdaten.person.lastName} />
+                  <Field
+                    label="Geburtsdatum"
+                    value={
+                      stammdaten.person.birthday
+                        ? formatDate(stammdaten.person.birthday)
+                        : null
+                    }
+                  />
+                  <Field
+                    label="Geschlecht"
+                    value={
+                      stammdaten.person.gender
+                        ? (genderLabels[stammdaten.person.gender] ?? null)
+                        : null
+                    }
+                  />
+                </>
+              ) : (
+                <>
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                </>
+              )}
             </FieldGrid>
           </SectionCard>
 
@@ -242,22 +245,33 @@ export function StammdatenTab({
             title="Kontakt"
             action={
               <EditAction
-                visible={canEditSections}
+                visible={canEditSections && Boolean(stammdaten)}
                 onClick={() => setOpenModal("kontakt")}
               />
             }
           >
             <FieldGrid>
-              <Field
-                label="Adresse"
-                value={formatAddress(stammdaten) ?? null}
-              />
-              <Field label="Telefon" value={stammdaten.kontakt.phone} />
-              <Field label="E-Mail" value={stammdaten.kontakt.email} />
-              <Field
-                label="Notfallkontakt"
-                value={formatEmergencyContact(stammdaten) ?? null}
-              />
+              {stammdaten ? (
+                <>
+                  <Field
+                    label="Adresse"
+                    value={formatAddress(stammdaten) ?? null}
+                  />
+                  <Field label="Telefon" value={stammdaten.kontakt.phone} />
+                  <Field label="E-Mail" value={stammdaten.kontakt.email} />
+                  <Field
+                    label="Notfallkontakt"
+                    value={formatEmergencyContact(stammdaten) ?? null}
+                  />
+                </>
+              ) : (
+                <>
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                </>
+              )}
             </FieldGrid>
           </SectionCard>
 
@@ -267,55 +281,67 @@ export function StammdatenTab({
             title="Arbeitsvertrag"
             action={
               <EditAction
-                visible={canEditSections}
+                visible={canEditSections && Boolean(stammdaten)}
                 onClick={() => setOpenModal("arbeitsvertrag")}
               />
             }
           >
             <FieldGrid>
-              <Field
-                label="Eintrittsdatum"
-                value={
-                  stammdaten.arbeitsvertrag.entryDate
-                    ? formatDate(stammdaten.arbeitsvertrag.entryDate)
-                    : null
-                }
-              />
-              <Field
-                label="Beschäftigungstyp"
-                value={
-                  stammdaten.arbeitsvertrag.employmentType
-                    ? (employmentTypeLabels[
-                        stammdaten.arbeitsvertrag.employmentType
-                      ] ?? stammdaten.arbeitsvertrag.employmentType)
-                    : null
-                }
-              />
-              <Field
-                label="Befristet bis"
-                value={
-                  stammdaten.arbeitsvertrag.contractEndDate
-                    ? formatDate(stammdaten.arbeitsvertrag.contractEndDate)
-                    : "Unbefristet"
-                }
-              />
-              <Field
-                label="Probezeit bis"
-                value={
-                  stammdaten.arbeitsvertrag.probationEndDate
-                    ? formatDate(stammdaten.arbeitsvertrag.probationEndDate)
-                    : null
-                }
-              />
-              <Field
-                label="Wochenstunden lt. Vertrag"
-                value={
-                  stammdaten.arbeitsvertrag.weeklyHours != null
-                    ? `${stammdaten.arbeitsvertrag.weeklyHours.toLocaleString("de-DE")} Std.`
-                    : null
-                }
-                mono
-              />
+              {stammdaten ? (
+                <>
+                  <Field
+                    label="Eintrittsdatum"
+                    value={
+                      stammdaten.arbeitsvertrag.entryDate
+                        ? formatDate(stammdaten.arbeitsvertrag.entryDate)
+                        : null
+                    }
+                  />
+                  <Field
+                    label="Beschäftigungstyp"
+                    value={
+                      stammdaten.arbeitsvertrag.employmentType
+                        ? (employmentTypeLabels[
+                            stammdaten.arbeitsvertrag.employmentType
+                          ] ?? stammdaten.arbeitsvertrag.employmentType)
+                        : null
+                    }
+                  />
+                  <Field
+                    label="Befristet bis"
+                    value={
+                      stammdaten.arbeitsvertrag.contractEndDate
+                        ? formatDate(stammdaten.arbeitsvertrag.contractEndDate)
+                        : "Unbefristet"
+                    }
+                  />
+                  <Field
+                    label="Probezeit bis"
+                    value={
+                      stammdaten.arbeitsvertrag.probationEndDate
+                        ? formatDate(stammdaten.arbeitsvertrag.probationEndDate)
+                        : null
+                    }
+                  />
+                  <Field
+                    label="Wochenstunden lt. Vertrag"
+                    value={
+                      stammdaten.arbeitsvertrag.weeklyHours != null
+                        ? `${stammdaten.arbeitsvertrag.weeklyHours.toLocaleString("de-DE")} Std.`
+                        : null
+                    }
+                    mono
+                  />
+                </>
+              ) : (
+                <>
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                  <DataFieldSkeleton />
+                </>
+              )}
             </FieldGrid>
           </SectionCard>
 
@@ -326,12 +352,17 @@ export function StammdatenTab({
             description="Nachweise wie Erste-Hilfe-Kurs oder Schwimmschein, mit Ablaufdatum."
             action={
               <EditAction
-                visible={canEditSections}
+                visible={canEditSections && Boolean(stammdaten)}
                 onClick={() => setOpenModal("qualifikationen")}
               />
             }
           >
-            {stammdaten.qualifikationen.length === 0 ? (
+            {!stammdaten ? (
+              <FieldGrid>
+                <DataFieldSkeleton />
+                <DataFieldSkeleton />
+              </FieldGrid>
+            ) : stammdaten.qualifikationen.length === 0 ? (
               <p className="text-sm text-gray-400">
                 Keine Qualifikationen hinterlegt.
               </p>
@@ -381,18 +412,22 @@ export function StammdatenTab({
           description="Personalnummer aus dem Lohnsystem des Trägers. Ohne sie kann der spätere DATEV-Export diese Person keiner Abrechnung zuordnen."
           action={
             <EditAction
-              visible={canManagePayroll}
+              visible={canManagePayroll && !payrollLoading}
               onClick={() => setOpenModal("payroll")}
             />
           }
         >
           <FieldGrid>
-            <Field
-              label="Personalnummer"
-              value={personnelNumber ?? null}
-              emptyText="Nicht gesetzt"
-              mono
-            />
+            {payrollLoading ? (
+              <DataFieldSkeleton />
+            ) : (
+              <Field
+                label="Personalnummer"
+                value={personnelNumber ?? null}
+                emptyText="Nicht gesetzt"
+                mono
+              />
+            )}
           </FieldGrid>
           <p className="mt-4 text-xs text-gray-500">
             Lohnarten und DATEV-Mandantendaten werden zentral unter{" "}

--- a/frontend/src/components/staff/stammdaten-tab.tsx
+++ b/frontend/src/components/staff/stammdaten-tab.tsx
@@ -412,7 +412,7 @@ export function StammdatenTab({
           description="Personalnummer aus dem Lohnsystem des Trägers. Ohne sie kann der spätere DATEV-Export diese Person keiner Abrechnung zuordnen."
           action={
             <EditAction
-              visible={canManagePayroll && !payrollLoading}
+              visible={!payrollLoading}
               onClick={() => setOpenModal("payroll")}
             />
           }

--- a/frontend/src/components/staff/zeiterfassung-tab.tsx
+++ b/frontend/src/components/staff/zeiterfassung-tab.tsx
@@ -5,7 +5,11 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
-import { Loading } from "~/components/ui/loading";
+import {
+  CardGridSkeleton,
+  SkeletonRegion,
+  TableSkeleton,
+} from "~/components/ui/page-skeletons";
 import { SectionCard } from "~/components/ui/section-card";
 import { staffShiftService } from "~/lib/shift-api";
 import type { StaffShift } from "~/lib/shift-helpers";
@@ -229,7 +233,16 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
   );
 
   if (scheduleLoading) {
-    return <Loading fullPage={false} />;
+    return (
+      <SkeletonRegion label="Zeiterfassung wird geladen" className="space-y-5">
+        <CardGridSkeleton
+          cards={4}
+          rowsPerCard={1}
+          className="grid grid-cols-2 gap-4 sm:grid-cols-4"
+        />
+        <TableSkeleton rows={7} columns={5} />
+      </SkeletonRegion>
+    );
   }
 
   const handlePrev = () => {
@@ -349,8 +362,10 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
         )}
 
         {visibleLoading || shiftsLoading ? (
-          <div className="py-10">
-            <Loading fullPage={false} />
+          <div className="mt-4">
+            <SkeletonRegion label="Zeiterfassungstabelle wird geladen">
+              <TableSkeleton rows={7} columns={5} />
+            </SkeletonRegion>
           </div>
         ) : (
           <div className="mt-4">

--- a/frontend/src/components/students/care-plan-view.tsx
+++ b/frontend/src/components/students/care-plan-view.tsx
@@ -16,7 +16,10 @@ import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { Alert } from "~/components/ui/alert";
-import { Loading } from "~/components/ui/loading";
+import {
+  DetailSectionSkeleton,
+  SkeletonRegion,
+} from "~/components/ui/page-skeletons";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { ConceptSectionHeader } from "~/components/ui/concept-section-header";
 import { resolveDayDeviation } from "~/lib/care-plan-helpers";
@@ -299,7 +302,9 @@ export function CarePlanView({
               }
             />
           ) : loading ? (
-            <Loading message="Betreuungsplan wird geladen" fullPage={false} />
+            <SkeletonRegion label="Betreuungsplan wird geladen">
+              <DetailSectionSkeleton fields={4} />
+            </SkeletonRegion>
           ) : viewMode === "day" ? (
             <CarePlanDayTimeline
               day={dayData ?? null}

--- a/frontend/src/components/students/care-request-review-list.tsx
+++ b/frontend/src/components/students/care-request-review-list.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import {
   RequestReviewCard,
   ReviewDiffPanel,
@@ -166,7 +166,13 @@ export function CareRequestReviewList() {
     [reasons],
   );
 
-  if (loading) return <Loading fullPage={false} />;
+  if (loading) {
+    return (
+      <SkeletonRegion label="Betreuungszeit-Anfragen werden geladen">
+        <ListSkeleton rows={3} avatar={false} />
+      </SkeletonRegion>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/frontend/src/components/students/dokumente-tab.tsx
+++ b/frontend/src/components/students/dokumente-tab.tsx
@@ -8,7 +8,6 @@ import { ConfirmDeleteModal } from "~/components/ui/confirm-delete-modal";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
 import { EmptyState } from "~/components/ui/empty-state";
-import { Loading } from "~/components/ui/loading";
 import {
   OverflowMenu,
   type OverflowMenuEntry,
@@ -241,11 +240,7 @@ export function StudentDokumenteTab({
     },
   ];
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  if (error || !data) {
+  if (error) {
     return (
       <Alert type="error" message="Dokumente konnten nicht geladen werden." />
     );
@@ -352,6 +347,7 @@ export function StudentDokumenteTab({
           columns={columns}
           rows={filtered}
           getRowKey={(doc) => doc.id}
+          isLoading={isLoading}
           defaultSortKey="uploaded"
           defaultSortDirection="desc"
           paginationResetKey={filter}

--- a/frontend/src/components/students/excused-request-review-list.tsx
+++ b/frontend/src/components/students/excused-request-review-list.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import {
   RequestReviewCard,
   ReviewDiffPanel,
@@ -174,7 +174,13 @@ export function ExcusedRequestReviewList() {
     [reasons],
   );
 
-  if (loading) return <Loading fullPage={false} />;
+  if (loading) {
+    return (
+      <SkeletonRegion label="Entschuldigungs-Anfragen werden geladen">
+        <ListSkeleton rows={3} avatar={false} />
+      </SkeletonRegion>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/frontend/src/components/students/master-data-review-list.tsx
+++ b/frontend/src/components/students/master-data-review-list.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import {
   RequestReviewCard,
   ReviewDiffPanel,
@@ -157,7 +157,13 @@ export function MasterDataReviewList() {
     [reasons],
   );
 
-  if (loading) return <Loading fullPage={false} />;
+  if (loading) {
+    return (
+      <SkeletonRegion label="Änderungsanfragen werden geladen">
+        <ListSkeleton rows={3} avatar={false} />
+      </SkeletonRegion>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/frontend/src/components/students/offering-request-review-list.tsx
+++ b/frontend/src/components/students/offering-request-review-list.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Loading } from "~/components/ui/loading";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import {
   RequestReviewCard,
   ReviewDiffPanel,
@@ -130,7 +130,13 @@ export function OfferingRequestReviewList() {
     [reasons],
   );
 
-  if (loading) return <Loading fullPage={false} />;
+  if (loading) {
+    return (
+      <SkeletonRegion label="Angebots-Anfragen werden geladen">
+        <ListSkeleton rows={3} avatar={false} />
+      </SkeletonRegion>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/frontend/src/components/time-tracking/monatskarte.tsx
+++ b/frontend/src/components/time-tracking/monatskarte.tsx
@@ -10,6 +10,7 @@ import { Lock } from "lucide-react";
 
 import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
+import { Skeleton } from "~/components/ui/skeleton";
 import { StatusBadge } from "~/components/ui/status-badge";
 import { formatSignedDuration } from "~/components/staff/staff-time-views";
 import { formatLocalizedDate } from "~/lib/localized-date-format";
@@ -137,10 +138,30 @@ export function Monatskarte({
   onReopen,
 }: MonatskarteProps) {
   if (isLoading) {
+    // Mirrors the loaded card below: title row, then SummaryRow-shaped
+    // label/value lines in the same divide-y raster.
     return (
-      <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
-        <div className="h-40 animate-pulse rounded-lg bg-gray-100" />
-      </div>
+      <output
+        aria-label="Monatskarte wird geladen"
+        aria-live="polite"
+        className="moto-content-surface block rounded-2xl border p-4 shadow-sm sm:p-6"
+      >
+        <div className="mb-3 flex items-center">
+          <Skeleton className="h-5 w-44 rounded" />
+        </div>
+        <div className="divide-y divide-gray-100" aria-hidden="true">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="flex items-baseline justify-between gap-4 py-1.5"
+            >
+              <Skeleton className="h-4 w-32 rounded" />
+              <Skeleton className="h-4 w-16 rounded" />
+            </div>
+          ))}
+        </div>
+        <span className="sr-only">Monatskarte wird geladen</span>
+      </output>
     );
   }
   if (error) {

--- a/frontend/src/components/timetable/betreuungsplan-view.test.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.test.tsx
@@ -1377,7 +1377,14 @@ describe("BetreuungsplanView", () => {
 
     render(<BetreuungsplanView />);
 
-    expect(screen.getByTestId("timetable-page-skeleton")).toBeVisible();
+    // Chrome (PlanningContextBar title/navigation) renders immediately —
+    // only the calendar-grid content region skeletonizes (showSkeleton
+    // pattern, mirrors staff/page.tsx and rooms/page.tsx).
+    expect(screen.getByText("Betreuungsplan")).toBeVisible();
+    expect(screen.getByTestId("timetable-content-skeleton")).toBeVisible();
+    expect(
+      screen.queryByTestId("timetable-page-skeleton"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByTestId("loading")).not.toBeInTheDocument();
   });
 
@@ -1514,7 +1521,14 @@ describe("BetreuungsplanView", () => {
     setupSWR({ settingsSchemaLoading: true });
     render(<BetreuungsplanView />);
 
-    expect(screen.getByTestId("timetable-page-skeleton")).toBeVisible();
+    // Chrome renders immediately; only the content region skeletonizes
+    // while the settings schema (and therefore timetableDisabled) is
+    // still unresolved.
+    expect(screen.getByText("Betreuungsplan")).toBeVisible();
+    expect(screen.getByTestId("timetable-content-skeleton")).toBeVisible();
+    expect(
+      screen.queryByTestId("timetable-page-skeleton"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("week-grid")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/timetable/betreuungsplan-view.tsx
+++ b/frontend/src/components/timetable/betreuungsplan-view.tsx
@@ -1166,17 +1166,16 @@ function TimetablesContent() {
     toast,
   ]);
 
-  if (status === "loading") {
-    return <TimetablePageSkeleton />;
-  }
+  // While the session or the settings schema loads we cannot tell yet
+  // whether the feature is enabled or what the caller may do. The
+  // PlanningContextBar (title, navigation) renders immediately regardless —
+  // only the calendar-grid content below falls back to its skeleton, and
+  // permission-dependent toolbar bits (view switcher, export, "Neu") stay
+  // hidden until they resolve (hasPermission(undefined, …) is false while
+  // loading).
+  const showSkeleton = status === "loading" || settingsSchemaLoading;
 
-  // While the settings schema loads we cannot tell yet whether the feature
-  // is enabled — show the normal skeleton instead of flashing the planner.
-  if (settingsSchemaLoading) {
-    return <TimetablePageSkeleton />;
-  }
-
-  if (timetableDisabled) {
+  if (!showSkeleton && timetableDisabled) {
     return (
       <PlanningDisabledState
         pageTitle="Betreuungsplan"
@@ -1435,7 +1434,7 @@ function TimetablesContent() {
             )}
 
           {view === "month" &&
-            (isInstanceDataLoading ? (
+            (showSkeleton || isInstanceDataLoading ? (
               <TimetableContentSkeleton view="month" />
             ) : (
               <MonthPlannerGrid
@@ -1451,7 +1450,7 @@ function TimetablesContent() {
 
           {view === "week" && (
             <>
-              {isInstanceDataLoading ? (
+              {showSkeleton || isInstanceDataLoading ? (
                 <TimetableContentSkeleton view="week" />
               ) : (
                 <WeeklyCalendarGrid
@@ -1490,7 +1489,7 @@ function TimetablesContent() {
 
           {view === "series" && (
             <>
-              {templatesLoading ? (
+              {showSkeleton || templatesLoading ? (
                 <TimetableContentSkeleton view="series" />
               ) : (
                 <TemplateList

--- a/frontend/src/components/timetable/substitution-slide-over.tsx
+++ b/frontend/src/components/timetable/substitution-slide-over.tsx
@@ -42,8 +42,8 @@ import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Input } from "~/components/ui/input";
-import { Loading } from "~/components/ui/loading";
 import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
+import { ListSkeleton, SkeletonRegion } from "~/components/ui/page-skeletons";
 import { Radio } from "~/components/ui/radio";
 import {
   SlideOver,
@@ -1218,7 +1218,9 @@ function HistoryTab({
         </div>
 
         {isLoading ? (
-          <Loading />
+          <SkeletonRegion label="Verlauf wird geladen">
+            <ListSkeleton rows={4} avatar={false} />
+          </SkeletonRegion>
         ) : error ? (
           <p className="text-sm text-gray-500">
             Der Verlauf konnte nicht geladen werden. Bitte erneut versuchen.

--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 import { LOCATION_COLORS } from "~/lib/location-helper";
+import { Skeleton } from "~/components/ui/skeleton";
 
 type SortDirection = "asc" | "desc";
 
@@ -31,6 +32,9 @@ interface DataTableProps<T> {
   headerActions?: ReactNode;
   caption?: string;
   isLoading?: boolean;
+  // Skeleton rows shown while isLoading; match the typical result count so
+  // the swap to real rows doesn't jump.
+  loadingRowCount?: number;
   rowClassName?: (row: T) => string;
   defaultSortKey?: string;
   defaultSortDirection?: SortDirection;
@@ -52,6 +56,84 @@ const alignClass: Record<
   center: "text-center",
 };
 
+// Class constants shared between the real table and its skeleton state so
+// the two cannot drift apart — the skeleton IS this table's own markup.
+const surfaceClass =
+  "moto-content-surface overflow-hidden rounded-2xl border shadow-sm backdrop-blur-md";
+const tableClass = "w-full border-collapse text-left text-sm";
+const headRowClass =
+  "border-b border-gray-100 text-xs font-medium text-gray-500";
+const headCellClass = "px-3 py-3 sm:px-5";
+const bodyRowClass = "border-b border-gray-50 last:border-0";
+const bodyCellClass = "px-3 py-3 align-middle sm:px-5";
+
+// Deterministic width cycle: varied line lengths read as real data without
+// Math.random() (SSR-hydration-safe). First column widest, like a name.
+const skeletonWidths = ["w-3/4", "w-1/2", "w-2/3", "w-2/5", "w-3/5"];
+
+function skeletonWidth(row: number, col: number): string {
+  if (col === 0) return "w-32";
+  return skeletonWidths[(row + col) % skeletonWidths.length] ?? "w-2/3";
+}
+
+function SkeletonBodyRows({
+  columnCount,
+  rows,
+}: Readonly<{ columnCount: number; rows: number }>) {
+  return (
+    <>
+      {Array.from({ length: rows }, (_, r) => (
+        <tr key={r} className={bodyRowClass} aria-hidden="true">
+          {Array.from({ length: columnCount }, (_, c) => (
+            <td key={c} className={bodyCellClass}>
+              <Skeleton className={`h-4 rounded ${skeletonWidth(r, c)}`} />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Standalone loading table for call sites that don't have column definitions
+ * at hand (page-level fallbacks). Reuses the exact class constants of the
+ * real DataTable above; header cells show bars since the labels are unknown.
+ * Prefer `<DataTable isLoading>` whenever the columns exist — that renders
+ * the real header labels.
+ */
+export function DataTableSkeleton({
+  rows = 6,
+  columns = 5,
+  caption = false,
+}: Readonly<{ rows?: number; columns?: number; caption?: boolean }>) {
+  return (
+    <div className="w-full" aria-hidden="true">
+      {caption && <Skeleton className="mb-3 h-4 w-56 rounded" />}
+      <div className={surfaceClass}>
+        <div className="overflow-x-auto">
+          <table className={tableClass}>
+            <thead>
+              <tr className={headRowClass}>
+                {Array.from({ length: columns }, (_, c) => (
+                  <th key={c} scope="col" className={headCellClass}>
+                    <Skeleton
+                      className={`h-3 rounded ${c === 0 ? "w-24" : "w-16"}`}
+                    />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <SkeletonBodyRows columnCount={columns} rows={rows} />
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function DataTable<T>({
   columns,
   rows,
@@ -61,6 +143,7 @@ export function DataTable<T>({
   headerActions,
   caption,
   isLoading,
+  loadingRowCount = 6,
   rowClassName,
   defaultSortKey,
   defaultSortDirection = "asc",
@@ -125,6 +208,11 @@ export function DataTable<T>({
 
   return (
     <div className="w-full">
+      {isLoading && (
+        <output aria-live="polite" className="sr-only">
+          Wird geladen…
+        </output>
+      )}
       {(caption ?? headerActions) && (
         <div className="mb-3 flex items-center justify-between gap-3">
           {caption ? (
@@ -142,11 +230,11 @@ export function DataTable<T>({
           wird im inneren Container. Sonst zeichnet der Browser die
           Scrollleiste quer durch die abgerundeten Ecken und über den unteren
           Rand hinaus. */}
-      <div className="moto-content-surface overflow-hidden rounded-2xl border shadow-sm backdrop-blur-md">
+      <div className={surfaceClass}>
         <div className="overflow-x-auto">
-          <table className="w-full border-collapse text-left text-sm">
+          <table className={tableClass}>
             <thead>
-              <tr className="border-b border-gray-100 text-xs font-medium text-gray-500">
+              <tr className={headRowClass}>
                 {columns.map((col) => {
                   const align = alignClass[col.align ?? "left"];
                   const sortable = Boolean(col.sortValue);
@@ -156,7 +244,7 @@ export function DataTable<T>({
                       <th
                         key={col.key}
                         scope="col"
-                        className={`px-3 py-3 sm:px-5 ${align} ${col.headerClassName ?? ""}`}
+                        className={`${headCellClass} ${align} ${col.headerClassName ?? ""}`}
                       >
                         {col.header}
                       </th>
@@ -190,7 +278,7 @@ export function DataTable<T>({
                       key={col.key}
                       scope="col"
                       aria-sort={ariaSort}
-                      className={`px-3 py-3 sm:px-5 ${align} ${col.headerClassName ?? ""}`}
+                      className={`${headCellClass} ${align} ${col.headerClassName ?? ""}`}
                     >
                       <button
                         type="button"
@@ -213,14 +301,10 @@ export function DataTable<T>({
             </thead>
             <tbody>
               {isLoading ? (
-                <tr>
-                  <td
-                    colSpan={columns.length}
-                    className="px-5 py-10 text-center text-sm text-gray-500"
-                  >
-                    Wird geladen…
-                  </td>
-                </tr>
+                <SkeletonBodyRows
+                  columnCount={columns.length}
+                  rows={loadingRowCount}
+                />
               ) : sortedRows.length === 0 ? (
                 <tr>
                   <td
@@ -234,7 +318,7 @@ export function DataTable<T>({
                 visibleRows.map((row) => {
                   const rowKey = getRowKey(row);
                   const rowClasses = [
-                    "border-b border-gray-50 last:border-0 transition-colors",
+                    `${bodyRowClass} transition-colors`,
                     clickable ? "cursor-pointer hover:bg-gray-50" : "",
                     rowClassName ? rowClassName(row) : "",
                   ]
@@ -266,7 +350,7 @@ export function DataTable<T>({
                         return (
                           <td
                             key={col.key}
-                            className={`px-3 py-3 align-middle text-gray-900 sm:px-5 ${align} ${col.className ?? ""}`}
+                            className={`${bodyCellClass} text-gray-900 ${align} ${col.className ?? ""}`}
                           >
                             {col.render(row)}
                           </td>

--- a/frontend/src/components/ui/detail-modal-components.tsx
+++ b/frontend/src/components/ui/detail-modal-components.tsx
@@ -15,6 +15,7 @@ import {
   UsersThreeIcon,
 } from "@phosphor-icons/react";
 import { MotoDuotoneIcon } from "~/components/ui/moto-duotone-icon";
+import { Skeleton } from "~/components/ui/skeleton";
 
 // =============================================================================
 // DataField - Shared component for dt/dd data display patterns
@@ -46,6 +47,29 @@ export function DataField({
         className={`mt-0.5 ${mono ? "font-mono text-xs break-all text-gray-600 md:text-sm" : "text-sm font-medium break-words text-gray-900"}`}
       >
         {children}
+      </dd>
+    </div>
+  );
+}
+
+/**
+ * Loading twin of DataField, colocated so the two share one markup shape:
+ * same wrapper, same dt/dd, bars instead of text. Compose inside a real
+ * InfoSection/DataGrid — static chrome (titles, icons) renders real.
+ */
+export function DataFieldSkeleton({
+  fullWidth = false,
+}: Readonly<{ fullWidth?: boolean }>) {
+  return (
+    <div
+      className={fullWidth ? "col-span-1 sm:col-span-2" : ""}
+      aria-hidden="true"
+    >
+      <dt className="text-xs text-gray-500">
+        <Skeleton className="h-3 w-20 rounded" />
+      </dt>
+      <dd className="mt-0.5 text-sm font-medium text-gray-900">
+        <Skeleton className="h-4 w-2/3 rounded" />
       </dd>
     </div>
   );

--- a/frontend/src/components/ui/info-card.tsx
+++ b/frontend/src/components/ui/info-card.tsx
@@ -1,8 +1,14 @@
 import type React from "react";
 
+import { Skeleton } from "~/components/ui/skeleton";
+
 /**
  * Mobile-optimized info card component
- * Displays a card with an icon, title, and content
+ * Displays a card with an icon, title, and content.
+ *
+ * While `loading` is true the static chrome (icon, eyebrow, title) renders
+ * real and only the content area shows InfoItem-shaped bars — the skeleton
+ * is this card's own markup, so it cannot drift from the loaded state.
  */
 export function InfoCard({
   title,
@@ -10,12 +16,16 @@ export function InfoCard({
   icon,
   eyebrow,
   headingLevel = 2,
+  loading = false,
+  loadingRows = 3,
 }: Readonly<{
   title: string;
   children: React.ReactNode;
   icon: React.ReactNode;
   eyebrow?: string;
   headingLevel?: 1 | 2;
+  loading?: boolean;
+  loadingRows?: number;
 }>) {
   const Heading = headingLevel === 1 ? "h1" : "h2";
 
@@ -38,7 +48,42 @@ export function InfoCard({
       </div>
       {/* flex-1 lets a child opt into bottom-pinning via mt-auto (e.g. an action
           row that should align across cards of different content length). */}
-      <div className="flex flex-1 flex-col space-y-3">{children}</div>
+      <div className="flex flex-1 flex-col space-y-3">
+        {loading ? (
+          <>
+            <output aria-live="polite" className="sr-only">
+              Wird geladen…
+            </output>
+            {Array.from({ length: loadingRows }, (_, i) => (
+              <InfoItemSkeleton key={i} />
+            ))}
+          </>
+        ) : (
+          children
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Loading twin of InfoItem, colocated so the two share one markup shape:
+ * same row layout, same label/value stack, bars instead of text.
+ */
+export function InfoItemSkeleton({
+  icon = false,
+}: Readonly<{ icon?: boolean }>) {
+  return (
+    <div className="flex items-start gap-3" aria-hidden="true">
+      {icon && <Skeleton className="mt-0.5 h-4 w-4 flex-shrink-0 rounded" />}
+      <div className="min-w-0 flex-1">
+        <p className="mb-1 text-xs text-gray-500">
+          <Skeleton className="h-3 w-20 rounded" />
+        </p>
+        <div className="text-sm font-medium text-gray-900">
+          <Skeleton className="h-4 w-2/3 rounded" />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ui/info-card.tsx
+++ b/frontend/src/components/ui/info-card.tsx
@@ -70,9 +70,7 @@ export function InfoCard({
  * Loading twin of InfoItem, colocated so the two share one markup shape:
  * same row layout, same label/value stack, bars instead of text.
  */
-export function InfoItemSkeleton({
-  icon = false,
-}: Readonly<{ icon?: boolean }>) {
+function InfoItemSkeleton({ icon = false }: Readonly<{ icon?: boolean }>) {
   return (
     <div className="flex items-start gap-3" aria-hidden="true">
       {icon && <Skeleton className="mt-0.5 h-4 w-4 flex-shrink-0 rounded" />}

--- a/frontend/src/components/ui/loading.tsx
+++ b/frontend/src/components/ui/loading.tsx
@@ -1,5 +1,7 @@
 // components/ui/loading.tsx
-// Skeleton Loader using shadcn/ui Skeleton component
+// Generic content-shaped loading skeleton. Prefer a page-specific skeleton
+// (see ~/components/ui/page-skeletons) when the loaded layout is known;
+// Loading is the fallback for guards, token flows, and small embeds.
 
 "use client";
 
@@ -16,7 +18,7 @@ export function Loading({
 }: LoadingProps) {
   const containerClasses = fullPage
     ? "fixed inset-0 flex items-center justify-center bg-white/80 backdrop-blur-sm z-50"
-    : "flex items-center justify-start pt-24 pb-12"; // Changed justify-center to justify-start with top padding
+    : "flex items-center justify-start pt-24 pb-12";
 
   return (
     <output
@@ -24,21 +26,50 @@ export function Loading({
       aria-label={message}
       aria-live="polite"
     >
-      <div className="mx-auto flex w-full max-w-xs flex-col items-center gap-2 px-4">
-        {/* Text line skeleton */}
-        <Skeleton className="h-4 w-full rounded-full" />
-
-        {/* Circular skeleton */}
-        <Skeleton className="h-10 w-10 rounded-full" />
-
-        {/* Rectangular skeleton */}
-        <Skeleton className="h-14 w-52 rounded-md" />
-
-        {/* Rounded skeleton */}
-        <Skeleton className="h-14 w-52 rounded-lg" />
-        {/* SR-only message for assistive tech */}
-        <span className="sr-only">{message}</span>
-      </div>
+      {fullPage ? (
+        // Overlay: a single content card, like a modal about to fill in.
+        <div className="moto-content-surface w-full max-w-sm rounded-2xl border p-6 shadow-lg">
+          <div className="mb-4 flex items-center gap-3">
+            <Skeleton className="h-10 w-10 flex-shrink-0 rounded-xl" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-2/3 rounded" />
+              <Skeleton className="h-3 w-2/5 rounded" />
+            </div>
+          </div>
+          <div className="space-y-2.5">
+            <Skeleton className="h-3.5 w-full rounded" />
+            <Skeleton className="h-3.5 w-5/6 rounded" />
+            <Skeleton className="h-3.5 w-3/4 rounded" />
+          </div>
+        </div>
+      ) : (
+        // Inline: heading line over a field-row card — the silhouette of a
+        // typical content section, so the swap to real content doesn't jump.
+        <div className="w-full max-w-3xl space-y-4">
+          <Skeleton className="h-6 w-44 rounded" />
+          <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+            <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Skeleton className="h-3 w-24 rounded" />
+                <Skeleton className="h-4 w-3/4 rounded" />
+              </div>
+              <div className="space-y-1.5">
+                <Skeleton className="h-3 w-20 rounded" />
+                <Skeleton className="h-4 w-1/2 rounded" />
+              </div>
+              <div className="space-y-1.5">
+                <Skeleton className="h-3 w-28 rounded" />
+                <Skeleton className="h-4 w-2/3 rounded" />
+              </div>
+              <div className="space-y-1.5">
+                <Skeleton className="h-3 w-24 rounded" />
+                <Skeleton className="h-4 w-3/5 rounded" />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      <span className="sr-only">{message}</span>
     </output>
   );
 }

--- a/frontend/src/components/ui/page-header/types.ts
+++ b/frontend/src/components/ui/page-header/types.ts
@@ -37,6 +37,8 @@ export interface PageHeaderWithSearchProps {
     readonly onChange: (value: string) => void;
     readonly placeholder?: string;
     readonly className?: string;
+    /** Forwarded to the underlying `<input>` (combobox role, ARIA wiring, disabled state, etc.). */
+    readonly inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   };
 
   // Filter configuration

--- a/frontend/src/components/ui/page-skeletons.tsx
+++ b/frontend/src/components/ui/page-skeletons.tsx
@@ -64,6 +64,10 @@ export function SkeletonRegion({
  * bracket makes the fake content inert and invisible to assistive tech.
  * Scope: text-heavy detail/form surfaces only; never on screens with
  * images, charts, or many controls.
+ *
+ * @public Kept exported without a call site yet — this is the approach-4
+ * utility from docs/skeleton-loading-research.md, provided for the first
+ * matching detail surface.
  */
 export function SkeletonMask({
   children,

--- a/frontend/src/components/ui/page-skeletons.tsx
+++ b/frontend/src/components/ui/page-skeletons.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+// Shared realistic loading skeletons. Each primitive mirrors the markup of
+// its real kit counterpart (DataTable, InfoCard, PageHeaderWithSearch,
+// detail-modal-components) so the pulse state has the same silhouette as the
+// loaded screen and the swap causes no layout reshuffle.
+//
+// Composition rule: exactly one wrapper per loading region announces itself
+// (`<output aria-label=…>`); the primitives inside are plain presentational
+// divs. Use `SkeletonRegion` (or a page-level `<output>`) as that wrapper.
+
+import type React from "react";
+
+import { DataTableSkeleton } from "~/components/ui/data-table";
+import { Skeleton } from "~/components/ui/skeleton";
+
+// Deterministic width cycle — varied line lengths read as real text without
+// Math.random() (which would break SSR hydration and test snapshots).
+const LINE_WIDTHS = ["w-3/4", "w-1/2", "w-2/3", "w-5/6", "w-2/5", "w-3/5"];
+
+function lineWidth(i: number): string {
+  return LINE_WIDTHS[i % LINE_WIDTHS.length] ?? "w-2/3";
+}
+
+/**
+ * Announcing wrapper: one per loading region. The region (and its label for
+ * tests/AT) mounts immediately, but the visual skeleton fades in only after
+ * 300 ms (`.moto-skeleton-defer`) — fast responses never flash a skeleton
+ * (NN/g: no indicator under ~1 s). Pass `defer={false}` only when the region
+ * replaces an already-visible skeleton and must not blink.
+ */
+export function SkeletonRegion({
+  label,
+  className,
+  children,
+  testId,
+  defer = true,
+}: Readonly<{
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+  testId?: string;
+  defer?: boolean;
+}>) {
+  return (
+    <output
+      aria-label={label}
+      aria-live="polite"
+      data-testid={testId}
+      className={`block w-full ${className ?? ""}`}
+    >
+      <div className={defer ? "moto-skeleton-defer" : undefined}>
+        {children}
+      </div>
+      <span className="sr-only">{label}</span>
+    </output>
+  );
+}
+
+/**
+ * CSS-masking bracket (approach 4 in docs/skeleton-loading-research.md):
+ * renders REAL component markup with placeholder data as a loading state —
+ * automatically structure-identical because it IS the structure. The
+ * bracket makes the fake content inert and invisible to assistive tech.
+ * Scope: text-heavy detail/form surfaces only; never on screens with
+ * images, charts, or many controls.
+ */
+export function SkeletonMask({
+  children,
+  className,
+}: Readonly<{ children: React.ReactNode; className?: string }>) {
+  return (
+    <div
+      className={`moto-skeleton-mask ${className ?? ""}`}
+      aria-hidden="true"
+      inert
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Mirrors PageHeaderWithSearch: title row with search field, then an
+ * optional row of filter chips and action buttons.
+ */
+export function PageHeaderSkeleton({
+  search = true,
+  chips = 0,
+  actions = 0,
+}: Readonly<{ search?: boolean; chips?: number; actions?: number }>) {
+  return (
+    <div className="mb-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <Skeleton className="h-6 w-32 rounded" />
+        {search && (
+          <Skeleton className="h-10 w-full max-w-sm flex-1 rounded-lg sm:max-w-md" />
+        )}
+        {actions > 0 && (
+          <div className="flex flex-shrink-0 items-center gap-2">
+            {Array.from({ length: actions }, (_, i) => (
+              <Skeleton key={i} className="h-10 w-28 rounded-lg" />
+            ))}
+          </div>
+        )}
+      </div>
+      {chips > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: chips }, (_, i) => (
+            <Skeleton key={i} className="h-8 w-24 rounded-full" />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Loading table for call sites without column definitions. Thin alias of
+ * the colocated `DataTableSkeleton` in data-table.tsx, which shares its
+ * class constants with the real DataTable — zero drift by construction.
+ * Prefer `<DataTable isLoading>` whenever the columns exist: that renders
+ * the real header labels.
+ */
+export { DataTableSkeleton as TableSkeleton } from "~/components/ui/data-table";
+
+/** One InfoCard-shaped card: icon tile, title, then label/value rows. */
+export function CardSkeleton({ rows = 3 }: Readonly<{ rows?: number }>) {
+  return (
+    <div className="moto-content-surface flex h-full flex-col rounded-2xl border p-4 shadow-sm backdrop-blur sm:p-6">
+      <div className="mb-4 flex items-center gap-3">
+        <Skeleton className="h-9 w-9 flex-shrink-0 rounded-xl sm:h-10 sm:w-10" />
+        <Skeleton className="h-5 w-36 rounded" />
+      </div>
+      <div className="flex flex-1 flex-col space-y-3">
+        {Array.from({ length: rows }, (_, i) => (
+          <div key={i} className="space-y-1">
+            <Skeleton className="h-3 w-20 rounded" />
+            <Skeleton className={`h-4 rounded ${lineWidth(i)}`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Responsive grid of InfoCard-shaped cards (same breakpoints as the list pages). */
+export function CardGridSkeleton({
+  cards = 6,
+  rowsPerCard = 3,
+  className = "grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3",
+}: Readonly<{ cards?: number; rowsPerCard?: number; className?: string }>) {
+  return (
+    <div className={className}>
+      {Array.from({ length: cards }, (_, i) => (
+        <CardSkeleton key={i} rows={rowsPerCard} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Mirrors InfoSection + DataGrid from detail-modal-components: section
+ * heading, then a two-column grid of label/value field pairs.
+ */
+export function DetailSectionSkeleton({
+  fields = 4,
+}: Readonly<{ fields?: number }>) {
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+      <Skeleton className="mb-4 h-5 w-40 rounded" />
+      <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
+        {Array.from({ length: fields }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <Skeleton className="h-3 w-24 rounded" />
+            <Skeleton className={`h-4 rounded ${lineWidth(i)}`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Stacked detail sections — a whole detail page body. */
+export function DetailSkeleton({
+  sections = 2,
+  fieldsPerSection = 4,
+}: Readonly<{ sections?: number; fieldsPerSection?: number }>) {
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      {Array.from({ length: sections }, (_, i) => (
+        <DetailSectionSkeleton key={i} fields={fieldsPerSection} />
+      ))}
+    </div>
+  );
+}
+
+/** Mirrors a kit form: label + input pairs, footer action buttons. */
+export function FormSkeleton({ fields = 5 }: Readonly<{ fields?: number }>) {
+  return (
+    <div className="moto-content-surface rounded-2xl border p-4 shadow-sm sm:p-6">
+      <div className="space-y-5">
+        {Array.from({ length: fields }, (_, i) => (
+          <div key={i} className="space-y-1.5">
+            <Skeleton className="h-4 w-28 rounded" />
+            <Skeleton className="h-11 w-full rounded-md" />
+          </div>
+        ))}
+      </div>
+      <div className="mt-6 flex justify-end gap-2">
+        <Skeleton className="h-9 w-24 rounded-md" />
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Stacked list rows (avatar + two text lines + trailing badge) inside the
+ * canonical surface — for inboxes, request queues, and tab content.
+ */
+export function ListSkeleton({
+  rows = 6,
+  avatar = true,
+}: Readonly<{ rows?: number; avatar?: boolean }>) {
+  return (
+    <div className="moto-content-surface divide-y divide-gray-100 overflow-hidden rounded-2xl border shadow-sm">
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} className="flex items-center gap-3 px-4 py-3.5 sm:px-5">
+          {avatar && (
+            <Skeleton className="h-9 w-9 flex-shrink-0 rounded-full" />
+          )}
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <Skeleton className={`h-4 rounded ${lineWidth(i)}`} />
+            <Skeleton className={`h-3 rounded ${lineWidth(i + 3)}`} />
+          </div>
+          <Skeleton className="h-6 w-16 flex-shrink-0 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Full generic list page: header + table. The right default when a page's
+ * loaded state is a PageHeaderWithSearch over a DataTable.
+ */
+export function ListPageSkeleton({
+  label,
+  chips = 0,
+  rows = 8,
+  columns = 5,
+  testId,
+}: Readonly<{
+  label: string;
+  chips?: number;
+  rows?: number;
+  columns?: number;
+  testId?: string;
+}>) {
+  return (
+    <SkeletonRegion label={label} testId={testId}>
+      <PageHeaderSkeleton chips={chips} />
+      <DataTableSkeleton rows={rows} columns={columns} />
+    </SkeletonRegion>
+  );
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -6,7 +6,10 @@ function Skeleton({
 }: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-gray-200", className)}
+      className={cn(
+        "animate-pulse rounded-md bg-gray-200 motion-reduce:animate-none",
+        className,
+      )}
       {...props}
     />
   );

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -483,6 +483,51 @@
   z-index: 60;
 }
 
+/* Anti-flash for loading skeletons (NN/g: no indicator under ~1 s). The
+   region stays in the DOM (labels/queries work immediately) but its visual
+   content only appears after 300 ms — fast responses never flash a skeleton.
+   Opacity-only, so it is not motion in the prefers-reduced-motion sense. */
+@keyframes moto-skeleton-appear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.moto-skeleton-defer {
+  animation: moto-skeleton-appear 120ms linear 300ms both;
+}
+
+/* Skeleton mask: renders REAL component markup with placeholder data as its
+   own loading state — text becomes bars, controls become inert. Scope: only
+   text-heavy detail/form surfaces without images or charts (see
+   docs/skeleton-loading-research.md). The container that applies this class
+   must also set aria-hidden="true" and inert so fake content reaches neither
+   screen readers nor the tab order. */
+.moto-skeleton-mask {
+  pointer-events: none;
+  user-select: none;
+}
+
+.moto-skeleton-mask :is(p, span, dt, dd, h1, h2, h3, h4, label, a, td, th, li) {
+  color: transparent !important;
+  background: var(--color-gray-200);
+  border-radius: 6px;
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.moto-skeleton-mask :is(img, svg, video, button, input, select, textarea) {
+  visibility: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .moto-skeleton-mask :is(p, span, dt, dd, h1, h2, h3, h4, label, a, td, th, li) {
+    animation: none;
+  }
+}
+
 /* Print rules reset unlayered page styles that Tailwind print utilities cannot
    override, then add a dedicated guide background for PDF exports. */
 @media print {


### PR DESCRIPTION
## Summary

Loading states now keep the page’s real chrome visible across tenant, operator, and parents portals. Headers, search, filters, tabs, actions, and known table labels render immediately; only data-dependent content shows skeletons on an initial load without cached data.

- `DataTable` renders its own header and column labels while loading, with skeleton rows derived from its columns. `loadingRowCount` controls the placeholder row count; `DataTableSkeleton` remains available for fallbacks without column definitions.
- `InfoCard` and detail fields provide colocated loading states so static card and section chrome stays visible.
- Shared page, list, card, form, detail, and message skeletons match the loaded layouts more closely.
- Count badges that would otherwise show a misleading `0` stay hidden until data is available.
- Parent dashboard, child list, and master-data pages keep their headers mounted while their content loads.
- Skeleton visuals wait 300 ms before appearing to avoid flashing on fast responses. Skeleton content is hidden from assistive technology, loading regions announce once, and pulse animation respects reduced-motion preferences.
- `SkeletonMask` is available for suitable text-heavy detail or form surfaces, with inert and inaccessible placeholder content.

## Verification

```bash
cd frontend && pnpm run check
cd frontend && pnpm test:run
cd frontend && pnpm run knip
cd frontend && pnpm run depcruise
```

## Screenshots

Loading/loaded pairs for Elternmitteilungen, Mitarbeiter (desktop and mobile), and table skeletons are in the PR screenshots comment.
