### PR TITLE
fix(frontend): Stammdaten-Änderungsanfragen zeigen Werte auf Deutsch

### DIFF
--- a/frontend/src/components/students/master-data-review-list.test.tsx
+++ b/frontend/src/components/students/master-data-review-list.test.tsx
@@ -73,8 +73,10 @@ describe("MasterDataReviewList", () => {
     expect(await screen.findAllByText("Lara Beispiel")).toHaveLength(2);
     expandAll();
     expect(screen.getByText("Vorname")).toBeInTheDocument();
-    expect(screen.getByText("mon: pickup")).toBeInTheDocument();
-    expect(screen.getByText("mon: bus/alone")).toBeInTheDocument();
+    expect(screen.getByText("Montag: Wird abgeholt")).toBeInTheDocument();
+    expect(
+      screen.getByText("Montag: Fährt Bus / Geht zu Fuß"),
+    ).toBeInTheDocument();
 
     const reasonInputs = screen.getAllByPlaceholderText(
       "Begründung (optional)",
@@ -89,6 +91,59 @@ describe("MasterDataReviewList", () => {
       expect(screen.queryByText("Vorname")).not.toBeInTheDocument(),
     );
     expect(screen.getByText("Änderung übernommen")).toBeInTheDocument();
+  });
+
+  it("shows German labels for contact method and language values", async () => {
+    mockList.mockResolvedValue([
+      row({
+        field_key: "preferred_contact_method",
+        old_value: "email",
+        new_value: "mobile",
+      }),
+      row({
+        id: "101",
+        field_key: "language_preference",
+        old_value: "de",
+        new_value: "tr",
+      }),
+    ]);
+
+    render(<MasterDataReviewList />);
+
+    expect(await screen.findAllByText("Lara Beispiel")).toHaveLength(2);
+    expandAll();
+    expect(screen.getByText("E-Mail")).toBeInTheDocument();
+    expect(screen.getByText("Mobiltelefon")).toBeInTheDocument();
+    expect(screen.getByText("Deutsch")).toBeInTheDocument();
+    expect(screen.getByText("Türkisch")).toBeInTheDocument();
+  });
+
+  it("falls back to raw values for unknown keys without crashing", async () => {
+    mockList.mockResolvedValue([
+      row({
+        field_key: "allowed_departure_modes",
+        old_value: { mon: ["teleport"], someday: ["pickup"] },
+        new_value: { tue: "not-an-array" },
+      }),
+      row({
+        id: "101",
+        field_key: "preferred_contact_method",
+        old_value: "carrier_pigeon",
+        new_value: "email",
+      }),
+    ]);
+
+    render(<MasterDataReviewList />);
+
+    expect(await screen.findAllByText("Lara Beispiel")).toHaveLength(2);
+    expandAll();
+    // Unknown mode and weekday keys stay visible as raw values.
+    expect(
+      screen.getByText("Montag: teleport, someday: Wird abgeholt"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Dienstag")).toBeInTheDocument();
+    expect(screen.getByText("carrier_pigeon")).toBeInTheDocument();
+    expect(screen.getByText("E-Mail")).toBeInTheDocument();
   });
 
   it("rejects requests and shows the rejection notice", async () => {

--- a/frontend/src/components/students/master-data-review-list.test.tsx
+++ b/frontend/src/components/students/master-data-review-list.test.tsx
@@ -118,6 +118,30 @@ describe("MasterDataReviewList", () => {
     expect(screen.getByText("Türkisch")).toBeInTheDocument();
   });
 
+  it("renders birthdays in German date format, invalid dates raw", async () => {
+    mockList.mockResolvedValue([
+      row({
+        field_key: "birthday",
+        old_value: "2018-05-03",
+        new_value: "2018-06-14",
+      }),
+      row({
+        id: "101",
+        field_key: "birthday",
+        old_value: null,
+        new_value: "kein-datum",
+      }),
+    ]);
+
+    render(<MasterDataReviewList />);
+
+    expect(await screen.findAllByText("Lara Beispiel")).toHaveLength(2);
+    expandAll();
+    expect(screen.getByText("03.05.2018")).toBeInTheDocument();
+    expect(screen.getByText("14.06.2018")).toBeInTheDocument();
+    expect(screen.getByText("kein-datum")).toBeInTheDocument();
+  });
+
   it("falls back to raw values for unknown keys without crashing", async () => {
     mockList.mockResolvedValue([
       row({

--- a/frontend/src/components/students/master-data-review-list.test.tsx
+++ b/frontend/src/components/students/master-data-review-list.test.tsx
@@ -131,19 +131,27 @@ describe("MasterDataReviewList", () => {
         old_value: "carrier_pigeon",
         new_value: "email",
       }),
+      row({
+        id: "102",
+        field_key: "language_preference",
+        old_value: "xx",
+        new_value: "de",
+      }),
     ]);
 
     render(<MasterDataReviewList />);
 
-    expect(await screen.findAllByText("Lara Beispiel")).toHaveLength(2);
+    expect(await screen.findAllByText("Lara Beispiel")).toHaveLength(3);
     expandAll();
-    // Unknown mode and weekday keys stay visible as raw values.
+    // Unknown mode, weekday, contact, and language keys stay visible as raw values.
     expect(
       screen.getByText("Montag: teleport, someday: Wird abgeholt"),
     ).toBeInTheDocument();
     expect(screen.getByText("Dienstag")).toBeInTheDocument();
     expect(screen.getByText("carrier_pigeon")).toBeInTheDocument();
     expect(screen.getByText("E-Mail")).toBeInTheDocument();
+    expect(screen.getByText("xx")).toBeInTheDocument();
+    expect(screen.getByText("Deutsch")).toBeInTheDocument();
   });
 
   it("rejects requests and shows the rejection notice", async () => {

--- a/frontend/src/components/students/master-data-review-list.tsx
+++ b/frontend/src/components/students/master-data-review-list.tsx
@@ -7,7 +7,7 @@ import {
   RequestReviewCard,
   ReviewDiffPanel,
 } from "~/components/students/request-review-card";
-import { CONTACT_METHODS, getLanguageLabel } from "~/lib/guardian-helpers";
+import { CONTACT_METHODS, LANGUAGE_PREFERENCES } from "~/lib/guardian-helpers";
 import { createLogger } from "~/lib/logger";
 import {
   type StaffMasterDataChange,
@@ -58,6 +58,10 @@ const CONTACT_METHOD_LABELS: Record<string, string> = Object.fromEntries(
   CONTACT_METHODS.map((method) => [method.value, method.label]),
 );
 
+const LANGUAGE_LABELS: Record<string, string> = Object.fromEntries(
+  LANGUAGE_PREFERENCES.map((lang) => [lang.value, lang.label]),
+);
+
 function departureModeLabel(mode: unknown): string {
   return DEPARTURE_MODE_LABELS[mode as DepartureMode] ?? String(mode);
 }
@@ -67,7 +71,7 @@ function formatValue(field: string, value: unknown, empty: string): string {
   if (typeof value === "string") {
     if (field === "preferred_contact_method")
       return CONTACT_METHOD_LABELS[value] ?? value;
-    if (field === "language_preference") return getLanguageLabel(value);
+    if (field === "language_preference") return LANGUAGE_LABELS[value] ?? value;
     return value;
   }
   if (typeof value === "object") {

--- a/frontend/src/components/students/master-data-review-list.tsx
+++ b/frontend/src/components/students/master-data-review-list.tsx
@@ -7,6 +7,7 @@ import {
   RequestReviewCard,
   ReviewDiffPanel,
 } from "~/components/students/request-review-card";
+import { formatDate } from "~/lib/date-helpers";
 import { CONTACT_METHODS, LANGUAGE_PREFERENCES } from "~/lib/guardian-helpers";
 import { createLogger } from "~/lib/logger";
 import {
@@ -72,6 +73,10 @@ function formatValue(field: string, value: unknown, empty: string): string {
     if (field === "preferred_contact_method")
       return CONTACT_METHOD_LABELS[value] ?? value;
     if (field === "language_preference") return LANGUAGE_LABELS[value] ?? value;
+    // Only format well-formed ISO dates — formatDate on anything else yields
+    // "Invalid Date", which would break the raw-value fallback contract.
+    if (field === "birthday" && /^\d{4}-\d{2}-\d{2}$/.test(value))
+      return formatDate(value);
     return value;
   }
   if (typeof value === "object") {

--- a/frontend/src/components/students/master-data-review-list.tsx
+++ b/frontend/src/components/students/master-data-review-list.tsx
@@ -7,12 +7,18 @@ import {
   RequestReviewCard,
   ReviewDiffPanel,
 } from "~/components/students/request-review-card";
+import { CONTACT_METHODS, getLanguageLabel } from "~/lib/guardian-helpers";
 import { createLogger } from "~/lib/logger";
 import {
   type StaffMasterDataChange,
   decideMasterDataChangeRequest,
   listMasterDataChangeRequests,
 } from "~/lib/master-data-review-api";
+import {
+  DEPARTURE_MODE_LABELS,
+  DEPARTURE_WEEKDAYS,
+  type DepartureMode,
+} from "~/lib/student-helpers";
 
 const logger = createLogger({ component: "MasterDataReviewList" });
 
@@ -42,15 +48,38 @@ function fieldLabel(field: string): string {
   return FIELD_LABELS[field] ?? field;
 }
 
-function formatValue(value: unknown, empty: string): string {
+// German labels for the wire values (#2362). Unknown keys fall back to the raw
+// value so future wire additions stay visible instead of crashing or vanishing.
+const WEEKDAY_LABELS: Record<string, string> = Object.fromEntries(
+  DEPARTURE_WEEKDAYS.map((day) => [day.key, day.label]),
+);
+
+const CONTACT_METHOD_LABELS: Record<string, string> = Object.fromEntries(
+  CONTACT_METHODS.map((method) => [method.value, method.label]),
+);
+
+function departureModeLabel(mode: unknown): string {
+  return DEPARTURE_MODE_LABELS[mode as DepartureMode] ?? String(mode);
+}
+
+function formatValue(field: string, value: unknown, empty: string): string {
   if (value === null || value === undefined || value === "") return empty;
-  if (typeof value === "string") return value;
+  if (typeof value === "string") {
+    if (field === "preferred_contact_method")
+      return CONTACT_METHOD_LABELS[value] ?? value;
+    if (field === "language_preference") return getLanguageLabel(value);
+    return value;
+  }
   if (typeof value === "object") {
-    // Departure modes: { mon: ["pickup"], ... } — render a compact summary.
+    // Departure modes: { mon: ["pickup"], ... } — render a compact summary
+    // with German weekday and mode labels ("Montag: Wird abgeholt").
     return Object.entries(value as Record<string, unknown>)
-      .map(([day, modes]) =>
-        Array.isArray(modes) ? `${day}: ${modes.join("/")}` : `${day}`,
-      )
+      .map(([day, modes]) => {
+        const dayLabel = WEEKDAY_LABELS[day] ?? day;
+        return Array.isArray(modes)
+          ? `${dayLabel}: ${modes.map(departureModeLabel).join(" / ")}`
+          : dayLabel;
+      })
       .join(", ");
   }
   return String(value);
@@ -201,13 +230,13 @@ export function MasterDataReviewList() {
                   shows only the value change. */}
               <div className="flex flex-wrap items-baseline gap-2 text-sm">
                 <span className="text-gray-400 line-through">
-                  {formatValue(row.old_value, EMPTY_VALUE)}
+                  {formatValue(row.field_key, row.old_value, EMPTY_VALUE)}
                 </span>
                 <span className="text-gray-400" aria-hidden="true">
                   →
                 </span>
                 <span className="font-medium text-gray-900">
-                  {formatValue(row.new_value, EMPTY_VALUE)}
+                  {formatValue(row.field_key, row.new_value, EMPTY_VALUE)}
                 </span>
               </div>
             </ReviewDiffPanel>

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -136,7 +136,7 @@ export const DEPARTURE_WEEKDAYS: ReadonlyArray<{
 ] as const;
 
 /** German labels for the departure modes (shown in forms and badges). */
-const DEPARTURE_MODE_LABELS: Record<DepartureMode, string> = {
+export const DEPARTURE_MODE_LABELS: Record<DepartureMode, string> = {
   alone: "Geht zu Fuß",
   bus: "Fährt Bus",
   pickup: "Wird abgeholt",


### PR DESCRIPTION
Closes #2362

## Was

Die Staff-Ansicht für Stammdaten-Änderungsanfragen zeigt Werte verständlich auf Deutsch:

- Heimwege mit Wochentag und Modi, z. B. „Montag: Fährt Bus / Geht zu Fuß“
- Kontaktweg und Sprache mit den vorhandenen Frontend-Labels
- Geburtsdaten im deutschen Datumsformat
- Unbekannte Codes und ungültige Datumswerte bleiben als Rohwert sichtbar

Die Ansicht nutzt vorhandene Frontend-Helper; es gibt keine Backend-Änderung.

> **Hinweis:** Die Heimwegtexte entsprechen den Labels im Kinderprofil („Geht zu Fuß“), nicht den abweichenden Formulierungen der Betreuungsplan-Queue.

## Tests

- `cd frontend && pnpm test:run src/components/students/master-data-review-list.test.tsx`
- `cd frontend && pnpm run check`

Die Komponententests decken deutsche Labels, Datumsformatierung sowie Fallbacks für unbekannte und ungültige Werte ab.
