### PR TITLE
Zeiterfassung: Hinweis-Dialog statt stillem No-Op beim Nachtragen fehlender Tage

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
@@ -108,7 +108,9 @@ vi.mock("~/components/staff/uebersicht-tab", () => ({
 }));
 
 vi.mock("~/components/staff/zeiterfassung-tab", () => ({
-  ZeiterfassungTab: () => <div data-testid="zeiterfassung-tab" />,
+  ZeiterfassungTab: ({ initialDate }: { initialDate?: string }) => (
+    <div data-testid="zeiterfassung-tab" data-initial-date={initialDate} />
+  ),
 }));
 
 vi.mock("~/components/staff/arbeitszeitmodell-tab", () => ({
@@ -127,6 +129,7 @@ describe("StaffDetailContent permissions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     searchParams.delete("tab");
+    searchParams.delete("date");
     window.scrollTo = vi.fn();
   });
 
@@ -168,6 +171,55 @@ describe("StaffDetailContent permissions", () => {
       screen.queryByRole("link", { name: "Abrechnung" }),
     ).not.toBeInTheDocument();
     expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("passes the selected date from a time-tracking deep link", () => {
+    searchParams.set("tab", "zeiterfassung");
+    searchParams.set("date", "2026-01-05");
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "7",
+          token: "test-token",
+          roles: ["teacher"],
+          permissions: ["time_tracking:manage"],
+        },
+        expires: "2099-01-01T00:00:00.000Z",
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+
+    render(<StaffDetailContent />);
+
+    expect(screen.getByTestId("zeiterfassung-tab")).toHaveAttribute(
+      "data-initial-date",
+      "2026-01-05",
+    );
+  });
+
+  it("ignores an invalid date from a time-tracking deep link", () => {
+    searchParams.set("tab", "zeiterfassung");
+    searchParams.set("date", "2026-02-31");
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "7",
+          token: "test-token",
+          roles: ["teacher"],
+          permissions: ["time_tracking:manage"],
+        },
+        expires: "2099-01-01T00:00:00.000Z",
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+
+    render(<StaffDetailContent />);
+
+    expect(screen.getByTestId("zeiterfassung-tab")).not.toHaveAttribute(
+      "data-initial-date",
+    );
   });
 
   it("links payroll settings for managers with config permission", () => {

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -34,6 +34,7 @@ import { UebersichtTab } from "~/components/staff/uebersicht-tab";
 import { ZeiterfassungTab } from "~/components/staff/zeiterfassung-tab";
 import { staffAbsenceService } from "~/lib/staff-api";
 import { MOTO_CONCEPTS } from "~/lib/moto-concepts";
+import { isValidISODate } from "~/lib/date-helpers";
 import { DetailSkeleton } from "~/components/ui/page-skeletons";
 import { StaffDetailSkeleton, StaffHeaderSkeleton } from "./page-skeleton";
 
@@ -164,6 +165,13 @@ export default function StaffDetailContent() {
     canViewFinancial ||
     hasPermission(session, "staff_documents:health");
   const requestedTab = searchParams.get("tab");
+  const requestedDate = searchParams.get("date");
+  const initialTimeTrackingDate =
+    requestedTab === "zeiterfassung" &&
+    requestedDate !== null &&
+    isValidISODate(requestedDate)
+      ? requestedDate
+      : undefined;
 
   const {
     data: staff,
@@ -327,7 +335,10 @@ export default function StaffDetailContent() {
 
             {canViewTimeTracking ? (
               <TabsPrimitive.Content value="zeiterfassung">
-                <ZeiterfassungTab staffId={staffId} />
+                <ZeiterfassungTab
+                  staffId={staffId}
+                  initialDate={initialTimeTrackingDate}
+                />
               </TabsPrimitive.Content>
             ) : null}
 

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.tsx
@@ -266,13 +266,15 @@ export default function StaffDetailContent() {
         defaultValue={
           requestedTab === "dokumente" && canViewDocuments
             ? "dokumente"
-            : canViewTimeTracking
-              ? "uebersicht"
-              : canViewStammdaten
-                ? "stammdaten"
-                : canViewDocuments
-                  ? "dokumente"
-                  : "abwesenheiten"
+            : requestedTab === "zeiterfassung" && canViewTimeTracking
+              ? "zeiterfassung"
+              : canViewTimeTracking
+                ? "uebersicht"
+                : canViewStammdaten
+                  ? "stammdaten"
+                  : canViewDocuments
+                    ? "dokumente"
+                    : "abwesenheiten"
         }
         className="w-full"
       >

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -358,6 +358,7 @@ vi.mock("lucide-react", () => ({
 
 import TimeTrackingPage from "./page";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import { useSWRAuth } from "~/lib/swr";
 import { useToast } from "~/contexts/ToastContext";
 import { timeTrackingService } from "~/lib/time-tracking-api";
@@ -4878,5 +4879,70 @@ describe("deviation-reason gate (F9)", () => {
       expect(timeTrackingService.checkOut).toHaveBeenCalledTimes(2);
     });
     expect(screen.getByText("Abweichung vom Dienstplan")).toBeInTheDocument();
+  });
+});
+
+// Ein Klick auf den Stift darf nie ein stiller No-Op sein (#2361): Tage ohne
+// Buchung und ohne Abwesenheit bekommen einen erklärenden Hinweis-Dialog,
+// Berechtigte zusätzlich den Absprung in die eigene Verwaltungs-Ansicht.
+describe("empty-day hint dialog (#2361)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a hint dialog instead of nothing for a day without booking", async () => {
+    setupDefaultMocks();
+
+    render(<TimeTrackingPage />);
+
+    fireEvent.click(screen.getAllByLabelText("Eintrag bearbeiten")[0]!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Kein Eintrag vorhanden")).toBeInTheDocument();
+    // Ohne time_tracking:manage gibt es keinen Nachtragen-Absprung.
+    expect(
+      screen.queryByRole("button", { name: "Eintrag nachtragen" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links managers to their own admin Zeiterfassung", async () => {
+    setupDefaultMocks();
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push,
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    } as never);
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "1",
+          token: "test-token",
+          permissions: ["time_tracking:manage"],
+        },
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    } as never);
+
+    render(<TimeTrackingPage />);
+
+    fireEvent.click(screen.getAllByLabelText("Eintrag bearbeiten")[0]!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Eintrag nachtragen" }));
+    // Der Tenant-Router stellt je nach Routing-Modus den Slug voran — hier
+    // zählt nur, dass die eigene Admin-Zeiterfassung angesteuert wird.
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining("/staff/10?tab=zeiterfassung"),
+    );
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -4945,4 +4945,70 @@ describe("empty-day hint dialog (#2361)", () => {
       expect.stringContaining("/staff/10?tab=zeiterfassung"),
     );
   });
+
+  it("offers managers the backfill link for a half-day absence", async () => {
+    const halfDayAbsence: StaffAbsence = {
+      ...mockVacationAbsence,
+      dateStart: weekdayISO,
+      dateEnd: weekdayISO,
+    };
+    setupDefaultMocks({ absences: [halfDayAbsence] });
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({
+      push,
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    } as never);
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "1",
+          token: "test-token",
+          permissions: ["time_tracking:manage"],
+        },
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    } as never);
+
+    render(<TimeTrackingPage />);
+
+    fireEvent.click(screen.getAllByLabelText("Eintrag bearbeiten")[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Nachtragen" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Arbeitszeit")).toBeInTheDocument();
+    expect(screen.getByText("Abwesenheit")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Nachtragen" }));
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining("/staff/10?tab=zeiterfassung"),
+    );
+  });
+
+  it("keeps the half-day absence editor focused for non-managers", async () => {
+    const halfDayAbsence: StaffAbsence = {
+      ...mockVacationAbsence,
+      dateStart: weekdayISO,
+      dateEnd: weekdayISO,
+    };
+    setupDefaultMocks({ absences: [halfDayAbsence] });
+
+    render(<TimeTrackingPage />);
+
+    fireEvent.click(screen.getAllByLabelText("Eintrag bearbeiten")[0]!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Abwesenheit bearbeiten")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Nachtragen" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -125,6 +125,7 @@ vi.mock("~/components/staff/staff-session-table", () => ({
   StaffSessionTable: ({
     sessions = [],
     absences = [],
+    absencesUnresolved = false,
     onEditDay,
   }: {
     sessions?: Array<{
@@ -141,6 +142,7 @@ vi.mock("~/components/staff/staff-session-table", () => ({
       absence_type: string;
       half_day?: boolean;
     }>;
+    absencesUnresolved?: boolean;
     onEditDay?: (date: Date) => void;
   }) => {
     const session = sessions[0];
@@ -158,7 +160,10 @@ vi.mock("~/components/staff/staff-session-table", () => ({
     };
 
     return (
-      <table>
+      <table
+        data-testid="staff-session-table"
+        data-absences-unresolved={absencesUnresolved}
+      >
         <thead>
           <tr>
             <th>Start</th>
@@ -522,6 +527,7 @@ function setupDefaultMocks(overrides?: {
   currentSession?: WorkSession | null;
   history?: WorkSessionHistory[];
   absences?: StaffAbsence[];
+  tableAbsencesError?: Error;
   historyLoading?: boolean;
   configLoading?: boolean;
   scheduleTargets?: ReadonlyMap<string, number>;
@@ -590,11 +596,11 @@ function setupDefaultMocks(overrides?: {
       } as never;
     } else if (key?.startsWith("time-tracking-table-absences")) {
       return {
-        data: absences,
+        data: overrides?.tableAbsencesError ? undefined : absences,
         isLoading: false,
         mutate: mockMutate,
         isValidating: false,
-        error: undefined,
+        error: overrides?.tableAbsencesError,
       } as never;
     } else if (key?.startsWith("time-tracking-table-")) {
       return {
@@ -718,6 +724,19 @@ describe("TimeTrackingPage", () => {
       setupDefaultMocks();
       render(<TimeTrackingPage />);
       expect(screen.getAllByText("Zeiterfassung").length).toBeGreaterThan(0);
+    });
+
+    it("keeps backfills unresolved when the table absence fetch fails", () => {
+      setupDefaultMocks({
+        tableAbsencesError: new Error("absence fetch failed"),
+      });
+
+      render(<TimeTrackingPage />);
+
+      expect(screen.getByTestId("staff-session-table")).toHaveAttribute(
+        "data-absences-unresolved",
+        "true",
+      );
     });
 
     it("renders Stempeluhr heading", () => {
@@ -4942,7 +4961,7 @@ describe("empty-day hint dialog (#2361)", () => {
     // Der Tenant-Router stellt je nach Routing-Modus den Slug voran — hier
     // zählt nur, dass die eigene Admin-Zeiterfassung angesteuert wird.
     expect(push).toHaveBeenCalledWith(
-      expect.stringContaining("/staff/10?tab=zeiterfassung"),
+      expect.stringContaining(`/staff/10?tab=zeiterfassung&date=${todayISO}`),
     );
   });
 
@@ -4988,7 +5007,7 @@ describe("empty-day hint dialog (#2361)", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Nachtragen" }));
     expect(push).toHaveBeenCalledWith(
-      expect.stringContaining("/staff/10?tab=zeiterfassung"),
+      expect.stringContaining(`/staff/10?tab=zeiterfassung&date=${weekdayISO}`),
     );
   });
 
@@ -5010,5 +5029,36 @@ describe("empty-day hint dialog (#2361)", () => {
     expect(
       screen.queryByRole("button", { name: "Nachtragen" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("offers managers the backfill link for a requested full-day absence", async () => {
+    const requestedAbsence: StaffAbsence = {
+      ...mockAbsence,
+      dateStart: weekdayISO,
+      dateEnd: weekdayISO,
+      status: "requested",
+    };
+    setupDefaultMocks({ absences: [requestedAbsence] });
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: {
+          id: "1",
+          token: "test-token",
+          permissions: ["time_tracking:manage"],
+        },
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    } as never);
+
+    render(<TimeTrackingPage />);
+
+    fireEvent.click(screen.getAllByLabelText("Eintrag bearbeiten")[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Nachtragen" }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -4903,7 +4903,7 @@ describe("empty-day hint dialog (#2361)", () => {
     expect(screen.getByText("Kein Eintrag vorhanden")).toBeInTheDocument();
     // Ohne time_tracking:manage gibt es keinen Nachtragen-Absprung.
     expect(
-      screen.queryByRole("button", { name: "Eintrag nachtragen" }),
+      screen.queryByRole("button", { name: "Nachtragen" }),
     ).not.toBeInTheDocument();
   });
 
@@ -4938,7 +4938,7 @@ describe("empty-day hint dialog (#2361)", () => {
       expect(screen.getByTestId("modal")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Eintrag nachtragen" }));
+    fireEvent.click(screen.getByRole("button", { name: "Nachtragen" }));
     // Der Tenant-Router stellt je nach Routing-Modus den Slug voran — hier
     // zählt nur, dass die eigene Admin-Zeiterfassung angesteuert wird.
     expect(push).toHaveBeenCalledWith(

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -10,6 +10,8 @@ import React, {
 } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
+import { hasPermission } from "~/lib/auth-utils";
+import { useTenantRouter } from "~/lib/tenant-router";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   SkeletonRegion,
@@ -61,7 +63,12 @@ import { LeaveRequestsCard } from "~/components/time-tracking/leave-requests-car
 import type { StaffHistorySession, StaffAbsenceRow } from "~/lib/staff-api";
 import { ownShiftService } from "~/lib/shift-api";
 import type { StaffShift } from "~/lib/shift-helpers";
-import { berlinTodayISO, parseISODate, toISODate } from "~/lib/date-helpers";
+import {
+  berlinTodayISO,
+  formatDate,
+  parseISODate,
+  toISODate,
+} from "~/lib/date-helpers";
 import { useBerlinToday } from "~/lib/hooks/use-berlin-today";
 import { MOTO_COLOR_PALETTE } from "~/lib/location-helper";
 import { useToast } from "~/contexts/ToastContext";
@@ -2316,11 +2323,17 @@ function EditSessionModal({
   absence,
   onUpdateAbsence,
   onDeleteAbsence,
+  canManage,
+  ownStaffId,
 }: {
   readonly isOpen: boolean;
   readonly onClose: () => void;
   readonly session: WorkSessionHistory | null;
   readonly date: Date | null;
+  // Nachtragen ist bewusst admin-only (#2361). Mit time_tracking:manage
+  // bietet der Hinweis-Dialog den Absprung in die eigene Verwaltungs-Ansicht.
+  readonly canManage: boolean;
+  readonly ownStaffId: string | null;
   readonly onSave: (
     id: string,
     updates: {
@@ -2366,6 +2379,7 @@ function EditSessionModal({
   const [absenceDeleting, setAbsenceDeleting] = useState(false);
 
   const [activeTab, setActiveTab] = useState<"session" | "absence">("session");
+  const router = useTenantRouter();
 
   const hasIndividualBreaks = (session?.breaks.length ?? 0) > 0;
   const hasSession = session !== null;
@@ -2420,10 +2434,69 @@ function EditSessionModal({
     }
   }, [absDateStart, absDateEnd]);
 
-  if (!date || (!hasSession && !hasAbsence)) return null;
+  if (!date) return null;
 
   const dayIndex = (date.getDay() + 6) % 7;
   const dayName = DAY_NAMES_LONG[dayIndex] ?? "";
+
+  // Tag ohne Buchung und ohne Abwesenheit: kein stiller No-Op mehr (#2361).
+  // Nachtragen bleibt admin-only — der Dialog erklärt den Weg, Berechtigte
+  // springen direkt in die eigene Verwaltungs-Ansicht ab.
+  if (!hasSession && !hasAbsence) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        title="Kein Eintrag vorhanden"
+        footer={
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={onClose}
+              className="flex-1"
+            >
+              Schließen
+            </Button>
+            {canManage && ownStaffId && (
+              <Button
+                type="button"
+                variant="primary"
+                size="md"
+                onClick={() =>
+                  router.push(`/staff/${ownStaffId}?tab=zeiterfassung`)
+                }
+                className="flex-1"
+              >
+                Eintrag nachtragen
+              </Button>
+            )}
+          </div>
+        }
+      >
+        <div className="space-y-3 py-2 text-sm text-gray-600">
+          <p>
+            Für {dayName}, den {formatDate(toISODate(date))} ist keine
+            Arbeitszeit eingetragen.
+          </p>
+          {canManage && ownStaffId ? (
+            <p>
+              Fehlende Arbeitszeiten werden in der Verwaltungs-Ansicht
+              nachgetragen. Der Knopf unten öffnet die eigene Zeiterfassung
+              dort.
+            </p>
+          ) : (
+            <p>
+              Fehlende Arbeitszeiten kann nur die Leitung nachtragen (unter
+              Mitarbeitende in der Zeiterfassung der Person). Bitte dort melden,
+              damit der Tag ergänzt wird.
+            </p>
+          )}
+        </div>
+      </Modal>
+    );
+  }
 
   // Calculate total break from individual breaks or fallback dropdown
   const editedBreak = hasIndividualBreaks
@@ -3060,12 +3133,18 @@ function CreateAbsenceModal({
 // ─── Main Content ─────────────────────────────────────────────────────────────
 
 function TimeTrackingContent() {
-  const { status: authStatus } = useSession({
+  const { data: authSession, status: authStatus } = useSession({
     required: true,
     onUnauthenticated() {
       redirect("/");
     },
   });
+  // Nachtragen fehlender Tage ist admin-only (#2361); mit dieser Berechtigung
+  // bietet der Hinweis-Dialog den Absprung in die eigene Verwaltungs-Ansicht.
+  const canManageTimeTracking = hasPermission(
+    authSession,
+    "time_tracking:manage",
+  );
 
   const toast = useToast();
   const todayISO = useBerlinToday();
@@ -3799,6 +3878,8 @@ function TimeTrackingContent() {
         absence={editModal?.absence ?? null}
         onUpdateAbsence={handleUpdateAbsence}
         onDeleteAbsence={handleDeleteAbsence}
+        canManage={canManageTimeTracking}
+        ownStaffId={ownStaffId}
       />
 
       {/* Create absence modal */}

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -81,6 +81,7 @@ import { staffScheduleService } from "~/lib/staff-api";
 import {
   adaptAbsenceForMetrics,
   adaptHistorySessionForMetrics,
+  isEffectiveAbsenceStatus,
   isHalfAbsenceBoundary,
   startOfYear,
 } from "~/lib/staff-metrics-helpers";
@@ -1598,12 +1599,15 @@ function OwnZeiterfassungSection({
   );
   const tableHistory = useMemo(() => tableData?.sessions ?? [], [tableData]);
 
-  const { data: tableAbsenceData, isLoading: tableAbsencesLoading } =
-    useSWRAuth<StaffAbsence[]>(
-      `time-tracking-table-absences-${visibleFromKey}-${visibleToKey}`,
-      () => timeTrackingService.getAbsences(visibleFromKey, visibleToKey),
-      { keepPreviousData: true, revalidateOnFocus: false },
-    );
+  const {
+    data: tableAbsenceData,
+    isLoading: tableAbsencesLoading,
+    error: tableAbsencesError,
+  } = useSWRAuth<StaffAbsence[]>(
+    `time-tracking-table-absences-${visibleFromKey}-${visibleToKey}`,
+    () => timeTrackingService.getAbsences(visibleFromKey, visibleToKey),
+    { keepPreviousData: true, revalidateOnFocus: false },
+  );
   const tableAbsences = useMemo(
     () => tableAbsenceData ?? [],
     [tableAbsenceData],
@@ -1925,7 +1929,11 @@ function OwnZeiterfassungSection({
             to={visibleTo}
             sessions={adaptedSessions}
             absences={adaptedAbsences}
-            absencesPending={tableAbsencesLoading}
+            absencesUnresolved={
+              tableAbsencesLoading ||
+              tableAbsencesError != null ||
+              tableAbsenceData === undefined
+            }
             schedule={schedule}
             dailyTargets={dailyTargets}
             dailyTargetsError={dailyTargetsError != null}
@@ -2516,10 +2524,14 @@ function EditSessionModal({
     : false;
   const onBackfill =
     canManage && ownStaffId
-      ? () => router.push(`/staff/${ownStaffId}?tab=zeiterfassung`)
+      ? () =>
+          router.push(`/staff/${ownStaffId}?tab=zeiterfassung&date=${dateKey}`)
       : null;
   const hasBackfillableAbsence =
-    !hasSession && hasAbsence && absenceIsHalfDay && onBackfill !== null;
+    !hasSession &&
+    hasAbsence &&
+    (absenceIsHalfDay || !isEffectiveAbsenceStatus(absence.status)) &&
+    onBackfill !== null;
   const hasBothSections = hasBoth || hasBackfillableAbsence;
 
   // Tag ohne Buchung und ohne Abwesenheit: kein stiller No-Op mehr (#2361).

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -2469,7 +2469,7 @@ function EditSessionModal({
                 }
                 className="flex-1"
               >
-                Eintrag nachtragen
+                Nachtragen
               </Button>
             )}
           </div>
@@ -2482,15 +2482,13 @@ function EditSessionModal({
           </p>
           {canManage && ownStaffId ? (
             <p>
-              Fehlende Arbeitszeiten werden in der Verwaltungs-Ansicht
-              nachgetragen. Der Knopf unten öffnet die eigene Zeiterfassung
-              dort.
+              Mit „Nachtragen“ öffnen Sie die passende Seite. Dort tragen Sie
+              die Arbeitszeit für diesen Tag ein.
             </p>
           ) : (
             <p>
-              Fehlende Arbeitszeiten kann nur die Leitung nachtragen (unter
-              Mitarbeitende in der Zeiterfassung der Person). Bitte dort melden,
-              damit der Tag ergänzt wird.
+              Nur die Leitung kann fehlende Tage nachtragen. Bitte melden Sie
+              sich dort.
             </p>
           )}
         </div>

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.tsx
@@ -81,6 +81,7 @@ import { staffScheduleService } from "~/lib/staff-api";
 import {
   adaptAbsenceForMetrics,
   adaptHistorySessionForMetrics,
+  isHalfAbsenceBoundary,
   startOfYear,
 } from "~/lib/staff-metrics-helpers";
 import {
@@ -1597,11 +1598,12 @@ function OwnZeiterfassungSection({
   );
   const tableHistory = useMemo(() => tableData?.sessions ?? [], [tableData]);
 
-  const { data: tableAbsenceData } = useSWRAuth<StaffAbsence[]>(
-    `time-tracking-table-absences-${visibleFromKey}-${visibleToKey}`,
-    () => timeTrackingService.getAbsences(visibleFromKey, visibleToKey),
-    { keepPreviousData: true, revalidateOnFocus: false },
-  );
+  const { data: tableAbsenceData, isLoading: tableAbsencesLoading } =
+    useSWRAuth<StaffAbsence[]>(
+      `time-tracking-table-absences-${visibleFromKey}-${visibleToKey}`,
+      () => timeTrackingService.getAbsences(visibleFromKey, visibleToKey),
+      { keepPreviousData: true, revalidateOnFocus: false },
+    );
   const tableAbsences = useMemo(
     () => tableAbsenceData ?? [],
     [tableAbsenceData],
@@ -1923,6 +1925,7 @@ function OwnZeiterfassungSection({
             to={visibleTo}
             sessions={adaptedSessions}
             absences={adaptedAbsences}
+            absencesPending={tableAbsencesLoading}
             schedule={schedule}
             dailyTargets={dailyTargets}
             dailyTargetsError={dailyTargetsError != null}
@@ -2302,16 +2305,80 @@ function ModalActions({
 
 /** Get modal footer based on context */
 function getEditModalFooter(
-  hasBoth: boolean,
+  hasBothSections: boolean,
   hasAbsence: boolean,
   activeTab: "session" | "absence",
   sessionFooter: React.ReactNode,
   absenceFooter: React.ReactNode,
 ): React.ReactNode {
-  if (hasBoth) {
+  if (hasBothSections) {
     return activeTab === "session" ? sessionFooter : absenceFooter;
   }
   return hasAbsence ? absenceFooter : sessionFooter;
+}
+
+function MissingSessionHint({
+  date,
+  canManage,
+}: {
+  readonly date: Date;
+  readonly canManage: boolean;
+}) {
+  const dayIndex = (date.getDay() + 6) % 7;
+  const dayName = DAY_NAMES_LONG[dayIndex] ?? "";
+
+  return (
+    <div className="space-y-3 py-2 text-sm text-gray-600">
+      <p>
+        Für {dayName}, den {formatDate(toISODate(date))} ist keine Arbeitszeit
+        eingetragen.
+      </p>
+      {canManage ? (
+        <p>
+          Mit „Nachtragen“ öffnen Sie die passende Seite. Dort tragen Sie die
+          Arbeitszeit für diesen Tag ein.
+        </p>
+      ) : (
+        <p>
+          Nur die Leitung kann fehlende Tage nachtragen. Bitte melden Sie sich
+          dort.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function BackfillFooter({
+  onClose,
+  onBackfill,
+}: {
+  readonly onClose: () => void;
+  readonly onBackfill: (() => void) | null;
+}) {
+  return (
+    <div className="flex w-full flex-col-reverse gap-3 sm:flex-row">
+      <Button
+        type="button"
+        variant="outline"
+        size="md"
+        onClick={onClose}
+        className="flex-1"
+      >
+        Schließen
+      </Button>
+      {onBackfill && (
+        <Button
+          type="button"
+          variant="primary"
+          size="md"
+          onClick={onBackfill}
+          className="flex-1"
+        >
+          Nachtragen
+        </Button>
+      )}
+    </div>
+  );
 }
 
 function EditSessionModal({
@@ -2438,6 +2505,22 @@ function EditSessionModal({
 
   const dayIndex = (date.getDay() + 6) % 7;
   const dayName = DAY_NAMES_LONG[dayIndex] ?? "";
+  const dateKey = toISODate(date);
+  const absenceIsHalfDay = absence
+    ? isHalfAbsenceBoundary(
+        adaptAbsenceForMetrics(absence),
+        dateKey,
+        absence.dateStart.slice(0, 10),
+        absence.dateEnd.slice(0, 10),
+      )
+    : false;
+  const onBackfill =
+    canManage && ownStaffId
+      ? () => router.push(`/staff/${ownStaffId}?tab=zeiterfassung`)
+      : null;
+  const hasBackfillableAbsence =
+    !hasSession && hasAbsence && absenceIsHalfDay && onBackfill !== null;
+  const hasBothSections = hasBoth || hasBackfillableAbsence;
 
   // Tag ohne Buchung und ohne Abwesenheit: kein stiller No-Op mehr (#2361).
   // Nachtragen bleibt admin-only — der Dialog erklärt den Weg, Berechtigte
@@ -2448,50 +2531,9 @@ function EditSessionModal({
         isOpen={isOpen}
         onClose={onClose}
         title="Kein Eintrag vorhanden"
-        footer={
-          <div className="flex gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              size="md"
-              onClick={onClose}
-              className="flex-1"
-            >
-              Schließen
-            </Button>
-            {canManage && ownStaffId && (
-              <Button
-                type="button"
-                variant="primary"
-                size="md"
-                onClick={() =>
-                  router.push(`/staff/${ownStaffId}?tab=zeiterfassung`)
-                }
-                className="flex-1"
-              >
-                Nachtragen
-              </Button>
-            )}
-          </div>
-        }
+        footer={<BackfillFooter onClose={onClose} onBackfill={onBackfill} />}
       >
-        <div className="space-y-3 py-2 text-sm text-gray-600">
-          <p>
-            Für {dayName}, den {formatDate(toISODate(date))} ist keine
-            Arbeitszeit eingetragen.
-          </p>
-          {canManage && ownStaffId ? (
-            <p>
-              Mit „Nachtragen“ öffnen Sie die passende Seite. Dort tragen Sie
-              die Arbeitszeit für diesen Tag ein.
-            </p>
-          ) : (
-            <p>
-              Nur die Leitung kann fehlende Tage nachtragen. Bitte melden Sie
-              sich dort.
-            </p>
-          )}
-        </div>
+        <MissingSessionHint date={date} canManage={onBackfill !== null} />
       </Modal>
     );
   }
@@ -2595,12 +2637,15 @@ function EditSessionModal({
     }
   };
 
-  const modalTitle = getEditModalTitle(hasSession, hasAbsence);
+  const modalTitle = getEditModalTitle(
+    hasSession || hasBackfillableAbsence,
+    hasAbsence,
+  );
 
   // With only one of the two present there is no switcher, and the visible
   // section is pinned to whichever exists — `activeTab` alone would keep an
   // absence-only day on the (empty) "session" section.
-  const effectiveTab: "session" | "absence" = hasBoth
+  const effectiveTab: "session" | "absence" = hasBothSections
     ? activeTab
     : hasAbsence
       ? "absence"
@@ -2616,6 +2661,10 @@ function EditSessionModal({
         saving || !startTime || !notes.trim() || hasInvalidTimeRange
       }
     />
+  );
+
+  const backfillFooter = (
+    <BackfillFooter onClose={onClose} onBackfill={onBackfill} />
   );
 
   const absenceFooter = (
@@ -2634,10 +2683,10 @@ function EditSessionModal({
   );
 
   const footer = getEditModalFooter(
-    hasBoth,
+    hasBothSections,
     hasAbsence,
     activeTab,
-    sessionFooter,
+    hasSession ? sessionFooter : backfillFooter,
     isManagerControlledAbsence ? readOnlyAbsenceFooter : absenceFooter,
   );
 
@@ -2648,10 +2697,11 @@ function EditSessionModal({
           {dayName}, {formatDateGerman(date)}
         </p>
 
-        {/* Section switcher (only when both session + absence exist). The kit
+        {/* Section switcher for a session or a backfillable half-day alongside
+            an absence. The kit
             SegmentedControl, NOT ui/Tabs: Radix tabs activate on mousedown, and
             the existing modal tests drive this switcher with fireEvent.click. */}
-        {hasBoth && (
+        {hasBothSections && (
           <SegmentedControl
             ariaLabel="Abschnitt"
             fullWidth
@@ -2660,6 +2710,12 @@ function EditSessionModal({
             onChange={setActiveTab}
           />
         )}
+
+        {!hasSession &&
+          hasBackfillableAbsence &&
+          effectiveTab === "session" && (
+            <MissingSessionHint date={date} canManage={onBackfill !== null} />
+          )}
 
         {/* ── Session section ──────────────────────────────────────────── */}
         {hasSession && effectiveTab === "session" && (

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1278,7 +1278,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Tageszeilen prüfen: Plan (geplante Schicht), Check-in, Check-out, Pause, Soll, Ist, Saldo, Status, Quelle und Hinweise zeigen, ob ein Tag vollständig erfasst wurde.",
           "Gesetzliche Feiertage (nach dem Bundesland der Einrichtung) tragen das Badge `Feiertag`. An diesen Tagen ist das Soll automatisch 0, es entstehen also keine Minusstunden. Wird an einem Feiertag trotzdem gestempelt, erscheint der Hinweis `Feiertagsarbeit`.",
           "Von der Einrichtung hinterlegte OGS-Schließtage (z. B. pädagogische Tage oder die Sommerschließung) tragen das Badge `Schließtag` und setzen das Soll ebenfalls auf 0. Fällt ein Schließtag auf einen Feiertag, zeigt die Zeile das Feiertag-Badge.",
-          "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren. Bei jeder Arbeitszeit-Korrektur einen Grund angeben. Fehlende Arbeitstage kann nur die Leitung nachtragen: unter `Mitarbeiter` die Person öffnen und im Bereich `Zeiterfassung` den Tag ergänzen.",
+          "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren. Bei jeder Arbeitszeit-Korrektur einen Grund angeben. Fehlende Arbeitstage kann nur die Leitung nachtragen: unter `Mitarbeitende` die Person öffnen und im Bereich `Zeiterfassung` den Tag ergänzen.",
           "Geänderte Tage aufklappen, um die Änderungshistorie zu sehen. Für Auswertungen den Export im Tabellenkopf nutzen.",
         ],
         callout: {

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1278,7 +1278,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Tageszeilen prüfen: Plan (geplante Schicht), Check-in, Check-out, Pause, Soll, Ist, Saldo, Status, Quelle und Hinweise zeigen, ob ein Tag vollständig erfasst wurde.",
           "Gesetzliche Feiertage (nach dem Bundesland der Einrichtung) tragen das Badge `Feiertag`. An diesen Tagen ist das Soll automatisch 0, es entstehen also keine Minusstunden. Wird an einem Feiertag trotzdem gestempelt, erscheint der Hinweis `Feiertagsarbeit`.",
           "Von der Einrichtung hinterlegte OGS-Schließtage (z. B. pädagogische Tage oder die Sommerschließung) tragen das Badge `Schließtag` und setzen das Soll ebenfalls auf 0. Fällt ein Schließtag auf einen Feiertag, zeigt die Zeile das Feiertag-Badge.",
-          "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren oder fehlende Arbeitstage nachtragen. Bei jeder Arbeitszeit-Korrektur einen Grund angeben.",
+          "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren. Bei jeder Arbeitszeit-Korrektur einen Grund angeben. Fehlende Arbeitstage kann nur die Leitung nachtragen: unter `Mitarbeitende` die Person öffnen und im Bereich `Zeiterfassung` den Tag ergänzen.",
           "Geänderte Tage aufklappen, um die Änderungshistorie zu sehen. Für Auswertungen den Export im Tabellenkopf nutzen.",
         ],
         callout: {

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1278,7 +1278,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Tageszeilen prüfen: Plan (geplante Schicht), Check-in, Check-out, Pause, Soll, Ist, Saldo, Status, Quelle und Hinweise zeigen, ob ein Tag vollständig erfasst wurde.",
           "Gesetzliche Feiertage (nach dem Bundesland der Einrichtung) tragen das Badge `Feiertag`. An diesen Tagen ist das Soll automatisch 0, es entstehen also keine Minusstunden. Wird an einem Feiertag trotzdem gestempelt, erscheint der Hinweis `Feiertagsarbeit`.",
           "Von der Einrichtung hinterlegte OGS-Schließtage (z. B. pädagogische Tage oder die Sommerschließung) tragen das Badge `Schließtag` und setzen das Soll ebenfalls auf 0. Fällt ein Schließtag auf einen Feiertag, zeigt die Zeile das Feiertag-Badge.",
-          "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren. Bei jeder Arbeitszeit-Korrektur einen Grund angeben. Fehlende Arbeitstage kann nur die Leitung nachtragen: unter `Mitarbeitende` die Person öffnen und im Bereich `Zeiterfassung` den Tag ergänzen.",
+          "Über das Stift-Symbol eigene Arbeitszeiteinträge korrigieren. Bei jeder Arbeitszeit-Korrektur einen Grund angeben. Fehlende Arbeitstage kann nur die Leitung nachtragen: unter `Mitarbeiter` die Person öffnen und im Bereich `Zeiterfassung` den Tag ergänzen.",
           "Geänderte Tage aufklappen, um die Änderungshistorie zu sehen. Für Auswertungen den Export im Tabellenkopf nutzen.",
         ],
         callout: {

--- a/frontend/src/components/staff/staff-session-table.edit.test.tsx
+++ b/frontend/src/components/staff/staff-session-table.edit.test.tsx
@@ -57,7 +57,7 @@ const mondayFullDayAbsence: StaffAbsenceRow = {
 function renderTable(props: {
   sessions?: readonly StaffHistorySession[];
   absences?: readonly StaffAbsenceRow[];
-  absencesPending?: boolean;
+  absencesUnresolved?: boolean;
 }) {
   return render(
     <StaffSessionTable
@@ -66,7 +66,7 @@ function renderTable(props: {
       to={to}
       sessions={props.sessions ?? []}
       absences={props.absences}
-      absencesPending={props.absencesPending}
+      absencesUnresolved={props.absencesUnresolved}
       schedule={schedule}
       accountStartDate=""
       accountStartDatePending={false}
@@ -128,13 +128,38 @@ describe("StaffSessionTable Stift-Verfügbarkeit", () => {
     },
   );
 
-  it("zeigt keinen Nachtragen-Stift, solange Abwesenheiten laden", () => {
-    renderTable({ absencesPending: true });
+  it("zeigt keinen Nachtragen-Stift, solange Abwesenheitsdaten nicht aufgelöst sind", () => {
+    renderTable({ absencesUnresolved: true });
 
     const row = screen.getByText("05.01.").closest("tr");
     expect(row).not.toBeNull();
     expect(
       within(row!).queryByRole("button", { name: "Eintrag nachtragen" }),
     ).not.toBeInTheDocument();
+  });
+
+  it.each(["requested", "question", "declined", "canceled"])(
+    "erlaubt Nachtragen bei ganztägiger nicht wirksamer Abwesenheit mit Status %s",
+    (status) => {
+      renderTable({
+        absences: [{ ...mondayFullDayAbsence, status }],
+      });
+
+      const row = screen.getByText("05.01.").closest("tr");
+      expect(row).not.toBeNull();
+      expect(
+        within(row!).getByRole("button", { name: "Eintrag nachtragen" }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("lässt eine bestehende Buchung während des Abwesenheiten-Ladens bearbeiten", () => {
+    renderTable({ sessions: [mondaySession], absencesUnresolved: true });
+
+    const row = screen.getByText("05.01.").closest("tr");
+    expect(row).not.toBeNull();
+    expect(
+      within(row!).getByRole("button", { name: "Eintrag bearbeiten" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/staff/staff-session-table.edit.test.tsx
+++ b/frontend/src/components/staff/staff-session-table.edit.test.tsx
@@ -49,9 +49,15 @@ const mondaySickAbsence: StaffAbsenceRow = {
   status: "approved",
 };
 
+const mondayFullDayAbsence: StaffAbsenceRow = {
+  ...mondaySickAbsence,
+  half_day: false,
+};
+
 function renderTable(props: {
   sessions?: readonly StaffHistorySession[];
   absences?: readonly StaffAbsenceRow[];
+  absencesPending?: boolean;
 }) {
   return render(
     <StaffSessionTable
@@ -60,6 +66,7 @@ function renderTable(props: {
       to={to}
       sessions={props.sessions ?? []}
       absences={props.absences}
+      absencesPending={props.absencesPending}
       schedule={schedule}
       accountStartDate=""
       accountStartDatePending={false}
@@ -95,5 +102,39 @@ describe("StaffSessionTable Stift-Verfügbarkeit", () => {
     expect(
       within(row!).getByRole("button", { name: "Eintrag bearbeiten" }),
     ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["sick", "reported"],
+    ["sick", "approved"],
+    ["vacation", "reported"],
+    ["vacation", "approved"],
+    ["training", "reported"],
+    ["training", "approved"],
+  ])(
+    "zeigt keinen Nachtragen-Stift bei ganztägiger %s-Abwesenheit mit Status %s",
+    (absenceType, status) => {
+      renderTable({
+        absences: [
+          { ...mondayFullDayAbsence, absence_type: absenceType, status },
+        ],
+      });
+
+      const row = screen.getByText("05.01.").closest("tr");
+      expect(row).not.toBeNull();
+      expect(
+        within(row!).queryByRole("button", { name: "Eintrag nachtragen" }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("zeigt keinen Nachtragen-Stift, solange Abwesenheiten laden", () => {
+    renderTable({ absencesPending: true });
+
+    const row = screen.getByText("05.01.").closest("tr");
+    expect(row).not.toBeNull();
+    expect(
+      within(row!).queryByRole("button", { name: "Eintrag nachtragen" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/staff/staff-session-table.edit.test.tsx
+++ b/frontend/src/components/staff/staff-session-table.edit.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  StaffAbsenceRow,
+  StaffHistorySession,
+  StaffSchedule,
+} from "~/lib/staff-api";
+
+import { StaffSessionTable } from "./staff-session-table";
+
+// Mo–Fr 8h nach dem heute gültigen Plan — nur damit die Zeilen sichtbar sind.
+const schedule: StaffSchedule = {
+  mode: "custom",
+  model: null,
+  rotationLength: 1,
+  rotationAnchorDate: "2026-01-05",
+  entries: [0, 1, 2, 3, 4].map((dayOfWeek) => ({
+    weekIndex: 0,
+    dayOfWeek,
+    targetMinutes: 480,
+  })),
+  weeklyTotals: [2400],
+  validFrom: "2026-01-05",
+};
+
+// Eine Woche Mo–So, komplett in der Vergangenheit.
+const from = new Date(2026, 0, 5);
+const to = new Date(2026, 0, 11);
+const today = new Date(2026, 5, 15);
+
+const mondaySession: StaffHistorySession = {
+  id: 41,
+  date: "2026-01-05",
+  net_minutes: 180,
+  check_in_time: "2026-01-05T09:00:00Z",
+  check_out_time: "2026-01-05T12:00:00Z",
+  break_minutes: 0,
+};
+
+const mondaySickAbsence: StaffAbsenceRow = {
+  id: 7,
+  staff_id: 1,
+  absence_type: "sick",
+  date_start: "2026-01-05",
+  date_end: "2026-01-05",
+  half_day: true,
+  note: "",
+  status: "approved",
+};
+
+function renderTable(props: {
+  sessions?: readonly StaffHistorySession[];
+  absences?: readonly StaffAbsenceRow[];
+}) {
+  return render(
+    <StaffSessionTable
+      staffId="1"
+      from={from}
+      to={to}
+      sessions={props.sessions ?? []}
+      absences={props.absences}
+      schedule={schedule}
+      accountStartDate=""
+      accountStartDatePending={false}
+      accountStartDateError={false}
+      today={today}
+      isAdminView
+    />,
+  );
+}
+
+// Der Stift darf auf Tagen mit Abwesenheit nicht fehlen (#2361): eine halbe
+// Krankmeldung schließt Arbeitszeit am selben Tag nicht aus, und Nachtragen
+// muss auch dort erreichbar sein.
+describe("StaffSessionTable Stift-Verfügbarkeit", () => {
+  it("zeigt den Nachtragen-Stift auch auf einem Tag mit Abwesenheit ohne Buchung", () => {
+    renderTable({ absences: [mondaySickAbsence] });
+
+    const row = screen.getByText("05.01.").closest("tr");
+    expect(row).not.toBeNull();
+    expect(
+      within(row!).getByRole("button", { name: "Eintrag nachtragen" }),
+    ).toBeInTheDocument();
+  });
+
+  it("zeigt den Bearbeiten-Stift auf einem Tag mit Buchung und Abwesenheit", () => {
+    renderTable({
+      sessions: [mondaySession],
+      absences: [mondaySickAbsence],
+    });
+
+    const row = screen.getByText("05.01.").closest("tr");
+    expect(row).not.toBeNull();
+    expect(
+      within(row!).getByRole("button", { name: "Eintrag bearbeiten" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/staff/staff-session-table.tsx
+++ b/frontend/src/components/staff/staff-session-table.tsx
@@ -23,6 +23,7 @@ import type {
 import { staffSessionEditsService } from "~/lib/staff-api";
 import type { StaffShift } from "~/lib/shift-helpers";
 import {
+  isEffectiveAbsenceStatus,
   isHalfAbsenceBoundary,
   resolveTargetForDate,
   toIsoDayOfWeek,
@@ -63,7 +64,7 @@ export function StaffSessionTable({
   to,
   sessions,
   absences,
-  absencesPending,
+  absencesUnresolved,
   schedule,
   dailyTargets,
   dailyTargetsError,
@@ -84,7 +85,7 @@ export function StaffSessionTable({
   readonly to: Date;
   readonly sessions: readonly StaffHistorySession[];
   readonly absences?: readonly StaffAbsenceRow[];
-  readonly absencesPending?: boolean;
+  readonly absencesUnresolved?: boolean;
   readonly schedule: StaffSchedule | null;
   // Server-resolved Soll je Tag (#1842), keyed YYYY-MM-DD. Wenn gesetzt, ist
   // das die Quelle für die Soll-Spalte: `schedule` beschreibt NUR den heute
@@ -393,9 +394,10 @@ export function StaffSessionTable({
                 const canExpand = hasAuditHistory && session != null;
                 // Edit / nachtragen is available for past or present days,
                 // regardless of whether a session already exists. On an
-                // absence-only day, however, only a half-day boundary may
-                // receive additional work: full-day absences already credit
-                // the complete target in the monthly balance (#2361).
+                // absence-only day, however, only a half-day boundary or a
+                // non-effective absence may receive additional work: effective
+                // full-day absences already credit the complete target in the
+                // monthly balance (#2361).
                 //
                 // Wochenendtage bekommen sie sehr wohl (#1967): eine Zeile ist
                 // nur sichtbar, wenn dort real gearbeitet oder geplant wurde,
@@ -409,11 +411,15 @@ export function StaffSessionTable({
                       absence.date_end.slice(0, 10),
                     )
                   : false;
+                const absenceBlocksBackfill =
+                  absence != null &&
+                  isEffectiveAbsenceStatus(absence.status) &&
+                  !absenceIsHalfDay;
                 const canEdit =
                   isAdminView &&
                   !isFuture &&
-                  !absencesPending &&
-                  (session != null || absence == null || absenceIsHalfDay);
+                  (session != null ||
+                    (!absencesUnresolved && !absenceBlocksBackfill));
                 return (
                   <Fragment key={key}>
                     <tr

--- a/frontend/src/components/staff/staff-session-table.tsx
+++ b/frontend/src/components/staff/staff-session-table.tsx
@@ -389,16 +389,16 @@ export function StaffSessionTable({
                 // nothing to reveal.
                 const canExpand = hasAuditHistory && session != null;
                 // Edit / nachtragen is available for past or present days,
-                // regardless of whether a session already exists. The SquarePen
-                // action lands on Tranche 1b — for now the wiring is in place
-                // and the click is a no-op + logger entry. Future days and
-                // absence-only days don't get the action.
+                // regardless of whether a session already exists — auch auf
+                // Tagen mit Abwesenheit (#2361): eine halbe Krankmeldung
+                // schließt Arbeitszeit am selben Tag nicht aus, und ein
+                // fehlender Stift las sich als "Tag ist gesperrt".
                 //
                 // Wochenendtage bekommen sie sehr wohl (#1967): eine Zeile ist
                 // nur sichtbar, wenn dort real gearbeitet oder geplant wurde,
                 // und genau die muss korrigierbar sein.
                 const isWeekend = dow >= 5;
-                const canEdit = isAdminView && !isFuture && absence == null;
+                const canEdit = isAdminView && !isFuture;
                 return (
                   <Fragment key={key}>
                     <tr

--- a/frontend/src/components/staff/staff-session-table.tsx
+++ b/frontend/src/components/staff/staff-session-table.tsx
@@ -23,6 +23,7 @@ import type {
 import { staffSessionEditsService } from "~/lib/staff-api";
 import type { StaffShift } from "~/lib/shift-helpers";
 import {
+  isHalfAbsenceBoundary,
   resolveTargetForDate,
   toIsoDayOfWeek,
 } from "~/lib/staff-metrics-helpers";
@@ -62,6 +63,7 @@ export function StaffSessionTable({
   to,
   sessions,
   absences,
+  absencesPending,
   schedule,
   dailyTargets,
   dailyTargetsError,
@@ -82,6 +84,7 @@ export function StaffSessionTable({
   readonly to: Date;
   readonly sessions: readonly StaffHistorySession[];
   readonly absences?: readonly StaffAbsenceRow[];
+  readonly absencesPending?: boolean;
   readonly schedule: StaffSchedule | null;
   // Server-resolved Soll je Tag (#1842), keyed YYYY-MM-DD. Wenn gesetzt, ist
   // das die Quelle für die Soll-Spalte: `schedule` beschreibt NUR den heute
@@ -389,16 +392,28 @@ export function StaffSessionTable({
                 // nothing to reveal.
                 const canExpand = hasAuditHistory && session != null;
                 // Edit / nachtragen is available for past or present days,
-                // regardless of whether a session already exists — auch auf
-                // Tagen mit Abwesenheit (#2361): eine halbe Krankmeldung
-                // schließt Arbeitszeit am selben Tag nicht aus, und ein
-                // fehlender Stift las sich als "Tag ist gesperrt".
+                // regardless of whether a session already exists. On an
+                // absence-only day, however, only a half-day boundary may
+                // receive additional work: full-day absences already credit
+                // the complete target in the monthly balance (#2361).
                 //
                 // Wochenendtage bekommen sie sehr wohl (#1967): eine Zeile ist
                 // nur sichtbar, wenn dort real gearbeitet oder geplant wurde,
                 // und genau die muss korrigierbar sein.
                 const isWeekend = dow >= 5;
-                const canEdit = isAdminView && !isFuture;
+                const absenceIsHalfDay = absence
+                  ? isHalfAbsenceBoundary(
+                      absence,
+                      key,
+                      absence.date_start.slice(0, 10),
+                      absence.date_end.slice(0, 10),
+                    )
+                  : false;
+                const canEdit =
+                  isAdminView &&
+                  !isFuture &&
+                  !absencesPending &&
+                  (session != null || absence == null || absenceIsHalfDay);
                 return (
                   <Fragment key={key}>
                     <tr
@@ -744,16 +759,10 @@ function computeRowStatus(
   if (absence) {
     const startDate = absence.date_start.slice(0, 10);
     const endDate = absence.date_end.slice(0, 10);
-    const legacyHalfDay =
-      absence.half_day && !absence.start_half_day && !absence.end_half_day;
-    const halfDay =
-      legacyHalfDay ||
-      (dateKey === startDate && Boolean(absence.start_half_day)) ||
-      (dateKey === endDate && Boolean(absence.end_half_day));
     return {
       kind: "absence",
       absenceType: absence.absence_type,
-      halfDay,
+      halfDay: isHalfAbsenceBoundary(absence, dateKey, startDate, endDate),
     };
   }
   if (target > 0 && !isFuture) {

--- a/frontend/src/components/staff/zeiterfassung-tab.invalidation.test.ts
+++ b/frontend/src/components/staff/zeiterfassung-tab.invalidation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isStaleAfterMonthReopen } from "./zeiterfassung-tab";
+import { berlinTodayISO } from "~/lib/date-helpers";
+import { startOfWeek, toDateKey } from "~/lib/staff-metrics-helpers";
+import {
+  isStaleAfterMonthReopen,
+  resolveInitialTimeTrackingDate,
+} from "./zeiterfassung-tab";
 
 describe("isStaleAfterMonthReopen", () => {
   it("invalidates staff, self-service, overview, dashboard, and close-status caches", () => {
@@ -21,5 +26,19 @@ describe("isStaleAfterMonthReopen", () => {
     ).toBe(false);
     expect(isStaleAfterMonthReopen("phoenix:staff-list", "42")).toBe(false);
     expect(isStaleAfterMonthReopen(null, "42")).toBe(false);
+  });
+});
+
+describe("resolveInitialTimeTrackingDate", () => {
+  it("initializes the view to the selected historic week", () => {
+    const initialDate = resolveInitialTimeTrackingDate("2026-01-08");
+
+    expect(toDateKey(startOfWeek(initialDate))).toBe("2026-01-05");
+  });
+
+  it("falls back to today for an invalid URL date", () => {
+    expect(toDateKey(resolveInitialTimeTrackingDate("2026-02-31"))).toBe(
+      berlinTodayISO(),
+    );
   });
 });

--- a/frontend/src/components/staff/zeiterfassung-tab.tsx
+++ b/frontend/src/components/staff/zeiterfassung-tab.tsx
@@ -37,7 +37,11 @@ import {
   getWeekNumber,
   OPEN_MONTH_REFRESH_MS,
 } from "~/lib/time-tracking-helpers";
-import { berlinTodayISO, parseISODate } from "~/lib/date-helpers";
+import {
+  berlinTodayISO,
+  isValidISODate,
+  parseISODate,
+} from "~/lib/date-helpers";
 import { useBerlinToday } from "~/lib/hooks/use-berlin-today";
 import { usePeriodMetrics } from "~/lib/hooks/use-period-metrics";
 import { timeTrackingService } from "~/lib/time-tracking-api";
@@ -65,12 +69,24 @@ export function isStaleAfterMonthReopen(
   );
 }
 
+export function resolveInitialTimeTrackingDate(initialDate?: string): Date {
+  return parseISODate(
+    initialDate && isValidISODate(initialDate) ? initialDate : berlinTodayISO(),
+  );
+}
+
 // Zeiterfassung tab. Day-row table comparing Soll vs Ist for each day in
 // the visible window (week or month). A row click expands the read-only
 // audit history; the pencil action opens admin-session-edit-modal, where
 // corrections and backfills go through the time_tracking:manage endpoints
 // with a mandatory audit reason.
-export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
+export function ZeiterfassungTab({
+  staffId,
+  initialDate,
+}: {
+  readonly staffId: string;
+  readonly initialDate?: string;
+}) {
   // The Berlin day, not the browser's, and re-rendered on the rollover: this
   // tab stays mounted for hours, and `new Date()` frozen at mount would keep
   // pointing "Dieser Monat" and the open-month poll at yesterday's month after
@@ -81,10 +97,10 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
 
   const [viewMode, setViewMode] = useState<ViewMode>("week");
   const [monthAnchor, setMonthAnchor] = useState(() =>
-    startOfMonth(parseISODate(berlinTodayISO())),
+    startOfMonth(resolveInitialTimeTrackingDate(initialDate)),
   );
   const [weekAnchor, setWeekAnchor] = useState(() =>
-    startOfWeek(parseISODate(berlinTodayISO())),
+    startOfWeek(resolveInitialTimeTrackingDate(initialDate)),
   );
 
   const { data: schedule, isLoading: scheduleLoading } = useSWRAuth(
@@ -129,12 +145,15 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
   );
   // Absences are loaded in parallel with sessions so the table can show Krank/
   // Urlaub badges next to "Vor Ort"/"Homeoffice" (matches the MA-Sicht).
-  const { data: visibleAbsences, isLoading: visibleAbsencesLoading } =
-    useSWRAuth<readonly StaffAbsenceRow[]>(
-      `staff-absences-${staffId}-${visibleFromKey}-${visibleToKey}`,
-      () =>
-        staffAbsenceService.getAbsences(staffId, visibleFromKey, visibleToKey),
-    );
+  const {
+    data: visibleAbsences,
+    isLoading: visibleAbsencesLoading,
+    error: visibleAbsencesError,
+  } = useSWRAuth<readonly StaffAbsenceRow[]>(
+    `staff-absences-${staffId}-${visibleFromKey}-${visibleToKey}`,
+    () =>
+      staffAbsenceService.getAbsences(staffId, visibleFromKey, visibleToKey),
+  );
   // Planned Dienstplan shifts for the visible range feed the table's Plan
   // column (#1844) — plan next to Ist, with the deviation reason in the audit
   // expand. Does not touch the Soll/Saldo math (Arbeitszeitmodell, #1842).
@@ -384,7 +403,11 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
               to={visibleTo}
               sessions={visibleSessions ?? []}
               absences={visibleAbsences ?? []}
-              absencesPending={visibleAbsencesLoading}
+              absencesUnresolved={
+                visibleAbsencesLoading ||
+                visibleAbsencesError != null ||
+                visibleAbsences === undefined
+              }
               schedule={schedule ?? null}
               dailyTargets={dailyTargets}
               dailyTargetsError={dailyTargetsError != null}

--- a/frontend/src/components/staff/zeiterfassung-tab.tsx
+++ b/frontend/src/components/staff/zeiterfassung-tab.tsx
@@ -129,11 +129,12 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
   );
   // Absences are loaded in parallel with sessions so the table can show Krank/
   // Urlaub badges next to "Vor Ort"/"Homeoffice" (matches the MA-Sicht).
-  const { data: visibleAbsences } = useSWRAuth<readonly StaffAbsenceRow[]>(
-    `staff-absences-${staffId}-${visibleFromKey}-${visibleToKey}`,
-    () =>
-      staffAbsenceService.getAbsences(staffId, visibleFromKey, visibleToKey),
-  );
+  const { data: visibleAbsences, isLoading: visibleAbsencesLoading } =
+    useSWRAuth<readonly StaffAbsenceRow[]>(
+      `staff-absences-${staffId}-${visibleFromKey}-${visibleToKey}`,
+      () =>
+        staffAbsenceService.getAbsences(staffId, visibleFromKey, visibleToKey),
+    );
   // Planned Dienstplan shifts for the visible range feed the table's Plan
   // column (#1844) — plan next to Ist, with the deviation reason in the audit
   // expand. Does not touch the Soll/Saldo math (Arbeitszeitmodell, #1842).
@@ -383,6 +384,7 @@ export function ZeiterfassungTab({ staffId }: { readonly staffId: string }) {
               to={visibleTo}
               sessions={visibleSessions ?? []}
               absences={visibleAbsences ?? []}
+              absencesPending={visibleAbsencesLoading}
               schedule={schedule ?? null}
               dailyTargets={dailyTargets}
               dailyTargetsError={dailyTargetsError != null}

--- a/frontend/src/lib/staff-metrics-helpers.ts
+++ b/frontend/src/lib/staff-metrics-helpers.ts
@@ -247,7 +247,7 @@ function absenceCreditForDay(
     : target;
 }
 
-function isEffectiveAbsenceStatus(status: string): boolean {
+export function isEffectiveAbsenceStatus(status: string): boolean {
   return status === "reported" || status === "approved";
 }
 


### PR DESCRIPTION
Closes #2361

## Problem

Auf `/time-tracking` reagierte der Stift bei fehlender Arbeitszeit ohne Abwesenheit bisher nicht sichtbar. Das ließ offen, wie fehlende Tage nachgetragen werden können.

## Änderungen

- Fehlende Arbeitszeit ohne Abwesenheit öffnet nun einen Hinweis-Dialog:
  - ohne `time_tracking:manage`: Hinweis auf die Leitung;
  - mit `time_tracking:manage`: „Nachtragen“ öffnet das eigene Mitarbeiterprofil im Reiter `Zeiterfassung` und zeigt die Woche des betroffenen Tages.
- Nachtragen bleibt admin-only; es gibt keinen neuen Backend-Endpoint.
- In der Verwaltungsansicht ist der Stift für vergangene und heutige Tage verfügbar, sofern keine wirksame ganztägige Abwesenheit besteht. Halbtägige sowie noch nicht wirksame Abwesenheiten können ergänzt werden.
- Während Abwesenheiten noch laden oder nicht geladen werden können, bleibt das Nachtragen gesperrt.
- `/staff/{id}?tab=zeiterfassung&date=YYYY-MM-DD` wählt den Reiter und den Zeitraum des Datums vor.
- Der Hilfe-Guide beschreibt fehlende Arbeitstage nun als Aufgabe der Leitung.

## Verifikation

- `cd frontend && pnpm run check`
- Relevante Tests:
  - `frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx`
  - `frontend/src/components/staff/staff-session-table.edit.test.tsx`
  - `frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx`
