### PR TITLE
Team bei neuen Elternnachrichten benachrichtigen

### DIFF
--- a/backend/database/migrations/001015298_staff_parent_message_notification_debounce.go
+++ b/backend/database/migrations/001015298_staff_parent_message_notification_debounce.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	staffParentMessageNotificationDebounceVersion     = "1.15.298"
+	staffParentMessageNotificationDebounceDescription = "Debounce staff notifications for parent messages (#2363)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     staffParentMessageNotificationDebounceVersion,
+		Description: staffParentMessageNotificationDebounceDescription,
+		DependsOn:   []string{parentMessageTeamHandledVersion},
+	})
+	Migrations.MustRegister(staffParentMessageNotificationDebounceUp, staffParentMessageNotificationDebounceDown)
+}
+
+func staffParentMessageNotificationDebounceUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.298: Adding the staff parent-message notification debounce claim...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE users.parent_message_threads
+			ADD COLUMN IF NOT EXISTS last_staff_message_notification_at TIMESTAMPTZ;
+	`)
+	if err != nil {
+		return fmt.Errorf("add staff parent-message notification debounce claim: %w", err)
+	}
+	return nil
+}
+
+func staffParentMessageNotificationDebounceDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back 1.15.298: Removing the staff parent-message notification debounce claim...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE users.parent_message_threads
+			DROP COLUMN IF EXISTS last_staff_message_notification_at;
+	`)
+	if err != nil {
+		return fmt.Errorf("remove staff parent-message notification debounce claim: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/users/parent_message_thread.go
+++ b/backend/database/repositories/users/parent_message_thread.go
@@ -145,6 +145,33 @@ func (r *ParentMessageThreadRepository) TouchLastMessage(ctx context.Context, th
 	return nil
 }
 
+// ClaimStaffMessageNotification atomically claims one staff-notification
+// window for a thread. The database clock keeps the decision consistent across
+// processes and avoids application-host clock skew.
+func (r *ParentMessageThreadRepository) ClaimStaffMessageNotification(ctx context.Context, threadID int64, cooldown time.Duration) (bool, error) {
+	if cooldown <= 0 {
+		return false, errors.New("staff message notification cooldown must be positive")
+	}
+	query := base.GetDB(ctx, r.DB).NewUpdate().
+		Model((*users.ParentMessageThread)(nil)).
+		ModelTableExpr(tableExprParentMessageThreadsAsThread).
+		Set("last_staff_message_notification_at = clock_timestamp()").
+		Where(`"parent_message_thread".id = ?`, threadID).
+		Where(`("parent_message_thread".last_staff_message_notification_at IS NULL
+			OR "parent_message_thread".last_staff_message_notification_at < clock_timestamp() - (? * INTERVAL '1 microsecond'))`, cooldown.Microseconds())
+	query = base.WithTenantFilter(ctx, query, "parent_message_thread")
+
+	result, err := query.Exec(ctx)
+	if err != nil {
+		return false, &modelBase.DatabaseError{Op: "claim staff parent-message notification", Err: err}
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, &modelBase.DatabaseError{Op: "count claimed staff parent-message notifications", Err: err}
+	}
+	return rows == 1, nil
+}
+
 // ListGuardiansForStudent returns the child's account-holding guardians who may
 // actually use the parent portal for THIS child, primary first, for the staff
 // "new conversation" recipient picker. A guardian is included only when the

--- a/backend/database/repositories/users/parent_messaging_repository_test.go
+++ b/backend/database/repositories/users/parent_messaging_repository_test.go
@@ -286,6 +286,37 @@ func TestParentMessaging_MessageAppendLockSerializesThreadWrites(t *testing.T) {
 	require.NoError(t, repo.LockForMessageAppend(followUpCtx, thread.ID))
 }
 
+func TestParentMessaging_StaffNotificationClaimDebouncesOneThread(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	repo := usersRepo.NewParentMessageThreadRepository(db)
+	ctx := tenantCtx()
+	thread := newThread(chain.StudentID, chain.AccountID)
+	require.NoError(t, repo.Create(ctx, thread))
+
+	claimed, err := repo.ClaimStaffMessageNotification(ctx, thread.ID, time.Minute)
+	require.NoError(t, err)
+	assert.True(t, claimed, "the first parent message claims the notification window")
+
+	claimed, err = repo.ClaimStaffMessageNotification(ctx, thread.ID, time.Minute)
+	require.NoError(t, err)
+	assert.False(t, claimed, "a second message inside the window is suppressed")
+
+	_, err = db.NewUpdate().
+		TableExpr(`users.parent_message_threads AS "parent_message_thread"`).
+		Set("last_staff_message_notification_at = clock_timestamp() - INTERVAL '61 seconds'").
+		Where(`"parent_message_thread".id = ?`, thread.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	claimed, err = repo.ClaimStaffMessageNotification(ctx, thread.ID, time.Minute)
+	require.NoError(t, err)
+	assert.True(t, claimed, "a later follow-up starts a new notification window")
+}
+
 // newRequestCreatedPill builds a "request created" event pill as the emitter
 // stores it: a system event attributed to the GUARDIAN side (event_actor_kind),
 // so it counts as unread to a staff reader. actorAccountID is the submitting

--- a/backend/models/users/parent_message_thread.go
+++ b/backend/models/users/parent_message_thread.go
@@ -44,6 +44,9 @@ type ParentMessageThread struct {
 	// covered by a staff reply. Personal read cursors remain account-specific.
 	StaffHandledUpToAt        *time.Time `bun:"staff_handled_up_to_at" json:"-"`
 	StaffHandledUpToMessageID *int64     `bun:"staff_handled_up_to_message_id" json:"-"`
+	// LastStaffMessageNotificationAt is the database-clock claim used to
+	// collapse a short burst of guardian messages into one staff notification.
+	LastStaffMessageNotificationAt *time.Time `bun:"last_staff_message_notification_at" json:"-"`
 }
 
 // ParentMessageThreadRepository is the tenant-scoped data-access contract for
@@ -62,6 +65,10 @@ type ParentMessageThreadRepository interface {
 	// messages share a timestamp and the higher id wins. Callers must still insert
 	// the message row separately.
 	TouchLastMessage(ctx context.Context, threadID int64, at time.Time, messageID int64, senderKind, body string) error
+	// ClaimStaffMessageNotification atomically opens one notification window for
+	// the thread. It returns false while a previous claim is still inside the
+	// cooldown. PostgreSQL supplies the clock so multiple app hosts agree.
+	ClaimStaffMessageNotification(ctx context.Context, threadID int64, cooldown time.Duration) (bool, error)
 	// FindByID returns the thread by id (tenant-scoped), or nil when absent.
 	FindByID(ctx context.Context, id int64) (*ParentMessageThread, error)
 	// FindByStudentGuardian returns the single conversation for a (student,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1861,6 +1861,22 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		db,
 		repos.AccountTenant,
 	)
+	staffNotificationRecipients := notifications.NewStaffRecipientResolver(
+		notificationPreferencesService,
+		repos.Student,
+		repos.Group,
+		repos.Staff,
+		repos.Account,
+		settingsService,
+		repos.WorkSession,
+	)
+	staffParentMessageNotifier := notifications.NewStaffParentMessageNotifier(
+		notificationsService,
+		staffNotificationRecipients,
+		repos.ParentMessageThread,
+		db,
+		logger.With("producer", "staff_parent_message_notifications"),
+	)
 
 	// Decided change requests reach the parent's devices through the pill
 	// emitter, which is where all three request flows already converge (#1671).
@@ -1931,6 +1947,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		MessageThreadRepo:        repos.ParentMessageThread,
 		MessageRepo:              repos.ParentMessage,
 		MessageReadRepo:          repos.ParentMessageRead,
+		ParentMessageNotifier:    staffParentMessageNotifier,
 		ArrivalSchedules:         arrivalScheduleService,
 		PickupSchedules:          pickupScheduleService,
 		CareRequests:             careRequestService,
@@ -2047,13 +2064,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 
 	absenceNotifier := notifications.NewAbsenceNotifier(
 		notificationsService,
-		notificationPreferencesService,
-		repos.Student,
-		repos.Group,
-		repos.Staff,
-		repos.Account,
-		settingsService,
-		repos.WorkSession,
+		staffNotificationRecipients,
 		db,
 		logger.With("producer", "absence_notifications"),
 	)

--- a/backend/services/notifications/absence_producer.go
+++ b/backend/services/notifications/absence_producer.go
@@ -9,9 +9,6 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
-	configModel "github.com/moto-nrw/project-phoenix/models/config"
-	educationModel "github.com/moto-nrw/project-phoenix/models/education"
-	userModel "github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -67,55 +64,24 @@ type AbsenceNotifier interface {
 }
 
 type absenceNotifier struct {
-	notifier     Service
-	preferences  PreferenceService
-	students     userModel.StudentRepository
-	groups       educationModel.GroupRepository
-	staff        userModel.StaffRepository
-	accounts     authAccountReader
-	settings     settingsBoolReader
-	workSessions dutyReader
-	db           *bun.DB
-	logger       *slog.Logger
-}
-
-// authAccountReader is the slice of the account repository this producer needs.
-type authAccountReader interface {
-	ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error)
-}
-
-type settingsBoolReader interface {
-	ResolveBool(ctx context.Context, key string) (bool, error)
-}
-
-type dutyReader interface {
-	GetTodayPresenceMap(ctx context.Context) (map[int64]string, error)
+	notifier   Service
+	recipients StaffRecipientResolver
+	db         *bun.DB
+	logger     *slog.Logger
 }
 
 // NewAbsenceNotifier builds the sick/excused producer.
 func NewAbsenceNotifier(
 	notifier Service,
-	preferences PreferenceService,
-	students userModel.StudentRepository,
-	groups educationModel.GroupRepository,
-	staff userModel.StaffRepository,
-	accounts authAccountReader,
-	settings settingsBoolReader,
-	workSessions dutyReader,
+	recipients StaffRecipientResolver,
 	db *bun.DB,
 	logger *slog.Logger,
 ) AbsenceNotifier {
 	return &absenceNotifier{
-		notifier:     notifier,
-		preferences:  preferences,
-		students:     students,
-		groups:       groups,
-		staff:        staff,
-		accounts:     accounts,
-		settings:     settings,
-		workSessions: workSessions,
-		db:           db,
-		logger:       logger,
+		notifier:   notifier,
+		recipients: recipients,
+		db:         db,
+		logger:     logger,
 	}
 }
 
@@ -155,7 +121,7 @@ func (n *absenceNotifier) NotifyAbsenceReported(ctx context.Context, report Abse
 }
 
 func (n *absenceNotifier) notify(ctx context.Context, report AbsenceReport) error {
-	if n.notifier == nil || n.preferences == nil || n.settings == nil || n.workSessions == nil {
+	if n.notifier == nil || n.recipients == nil {
 		return nil
 	}
 	if report.TenantID <= 0 || len(report.StudentIDs) == 0 {
@@ -216,83 +182,29 @@ type absenceDelivery struct {
 // supervision relation, adds the full submission for effective admins, then
 // applies consent. Accounts with identical visibility share one event.
 func (n *absenceNotifier) resolveDeliveries(ctx context.Context, report AbsenceReport) ([]absenceDelivery, error) {
-	allStudentIDs := uniqueInt64s(report.StudentIDs)
-	studentsByGroup, groupIDs, err := n.studentIDsByGroup(ctx, allStudentIDs)
-	if err != nil {
-		return nil, err
-	}
-	visibleByAccount := make(map[int64]map[int64]struct{})
-	if len(groupIDs) > 0 {
-		pairs, perr := n.groups.ListStaffIDsByEducationGroupIDs(ctx, groupIDs, timezone.TodayDate())
-		if perr != nil {
-			return nil, fmt.Errorf("resolve supervising staff: %w", perr)
-		}
-		staffIDs := make([]int64, 0, len(pairs))
-		for _, pair := range pairs {
-			staffIDs = append(staffIDs, pair.StaffID)
-		}
-		accountsByStaff, aerr := n.staff.ListAccountIDsByStaffIDs(ctx, staffIDs)
-		if aerr != nil {
-			return nil, fmt.Errorf("resolve staff accounts: %w", aerr)
-		}
-		for _, pair := range pairs {
-			accountID, ok := accountsByStaff[pair.StaffID]
-			if !ok {
-				continue
-			}
-			addVisibleStudents(visibleByAccount, accountID, studentsByGroup[pair.GroupID])
-		}
-	}
-
-	// The office owns attendance bookkeeping and parent contact, so it hears
-	// about an absence regardless of which group the child is in. This is also
-	// what covers a child with no group at all.
-	adminIDs, err := n.accounts.ListEffectiveAdminAccountIDs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolve admin accounts: %w", err)
-	}
-	for _, accountID := range adminIDs {
-		addVisibleStudents(visibleByAccount, accountID, allStudentIDs)
-	}
-
-	delete(visibleByAccount, report.ActorAccountID)
-	for _, accountID := range report.ExcludedAccountIDs {
-		delete(visibleByAccount, accountID)
-	}
-	if len(visibleByAccount) == 0 {
-		return nil, nil
-	}
-
-	candidateIDs := make([]int64, 0, len(visibleByAccount))
-	for accountID := range visibleByAccount {
-		candidateIDs = append(candidateIDs, accountID)
-	}
-	sort.Slice(candidateIDs, func(i, j int) bool { return candidateIDs[i] < candidateIDs[j] })
-
-	optedIn, err := n.preferences.FilterOptedIn(ctx, TypeStudentAbsenceReported, candidateIDs)
-	if err != nil {
-		return nil, err
-	}
-	optedIn, err = n.filterOnDutyAccounts(ctx, optedIn)
+	excluded := make([]int64, 0, len(report.ExcludedAccountIDs)+1)
+	excluded = append(excluded, report.ExcludedAccountIDs...)
+	excluded = append(excluded, report.ActorAccountID)
+	scopes, err := n.recipients.Resolve(ctx, StaffRecipientRequest{
+		StudentIDs:         report.StudentIDs,
+		NotificationType:   TypeStudentAbsenceReported,
+		ExcludedAccountIDs: excluded,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	byScope := make(map[string]*absenceDelivery, len(optedIn))
-	keys := make([]string, 0, len(optedIn))
-	for _, accountID := range optedIn {
-		studentIDs := sortedInt64Set(visibleByAccount[accountID])
-		if len(studentIDs) == 0 {
-			continue
-		}
-		key := fmt.Sprint(studentIDs)
+	byScope := make(map[string]*absenceDelivery, len(scopes))
+	keys := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		key := fmt.Sprint(scope.StudentIDs)
 		delivery := byScope[key]
 		if delivery == nil {
-			delivery = &absenceDelivery{studentIDs: studentIDs}
+			delivery = &absenceDelivery{studentIDs: scope.StudentIDs}
 			byScope[key] = delivery
 			keys = append(keys, key)
 		}
-		delivery.accountIDs = append(delivery.accountIDs, accountID)
+		delivery.accountIDs = append(delivery.accountIDs, scope.AccountID)
 	}
 	sort.Strings(keys)
 
@@ -305,114 +217,6 @@ func (n *absenceNotifier) resolveDeliveries(ctx context.Context, report AbsenceR
 		deliveries = append(deliveries, *delivery)
 	}
 	return deliveries, nil
-}
-
-func (n *absenceNotifier) filterOnDutyAccounts(ctx context.Context, accountIDs []int64) ([]int64, error) {
-	if len(accountIDs) == 0 {
-		return nil, nil
-	}
-	onDutyOnly, err := n.settings.ResolveBool(ctx, configModel.KeyNotificationsOnDutyOnly)
-	if err != nil {
-		return nil, fmt.Errorf("resolve on-duty notification setting: %w", err)
-	}
-	if !onDutyOnly {
-		return accountIDs, nil
-	}
-
-	presence, err := n.workSessions.GetTodayPresenceMap(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("load staff presence: %w", err)
-	}
-	onDutyStaffIDs := make([]int64, 0, len(presence))
-	for staffID, status := range presence {
-		if status == activeModel.WorkSessionStatusPresent || status == activeModel.WorkSessionStatusHomeOffice {
-			onDutyStaffIDs = append(onDutyStaffIDs, staffID)
-		}
-	}
-	if len(onDutyStaffIDs) == 0 {
-		return nil, nil
-	}
-	accountsByStaff, err := n.staff.ListAccountIDsByStaffIDs(ctx, onDutyStaffIDs)
-	if err != nil {
-		return nil, fmt.Errorf("resolve staff accounts for duty filter: %w", err)
-	}
-	onDutyAccounts := make(map[int64]struct{}, len(accountsByStaff))
-	for _, staffID := range onDutyStaffIDs {
-		if accountID := accountsByStaff[staffID]; accountID > 0 {
-			onDutyAccounts[accountID] = struct{}{}
-		}
-	}
-
-	filtered := make([]int64, 0, len(accountIDs))
-	for _, accountID := range accountIDs {
-		if _, ok := onDutyAccounts[accountID]; ok {
-			filtered = append(filtered, accountID)
-		}
-	}
-	return filtered, nil
-}
-
-func addVisibleStudents(visibleByAccount map[int64]map[int64]struct{}, accountID int64, studentIDs []int64) {
-	if accountID <= 0 || len(studentIDs) == 0 {
-		return
-	}
-	if visibleByAccount[accountID] == nil {
-		visibleByAccount[accountID] = make(map[int64]struct{}, len(studentIDs))
-	}
-	for _, studentID := range studentIDs {
-		visibleByAccount[accountID][studentID] = struct{}{}
-	}
-}
-
-func uniqueInt64s(ids []int64) []int64 {
-	seen := make(map[int64]struct{}, len(ids))
-	unique := make([]int64, 0, len(ids))
-	for _, id := range ids {
-		if _, exists := seen[id]; exists {
-			continue
-		}
-		seen[id] = struct{}{}
-		unique = append(unique, id)
-	}
-	return unique
-}
-
-func sortedInt64Set(ids map[int64]struct{}) []int64 {
-	sorted := make([]int64, 0, len(ids))
-	for id := range ids {
-		sorted = append(sorted, id)
-	}
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
-	return sorted
-}
-
-// studentIDsByGroup retains which reported children belong to each education
-// group; flattening this relation would leak the total submission size across
-// group boundaries.
-func (n *absenceNotifier) studentIDsByGroup(ctx context.Context, studentIDs []int64) (map[int64][]int64, []int64, error) {
-	if n.students == nil {
-		return map[int64][]int64{}, nil, nil
-	}
-	students, err := n.students.FindReadScopeByIDs(ctx, studentIDs)
-	if err != nil {
-		return nil, nil, fmt.Errorf("load reported students: %w", err)
-	}
-	studentsByGroup := make(map[int64][]int64)
-	seen := make(map[int64]struct{}, len(students))
-	groupIDs := make([]int64, 0, len(students))
-	for _, studentID := range studentIDs {
-		student := students[studentID]
-		if student == nil || student.GroupID == nil {
-			continue
-		}
-		studentsByGroup[*student.GroupID] = append(studentsByGroup[*student.GroupID], studentID)
-		if _, dup := seen[*student.GroupID]; dup {
-			continue
-		}
-		seen[*student.GroupID] = struct{}{}
-		groupIDs = append(groupIDs, *student.GroupID)
-	}
-	return studentsByGroup, groupIDs, nil
 }
 
 func absenceBody(report AbsenceReport) string {

--- a/backend/services/notifications/absence_producer_mock_test.go
+++ b/backend/services/notifications/absence_producer_mock_test.go
@@ -198,8 +198,9 @@ func newAbsenceWorld() (notifications.AbsenceNotifier, *absenceWorld) {
 			absenceAdminStaff: activeModel.WorkSessionStatusPresent,
 		}},
 	}
-	producer := notifications.NewAbsenceNotifier(
-		w.notifier, w.consent, w.students, w.groups, w.staff, w.admins, w.settings, w.duty, nil, nil)
+	recipients := notifications.NewStaffRecipientResolver(
+		w.consent, w.students, w.groups, w.staff, w.admins, w.settings, w.duty)
+	producer := notifications.NewAbsenceNotifier(w.notifier, recipients, nil, nil)
 	return producer, w
 }
 
@@ -536,7 +537,7 @@ func TestAbsenceNotifierSwallowsFailures(t *testing.T) {
 // fallback audience.
 func TestAbsenceNotifierWithoutDependencies(t *testing.T) {
 	notifier := &captureNotifier{}
-	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	producer := notifications.NewAbsenceNotifier(nil, nil, nil, nil)
 	assert.NotPanics(t, func() {
 		producer.NotifyAbsenceReported(context.Background(), sickToday(absenceStudentA))
 	})

--- a/backend/services/notifications/staff_parent_message_producer.go
+++ b/backend/services/notifications/staff_parent_message_producer.go
@@ -1,0 +1,138 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+const staffParentMessageCooldown = time.Minute
+
+// StaffParentMessageReport identifies one guardian-authored thread message.
+// IDs are used only for recipient resolution, debounce and the authenticated
+// deep link; none is rendered in the notification copy.
+type StaffParentMessageReport struct {
+	TenantID       int64
+	ThreadID       int64
+	StudentID      int64
+	ActorAccountID int64
+}
+
+// StaffParentMessageNotifier tells responsible staff that a guardian wrote in
+// a child-related thread.
+type StaffParentMessageNotifier interface {
+	// NotifyStaffParentMessage is fire-and-forget. The message is already
+	// committed when callers invoke it, so notification failures are only logged.
+	NotifyStaffParentMessage(ctx context.Context, report StaffParentMessageReport)
+}
+
+type staffParentMessageNotifier struct {
+	notifier   Service
+	recipients StaffRecipientResolver
+	threads    userModel.ParentMessageThreadRepository
+	db         *bun.DB
+	logger     *slog.Logger
+}
+
+// NewStaffParentMessageNotifier builds the parent-message producer.
+func NewStaffParentMessageNotifier(
+	notifier Service,
+	recipients StaffRecipientResolver,
+	threads userModel.ParentMessageThreadRepository,
+	db *bun.DB,
+	logger *slog.Logger,
+) StaffParentMessageNotifier {
+	return &staffParentMessageNotifier{
+		notifier:   notifier,
+		recipients: recipients,
+		threads:    threads,
+		db:         db,
+		logger:     logger,
+	}
+}
+
+func (n *staffParentMessageNotifier) getLogger() *slog.Logger {
+	if n.logger == nil {
+		return slog.Default()
+	}
+	return n.logger
+}
+
+func (n *staffParentMessageNotifier) NotifyStaffParentMessage(ctx context.Context, report StaffParentMessageReport) {
+	if report.TenantID <= 0 {
+		return
+	}
+
+	var err error
+	if n.db == nil {
+		err = n.notify(ctx, report)
+	} else {
+		err = tenant.WithTenantTx(ctx, n.db, report.TenantID, func(txCtx context.Context, _ bun.Tx) error {
+			return n.notify(txCtx, report)
+		})
+	}
+	if err == nil || errors.Is(err, ErrDisabled) || errors.Is(err, ErrOutsideActiveWindow) {
+		return
+	}
+	n.getLogger().Warn("staff parent-message notification failed",
+		slog.Int64("tenant_id", report.TenantID),
+		slog.Int64("thread_id", report.ThreadID),
+		slog.String("error", err.Error()),
+	)
+}
+
+func (n *staffParentMessageNotifier) notify(ctx context.Context, report StaffParentMessageReport) error {
+	if n.notifier == nil || n.recipients == nil || n.threads == nil {
+		return nil
+	}
+	if report.ThreadID <= 0 || report.StudentID <= 0 {
+		return nil
+	}
+
+	accountIDs, err := n.resolveAccountIDs(ctx, report)
+	if err != nil || len(accountIDs) == 0 {
+		return err
+	}
+	claimed, err := n.threads.ClaimStaffMessageNotification(ctx, report.ThreadID, staffParentMessageCooldown)
+	if err != nil || !claimed {
+		return err
+	}
+	return n.notifier.Notify(ctx, staffParentMessageEvent(report, accountIDs))
+}
+
+func (n *staffParentMessageNotifier) resolveAccountIDs(ctx context.Context, report StaffParentMessageReport) ([]int64, error) {
+	scopes, err := n.recipients.Resolve(ctx, StaffRecipientRequest{
+		StudentIDs:         []int64{report.StudentID},
+		NotificationType:   TypeStaffParentMessage,
+		ExcludedAccountIDs: []int64{report.ActorAccountID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	accountIDs := make([]int64, 0, len(scopes))
+	for _, scope := range scopes {
+		accountIDs = append(accountIDs, scope.AccountID)
+	}
+	return accountIDs, nil
+}
+
+func staffParentMessageEvent(report StaffParentMessageReport, accountIDs []int64) Event {
+	return Event{
+		Type:     TypeStaffParentMessage,
+		Title:    "Neue Nachricht von Eltern",
+		Body:     "Eltern haben der OGS eine neue Nachricht geschrieben.",
+		DeepLink: fmt.Sprintf("/messages/%d", report.ThreadID),
+		Priority: PriorityNormal,
+		Audience: Audience{
+			TenantID:        report.TenantID,
+			Scope:           ScopeStaff,
+			StaffAccountIDs: accountIDs,
+		},
+	}
+}

--- a/backend/services/notifications/staff_parent_message_producer_test.go
+++ b/backend/services/notifications/staff_parent_message_producer_test.go
@@ -1,0 +1,88 @@
+package notifications_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubStaffRecipients struct {
+	scopes  []notifications.StaffRecipientScope
+	request notifications.StaffRecipientRequest
+	err     error
+}
+
+func (s *stubStaffRecipients) Resolve(_ context.Context, request notifications.StaffRecipientRequest) ([]notifications.StaffRecipientScope, error) {
+	s.request = request
+	return s.scopes, s.err
+}
+
+type stubParentMessageThreadClaims struct {
+	userModel.ParentMessageThreadRepository
+	claimed  bool
+	threadID int64
+}
+
+func (s *stubParentMessageThreadClaims) ClaimStaffMessageNotification(_ context.Context, threadID int64, _ time.Duration) (bool, error) {
+	s.threadID = threadID
+	return s.claimed, nil
+}
+
+func TestStaffParentMessageNotifierAddressesResponsibleStaff(t *testing.T) {
+	notifier := &captureNotifier{}
+	recipients := &stubStaffRecipients{scopes: []notifications.StaffRecipientScope{
+		{AccountID: absenceAccountA, StudentIDs: []int64{absenceStudentA}},
+		{AccountID: absenceAdmin, StudentIDs: []int64{absenceStudentA}},
+	}}
+	claims := &stubParentMessageThreadClaims{claimed: true}
+	producer := notifications.NewStaffParentMessageNotifier(notifier, recipients, claims, nil, nil)
+
+	producer.NotifyStaffParentMessage(context.Background(), notifications.StaffParentMessageReport{
+		TenantID:       absenceTenant,
+		ThreadID:       901,
+		StudentID:      absenceStudentA,
+		ActorAccountID: absenceActorAcct,
+	})
+
+	require.Len(t, notifier.events, 1)
+	event := notifier.events[0]
+	assert.Equal(t, notifications.TypeStaffParentMessage, event.Type)
+	assert.Equal(t, notifications.ScopeStaff, event.Audience.Scope)
+	assert.Equal(t, absenceTenant, event.Audience.TenantID)
+	assert.Equal(t, []int64{absenceAccountA, absenceAdmin}, event.Audience.StaffAccountIDs)
+	assert.Equal(t, "Neue Nachricht von Eltern", event.Title)
+	assert.Equal(t, "Eltern haben der OGS eine neue Nachricht geschrieben.", event.Body)
+	assert.Equal(t, "/messages/901", event.DeepLink)
+	assert.Equal(t, notifications.PriorityNormal, event.Priority)
+	assert.Empty(t, event.Data)
+
+	assert.Equal(t, notifications.StaffRecipientRequest{
+		StudentIDs:         []int64{absenceStudentA},
+		NotificationType:   notifications.TypeStaffParentMessage,
+		ExcludedAccountIDs: []int64{absenceActorAcct},
+	}, recipients.request)
+	assert.Equal(t, int64(901), claims.threadID)
+}
+
+func TestStaffParentMessageNotifierSuppressesUnclaimedThread(t *testing.T) {
+	notifier := &captureNotifier{}
+	recipients := &stubStaffRecipients{scopes: []notifications.StaffRecipientScope{
+		{AccountID: absenceAccountA, StudentIDs: []int64{absenceStudentA}},
+	}}
+	claims := &stubParentMessageThreadClaims{claimed: false}
+	producer := notifications.NewStaffParentMessageNotifier(notifier, recipients, claims, nil, nil)
+
+	producer.NotifyStaffParentMessage(context.Background(), notifications.StaffParentMessageReport{
+		TenantID:  absenceTenant,
+		ThreadID:  901,
+		StudentID: absenceStudentA,
+	})
+
+	assert.Empty(t, notifier.events)
+	assert.Equal(t, int64(901), claims.threadID)
+}

--- a/backend/services/notifications/staff_recipient_resolver.go
+++ b/backend/services/notifications/staff_recipient_resolver.go
@@ -1,0 +1,294 @@
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	educationModel "github.com/moto-nrw/project-phoenix/models/education"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// StaffRecipientRequest describes a child-related staff notification. The
+// resolver builds recipients from responsibility first, then applies personal
+// consent and the tenant's on-duty rule.
+type StaffRecipientRequest struct {
+	StudentIDs         []int64
+	NotificationType   string
+	ExcludedAccountIDs []int64
+}
+
+// StaffRecipientScope is one account and the requested children that account
+// is responsible for. Keeping the child subset prevents aggregate copy from
+// revealing children outside a group supervisor's responsibility.
+type StaffRecipientScope struct {
+	AccountID  int64
+	StudentIDs []int64
+}
+
+// StaffRecipientResolver resolves the responsible staff accounts for child-
+// related notifications.
+type StaffRecipientResolver interface {
+	Resolve(ctx context.Context, request StaffRecipientRequest) ([]StaffRecipientScope, error)
+}
+
+type staffRecipientResolver struct {
+	preferences  PreferenceService
+	students     userModel.StudentRepository
+	groups       educationModel.GroupRepository
+	staff        userModel.StaffRepository
+	accounts     authAccountReader
+	settings     settingsBoolReader
+	workSessions dutyReader
+}
+
+// authAccountReader is the slice of the account repository this resolver needs.
+type authAccountReader interface {
+	ListEffectiveAdminAccountIDs(ctx context.Context) ([]int64, error)
+}
+
+type settingsBoolReader interface {
+	ResolveBool(ctx context.Context, key string) (bool, error)
+}
+
+type dutyReader interface {
+	GetTodayPresenceMap(ctx context.Context) (map[int64]string, error)
+}
+
+// NewStaffRecipientResolver builds the shared responsibility resolver used by
+// personal staff notifications about children.
+func NewStaffRecipientResolver(
+	preferences PreferenceService,
+	students userModel.StudentRepository,
+	groups educationModel.GroupRepository,
+	staff userModel.StaffRepository,
+	accounts authAccountReader,
+	settings settingsBoolReader,
+	workSessions dutyReader,
+) StaffRecipientResolver {
+	return &staffRecipientResolver{
+		preferences:  preferences,
+		students:     students,
+		groups:       groups,
+		staff:        staff,
+		accounts:     accounts,
+		settings:     settings,
+		workSessions: workSessions,
+	}
+}
+
+func (r *staffRecipientResolver) Resolve(ctx context.Context, request StaffRecipientRequest) ([]StaffRecipientScope, error) {
+	if !r.configured() {
+		return nil, nil
+	}
+	allStudentIDs := uniqueInt64s(request.StudentIDs)
+	if len(allStudentIDs) == 0 {
+		return nil, nil
+	}
+
+	visibleByAccount, err := r.resolveVisibility(ctx, allStudentIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, accountID := range request.ExcludedAccountIDs {
+		delete(visibleByAccount, accountID)
+	}
+	if len(visibleByAccount) == 0 {
+		return nil, nil
+	}
+
+	optedIn, err := r.preferences.FilterOptedIn(ctx, request.NotificationType, sortedAccountIDs(visibleByAccount))
+	if err != nil {
+		return nil, err
+	}
+	optedIn, err = r.filterOnDutyAccounts(ctx, optedIn)
+	if err != nil {
+		return nil, err
+	}
+
+	return staffRecipientScopes(visibleByAccount, optedIn), nil
+}
+
+func (r *staffRecipientResolver) configured() bool {
+	return r.preferences != nil && r.students != nil && r.groups != nil && r.staff != nil &&
+		r.accounts != nil && r.settings != nil && r.workSessions != nil
+}
+
+func (r *staffRecipientResolver) resolveVisibility(ctx context.Context, studentIDs []int64) (map[int64]map[int64]struct{}, error) {
+	studentsByGroup, groupIDs, err := r.studentIDsByGroup(ctx, studentIDs)
+	if err != nil {
+		return nil, err
+	}
+	visibleByAccount := make(map[int64]map[int64]struct{})
+	if err := r.addGroupStaff(ctx, visibleByAccount, studentsByGroup, groupIDs); err != nil {
+		return nil, err
+	}
+	adminIDs, err := r.accounts.ListEffectiveAdminAccountIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve admin accounts: %w", err)
+	}
+	for _, accountID := range adminIDs {
+		addVisibleStudents(visibleByAccount, accountID, studentIDs)
+	}
+	return visibleByAccount, nil
+}
+
+func (r *staffRecipientResolver) addGroupStaff(ctx context.Context, visibleByAccount map[int64]map[int64]struct{}, studentsByGroup map[int64][]int64, groupIDs []int64) error {
+	if len(groupIDs) == 0 {
+		return nil
+	}
+	pairs, err := r.groups.ListStaffIDsByEducationGroupIDs(ctx, groupIDs, timezone.TodayDate())
+	if err != nil {
+		return fmt.Errorf("resolve supervising staff: %w", err)
+	}
+	staffIDs := make([]int64, 0, len(pairs))
+	for _, pair := range pairs {
+		staffIDs = append(staffIDs, pair.StaffID)
+	}
+	accountsByStaff, err := r.staff.ListAccountIDsByStaffIDs(ctx, staffIDs)
+	if err != nil {
+		return fmt.Errorf("resolve staff accounts: %w", err)
+	}
+	for _, pair := range pairs {
+		if accountID := accountsByStaff[pair.StaffID]; accountID > 0 {
+			addVisibleStudents(visibleByAccount, accountID, studentsByGroup[pair.GroupID])
+		}
+	}
+	return nil
+}
+
+func (r *staffRecipientResolver) filterOnDutyAccounts(ctx context.Context, accountIDs []int64) ([]int64, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+	onDutyOnly, err := r.settings.ResolveBool(ctx, configModel.KeyNotificationsOnDutyOnly)
+	if err != nil {
+		return nil, fmt.Errorf("resolve on-duty notification setting: %w", err)
+	}
+	if !onDutyOnly {
+		return accountIDs, nil
+	}
+
+	onDutyAccounts, err := r.onDutyAccountIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]int64, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if _, ok := onDutyAccounts[accountID]; ok {
+			filtered = append(filtered, accountID)
+		}
+	}
+	return filtered, nil
+}
+
+func (r *staffRecipientResolver) onDutyAccountIDs(ctx context.Context) (map[int64]struct{}, error) {
+	presence, err := r.workSessions.GetTodayPresenceMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load staff presence: %w", err)
+	}
+	onDutyStaffIDs := make([]int64, 0, len(presence))
+	for staffID, status := range presence {
+		if status == activeModel.WorkSessionStatusPresent || status == activeModel.WorkSessionStatusHomeOffice {
+			onDutyStaffIDs = append(onDutyStaffIDs, staffID)
+		}
+	}
+	if len(onDutyStaffIDs) == 0 {
+		return map[int64]struct{}{}, nil
+	}
+	accountsByStaff, err := r.staff.ListAccountIDsByStaffIDs(ctx, onDutyStaffIDs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve staff accounts for duty filter: %w", err)
+	}
+	onDutyAccounts := make(map[int64]struct{}, len(accountsByStaff))
+	for _, staffID := range onDutyStaffIDs {
+		if accountID := accountsByStaff[staffID]; accountID > 0 {
+			onDutyAccounts[accountID] = struct{}{}
+		}
+	}
+	return onDutyAccounts, nil
+}
+
+// studentIDsByGroup retains which requested children belong to each education
+// group; flattening this relation would leak the total submission size across
+// group boundaries.
+func (r *staffRecipientResolver) studentIDsByGroup(ctx context.Context, studentIDs []int64) (map[int64][]int64, []int64, error) {
+	students, err := r.students.FindReadScopeByIDs(ctx, studentIDs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load reported students: %w", err)
+	}
+	studentsByGroup := make(map[int64][]int64)
+	seen := make(map[int64]struct{}, len(students))
+	groupIDs := make([]int64, 0, len(students))
+	for _, studentID := range studentIDs {
+		student := students[studentID]
+		if student == nil || student.GroupID == nil {
+			continue
+		}
+		studentsByGroup[*student.GroupID] = append(studentsByGroup[*student.GroupID], studentID)
+		if _, dup := seen[*student.GroupID]; dup {
+			continue
+		}
+		seen[*student.GroupID] = struct{}{}
+		groupIDs = append(groupIDs, *student.GroupID)
+	}
+	return studentsByGroup, groupIDs, nil
+}
+
+func addVisibleStudents(visibleByAccount map[int64]map[int64]struct{}, accountID int64, studentIDs []int64) {
+	if accountID <= 0 || len(studentIDs) == 0 {
+		return
+	}
+	if visibleByAccount[accountID] == nil {
+		visibleByAccount[accountID] = make(map[int64]struct{}, len(studentIDs))
+	}
+	for _, studentID := range studentIDs {
+		visibleByAccount[accountID][studentID] = struct{}{}
+	}
+}
+
+func sortedAccountIDs(visibleByAccount map[int64]map[int64]struct{}) []int64 {
+	accountIDs := make([]int64, 0, len(visibleByAccount))
+	for accountID := range visibleByAccount {
+		accountIDs = append(accountIDs, accountID)
+	}
+	sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
+	return accountIDs
+}
+
+func staffRecipientScopes(visibleByAccount map[int64]map[int64]struct{}, accountIDs []int64) []StaffRecipientScope {
+	scopes := make([]StaffRecipientScope, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		studentIDs := sortedInt64Set(visibleByAccount[accountID])
+		if len(studentIDs) > 0 {
+			scopes = append(scopes, StaffRecipientScope{AccountID: accountID, StudentIDs: studentIDs})
+		}
+	}
+	sort.Slice(scopes, func(i, j int) bool { return scopes[i].AccountID < scopes[j].AccountID })
+	return scopes
+}
+
+func uniqueInt64s(ids []int64) []int64 {
+	seen := make(map[int64]struct{}, len(ids))
+	unique := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	return unique
+}
+
+func sortedInt64Set(ids map[int64]struct{}) []int64 {
+	sorted := make([]int64, 0, len(ids))
+	for id := range ids {
+		sorted = append(sorted, id)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted
+}

--- a/backend/services/notifications/staff_recipient_resolver_test.go
+++ b/backend/services/notifications/staff_recipient_resolver_test.go
@@ -1,0 +1,52 @@
+package notifications_test
+
+import (
+	"context"
+	"testing"
+
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	userModel "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/services/notifications"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaffRecipientResolverReachesGroupTeamAndAdmins(t *testing.T) {
+	groupID := absenceGroupA
+	resolver := notifications.NewStaffRecipientResolver(
+		&stubConsent{allowed: map[int64]struct{}{
+			absenceAccountA: {},
+			absenceAdmin:    {},
+		}},
+		&fakeStudentReader{byID: map[int64]*userModel.Student{
+			absenceStudentA: {GroupID: &groupID},
+		}},
+		&fakeGroupReader{staffByGroup: map[int64][]int64{
+			absenceGroupA: {absenceStaffA},
+		}},
+		&fakeStaffAccountReader{accounts: map[int64]int64{
+			absenceStaffA:     absenceAccountA,
+			absenceAdminStaff: absenceAdmin,
+		}},
+		&fakeAdminReader{ids: []int64{absenceAdmin}},
+		&fakeOnDutySetting{enabled: true},
+		&fakeDutyReader{presence: map[int64]string{
+			absenceStaffA:     activeModel.WorkSessionStatusPresent,
+			absenceAdminStaff: activeModel.WorkSessionStatusPresent,
+		}},
+	)
+
+	scopes, err := resolver.Resolve(context.Background(), notifications.StaffRecipientRequest{
+		StudentIDs:       []int64{absenceStudentA},
+		NotificationType: notifications.TypeStudentAbsenceReported,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, scopes, 2)
+	byAccount := make(map[int64][]int64, len(scopes))
+	for _, scope := range scopes {
+		byAccount[scope.AccountID] = scope.StudentIDs
+	}
+	assert.Equal(t, []int64{absenceStudentA}, byAccount[absenceAccountA])
+	assert.Equal(t, []int64{absenceStudentA}, byAccount[absenceAdmin])
+}

--- a/backend/services/notifications/types.go
+++ b/backend/services/notifications/types.go
@@ -57,6 +57,7 @@ const (
 	TypeActivityOverdue        = "activity_overdue"
 	TypeMyActivityStarting     = "my_activity_starting"
 	TypeStudentAbsenceReported = "student_absence_reported"
+	TypeStaffParentMessage     = "staff_parent_message"
 	TypeParentAnnouncement     = "parent_announcement"
 
 	// Parent-facing types added with issue #1671. Each one mirrors a channel the
@@ -199,6 +200,15 @@ func init() {
 		Group:       GroupChildren,
 		Portal:      PortalStaff,
 		TenantGate:  configModel.KeyNotificationsAbsenceReportedEnabled,
+		SortOrder:   1,
+	})
+	RegisterType(TypeDefinition{
+		Key:         TypeStaffParentMessage,
+		Label:       "Nachrichten von Eltern",
+		Description: "Wenn Eltern der OGS eine neue Nachricht schreiben.",
+		Group:       GroupMessages,
+		Portal:      PortalStaff,
+		TenantGate:  configModel.KeyParentNotesEnabled,
 		SortOrder:   1,
 	})
 

--- a/backend/services/notifications/types_test.go
+++ b/backend/services/notifications/types_test.go
@@ -28,7 +28,7 @@ func TestNotificationTypeKeysMatchReminders(t *testing.T) {
 func TestNotificationTypeCatalogue(t *testing.T) {
 	t.Run("staff catalogue is grouped and ordered", func(t *testing.T) {
 		defs := notifications.TypesForPortal(notifications.PortalStaff)
-		require.Len(t, defs, 6)
+		require.Len(t, defs, 7)
 
 		keys := make([]string, len(defs))
 		for i, def := range defs {
@@ -41,6 +41,7 @@ func TestNotificationTypeCatalogue(t *testing.T) {
 			notifications.TypeActivityOverdue,
 			notifications.TypeMyActivityStarting,
 			notifications.TypeStudentAbsenceReported,
+			notifications.TypeStaffParentMessage,
 		}, keys, "order is fixed by group then SortOrder, not by registration order")
 	})
 
@@ -88,6 +89,7 @@ func TestNotificationTypeCatalogue(t *testing.T) {
 			notifications.TypeActivityStart:             configModel.KeyRemindersActivityStartEnabled,
 			notifications.TypeActivityOverdue:           configModel.KeyRemindersActivityOverdueEnabled,
 			notifications.TypeStudentAbsenceReported:    configModel.KeyNotificationsAbsenceReportedEnabled,
+			notifications.TypeStaffParentMessage:        configModel.KeyParentNotesEnabled,
 			notifications.TypeParentMessage:             configModel.KeyParentNotesEnabled,
 			notifications.TypeParentRequestDecided:      configModel.KeyParentNotesEnabled,
 			notifications.TypeParentAppointmentReminder: configModel.KeyCalendarAppointmentReminderEnabled,

--- a/backend/services/parent/parent_messaging_read_service_test.go
+++ b/backend/services/parent/parent_messaging_read_service_test.go
@@ -19,6 +19,7 @@ import (
 	repositories "github.com/moto-nrw/project-phoenix/database/repositories"
 	configModels "github.com/moto-nrw/project-phoenix/models/config"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	notificationsSvc "github.com/moto-nrw/project-phoenix/services/notifications"
 	parentService "github.com/moto-nrw/project-phoenix/services/parent"
 	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -29,6 +30,10 @@ import (
 // profile repo (so resolveGuardianName resolves a real name) and returns the
 // service, broadcaster, db, and repo factory.
 func buildReadService(t *testing.T, enabled bool) (parentService.Service, *testpkg.RecordingBroadcaster, *bun.DB, *repositories.Factory) {
+	return buildReadServiceWithNotifier(t, enabled, nil)
+}
+
+func buildReadServiceWithNotifier(t *testing.T, enabled bool, notifier notificationsSvc.StaffParentMessageNotifier) (parentService.Service, *testpkg.RecordingBroadcaster, *bun.DB, *repositories.Factory) {
 	t.Helper()
 	db := testpkg.SetupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
@@ -48,14 +53,23 @@ func buildReadService(t *testing.T, enabled bool) (parentService.Service, *testp
 				configModels.KeyGuardianParentInviteMode: configModels.ParentInviteModeDisabled,
 			},
 		},
-		Broadcaster:       bc,
-		MessageThreadRepo: repos.ParentMessageThread,
-		MessageRepo:       repos.ParentMessage,
-		MessageReadRepo:   repos.ParentMessageRead,
-		DB:                db,
-		Logger:            slog.Default(),
+		Broadcaster:           bc,
+		MessageThreadRepo:     repos.ParentMessageThread,
+		MessageRepo:           repos.ParentMessage,
+		MessageReadRepo:       repos.ParentMessageRead,
+		ParentMessageNotifier: notifier,
+		DB:                    db,
+		Logger:                slog.Default(),
 	})
 	return svc, bc, db, repos
+}
+
+type recordingStaffParentMessageNotifier struct {
+	reports []notificationsSvc.StaffParentMessageReport
+}
+
+func (n *recordingStaffParentMessageNotifier) NotifyStaffParentMessage(_ context.Context, report notificationsSvc.StaffParentMessageReport) {
+	n.reports = append(n.reports, report)
 }
 
 // seedStaffReply inserts a staff-authored message into the guardian's child
@@ -221,4 +235,21 @@ func TestPostChildMessage_DenormalizesGuardianName(t *testing.T) {
 	require.Len(t, view.Messages, 1)
 	assert.Equal(t, "Sabine Schneider", view.Messages[0].SenderName,
 		"the guardian's tenant-scoped profile name is denormalized onto the message")
+}
+
+func TestPostChildMessage_NotifiesStaffAfterCommit(t *testing.T) {
+	notifier := &recordingStaffParentMessageNotifier{}
+	svc, _, db, _ := buildReadServiceWithNotifier(t, true, notifier)
+	chain := testpkg.CreateTestParentGuardianChain(t, db)
+	defer testpkg.CleanupParentGuardianChain(t, db, chain)
+
+	view, err := svc.PostChildMessage(context.Background(), chain.AccountID, chain.StudentID, "Hallo OGS")
+	require.NoError(t, err)
+	require.Len(t, notifier.reports, 1)
+	assert.Equal(t, notificationsSvc.StaffParentMessageReport{
+		TenantID:       chain.TenantID,
+		ThreadID:       view.ThreadID,
+		StudentID:      chain.StudentID,
+		ActorAccountID: chain.AccountID,
+	}, notifier.reports[0])
 }

--- a/backend/services/parent/parent_messaging_service.go
+++ b/backend/services/parent/parent_messaging_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	notificationsSvc "github.com/moto-nrw/project-phoenix/services/notifications"
 	"github.com/moto-nrw/project-phoenix/services/parentmessaging"
 	"github.com/moto-nrw/project-phoenix/tenant"
 )
@@ -346,6 +347,14 @@ func (s *service) PostChildMessage(ctx context.Context, accountID, studentID int
 		capturedThread := view.ThreadID
 		tenant.RegisterAfterCommit(txCtx, func() {
 			s.broadcastParentMessage(captured, accountID, capturedThread, studentID)
+			if s.ParentMessageNotifier != nil {
+				s.ParentMessageNotifier.NotifyStaffParentMessage(context.Background(), notificationsSvc.StaffParentMessageReport{
+					TenantID:       captured,
+					ThreadID:       capturedThread,
+					StudentID:      studentID,
+					ActorAccountID: accountID,
+				})
+			}
 		})
 		return nil
 	})

--- a/backend/services/parent/parent_service.go
+++ b/backend/services/parent/parent_service.go
@@ -447,6 +447,9 @@ type ServiceConfig struct {
 	// AbsenceNotifier informs the child's group and the office that an absence
 	// was reported. Optional and best-effort, after-commit only.
 	AbsenceNotifier notificationsSvc.AbsenceNotifier
+	// StaffParentMessageNotifier informs responsible staff after a guardian
+	// message commits. Optional and best-effort, after-commit only.
+	ParentMessageNotifier notificationsSvc.StaffParentMessageNotifier
 
 	// Emitter posts notification pills into the child's parent-OGS thread for
 	// self-service actions (sick note, one-day pickup change) and master-data

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -21,7 +21,7 @@ they are checked in this order:
 | 2 | Delivery window `notifications.active_window_start`/`_end` (`test` events exempt) | `router.withinActiveWindow` |
 | 3 | The type's school-wide gate, if it has one (`TypeDefinition.TenantGate`) | `PreferenceService.FilterOptedIn` |
 | 4 | The recipient's own consent for that type | `PreferenceService.FilterOptedIn` |
-| 5 | `notifications.on_duty_only`, for personal staff notifications | the reminder tick / absence producer |
+| 5 | `notifications.on_duty_only`, for personal staff notifications | the reminder tick / shared staff recipient resolver |
 
 Gate 1 defaults to **on** since the personal-notification epic. That is only
 safe because gates 3–5 exist: every producer routes through consent, and an
@@ -309,6 +309,23 @@ all three staff-side entry points
 `excused_request_service.go`). Every call runs after the absence transaction
 commits; the producer opens a fresh tenant transaction for its RLS-scoped
 recipient and consent reads.
+
+### Guardian messages to staff (`services/notifications/staff_parent_message_producer.go`)
+
+After a guardian message commits, `NotifyStaffParentMessage` addresses the
+child's fixed-group staff, today's active substitutions and the school's
+effective admins. The shared staff recipient resolver then applies the
+`staff_parent_message` consent and `notifications.on_duty_only`. The guardian
+account that wrote the message is excluded in case it also has a staff role.
+
+The notification uses `ScopeStaff`, contains no child or guardian name and
+opens `/messages/{threadID}`. A database-backed claim on the thread suppresses
+further notifications for 60 seconds, so a short sequence of chat messages
+does not create one system notification per message. The existing
+`parent_message` SSE broadcast still updates the unread badge independently.
+Existing accounts receive no preference backfill: because no prior staff
+notification existed for this direction, the new switch starts off until each
+person explicitly enables it.
 
 ### Parent announcements (`services/announcement/service.go`)
 

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1795,7 +1795,11 @@ export const appChapters: readonly GuideChapter[] = [
           "Jede Person entscheidet selbst, worüber sie Bescheid bekommt. Ohne diese Auswahl wird nichts verschickt, auch nicht als Push. Die Auswahl gilt für alle Geräte.",
         steps: [
           "Im eigenen Profil den Abschnitt `Benachrichtigungen` öffnen.",
-          "Die gewünschten Arten einschalten. Sie sind nach Themen sortiert: `Abholungen` (anstehend, überfällig), `Aktivitäten` (Aktivität im eigenen Aufsichtsraum, nicht gestartete Aktivität, eigener Einsatz aus dem Betreuungsplan) und `Kinder` (Krankmeldung eines Kindes aus den eigenen Gruppen).",
+          "Die gewünschten Arten einschalten. Sie sind nach Themen sortiert.",
+          "`Abholungen`: anstehende und überfällige Abholungen.",
+          "`Aktivitäten`: Hinweise zu eigenen Räumen, Aktivitäten und Einsätzen.",
+          "`Kinder`: Krankmeldungen für Kinder aus den eigenen Gruppen.",
+          "`Mitteilungen`: neue Nachrichten von Eltern.",
           "Jeder Schalter speichert sofort. `Alle deaktivieren` oben rechts schaltet alles auf einmal ab.",
           "Steht unter einer Art `Von Ihrer Schule derzeit deaktiviert`, bleibt sie still. Der eigene Schalter darf trotzdem an bleiben und greift wieder, sobald die Schule die Art einschaltet.",
         ],
@@ -1804,8 +1808,7 @@ export const appChapters: readonly GuideChapter[] = [
           body: "Diese Auswahl beantwortet `worüber`, der nächste Schritt `auf welchem Gerät`. Ohne Push-Freigabe erscheinen die Hinweise weiterhin in der geöffneten App; ohne Auswahl hier kommt auf keinem Weg etwas an.",
           tone: "blue",
         },
-        screenshot:
-          "Profilseite mit dem Abschnitt Benachrichtigungen: Schalter je Art, gruppiert nach Abholungen, Aktivitäten und Kinder, mit der Schaltfläche Alle deaktivieren.",
+        screenshot: "Benachrichtigungen im Profil, nach Themen geordnet.",
       },
       {
         id: "eigenen-geburtstag-anzeigen",


### PR DESCRIPTION
## Beschreibung

Neue Nachrichten aus dem Elternportal benachrichtigen das zuständige OGS-Team auch per Push und in der geöffneten App.

Empfänger sind die Mitarbeitenden der festen Gruppe des Kindes, die für heute eingetragenen Vertretungen sowie effektive Schul-Admins. Es gelten die bestehenden Benachrichtigungsregeln:

- `Eltern-OGS-Nachrichten` muss für die Schule aktiviert sein.
- Mitarbeitende aktivieren im Profil unter **Benachrichtigungen** → **Mitteilungen** den Typ **Nachrichten von Eltern**.
- Bei aktivem `Nur während des Dienstes` erhalten nur anwesende Mitarbeitende oder Personen im Homeoffice Hinweise.
- Push benötigt eine aktive Subscription auf dem jeweiligen Gerät.

**Titel:** Neue Nachricht von Eltern  
**Text:** Eltern haben der OGS eine neue Nachricht geschrieben.

Die Benachrichtigung enthält keine Namen von Kindern oder Eltern und öffnet nach Anmeldung die Unterhaltung unter `/messages/{threadId}`. Weitere Nachrichten im selben Thread lösen für 60 Sekunden keine weitere Benachrichtigung aus; der bestehende ungelesene Zähler aktualisiert sich weiter.

Der neue persönliche Schalter ist für Bestandskonten zunächst aus. Es gibt keinen Backfill, da diese Benachrichtigungsrichtung neu ist.

Die Empfängerauflösung für Krankmeldungen und Elternnachrichten nutzt nun dieselbe Logik für Gruppenverantwortung, Vertretungen, Admins, Opt-in und Dienststatus. Die In-App-Hilfe ergänzt die Kategorie **Mitteilungen**.

## Rollout

Migration `1.15.298` ergänzt den Nachrichten-Thread um den datenbankgestützten Zeitpunkt für die 60-Sekunden-Entprellung.

## Related Issues

- Closes #2363

## Tests

Aktualisiert: Unit- und Integrationstests für Empfängerauflösung, Versand nach Commit und Entprellung.

```bash
cd backend && APP_ENV=test go test -p 1 ./...
cd backend && golangci-lint run --timeout 10m
cd frontend && pnpm run check
```

## Screenshots

Keine neue UI-Komponente. Der neue Typ erscheint automatisch in den Profil-Einstellungen; die In-App-Hilfe wurde ergänzt.
