### PR TITLE
fix(iot-checkin): offer daily checkout from the Schulhof

### DIFF
--- a/backend/api/iot/checkin/schulhof_daily_checkout_test.go
+++ b/backend/api/iot/checkin/schulhof_daily_checkout_test.go
@@ -1,0 +1,242 @@
+package checkin_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// TestDeviceCheckout_SchulhofOffersNachHauseWithoutAutoSendingHome drives the
+// GS-Barnstorf regression (#2377) through the real handler chain: a child whose
+// education group owns a room checks in at the Schulhof and scans out there
+// again.
+//
+// Both halves of the contract are asserted together on purpose, because fixing
+// one by breaking the other is the trap this bug invites:
+//
+//   - daily_checkout_available must be true, or PyrePortal hides "nach Hause"
+//     and the child stays "unterwegs" (the reported bug); and
+//   - the action must stay "checked_out", NOT "checked_out_daily" — PyrePortal
+//     builds its destination modal only for "checked_out", so an upgraded
+//     action would show no buttons at all and silently send home every child
+//     who scanned out at the yard, including those heading back inside.
+func TestDeviceCheckout_SchulhofOffersNachHauseWithoutAutoSendingHome(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	// No configured checkout time → the time gate is open, so this test
+	// exercises the ROOM gate in isolation. Restored afterwards so a value in
+	// the developer's .env cannot leak into (or out of) this test.
+	previousCheckoutTime, hadCheckoutTime := os.LookupEnv("STUDENT_DAILY_CHECKOUT_TIME")
+	require.NoError(t, os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME"))
+	defer func() {
+		if hadCheckoutTime {
+			_ = os.Setenv("STUDENT_DAILY_CHECKOUT_TIME", previousCheckoutTime)
+		}
+	}()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "schulhof-home")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "SchulhofHome", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "SchulhofHome", "Student", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("SCHULHOFHOME%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	// The whole point of the bug: the child's group HAS its own room, which is
+	// what made the old room gate reject every Schulhof checkout.
+	groupRoom := testpkg.CreateTestRoom(t, ctx.db, "Hausaufgaben 1/2")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, groupRoom.ID)
+
+	educationGroup := testpkg.CreateTestEducationGroup(t, ctx.db, "Hausaufgaben")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, educationGroup.ID)
+
+	defer assignGroupRoom(t, ctx, educationGroup.ID, groupRoom.ID)()
+	defer assignStudentToGroup(t, ctx, student.ID, educationGroup.ID)()
+
+	schulhof := createSchulhofRoom(t, ctx.db)
+	defer cleanupSchulhofInfrastructure(t, ctx.db, schulhof.ID)
+
+	router := chi.NewRouter()
+	router.Mount("/", ctx.resource.Router())
+
+	// Step 1: the child goes out to the yard (auto-creates the Schulhof
+	// activity/active group on first use).
+	checkinBody := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      schulhof.ID,
+	}
+	checkinReq := testutil.NewAuthenticatedRequest(t, "POST", "/checkin", checkinBody,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+	checkinRR := testutil.ExecuteRequest(router, checkinReq)
+	testutil.AssertSuccessResponse(t, checkinRR, http.StatusOK)
+
+	checkinData := responseData(t, checkinRR.Body.Bytes())
+	require.Equal(t, "checked_in", checkinData["action"])
+	require.Equal(t, "Schulhof", checkinData["room_name"])
+
+	// Step 2: the child scans out at the yard kiosk to go home.
+	checkoutBody := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkout",
+	}
+	checkoutReq := testutil.NewAuthenticatedRequest(t, "POST", "/checkin", checkoutBody,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+	)
+	checkoutRR := testutil.ExecuteRequest(router, checkoutReq)
+	testutil.AssertSuccessResponse(t, checkoutRR, http.StatusOK)
+
+	checkoutData := responseData(t, checkoutRR.Body.Bytes())
+
+	assert.Equal(t, true, checkoutData["daily_checkout_available"],
+		`the yard kiosk must offer "nach Hause" — without it children stay "unterwegs" (#2377)`)
+	assert.Equal(t, "checked_out", checkoutData["action"],
+		`the yard must not auto-send the child home: PyrePortal renders its destination modal only for "checked_out"`)
+}
+
+// TestDeviceCheckout_OrdinaryRoomDoesNotOfferNachHause is the counterpart: the
+// Schulhof branch must not have opened "nach Hause" everywhere. A child leaving
+// an ordinary room that is neither their group room nor the yard is still only
+// moving between rooms.
+func TestDeviceCheckout_OrdinaryRoomDoesNotOfferNachHause(t *testing.T) {
+	ctx := setupTestContext(t)
+	defer func() { _ = ctx.db.Close() }()
+
+	previousCheckoutTime, hadCheckoutTime := os.LookupEnv("STUDENT_DAILY_CHECKOUT_TIME")
+	require.NoError(t, os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME"))
+	defer func() {
+		if hadCheckoutTime {
+			_ = os.Setenv("STUDENT_DAILY_CHECKOUT_TIME", previousCheckoutTime)
+		}
+	}()
+
+	device := testpkg.CreateTestDevice(t, ctx.db, "ordinary-room")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, device.ID)
+
+	staff := testpkg.CreateTestStaff(t, ctx.db, "Ordinary", "Staff")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, staff.ID)
+
+	student := testpkg.CreateTestStudent(t, ctx.db, "Ordinary", "Student", "1a")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, student.ID)
+
+	tagID := fmt.Sprintf("ORDINARY%d", time.Now().UnixNano())
+	card := testpkg.CreateTestRFIDCard(t, ctx.db, tagID)
+	defer testpkg.CleanupRFIDCards(t, ctx.db, card.ID)
+	testpkg.LinkRFIDToStudent(t, ctx.db, student.PersonID, card.ID)
+
+	groupRoom := testpkg.CreateTestRoom(t, ctx.db, "Hausaufgaben 3/4")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, groupRoom.ID)
+
+	educationGroup := testpkg.CreateTestEducationGroup(t, ctx.db, "Hausaufgaben34")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, educationGroup.ID)
+
+	defer assignGroupRoom(t, ctx, educationGroup.ID, groupRoom.ID)()
+	defer assignStudentToGroup(t, ctx, student.ID, educationGroup.ID)()
+
+	// An ordinary room with its own running activity — not the group room, not
+	// the Schulhof.
+	otherRoom := testpkg.CreateTestRoom(t, ctx.db, "Musikraum")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, otherRoom.ID)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Musik")
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activity.ID)
+
+	activeGroup := testpkg.CreateTestActiveGroup(t, ctx.db, activity.ID, otherRoom.ID)
+	defer testpkg.CleanupActivityFixtures(t, ctx.db, activeGroup.ID)
+
+	router := chi.NewRouter()
+	router.Mount("/", ctx.resource.Router())
+
+	checkinBody := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkin",
+		"room_id":      otherRoom.ID,
+	}
+	checkinReq := testutil.NewAuthenticatedRequest(t, "POST", "/checkin", checkinBody,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+		testutil.WithStaffContext(staff),
+	)
+	checkinRR := testutil.ExecuteRequest(router, checkinReq)
+	testutil.AssertSuccessResponse(t, checkinRR, http.StatusOK)
+	require.Equal(t, "checked_in", responseData(t, checkinRR.Body.Bytes())["action"])
+
+	checkoutBody := map[string]interface{}{
+		"student_rfid": card.ID,
+		"action":       "checkout",
+	}
+	checkoutReq := testutil.NewAuthenticatedRequest(t, "POST", "/checkin", checkoutBody,
+		testutil.WithDeviceContext(createTestDeviceContext(device)),
+	)
+	checkoutRR := testutil.ExecuteRequest(router, checkoutReq)
+	testutil.AssertSuccessResponse(t, checkoutRR, http.StatusOK)
+
+	checkoutData := responseData(t, checkoutRR.Body.Bytes())
+	assert.Equal(t, "checked_out", checkoutData["action"])
+	assert.Equal(t, false, checkoutData["daily_checkout_available"],
+		"an ordinary room must not offer nach Hause")
+}
+
+// responseData unwraps the standard {"data": {...}} envelope.
+func responseData(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+
+	response := testutil.ParseJSONResponse(t, body)
+	data, ok := response["data"].(map[string]interface{})
+	require.True(t, ok, "response should have a data field")
+	return data
+}
+
+// assignGroupRoom points an education group at its group room and returns the
+// undo. The fixture helper creates roomless groups, and a group WITH a room is
+// precisely the configuration that triggered #2377.
+//
+// The caller must defer the returned undo: the shared fixture cleanup deletes
+// the room while education.groups still references it, and that FK nulls the
+// row's tenant_id, which the NOT NULL constraint then rejects — leaving the
+// fixture behind.
+func assignGroupRoom(t *testing.T, ctx *testContext, groupID, roomID int64) func() {
+	t.Helper()
+
+	setColumn(t, ctx, "education.groups", "room_id", roomID, groupID)
+	return func() { setColumn(t, ctx, "education.groups", "room_id", nil, groupID) }
+}
+
+// assignStudentToGroup gives the student the group membership both daily
+// checkout gates require, and returns the undo the caller must defer (same
+// cleanup-ordering reason as assignGroupRoom).
+func assignStudentToGroup(t *testing.T, ctx *testContext, studentID, groupID int64) func() {
+	t.Helper()
+
+	setColumn(t, ctx, "users.students", "group_id", groupID, studentID)
+	return func() { setColumn(t, ctx, "users.students", "group_id", nil, studentID) }
+}
+
+// setColumn writes a single column on a fixture row, using nil to clear it.
+func setColumn(t *testing.T, ctx *testContext, table, column string, value any, id int64) {
+	t.Helper()
+
+	_, err := ctx.db.NewUpdate().
+		TableExpr(table).
+		Set(column+" = ?", value).
+		Where("id = ?", id).
+		Exec(testutil.TenantContext(1))
+	require.NoError(t, err, "failed to set %s.%s", table, column)
+}

--- a/backend/services/iot/checkin/checkout_gate.go
+++ b/backend/services/iot/checkin/checkout_gate.go
@@ -2,6 +2,7 @@ package checkin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	configSvc "github.com/moto-nrw/project-phoenix/services/config"
+	facilitiesSvc "github.com/moto-nrw/project-phoenix/services/facilities"
 )
 
 // timeNow is a package-local clock hook that tests may override to pin the
@@ -63,15 +65,35 @@ func (s *CheckinService) studentDailyCheckoutTime(ctx context.Context) (*time.Ti
 	return &checkoutTime, nil
 }
 
-// ShouldUpgradeToDailyCheckout checks if a checkout should be upgraded to daily checkout.
+// ShouldUpgradeToDailyCheckout reports whether a plain checkout should be
+// rewritten to "checked_out_daily" — the child went home, without being asked.
+//
+// This is deliberately STRICTER than ShouldShowDailyCheckoutWithGroup: the
+// upgrade decides FOR the child, so it only fires where leaving is unambiguous
+// (the child's own group room). PyrePortal builds its destination modal only
+// for action "checked_out", so anything upgraded here shows no buttons at all
+// — see the contract note on ShouldShowDailyCheckoutWithGroup.
 func (s *CheckinService) ShouldUpgradeToDailyCheckout(ctx context.Context, action string, student *users.Student, currentVisit *active.Visit) bool {
 	if action != "checked_out" {
 		return false
 	}
-	if student.GroupID == nil || currentVisit == nil || currentVisit.ActiveGroup == nil {
+	if !dailyCheckoutPreconditions(student, currentVisit) {
 		return false
 	}
-	return s.ShouldShowDailyCheckoutWithGroup(ctx, student, currentVisit)
+	if !s.IsAfterCheckoutTimeGate(ctx, student) {
+		return false
+	}
+	return s.isFromOwnGroupRoom(ctx, student, currentVisit)
+}
+
+// dailyCheckoutPreconditions reports whether the student/visit pair carries the
+// data both daily-checkout gates need: a group membership and a resolved active
+// group on the visit being closed.
+func dailyCheckoutPreconditions(student *users.Student, currentVisit *active.Visit) bool {
+	if student == nil || student.GroupID == nil {
+		return false
+	}
+	return currentVisit != nil && currentVisit.ActiveGroup != nil
 }
 
 // IsAfterCheckoutTimeGate checks whether the current time is past the applicable
@@ -144,12 +166,23 @@ func (s *CheckinService) isAfterGlobalCheckoutTime(ctx context.Context) bool {
 	return timeNow().After(*checkoutTime)
 }
 
-// ShouldShowDailyCheckoutWithGroup checks if daily checkout should be shown by verifying education group room.
+// ShouldShowDailyCheckoutWithGroup reports whether the kiosk may OFFER "nach
+// Hause" after this checkout — it drives the daily_checkout_available response
+// flag that PyrePortal renders the button from.
+//
+// Cross-repo contract: PyrePortal only builds the checkout destination modal
+// for action "checked_out" (ActivityScanningPage: handleCheckoutAction runs in
+// that case alone). A response flagged available but upgraded to
+// "checked_out_daily" therefore shows the child NO buttons, so this predicate
+// must stay independent of ShouldUpgradeToDailyCheckout rather than share it.
+//
+// Two rooms qualify as "on the way out":
+//   - the child's own group room (or any room, when the group has none), and
+//   - the Schulhof, which since #2161 is a regular room but is precisely the
+//     route home. Without it a yard kiosk never offered "nach Hause" and
+//     children stayed "unterwegs" until staff logged them out by hand (#2377).
 func (s *CheckinService) ShouldShowDailyCheckoutWithGroup(ctx context.Context, student *users.Student, currentVisit *active.Visit) bool {
-	if student.GroupID == nil {
-		return false
-	}
-	if currentVisit == nil || currentVisit.ActiveGroup == nil {
+	if !dailyCheckoutPreconditions(student, currentVisit) {
 		return false
 	}
 
@@ -157,15 +190,52 @@ func (s *CheckinService) ShouldShowDailyCheckoutWithGroup(ctx context.Context, s
 		return false
 	}
 
+	if s.isFromOwnGroupRoom(ctx, student, currentVisit) {
+		return true
+	}
+
+	// Checked last: it costs a room lookup, and the common case is a child
+	// leaving their own group room.
+	return s.isSchulhofRoom(ctx, currentVisit.ActiveGroup.RoomID)
+}
+
+// isFromOwnGroupRoom reports whether the visit being closed happened in the
+// room assigned to the student's education group. A group without a room is
+// unconstrained, so every room counts as its own.
+func (s *CheckinService) isFromOwnGroupRoom(ctx context.Context, student *users.Student, currentVisit *active.Visit) bool {
 	educationGroup, err := s.education.GetGroup(ctx, *student.GroupID)
 	if err != nil || educationGroup == nil {
 		return false
 	}
 
-	// If the group has no room assigned, daily checkout is available from any room
 	if educationGroup.RoomID == nil {
 		return true
 	}
 
 	return currentVisit.ActiveGroup.RoomID == *educationGroup.RoomID
+}
+
+// isSchulhofRoom reports whether roomID is this tenant's canonical Schulhof
+// room. A school that never provisioned the yard has no such room, which is
+// normal and simply means the answer is no — the scan must not fail over it.
+func (s *CheckinService) isSchulhofRoom(ctx context.Context, roomID int64) bool {
+	if s.facilities == nil {
+		return false
+	}
+
+	room, err := facilitiesSvc.FindCanonicalSchulhofRoom(ctx, s.facilities)
+	if err != nil {
+		if !errors.Is(err, facilitiesSvc.ErrRoomNotFound) {
+			// A non-canonical or unprotected room named "Schulhof" is a
+			// configuration problem that silently disables "nach Hause" at the
+			// yard kiosk — worth surfacing rather than swallowing.
+			s.getLogger().WarnContext(ctx, "could not resolve Schulhof room for daily-checkout gate",
+				slog.Int64("room_id", roomID),
+				slog.String("error", err.Error()),
+			)
+		}
+		return false
+	}
+
+	return room != nil && room.ID == roomID
 }

--- a/backend/services/iot/checkin/checkout_gate_internal_test.go
+++ b/backend/services/iot/checkin/checkout_gate_internal_test.go
@@ -16,13 +16,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/moto-nrw/project-phoenix/constants"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/education"
+	facilityModels "github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	educationSvc "github.com/moto-nrw/project-phoenix/services/education"
+	facilitiesSvc "github.com/moto-nrw/project-phoenix/services/facilities"
 	scheduleSvc "github.com/moto-nrw/project-phoenix/services/schedule"
 )
 
@@ -58,6 +61,31 @@ type mockEducationService struct {
 
 func (m *mockEducationService) GetGroup(_ context.Context, _ int64) (*education.Group, error) {
 	return m.group, m.err
+}
+
+// mockFacilitiesService is a minimal mock for testing the Schulhof branch of
+// ShouldShowDailyCheckoutWithGroup. Only FindRoomByName is exercised — it is
+// the single call FindCanonicalSchulhofRoom makes.
+type mockFacilitiesService struct {
+	facilitiesSvc.Service
+	room *facilityModels.Room
+	err  error
+}
+
+func (m *mockFacilitiesService) FindRoomByName(_ context.Context, _ string) (*facilityModels.Room, error) {
+	return m.room, m.err
+}
+
+// newSchulhofFacilities builds a facilities mock returning the canonical
+// Schulhof room (correct name, marked as a system room) under roomID.
+func newSchulhofFacilities(roomID int64) *mockFacilitiesService {
+	return &mockFacilitiesService{
+		room: &facilityModels.Room{
+			Model:    base.Model{ID: roomID},
+			Name:     constants.SchulhofRoomName,
+			IsSystem: true,
+		},
+	}
 }
 
 // newMockSettingsService builds a configtest.Mock reproducing the behavior of
@@ -488,6 +516,117 @@ func TestShouldShowDailyCheckoutWithGroup_EducationServiceError(t *testing.T) {
 	visit := &active.Visit{ActiveGroup: &active.Group{RoomID: 1}}
 	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
 	assert.False(t, result, "Should return false when education service errors")
+}
+
+// =============================================================================
+// Schulhof daily-checkout TESTS (#2377)
+//
+// A child leaving from the schoolyard must be OFFERED "nach Hause" without
+// being sent home automatically: PyrePortal renders its destination modal only
+// for action "checked_out", so the availability flag and the action upgrade
+// must disagree at the Schulhof.
+// =============================================================================
+
+// newSchulhofScenario builds the GS-Barnstorf shape: the student's group owns a
+// room, and the visit being closed happened in the Schulhof room instead.
+func newSchulhofScenario(t *testing.T) (*CheckinService, *users.Student, *active.Visit) {
+	t.Helper()
+	_ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME")
+
+	const groupRoomID, schulhofRoomID = int64(42), int64(7)
+	groupRoom := groupRoomID
+
+	s := &CheckinService{
+		settings:   newMockSettingsService(map[string]string{}, nil, nil),
+		education:  &mockEducationService{group: &education.Group{Model: base.Model{ID: 1}, RoomID: &groupRoom}},
+		facilities: newSchulhofFacilities(schulhofRoomID),
+	}
+	groupID := int64(1)
+	student := &users.Student{Model: base.Model{ID: 1}, GroupID: &groupID}
+	visit := &active.Visit{ActiveGroup: &active.Group{RoomID: schulhofRoomID}}
+	return s, student, visit
+}
+
+func TestShouldShowDailyCheckoutWithGroup_SchulhofRoom_Offered(t *testing.T) {
+	s, student, visit := newSchulhofScenario(t)
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.True(t, result, "nach Hause must be offered when checking out from the Schulhof")
+}
+
+func TestShouldUpgradeToDailyCheckout_SchulhofRoom_NoAutoUpgrade(t *testing.T) {
+	s, student, visit := newSchulhofScenario(t)
+
+	result := s.ShouldUpgradeToDailyCheckout(context.Background(), "checked_out", student, visit)
+	assert.False(t, result,
+		"the Schulhof must not auto-send the child home — the action has to stay checked_out so PyrePortal renders the destination modal")
+}
+
+func TestShouldShowDailyCheckoutWithGroup_SchulhofRoom_BeforeCheckoutTime(t *testing.T) {
+	s, student, visit := newSchulhofScenario(t)
+	// A configured time in the future must still suppress the offer: the
+	// Schulhof relaxes the ROOM gate, never the time gate.
+	require.NoError(t, os.Setenv("STUDENT_DAILY_CHECKOUT_TIME", "23:59"))
+	defer func() { _ = os.Unsetenv("STUDENT_DAILY_CHECKOUT_TIME") }()
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.False(t, result, "the time gate still applies at the Schulhof")
+}
+
+func TestShouldShowDailyCheckoutWithGroup_OrdinaryRoom_NotOffered(t *testing.T) {
+	s, student, _ := newSchulhofScenario(t)
+	// Same school, but the child left an ordinary room that is neither their
+	// group room nor the yard.
+	visit := &active.Visit{ActiveGroup: &active.Group{RoomID: 99}}
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.False(t, result, "an ordinary room must not offer nach Hause")
+}
+
+func TestShouldShowDailyCheckoutWithGroup_NoSchulhofRoomProvisioned(t *testing.T) {
+	s, student, visit := newSchulhofScenario(t)
+	// A school that never enabled the yard has no Schulhof room; the lookup
+	// failing must not make the scan fail.
+	s.facilities = &mockFacilitiesService{
+		err: &facilitiesSvc.FacilitiesError{Op: "find room by name", Err: facilitiesSvc.ErrRoomNotFound},
+	}
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.False(t, result, "a missing Schulhof room means not offered, not an error")
+}
+
+func TestShouldShowDailyCheckoutWithGroup_NonCanonicalSchulhofRoom(t *testing.T) {
+	s, student, visit := newSchulhofScenario(t)
+	// An unprotected room that merely matches case-insensitively must not be
+	// adopted as the yard (FindCanonicalSchulhofRoom rejects it).
+	s.facilities = &mockFacilitiesService{
+		room: &facilityModels.Room{
+			Model:    base.Model{ID: 7},
+			Name:     constants.SchulhofRoomName,
+			IsSystem: false,
+		},
+	}
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.False(t, result, "a non-system room named Schulhof must not unlock nach Hause")
+}
+
+func TestShouldShowDailyCheckoutWithGroup_NilFacilitiesService(t *testing.T) {
+	s, student, visit := newSchulhofScenario(t)
+	s.facilities = nil
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.False(t, result, "a nil facilities service must not panic the checkout gate")
+}
+
+func TestShouldUpgradeToDailyCheckout_OwnGroupRoom_StillUpgrades(t *testing.T) {
+	s, student, _ := newSchulhofScenario(t)
+	// Leaving the child's OWN group room keeps the pre-existing automatic
+	// daily checkout — this fix must not change that path.
+	visit := &active.Visit{ActiveGroup: &active.Group{RoomID: 42}}
+
+	result := s.ShouldUpgradeToDailyCheckout(context.Background(), "checked_out", student, visit)
+	assert.True(t, result, "the own-group-room auto-upgrade is unchanged")
 }
 
 // =============================================================================

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -2389,7 +2389,7 @@ export const nfcChapters: readonly GuideChapter[] = [
         ],
         callout: {
           title: "Welche Buttons erscheinen",
-          body: "Welche Ziele unter `Wohin geht ...?` angezeigt werden, steuern Sie in den Einstellungen unter `Geräte` (siehe Kapitel „NFC-Einstellungen prüfen“). `Schulhof` und `Toilette` legen automatisch einen passenden Raum an.",
+          body: "Welche Ziele unter `Wohin geht ...?` angezeigt werden, steuern Sie in den Einstellungen unter `Geräte` (siehe Kapitel „NFC-Einstellungen prüfen“). `Schulhof` und `Toilette` legen automatisch einen passenden Raum an. `nach Hause` erscheint beim Auschecken aus dem eigenen Gruppenraum und vom Schulhof; ist eine Checkout-Zeit hinterlegt, erst ab dieser Uhrzeit.",
           tone: "gray",
         },
         screenshot:


### PR DESCRIPTION
# Pull Request

  ## Description

  Since the Schulhof became a regular room (#2161), the daily-checkout room gate treated it like any other subject room.
  A yard kiosk therefore never set `daily_checkout_available`, PyrePortal hid the "nach Hause" button, and children who
  went home from the yard stayed "unterwegs" until staff logged them out by hand (reported by GS Barnstorf,
  17.08.2026).

  The obvious fix was wrong: `ShouldShowDailyCheckoutWithGroup` (the availability flag) and
  `ShouldUpgradeToDailyCheckout` (the action rewrite) shared one predicate. Relaxing that predicate would also have
  rewritten the action to `checked_out_daily` — and PyrePortal builds its destination modal only for `checked_out`.
  Every yard scan-out would then have shown *no* buttons at all and silently sent the child home, including children
  heading back inside.

  So the two are split instead:

  - **Availability** now also accepts the canonical Schulhof room, resolved via `FindCanonicalSchulhofRoom`, so a
  non-system room merely *named* "Schulhof" cannot unlock it, and a school without a yard room simply gets `false`
  rather than a failed scan.
  - **Action upgrade** keeps the strict own-group-room check, so a yard checkout stays `checked_out` and the child is
  offered the choice (nach Hause / zurück).

  Time gates are unchanged and still evaluated first; the room lookup runs only after they pass and only when the child
  did not leave their own group room. A misconfigured (non-canonical) Schulhof room is logged as a warning rather than
  swallowed, since it silently disables "nach Hause" at the yard kiosk.

  **Cross-repo:** backend-only. PyrePortal already renders the button from `daily_checkout_available` and needs no
  change.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Documentation update <!-- in-app help guide callout -->
  - [ ] Configuration change
  - [ ] Security improvement
  - [ ] Refactoring
  - [ ] Performance improvement
  - [x] Test addition/modification
  - [ ] CI/CD improvement

  ## Related Issues
  - Fixes #2377
  - Related to #2161 (Schulhof as a regular room)

  ## Testing
  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [ ] Manual testing performed
  - [ ] Testing documentation updated

  New service-level tests (`checkout_gate_internal_test.go`) pin the split behaviour:
  - Schulhof room → offered, but **not** auto-upgraded (`..._SchulhofRoom_Offered`, `..._SchulhofRoom_NoAutoUpgrade`)
  - Schulhof before the configured checkout time → not offered
  - ordinary room → not offered
  - school with no Schulhof room provisioned → `false`, no error
  - non-canonical room named "Schulhof" → not accepted
  - nil facilities service → `false`
  - own group room → still upgrades (regression guard)

  New hermetic API tests (`backend/api/iot/checkin/schulhof_daily_checkout_test.go`) drive a real device checkout
  through the router and assert the wire contract PyrePortal depends on: from the Schulhof the response carries `action:
  "checked_out"` **with** `daily_checkout_available: true`; from an ordinary room the flag stays false.

  Run with `go test ./services/iot/checkin/... ./api/iot/checkin/...` from `backend/`.

  ## Security Checklist
  - [x] I have followed the security guidelines
  - [x] No sensitive information is committed (secrets, credentials, certificates)
  - [x] Environment variables are properly managed with templates
  - [x] Code does not contain hardcoded secrets
  - [x] No potential security vulnerabilities introduced

  No auth, tenancy, or data-exposure surface changes. The room lookup goes through the existing tenant-scoped facilities
  service.

  ## Screenshots or Examples

  Wire-level behaviour change on a checkout scan from the Schulhof, after the checkout time:

  - **before** — `{ "action": "checked_out", "daily_checkout_available": false }` → button hidden, child stays
  "unterwegs"
  - **after** — `{ "action": "checked_out", "daily_checkout_available": true }` → kiosk offers "nach Hause", child still
  chooses

  ## Checklist
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, especially in hard-to-understand areas
  - [x] I have updated the documentation as needed
  - [x] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed
  screenshot
  - [x] All tests are passing
  - [x] My changes generate no new warnings or errors
  - [x] I have checked for and resolved any merge conflicts

  ## Additional Notes

  The help-guide callout in the NFC chapter now states when "nach Hause" appears: when checking out of the child's own
  group room **and** from the Schulhof, and — if a checkout time is configured — only from that time onward. No
  screenshot change was needed.

  The doc comments on both predicates now spell out the PyrePortal contract (`handleCheckoutAction` runs only for
  `action: "checked_out"`), so the next person is not tempted to merge them back into one.