### PR TITLE
Angebots-Editor: Wirkrichtung der Mitbuchungs-Regel eindeutig machen

### DIFF
--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -1825,7 +1825,8 @@ function CareOfferingAutomationFields({
                 </p>
               ))}
               <p className="mt-1 text-gray-500">
-                Die Regel gilt nur in diese Richtung, nicht umgekehrt.
+                Andersherum gilt das nicht: Wer nur {offeringLabelMidSentence}{" "}
+                wählt, bekommt die anderen Angebote nicht automatisch dazu.
               </p>
             </div>
           ) : null}

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -1769,6 +1769,15 @@ function CareOfferingAutomationFields({
         .sort((a, b) => a - b),
     });
   };
+  const offeringName = draft.name.trim();
+  // Sentence-start vs. mid-sentence variant of the same label.
+  const offeringLabel = offeringName ? `„${offeringName}“` : "Dieses Angebot";
+  const offeringLabelMidSentence = offeringName
+    ? `„${offeringName}“`
+    : "dieses Angebot";
+  const selectedTriggers = triggerOptions.filter((offering) =>
+    (draft.auto_add_trigger_offering_ids ?? []).includes(offering.id),
+  );
 
   return (
     <fieldset className="rounded-xl border border-gray-200 p-4">
@@ -1785,7 +1794,8 @@ function CareOfferingAutomationFields({
 
         <div className="rounded-lg border border-gray-100 bg-gray-50/70 p-3">
           <p className="text-xs font-medium text-gray-700">
-            Dieses Angebot mitbuchen, wenn Eltern eines dieser Angebote wählen:
+            {offeringLabel} wird automatisch mitgebucht, wenn Eltern eines
+            dieser Angebote wählen:
           </p>
           {triggerOptions.length > 0 ? (
             <div className="mt-2 grid gap-2 sm:grid-cols-2">
@@ -1806,6 +1816,19 @@ function CareOfferingAutomationFields({
               In dieser Phase gibt es noch kein anderes Angebot als Auslöser.
             </p>
           )}
+          {selectedTriggers.length > 0 ? (
+            <div className="mt-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700">
+              {selectedTriggers.map((trigger) => (
+                <p key={trigger.id}>
+                  Wenn Eltern „{trigger.name}“ wählen, wird{" "}
+                  {offeringLabelMidSentence} automatisch mitgebucht.
+                </p>
+              ))}
+              <p className="mt-1 text-gray-500">
+                Die Regel gilt nur in diese Richtung, nicht umgekehrt.
+              </p>
+            </div>
+          ) : null}
           {draft.auto_add_trigger_offering_ids.length > 0 &&
           draft.days_of_week_mode !== "parent_choice" ? (
             <p className="border-moto-amber/50 bg-moto-amber/10 text-moto-amber-strong mt-2 rounded-lg border px-3 py-2 text-xs">

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -610,7 +610,7 @@ describe("CareOfferingsEditor", () => {
 
     // No preview until a trigger is checked.
     expect(
-      screen.queryByText(/Die Regel gilt nur in diese Richtung/),
+      screen.queryByText(/Andersherum gilt das nicht/),
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("checkbox", { name: /Ganztag/ }));
@@ -622,7 +622,7 @@ describe("CareOfferingsEditor", () => {
     ).toBeVisible();
     expect(
       screen.getByText(
-        "Die Regel gilt nur in diese Richtung, nicht umgekehrt.",
+        "Andersherum gilt das nicht: Wer nur „Randstunde“ wählt, bekommt die anderen Angebote nicht automatisch dazu.",
       ),
     ).toBeVisible();
   });

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -579,6 +579,54 @@ describe("CareOfferingsEditor", () => {
     });
   });
 
+  it("names the edited offering in the auto-add rule and previews the rule direction", async () => {
+    mocks.listPhases.mockResolvedValue([phase()]);
+    mocks.listCareOfferings.mockResolvedValue([
+      offering({ id: "trigger", name: "Ganztag" }),
+    ]);
+
+    render(<CareOfferingsEditor />);
+    expect(await screen.findByText("Ganztag")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Neues Betreuungsangebot" }),
+    );
+
+    // Without a name yet, the generic wording stays.
+    expect(
+      screen.getByText(
+        "Dieses Angebot wird automatisch mitgebucht, wenn Eltern eines dieser Angebote wählen:",
+      ),
+    ).toBeVisible();
+
+    fireEvent.change(await waitForInputByName("name"), {
+      target: { value: "Randstunde" },
+    });
+    expect(
+      screen.getByText(
+        "„Randstunde“ wird automatisch mitgebucht, wenn Eltern eines dieser Angebote wählen:",
+      ),
+    ).toBeVisible();
+
+    // No preview until a trigger is checked.
+    expect(
+      screen.queryByText(/Die Regel gilt nur in diese Richtung/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Ganztag/ }));
+
+    expect(
+      screen.getByText(
+        "Wenn Eltern „Ganztag“ wählen, wird „Randstunde“ automatisch mitgebucht.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        "Die Regel gilt nur in diese Richtung, nicht umgekehrt.",
+      ),
+    ).toBeVisible();
+  });
+
   it("clears hidden auto-add trigger IDs when an edited offering changes phase", async () => {
     mocks.listPhases.mockResolvedValue([
       phase(),


### PR DESCRIPTION
Closes #2371

## Was ist neu

Im Regel-Abschnitt „Betreuungstage & Mitbuchung" des Angebots-Editors:

- Die Überschrift nennt das bearbeitete Angebot beim Namen: „**Randstunde**" wird automatisch mitgebucht, wenn Eltern eines dieser Angebote wählen. Solange noch kein Name eingegeben ist, bleibt die bisherige Formulierung „Dieses Angebot" stehen.
- Sobald mindestens ein Auslöser angehakt ist, erscheint ein Vorschau-Kasten mit einem Klartext-Satz pro Auslöser: „Wenn Eltern „Ganztag" wählen, wird „Randstunde" automatisch mitgebucht."
- Darunter steht der Hinweis: „Die Regel gilt nur in diese Richtung, nicht umgekehrt."

Damit ist die Wirkrichtung der Regel direkt beim Anlegen ablesbar (Folge des Support-Falls aus #2365).

## Tests

- Neuer Test in `enrollment-admin-editors.test.tsx`: Fallback-Text ohne Namen, benannte Überschrift, Vorschau erst nach Anhaken eines Auslösers, Richtungs-Hinweis.
- Voller Frontend-Suite-Lauf grün (13.989 Tests), `pnpm run check` grün.