### PR TITLE
feat: Klassenlisteneinträge für Kinder ohne OGS-Stammdatensatz (#2382)

### DIFF
--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -27,6 +27,7 @@ import (
 	birthdaysAPI "github.com/moto-nrw/project-phoenix/api/birthdays"
 	calendarAPI "github.com/moto-nrw/project-phoenix/api/calendar"
 	classdayAPI "github.com/moto-nrw/project-phoenix/api/classday"
+	classlistentriesAPI "github.com/moto-nrw/project-phoenix/api/classlistentries"
 	apiCommon "github.com/moto-nrw/project-phoenix/api/common"
 	configAPI "github.com/moto-nrw/project-phoenix/api/config"
 	databaseAPI "github.com/moto-nrw/project-phoenix/api/database"
@@ -123,6 +124,7 @@ type API struct {
 	Users            *usersAPI.Resource
 	Birthdays        *birthdaysAPI.Resource
 	ClassDay         *classdayAPI.Resource
+	ClassListEntries *classlistentriesAPI.Resource
 	School           *schoolAPI.Resource
 	UserContext      *usercontextAPI.Resource
 	Substitutions    *substitutionsAPI.Resource
@@ -486,6 +488,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 		PersonService:           api.Services.Users,
 		GuardianService:         api.Services.Guardian,
 		StudentService:          api.Services.Students,
+		ClassListEntryService:   api.Services.ClassListEntries,
 		StudentDeletionService:  api.Services.StudentDeletion,
 		StudentAuditService:     api.Services.StudentAudit,
 		EducationService:        api.Services.Education,
@@ -530,7 +533,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Announcements = announcementAPI.NewResource(api.Services.ParentAnnouncement, db)
 	api.Groups = groupsAPI.NewResource(api.Services.Education, api.Services.Active, api.Services.Users, api.Services.UserContext, db)
 	api.Guardians = guardiansAPI.NewResource(api.Services.Guardian, api.Services.GuardianInvitation, api.Services.Users, api.Services.Education, api.Services.UserContext, db)
-	api.Import = importAPI.NewResource(api.Services.Import, api.Services.StaffImport, api.Services.Users, db)
+	api.Import = importAPI.NewResource(api.Services.Import, api.Services.StaffImport, api.Services.ClassListImport, api.Services.Users, db)
 	api.Import.SetOpeningBalanceImportFactory(api.Services.OpeningBalanceImport)
 	api.Activities = activitiesAPI.NewResource(api.Services.Activities, api.Services.Schedule, api.Services.Users, api.Services.UserContext, db)
 	api.Staff = staffAPI.NewResource(api.Services.Users, api.Services.StaffDocuments, api.Services.StaffOffboarding, api.Services.Education, api.Services.Auth, api.Services.WorkSession, api.Services.StaffAbsence, api.Services.WorkTimeMonth, api.Services.StaffBalanceAdjust, api.Services.StaffMonthClose, api.Services.StaffOverview, api.Services.TimeTrackingAuditLog, api.Services.StaffTimeExport, db, logger.With("handler", "staff"))
@@ -590,6 +593,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Birthdays = birthdaysAPI.NewResource(api.Services.Birthdays, api.Services.ListExport, api.Services.UserContext, api.Services.Settings, db, logger.With("handler", "birthdays"))
 	api.UserContext = usercontextAPI.NewResource(api.Services.UserContext, db)
 	api.ClassDay = classdayAPI.NewResource(api.Services.EnrollmentReport, api.Services.UserContext, db, logger.With("handler", "class-day"))
+	api.ClassListEntries = classlistentriesAPI.NewResource(api.Services.ClassListEntries, db, logger.With("handler", "class-list-entries"))
 	api.School = schoolAPI.NewResource(api.Services.Auth, api.Services.MFA, api.ClassDay)
 	api.Substitutions = substitutionsAPI.NewResource(api.Services.Education, db)
 	api.Database = databaseAPI.NewResource(api.Services.Database, db)
@@ -876,6 +880,9 @@ func (a *API) registerTenantRoutes() {
 
 		// Mount the Lehrkraft class-day view (#1772)
 		r.Mount("/class-day", a.ClassDay.Router())
+
+		// Mount class-list-only entries (#2382)
+		r.Mount("/class-list-entries", a.ClassListEntries.Router())
 
 		// Mount substitutions resources
 		r.Mount("/substitutions", a.Substitutions.Router())

--- a/backend/api/classlistentries/api.go
+++ b/backend/api/classlistentries/api.go
@@ -77,9 +77,12 @@ func (req *EntryRequest) Bind(_ *http.Request) error {
 	return nil
 }
 
-// AssignRequest names the student an entry is resolved into.
+// AssignRequest names the student an entry is resolved into. StudentID binds
+// via `,string` (the wire value is a quoted decimal): JavaScript clients and
+// the Next.js proxy round JSON numbers beyond 2^53, so 64-bit IDs must travel
+// as strings to stay lossless.
 type AssignRequest struct {
-	StudentID int64 `json:"student_id"`
+	StudentID int64 `json:"student_id,string"`
 }
 
 // Bind validates the payload.

--- a/backend/api/classlistentries/api.go
+++ b/backend/api/classlistentries/api.go
@@ -1,0 +1,222 @@
+// Package classlistentries manages the minimal class-list-only entries
+// (#2382): children of the class cohort without an OGS record — only name and
+// free-text school class. The entries surface exclusively on class lists and
+// the Lehrkraft class-day view; they are deliberately invisible to the
+// student search, attendance, care planning and the parent portal, which is
+// guaranteed structurally (no student row exists to reference).
+package classlistentries
+
+import (
+	"cmp"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+	"github.com/uptrace/bun"
+)
+
+// Resource wires the class-list entry endpoints.
+type Resource struct {
+	Service usersService.ClassListEntryService
+	db      *bun.DB
+	logger  *slog.Logger
+}
+
+// NewResource creates the class-list entry resource.
+func NewResource(service usersService.ClassListEntryService, db *bun.DB, logger *slog.Logger) *Resource {
+	return &Resource{Service: service, db: db, logger: logger}
+}
+
+func (rs *Resource) getLogger() *slog.Logger {
+	return cmp.Or(rs.logger, slog.Default())
+}
+
+// Router returns the class-list entry router.
+func (rs *Resource) Router() chi.Router {
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+
+	common.ProtectedTenantGroup(r, rs.db, func(r chi.Router, withTx common.Middleware) {
+		r.With(authorize.RequiresPermission(permissions.UsersRead), withTx).Get("/", rs.listEntries)
+		r.With(authorize.RequiresPermission(permissions.UsersCreate), withTx).Post("/", rs.createEntry)
+		r.With(authorize.RequiresPermission(permissions.UsersUpdate), withTx).Put("/{id}", rs.updateEntry)
+		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Delete("/{id}", rs.deleteEntry)
+		r.With(authorize.RequiresPermission(permissions.UsersDelete), withTx).Post("/{id}/assign", rs.assignEntry)
+	})
+
+	return r
+}
+
+// EntryRequest is the create/update payload.
+type EntryRequest struct {
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	SchoolClass string `json:"school_class"`
+}
+
+// Bind validates the payload.
+func (req *EntryRequest) Bind(_ *http.Request) error {
+	if req.FirstName == "" || req.LastName == "" || req.SchoolClass == "" {
+		return errors.New("Vorname, Nachname und Klasse sind erforderlich") //nolint:staticcheck // ST1005: user-facing German message
+	}
+	return nil
+}
+
+// AssignRequest names the student an entry is resolved into.
+type AssignRequest struct {
+	StudentID int64 `json:"student_id"`
+}
+
+// Bind validates the payload.
+func (req *AssignRequest) Bind(_ *http.Request) error {
+	if req.StudentID <= 0 {
+		return errors.New("student_id ist erforderlich") //nolint:staticcheck // ST1005: user-facing German message
+	}
+	return nil
+}
+
+// EntryResponse is one entry on the wire. MatchingStudentIDs carries the IDs
+// of regular students sharing name and class — the hint for a deliberate
+// "Zuordnen" resolution, never an automatic merge.
+type EntryResponse struct {
+	ID                 int64     `json:"id"`
+	FirstName          string    `json:"first_name"`
+	LastName           string    `json:"last_name"`
+	SchoolClass        string    `json:"school_class"`
+	CreatedAt          time.Time `json:"created_at"`
+	MatchingStudentIDs []int64   `json:"matching_student_ids"`
+}
+
+func entryResponse(entry *userModels.ClassListEntry, matches []int64) EntryResponse {
+	if matches == nil {
+		matches = []int64{}
+	}
+	return EntryResponse{
+		ID:                 entry.ID,
+		FirstName:          entry.FirstName,
+		LastName:           entry.LastName,
+		SchoolClass:        entry.SchoolClass,
+		CreatedAt:          entry.CreatedAt,
+		MatchingStudentIDs: matches,
+	}
+}
+
+func (rs *Resource) listEntries(w http.ResponseWriter, r *http.Request) {
+	entries, err := rs.Service.List(r.Context())
+	if err != nil {
+		rs.getLogger().Error("class list entries: list failed", "error", err.Error())
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
+	out := make([]EntryResponse, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entryResponse(entry.Entry, entry.MatchingStudentIDs))
+	}
+	common.Respond(w, r, http.StatusOK, out, "Class list entries retrieved successfully")
+}
+
+func (rs *Resource) createEntry(w http.ResponseWriter, r *http.Request) {
+	req := &EntryRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	entry, err := rs.Service.Create(r.Context(), usersService.ClassListEntryInput{
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		SchoolClass: req.SchoolClass,
+	}, accountID(r))
+	if err != nil {
+		rs.renderServiceError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusCreated, entryResponse(entry, nil), "Class list entry created successfully")
+}
+
+func (rs *Resource) updateEntry(w http.ResponseWriter, r *http.Request) {
+	id, ok := entryID(w, r)
+	if !ok {
+		return
+	}
+	req := &EntryRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	entry, err := rs.Service.Update(r.Context(), id, usersService.ClassListEntryInput{
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		SchoolClass: req.SchoolClass,
+	}, accountID(r))
+	if err != nil {
+		rs.renderServiceError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, entryResponse(entry, nil), "Class list entry updated successfully")
+}
+
+func (rs *Resource) deleteEntry(w http.ResponseWriter, r *http.Request) {
+	id, ok := entryID(w, r)
+	if !ok {
+		return
+	}
+	if err := rs.Service.Delete(r.Context(), id, accountID(r)); err != nil {
+		rs.renderServiceError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, nil, "Class list entry deleted successfully")
+}
+
+func (rs *Resource) assignEntry(w http.ResponseWriter, r *http.Request) {
+	id, ok := entryID(w, r)
+	if !ok {
+		return
+	}
+	req := &AssignRequest{}
+	if err := render.Bind(r, req); err != nil {
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+		return
+	}
+	if err := rs.Service.Assign(r.Context(), id, req.StudentID, accountID(r)); err != nil {
+		rs.renderServiceError(w, r, err)
+		return
+	}
+	common.Respond(w, r, http.StatusOK, nil, "Class list entry assigned successfully")
+}
+
+func (rs *Resource) renderServiceError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, usersService.ErrClassListEntryNotFound):
+		common.RenderError(w, r, common.ErrorNotFound(err))
+	case errors.Is(err, usersService.ErrClassListEntryDuplicate),
+		errors.Is(err, usersService.ErrClassListEntryStudentExists),
+		errors.Is(err, usersService.ErrClassListEntryStudentNotFound):
+		common.RenderError(w, r, common.ErrorInvalidRequest(err))
+	default:
+		rs.getLogger().Error("class list entries: request failed", "error", err.Error())
+		common.RenderError(w, r, common.ErrorInternalServer(err))
+	}
+}
+
+func entryID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid entry ID")))
+		return 0, false
+	}
+	return id, true
+}
+
+func accountID(r *http.Request) int64 {
+	return int64(jwt.ClaimsFromCtx(r.Context()).ID)
+}

--- a/backend/api/classlistentries/api.go
+++ b/backend/api/classlistentries/api.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -95,19 +96,22 @@ func (req *AssignRequest) Bind(_ *http.Request) error {
 
 // EntryResponse is one entry on the wire. MatchingStudentIDs carries the IDs
 // of regular students sharing name and class — the hint for a deliberate
-// "Zuordnen" resolution, never an automatic merge.
+// "Zuordnen" resolution, never an automatic merge. All IDs are serialized as
+// JSON strings for the same reason AssignRequest binds with `,string`:
+// JavaScript clients and the Next.js proxy round JSON numbers beyond 2^53.
 type EntryResponse struct {
-	ID                 int64     `json:"id"`
+	ID                 int64     `json:"id,string"`
 	FirstName          string    `json:"first_name"`
 	LastName           string    `json:"last_name"`
 	SchoolClass        string    `json:"school_class"`
 	CreatedAt          time.Time `json:"created_at"`
-	MatchingStudentIDs []int64   `json:"matching_student_ids"`
+	MatchingStudentIDs []string  `json:"matching_student_ids"`
 }
 
 func entryResponse(entry *userModels.ClassListEntry, matches []int64) EntryResponse {
-	if matches == nil {
-		matches = []int64{}
+	matchIDs := make([]string, 0, len(matches))
+	for _, id := range matches {
+		matchIDs = append(matchIDs, strconv.FormatInt(id, 10))
 	}
 	return EntryResponse{
 		ID:                 entry.ID,
@@ -115,7 +119,7 @@ func entryResponse(entry *userModels.ClassListEntry, matches []int64) EntryRespo
 		LastName:           entry.LastName,
 		SchoolClass:        entry.SchoolClass,
 		CreatedAt:          entry.CreatedAt,
-		MatchingStudentIDs: matches,
+		MatchingStudentIDs: matchIDs,
 	}
 }
 

--- a/backend/api/classlistentries/api.go
+++ b/backend/api/classlistentries/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -64,8 +64,13 @@ type EntryRequest struct {
 	SchoolClass string `json:"school_class"`
 }
 
-// Bind validates the payload.
+// Bind validates the payload. Fields are trimmed here so a whitespace-only
+// value is rejected as the invalid request it is (400) instead of tripping
+// the service-level validation later.
 func (req *EntryRequest) Bind(_ *http.Request) error {
+	req.FirstName = strings.TrimSpace(req.FirstName)
+	req.LastName = strings.TrimSpace(req.LastName)
+	req.SchoolClass = strings.TrimSpace(req.SchoolClass)
 	if req.FirstName == "" || req.LastName == "" || req.SchoolClass == "" {
 		return errors.New("Vorname, Nachname und Klasse sind erforderlich") //nolint:staticcheck // ST1005: user-facing German message
 	}
@@ -200,7 +205,8 @@ func (rs *Resource) renderServiceError(w http.ResponseWriter, r *http.Request, e
 		common.RenderError(w, r, common.ErrorNotFound(err))
 	case errors.Is(err, usersService.ErrClassListEntryDuplicate),
 		errors.Is(err, usersService.ErrClassListEntryStudentExists),
-		errors.Is(err, usersService.ErrClassListEntryStudentNotFound):
+		errors.Is(err, usersService.ErrClassListEntryStudentNotFound),
+		errors.Is(err, usersService.ErrClassListEntryAssignMismatch):
 		common.RenderError(w, r, common.ErrorInvalidRequest(err))
 	default:
 		rs.getLogger().Error("class list entries: request failed", "error", err.Error())
@@ -209,12 +215,7 @@ func (rs *Resource) renderServiceError(w http.ResponseWriter, r *http.Request, e
 }
 
 func entryID(w http.ResponseWriter, r *http.Request) (int64, bool) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-	if err != nil || id <= 0 {
-		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid entry ID")))
-		return 0, false
-	}
-	return id, true
+	return common.ParsePositiveInt64IDWithError(w, r, "id", "invalid entry ID")
 }
 
 func accountID(r *http.Request) int64 {

--- a/backend/api/classlistentries/class_list_entries_api_test.go
+++ b/backend/api/classlistentries/class_list_entries_api_test.go
@@ -124,3 +124,23 @@ func TestClassListEntriesAppearInClassDay(t *testing.T) {
 	assert.Contains(t, body, fmt.Sprintf(`"list_entry_id":%d`, entry.ID))
 	assert.Contains(t, body, `"list_entry":true`)
 }
+
+// Whitespace-only fields are an invalid request, not a server error: Bind
+// trims and rejects them before the service runs (#2399 review).
+func TestClassListEntriesWhitespaceOnlyIs400(t *testing.T) {
+	db, factory := testutil.SetupAPITest(t)
+
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("cle-ws-%d@test.local", time.Now().UnixNano()))
+	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, account.ID) })
+
+	resource := classlistentries.NewResource(factory.ClassListEntries, db, nil)
+	router := resource.Router()
+	claims := jwt.AppClaims{ID: int(account.ID), Sub: account.Email, Roles: []string{"admin"}, TenantID: 1}
+
+	body := `{"first_name":"  ","last_name":"Aalders","school_class":"1a"}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:create"})
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "erforderlich")
+}

--- a/backend/api/classlistentries/class_list_entries_api_test.go
+++ b/backend/api/classlistentries/class_list_entries_api_test.go
@@ -80,7 +80,7 @@ func TestClassListEntriesAPI(t *testing.T) {
 	student := testpkg.CreateTestStudent(t, db, "Zoe", "Aalders", className+"-b")
 	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, db, student.ID) })
 
-	assignBody := fmt.Sprintf(`{"student_id":%d}`, student.ID)
+	assignBody := fmt.Sprintf(`{"student_id":"%d"}`, student.ID)
 	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/%d/assign", entryID), strings.NewReader(assignBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:delete"})

--- a/backend/api/classlistentries/class_list_entries_api_test.go
+++ b/backend/api/classlistentries/class_list_entries_api_test.go
@@ -1,0 +1,126 @@
+// Router-level tests for /api/class-list-entries (#2382): permission gates,
+// the CRUD + assign flow, and the class-day merge of list-only entries.
+package classlistentries_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/classday"
+	"github.com/moto-nrw/project-phoenix/api/classlistentries"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func TestClassListEntriesAPI(t *testing.T) {
+	db, factory := testutil.SetupAPITest(t)
+
+	account := testpkg.CreateTestAccount(t, db, fmt.Sprintf("cle-api-%d@test.local", time.Now().UnixNano()))
+	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, db, account.ID) })
+
+	resource := classlistentries.NewResource(factory.ClassListEntries, db, nil)
+	router := resource.Router()
+
+	claims := jwt.AppClaims{ID: int(account.ID), Sub: account.Email, Roles: []string{"admin"}, TenantID: 1}
+	className := fmt.Sprintf("cle%d", time.Now().UnixNano()%100000)
+
+	// Missing permission → 403 before any data access.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"class_day:read"})
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+
+	// Create.
+	body := fmt.Sprintf(`{"first_name":"Zoe","last_name":"Aalders","school_class":"%s"}`, className)
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:create"})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var created struct {
+		Data struct {
+			ID int64 `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	entryID := created.Data.ID
+	require.NotZero(t, entryID)
+	t.Cleanup(func() { testpkg.CleanupClassListEntryFixtures(t, db, entryID) })
+
+	// Duplicate create → 400 with the German message.
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:create"})
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "existiert in dieser Klasse bereits")
+
+	// List (users:read) shows the entry.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:read"})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "Aalders")
+
+	// Move to another class (users:update).
+	moveBody := fmt.Sprintf(`{"first_name":"Zoe","last_name":"Aalders","school_class":"%s-b"}`, className)
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/%d", entryID), strings.NewReader(moveBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:update"})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), className+"-b")
+
+	// Assign to a real student (users:delete) deletes the entry.
+	student := testpkg.CreateTestStudent(t, db, "Zoe", "Aalders", className+"-b")
+	t.Cleanup(func() { testpkg.CleanupActivityFixtures(t, db, student.ID) })
+
+	assignBody := fmt.Sprintf(`{"student_id":%d}`, student.ID)
+	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/%d/assign", entryID), strings.NewReader(assignBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:delete"})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Gone after the assign.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:read"})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), fmt.Sprintf(`"id":%d`, entryID))
+}
+
+func TestClassListEntriesAppearInClassDay(t *testing.T) {
+	db, factory := testutil.SetupAPITest(t)
+
+	staff, account := testpkg.CreateTestStaffWithAccount(t, db, "CleDay", fmt.Sprintf("API-%d", time.Now().UnixNano()))
+	className := fmt.Sprintf("cled%d", time.Now().UnixNano()%100000)
+	assignment := testpkg.CreateTestClassTeacher(t, db, staff.ID, className)
+	student := testpkg.CreateTestStudent(t, db, "Klara", "Klassentag", className)
+	entry := testpkg.CreateTestClassListEntry(t, db, "Nico", "NurListe", className)
+	t.Cleanup(func() {
+		tenantCtx := testpkg.TenantContext(1)
+		_, _ = db.NewDelete().TableExpr("education.class_teachers").Where("id = ?", assignment.ID).Exec(tenantCtx)
+		testpkg.CleanupActivityFixtures(t, db, student.ID)
+		testpkg.CleanupStaffFixtures(t, db, staff.ID)
+		testpkg.CleanupAuthFixtures(t, db, account.ID)
+	})
+
+	classDayRouter := classday.NewResource(factory.EnrollmentReport, factory.UserContext, db, nil).Router()
+	claims := jwt.AppClaims{ID: int(account.ID), Sub: account.Email, Roles: []string{"lehrkraft"}, TenantID: 1}
+
+	req := httptest.NewRequest(http.MethodGet, "/?date=2026-08-05", nil)
+	rec := testutil.ExecuteWithAuthPermissions(t, classDayRouter, req, claims, []string{"class_day:read"})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Both the regular student and the list-only entry are on the sheet; the
+	// entry is flagged, never staying, and carries no departure instruction.
+	body := rec.Body.String()
+	assert.Contains(t, body, "Klassentag")
+	assert.Contains(t, body, "NurListe")
+	assert.Contains(t, body, fmt.Sprintf(`"list_entry_id":%d`, entry.ID))
+	assert.Contains(t, body, `"list_entry":true`)
+}

--- a/backend/api/classlistentries/class_list_entries_api_test.go
+++ b/backend/api/classlistentries/class_list_entries_api_test.go
@@ -45,9 +45,11 @@ func TestClassListEntriesAPI(t *testing.T) {
 	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:create"})
 	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
 
+	// IDs travel as JSON strings (lossless beyond 2^53) — `,string` decodes the
+	// quoted wire value.
 	var created struct {
 		Data struct {
-			ID int64 `json:"id"`
+			ID int64 `json:"id,string"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
@@ -90,7 +92,7 @@ func TestClassListEntriesAPI(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/", nil)
 	rec = testutil.ExecuteWithAuthPermissions(t, router, req, claims, []string{"users:read"})
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
-	assert.NotContains(t, rec.Body.String(), fmt.Sprintf(`"id":%d`, entryID))
+	assert.NotContains(t, rec.Body.String(), fmt.Sprintf(`"id":"%d"`, entryID))
 }
 
 func TestClassListEntriesAppearInClassDay(t *testing.T) {

--- a/backend/api/classlistentries/class_list_entries_api_test.go
+++ b/backend/api/classlistentries/class_list_entries_api_test.go
@@ -123,7 +123,7 @@ func TestClassListEntriesAppearInClassDay(t *testing.T) {
 	body := rec.Body.String()
 	assert.Contains(t, body, "Klassentag")
 	assert.Contains(t, body, "NurListe")
-	assert.Contains(t, body, fmt.Sprintf(`"list_entry_id":%d`, entry.ID))
+	assert.Contains(t, body, fmt.Sprintf(`"list_entry_id":"%d"`, entry.ID))
 	assert.Contains(t, body, `"list_entry":true`)
 }
 

--- a/backend/api/enrollment/class_list_entries_marker_test.go
+++ b/backend/api/enrollment/class_list_entries_marker_test.go
@@ -1,0 +1,55 @@
+package enrollment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/services/listexport"
+
+	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+)
+
+// The class-roster table has no status column, so a class-list-only entry
+// (#2382) carries its "Keine Betreuung" marker in the name cell and renders
+// "—" in every weekday cell like a non-care day.
+func TestClassRosterTableDocumentMarksListEntries(t *testing.T) {
+	report := &enrollmentService.ClassRosterReport{
+		Filters: enrollmentService.ClassRosterAppliedFilters{SchoolClass: "1a"},
+		Totals:  enrollmentService.ClassRosterTotals{Students: 2, Registered: 1, ListEntries: 1},
+		Rows: []enrollmentService.ClassRosterRow{
+			{
+				ListEntry:         true,
+				ListEntryID:       101,
+				FirstName:         "Zoe",
+				LastName:          "Aalders",
+				SchoolClass:       "1a",
+				EnrollmentSummary: enrollmentService.ClassListEntryNoCareLabel,
+			},
+			{
+				StudentID:   21,
+				FirstName:   "Mila",
+				LastName:    "Anders",
+				SchoolClass: "1a",
+				Registered:  true,
+				CareDays:    []string{"mon"},
+				PickupByDay: map[string]string{"mon": "15:00"},
+			},
+		},
+	}
+
+	doc := buildClassRosterTableDocument(report)
+	require.Len(t, doc.Rows, 2)
+
+	entryRow := doc.Rows[0]
+	assert.Equal(t, "Zoe Aalders (Keine Betreuung)", entryRow.Values[listexport.ColumnName])
+	assert.Equal(t, "—", entryRow.Values[listexport.ColumnWeeklyMonday])
+	assert.Equal(t, "—", entryRow.Values[listexport.ColumnWeeklyFriday])
+
+	studentRow := doc.Rows[1]
+	assert.Equal(t, "Mila Anders", studentRow.Values[listexport.ColumnName])
+	assert.Equal(t, "15:00 Uhr", studentRow.Values[listexport.ColumnWeeklyMonday])
+
+	assert.Equal(t, "2 Kinder, 1 angemeldet, 1 ohne Betreuung", classRosterSubtitle(report))
+}

--- a/backend/api/enrollment/report_handlers.go
+++ b/backend/api/enrollment/report_handlers.go
@@ -778,8 +778,15 @@ func buildClassRosterTableDocument(report *enrollmentService.ClassRosterReport) 
 			currentClass = class
 			rows = append(rows, listexport.Row{GroupTitle: listexport.ClassGroupTitle(class)})
 		}
+		name := strings.TrimSpace(row.FirstName + " " + row.LastName)
+		if row.ListEntry {
+			// Class-list-only entry (#2382): the child has no OGS record at
+			// all. The marker sits in the name cell because the roster table
+			// has no status column — every weekday cell stays "—".
+			name += " (" + enrollmentService.ClassListEntryNoCareLabel + ")"
+		}
 		rows = append(rows, listexport.Row{Values: map[listexport.ColumnID]string{
-			listexport.ColumnName:             strings.TrimSpace(row.FirstName + " " + row.LastName),
+			listexport.ColumnName:             name,
 			listexport.ColumnSchoolClass:      row.SchoolClass,
 			listexport.ColumnWeeklyMonday:     classRosterWeeklyCell(row, "mon"),
 			listexport.ColumnWeeklyTuesday:    classRosterWeeklyCell(row, "tue"),
@@ -820,7 +827,11 @@ func classRosterSubtitle(report *enrollmentService.ClassRosterReport) string {
 	if report == nil {
 		return "0 Kinder"
 	}
-	return fmt.Sprintf("%d Kinder, %d angemeldet", report.Totals.Students, report.Totals.Registered)
+	subtitle := fmt.Sprintf("%d Kinder, %d angemeldet", report.Totals.Students, report.Totals.Registered)
+	if report.Totals.ListEntries > 0 {
+		subtitle += fmt.Sprintf(", %d ohne Betreuung", report.Totals.ListEntries)
+	}
+	return subtitle
 }
 
 func classRosterFilterLabels(report *enrollmentService.ClassRosterReport) []string {

--- a/backend/api/import/api.go
+++ b/backend/api/import/api.go
@@ -46,8 +46,9 @@ const (
 
 // Resource defines the import resource
 type Resource struct {
-	studentImportService *importService.ImportService[importModels.StudentImportRow]
-	staffImportService   *importService.ImportService[importModels.StaffImportRow]
+	studentImportService   *importService.ImportService[importModels.StudentImportRow]
+	staffImportService     *importService.ImportService[importModels.StaffImportRow]
+	classListImportService *importService.ImportService[importModels.ClassListEntryImportRow]
 	// openingBalanceImportFactory builds a request-scoped opening balance
 	// import service (#2132) — Stichtag/Begründung/actor come from the
 	// upload form. Wired via SetOpeningBalanceImportFactory.
@@ -66,14 +67,16 @@ func (rs *Resource) SetOpeningBalanceImportFactory(factory importService.Opening
 func NewResource(
 	studentImportService *importService.ImportService[importModels.StudentImportRow],
 	staffImportService *importService.ImportService[importModels.StaffImportRow],
+	classListImportService *importService.ImportService[importModels.ClassListEntryImportRow],
 	personService userSvc.PersonService,
 	db *bun.DB,
 ) *Resource {
 	return &Resource{
-		studentImportService: studentImportService,
-		staffImportService:   staffImportService,
-		personService:        personService,
-		db:                   db,
+		studentImportService:   studentImportService,
+		staffImportService:     staffImportService,
+		classListImportService: classListImportService,
+		personService:          personService,
+		db:                     db,
 	}
 }
 
@@ -120,6 +123,16 @@ func (rs *Resource) Router() chi.Router {
 			// Note: no withTx here — the handler manages its own WithTenantTx
 			// to control commit/rollback based on import results.
 			r.With(authorize.RequiresPermission(permTimeTrackingManage)).Post(routeImport, rs.ImportOpeningBalances)
+		})
+
+		// Class-list entry (Klassenlisteneintrag, #2382) import endpoints
+		r.Route("/class-list-entries", func(r chi.Router) {
+			r.With(authorize.RequiresPermission(permUsersRead), withTx).Get(routeTemplate, rs.DownloadClassListTemplate)
+			// Note: no withTx on preview/import — the handler owns its tenant
+			// transaction so the GDPR audit row is committed before the
+			// success response.
+			r.With(authorize.RequiresPermission(permUsersCreate)).Post(routePreview, rs.PreviewClassListImport)
+			r.With(authorize.RequiresPermission(permUsersCreate)).Post(routeImport, rs.ImportClassList)
 		})
 
 		// Staff (Mitarbeiter) import endpoints

--- a/backend/api/import/class_list.go
+++ b/backend/api/import/class_list.go
@@ -25,16 +25,12 @@ func getClassListImportHeaders() []string {
 	return []string{"Vorname", "Nachname", "Klasse"}
 }
 
-// getClassListImportExamples returns example data rows for the template —
-// exactly the canonical rows the parsers drop again on upload, so an
-// unchanged template never imports the demo children as real tenant data.
-func getClassListImportExamples() [][]any {
-	examples := make([][]any, 0, len(importService.ClassListTemplateExampleRows))
-	for _, row := range importService.ClassListTemplateExampleRows {
-		examples = append(examples, []any{row.FirstName, row.LastName, row.SchoolClass})
-	}
-	return examples
-}
+// The class-list template deliberately ships NO example data rows (#2399
+// review round 10): a class-list row is nothing but a name and a class, so
+// any rule that recognizes example rows again on upload is a name blocklist
+// that would silently drop a real child of the same name. The columns are
+// explained on the "Hinweise" sheet instead, and an unchanged template upload
+// is rejected as "keine Datenzeilen" because it carries none.
 
 // ClassListFileUploadResult carries the parsed rows plus the original
 // filename for the audit trail.
@@ -94,15 +90,6 @@ func (rs *Resource) downloadClassListTemplateCSV(w http.ResponseWriter, _ *http.
 		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
 		return
 	}
-	for _, row := range getClassListImportExamples() {
-		strRow := make([]string, len(row))
-		for i, v := range row {
-			strRow[i] = fmt.Sprintf("%v", v)
-		}
-		if err := csvWriter.Write(strRow); err != nil {
-			slog.Default().Error("Error writing CSV row", slog.String("error", err.Error()))
-		}
-	}
 	csvWriter.Flush()
 }
 
@@ -126,7 +113,6 @@ func (rs *Resource) downloadClassListTemplateXLSX(w http.ResponseWriter, _ *http
 
 	headers := getClassListImportHeaders()
 	writeExcelHeaders(f, sheetName, headers)
-	writeExcelExampleRows(f, sheetName, getClassListImportExamples())
 	setExcelColumnWidths(f, sheetName, len(headers), 20)
 	writeClassListHinweiseSheet(f)
 
@@ -152,7 +138,7 @@ func writeClassListHinweiseSheet(f *excelize.File) {
 		{"", "", ""},
 		{"Hinweis", "", "Klassenlisteneinträge sind Kinder OHNE OGS-Betreuung: Sie erscheinen nur auf Klassenlisten und in der Klassenansicht, nie in Anwesenheit oder Betreuungsplanung."},
 		{"Hinweis", "", "Kinder, die bereits in moto angelegt sind, werden übersprungen — sie stehen schon auf der Klassenliste."},
-		{"Hinweis", "", "Die Beispielzeilen der Vorlage (Lena Beispiel, Jonas Muster) werden beim Import ignoriert — bitte durch echte Daten ersetzen."},
+		{"Hinweis", "", "Die Vorlage enthält nur die Kopfzeile: Bitte tragen Sie die Kinder ab Zeile 2 des Tabellenblatts \"Klassenliste\" ein, eine Zeile pro Kind."},
 	}
 	for rowIdx, row := range rows {
 		for colIdx, val := range row {

--- a/backend/api/import/class_list.go
+++ b/backend/api/import/class_list.go
@@ -25,12 +25,15 @@ func getClassListImportHeaders() []string {
 	return []string{"Vorname", "Nachname", "Klasse"}
 }
 
-// getClassListImportExamples returns example data rows for the template.
+// getClassListImportExamples returns example data rows for the template —
+// exactly the canonical rows the parsers drop again on upload, so an
+// unchanged template never imports the demo children as real tenant data.
 func getClassListImportExamples() [][]any {
-	return [][]any{
-		{"Lena", "Beispiel", "1a"},
-		{"Jonas", "Muster", "3b"},
+	examples := make([][]any, 0, len(importService.ClassListTemplateExampleRows))
+	for _, row := range importService.ClassListTemplateExampleRows {
+		examples = append(examples, []any{row.FirstName, row.LastName, row.SchoolClass})
 	}
+	return examples
 }
 
 // ClassListFileUploadResult carries the parsed rows plus the original
@@ -149,6 +152,7 @@ func writeClassListHinweiseSheet(f *excelize.File) {
 		{"", "", ""},
 		{"Hinweis", "", "Klassenlisteneinträge sind Kinder OHNE OGS-Betreuung: Sie erscheinen nur auf Klassenlisten und in der Klassenansicht, nie in Anwesenheit oder Betreuungsplanung."},
 		{"Hinweis", "", "Kinder, die bereits in moto angelegt sind, werden übersprungen — sie stehen schon auf der Klassenliste."},
+		{"Hinweis", "", "Die Beispielzeilen der Vorlage (Lena Beispiel, Jonas Muster) werden beim Import ignoriert — bitte durch echte Daten ersetzen."},
 	}
 	for rowIdx, row := range rows {
 		for colIdx, val := range row {

--- a/backend/api/import/class_list.go
+++ b/backend/api/import/class_list.go
@@ -1,0 +1,227 @@
+package importapi
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/uptrace/bun"
+	"github.com/xuri/excelize/v2"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	importService "github.com/moto-nrw/project-phoenix/services/import"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// Class-list entry import (#2382): the bulk form of the minimal
+// Klassenlisteneintrag — Vorname, Nachname, Klasse, nothing else.
+
+// getClassListImportHeaders returns the header row for the template.
+func getClassListImportHeaders() []string {
+	return []string{"Vorname", "Nachname", "Klasse"}
+}
+
+// getClassListImportExamples returns example data rows for the template.
+func getClassListImportExamples() [][]any {
+	return [][]any{
+		{"Lena", "Beispiel", "1a"},
+		{"Jonas", "Muster", "3b"},
+	}
+}
+
+// ClassListFileUploadResult carries the parsed rows plus the original
+// filename for the audit trail.
+type ClassListFileUploadResult struct {
+	Rows     []importModels.ClassListEntryImportRow
+	Filename string
+}
+
+// validateAndParseClassListFile handles upload validation and parsing for
+// class-list entry imports. Supports both CSV and Excel (.xlsx) files.
+func (rs *Resource) validateAndParseClassListFile(w http.ResponseWriter, r *http.Request) (*ClassListFileUploadResult, bool) {
+	file, header, isExcel, ok := rs.openValidatedUploadFile(w, r)
+	if !ok {
+		return nil, false
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			slog.Default().Error("failed to close file", slog.String("error", err.Error()))
+		}
+	}()
+
+	var rows []importModels.ClassListEntryImportRow
+	var err error
+	if isExcel {
+		rows, err = importService.ParseClassListXLSX(file)
+	} else {
+		rows, err = importService.ParseClassListCSV(file)
+	}
+	if err != nil {
+		render.Status(r, http.StatusBadRequest)
+		common.RenderError(w, r, common.ErrorInvalidRequest(fmt.Errorf("Datei-Fehler: %s", err.Error())))
+		return nil, false
+	}
+
+	return &ClassListFileUploadResult{
+		Rows:     rows,
+		Filename: header.Filename,
+	}, true
+}
+
+// DownloadClassListTemplate handles the template download (CSV or Excel).
+func (rs *Resource) DownloadClassListTemplate(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("format") == "xlsx" {
+		rs.downloadClassListTemplateXLSX(w, r)
+		return
+	}
+	rs.downloadClassListTemplateCSV(w, r)
+}
+
+func (rs *Resource) downloadClassListTemplateCSV(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition", "attachment; filename=klassenliste-import-vorlage.csv")
+
+	csvWriter := csv.NewWriter(w)
+	if err := csvWriter.Write(getClassListImportHeaders()); err != nil {
+		slog.Default().Error("Error writing CSV headers", slog.String("error", err.Error()))
+		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
+		return
+	}
+	for _, row := range getClassListImportExamples() {
+		strRow := make([]string, len(row))
+		for i, v := range row {
+			strRow[i] = fmt.Sprintf("%v", v)
+		}
+		if err := csvWriter.Write(strRow); err != nil {
+			slog.Default().Error("Error writing CSV row", slog.String("error", err.Error()))
+		}
+	}
+	csvWriter.Flush()
+}
+
+func (rs *Resource) downloadClassListTemplateXLSX(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	w.Header().Set("Content-Disposition", "attachment; filename=klassenliste-import-vorlage.xlsx")
+
+	f := excelize.NewFile()
+	defer func() {
+		if err := f.Close(); err != nil {
+			slog.Default().Error("Error closing Excel file", slog.String("error", err.Error()))
+		}
+	}()
+
+	sheetName := "Klassenliste"
+	if err := setupExcelSheet(f, sheetName); err != nil {
+		slog.Default().Error("Error setting up sheet", slog.String("error", err.Error()))
+		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
+		return
+	}
+
+	headers := getClassListImportHeaders()
+	writeExcelHeaders(f, sheetName, headers)
+	writeExcelExampleRows(f, sheetName, getClassListImportExamples())
+	setExcelColumnWidths(f, sheetName, len(headers), 20)
+	writeClassListHinweiseSheet(f)
+
+	if err := f.Write(w); err != nil {
+		slog.Default().Error("Error writing Excel file", slog.String("error", err.Error()))
+		http.Error(w, errTemplateCreation, http.StatusInternalServerError)
+	}
+}
+
+// writeClassListHinweiseSheet adds a "Hinweise" sheet describing the columns.
+func writeClassListHinweiseSheet(f *excelize.File) {
+	sheetName := "Hinweise"
+	if _, err := f.NewSheet(sheetName); err != nil {
+		slog.Default().Error("Error creating Hinweise sheet", slog.String("error", err.Error()))
+		return
+	}
+
+	rows := [][]string{
+		{"Spalte", "Pflicht?", "Beschreibung"},
+		{"Vorname", "Ja", "Vorname des Kindes"},
+		{"Nachname", "Ja", "Nachname des Kindes"},
+		{"Klasse", "Ja", "Schulklasse (z.B. 1a) — wie bei den regulären Kindern geschrieben"},
+		{"", "", ""},
+		{"Hinweis", "", "Klassenlisteneinträge sind Kinder OHNE OGS-Betreuung: Sie erscheinen nur auf Klassenlisten und in der Klassenansicht, nie in Anwesenheit oder Betreuungsplanung."},
+		{"Hinweis", "", "Kinder, die bereits in moto angelegt sind, werden übersprungen — sie stehen schon auf der Klassenliste."},
+	}
+	for rowIdx, row := range rows {
+		for colIdx, val := range row {
+			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+1)
+			_ = f.SetCellValue(sheetName, cell, val)
+		}
+	}
+	_ = f.SetColWidth(sheetName, "A", "A", 14)
+	_ = f.SetColWidth(sheetName, "B", "B", 10)
+	_ = f.SetColWidth(sheetName, "C", "C", 80)
+}
+
+// PreviewClassListImport handles the class-list import preview (dry-run).
+func (rs *Resource) PreviewClassListImport(w http.ResponseWriter, r *http.Request) {
+	rs.runClassListImport(w, r, true)
+}
+
+// ImportClassList handles the actual class-list entry import.
+func (rs *Resource) ImportClassList(w http.ResponseWriter, r *http.Request) {
+	rs.runClassListImport(w, r, false)
+}
+
+// runClassListImport shares the preview/import flow: both own their tenant
+// transaction so the GDPR audit row is committed before the success response
+// (same contract as the staff import).
+func (rs *Resource) runClassListImport(w http.ResponseWriter, r *http.Request, dryRun bool) {
+	uploadResult, ok := rs.validateAndParseClassListFile(w, r)
+	if !ok {
+		return
+	}
+
+	accountID, err := getAccountIDFromContext(r.Context())
+	if err != nil {
+		common.RenderError(w, r, common.ErrorUnauthorized(err))
+		return
+	}
+
+	tenantID := tenant.FromContext(r.Context())
+	var result *importModels.ImportResult[importModels.ClassListEntryImportRow]
+	if err := tenant.WithTenantTx(r.Context(), rs.db, tenantID, func(ctx context.Context, _ bun.Tx) error {
+		request := importModels.ImportRequest[importModels.ClassListEntryImportRow]{
+			Rows:            uploadResult.Rows,
+			Mode:            importModels.ImportModeCreate,
+			DryRun:          dryRun,
+			StopOnError:     false,
+			UserID:          accountID,
+			SkipInvalidRows: !dryRun,
+		}
+
+		var txErr error
+		result, txErr = rs.classListImportService.Import(ctx, request)
+		if txErr != nil {
+			return txErr
+		}
+		// GDPR Compliance: audit log for preview and import (Article 30).
+		return rs.classListImportService.RecordAuditInTransaction(ctx, "class_list_entries", uploadResult.Filename, result, accountID, dryRun, tenantID)
+	}); err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("Import fehlgeschlagen", err))
+		return
+	}
+
+	if dryRun {
+		common.Respond(w, r, http.StatusOK, result, "Import-Vorschau erfolgreich")
+		return
+	}
+
+	slog.Default().Info("Class list entry import completed",
+		slog.Int("created", result.CreatedCount),
+		slog.Int("errors", result.ErrorCount),
+		slog.String("filename", uploadResult.Filename))
+
+	message := fmt.Sprintf("Import abgeschlossen: %d erstellt, %d Fehler",
+		result.CreatedCount, result.ErrorCount)
+
+	common.Respond(w, r, http.StatusOK, result, message)
+}

--- a/backend/api/import/import_test.go
+++ b/backend/api/import/import_test.go
@@ -61,7 +61,7 @@ func setupTestContext(t *testing.T) *testContext {
 	repos := repositories.NewFactory(db)
 
 	// Create import resource
-	resource := importAPI.NewResource(svc.Import, svc.StaffImport, svc.Users, db)
+	resource := importAPI.NewResource(svc.Import, svc.StaffImport, svc.ClassListImport, svc.Users, db)
 
 	return &testContext{
 		db:       db,

--- a/backend/api/students/api.go
+++ b/backend/api/students/api.go
@@ -61,10 +61,14 @@ type ResourceConfig struct {
 	// "kommt heute" on every weekday, including the ones they are not booked
 	// for. Optional: nil keeps the unfiltered pre-#1747 behaviour, which is
 	// what bare test Resources rely on.
-	CareDayService          scheduleService.CareDayService
-	SchoolService           platformSvc.SchoolService
-	SettingsService         configService.SettingsService
-	StudentService          userService.StudentService
+	CareDayService  scheduleService.CareDayService
+	SchoolService   platformSvc.SchoolService
+	SettingsService configService.SettingsService
+	StudentService  userService.StudentService
+	// ClassListEntryService supplies the class-list-only entries (#2382) the
+	// "Klassenliste" export merges into the Klassenverband. Optional: nil
+	// exports without entries (bare test Resources).
+	ClassListEntryService   userService.ClassListEntryService
 	StudentDeletionService  userService.StudentDeletionService
 	StudentAuditService     userService.StudentAuditService
 	MasterDataReviewService userService.MasterDataReviewService

--- a/backend/api/students/class_list_entries_export.go
+++ b/backend/api/students/class_list_entries_export.go
@@ -129,25 +129,55 @@ func (rs *Resource) mergeClassListEntrySources(r *http.Request, req studentExpor
 			row:         classListEntryExportRow(entry),
 		})
 	}
-	return mergeClassListEntryRowSources(sources, entrySources, exportSortMode(req) == ""), nil
+	return mergeClassListEntryRowSources(sources, entrySources, exportSortMode(req) == "", req.Filters.GroupByClass), nil
 }
 
 // mergeClassListEntryRowSources interleaves entry rows into the
-// already-sorted student rows: by class, then German name collation. When the
-// students follow a non-name sort (pickup/arrival time), entries land at the
-// end of their class block — they have no time to sort by. The result feeds
-// the same grouped/ungrouped row builders as before.
-func mergeClassListEntryRowSources(students []exportRowSource, entries []exportRowSource, nameSorted bool) []exportRowSource {
+// already-sorted student rows. Class ordering is applied ONLY where the
+// document shape requires it — a grouped export, whose class headings depend
+// on class-contiguous rows. An ungrouped export keeps the order the requested
+// sort mode produced: name-sorted documents interleave the entries by German
+// name collation, and a time/birthday sort (which an entry has no value for)
+// keeps the student order untouched and appends the entries at the end,
+// class-then-name sorted among themselves.
+func mergeClassListEntryRowSources(students []exportRowSource, entries []exportRowSource, nameSorted, grouped bool) []exportRowSource {
 	if len(entries) == 0 {
 		return students
 	}
-	merged := make([]exportRowSource, 0, len(students)+len(entries))
-	merged = append(merged, students...)
-	merged = append(merged, entries...)
-	// Stable: within a class the existing student order (whatever sort mode
-	// produced it) survives; entries slot in by name or sink to the block end.
-	stableSortRowSources(merged, nameSorted)
-	return merged
+	if grouped {
+		merged := make([]exportRowSource, 0, len(students)+len(entries))
+		merged = append(merged, students...)
+		merged = append(merged, entries...)
+		// Stable: within a class the existing student order (whatever sort
+		// mode produced it) survives; entries slot in by name or sink to the
+		// block end.
+		stableSortRowSources(merged, nameSorted)
+		return merged
+	}
+	if nameSorted {
+		merged := make([]exportRowSource, 0, len(students)+len(entries))
+		merged = append(merged, students...)
+		merged = append(merged, entries...)
+		sortRowSourcesByName(merged)
+		return merged
+	}
+	stableSortRowSources(entries, true)
+	return append(students, entries...)
+}
+
+// sortRowSourcesByName orders by German name collation only — the ungrouped,
+// name-sorted document shape. Students win ties against entries.
+func sortRowSourcesByName(sources []exportRowSource) {
+	sort.SliceStable(sources, func(i, j int) bool {
+		a, b := sources[i], sources[j]
+		if r := collation.CompareGermanNames(a.lastName, a.firstName, b.lastName, b.firstName); r != 0 {
+			return r < 0
+		}
+		if a.entryTie != b.entryTie {
+			return !a.entryTie
+		}
+		return false
+	})
 }
 
 func stableSortRowSources(sources []exportRowSource, nameSorted bool) {

--- a/backend/api/students/class_list_entries_export.go
+++ b/backend/api/students/class_list_entries_export.go
@@ -1,0 +1,185 @@
+package students
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/internal/collation"
+	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
+	"github.com/moto-nrw/project-phoenix/internal/strutil"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+	"github.com/moto-nrw/project-phoenix/services/listexport"
+)
+
+// This file merges the class-list-only entries (#2382) into the student
+// database "Klassenliste" export: the same children the phase class roster
+// shows must appear here too, or the two exports both called "Klassenliste"
+// disagree about the Klassenverband.
+
+// classListEntryExportEligible reports whether the export may carry list
+// entries at all. Entries only exist as name + class, so any active filter on
+// a property they don't have (group, room, lifecycle status, bus, photo
+// consent, pickup, day status, times, birthday months) excludes every entry
+// semantically — the merged list would claim they matched the filter.
+func classListEntryExportEligible(preset listexport.Preset, f studentExportFilters) bool {
+	if preset != listexport.PresetClassRoster {
+		return false
+	}
+	return f.GroupID == "" && f.RoomID == "" && f.Status == "" && f.Bus == "" &&
+		f.PhotoConsent == "" && f.PickupStatus == "" && f.DayStatus == "" &&
+		f.PickupTime == "" && f.ArrivalTime == "" && len(f.Months) == 0
+}
+
+// classListEntriesForExport loads and filters the entries for the export:
+// the search matches names, the class filter (comma-separated, #2218) and
+// the year filter match the class string — the same dimensions the student
+// side filters by.
+func (rs *Resource) classListEntriesForExport(r *http.Request, filters studentExportFilters) ([]*userModels.ClassListEntry, error) {
+	if rs.ClassListEntryService == nil {
+		return nil, nil
+	}
+	entries, err := rs.ClassListEntryService.ListAll(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	classFilter := map[string]bool{}
+	for _, class := range strings.Split(filters.SchoolClass, ",") {
+		if key := schoolclass.Normalize(class); key != "" {
+			classFilter[key] = true
+		}
+	}
+	kept := make([]*userModels.ClassListEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		if len(classFilter) > 0 && !classFilter[schoolclass.Normalize(entry.SchoolClass)] {
+			continue
+		}
+		if !matchesExportYearFilter(entry.SchoolClass, filters.Year) {
+			continue
+		}
+		if !classListEntryMatchesSearch(entry, filters.Search) {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	return kept, nil
+}
+
+func classListEntryMatchesSearch(entry *userModels.ClassListEntry, search string) bool {
+	if search == "" {
+		return true
+	}
+	fullName := entry.FirstName + " " + entry.LastName
+	return strutil.ContainsFold(entry.FirstName, search) ||
+		strutil.ContainsFold(entry.LastName, search) ||
+		strutil.ContainsFold(fullName, search)
+}
+
+// classListEntryExportRow renders one entry: name with the "Keine Betreuung"
+// marker, class, and "—" in the weekday cells like a non-care day of a
+// student row. Every other column stays empty — the entry has no data there,
+// and an invented value is exactly what #2382 forbids.
+func classListEntryExportRow(entry *userModels.ClassListEntry) listexport.Row {
+	return listexport.Row{Values: map[listexport.ColumnID]string{
+		listexport.ColumnName:              strings.TrimSpace(entry.FirstName+" "+entry.LastName) + " (" + enrollmentService.ClassListEntryNoCareLabel + ")",
+		listexport.ColumnSchoolClass:       entry.SchoolClass,
+		listexport.ColumnEnrollmentSummary: enrollmentService.ClassListEntryNoCareLabel,
+		listexport.ColumnWeeklyMonday:      "—",
+		listexport.ColumnWeeklyTuesday:     "—",
+		listexport.ColumnWeeklyWednesday:   "—",
+		listexport.ColumnWeeklyThursday:    "—",
+		listexport.ColumnWeeklyFriday:      "—",
+	}}
+}
+
+// exportRowSource is one future document row with the sort keys the merge
+// needs (rows themselves don't carry name/class separately).
+type exportRowSource struct {
+	schoolClass string
+	lastName    string
+	firstName   string
+	// entryTie breaks ties between a student and an entry deterministically
+	// (students first) without ever comparing IDs across the two kinds.
+	entryTie bool
+	row      listexport.Row
+}
+
+// mergeClassListEntrySources loads, filters and interleaves the class-list
+// entries into the student row sources when the export is eligible; a
+// non-eligible export passes through unchanged.
+func (rs *Resource) mergeClassListEntrySources(r *http.Request, req studentExportRequest, sources []exportRowSource) ([]exportRowSource, error) {
+	if !classListEntryExportEligible(req.Preset, req.Filters) {
+		return sources, nil
+	}
+	entries, err := rs.classListEntriesForExport(r, req.Filters)
+	if err != nil {
+		return nil, err
+	}
+	entrySources := make([]exportRowSource, 0, len(entries))
+	for _, entry := range entries {
+		entrySources = append(entrySources, exportRowSource{
+			schoolClass: entry.SchoolClass,
+			lastName:    entry.LastName,
+			firstName:   entry.FirstName,
+			entryTie:    true,
+			row:         classListEntryExportRow(entry),
+		})
+	}
+	return mergeClassListEntryRowSources(sources, entrySources, exportSortMode(req) == ""), nil
+}
+
+// mergeClassListEntryRowSources interleaves entry rows into the
+// already-sorted student rows: by class, then German name collation. When the
+// students follow a non-name sort (pickup/arrival time), entries land at the
+// end of their class block — they have no time to sort by. The result feeds
+// the same grouped/ungrouped row builders as before.
+func mergeClassListEntryRowSources(students []exportRowSource, entries []exportRowSource, nameSorted bool) []exportRowSource {
+	if len(entries) == 0 {
+		return students
+	}
+	merged := make([]exportRowSource, 0, len(students)+len(entries))
+	merged = append(merged, students...)
+	merged = append(merged, entries...)
+	// Stable: within a class the existing student order (whatever sort mode
+	// produced it) survives; entries slot in by name or sink to the block end.
+	stableSortRowSources(merged, nameSorted)
+	return merged
+}
+
+func stableSortRowSources(sources []exportRowSource, nameSorted bool) {
+	sort.SliceStable(sources, func(i, j int) bool {
+		a, b := sources[i], sources[j]
+		if r := collation.CompareSchoolClasses(a.schoolClass, b.schoolClass); r != 0 {
+			return r < 0
+		}
+		if nameSorted {
+			if r := collation.CompareGermanNames(a.lastName, a.firstName, b.lastName, b.firstName); r != 0 {
+				return r < 0
+			}
+		}
+		if a.entryTie != b.entryTie {
+			return !a.entryTie
+		}
+		return false
+	})
+}
+
+// buildExportRowSources renders the final rows (grouped or flat) from the
+// merged sources, reusing the exact heading semantics of
+// buildGroupedExportRows.
+func buildExportRowSources(sources []exportRowSource, grouped bool) []listexport.Row {
+	rows := make([]listexport.Row, 0, len(sources))
+	currentClass := ""
+	for i, source := range sources {
+		if class := strings.TrimSpace(source.schoolClass); grouped && (i == 0 || collation.CompareSchoolClasses(class, currentClass) != 0) {
+			currentClass = class
+			rows = append(rows, listexport.Row{GroupTitle: listexport.ClassGroupTitle(class)})
+		}
+		rows = append(rows, source.row)
+	}
+	return rows
+}

--- a/backend/api/students/class_list_entries_export.go
+++ b/backend/api/students/class_list_entries_export.go
@@ -22,13 +22,17 @@ import (
 // entries at all. Entries only exist as name + class, so any active filter on
 // a property they don't have (group, room, lifecycle status, bus, photo
 // consent, pickup, day status, times, birthday months) excludes every entry
-// semantically — the merged list would claim they matched the filter.
+// semantically — the merged list would claim they matched the filter. The
+// enum filters share the student side's isActiveFilterValue semantics: an
+// explicit "all" filters nothing there, so it must not drop the entries here.
 func classListEntryExportEligible(preset listexport.Preset, f studentExportFilters) bool {
 	if preset != listexport.PresetClassRoster {
 		return false
 	}
-	return f.GroupID == "" && f.RoomID == "" && f.Status == "" && f.Bus == "" &&
-		f.PhotoConsent == "" && f.PickupStatus == "" && f.DayStatus == "" &&
+	return f.GroupID == "" && f.RoomID == "" &&
+		!isActiveFilterValue(f.Status) && !isActiveFilterValue(f.Bus) &&
+		!isActiveFilterValue(f.PhotoConsent) && !isActiveFilterValue(f.PickupStatus) &&
+		!isActiveFilterValue(f.DayStatus) &&
 		f.PickupTime == "" && f.ArrivalTime == "" && len(f.Months) == 0
 }
 

--- a/backend/api/students/class_list_entries_export_test.go
+++ b/backend/api/students/class_list_entries_export_test.go
@@ -1,0 +1,50 @@
+package students
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/services/listexport"
+	"github.com/stretchr/testify/assert"
+)
+
+// Explicit "all" values are the student side's "no filter" sentinels
+// (isActiveFilterValue): a request carrying them keeps every student, so it
+// must keep the class-list entries too (#2399 review round 9).
+func TestClassListEntryExportEligibleTreatsAllAsInactive(t *testing.T) {
+	eligible := classListEntryExportEligible(listexport.PresetClassRoster, studentExportFilters{
+		Status:       "all",
+		Bus:          "all",
+		PhotoConsent: "all",
+		PickupStatus: "all",
+		DayStatus:    DayPlanningStatusAll,
+	})
+	assert.True(t, eligible, "explicit 'all' filters keep every student and must keep the entries")
+
+	assert.True(t, classListEntryExportEligible(listexport.PresetClassRoster, studentExportFilters{}),
+		"an unfiltered class roster carries the entries")
+}
+
+// Any genuinely active filter targets a property an entry does not have — the
+// entries drop out, and a non-class-roster preset never carries them.
+func TestClassListEntryExportEligibleActiveFilterExcludesEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters studentExportFilters
+	}{
+		{"status", studentExportFilters{Status: "klassenfahrt"}},
+		{"bus", studentExportFilters{Bus: "yes"}},
+		{"photo_consent", studentExportFilters{PhotoConsent: "no"}},
+		{"pickup_status", studentExportFilters{PickupStatus: "self"}},
+		{"day_status", studentExportFilters{DayStatus: DayPlanningStatusComesToday}},
+		{"group", studentExportFilters{GroupID: "5"}},
+		{"room", studentExportFilters{RoomID: "7"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, classListEntryExportEligible(listexport.PresetClassRoster, tt.filters))
+		})
+	}
+
+	assert.False(t, classListEntryExportEligible(listexport.PresetOGSWeekly, studentExportFilters{}),
+		"only the class roster preset carries entries")
+}

--- a/backend/api/students/export_handlers.go
+++ b/backend/api/students/export_handlers.go
@@ -144,15 +144,19 @@ func (rs *Resource) exportStudents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var rows []listexport.Row
-	if req.Filters.GroupByClass {
-		rows = buildGroupedExportRows(responses, weekly, enrollmentSummaries, planningDate, isToday)
-	} else {
-		rows = buildExportRows(responses, weekly, enrollmentSummaries, planningDate, isToday)
+	sources := responseRowSources(responses, weekly, enrollmentSummaries, planningDate, isToday)
+	// Class-list-only entries (#2382) complete the Klassenverband of the
+	// "Klassenliste" preset; filters on properties they don't have exclude
+	// them (classListEntryExportEligible).
+	sources, err = rs.mergeClassListEntrySources(r, req, sources)
+	if err != nil {
+		renderError(w, r, common.ErrorInternalServer(err))
+		return
 	}
+	rows := buildExportRowSources(sources, req.Filters.GroupByClass)
 	doc := listexport.Document{
 		Title:       exportTitle(req),
-		Subtitle:    rs.exportSubtitle(r, len(responses)),
+		Subtitle:    rs.exportSubtitle(r, len(sources)),
 		GeneratedAt: time.Now(),
 		Filters:     exportFilterLabelsForDate(req.Filters, planningDate, isToday),
 		Columns:     columns,
@@ -606,28 +610,28 @@ func groupExportResponsesByClass(students []StudentResponse) {
 	})
 }
 
-func buildGroupedExportRows(students []StudentResponse, weekly map[int64]weeklySchedule, enrollmentSummaries map[int64]string, onDate timezone.Date, isToday bool) []listexport.Row {
-	rows := make([]listexport.Row, 0, len(students))
-	currentClass := ""
-	for i, student := range students {
-		// Boundary detection must use the sort comparator's equivalence:
-		// label variants like "1a"/"1A"/"1 a" are one logical class and
-		// must share a single heading (first-seen label).
-		if class := strings.TrimSpace(student.SchoolClass); i == 0 || collation.CompareSchoolClasses(class, currentClass) != 0 {
-			currentClass = class
-			rows = append(rows, listexport.Row{GroupTitle: listexport.ClassGroupTitle(class)})
-		}
-		rows = append(rows, buildExportRow(student, weekly[student.ID], enrollmentSummaries, onDate, isToday))
+// responseRowSources renders every student response into its future document
+// row plus the sort keys the class-list-entry merge (#2382) needs. The order
+// of `students` (whatever sort mode produced it) is preserved.
+func responseRowSources(students []StudentResponse, weekly map[int64]weeklySchedule, enrollmentSummaries map[int64]string, onDate timezone.Date, isToday bool) []exportRowSource {
+	sources := make([]exportRowSource, 0, len(students))
+	for _, student := range students {
+		sources = append(sources, exportRowSource{
+			schoolClass: student.SchoolClass,
+			lastName:    student.LastName,
+			firstName:   student.FirstName,
+			row:         buildExportRow(student, weekly[student.ID], enrollmentSummaries, onDate, isToday),
+		})
 	}
-	return rows
+	return sources
+}
+
+func buildGroupedExportRows(students []StudentResponse, weekly map[int64]weeklySchedule, enrollmentSummaries map[int64]string, onDate timezone.Date, isToday bool) []listexport.Row {
+	return buildExportRowSources(responseRowSources(students, weekly, enrollmentSummaries, onDate, isToday), true)
 }
 
 func buildExportRows(students []StudentResponse, weekly map[int64]weeklySchedule, enrollmentSummaries map[int64]string, onDate timezone.Date, isToday bool) []listexport.Row {
-	rows := make([]listexport.Row, 0, len(students))
-	for _, student := range students {
-		rows = append(rows, buildExportRow(student, weekly[student.ID], enrollmentSummaries, onDate, isToday))
-	}
-	return rows
+	return buildExportRowSources(responseRowSources(students, weekly, enrollmentSummaries, onDate, isToday), false)
 }
 
 // birthdayExportCell renders the birth date German-style ("02.09.2018").

--- a/backend/api/students/export_handlers.go
+++ b/backend/api/students/export_handlers.go
@@ -153,6 +153,13 @@ func (rs *Resource) exportStudents(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
+	// Re-check the cap on the FINAL merged source set: the class-list entries
+	// joined after the student-side check above, and the document limit is a
+	// limit on rows in the file, not on students alone.
+	if errResp := exportSelectionCapError(len(sources)); errResp != nil {
+		renderError(w, r, errResp)
+		return
+	}
 	rows := buildExportRowSources(sources, req.Filters.GroupByClass)
 	doc := listexport.Document{
 		Title:       exportTitle(req),

--- a/backend/api/students/student_handlers.go
+++ b/backend/api/students/student_handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/collation"
 	"github.com/moto-nrw/project-phoenix/internal/strutil"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
@@ -385,7 +387,46 @@ func (rs *Resource) listSchoolClasses(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r, common.ErrorInternalServer(err))
 		return
 	}
+	classes, err = rs.appendClassListEntryClasses(r.Context(), classes)
+	if err != nil {
+		renderError(w, r, common.ErrorInternalServer(err))
+		return
+	}
 	common.Respond(w, r, http.StatusOK, classes, "School classes retrieved successfully")
+}
+
+// appendClassListEntryClasses unions the classes that exist only through
+// class-list-only entries (#2382) into the dropdown list: a class whose
+// children are all list entries must still be selectable for class lists.
+// Dedupe uses the LOWER(TRIM(...)) identity every class comparison uses.
+func (rs *Resource) appendClassListEntryClasses(ctx context.Context, classes []string) ([]string, error) {
+	if rs.ClassListEntryService == nil {
+		return classes, nil
+	}
+	entries, err := rs.ClassListEntryService.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(classes))
+	for _, class := range classes {
+		seen[strings.ToLower(strings.TrimSpace(class))] = true
+	}
+	added := false
+	for _, entry := range entries {
+		key := strings.ToLower(strings.TrimSpace(entry.SchoolClass))
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		classes = append(classes, strings.TrimSpace(entry.SchoolClass))
+		added = true
+	}
+	if added {
+		sort.SliceStable(classes, func(i, j int) bool {
+			return collation.CompareSchoolClasses(classes[i], classes[j]) < 0
+		})
+	}
+	return classes, nil
 }
 
 // getStudent handles getting a student by ID

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -10,6 +10,7 @@ DELETE /api/activities/{id}/students/{studentId}
 DELETE /api/activities/{id}/supervisors/{supervisorId}
 DELETE /api/admin/grade-transitions/{id}/
 DELETE /api/calendar/appointments/{appointmentId}
+DELETE /api/class-list-entries/{id}
 DELETE /api/display/{id}/
 DELETE /api/enrollment/admin/requests/{id}/
 DELETE /api/enrollment/admin/requests/{id}/children/{childId}
@@ -160,6 +161,7 @@ GET /api/calendar/my
 GET /api/calendar/recipient-options
 GET /api/class-day/
 GET /api/class-day/classes
+GET /api/class-list-entries/
 GET /api/database/stats
 GET /api/display/
 GET /api/display/dashboard
@@ -219,6 +221,7 @@ GET /api/guardians/{id}
 GET /api/guardians/{id}/delete-preview
 GET /api/guardians/{id}/phone-numbers/
 GET /api/guardians/{id}/students
+GET /api/import/class-list-entries/template
 GET /api/import/opening-balances/template
 GET /api/import/students/template
 GET /api/import/teachers/template
@@ -563,6 +566,8 @@ POST /api/calendar/appointments
 POST /api/calendar/appointments/{appointmentId}/cancel
 POST /api/calendar/appointments/{appointmentId}/occurrences/{occurrenceDate}/cancel
 POST /api/calendar/recipients/{recipientId}/response
+POST /api/class-list-entries/
+POST /api/class-list-entries/{id}/assign
 POST /api/display/
 POST /api/display/{id}/regenerate
 POST /api/emergency/snapshot/export
@@ -603,6 +608,8 @@ POST /api/guardians/students/{studentId}/invite
 POST /api/guardians/{id}/invite
 POST /api/guardians/{id}/phone-numbers/
 POST /api/guardians/{id}/phone-numbers/{phoneId}/set-primary
+POST /api/import/class-list-entries/import
+POST /api/import/class-list-entries/preview
 POST /api/import/opening-balances/import
 POST /api/import/opening-balances/preview
 POST /api/import/students/import
@@ -846,6 +853,7 @@ PUT /api/activities/{id}/supervisors/{supervisorId}
 PUT /api/admin/grade-transitions/{id}/
 PUT /api/birthdays/opt-out
 PUT /api/calendar/appointments/{appointmentId}
+PUT /api/class-list-entries/{id}
 PUT /api/enrollment/admin/requests/{id}/children/{childId}/data-correction
 PUT /api/enrollment/admin/requests/{id}/children/{childId}/offerings
 PUT /api/enrollment/care-offerings/{id}/

--- a/backend/database/migrations/001015301_class_list_entries.go
+++ b/backend/database/migrations/001015301_class_list_entries.go
@@ -123,8 +123,10 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
 			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
 
-		-- Append-only from the application's point of view; DELETE stays with
-		-- the retention cleanup, which runs on the superuser CLI connection.
+		-- Append-only from the application's point of view: the app role gets
+		-- no DELETE. No retention cleanup consumes this table yet (same as
+		-- audit.staff_master_data_changes); a future cleanup would run on the
+		-- superuser CLI connection and needs no extra grant here.
 		GRANT SELECT, INSERT ON audit.class_list_entry_changes TO phoenix_tenant;
 		GRANT USAGE ON SEQUENCE audit.class_list_entry_changes_id_seq TO phoenix_tenant;
 	`)

--- a/backend/database/migrations/001015301_class_list_entries.go
+++ b/backend/database/migrations/001015301_class_list_entries.go
@@ -1,0 +1,160 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	classListEntriesVersion     = "1.15.301"
+	classListEntriesDescription = "Minimal class-list-only entries (Name + Klasse) for children without an OGS record (#2382)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     classListEntriesVersion,
+		Description: classListEntriesDescription,
+		DependsOn:   []string{classTeachersVersion},
+	})
+
+	Migrations.MustRegister(
+		func(ctx context.Context, db *bun.DB) error {
+			return classListEntriesUp(ctx, db)
+		},
+		func(ctx context.Context, db *bun.DB) error {
+			return classListEntriesDown(ctx, db)
+		},
+	)
+}
+
+// classListEntriesUp creates users.class_list_entries (#2382): one row is a
+// child of the class cohort that has NO OGS record — only first name, last
+// name and the free-text school class. The row exists so class lists and the
+// Lehrkraft class-day view can show the complete Klassenverband; it is
+// deliberately NOT a student: no person, no guardians, no attendance, no care
+// planning can ever reference it. The class is the same free-text value as
+// users.students.school_class, matched via LOWER(BTRIM(...)).
+//
+// audit.class_list_entry_changes is the append-only trail: entries are
+// personal data of children, so create / update / delete / assign must leave
+// a trace (same contract as audit.staff_master_data_changes).
+func classListEntriesUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.301: Class-list-only entries...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS users.class_list_entries (
+			id           BIGSERIAL PRIMARY KEY,
+			tenant_id    BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			first_name   TEXT NOT NULL,
+			last_name    TEXT NOT NULL,
+			school_class TEXT NOT NULL,
+			created_by   BIGINT,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_class_list_entries_first_name CHECK (BTRIM(first_name) <> ''),
+			CONSTRAINT chk_class_list_entries_last_name CHECK (BTRIM(last_name) <> ''),
+			CONSTRAINT chk_class_list_entries_school_class CHECK (BTRIM(school_class) <> '')
+		);
+
+		-- One child appears once per class: an identical name in the same
+		-- class is an input error, never a second child (twins differ in the
+		-- first name). Race-safe backstop for the service-level guard.
+		CREATE UNIQUE INDEX IF NOT EXISTS uniq_class_list_entries_name_class
+			ON users.class_list_entries (tenant_id, LOWER(BTRIM(first_name)), LOWER(BTRIM(last_name)), LOWER(BTRIM(school_class)));
+
+		CREATE INDEX IF NOT EXISTS idx_class_list_entries_tenant_class
+			ON users.class_list_entries (tenant_id, LOWER(BTRIM(school_class)));
+
+		DROP TRIGGER IF EXISTS update_class_list_entries_updated_at ON users.class_list_entries;
+		CREATE TRIGGER update_class_list_entries_updated_at
+		BEFORE UPDATE ON users.class_list_entries
+		FOR EACH ROW
+		EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE users.class_list_entries ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE users.class_list_entries FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_users_class_list_entries ON users.class_list_entries;
+		CREATE POLICY tenant_isolation_users_class_list_entries ON users.class_list_entries
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON users.class_list_entries TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE users.class_list_entries_id_seq TO phoenix_tenant;
+
+		CREATE TABLE IF NOT EXISTS audit.class_list_entry_changes (
+			id                 BIGSERIAL PRIMARY KEY,
+			tenant_id          BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			entry_id           BIGINT NOT NULL,
+			action             TEXT NOT NULL,
+			old_value          TEXT NOT NULL DEFAULT '',
+			new_value          TEXT NOT NULL DEFAULT '',
+			matched_student_id BIGINT,
+			changed_by         BIGINT NOT NULL,
+			occurred_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_class_list_entry_changes_action
+				CHECK (action IN ('created', 'updated', 'deleted', 'assigned'))
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_class_list_entry_changes_entry
+			ON audit.class_list_entry_changes (tenant_id, entry_id, occurred_at DESC);
+
+		ALTER TABLE audit.class_list_entry_changes ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE audit.class_list_entry_changes FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_class_list_entry_changes ON audit.class_list_entry_changes;
+		CREATE POLICY tenant_isolation_class_list_entry_changes ON audit.class_list_entry_changes
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		-- Append-only from the application's point of view; DELETE stays with
+		-- the retention cleanup, which runs on the superuser CLI connection.
+		GRANT SELECT, INSERT ON audit.class_list_entry_changes TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE audit.class_list_entry_changes_id_seq TO phoenix_tenant;
+	`)
+	if err != nil {
+		return fmt.Errorf("error creating users.class_list_entries: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func classListEntriesDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.301: Dropping users.class_list_entries...")
+
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		DROP TABLE IF EXISTS audit.class_list_entry_changes;
+		DROP TABLE IF EXISTS users.class_list_entries;
+	`)
+	if err != nil {
+		return fmt.Errorf("error dropping users.class_list_entries: %w", err)
+	}
+
+	return tx.Commit()
+}

--- a/backend/database/migrations/001015303_class_list_entries.go
+++ b/backend/database/migrations/001015303_class_list_entries.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	classListEntriesVersion     = "1.15.301"
+	classListEntriesVersion     = "1.15.303"
 	classListEntriesDescription = "Minimal class-list-only entries (Name + Klasse) for children without an OGS record (#2382)"
 )
 
@@ -43,7 +43,7 @@ func init() {
 // personal data of children, so create / update / delete / assign must leave
 // a trace (same contract as audit.staff_master_data_changes).
 func classListEntriesUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.301: Class-list-only entries...")
+	fmt.Println("Migration 1.15.303: Class-list-only entries...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
@@ -138,7 +138,7 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 }
 
 func classListEntriesDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.301: Dropping users.class_list_entries...")
+	fmt.Println("Rolling back migration 1.15.303: Dropping users.class_list_entries...")
 
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {

--- a/backend/database/migrations/001015303_class_list_entries.go
+++ b/backend/database/migrations/001015303_class_list_entries.go
@@ -2,9 +2,7 @@ package migrations
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"log"
 
 	"github.com/uptrace/bun"
 )
@@ -21,14 +19,7 @@ func init() {
 		DependsOn:   []string{classTeachersVersion},
 	})
 
-	Migrations.MustRegister(
-		func(ctx context.Context, db *bun.DB) error {
-			return classListEntriesUp(ctx, db)
-		},
-		func(ctx context.Context, db *bun.DB) error {
-			return classListEntriesDown(ctx, db)
-		},
-	)
+	Migrations.MustRegister(classListEntriesUp, classListEntriesDown)
 }
 
 // classListEntriesUp creates users.class_list_entries (#2382): one row is a
@@ -42,20 +33,18 @@ func init() {
 // audit.class_list_entry_changes is the append-only trail: entries are
 // personal data of children, so create / update / delete / assign must leave
 // a trace (same contract as audit.staff_master_data_changes).
+//
+// education.grade_transition_class_list_entries is the per-transition ledger
+// of what a grade-transition apply did to the entries — 'removed' rows it
+// deleted (with their original display form), 'created' rows it inserted.
+// The revert replays this ledger instead of guessing a reverse rename from
+// the mappings, which cannot distinguish an entry the apply renamed into
+// "2a" from a pre-existing "2a" entry it never touched (mirror of
+// education.grade_transition_class_teachers).
 func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.303: Class-list-only entries...")
 
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
-			log.Printf("Error rolling back transaction: %v", err)
-		}
-	}()
-
-	_, err = tx.ExecContext(ctx, `
+	_, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS users.class_list_entries (
 			id           BIGSERIAL PRIMARY KEY,
 			tenant_id    BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
@@ -129,28 +118,56 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 		-- superuser CLI connection and needs no extra grant here.
 		GRANT SELECT, INSERT ON audit.class_list_entry_changes TO phoenix_tenant;
 		GRANT USAGE ON SEQUENCE audit.class_list_entry_changes_id_seq TO phoenix_tenant;
+
+		CREATE TABLE IF NOT EXISTS education.grade_transition_class_list_entries (
+			id            BIGSERIAL PRIMARY KEY,
+			tenant_id     BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
+			transition_id BIGINT NOT NULL REFERENCES education.grade_transitions(id) ON DELETE CASCADE,
+			first_name    TEXT NOT NULL,
+			last_name     TEXT NOT NULL,
+			school_class  TEXT NOT NULL,
+			action        TEXT NOT NULL,
+			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_gtcle_first_name CHECK (BTRIM(first_name) <> ''),
+			CONSTRAINT chk_gtcle_last_name CHECK (BTRIM(last_name) <> ''),
+			CONSTRAINT chk_gtcle_school_class CHECK (BTRIM(school_class) <> ''),
+			CONSTRAINT chk_gtcle_action CHECK (action IN ('removed', 'created'))
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_gtcle_tenant_transition
+			ON education.grade_transition_class_list_entries (tenant_id, transition_id);
+
+		DROP TRIGGER IF EXISTS update_grade_transition_class_list_entries_updated_at ON education.grade_transition_class_list_entries;
+		CREATE TRIGGER update_grade_transition_class_list_entries_updated_at
+		BEFORE UPDATE ON education.grade_transition_class_list_entries
+		FOR EACH ROW
+		EXECUTE FUNCTION update_modified_column();
+
+		ALTER TABLE education.grade_transition_class_list_entries ENABLE ROW LEVEL SECURITY;
+		ALTER TABLE education.grade_transition_class_list_entries FORCE ROW LEVEL SECURITY;
+
+		DROP POLICY IF EXISTS tenant_isolation_education_grade_transition_class_list_entries ON education.grade_transition_class_list_entries;
+		CREATE POLICY tenant_isolation_education_grade_transition_class_list_entries ON education.grade_transition_class_list_entries
+			FOR ALL
+			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
+
+		GRANT SELECT, INSERT, UPDATE, DELETE ON education.grade_transition_class_list_entries TO phoenix_tenant;
+		GRANT USAGE ON SEQUENCE education.grade_transition_class_list_entries_id_seq TO phoenix_tenant;
 	`)
 	if err != nil {
 		return fmt.Errorf("error creating users.class_list_entries: %w", err)
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 func classListEntriesDown(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Rolling back migration 1.15.303: Dropping users.class_list_entries...")
 
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil && err.Error() != "sql: transaction has already been committed or rolled back" {
-			log.Printf("Error rolling back transaction: %v", err)
-		}
-	}()
-
-	_, err = tx.ExecContext(ctx, `
+	_, err := db.ExecContext(ctx, `
+		DROP TABLE IF EXISTS education.grade_transition_class_list_entries;
 		DROP TABLE IF EXISTS audit.class_list_entry_changes;
 		DROP TABLE IF EXISTS users.class_list_entries;
 	`)
@@ -158,5 +175,5 @@ func classListEntriesDown(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error dropping users.class_list_entries: %w", err)
 	}
 
-	return tx.Commit()
+	return nil
 }

--- a/backend/database/migrations/001015304_class_list_entries.go
+++ b/backend/database/migrations/001015304_class_list_entries.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	classListEntriesVersion     = "1.15.303"
+	classListEntriesVersion     = "1.15.304"
 	classListEntriesDescription = "Minimal class-list-only entries (Name + Klasse) for children without an OGS record (#2382)"
 )
 
@@ -42,7 +42,7 @@ func init() {
 // "2a" from a pre-existing "2a" entry it never touched (mirror of
 // education.grade_transition_class_teachers).
 func classListEntriesUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.303: Class-list-only entries...")
+	fmt.Println("Migration 1.15.304: Class-list-only entries...")
 
 	_, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS users.class_list_entries (
@@ -164,7 +164,7 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 }
 
 func classListEntriesDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.303: Dropping users.class_list_entries...")
+	fmt.Println("Rolling back migration 1.15.304: Dropping users.class_list_entries...")
 
 	_, err := db.ExecContext(ctx, `
 		DROP TABLE IF EXISTS education.grade_transition_class_list_entries;

--- a/backend/database/migrations/001015306_class_list_entries.go
+++ b/backend/database/migrations/001015306_class_list_entries.go
@@ -40,7 +40,10 @@ func init() {
 // The revert replays this ledger instead of guessing a reverse rename from
 // the mappings, which cannot distinguish an entry the apply renamed into
 // "2a" from a pre-existing "2a" entry it never touched (mirror of
-// education.grade_transition_class_teachers).
+// education.grade_transition_class_teachers). 'created' rows additionally
+// carry entry_id, the id of the row the apply inserted: without it a revert
+// can only match by normalized identity and would silently overwrite an
+// admin's display-form edit ("2a" → "2A") made between apply and revert.
 func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 	fmt.Println("Migration 1.15.306: Class-list-only entries...")
 
@@ -119,10 +122,14 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 		GRANT SELECT, INSERT ON audit.class_list_entry_changes TO phoenix_tenant;
 		GRANT USAGE ON SEQUENCE audit.class_list_entry_changes_id_seq TO phoenix_tenant;
 
+		-- entry_id deliberately carries NO foreign key: the revert deletes the
+		-- very row it points at, and ON DELETE SET NULL / CASCADE would erase
+		-- the ledger evidence the revert reasons about.
 		CREATE TABLE IF NOT EXISTS education.grade_transition_class_list_entries (
 			id            BIGSERIAL PRIMARY KEY,
 			tenant_id     BIGINT NOT NULL REFERENCES platform.schools(id) ON DELETE CASCADE,
 			transition_id BIGINT NOT NULL REFERENCES education.grade_transitions(id) ON DELETE CASCADE,
+			entry_id      BIGINT,
 			first_name    TEXT NOT NULL,
 			last_name     TEXT NOT NULL,
 			school_class  TEXT NOT NULL,

--- a/backend/database/migrations/001015306_class_list_entries.go
+++ b/backend/database/migrations/001015306_class_list_entries.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	classListEntriesVersion     = "1.15.304"
+	classListEntriesVersion     = "1.15.306"
 	classListEntriesDescription = "Minimal class-list-only entries (Name + Klasse) for children without an OGS record (#2382)"
 )
 
@@ -42,7 +42,7 @@ func init() {
 // "2a" from a pre-existing "2a" entry it never touched (mirror of
 // education.grade_transition_class_teachers).
 func classListEntriesUp(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Migration 1.15.304: Class-list-only entries...")
+	fmt.Println("Migration 1.15.306: Class-list-only entries...")
 
 	_, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS users.class_list_entries (
@@ -164,7 +164,7 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 }
 
 func classListEntriesDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.304: Dropping users.class_list_entries...")
+	fmt.Println("Rolling back migration 1.15.306: Dropping users.class_list_entries...")
 
 	_, err := db.ExecContext(ctx, `
 		DROP TABLE IF EXISTS education.grade_transition_class_list_entries;

--- a/backend/database/migrations/001015306_class_list_entries.go
+++ b/backend/database/migrations/001015306_class_list_entries.go
@@ -77,15 +77,6 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 		FOR EACH ROW
 		EXECUTE FUNCTION update_modified_column();
 
-		ALTER TABLE users.class_list_entries ENABLE ROW LEVEL SECURITY;
-		ALTER TABLE users.class_list_entries FORCE ROW LEVEL SECURITY;
-
-		DROP POLICY IF EXISTS tenant_isolation_users_class_list_entries ON users.class_list_entries;
-		CREATE POLICY tenant_isolation_users_class_list_entries ON users.class_list_entries
-			FOR ALL
-			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
-			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
-
 		GRANT SELECT, INSERT, UPDATE, DELETE ON users.class_list_entries TO phoenix_tenant;
 		GRANT USAGE ON SEQUENCE users.class_list_entries_id_seq TO phoenix_tenant;
 
@@ -105,15 +96,6 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 
 		CREATE INDEX IF NOT EXISTS idx_class_list_entry_changes_entry
 			ON audit.class_list_entry_changes (tenant_id, entry_id, occurred_at DESC);
-
-		ALTER TABLE audit.class_list_entry_changes ENABLE ROW LEVEL SECURITY;
-		ALTER TABLE audit.class_list_entry_changes FORCE ROW LEVEL SECURITY;
-
-		DROP POLICY IF EXISTS tenant_isolation_class_list_entry_changes ON audit.class_list_entry_changes;
-		CREATE POLICY tenant_isolation_class_list_entry_changes ON audit.class_list_entry_changes
-			FOR ALL
-			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
-			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
 
 		-- Append-only from the application's point of view: the app role gets
 		-- no DELETE. No retention cleanup consumes this table yet (same as
@@ -151,15 +133,6 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 		FOR EACH ROW
 		EXECUTE FUNCTION update_modified_column();
 
-		ALTER TABLE education.grade_transition_class_list_entries ENABLE ROW LEVEL SECURITY;
-		ALTER TABLE education.grade_transition_class_list_entries FORCE ROW LEVEL SECURITY;
-
-		DROP POLICY IF EXISTS tenant_isolation_education_grade_transition_class_list_entries ON education.grade_transition_class_list_entries;
-		CREATE POLICY tenant_isolation_education_grade_transition_class_list_entries ON education.grade_transition_class_list_entries
-			FOR ALL
-			USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
-			WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint);
-
 		GRANT SELECT, INSERT, UPDATE, DELETE ON education.grade_transition_class_list_entries TO phoenix_tenant;
 		GRANT USAGE ON SEQUENCE education.grade_transition_class_list_entries_id_seq TO phoenix_tenant;
 	`)
@@ -167,7 +140,13 @@ func classListEntriesUp(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("error creating users.class_list_entries: %w", err)
 	}
 
-	return nil
+	// Tenant isolation for all three tables through the shared provisioning
+	// path (see rls_provisioning.go) instead of hand-copied DDL per table.
+	return provisionTenantRLS(ctx, db,
+		"users.class_list_entries",
+		"audit.class_list_entry_changes",
+		"education.grade_transition_class_list_entries",
+	)
 }
 
 func classListEntriesDown(ctx context.Context, db *bun.DB) error {

--- a/backend/database/migrations/rls_provisioning.go
+++ b/backend/database/migrations/rls_provisioning.go
@@ -1,0 +1,63 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/uptrace/bun"
+)
+
+// provisionTenantRLS is the shared provisioning path for tenant isolation on
+// newly created tenant-scoped tables. It applies exactly the contract migration
+// 1.15.1 established for the original 58 tables: row level security enabled and
+// forced, plus the canonical policy
+//
+//	tenant_isolation_<schema>_<table>
+//
+// matching tenant_id against the app.current_tenant_id session setting that
+// TenantTxMiddleware sets per request.
+//
+// Every table passed in must be schema-qualified and carry a NOT NULL
+// tenant_id.
+//
+// Why this lives in the migrations package: DDL is the only channel the project
+// has for schema provisioning, and this DDL is not optional. The CLI connects
+// as the postgres superuser, which bypasses RLS, but the HTTP server connects
+// as phoenix_auth and switches to phoenix_tenant per request — for those roles
+// the statements below ARE the tenant boundary. A tenant table that ships
+// without them is readable across schools.
+//
+// Use this helper instead of hand-copying the four statements into each new
+// migration; it keeps the policy shape and naming identical everywhere.
+func provisionTenantRLS(ctx context.Context, db *bun.DB, tables ...string) error {
+	for _, table := range tables {
+		schema, name, ok := strings.Cut(table, ".")
+		if !ok {
+			return fmt.Errorf("provisionTenantRLS: table %q is not schema-qualified", table)
+		}
+		policy := fmt.Sprintf("tenant_isolation_%s_%s", schema, name)
+
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(
+			`ALTER TABLE %s ENABLE ROW LEVEL SECURITY`, table)); err != nil {
+			return fmt.Errorf("provisionTenantRLS: enable on %s: %w", table, err)
+		}
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(
+			`ALTER TABLE %s FORCE ROW LEVEL SECURITY`, table)); err != nil {
+			return fmt.Errorf("provisionTenantRLS: force on %s: %w", table, err)
+		}
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(
+			`DROP POLICY IF EXISTS %s ON %s`, policy, table)); err != nil {
+			return fmt.Errorf("provisionTenantRLS: drop policy on %s: %w", table, err)
+		}
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(
+			`CREATE POLICY %s ON %s FOR ALL
+				USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)
+				WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::bigint)`,
+			policy, table)); err != nil {
+			return fmt.Errorf("provisionTenantRLS: create policy on %s: %w", table, err)
+		}
+	}
+
+	return nil
+}

--- a/backend/database/repositories/audit/class_list_entry_change.go
+++ b/backend/database/repositories/audit/class_list_entry_change.go
@@ -1,0 +1,55 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/uptrace/bun"
+)
+
+// ClassListEntryChangeRepository is the append-only writer for
+// audit.class_list_entry_changes (#2382).
+type ClassListEntryChangeRepository struct {
+	db *bun.DB
+}
+
+// NewClassListEntryChangeRepository creates the audit writer.
+func NewClassListEntryChangeRepository(db *bun.DB) auditModels.ClassListEntryChangeRepository {
+	return &ClassListEntryChangeRepository{db: db}
+}
+
+// Create inserts one change row.
+func (r *ClassListEntryChangeRepository) Create(ctx context.Context, change *auditModels.ClassListEntryChange) error {
+	if change == nil {
+		return fmt.Errorf("class list entry change audit event is required")
+	}
+	if err := change.Validate(); err != nil {
+		return fmt.Errorf("invalid class list entry change audit event: %w", err)
+	}
+	base.EnsureTenantID(ctx, change)
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(change).
+		ModelTableExpr(`audit.class_list_entry_changes AS "class_list_entry_change"`).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("create class list entry change audit event: %w", err)
+	}
+	return nil
+}
+
+// ListByEntryID returns the trail of one entry, newest first.
+func (r *ClassListEntryChangeRepository) ListByEntryID(ctx context.Context, entryID int64) ([]*auditModels.ClassListEntryChange, error) {
+	var changes []*auditModels.ClassListEntryChange
+	err := base.GetDB(ctx, r.db).NewSelect().
+		Model(&changes).
+		ModelTableExpr(`audit.class_list_entry_changes AS "class_list_entry_change"`).
+		Where(`"class_list_entry_change".entry_id = ?`, entryID).
+		OrderExpr(`"class_list_entry_change".occurred_at DESC, "class_list_entry_change".id DESC`).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list class list entry changes: %w", err)
+	}
+	return changes, nil
+}

--- a/backend/database/repositories/education/grade_transition.go
+++ b/backend/database/repositories/education/grade_transition.go
@@ -585,6 +585,57 @@ func (r *GradeTransitionRepository) GetClassTeacherHistory(ctx context.Context, 
 	return history, nil
 }
 
+// CreateClassListEntryHistoryBatch records what an apply did to
+// users.class_list_entries (#2382). One transition applies at most once
+// (a reverted transition can never be re-applied), so entries are never
+// cleared or rewritten.
+func (r *GradeTransitionRepository) CreateClassListEntryHistoryBatch(ctx context.Context, history []*education.GradeTransitionClassListEntry) error {
+	if len(history) == 0 {
+		return nil
+	}
+
+	for _, h := range history {
+		if err := h.Validate(); err != nil {
+			return err
+		}
+		base.EnsureTenantID(ctx, h)
+	}
+
+	_, err := base.GetDB(ctx, r.db).NewInsert().
+		Model(&history).
+		ModelTableExpr(`education.grade_transition_class_list_entries`).
+		Exec(ctx)
+	if err != nil {
+		return &modelBase.DatabaseError{
+			Op:  "create class list entry history batch",
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// GetClassListEntryHistory retrieves the class-list-entry ledger of a
+// transition.
+func (r *GradeTransitionRepository) GetClassListEntryHistory(ctx context.Context, transitionID int64) ([]*education.GradeTransitionClassListEntry, error) {
+	var history []*education.GradeTransitionClassListEntry
+	query := base.GetDB(ctx, r.db).NewSelect().
+		TableExpr(`education.grade_transition_class_list_entries AS "gtcle"`).
+		ColumnExpr(`"gtcle".*`).
+		Where(`"gtcle".`+whereTransitionID, transitionID).
+		Order("created_at ASC")
+
+	query = base.WithTenantFilter(ctx, query, "gtcle")
+
+	if err := query.Scan(ctx, &history); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "get class list entry history",
+			Err: err,
+		}
+	}
+
+	return history, nil
+}
+
 // GetDistinctClasses retrieves all distinct school_class values from students
 func (r *GradeTransitionRepository) GetDistinctClasses(ctx context.Context) ([]string, error) {
 	var classes []string

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -70,6 +70,7 @@ type Factory struct {
 	RFIDCard            userModels.RFIDCardRepository
 	Staff               userModels.StaffRepository
 	Student             userModels.StudentRepository
+	ClassListEntry      userModels.ClassListEntryRepository
 	StudentDeletion     userModels.StudentDeletionRepository
 	Teacher             userModels.TeacherRepository
 	Guest               userModels.GuestRepository
@@ -190,6 +191,7 @@ type Factory struct {
 	TimeTrackingDeletion         auditModels.TimeTrackingDeletionRepository
 	PersonnelNumberChange        auditModels.PersonnelNumberChangeCreator
 	StaffMasterDataChange        auditModels.StaffMasterDataChangeCreator
+	ClassListEntryChange         auditModels.ClassListEntryChangeRepository
 	TimeTrackingAuditLog         auditModels.TimeTrackingAuditLogRepository
 
 	// Platform domain (operator dashboard)
@@ -286,6 +288,7 @@ func NewFactory(db *bun.DB) *Factory {
 		RFIDCard:            users.NewRFIDCardRepository(db),
 		Staff:               users.NewStaffRepository(db),
 		Student:             users.NewStudentRepository(db),
+		ClassListEntry:      users.NewClassListEntryRepository(db),
 		StudentDeletion:     users.NewStudentDeletionRepository(db),
 		Teacher:             users.NewTeacherRepository(db),
 		Guest:               users.NewGuestRepository(db),
@@ -406,6 +409,7 @@ func NewFactory(db *bun.DB) *Factory {
 		TimeTrackingDeletion:         audit.NewTimeTrackingDeletionRepository(db),
 		PersonnelNumberChange:        audit.NewPersonnelNumberChangeRepository(db),
 		StaffMasterDataChange:        audit.NewStaffMasterDataChangeRepository(db),
+		ClassListEntryChange:         audit.NewClassListEntryChangeRepository(db),
 		TimeTrackingAuditLog:         audit.NewTimeTrackingAuditLogRepository(db),
 
 		// Platform repositories

--- a/backend/database/repositories/users/class_list_entry.go
+++ b/backend/database/repositories/users/class_list_entry.go
@@ -1,0 +1,72 @@
+package users
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/uptrace/bun"
+)
+
+// ClassListEntryRepository implements users.ClassListEntryRepository (#2382).
+type ClassListEntryRepository struct {
+	*base.Repository[*users.ClassListEntry]
+	db *bun.DB
+}
+
+// NewClassListEntryRepository creates a new ClassListEntryRepository.
+func NewClassListEntryRepository(db *bun.DB) users.ClassListEntryRepository {
+	repo := base.NewRepository[*users.ClassListEntry](db, "users.class_list_entries", "ClassListEntry")
+	repo.TenantScoped = true
+	return &ClassListEntryRepository{
+		Repository: repo,
+		db:         db,
+	}
+}
+
+// FindBySchoolClass returns the entries of one class, matched like every
+// other class comparison via LOWER(BTRIM(...)), name-sorted.
+func (r *ClassListEntryRepository) FindBySchoolClass(ctx context.Context, schoolClass string) ([]*users.ClassListEntry, error) {
+	var entries []*users.ClassListEntry
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&entries).
+		ModelTableExpr(`users.class_list_entries AS "class_list_entry"`).
+		Where(`LOWER(BTRIM("class_list_entry".school_class)) = LOWER(BTRIM(?))`, schoolClass).
+		OrderExpr(`LOWER("class_list_entry".last_name) ASC, LOWER("class_list_entry".first_name) ASC, "class_list_entry".id ASC`)
+
+	query = base.WithTenantFilter(ctx, query, "class_list_entry")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by school class",
+			Err: err,
+		}
+	}
+
+	return entries, nil
+}
+
+// FindByNameAndClass returns entries matching first name, last name and class
+// case-insensitively — the duplicate guard for create and import (mirror of
+// StudentRepository.FindByNameAndClass).
+func (r *ClassListEntryRepository) FindByNameAndClass(ctx context.Context, firstName, lastName, schoolClass string) ([]*users.ClassListEntry, error) {
+	var entries []*users.ClassListEntry
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&entries).
+		ModelTableExpr(`users.class_list_entries AS "class_list_entry"`).
+		Where(`LOWER(BTRIM("class_list_entry".first_name)) = LOWER(BTRIM(?))`, firstName).
+		Where(`LOWER(BTRIM("class_list_entry".last_name)) = LOWER(BTRIM(?))`, lastName).
+		Where(`LOWER(BTRIM("class_list_entry".school_class)) = LOWER(BTRIM(?))`, schoolClass)
+
+	query = base.WithTenantFilter(ctx, query, "class_list_entry")
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, &modelBase.DatabaseError{
+			Op:  "find by name and class",
+			Err: err,
+		}
+	}
+
+	return entries, nil
+}

--- a/backend/database/repositories/users/student.go
+++ b/backend/database/repositories/users/student.go
@@ -1775,7 +1775,11 @@ func (r *StudentRepository) PurgeAllPhotos(ctx context.Context) ([]string, error
 	return urls, nil
 }
 
-// FindByNameAndClass retrieves students by first name, last name, and school class (for import duplicate detection)
+// FindByNameAndClass retrieves students by first name, last name, and school
+// class (for import duplicate detection). Matching is case-insensitive and
+// trims BOTH sides: a stored name with surrounding whitespace must not slip
+// past the class-list duplicate guards (mirror of
+// ClassListEntryRepository.FindByNameAndClass).
 //
 // Alumni are excluded, matching the soft-delete default in List: graduation
 // keeps the student row around, and a graduate must not block the import of a
@@ -1788,9 +1792,9 @@ func (r *StudentRepository) FindByNameAndClass(ctx context.Context, firstName, l
 		Model(&students).
 		ModelTableExpr(`users.students AS "student"`).
 		Join(`INNER JOIN users.persons AS "person" ON "person".id = "student".person_id`).
-		Where(`LOWER("person".first_name) = LOWER(?)`, firstName).
-		Where(`LOWER("person".last_name) = LOWER(?)`, lastName).
-		Where(`LOWER("student".school_class) = LOWER(?)`, schoolClass).
+		Where(`LOWER(BTRIM("person".first_name)) = LOWER(BTRIM(?))`, firstName).
+		Where(`LOWER(BTRIM("person".last_name)) = LOWER(BTRIM(?))`, lastName).
+		Where(`LOWER(BTRIM("student".school_class)) = LOWER(BTRIM(?))`, schoolClass).
 		Where(`"student".status <> ?`, string(users.StudentStatusAlumnus))
 
 	query = base.WithTenantFilter(ctx, query, "student")

--- a/backend/models/audit/class_list_entry_change.go
+++ b/backend/models/audit/class_list_entry_change.go
@@ -1,0 +1,64 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/uptrace/bun"
+)
+
+// Class-list entry audit actions (#2382). Part of the audit wire format.
+const (
+	ClassListEntryActionCreated  = "created"
+	ClassListEntryActionUpdated  = "updated"
+	ClassListEntryActionDeleted  = "deleted"
+	ClassListEntryActionAssigned = "assigned"
+)
+
+// ClassListEntryChange is an append-only audit row for one change to a
+// class-list-only entry (#2382). Entries carry children's names, so every
+// create / update / delete / assign must leave a trace — same contract as
+// audit.staff_master_data_changes, written in the same tenant transaction as
+// the change itself. Old/new carry the display form "Vorname Nachname
+// (Klasse)"; MatchedStudentID records which student an "assigned" resolution
+// attached the entry to before deleting it.
+type ClassListEntryChange struct {
+	bun.BaseModel `bun:"schema:audit,table:class_list_entry_changes"`
+	ID            int64 `bun:"id,pk,autoincrement" json:"id"`
+	base.TenantModel
+	EntryID          int64     `bun:"entry_id,notnull" json:"entry_id"`
+	Action           string    `bun:"action,notnull" json:"action"`
+	OldValue         string    `bun:"old_value,notnull" json:"old_value"`
+	NewValue         string    `bun:"new_value,notnull" json:"new_value"`
+	MatchedStudentID *int64    `bun:"matched_student_id" json:"matched_student_id,omitempty"`
+	ChangedBy        int64     `bun:"changed_by,notnull" json:"changed_by"`
+	OccurredAt       time.Time `bun:"occurred_at,nullzero,notnull,default:now()" json:"occurred_at"`
+}
+
+// Validate ensures the audit row is complete.
+func (c *ClassListEntryChange) Validate() error {
+	if c.EntryID <= 0 {
+		return errors.New("entry_id is required")
+	}
+	if c.ChangedBy <= 0 {
+		return errors.New("changed_by is required")
+	}
+	switch c.Action {
+	case ClassListEntryActionCreated, ClassListEntryActionUpdated,
+		ClassListEntryActionDeleted, ClassListEntryActionAssigned:
+		// valid
+	default:
+		return errors.New("unknown class list entry action")
+	}
+	return nil
+}
+
+// ClassListEntryChangeRepository is append-only; there is no application-side
+// update or delete on the trail.
+type ClassListEntryChangeRepository interface {
+	Create(ctx context.Context, change *ClassListEntryChange) error
+	// ListByEntryID returns the trail of one entry, newest first.
+	ListByEntryID(ctx context.Context, entryID int64) ([]*ClassListEntryChange, error)
+}

--- a/backend/models/audit/class_list_entry_change_test.go
+++ b/backend/models/audit/class_list_entry_change_test.go
@@ -1,0 +1,42 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validClassListEntryChange() *ClassListEntryChange {
+	return &ClassListEntryChange{
+		EntryID:   1,
+		Action:    ClassListEntryActionCreated,
+		NewValue:  "Zoe Aalders (1a)",
+		ChangedBy: 2,
+	}
+}
+
+func TestClassListEntryChangeValidate(t *testing.T) {
+	require.NoError(t, validClassListEntryChange().Validate())
+
+	for _, action := range []string{
+		ClassListEntryActionCreated, ClassListEntryActionUpdated,
+		ClassListEntryActionDeleted, ClassListEntryActionAssigned,
+	} {
+		change := validClassListEntryChange()
+		change.Action = action
+		assert.NoError(t, change.Validate(), action)
+	}
+
+	noEntry := validClassListEntryChange()
+	noEntry.EntryID = 0
+	assert.ErrorContains(t, noEntry.Validate(), "entry_id")
+
+	noActor := validClassListEntryChange()
+	noActor.ChangedBy = 0
+	assert.ErrorContains(t, noActor.Validate(), "changed_by")
+
+	badAction := validClassListEntryChange()
+	badAction.Action = "renamed"
+	assert.ErrorContains(t, badAction.Validate(), "unknown class list entry action")
+}

--- a/backend/models/education/grade_transition.go
+++ b/backend/models/education/grade_transition.go
@@ -193,6 +193,11 @@ type GradeTransitionRepository interface {
 	CreateClassTeacherHistoryBatch(ctx context.Context, history []*GradeTransitionClassTeacher) error
 	GetClassTeacherHistory(ctx context.Context, transitionID int64) ([]*GradeTransitionClassTeacher, error)
 
+	// Class-list-entry ledger (#2382): what the apply did to
+	// users.class_list_entries, replayed exactly by the revert.
+	CreateClassListEntryHistoryBatch(ctx context.Context, history []*GradeTransitionClassListEntry) error
+	GetClassListEntryHistory(ctx context.Context, transitionID int64) ([]*GradeTransitionClassListEntry, error)
+
 	// Bulk operations
 	GetDistinctClasses(ctx context.Context) ([]string, error)
 	GetStudentCountByClass(ctx context.Context, className string) (int, error)

--- a/backend/models/education/grade_transition_class_list_entry.go
+++ b/backend/models/education/grade_transition_class_list_entry.go
@@ -17,11 +17,17 @@ import (
 type GradeTransitionClassListEntry struct {
 	base.Model `bun:"schema:education,table:grade_transition_class_list_entries"`
 	base.TenantModel
-	TransitionID int64  `bun:"transition_id,notnull" json:"transition_id"`
-	FirstName    string `bun:"first_name,notnull" json:"first_name"`
-	LastName     string `bun:"last_name,notnull" json:"last_name"`
-	SchoolClass  string `bun:"school_class,notnull" json:"school_class"`
-	Action       string `bun:"action,notnull" json:"action"`
+	TransitionID int64 `bun:"transition_id,notnull" json:"transition_id"`
+	// EntryID is the row the apply inserted ('created' rows only; nil on
+	// 'removed' rows, whose row is gone). The revert resolves created rows by
+	// this ID instead of by name and class: an admin edit that keeps the
+	// normalized identity ("2a" → "2A") is invisible to an identity lookup and
+	// would be silently overwritten.
+	EntryID     *int64 `bun:"entry_id" json:"entry_id,omitempty"`
+	FirstName   string `bun:"first_name,notnull" json:"first_name"`
+	LastName    string `bun:"last_name,notnull" json:"last_name"`
+	SchoolClass string `bun:"school_class,notnull" json:"school_class"`
+	Action      string `bun:"action,notnull" json:"action"`
 }
 
 // Validate ensures ledger entry data is valid
@@ -40,6 +46,9 @@ func (h *GradeTransitionClassListEntry) Validate() error {
 	}
 	if h.Action != ClassTeacherActionRemoved && h.Action != ClassTeacherActionCreated {
 		return errors.New("action must be removed or created")
+	}
+	if h.EntryID != nil && *h.EntryID <= 0 {
+		return errors.New("entry ID must be positive")
 	}
 	return nil
 }

--- a/backend/models/education/grade_transition_class_list_entry.go
+++ b/backend/models/education/grade_transition_class_list_entry.go
@@ -1,0 +1,45 @@
+package education
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// GradeTransitionClassListEntry is one ledger entry of what a grade-transition
+// apply did to users.class_list_entries (#2382): 'removed' rows it deleted
+// (with their original display form), 'created' rows it inserted. The revert
+// replays these entries exactly instead of reversing the class mappings — a
+// reverse rename cannot distinguish an entry the apply renamed into a class
+// from a pre-existing entry of that class it never touched. Mirrors
+// GradeTransitionClassTeacher; the action values are shared.
+type GradeTransitionClassListEntry struct {
+	base.Model `bun:"schema:education,table:grade_transition_class_list_entries"`
+	base.TenantModel
+	TransitionID int64  `bun:"transition_id,notnull" json:"transition_id"`
+	FirstName    string `bun:"first_name,notnull" json:"first_name"`
+	LastName     string `bun:"last_name,notnull" json:"last_name"`
+	SchoolClass  string `bun:"school_class,notnull" json:"school_class"`
+	Action       string `bun:"action,notnull" json:"action"`
+}
+
+// Validate ensures ledger entry data is valid
+func (h *GradeTransitionClassListEntry) Validate() error {
+	if h.TransitionID <= 0 {
+		return errors.New("transition ID is required")
+	}
+	if strings.TrimSpace(h.FirstName) == "" {
+		return errors.New("first name is required")
+	}
+	if strings.TrimSpace(h.LastName) == "" {
+		return errors.New("last name is required")
+	}
+	if strings.TrimSpace(h.SchoolClass) == "" {
+		return errors.New("school class is required")
+	}
+	if h.Action != ClassTeacherActionRemoved && h.Action != ClassTeacherActionCreated {
+		return errors.New("action must be removed or created")
+	}
+	return nil
+}

--- a/backend/models/education/grade_transition_class_list_entry_test.go
+++ b/backend/models/education/grade_transition_class_list_entry_test.go
@@ -44,4 +44,15 @@ func TestGradeTransitionClassListEntryValidate(t *testing.T) {
 	badAction := validClassListEntryLedgerRow()
 	badAction.Action = "renamed"
 	assert.ErrorContains(t, badAction.Validate(), "removed or created")
+
+	withEntry := validClassListEntryLedgerRow()
+	withEntry.Action = ClassTeacherActionCreated
+	entryID := int64(42)
+	withEntry.EntryID = &entryID
+	require.NoError(t, withEntry.Validate())
+
+	badEntry := validClassListEntryLedgerRow()
+	zero := int64(0)
+	badEntry.EntryID = &zero
+	assert.ErrorContains(t, badEntry.Validate(), "entry ID")
 }

--- a/backend/models/education/grade_transition_class_list_entry_test.go
+++ b/backend/models/education/grade_transition_class_list_entry_test.go
@@ -1,0 +1,47 @@
+package education
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validClassListEntryLedgerRow() *GradeTransitionClassListEntry {
+	row := &GradeTransitionClassListEntry{
+		TransitionID: 1,
+		FirstName:    "Zoe",
+		LastName:     "Aalders",
+		SchoolClass:  "1a",
+		Action:       ClassTeacherActionRemoved,
+	}
+	return row
+}
+
+func TestGradeTransitionClassListEntryValidate(t *testing.T) {
+	require.NoError(t, validClassListEntryLedgerRow().Validate())
+
+	created := validClassListEntryLedgerRow()
+	created.Action = ClassTeacherActionCreated
+	require.NoError(t, created.Validate())
+
+	noTransition := validClassListEntryLedgerRow()
+	noTransition.TransitionID = 0
+	assert.ErrorContains(t, noTransition.Validate(), "transition ID")
+
+	noFirstName := validClassListEntryLedgerRow()
+	noFirstName.FirstName = "  "
+	assert.ErrorContains(t, noFirstName.Validate(), "first name")
+
+	noLastName := validClassListEntryLedgerRow()
+	noLastName.LastName = ""
+	assert.ErrorContains(t, noLastName.Validate(), "last name")
+
+	noClass := validClassListEntryLedgerRow()
+	noClass.SchoolClass = " "
+	assert.ErrorContains(t, noClass.Validate(), "school class")
+
+	badAction := validClassListEntryLedgerRow()
+	badAction.Action = "renamed"
+	assert.ErrorContains(t, badAction.Validate(), "removed or created")
+}

--- a/backend/models/import/class_list.go
+++ b/backend/models/import/class_list.go
@@ -1,0 +1,11 @@
+package importpkg
+
+// ClassListEntryImportRow is one row of the class-list entry bulk import
+// (#2382): the minimal Klassenlisteneintrag — name and school class, nothing
+// else. Deliberately no guardians, birthday, group or schedule columns; a
+// child needing any of those is a regular student import.
+type ClassListEntryImportRow struct {
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	SchoolClass string `json:"school_class"`
+}

--- a/backend/models/users/class_list_entry.go
+++ b/backend/models/users/class_list_entry.go
@@ -1,0 +1,48 @@
+package users
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/models/base"
+)
+
+// ClassListEntry is a child of the class cohort WITHOUT an OGS record
+// (#2382): only first name, last name and the free-text school class. It
+// exists so class lists and the Lehrkraft class-day view can show the
+// complete Klassenverband ("Keine Betreuung") — it is deliberately NOT a
+// student: no person, no guardians, no attendance, no care planning can ever
+// reference it, and it must never surface in the student search, the parent
+// portal or any planning view. SchoolClass stores the display form as
+// entered; comparisons go through schoolclass.Normalize like every other
+// class string (see models/education.ClassTeacher).
+type ClassListEntry struct {
+	base.Model `bun:"schema:users,table:class_list_entries"`
+	base.TenantModel
+	FirstName   string `bun:"first_name,notnull" json:"first_name"`
+	LastName    string `bun:"last_name,notnull" json:"last_name"`
+	SchoolClass string `bun:"school_class,notnull" json:"school_class"`
+	// CreatedBy is the creating account ID; nil for rows created by system
+	// paths without an authenticated account.
+	CreatedBy *int64 `bun:"created_by" json:"created_by,omitempty"`
+}
+
+// Validate ensures class list entry data is valid.
+func (e *ClassListEntry) Validate() error {
+	if strings.TrimSpace(e.FirstName) == "" {
+		return errors.New("first name is required")
+	}
+	if strings.TrimSpace(e.LastName) == "" {
+		return errors.New("last name is required")
+	}
+	if strings.TrimSpace(e.SchoolClass) == "" {
+		return errors.New("school class is required")
+	}
+	return nil
+}
+
+// DisplayValue renders the audit-trail representation of the entry:
+// "Vorname Nachname (Klasse)".
+func (e *ClassListEntry) DisplayValue() string {
+	return strings.TrimSpace(e.FirstName) + " " + strings.TrimSpace(e.LastName) + " (" + strings.TrimSpace(e.SchoolClass) + ")"
+}

--- a/backend/models/users/class_list_entry.go
+++ b/backend/models/users/class_list_entry.go
@@ -16,6 +16,12 @@ import (
 // portal or any planning view. SchoolClass stores the display form as
 // entered; comparisons go through schoolclass.Normalize like every other
 // class string (see models/education.ClassTeacher).
+// ClassListEntryUniqueIndexName is the unique index behind the "one child
+// once per class" rule (tenant, LOWER(BTRIM(first/last/class))). The service
+// maps a 23505 on it to ErrClassListEntryDuplicate so a concurrent create
+// loses with the documented duplicate response instead of a 500.
+const ClassListEntryUniqueIndexName = "uniq_class_list_entries_name_class"
+
 type ClassListEntry struct {
 	base.Model `bun:"schema:users,table:class_list_entries"`
 	base.TenantModel

--- a/backend/models/users/class_list_entry_test.go
+++ b/backend/models/users/class_list_entry_test.go
@@ -1,0 +1,37 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validClassListEntry() *ClassListEntry {
+	return &ClassListEntry{
+		FirstName:   "Zoe",
+		LastName:    "Aalders",
+		SchoolClass: "1a",
+	}
+}
+
+func TestClassListEntryValidate(t *testing.T) {
+	require.NoError(t, validClassListEntry().Validate())
+
+	noFirstName := validClassListEntry()
+	noFirstName.FirstName = "  "
+	assert.ErrorContains(t, noFirstName.Validate(), "first name")
+
+	noLastName := validClassListEntry()
+	noLastName.LastName = ""
+	assert.ErrorContains(t, noLastName.Validate(), "last name")
+
+	noClass := validClassListEntry()
+	noClass.SchoolClass = " "
+	assert.ErrorContains(t, noClass.Validate(), "school class")
+}
+
+func TestClassListEntryDisplayValue(t *testing.T) {
+	entry := &ClassListEntry{FirstName: " Zoe ", LastName: " Aalders ", SchoolClass: " 1a "}
+	assert.Equal(t, "Zoe Aalders (1a)", entry.DisplayValue())
+}

--- a/backend/models/users/repository.go
+++ b/backend/models/users/repository.go
@@ -244,6 +244,18 @@ type StudentRepository interface {
 	FindByIDsForUpdate(ctx context.Context, ids []int64) (map[int64]*Student, error)
 }
 
+// ClassListEntryRepository defines operations for the class-list-only entries
+// (#2382). School classes are free-text strings; every class comparison uses
+// LOWER(BTRIM(...)) — see models/users.ClassListEntry.
+type ClassListEntryRepository interface {
+	base.CRUDRepository[*ClassListEntry]
+	// FindBySchoolClass returns the entries of one class, name-sorted.
+	FindBySchoolClass(ctx context.Context, schoolClass string) ([]*ClassListEntry, error)
+	// FindByNameAndClass returns entries matching first name, last name and
+	// class case-insensitively (duplicate guard for create and import).
+	FindByNameAndClass(ctx context.Context, firstName, lastName, schoolClass string) ([]*ClassListEntry, error)
+}
+
 // StaffRepository defines operations for managing staff members
 type StaffRepository interface {
 	base.CRUDRepository[*Staff]

--- a/backend/services/education/grade_transition_class_list_entries.go
+++ b/backend/services/education/grade_transition_class_list_entries.go
@@ -26,6 +26,48 @@ import (
 // students themselves are reactivated. The audit trail records every rewrite
 // either way.
 
+// classListEntryRenameLookup resolves an entry's class against the
+// transition's renames: exact (trimmed) match first — the condition the
+// students and Klassenlehrer rows move under — then a schoolclass.Normalize
+// fallback. Entries need the fallback because their cohort identity is the
+// NORMALIZED class everywhere else (unique index, filters, exports): an entry
+// stored as "1A" belongs to the "1a" cohort, and without the fallback it
+// would stay behind and silently attach to the NEXT incoming 1a. A normalized
+// key two mappings collapse onto with different targets is ambiguous and
+// excluded from the fallback — those classes still remap via their exact
+// forms.
+type classListEntryRenameLookup struct {
+	exact      map[string]string
+	normalized map[string]string
+}
+
+func newClassListEntryRenameLookup(renames map[string]string) classListEntryRenameLookup {
+	normalized := make(map[string]string, len(renames))
+	ambiguous := make(map[string]bool)
+	for from, to := range renames {
+		key := schoolclass.Normalize(from)
+		if existing, seen := normalized[key]; seen && existing != to {
+			ambiguous[key] = true
+			continue
+		}
+		normalized[key] = to
+	}
+	for key := range ambiguous {
+		delete(normalized, key)
+	}
+	return classListEntryRenameLookup{exact: renames, normalized: normalized}
+}
+
+// target returns the rename target for a class ("" = graduates) and whether
+// the class is part of the transition at all.
+func (l classListEntryRenameLookup) target(schoolClass string) (string, bool) {
+	if to, ok := l.exact[strings.TrimSpace(schoolClass)]; ok {
+		return to, true
+	}
+	to, ok := l.normalized[schoolclass.Normalize(schoolClass)]
+	return to, ok
+}
+
 // remapClassListEntries follows the transition's class renames for
 // users.class_list_entries. Affected rows are deleted and re-inserted (mirror
 // of remapClassTeacherAssignments): simultaneous renames ("1a"→"2a" while
@@ -47,6 +89,7 @@ func (s *GradeTransitionService) remapClassListEntries(
 	if len(renames) == 0 {
 		return nil
 	}
+	lookup := newClassListEntryRenameLookup(renames)
 
 	entries, err := s.classListEntryRepo.List(ctx, nil)
 	if err != nil {
@@ -56,7 +99,7 @@ func (s *GradeTransitionService) remapClassListEntries(
 	var affected []*userModels.ClassListEntry
 	kept := make(map[string]bool, len(entries))
 	for _, entry := range entries {
-		if _, hit := renames[strings.TrimSpace(entry.SchoolClass)]; hit {
+		if _, hit := lookup.target(entry.SchoolClass); hit {
 			affected = append(affected, entry)
 			continue
 		}
@@ -82,7 +125,7 @@ func (s *GradeTransitionService) remapClassListEntries(
 	}
 
 	for _, entry := range affected {
-		target := renames[strings.TrimSpace(entry.SchoolClass)]
+		target, _ := lookup.target(entry.SchoolClass)
 		created, err := s.reinsertClassListEntry(ctx, entry, target, kept, accountID)
 		if err != nil {
 			return err
@@ -167,13 +210,13 @@ func (s *GradeTransitionService) revertClassListEntries(
 		}
 	}
 
-	renames := classTeacherRenames(mappings)
+	lookup := newClassListEntryRenameLookup(classTeacherRenames(mappings))
 
 	for _, item := range ledger {
 		if item.Action != education.ClassTeacherActionRemoved {
 			continue
 		}
-		if target := renames[strings.TrimSpace(item.SchoolClass)]; target != "" {
+		if target, hit := lookup.target(item.SchoolClass); hit && target != "" {
 			pairKey := classListEntryKey(item.FirstName, item.LastName, target)
 			if ledgerCreated[pairKey] && !deletedCreated[pairKey] {
 				continue // the admin removed the renamed child after the apply

--- a/backend/services/education/grade_transition_class_list_entries.go
+++ b/backend/services/education/grade_transition_class_list_entries.go
@@ -16,12 +16,15 @@ import (
 // (1a→2a), a graduating class loses them. Left untouched, a "1a" entry would
 // silently point at the NEXT incoming 1a cohort.
 //
-// Unlike the Klassenlehrer assignments there is deliberately NO ledger: an
-// entry carries no access scope, so the revert reverses the mapping's renames
-// directly (to→from). Entries a graduation deleted are NOT restored by a
-// revert — they are name-only rows destined for deletion, and re-creating
-// children's names the school already discarded would invert data
-// minimization. The audit trail records every rewrite either way.
+// Every rewrite lands in the transition's class-list-entry ledger
+// (education.grade_transition_class_list_entries, mirror of the Klassenlehrer
+// ledger): the revert replays exactly what the apply recorded instead of
+// reversing the mappings — a reverse rename cannot distinguish an entry the
+// apply renamed into a class from a pre-existing entry of that class it never
+// touched, and it would also drag entries created between apply and revert
+// along. Graduated entries are restored by the revert like the graduated
+// students themselves are reactivated. The audit trail records every rewrite
+// either way.
 
 // remapClassListEntries follows the transition's class renames for
 // users.class_list_entries. Affected rows are deleted and re-inserted (mirror
@@ -29,9 +32,11 @@ import (
 // "2a"→"3a") would otherwise collide with the unique name+class index
 // mid-sequence. A re-insert that would duplicate a surviving entry or a
 // student now holding the target class is skipped — the child already has
-// exactly one row on the class list.
+// exactly one row on the class list. Every delete and insert is recorded in
+// the transition's class-list-entry ledger so the revert can replay it.
 func (s *GradeTransitionService) remapClassListEntries(
 	ctx context.Context,
+	transitionID int64,
 	mappings []*education.GradeTransitionMapping,
 	accountID int64,
 ) error {
@@ -61,43 +66,69 @@ func (s *GradeTransitionService) remapClassListEntries(
 		return nil
 	}
 
+	var ledger []*education.GradeTransitionClassListEntry
+
 	for _, entry := range affected {
 		if err := s.classListEntryRepo.Delete(ctx, entry.ID); err != nil {
 			return fmt.Errorf("failed to delete class list entry: %w", err)
 		}
+		ledger = append(ledger, &education.GradeTransitionClassListEntry{
+			TransitionID: transitionID,
+			FirstName:    entry.FirstName,
+			LastName:     entry.LastName,
+			SchoolClass:  entry.SchoolClass,
+			Action:       education.ClassTeacherActionRemoved,
+		})
 	}
 
 	for _, entry := range affected {
 		target := renames[strings.TrimSpace(entry.SchoolClass)]
-		if err := s.reinsertClassListEntry(ctx, entry, target, kept, accountID); err != nil {
+		created, err := s.reinsertClassListEntry(ctx, entry, target, kept, accountID)
+		if err != nil {
 			return err
 		}
+		if created != nil {
+			ledger = append(ledger, &education.GradeTransitionClassListEntry{
+				TransitionID: transitionID,
+				FirstName:    created.FirstName,
+				LastName:     created.LastName,
+				SchoolClass:  created.SchoolClass,
+				Action:       education.ClassTeacherActionCreated,
+			})
+		}
+	}
+
+	if err := s.transitionRepo.CreateClassListEntryHistoryBatch(ctx, ledger); err != nil {
+		return fmt.Errorf("failed to record class list entry ledger: %w", err)
 	}
 	return nil
 }
 
-// revertClassListEntries reverses the transition's renames (to→from) for the
-// entries. Same delete/re-insert shape as the apply; graduated entries have
-// no reverse mapping and stay deleted. An entry created in a rename-target
-// class between apply and revert is renamed back with the rest — the revert
-// cannot tell it apart without a ledger, and a wrongly-renamed name-only row
-// is a visible, trivially fixable outcome.
+// revertClassListEntries replays the transition's class-list-entry ledger
+// backwards: rows the apply created are deleted again, rows it removed
+// (promotions AND graduations) are restored with their original display form.
+// Entries the apply never touched — a pre-existing entry of a rename target,
+// or one created between apply and revert — have no ledger entry and stay
+// untouched. Entries the admin changed since the apply win: a created row the
+// admin already deleted is not deleted again AND its paired removed entry is
+// not restored (the admin deliberately took the child off the list), and a
+// restore colliding with a surviving entry or a student of that name and
+// class is skipped — the child already has exactly one row on the list.
 func (s *GradeTransitionService) revertClassListEntries(
 	ctx context.Context,
+	transitionID int64,
 	mappings []*education.GradeTransitionMapping,
 	accountID int64,
 ) error {
 	if s.classListEntryRepo == nil {
 		return nil
 	}
-	renames := make(map[string]string, len(mappings))
-	for _, mapping := range mappings {
-		if mapping == nil || mapping.IsGraduating() {
-			continue
-		}
-		renames[strings.TrimSpace(*mapping.ToClass)] = strings.TrimSpace(mapping.FromClass)
+
+	ledger, err := s.transitionRepo.GetClassListEntryHistory(ctx, transitionID)
+	if err != nil {
+		return fmt.Errorf("failed to load class list entry ledger: %w", err)
 	}
-	if len(renames) == 0 {
+	if len(ledger) == 0 {
 		return nil
 	}
 
@@ -105,29 +136,74 @@ func (s *GradeTransitionService) revertClassListEntries(
 	if err != nil {
 		return fmt.Errorf("failed to list class list entries: %w", err)
 	}
-
-	var affected []*userModels.ClassListEntry
-	kept := make(map[string]bool, len(entries))
+	current := make(map[string]*userModels.ClassListEntry, len(entries))
 	for _, entry := range entries {
-		if _, hit := renames[strings.TrimSpace(entry.SchoolClass)]; hit {
-			affected = append(affected, entry)
+		current[classListEntryKey(entry.FirstName, entry.LastName, entry.SchoolClass)] = entry
+	}
+
+	// ledgerCreated: identities the apply inserted at all. deletedCreated:
+	// the subset this revert actually found and deleted — an identity in the
+	// first set but not the second was removed by the admin after the apply,
+	// and its paired restore must not resurrect the child.
+	ledgerCreated := make(map[string]bool)
+	deletedCreated := make(map[string]bool)
+	for _, item := range ledger {
+		if item.Action != education.ClassTeacherActionCreated {
 			continue
 		}
-		kept[classListEntryKey(entry.FirstName, entry.LastName, entry.SchoolClass)] = true
-	}
-	if len(affected) == 0 {
-		return nil
-	}
-
-	for _, entry := range affected {
-		if err := s.classListEntryRepo.Delete(ctx, entry.ID); err != nil {
+		key := classListEntryKey(item.FirstName, item.LastName, item.SchoolClass)
+		ledgerCreated[key] = true
+		row, ok := current[key]
+		if !ok {
+			continue
+		}
+		if err := s.classListEntryRepo.Delete(ctx, row.ID); err != nil {
 			return fmt.Errorf("failed to delete class list entry: %w", err)
+		}
+		delete(current, key)
+		deletedCreated[key] = true
+		if err := s.auditClassListEntryChange(ctx, row.ID, auditModels.ClassListEntryActionDeleted, row.DisplayValue(), "", accountID); err != nil {
+			return err
 		}
 	}
 
-	for _, entry := range affected {
-		target := renames[strings.TrimSpace(entry.SchoolClass)]
-		if err := s.reinsertClassListEntry(ctx, entry, target, kept, accountID); err != nil {
+	renames := classTeacherRenames(mappings)
+
+	for _, item := range ledger {
+		if item.Action != education.ClassTeacherActionRemoved {
+			continue
+		}
+		if target := renames[strings.TrimSpace(item.SchoolClass)]; target != "" {
+			pairKey := classListEntryKey(item.FirstName, item.LastName, target)
+			if ledgerCreated[pairKey] && !deletedCreated[pairKey] {
+				continue // the admin removed the renamed child after the apply
+			}
+		}
+		key := classListEntryKey(item.FirstName, item.LastName, item.SchoolClass)
+		if _, taken := current[key]; taken {
+			continue
+		}
+		probe := &userModels.ClassListEntry{FirstName: item.FirstName, LastName: item.LastName}
+		duplicate, err := s.classListEntryDuplicatesStudent(ctx, probe, item.SchoolClass)
+		if err != nil {
+			return err
+		}
+		if duplicate {
+			continue // the reactivated student of that name IS the row now
+		}
+		restored := &userModels.ClassListEntry{
+			FirstName:   item.FirstName,
+			LastName:    item.LastName,
+			SchoolClass: item.SchoolClass,
+		}
+		if accountID > 0 {
+			restored.CreatedBy = &accountID
+		}
+		if err := s.classListEntryRepo.Create(ctx, restored); err != nil {
+			return fmt.Errorf("failed to restore class list entry: %w", err)
+		}
+		current[key] = restored
+		if err := s.auditClassListEntryChange(ctx, restored.ID, auditModels.ClassListEntryActionCreated, "", restored.DisplayValue(), accountID); err != nil {
 			return err
 		}
 	}
@@ -135,21 +211,22 @@ func (s *GradeTransitionService) revertClassListEntries(
 }
 
 // reinsertClassListEntry re-creates one remapped entry under its target class
-// and writes the audit row. An empty target (graduation) or a duplicate at
-// the target (surviving entry or a student of that name) records a deletion
-// instead of inserting a second class-list row for the same child.
+// and writes the audit row, returning the created row (nil when nothing was
+// inserted). An empty target (graduation) or a duplicate at the target
+// (surviving entry or a student of that name) records a deletion instead of
+// inserting a second class-list row for the same child.
 func (s *GradeTransitionService) reinsertClassListEntry(
 	ctx context.Context,
 	entry *userModels.ClassListEntry,
 	target string,
 	kept map[string]bool,
 	accountID int64,
-) error {
+) (*userModels.ClassListEntry, error) {
 	oldValue := entry.DisplayValue()
 	if target != "" && !kept[classListEntryKey(entry.FirstName, entry.LastName, target)] {
 		duplicate, err := s.classListEntryDuplicatesStudent(ctx, entry, target)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !duplicate {
 			replacement := &userModels.ClassListEntry{
@@ -159,18 +236,19 @@ func (s *GradeTransitionService) reinsertClassListEntry(
 				CreatedBy:   entry.CreatedBy,
 			}
 			if err := s.classListEntryRepo.Create(ctx, replacement); err != nil {
-				return fmt.Errorf("failed to create class list entry: %w", err)
+				return nil, fmt.Errorf("failed to create class list entry: %w", err)
 			}
 			kept[classListEntryKey(entry.FirstName, entry.LastName, target)] = true
-			return s.auditClassListEntryChange(ctx, replacement.ID, auditModels.ClassListEntryActionUpdated, oldValue, replacement.DisplayValue(), accountID)
+			return replacement, s.auditClassListEntryChange(ctx, replacement.ID, auditModels.ClassListEntryActionUpdated, oldValue, replacement.DisplayValue(), accountID)
 		}
 	}
-	return s.auditClassListEntryChange(ctx, entry.ID, auditModels.ClassListEntryActionDeleted, oldValue, "", accountID)
+	return nil, s.auditClassListEntryChange(ctx, entry.ID, auditModels.ClassListEntryActionDeleted, oldValue, "", accountID)
 }
 
 // classListEntryDuplicatesStudent reports whether a regular student with the
-// entry's name already holds the target class (post-rename state: the student
-// writes of this transition ran first).
+// entry's name already holds the target class (post-rename state on apply,
+// post-restore state on revert: the student writes of the transition run
+// first either way).
 func (s *GradeTransitionService) classListEntryDuplicatesStudent(ctx context.Context, entry *userModels.ClassListEntry, target string) (bool, error) {
 	if s.studentRepo == nil {
 		return false, nil

--- a/backend/services/education/grade_transition_class_list_entries.go
+++ b/backend/services/education/grade_transition_class_list_entries.go
@@ -1,0 +1,207 @@
+package education
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/internal/schoolclass"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/moto-nrw/project-phoenix/models/education"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// The class-list-only entries (#2382) follow the school-year rollover the
+// same way the students do: a promoted class carries its entries along
+// (1a→2a), a graduating class loses them. Left untouched, a "1a" entry would
+// silently point at the NEXT incoming 1a cohort.
+//
+// Unlike the Klassenlehrer assignments there is deliberately NO ledger: an
+// entry carries no access scope, so the revert reverses the mapping's renames
+// directly (to→from). Entries a graduation deleted are NOT restored by a
+// revert — they are name-only rows destined for deletion, and re-creating
+// children's names the school already discarded would invert data
+// minimization. The audit trail records every rewrite either way.
+
+// remapClassListEntries follows the transition's class renames for
+// users.class_list_entries. Affected rows are deleted and re-inserted (mirror
+// of remapClassTeacherAssignments): simultaneous renames ("1a"→"2a" while
+// "2a"→"3a") would otherwise collide with the unique name+class index
+// mid-sequence. A re-insert that would duplicate a surviving entry or a
+// student now holding the target class is skipped — the child already has
+// exactly one row on the class list.
+func (s *GradeTransitionService) remapClassListEntries(
+	ctx context.Context,
+	mappings []*education.GradeTransitionMapping,
+	accountID int64,
+) error {
+	if s.classListEntryRepo == nil {
+		return nil
+	}
+	renames := classTeacherRenames(mappings)
+	if len(renames) == 0 {
+		return nil
+	}
+
+	entries, err := s.classListEntryRepo.List(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list class list entries: %w", err)
+	}
+
+	var affected []*userModels.ClassListEntry
+	kept := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if _, hit := renames[strings.TrimSpace(entry.SchoolClass)]; hit {
+			affected = append(affected, entry)
+			continue
+		}
+		kept[classListEntryKey(entry.FirstName, entry.LastName, entry.SchoolClass)] = true
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+
+	for _, entry := range affected {
+		if err := s.classListEntryRepo.Delete(ctx, entry.ID); err != nil {
+			return fmt.Errorf("failed to delete class list entry: %w", err)
+		}
+	}
+
+	for _, entry := range affected {
+		target := renames[strings.TrimSpace(entry.SchoolClass)]
+		if err := s.reinsertClassListEntry(ctx, entry, target, kept, accountID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// revertClassListEntries reverses the transition's renames (to→from) for the
+// entries. Same delete/re-insert shape as the apply; graduated entries have
+// no reverse mapping and stay deleted. An entry created in a rename-target
+// class between apply and revert is renamed back with the rest — the revert
+// cannot tell it apart without a ledger, and a wrongly-renamed name-only row
+// is a visible, trivially fixable outcome.
+func (s *GradeTransitionService) revertClassListEntries(
+	ctx context.Context,
+	mappings []*education.GradeTransitionMapping,
+	accountID int64,
+) error {
+	if s.classListEntryRepo == nil {
+		return nil
+	}
+	renames := make(map[string]string, len(mappings))
+	for _, mapping := range mappings {
+		if mapping == nil || mapping.IsGraduating() {
+			continue
+		}
+		renames[strings.TrimSpace(*mapping.ToClass)] = strings.TrimSpace(mapping.FromClass)
+	}
+	if len(renames) == 0 {
+		return nil
+	}
+
+	entries, err := s.classListEntryRepo.List(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list class list entries: %w", err)
+	}
+
+	var affected []*userModels.ClassListEntry
+	kept := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if _, hit := renames[strings.TrimSpace(entry.SchoolClass)]; hit {
+			affected = append(affected, entry)
+			continue
+		}
+		kept[classListEntryKey(entry.FirstName, entry.LastName, entry.SchoolClass)] = true
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+
+	for _, entry := range affected {
+		if err := s.classListEntryRepo.Delete(ctx, entry.ID); err != nil {
+			return fmt.Errorf("failed to delete class list entry: %w", err)
+		}
+	}
+
+	for _, entry := range affected {
+		target := renames[strings.TrimSpace(entry.SchoolClass)]
+		if err := s.reinsertClassListEntry(ctx, entry, target, kept, accountID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reinsertClassListEntry re-creates one remapped entry under its target class
+// and writes the audit row. An empty target (graduation) or a duplicate at
+// the target (surviving entry or a student of that name) records a deletion
+// instead of inserting a second class-list row for the same child.
+func (s *GradeTransitionService) reinsertClassListEntry(
+	ctx context.Context,
+	entry *userModels.ClassListEntry,
+	target string,
+	kept map[string]bool,
+	accountID int64,
+) error {
+	oldValue := entry.DisplayValue()
+	if target != "" && !kept[classListEntryKey(entry.FirstName, entry.LastName, target)] {
+		duplicate, err := s.classListEntryDuplicatesStudent(ctx, entry, target)
+		if err != nil {
+			return err
+		}
+		if !duplicate {
+			replacement := &userModels.ClassListEntry{
+				FirstName:   entry.FirstName,
+				LastName:    entry.LastName,
+				SchoolClass: target,
+				CreatedBy:   entry.CreatedBy,
+			}
+			if err := s.classListEntryRepo.Create(ctx, replacement); err != nil {
+				return fmt.Errorf("failed to create class list entry: %w", err)
+			}
+			kept[classListEntryKey(entry.FirstName, entry.LastName, target)] = true
+			return s.auditClassListEntryChange(ctx, replacement.ID, auditModels.ClassListEntryActionUpdated, oldValue, replacement.DisplayValue(), accountID)
+		}
+	}
+	return s.auditClassListEntryChange(ctx, entry.ID, auditModels.ClassListEntryActionDeleted, oldValue, "", accountID)
+}
+
+// classListEntryDuplicatesStudent reports whether a regular student with the
+// entry's name already holds the target class (post-rename state: the student
+// writes of this transition ran first).
+func (s *GradeTransitionService) classListEntryDuplicatesStudent(ctx context.Context, entry *userModels.ClassListEntry, target string) (bool, error) {
+	if s.studentRepo == nil {
+		return false, nil
+	}
+	students, err := s.studentRepo.FindByNameAndClass(ctx, entry.FirstName, entry.LastName, target)
+	if err != nil {
+		return false, fmt.Errorf("failed to check class list entry against students: %w", err)
+	}
+	return len(students) > 0, nil
+}
+
+func (s *GradeTransitionService) auditClassListEntryChange(ctx context.Context, entryID int64, action, oldValue, newValue string, accountID int64) error {
+	if s.classListEntryAudit == nil {
+		return nil
+	}
+	if err := s.classListEntryAudit.Create(ctx, &auditModels.ClassListEntryChange{
+		EntryID:   entryID,
+		Action:    action,
+		OldValue:  oldValue,
+		NewValue:  newValue,
+		ChangedBy: accountID,
+	}); err != nil {
+		return fmt.Errorf("failed to record class list entry change: %w", err)
+	}
+	return nil
+}
+
+// classListEntryKey is the duplicate identity of an entry: normalized name
+// and class, mirroring the unique index.
+func classListEntryKey(firstName, lastName, schoolClass string) string {
+	return strings.ToLower(strings.TrimSpace(firstName)) + "\x00" +
+		strings.ToLower(strings.TrimSpace(lastName)) + "\x00" +
+		schoolclass.Normalize(schoolClass)
+}

--- a/backend/services/education/grade_transition_class_list_entries.go
+++ b/backend/services/education/grade_transition_class_list_entries.go
@@ -131,8 +131,10 @@ func (s *GradeTransitionService) remapClassListEntries(
 			return err
 		}
 		if created != nil {
+			createdID := created.ID
 			ledger = append(ledger, &education.GradeTransitionClassListEntry{
 				TransitionID: transitionID,
+				EntryID:      &createdID,
 				FirstName:    created.FirstName,
 				LastName:     created.LastName,
 				SchoolClass:  created.SchoolClass,
@@ -153,10 +155,11 @@ func (s *GradeTransitionService) remapClassListEntries(
 // Entries the apply never touched — a pre-existing entry of a rename target,
 // or one created between apply and revert — have no ledger entry and stay
 // untouched. Entries the admin changed since the apply win: a created row the
-// admin already deleted is not deleted again AND its paired removed entry is
-// not restored (the admin deliberately took the child off the list), and a
-// restore colliding with a surviving entry or a student of that name and
-// class is skipped — the child already has exactly one row on the list.
+// admin already deleted or edited is left alone AND its paired removed entry
+// is not restored (the admin deliberately took the child off the list or
+// re-filed them), and a restore colliding with a surviving entry or a student
+// of that name and class is skipped — the child already has exactly one row on
+// the list.
 func (s *GradeTransitionService) revertClassListEntries(
 	ctx context.Context,
 	transitionID int64,
@@ -180,14 +183,16 @@ func (s *GradeTransitionService) revertClassListEntries(
 		return fmt.Errorf("failed to list class list entries: %w", err)
 	}
 	current := make(map[string]*userModels.ClassListEntry, len(entries))
+	byID := make(map[int64]*userModels.ClassListEntry, len(entries))
 	for _, entry := range entries {
 		current[classListEntryKey(entry.FirstName, entry.LastName, entry.SchoolClass)] = entry
+		byID[entry.ID] = entry
 	}
 
 	// ledgerCreated: identities the apply inserted at all. deletedCreated:
 	// the subset this revert actually found and deleted — an identity in the
-	// first set but not the second was removed by the admin after the apply,
-	// and its paired restore must not resurrect the child.
+	// first set but not the second was removed or edited by the admin after
+	// the apply, and its paired restore must not resurrect the child.
 	ledgerCreated := make(map[string]bool)
 	deletedCreated := make(map[string]bool)
 	for _, item := range ledger {
@@ -196,14 +201,14 @@ func (s *GradeTransitionService) revertClassListEntries(
 		}
 		key := classListEntryKey(item.FirstName, item.LastName, item.SchoolClass)
 		ledgerCreated[key] = true
-		row, ok := current[key]
-		if !ok {
+		row := resolveLedgerCreatedRow(item, current, byID)
+		if row == nil {
 			continue
 		}
 		if err := s.classListEntryRepo.Delete(ctx, row.ID); err != nil {
 			return fmt.Errorf("failed to delete class list entry: %w", err)
 		}
-		delete(current, key)
+		delete(current, classListEntryKey(row.FirstName, row.LastName, row.SchoolClass))
 		deletedCreated[key] = true
 		if err := s.auditClassListEntryChange(ctx, row.ID, auditModels.ClassListEntryActionDeleted, row.DisplayValue(), "", accountID); err != nil {
 			return err
@@ -251,6 +256,31 @@ func (s *GradeTransitionService) revertClassListEntries(
 		}
 	}
 	return nil
+}
+
+// resolveLedgerCreatedRow returns the row a 'created' ledger item inserted, or
+// nil when the revert must leave it alone: the admin deleted it, or edited it
+// since the apply. The lookup goes through the recorded row ID, because an
+// edit that keeps the normalized identity ("2a" → "2A", a corrected spelling
+// of a name) is invisible to an identity lookup — it would delete the row and
+// replay the pre-transition value over the admin's change. Ledger rows written
+// before the ID was recorded fall back to the identity lookup.
+func resolveLedgerCreatedRow(
+	item *education.GradeTransitionClassListEntry,
+	byKey map[string]*userModels.ClassListEntry,
+	byID map[int64]*userModels.ClassListEntry,
+) *userModels.ClassListEntry {
+	if item.EntryID == nil {
+		return byKey[classListEntryKey(item.FirstName, item.LastName, item.SchoolClass)]
+	}
+	row, ok := byID[*item.EntryID]
+	if !ok {
+		return nil // the admin deleted the row the apply created
+	}
+	if row.FirstName != item.FirstName || row.LastName != item.LastName || row.SchoolClass != item.SchoolClass {
+		return nil // the admin edited it since the apply — their change wins
+	}
+	return row
 }
 
 // reinsertClassListEntry re-creates one remapped entry under its target class

--- a/backend/services/education/grade_transition_class_list_entries_internal_test.go
+++ b/backend/services/education/grade_transition_class_list_entries_internal_test.go
@@ -1,0 +1,53 @@
+package education
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The lookup resolves exact (trimmed) forms first — the condition students
+// and Klassenlehrer rows move under — and falls back to the normalized class
+// identity entries are matched by everywhere else (#2399 review round 9).
+func TestClassListEntryRenameLookup(t *testing.T) {
+	lookup := newClassListEntryRenameLookup(map[string]string{
+		"1a": "2a",
+		"4a": "", // graduates
+	})
+
+	target, hit := lookup.target(" 1a ")
+	assert.True(t, hit)
+	assert.Equal(t, "2a", target, "exact trimmed form resolves directly")
+
+	target, hit = lookup.target("1A")
+	assert.True(t, hit)
+	assert.Equal(t, "2a", target, "case-divergent form resolves via the normalized fallback")
+
+	target, hit = lookup.target("4A")
+	assert.True(t, hit)
+	assert.Empty(t, target, "graduation resolves via the fallback too")
+
+	_, hit = lookup.target("1b")
+	assert.False(t, hit, "an unmapped class stays out of the transition")
+}
+
+// Two mappings collapsing onto one normalized key with different targets are
+// ambiguous: the exact forms still resolve, but no third display form may
+// pick one of the two targets arbitrarily.
+func TestClassListEntryRenameLookupAmbiguousNormalizedKey(t *testing.T) {
+	lookup := newClassListEntryRenameLookup(map[string]string{
+		"1ab": "2a",
+		"1AB": "2b",
+	})
+
+	target, hit := lookup.target("1ab")
+	assert.True(t, hit)
+	assert.Equal(t, "2a", target)
+
+	target, hit = lookup.target("1AB")
+	assert.True(t, hit)
+	assert.Equal(t, "2b", target)
+
+	_, hit = lookup.target("1Ab")
+	assert.False(t, hit, "an ambiguous normalized key is excluded from the fallback")
+}

--- a/backend/services/education/grade_transition_class_list_entries_test.go
+++ b/backend/services/education/grade_transition_class_list_entries_test.go
@@ -1,0 +1,272 @@
+package education_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	auditRepo "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	educationRepo "github.com/moto-nrw/project-phoenix/database/repositories/education"
+	usersRepo "github.com/moto-nrw/project-phoenix/database/repositories/users"
+	educationService "github.com/moto-nrw/project-phoenix/services/education"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// setupClassListEntryTransitionTest wires the transition service WITH the
+// class-list-entry repos — the shared setup leaves them nil, which disables
+// the remap entirely.
+func setupClassListEntryTransitionTest(t *testing.T) (*educationService.GradeTransitionService, *bun.DB, func()) {
+	t.Helper()
+
+	db := testpkg.SetupTestDB(t)
+
+	service := educationService.NewGradeTransitionService(educationService.GradeTransitionServiceDependencies{
+		TransitionRepo:      educationRepo.NewGradeTransitionRepository(db),
+		StudentRepo:         usersRepo.NewStudentRepository(db),
+		PersonRepo:          usersRepo.NewPersonRepository(db),
+		ClassTeacherRepo:    educationRepo.NewClassTeacherRepository(db),
+		StaffRepo:           usersRepo.NewStaffRepository(db),
+		ClassListEntryRepo:  usersRepo.NewClassListEntryRepository(db),
+		ClassListEntryAudit: auditRepo.NewClassListEntryChangeRepository(db),
+		DB:                  db,
+	})
+
+	cleanup := func() {
+		_ = db.Close()
+	}
+
+	return service, db, cleanup
+}
+
+// classListEntryClassesOf reads the current classes an entry name sits in,
+// straight from the table, sorted.
+func classListEntryClassesOf(t *testing.T, db *bun.DB, ctx context.Context, firstName, lastName string) []string {
+	t.Helper()
+	var classes []string
+	err := db.NewSelect().
+		TableExpr("users.class_list_entries").
+		Column("school_class").
+		Where("first_name = ? AND last_name = ?", firstName, lastName).
+		OrderExpr("LOWER(BTRIM(school_class)) ASC").
+		Scan(ctx, &classes)
+	require.NoError(t, err)
+	return classes
+}
+
+func cleanupClassListEntriesByName(t *testing.T, db *bun.DB, names [][2]string) {
+	t.Helper()
+	ctx := testpkg.TenantContext(1)
+	for _, name := range names {
+		_, _ = db.NewDelete().TableExpr("users.class_list_entries").
+			Where("first_name = ? AND last_name = ?", name[0], name[1]).
+			Exec(ctx)
+	}
+}
+
+// The class-list entries must follow the school-year rollover like the
+// students and the Klassenlehrer assignments (#2382): promoted classes carry
+// their entries along, graduating classes lose them — and the revert replays
+// the recorded ledger backwards, restoring exactly what the apply rewrote
+// while leaving pre-existing and newly created entries untouched (#2399
+// review blocker).
+func TestGradeTransitionService_Apply_RemapsClassListEntries(t *testing.T) {
+	service, db, cleanup := setupClassListEntryTransitionTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 20*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-cle@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1a-%s", suffix)
+	class2 := fmt.Sprintf("2a-%s", suffix)
+	class4 := fmt.Sprintf("4a-%s", suffix)
+	classOther := fmt.Sprintf("1b-%s", suffix)
+
+	// One child per mapped class so the transition has a locked cohort.
+	student1 := testpkg.CreateTestStudent(t, db, "CleMove", "Cohort1", class1)
+	student4 := testpkg.CreateTestStudent(t, db, "CleMove", "Cohort4", class4)
+	defer testpkg.CleanupActivityFixtures(t, db, student1.ID, student4.ID)
+
+	promoted := testpkg.CreateTestClassListEntry(t, db, "CleZoe", "Promoted", class1)
+	graduated := testpkg.CreateTestClassListEntry(t, db, "CleBen", "Graduated", class4)
+	unrelated := testpkg.CreateTestClassListEntry(t, db, "CleUli", "Unrelated", classOther)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, promoted.ID, graduated.ID, unrelated.ID)
+	defer cleanupClassListEntriesByName(t, db, [][2]string{
+		{"CleZoe", "Promoted"}, {"CleBen", "Graduated"}, {"CleUli", "Unrelated"}, {"CleNeu", "Dazwischen"},
+	})
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class4, nil) // graduates
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class2}, classListEntryClassesOf(t, db, ctx, "CleZoe", "Promoted"),
+		"promoted class must carry its entry along")
+	assert.Empty(t, classListEntryClassesOf(t, db, ctx, "CleBen", "Graduated"),
+		"graduating class must lose its entry")
+	assert.Equal(t, []string{classOther}, classListEntryClassesOf(t, db, ctx, "CleUli", "Unrelated"),
+		"an entry in an unmapped class must not move")
+
+	// Created BETWEEN apply and revert, in the rename-target class: the
+	// mapping-derived reverse rename would drag it to class1 — the ledger
+	// replay must leave it alone.
+	created := testpkg.CreateTestClassListEntry(t, db, "CleNeu", "Dazwischen", class2)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, created.ID)
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class1}, classListEntryClassesOf(t, db, ctx, "CleZoe", "Promoted"),
+		"revert must carry the promoted entry back")
+	assert.Equal(t, []string{class4}, classListEntryClassesOf(t, db, ctx, "CleBen", "Graduated"),
+		"revert must restore the graduated entry from the ledger, like it reactivates the students")
+	assert.Equal(t, []string{class2}, classListEntryClassesOf(t, db, ctx, "CleNeu", "Dazwischen"),
+		"an entry created after the apply must stay untouched by the revert")
+	assert.Equal(t, []string{classOther}, classListEntryClassesOf(t, db, ctx, "CleUli", "Unrelated"),
+		"an entry in an unmapped class must survive the revert unchanged")
+}
+
+// An entry the admin deliberately removed between apply and revert stays
+// removed: the ledger replay must not resurrect the child under the
+// pre-transition class name.
+func TestGradeTransitionService_Revert_KeepsAdminDeletedEntriesDeleted(t *testing.T) {
+	service, db, cleanup := setupClassListEntryTransitionTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 20*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-cle-del@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1c-%s", suffix)
+	class2 := fmt.Sprintf("2c-%s", suffix)
+
+	student := testpkg.CreateTestStudent(t, db, "CleDel", "Cohort", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+	entry := testpkg.CreateTestClassListEntry(t, db, "CleMia", "Entfernt", class1)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+	defer cleanupClassListEntriesByName(t, db, [][2]string{{"CleMia", "Entfernt"}})
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{class2}, classListEntryClassesOf(t, db, ctx, "CleMia", "Entfernt"))
+
+	// The admin takes the child off the list after the apply.
+	_, err = db.NewDelete().TableExpr("users.class_list_entries").
+		Where("first_name = ? AND last_name = ?", "CleMia", "Entfernt").
+		Exec(testpkg.TenantContext(1))
+	require.NoError(t, err)
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Empty(t, classListEntryClassesOf(t, db, ctx, "CleMia", "Entfernt"),
+		"a deliberately deleted entry must not be resurrected by the revert")
+}
+
+// Restores that would duplicate a child are skipped: an identical entry the
+// admin re-created under the old class, or a student who got a real record
+// under that name and class in the meantime — either way the child already
+// has exactly one row on the class list.
+func TestGradeTransitionService_Revert_SkipsCollidingRestores(t *testing.T) {
+	service, db, cleanup := setupClassListEntryTransitionTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 20*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-cle-coll@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1d-%s", suffix)
+	class2 := fmt.Sprintf("2d-%s", suffix)
+
+	cohort := testpkg.CreateTestStudent(t, db, "CleColl", "Cohort", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, cohort.ID)
+
+	entryAnna := testpkg.CreateTestClassListEntry(t, db, "CleAnna", "Kollision", class1)
+	entryBen := testpkg.CreateTestClassListEntry(t, db, "CleBen2", "Kollision", class1)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, entryAnna.ID, entryBen.ID)
+	defer cleanupClassListEntriesByName(t, db, [][2]string{
+		{"CleAnna", "Kollision"}, {"CleBen2", "Kollision"},
+	})
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	// Between apply and revert: Anna gets re-created as an entry under the
+	// OLD class name, Ben gets a real student record under the old class.
+	annaAgain := testpkg.CreateTestClassListEntry(t, db, "CleAnna", "Kollision", class1)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, annaAgain.ID)
+	benStudent := testpkg.CreateTestStudent(t, db, "CleBen2", "Kollision", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, benStudent.ID)
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class1}, classListEntryClassesOf(t, db, ctx, "CleAnna", "Kollision"),
+		"the re-created entry survives; the ledger restore must not duplicate it")
+	assert.Empty(t, classListEntryClassesOf(t, db, ctx, "CleBen2", "Kollision"),
+		"a child with a real student record must not get a second class-list row")
+}
+
+// A transition over classes without any entries writes no ledger — apply and
+// revert both no-op cleanly.
+func TestGradeTransitionService_ClassListEntries_NoEntriesNoLedger(t *testing.T) {
+	service, db, cleanup := setupClassListEntryTransitionTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 20*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-cle-empty@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1e-%s", suffix)
+	class2 := fmt.Sprintf("2e-%s", suffix)
+
+	cohort := testpkg.CreateTestStudent(t, db, "CleEmpty", "Cohort", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, cohort.ID)
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	count, err := db.NewSelect().
+		TableExpr("education.grade_transition_class_list_entries").
+		Where("transition_id = ?", transition.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count, "no entries, no ledger rows")
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+}

--- a/backend/services/education/grade_transition_class_list_entries_test.go
+++ b/backend/services/education/grade_transition_class_list_entries_test.go
@@ -3,6 +3,7 @@ package education_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -232,6 +233,51 @@ func TestGradeTransitionService_Revert_SkipsCollidingRestores(t *testing.T) {
 		"the re-created entry survives; the ledger restore must not duplicate it")
 	assert.Empty(t, classListEntryClassesOf(t, db, ctx, "CleBen2", "Kollision"),
 		"a child with a real student record must not get a second class-list row")
+}
+
+// An entry whose stored class differs from the mapping's display form only in
+// case belongs to the same cohort — the entry's class identity is the
+// normalized form everywhere else (unique index, filters, exports). The remap
+// must carry it along via the normalized fallback instead of leaving it
+// attached to the old class name, and the revert must restore its original
+// display form (#2399 review round 9).
+func TestGradeTransitionService_Apply_RemapsCaseDivergentEntryClass(t *testing.T) {
+	service, db, cleanup := setupClassListEntryTransitionTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 20*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-cle-case@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1f-%s", suffix)
+	class1Upper := strings.ToUpper(class1)
+	class2 := fmt.Sprintf("2f-%s", suffix)
+
+	cohort := testpkg.CreateTestStudent(t, db, "CleCase", "Cohort", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, cohort.ID)
+
+	entry := testpkg.CreateTestClassListEntry(t, db, "CleIda", "Grossklein", class1Upper)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+	defer cleanupClassListEntriesByName(t, db, [][2]string{{"CleIda", "Grossklein"}})
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class2}, classListEntryClassesOf(t, db, ctx, "CleIda", "Grossklein"),
+		"a case-divergent entry class must follow its cohort's rename")
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class1Upper}, classListEntryClassesOf(t, db, ctx, "CleIda", "Grossklein"),
+		"the revert must restore the entry with its original display form")
 }
 
 // A transition over classes without any entries writes no ledger — apply and

--- a/backend/services/education/grade_transition_class_list_entries_test.go
+++ b/backend/services/education/grade_transition_class_list_entries_test.go
@@ -280,6 +280,56 @@ func TestGradeTransitionService_Apply_RemapsCaseDivergentEntryClass(t *testing.T
 		"the revert must restore the entry with its original display form")
 }
 
+// An entry the admin edited between apply and revert keeps the edit, even when
+// the edit leaves the normalized identity untouched ("2g-xy" → "2G-XY"). The
+// revert resolves the row it created by the recorded ID, so a display-form
+// change is not mistaken for the untouched transition row and replayed over
+// (#2399 review round 11).
+func TestGradeTransitionService_Revert_KeepsAdminEditedCreatedEntry(t *testing.T) {
+	service, db, cleanup := setupClassListEntryTransitionTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(testpkg.TenantContext(1), 20*time.Second)
+	defer cancel()
+
+	account := testpkg.CreateTestAccount(t, db, "transition-cle-edit@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+
+	suffix := uuid.Must(uuid.NewV4()).String()[:8]
+	class1 := fmt.Sprintf("1g-%s", suffix)
+	class2 := fmt.Sprintf("2g-%s", suffix)
+	class2Upper := strings.ToUpper(class2)
+
+	cohort := testpkg.CreateTestStudent(t, db, "CleEdit", "Cohort", class1)
+	defer testpkg.CleanupActivityFixtures(t, db, cohort.ID)
+
+	entry := testpkg.CreateTestClassListEntry(t, db, "CleNina", "Bearbeitet", class1)
+	defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+	defer cleanupClassListEntriesByName(t, db, [][2]string{{"CleNina", "Bearbeitet"}})
+
+	transition := testpkg.CreateTestGradeTransition(t, db, "2026-2027", account.ID)
+	testpkg.CreateTestGradeTransitionMapping(t, db, transition.ID, class1, testpkg.StrPtr(class2))
+	defer testpkg.CleanupGradeTransitionFixtures(t, db, transition.ID)
+
+	_, err := service.Apply(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{class2}, classListEntryClassesOf(t, db, ctx, "CleNina", "Bearbeitet"))
+
+	// The admin corrects the class spelling after the apply — same child, same
+	// normalized class, different display form.
+	_, err = db.NewUpdate().TableExpr("users.class_list_entries").
+		Set("school_class = ?", class2Upper).
+		Where("first_name = ? AND last_name = ?", "CleNina", "Bearbeitet").
+		Exec(testpkg.TenantContext(1))
+	require.NoError(t, err)
+
+	_, err = service.Revert(ctx, transition.ID, account.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{class2Upper}, classListEntryClassesOf(t, db, ctx, "CleNina", "Bearbeitet"),
+		"an entry edited after the apply must survive the revert unchanged, in exactly one row")
+}
+
 // A transition over classes without any entries writes no ledger — apply and
 // revert both no-op cleanly.
 func TestGradeTransitionService_ClassListEntries_NoEntriesNoLedger(t *testing.T) {

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -894,8 +894,9 @@ func (s *GradeTransitionService) executeApply(
 	}
 
 	// The class-list-only entries (#2382) follow the same renames: promoted
-	// classes keep their entries, graduating classes lose them.
-	if err := s.remapClassListEntries(ctx, transition.Mappings, accountID); err != nil {
+	// classes keep their entries, graduating classes lose them. Every rewrite
+	// lands in the transition's class-list-entry ledger for the revert.
+	if err := s.remapClassListEntries(ctx, transition.ID, transition.Mappings, accountID); err != nil {
 		return err
 	}
 
@@ -1549,10 +1550,11 @@ func (s *GradeTransitionService) executeRevert(
 		return err
 	}
 
-	// The class-list-only entries (#2382) rename back along the reversed
-	// mappings; entries a graduation deleted stay deleted (no ledger — see
-	// grade_transition_class_list_entries.go).
-	if err := s.revertClassListEntries(ctx, transition.Mappings, accountID); err != nil {
+	// The class-list-only entries (#2382) replay their recorded ledger
+	// backwards, mirroring the Klassenlehrer revert above: created rows are
+	// deleted, removed rows (promotions AND graduations) are restored, and
+	// entries the apply never touched stay untouched.
+	if err := s.revertClassListEntries(ctx, transition.ID, transition.Mappings, accountID); err != nil {
 		return err
 	}
 

--- a/backend/services/education/grade_transition_service.go
+++ b/backend/services/education/grade_transition_service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/education"
 	"github.com/moto-nrw/project-phoenix/models/users"
@@ -194,6 +195,8 @@ type GradeTransitionService struct {
 	visitRepo              activeModels.VisitRepository
 	attendanceRepo         activeModels.AttendanceRepository
 	classTeacherRepo       education.ClassTeacherRepository
+	classListEntryRepo     users.ClassListEntryRepository
+	classListEntryAudit    auditModels.ClassListEntryChangeRepository
 	rosterReconciler       RosterReconciler
 	offeringSourceResyncer OfferingSourceResyncer
 	db                     *bun.DB
@@ -224,6 +227,12 @@ type GradeTransitionServiceDependencies struct {
 	// resurrected. Wire both together.
 	ClassTeacherRepo education.ClassTeacherRepository
 	StaffRepo        users.StaffRepository
+	// ClassListEntryRepo lets apply/revert follow the class renames for the
+	// class-list-only entries (#2382) — same rationale as ClassTeacherRepo.
+	// Optional; nil disables the remap. ClassListEntryAudit records every
+	// rewrite (nil disables the trail for tests).
+	ClassListEntryRepo  users.ClassListEntryRepository
+	ClassListEntryAudit auditModels.ClassListEntryChangeRepository
 	// RosterReconciler reconciles already-materialized future timetable rosters
 	// on apply (drop graduates) and revert (restore reactivated students).
 	// Optional; nil disables reconciliation for tests that don't exercise it.
@@ -234,15 +243,17 @@ type GradeTransitionServiceDependencies struct {
 // NewGradeTransitionService creates a new grade transition service
 func NewGradeTransitionService(deps GradeTransitionServiceDependencies) *GradeTransitionService {
 	return &GradeTransitionService{
-		transitionRepo:   deps.TransitionRepo,
-		studentRepo:      deps.StudentRepo,
-		personRepo:       deps.PersonRepo,
-		staffRepo:        deps.StaffRepo,
-		visitRepo:        deps.VisitRepo,
-		attendanceRepo:   deps.AttendanceRepo,
-		classTeacherRepo: deps.ClassTeacherRepo,
-		rosterReconciler: deps.RosterReconciler,
-		db:               deps.DB,
+		transitionRepo:      deps.TransitionRepo,
+		studentRepo:         deps.StudentRepo,
+		personRepo:          deps.PersonRepo,
+		staffRepo:           deps.StaffRepo,
+		visitRepo:           deps.VisitRepo,
+		attendanceRepo:      deps.AttendanceRepo,
+		classTeacherRepo:    deps.ClassTeacherRepo,
+		classListEntryRepo:  deps.ClassListEntryRepo,
+		classListEntryAudit: deps.ClassListEntryAudit,
+		rosterReconciler:    deps.RosterReconciler,
+		db:                  deps.DB,
 	}
 }
 
@@ -879,6 +890,12 @@ func (s *GradeTransitionService) executeApply(
 	// year's incoming cohort after this apply. Every rewrite lands in the
 	// transition's class-teacher ledger so the revert can replay it exactly.
 	if err := s.remapClassTeacherAssignments(ctx, transition.ID, transition.Mappings); err != nil {
+		return err
+	}
+
+	// The class-list-only entries (#2382) follow the same renames: promoted
+	// classes keep their entries, graduating classes lose them.
+	if err := s.remapClassListEntries(ctx, transition.Mappings, accountID); err != nil {
 		return err
 	}
 
@@ -1529,6 +1546,13 @@ func (s *GradeTransitionService) executeRevert(
 	// touched have no ledger entry and stay untouched, and rows the admin
 	// deliberately removed since the apply stay removed.
 	if err := s.revertClassTeacherAssignments(ctx, transition.ID, transition.Mappings); err != nil {
+		return err
+	}
+
+	// The class-list-only entries (#2382) rename back along the reversed
+	// mappings; entries a graduation deleted stay deleted (no ledger — see
+	// grade_transition_class_list_entries.go).
+	if err := s.revertClassListEntries(ctx, transition.Mappings, accountID); err != nil {
 		return err
 	}
 

--- a/backend/services/enrollment/class_day_service.go
+++ b/backend/services/enrollment/class_day_service.go
@@ -24,16 +24,23 @@ const StudentStatusDayCancelled = "cancelled"
 // names or contact details: the Lehrkraft view is a privacy-reduced
 // projection of the class roster — who stays, who goes home, and how.
 type ClassDayRow struct {
-	StudentID  int64    `json:"student_id"`
-	FirstName  string   `json:"first_name"`
-	LastName   string   `json:"last_name"`
-	GroupName  string   `json:"group_name,omitempty"`
-	Registered bool     `json:"registered"`
-	StaysToday bool     `json:"stays_today"`
-	Offerings  []string `json:"offerings"`
-	Arrival    string   `json:"arrival,omitempty"`
-	Pickup     string   `json:"pickup,omitempty"`
-	Departure  string   `json:"departure,omitempty"`
+	StudentID int64  `json:"student_id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	// ListEntry marks a class-list-only entry (#2382): a child of the class
+	// cohort with NO OGS record ("Keine Betreuung"). StudentID is 0;
+	// ListEntryID carries the users.class_list_entries id. The row never
+	// stays, never has offerings, times or a departure plan — and unlike a
+	// missing plan of an OGS child, that is a statement, not a gap.
+	ListEntry   bool     `json:"list_entry,omitempty"`
+	ListEntryID int64    `json:"list_entry_id,omitempty"`
+	GroupName   string   `json:"group_name,omitempty"`
+	Registered  bool     `json:"registered"`
+	StaysToday  bool     `json:"stays_today"`
+	Offerings   []string `json:"offerings"`
+	Arrival     string   `json:"arrival,omitempty"`
+	Pickup      string   `json:"pickup,omitempty"`
+	Departure   string   `json:"departure,omitempty"`
 	// Status is the scheduled day status ("sick" / "excused" / "class_trip",
 	// plus the derived "cancelled" when a pickup exception calls the care day
 	// off), empty when none is reported. The free-text note stays private.
@@ -337,9 +344,26 @@ func (s *reportService) ClassDay(ctx context.Context, schoolClass string, date t
 		}
 	}
 
+	// The class-list-only entries (#2382) complete the Klassenverband:
+	// children without any OGS record, marked "Keine Betreuung". They sort in
+	// alphabetically like every student row and can never stay in care.
+	entryRows, err := s.classListEntryRows(ctx, schoolClass, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(entryRows) > 0 {
+		if len(rosterRows)+len(entryRows) > maxReportRows {
+			return nil, fmt.Errorf("class day report: %d rows: %w", len(rosterRows)+len(entryRows), ErrReportExportTooLarge)
+		}
+		rosterRows = append(rosterRows, entryRows...)
+		sortClassRosterRows(rosterRows)
+	}
+
 	studentIDs := make([]int64, 0, len(rosterRows))
 	for _, row := range rosterRows {
-		studentIDs = append(studentIDs, row.StudentID)
+		if row.StudentID > 0 {
+			studentIDs = append(studentIDs, row.StudentID)
+		}
 	}
 
 	// Weekends render "Kein Schultag" — skip the status/departure/schedule
@@ -615,24 +639,29 @@ func buildClassDayReport(schoolClass string, date timezone.Date, phaseName strin
 		// zeroed totals below) — a weekend request must not serve any
 		// departure instruction to non-UI consumers either.
 		departure := ""
-		if weekday != "" {
+		if weekday != "" && !row.ListEntry {
+			// A class-list-only entry has no departure column at all: "Keine
+			// Betreuung" is the whole statement, and rendering "Keine Angabe"
+			// would suggest a plan gap the office should fill.
 			departure = departures[row.StudentID]
 			if departure == "" {
 				departure = classDayDepartureUnknown
 			}
 		}
 		dayRow := ClassDayRow{
-			StudentID:  row.StudentID,
-			FirstName:  row.FirstName,
-			LastName:   row.LastName,
-			GroupName:  row.GroupName,
-			Registered: row.Registered,
-			StaysToday: stays,
-			Offerings:  offerings,
-			Arrival:    arrival,
-			Pickup:     pickup,
-			Departure:  departure,
-			Status:     status,
+			StudentID:   row.StudentID,
+			FirstName:   row.FirstName,
+			LastName:    row.LastName,
+			ListEntry:   row.ListEntry,
+			ListEntryID: row.ListEntryID,
+			GroupName:   row.GroupName,
+			Registered:  row.Registered,
+			StaysToday:  stays,
+			Offerings:   offerings,
+			Arrival:     arrival,
+			Pickup:      pickup,
+			Departure:   departure,
+			Status:      status,
 		}
 		report.Rows = append(report.Rows, dayRow)
 		report.Totals.Students++

--- a/backend/services/enrollment/class_day_service.go
+++ b/backend/services/enrollment/class_day_service.go
@@ -52,6 +52,11 @@ type ClassDayTotals struct {
 	Staying  int `json:"staying"`
 	Leaving  int `json:"leaving"`
 	Absent   int `json:"absent"`
+	// ListEntries counts the class-list-only entries (#2382) among Students.
+	// They are neither staying nor leaving: "Keine Betreuung" is a roster
+	// statement, not a handoff instruction, so they get their own bucket
+	// instead of inflating "Gehen nach Hause".
+	ListEntries int `json:"list_entries"`
 }
 
 type ClassDayReport struct {
@@ -666,6 +671,11 @@ func buildClassDayReport(schoolClass string, date timezone.Date, phaseName strin
 		report.Rows = append(report.Rows, dayRow)
 		report.Totals.Students++
 		switch {
+		case row.ListEntry:
+			// A class-list-only entry neither stays nor leaves — "Keine
+			// Betreuung" is its own neutral roster bucket, never a
+			// "geht nach Hause" claim.
+			report.Totals.ListEntries++
 		case status != "":
 			report.Totals.Absent++
 		case stays:
@@ -680,6 +690,7 @@ func buildClassDayReport(schoolClass string, date timezone.Date, phaseName strin
 		report.Totals.Staying = 0
 		report.Totals.Leaving = 0
 		report.Totals.Absent = 0
+		report.Totals.ListEntries = 0
 	}
 	return report
 }

--- a/backend/services/enrollment/class_day_service.go
+++ b/backend/services/enrollment/class_day_service.go
@@ -29,11 +29,12 @@ type ClassDayRow struct {
 	LastName  string `json:"last_name"`
 	// ListEntry marks a class-list-only entry (#2382): a child of the class
 	// cohort with NO OGS record ("Keine Betreuung"). StudentID is 0;
-	// ListEntryID carries the users.class_list_entries id. The row never
-	// stays, never has offerings, times or a departure plan — and unlike a
-	// missing plan of an OGS child, that is a statement, not a gap.
+	// ListEntryID carries the users.class_list_entries id, serialized as a
+	// JSON string because JavaScript clients round numbers beyond 2^53. The
+	// row never stays, never has offerings, times or a departure plan — and
+	// unlike a missing plan of an OGS child, that is a statement, not a gap.
 	ListEntry   bool     `json:"list_entry,omitempty"`
-	ListEntryID int64    `json:"list_entry_id,omitempty"`
+	ListEntryID int64    `json:"list_entry_id,string,omitempty"`
 	GroupName   string   `json:"group_name,omitempty"`
 	Registered  bool     `json:"registered"`
 	StaysToday  bool     `json:"stays_today"`

--- a/backend/services/enrollment/class_list_entries_report_test.go
+++ b/backend/services/enrollment/class_list_entries_report_test.go
@@ -132,5 +132,8 @@ func TestBuildClassDayReportListEntryProjection(t *testing.T) {
 
 	assert.Equal(t, 2, report.Totals.Students)
 	assert.Equal(t, 1, report.Totals.Staying)
-	assert.Equal(t, 1, report.Totals.Leaving)
+	// The entry is NOT "geht nach Hause" — it lands in its own neutral
+	// "Keine Betreuung" bucket (#2399 review).
+	assert.Equal(t, 0, report.Totals.Leaving)
+	assert.Equal(t, 1, report.Totals.ListEntries)
 }

--- a/backend/services/enrollment/class_list_entries_report_test.go
+++ b/backend/services/enrollment/class_list_entries_report_test.go
@@ -1,0 +1,136 @@
+package enrollment
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// fakeClassListEntryRepo serves in-memory class-list entries (#2382).
+type fakeClassListEntryRepo struct {
+	userModels.ClassListEntryRepository
+	entries []*userModels.ClassListEntry
+}
+
+func (r *fakeClassListEntryRepo) List(_ context.Context, _ map[string]any) ([]*userModels.ClassListEntry, error) {
+	return r.entries, nil
+}
+
+func (r *fakeClassListEntryRepo) FindBySchoolClass(_ context.Context, schoolClass string) ([]*userModels.ClassListEntry, error) {
+	key := strings.ToLower(strings.TrimSpace(schoolClass))
+	var out []*userModels.ClassListEntry
+	for _, entry := range r.entries {
+		if strings.ToLower(strings.TrimSpace(entry.SchoolClass)) == key {
+			out = append(out, entry)
+		}
+	}
+	return out, nil
+}
+
+func classListEntry(id int64, firstName, lastName, schoolClass string) *userModels.ClassListEntry {
+	entry := &userModels.ClassListEntry{
+		FirstName:   firstName,
+		LastName:    lastName,
+		SchoolClass: schoolClass,
+	}
+	entry.ID = id
+	return entry
+}
+
+func TestClassRosterMergesClassListEntries(t *testing.T) {
+	svc := allClassesTestService()
+	svc.ClassListEntryRepo = &fakeClassListEntryRepo{entries: []*userModels.ClassListEntry{
+		classListEntry(101, "Zoe", "Aalders", "1a"),
+		classListEntry(102, "Ben", "Zorn", "3c"),
+	}}
+
+	report, err := svc.ClassRoster(context.Background(), ClassRosterFilters{PhaseID: 55, AllClasses: true})
+	require.NoError(t, err)
+
+	// 4 students + 2 entries; the 3c entry creates its own class section even
+	// though no student carries that class.
+	require.Len(t, report.Rows, 6)
+	assert.Equal(t, 6, report.Totals.Students)
+	assert.Equal(t, 2, report.Totals.ListEntries)
+
+	got := make([][2]string, 0, len(report.Rows))
+	for _, row := range report.Rows {
+		got = append(got, [2]string{row.SchoolClass, row.LastName})
+	}
+	assert.Equal(t, [][2]string{
+		{"1a", "Aalders"}, // list entry, alphabetically first in 1a
+		{"1a", "Anders"},
+		{"1a", "Becker"},
+		{"2b", "Dreyer"},
+		{"3c", "Zorn"}, // entry-only class gets its own section
+		{"10a", "Conrad"},
+	}, got)
+
+	for _, row := range report.Rows {
+		if row.ListEntry {
+			assert.Zero(t, row.StudentID)
+			assert.False(t, row.Registered)
+			assert.Equal(t, ClassListEntryNoCareLabel, row.EnrollmentSummary)
+			assert.Empty(t, row.CareDays)
+		}
+	}
+}
+
+func TestClassRosterSingleClassMergesOnlyThatClass(t *testing.T) {
+	svc := allClassesTestService()
+	svc.ClassListEntryRepo = &fakeClassListEntryRepo{entries: []*userModels.ClassListEntry{
+		classListEntry(101, "Zoe", "Aalders", "1a"),
+		classListEntry(102, "Ben", "Zorn", "3c"),
+	}}
+
+	report, err := svc.ClassRoster(context.Background(), ClassRosterFilters{PhaseID: 55, SchoolClass: "1a"})
+	require.NoError(t, err)
+
+	require.Len(t, report.Rows, 3)
+	assert.Equal(t, 1, report.Totals.ListEntries)
+	assert.Equal(t, "Aalders", report.Rows[0].LastName)
+	assert.True(t, report.Rows[0].ListEntry)
+}
+
+func TestBuildClassDayReportListEntryProjection(t *testing.T) {
+	rows := []ClassRosterRow{
+		{
+			StudentID:  21,
+			FirstName:  "Mila",
+			LastName:   "Anders",
+			Registered: true,
+			OfferingsByDay: map[string][]string{
+				"wed": {"Ganztag"},
+			},
+		},
+		{
+			ListEntry:         true,
+			ListEntryID:       101,
+			FirstName:         "Zoe",
+			LastName:          "Aalders",
+			EnrollmentSummary: ClassListEntryNoCareLabel,
+		},
+	}
+
+	report := buildClassDayReport("1a", timezone.NewDate(2026, 8, 5), "Schuljahr", rows, nil, nil, nil, nil, nil)
+
+	require.Len(t, report.Rows, 2)
+	entryRow := report.Rows[1]
+	require.True(t, entryRow.ListEntry)
+	assert.Equal(t, int64(101), entryRow.ListEntryID)
+	assert.Zero(t, entryRow.StudentID)
+	assert.False(t, entryRow.StaysToday)
+	// "Keine Betreuung" is the whole statement: no departure text at all —
+	// especially not "Keine Angabe", which would read as a plan gap.
+	assert.Empty(t, entryRow.Departure)
+
+	assert.Equal(t, 2, report.Totals.Students)
+	assert.Equal(t, 1, report.Totals.Staying)
+	assert.Equal(t, 1, report.Totals.Leaving)
+}

--- a/backend/services/enrollment/report_service.go
+++ b/backend/services/enrollment/report_service.go
@@ -195,11 +195,12 @@ type ClassRosterRow struct {
 	EnrollmentSummary string `json:"enrollment_summary"`
 	// ListEntry marks a class-list-only entry (#2382): a child of the class
 	// cohort with NO OGS record. StudentID is 0 for these rows; ListEntryID
-	// carries the users.class_list_entries id instead. The row exists only so
-	// the Klassenverband is complete — it can never carry offerings, times or
-	// guardians.
+	// carries the users.class_list_entries id instead, serialized as a JSON
+	// string because JavaScript clients round numbers beyond 2^53. The row
+	// exists only so the Klassenverband is complete — it can never carry
+	// offerings, times or guardians.
 	ListEntry      bool                   `json:"list_entry,omitempty"`
-	ListEntryID    int64                  `json:"list_entry_id,omitempty"`
+	ListEntryID    int64                  `json:"list_entry_id,string,omitempty"`
 	Offerings      []CareUsageRowOffering `json:"offerings"`
 	OfferingsByDay map[string][]string    `json:"offerings_by_day"`
 	CareDays       []string               `json:"care_days"`

--- a/backend/services/enrollment/report_service.go
+++ b/backend/services/enrollment/report_service.go
@@ -175,21 +175,36 @@ type ClassRosterAppliedFilters struct {
 type ClassRosterTotals struct {
 	Students   int `json:"students"`
 	Registered int `json:"registered"`
+	// ListEntries counts the class-list-only entries (#2382) among Students.
+	ListEntries int `json:"list_entries"`
 }
 
+// ClassListEntryNoCareLabel marks a class-list-only entry (#2382) on every
+// class-list surface: the child has no OGS record at all — deliberately
+// distinct from "Keine Anmeldung" (a known OGS child without an enrollment in
+// this phase).
+const ClassListEntryNoCareLabel = "Keine Betreuung"
+
 type ClassRosterRow struct {
-	StudentID         int64                  `json:"student_id"`
-	FirstName         string                 `json:"first_name"`
-	LastName          string                 `json:"last_name"`
-	SchoolClass       string                 `json:"school_class"`
-	GroupName         string                 `json:"group_name,omitempty"`
-	Registered        bool                   `json:"registered"`
-	EnrollmentSummary string                 `json:"enrollment_summary"`
-	Offerings         []CareUsageRowOffering `json:"offerings"`
-	OfferingsByDay    map[string][]string    `json:"offerings_by_day"`
-	CareDays          []string               `json:"care_days"`
-	ArrivalByDay      map[string]string      `json:"arrival_by_day"`
-	PickupByDay       map[string]string      `json:"pickup_by_day"`
+	StudentID         int64  `json:"student_id"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
+	SchoolClass       string `json:"school_class"`
+	GroupName         string `json:"group_name,omitempty"`
+	Registered        bool   `json:"registered"`
+	EnrollmentSummary string `json:"enrollment_summary"`
+	// ListEntry marks a class-list-only entry (#2382): a child of the class
+	// cohort with NO OGS record. StudentID is 0 for these rows; ListEntryID
+	// carries the users.class_list_entries id instead. The row exists only so
+	// the Klassenverband is complete — it can never carry offerings, times or
+	// guardians.
+	ListEntry      bool                   `json:"list_entry,omitempty"`
+	ListEntryID    int64                  `json:"list_entry_id,omitempty"`
+	Offerings      []CareUsageRowOffering `json:"offerings"`
+	OfferingsByDay map[string][]string    `json:"offerings_by_day"`
+	CareDays       []string               `json:"care_days"`
+	ArrivalByDay   map[string]string      `json:"arrival_by_day"`
+	PickupByDay    map[string]string      `json:"pickup_by_day"`
 	// SchedulePickupByDay is the maintained Kind-Gehzeit from
 	// schedule.student_pickup_schedules (manual rows and rolled-out
 	// Angebots-Gehzeiten). It outranks the enrollment-form answer in the
@@ -250,6 +265,11 @@ type ReportServiceConfig struct {
 	// StudentStatusDayRepo); no other report path consumes them.
 	PickupScheduleSvc  scheduleService.PickupScheduleService
 	ArrivalScheduleSvc scheduleService.ArrivalScheduleService
+	// ClassListEntryRepo supplies the class-list-only entries (#2382) the
+	// class roster and the class day view append to the Klassenverband.
+	// Optional: nil (older tests, report paths that never show class lists)
+	// simply serves rosters without list entries.
+	ClassListEntryRepo userModels.ClassListEntryRepository
 	// CareDaySvc owns the "kommt heute / kommt nicht" decision (timeless
 	// exception on EITHER leg cancels the day). The class day view consumes
 	// it instead of re-deriving the precedence from raw schedule entries —
@@ -545,7 +565,78 @@ func (s *reportService) ClassRoster(ctx context.Context, filters ClassRosterFilt
 	if err != nil {
 		return nil, err
 	}
-	return s.classRosterForStudents(ctx, filters, students)
+	report, err := s.classRosterForStudents(ctx, filters, students)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.appendClassListEntries(ctx, filters, report); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+// appendClassListEntries folds the class-list-only entries (#2382) into the
+// roster: children of the Klassenverband without any OGS record, marked
+// "Keine Betreuung". They sort into their class alphabetically like every
+// student row; the AllClasses heading logic keys off the row's class, so a
+// class that exists only through entries gets its own section automatically.
+func (s *reportService) appendClassListEntries(ctx context.Context, filters ClassRosterFilters, report *ClassRosterReport) error {
+	rows, err := s.classListEntryRows(ctx, filters.SchoolClass, filters.AllClasses)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if len(report.Rows)+len(rows) > maxReportRows {
+		return fmt.Errorf("class roster report: %d rows: %w", len(report.Rows)+len(rows), ErrReportExportTooLarge)
+	}
+	report.Rows = append(report.Rows, rows...)
+	sortClassRosterRows(report.Rows)
+	report.Totals.Students += len(rows)
+	report.Totals.ListEntries += len(rows)
+	return nil
+}
+
+// classListEntryRows loads the class-list-only entries — one class or all —
+// and renders them as roster rows. A nil repo (feature not wired) yields no
+// rows.
+func (s *reportService) classListEntryRows(ctx context.Context, schoolClass string, allClasses bool) ([]ClassRosterRow, error) {
+	if s.ClassListEntryRepo == nil {
+		return nil, nil
+	}
+	var entries []*userModels.ClassListEntry
+	var err error
+	if allClasses {
+		entries, err = s.ClassListEntryRepo.List(ctx, nil)
+	} else {
+		entries, err = s.ClassListEntryRepo.FindBySchoolClass(ctx, schoolClass)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("class roster report: list class list entries: %w", err)
+	}
+	rows := make([]ClassRosterRow, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		rows = append(rows, ClassRosterRow{
+			ListEntry:         true,
+			ListEntryID:       entry.ID,
+			FirstName:         entry.FirstName,
+			LastName:          entry.LastName,
+			SchoolClass:       entry.SchoolClass,
+			EnrollmentSummary: ClassListEntryNoCareLabel,
+			Offerings:         []CareUsageRowOffering{},
+			OfferingsByDay:    map[string][]string{},
+			CareDays:          []string{},
+			ArrivalByDay:      map[string]string{},
+			PickupByDay:       map[string]string{},
+			DepartureByDay:    map[string]string{},
+			Guardians:         []ClassRosterGuardian{},
+		})
+	}
+	return rows, nil
 }
 
 // classRosterForStudents builds the roster for an already-loaded student
@@ -1082,7 +1173,10 @@ func sortClassRosterRows(rows []ClassRosterRow) {
 		if r := collation.CompareGermanNames(rows[i].LastName, rows[i].FirstName, rows[j].LastName, rows[j].FirstName); r != 0 {
 			return r < 0
 		}
-		return rows[i].StudentID < rows[j].StudentID
+		if rows[i].StudentID != rows[j].StudentID {
+			return rows[i].StudentID < rows[j].StudentID
+		}
+		return rows[i].ListEntryID < rows[j].ListEntryID
 	})
 }
 

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -131,9 +131,10 @@ type Factory struct {
 	GuardianProfileLoader    *users.GuardianProfileLoader
 	UserContext              usercontext.UserContextService
 	Database                 database.DatabaseService
-	Import                   *importService.ImportService[importModels.StudentImportRow] // Student import service
-	StaffImport              *importService.ImportService[importModels.StaffImportRow]   // Staff (Mitarbeiter) import service
-	OpeningBalanceImport     importService.OpeningBalanceImportFactory                   // Opening balance import (#2132), request-scoped
+	Import                   *importService.ImportService[importModels.StudentImportRow]        // Student import service
+	StaffImport              *importService.ImportService[importModels.StaffImportRow]          // Staff (Mitarbeiter) import service
+	ClassListImport          *importService.ImportService[importModels.ClassListEntryImportRow] // Class-list entry import (#2382)
+	OpeningBalanceImport     importService.OpeningBalanceImportFactory                          // Opening balance import (#2132), request-scoped
 	ListExport               *listexport.RendererService
 	Emergency                *emergency.Service
 	SlotLists                slotlists.Service
@@ -159,6 +160,7 @@ type Factory struct {
 	Schools              platform.SchoolService
 	WorkTimeModels       *config.WorkTimeModelService
 	Students             users.StudentService
+	ClassListEntries     users.ClassListEntryService
 	StudentDeletion      users.StudentDeletionService
 	StudentAudit         users.StudentAuditService
 	MasterDataReview     users.MasterDataReviewService
@@ -347,15 +349,17 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 
 	// Initialize grade transition service
 	gradeTransitionService := education.NewGradeTransitionService(education.GradeTransitionServiceDependencies{
-		TransitionRepo:   repos.GradeTransition,
-		StudentRepo:      repos.Student,
-		PersonRepo:       repos.Person,
-		VisitRepo:        repos.ActiveVisit,
-		AttendanceRepo:   repos.Attendance,
-		ClassTeacherRepo: repos.ClassTeacher,
-		StaffRepo:        repos.Staff,
-		RosterReconciler: rosterReconciler,
-		DB:               db,
+		TransitionRepo:      repos.GradeTransition,
+		StudentRepo:         repos.Student,
+		PersonRepo:          repos.Person,
+		VisitRepo:           repos.ActiveVisit,
+		AttendanceRepo:      repos.Attendance,
+		ClassTeacherRepo:    repos.ClassTeacher,
+		StaffRepo:           repos.Staff,
+		ClassListEntryRepo:  repos.ClassListEntry,
+		ClassListEntryAudit: repos.ClassListEntryChange,
+		RosterReconciler:    rosterReconciler,
+		DB:                  db,
 	})
 
 	// Initialize settings service (new schema-driven settings system)
@@ -1394,6 +1398,15 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	staffImportService := importService.NewImportService(staffImportConfig)
 	staffImportService.SetAuditRepository(repos.DataImport)
 
+	// Class-list entry import (#2382): creates through the entry service so
+	// the duplicate guards and the audit trail apply to imported rows too.
+	classListImportConfig := importService.NewClassListImportConfig(importService.ClassListImportDeps{
+		EntryService: users.NewClassListEntryService(repos.ClassListEntry, repos.Student, repos.ClassListEntryChange),
+		EntryRepo:    repos.ClassListEntry,
+	})
+	classListImportService := importService.NewImportService(classListImportConfig)
+	classListImportService.SetAuditRepository(repos.DataImport)
+
 	// Opening balance import (#2132): the config is request-scoped (Stichtag,
 	// Begründung, and acting staff member come from the upload form), so the
 	// factory closes over the request-independent deps and builds a fresh
@@ -1742,6 +1755,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		PersonRepo:               repos.Person,
 		EducationGroupRepo:       repos.Group,
 		StudentStatusDayRepo:     repos.StudentStatusDay,
+		ClassListEntryRepo:       repos.ClassListEntry,
 		PickupScheduleSvc:        pickupScheduleService,
 		ArrivalScheduleSvc:       arrivalScheduleService,
 		CareDaySvc:               careDayService,
@@ -2273,6 +2287,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Database:                 databaseService,
 		Import:                   studentImportService,        // Student import service
 		StaffImport:              staffImportService,          // Staff (Mitarbeiter) import service
+		ClassListImport:          classListImportService,      // Class-list entry import (#2382)
 		OpeningBalanceImport:     openingBalanceImportFactory, // Opening balance import (#2132)
 		ListExport:               listExportService,
 		PlanExport:               planExportService,
@@ -2305,6 +2320,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Schools:                 platform.NewSchoolService(repos.School),
 		WorkTimeModels:          workTimeModelService,
 		Students:                studentService,
+		ClassListEntries:        users.NewClassListEntryService(repos.ClassListEntry, repos.Student, repos.ClassListEntryChange),
 		StudentDeletion:         studentDeletionService,
 		StudentAudit:            studentAuditService,
 		MasterDataReview:        users.NewMasterDataReviewServiceWithAudit(repos.StudentDataChangeRequest, repos.Student, repos.Person, userContextService, pillEmitter, studentAuditService, logger.With("service", "master-data-review"), realtimeHub),

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1403,6 +1403,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 	classListImportConfig := importService.NewClassListImportConfig(importService.ClassListImportDeps{
 		EntryService: users.NewClassListEntryService(repos.ClassListEntry, repos.Student, repos.ClassListEntryChange),
 		EntryRepo:    repos.ClassListEntry,
+		StudentRepo:  repos.Student,
 	})
 	classListImportService := importService.NewImportService(classListImportConfig)
 	classListImportService.SetAuditRepository(repos.DataImport)

--- a/backend/services/import/class_list_import_config.go
+++ b/backend/services/import/class_list_import_config.go
@@ -1,0 +1,125 @@
+package importpkg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+)
+
+// ClassListImportDeps are the dependencies of the class-list entry import
+// (#2382). The config creates through the service so the duplicate guards and
+// the audit trail apply to imported rows exactly like to manually created
+// ones.
+type ClassListImportDeps struct {
+	EntryService usersService.ClassListEntryService
+	EntryRepo    userModels.ClassListEntryRepository
+}
+
+// ClassListImportConfig implements ImportConfig for class-list entries.
+type ClassListImportConfig struct {
+	deps ClassListImportDeps
+}
+
+// NewClassListImportConfig creates the import config.
+func NewClassListImportConfig(deps ClassListImportDeps) *ClassListImportConfig {
+	return &ClassListImportConfig{deps: deps}
+}
+
+// PreloadReferenceData is a no-op: entries reference nothing.
+func (c *ClassListImportConfig) PreloadReferenceData(_ context.Context) error {
+	return nil
+}
+
+// Validate checks one row: all three fields are required.
+func (c *ClassListImportConfig) Validate(_ context.Context, row *importModels.ClassListEntryImportRow) []importModels.ValidationError {
+	var errs []importModels.ValidationError
+	row.FirstName = strings.TrimSpace(row.FirstName)
+	row.LastName = strings.TrimSpace(row.LastName)
+	row.SchoolClass = strings.TrimSpace(row.SchoolClass)
+
+	if row.FirstName == "" {
+		errs = append(errs, requiredFieldError("first_name", "Vorname ist erforderlich"))
+	}
+	if row.LastName == "" {
+		errs = append(errs, requiredFieldError("last_name", "Nachname ist erforderlich"))
+	}
+	if row.SchoolClass == "" {
+		errs = append(errs, requiredFieldError("school_class", "Klasse ist erforderlich"))
+	}
+	return errs
+}
+
+// ValidateBatch flags in-file duplicates: two rows with the same name and
+// class would hit the unique index on insert — report it as a row error
+// upfront instead.
+func (c *ClassListImportConfig) ValidateBatch(_ context.Context, rows []importModels.ClassListEntryImportRow) map[int][]importModels.ValidationError {
+	result := make(map[int][]importModels.ValidationError)
+	seen := make(map[string]int, len(rows))
+	for i, row := range rows {
+		key := strings.ToLower(strings.TrimSpace(row.FirstName)) + "\x00" +
+			strings.ToLower(strings.TrimSpace(row.LastName)) + "\x00" +
+			strings.ToLower(strings.TrimSpace(row.SchoolClass))
+		if key == "\x00\x00" {
+			continue
+		}
+		if firstRow, dup := seen[key]; dup {
+			result[i+1] = append(result[i+1], importModels.ValidationError{
+				Field:    "first_name",
+				Message:  fmt.Sprintf("Doppelter Eintrag in der Datei (bereits in Zeile %d)", firstRow),
+				Code:     "duplicate_in_file",
+				Severity: importModels.ErrorSeverityError,
+			})
+			continue
+		}
+		seen[key] = i + 1
+	}
+	return result
+}
+
+// FindExisting reports an already-existing entry with the same name and
+// class. The import mode is create-only, so a hit becomes the engine's
+// "already exists" row error.
+func (c *ClassListImportConfig) FindExisting(ctx context.Context, row importModels.ClassListEntryImportRow) (*int64, error) {
+	existing, err := c.deps.EntryRepo.FindByNameAndClass(ctx, row.FirstName, row.LastName, row.SchoolClass)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) > 0 {
+		id := existing[0].ID
+		return &id, nil
+	}
+	return nil, nil
+}
+
+// Create creates one entry through the service: duplicate-against-students
+// guard and audit row included.
+func (c *ClassListImportConfig) Create(ctx context.Context, row importModels.ClassListEntryImportRow) (int64, error) {
+	entry, err := c.deps.EntryService.Create(ctx, usersService.ClassListEntryInput{
+		FirstName:   row.FirstName,
+		LastName:    row.LastName,
+		SchoolClass: row.SchoolClass,
+	}, ImporterIDFromContext(ctx))
+	if err != nil {
+		if errors.Is(err, usersService.ErrClassListEntryStudentExists) || errors.Is(err, usersService.ErrClassListEntryDuplicate) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("create class list entry: %w", err)
+	}
+	return entry.ID, nil
+}
+
+// Update is not supported: an entry has nothing to update from a re-import —
+// the import mode is create-only.
+func (c *ClassListImportConfig) Update(_ context.Context, _ int64, _ importModels.ClassListEntryImportRow) error {
+	return errors.New("Klassenlisteneinträge werden beim Import nicht aktualisiert") //nolint:staticcheck // ST1005: user-facing German message
+}
+
+// EntityName returns the entity type name for logging and error messages.
+func (c *ClassListImportConfig) EntityName() string {
+	return "Klassenlisteneintrag"
+}

--- a/backend/services/import/class_list_import_config.go
+++ b/backend/services/import/class_list_import_config.go
@@ -18,6 +18,7 @@ import (
 type ClassListImportDeps struct {
 	EntryService usersService.ClassListEntryService
 	EntryRepo    userModels.ClassListEntryRepository
+	StudentRepo  userModels.StudentRepository
 }
 
 // ClassListImportConfig implements ImportConfig for class-list entries.
@@ -56,7 +57,9 @@ func (c *ClassListImportConfig) Validate(_ context.Context, row *importModels.Cl
 
 // ValidateBatch flags in-file duplicates: two rows with the same name and
 // class would hit the unique index on insert — report it as a row error
-// upfront instead.
+// upfront instead. The map is keyed by the zero-based slice index (that is
+// what the engine reads); the message shows the 1-based file row including
+// the header line, matching the engine's own row numbering.
 func (c *ClassListImportConfig) ValidateBatch(_ context.Context, rows []importModels.ClassListEntryImportRow) map[int][]importModels.ValidationError {
 	result := make(map[int][]importModels.ValidationError)
 	seen := make(map[string]int, len(rows))
@@ -68,22 +71,26 @@ func (c *ClassListImportConfig) ValidateBatch(_ context.Context, rows []importMo
 			continue
 		}
 		if firstRow, dup := seen[key]; dup {
-			result[i+1] = append(result[i+1], importModels.ValidationError{
+			result[i] = append(result[i], importModels.ValidationError{
 				Field:    "first_name",
-				Message:  fmt.Sprintf("Doppelter Eintrag in der Datei (bereits in Zeile %d)", firstRow),
+				Message:  fmt.Sprintf("Doppelter Eintrag in der Datei (bereits in Zeile %d)", firstRow+2),
 				Code:     "duplicate_in_file",
 				Severity: importModels.ErrorSeverityError,
 			})
 			continue
 		}
-		seen[key] = i + 1
+		seen[key] = i
 	}
 	return result
 }
 
-// FindExisting reports an already-existing entry with the same name and
-// class. The import mode is create-only, so a hit becomes the engine's
-// "already exists" row error.
+// FindExisting reports a child already on the class list: an existing entry
+// with the same name and class, or a regular student — a student IS the
+// child's row on the list, so the dry-run preview must report that case as
+// "already exists" too instead of counting it as creatable and failing only
+// on the actual create (via the service's ErrClassListEntryStudentExists
+// guard). The import mode is create-only, so the returned ID is never used
+// for an update; a hit becomes the engine's "already exists" row error.
 func (c *ClassListImportConfig) FindExisting(ctx context.Context, row importModels.ClassListEntryImportRow) (*int64, error) {
 	existing, err := c.deps.EntryRepo.FindByNameAndClass(ctx, row.FirstName, row.LastName, row.SchoolClass)
 	if err != nil {
@@ -91,6 +98,14 @@ func (c *ClassListImportConfig) FindExisting(ctx context.Context, row importMode
 	}
 	if len(existing) > 0 {
 		id := existing[0].ID
+		return &id, nil
+	}
+	students, err := c.deps.StudentRepo.FindByNameAndClass(ctx, row.FirstName, row.LastName, row.SchoolClass)
+	if err != nil {
+		return nil, err
+	}
+	if len(students) > 0 {
+		id := students[0].ID
 		return &id, nil
 	}
 	return nil, nil

--- a/backend/services/import/class_list_import_config_test.go
+++ b/backend/services/import/class_list_import_config_test.go
@@ -1,0 +1,155 @@
+package importpkg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+)
+
+// stubClassListEntryService only serves Create; every other method panics via
+// the embedded nil interface.
+type stubClassListEntryService struct {
+	usersService.ClassListEntryService
+	create func(ctx context.Context, input usersService.ClassListEntryInput, changedBy int64) (*userModels.ClassListEntry, error)
+}
+
+func (s stubClassListEntryService) Create(ctx context.Context, input usersService.ClassListEntryInput, changedBy int64) (*userModels.ClassListEntry, error) {
+	return s.create(ctx, input, changedBy)
+}
+
+// stubClassListEntryRepo only serves FindByNameAndClass.
+type stubClassListEntryRepo struct {
+	userModels.ClassListEntryRepository
+	findByNameAndClass func(ctx context.Context, firstName, lastName, schoolClass string) ([]*userModels.ClassListEntry, error)
+}
+
+func (r stubClassListEntryRepo) FindByNameAndClass(ctx context.Context, firstName, lastName, schoolClass string) ([]*userModels.ClassListEntry, error) {
+	return r.findByNameAndClass(ctx, firstName, lastName, schoolClass)
+}
+
+func classListRow(firstName, lastName, schoolClass string) importModels.ClassListEntryImportRow {
+	return importModels.ClassListEntryImportRow{
+		FirstName:   firstName,
+		LastName:    lastName,
+		SchoolClass: schoolClass,
+	}
+}
+
+func TestClassListImportConfig_Validate(t *testing.T) {
+	config := NewClassListImportConfig(ClassListImportDeps{})
+
+	require.NoError(t, config.PreloadReferenceData(context.Background()))
+	assert.Equal(t, "Klassenlisteneintrag", config.EntityName())
+
+	row := classListRow("  Zoe  ", " Aalders ", " 1a ")
+	errs := config.Validate(context.Background(), &row)
+	assert.Empty(t, errs)
+	assert.Equal(t, "Zoe", row.FirstName, "Validate must trim the fields")
+	assert.Equal(t, "Aalders", row.LastName)
+	assert.Equal(t, "1a", row.SchoolClass)
+
+	empty := classListRow("  ", "", " ")
+	errs = config.Validate(context.Background(), &empty)
+	require.Len(t, errs, 3)
+	fields := []string{errs[0].Field, errs[1].Field, errs[2].Field}
+	assert.ElementsMatch(t, []string{"first_name", "last_name", "school_class"}, fields)
+}
+
+func TestClassListImportConfig_ValidateBatchFlagsInFileDuplicates(t *testing.T) {
+	config := NewClassListImportConfig(ClassListImportDeps{})
+
+	rows := []importModels.ClassListEntryImportRow{
+		classListRow("Zoe", "Aalders", "1a"),
+		classListRow("Ben", "Zorn", "3c"),
+		classListRow(" zoe ", "AALDERS", "1A"), // case/space variant of row 1
+		classListRow("", "", ""),               // empty rows are ignored
+	}
+
+	result := config.ValidateBatch(context.Background(), rows)
+	require.Len(t, result, 1)
+	dup, ok := result[3]
+	require.True(t, ok, "the duplicate is reported on its own (1-based) row")
+	require.Len(t, dup, 1)
+	assert.Equal(t, "duplicate_in_file", dup[0].Code)
+	assert.Contains(t, dup[0].Message, "Zeile 1")
+}
+
+func TestClassListImportConfig_FindExisting(t *testing.T) {
+	existing := &userModels.ClassListEntry{}
+	existing.ID = 77
+
+	config := NewClassListImportConfig(ClassListImportDeps{
+		EntryRepo: stubClassListEntryRepo{findByNameAndClass: func(_ context.Context, firstName, lastName, schoolClass string) ([]*userModels.ClassListEntry, error) {
+			if firstName == "Zoe" && lastName == "Aalders" && schoolClass == "1a" {
+				return []*userModels.ClassListEntry{existing}, nil
+			}
+			return nil, nil
+		}},
+	})
+
+	id, err := config.FindExisting(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, existing.ID, *id)
+
+	id, err = config.FindExisting(context.Background(), classListRow("Ben", "Zorn", "3c"))
+	require.NoError(t, err)
+	assert.Nil(t, id)
+
+	failing := NewClassListImportConfig(ClassListImportDeps{
+		EntryRepo: stubClassListEntryRepo{findByNameAndClass: func(context.Context, string, string, string) ([]*userModels.ClassListEntry, error) {
+			return nil, errors.New("kaputt")
+		}},
+	})
+	_, err = failing.FindExisting(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	require.Error(t, err)
+}
+
+func TestClassListImportConfig_CreateMapsServiceErrors(t *testing.T) {
+	created := &userModels.ClassListEntry{}
+	created.ID = 9
+
+	config := NewClassListImportConfig(ClassListImportDeps{
+		EntryService: stubClassListEntryService{create: func(_ context.Context, input usersService.ClassListEntryInput, _ int64) (*userModels.ClassListEntry, error) {
+			assert.Equal(t, "Zoe", input.FirstName)
+			return created, nil
+		}},
+	})
+
+	id, err := config.Create(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, id)
+
+	// User-facing duplicate guards pass through verbatim so the row error in
+	// the import report carries the German message.
+	duplicate := NewClassListImportConfig(ClassListImportDeps{
+		EntryService: stubClassListEntryService{create: func(context.Context, usersService.ClassListEntryInput, int64) (*userModels.ClassListEntry, error) {
+			return nil, usersService.ErrClassListEntryStudentExists
+		}},
+	})
+	_, err = duplicate.Create(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	assert.ErrorIs(t, err, usersService.ErrClassListEntryStudentExists)
+
+	broken := NewClassListImportConfig(ClassListImportDeps{
+		EntryService: stubClassListEntryService{create: func(context.Context, usersService.ClassListEntryInput, int64) (*userModels.ClassListEntry, error) {
+			return nil, errors.New("kaputt")
+		}},
+	})
+	_, err = broken.Create(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create class list entry")
+}
+
+func TestClassListImportConfig_UpdateIsRefused(t *testing.T) {
+	config := NewClassListImportConfig(ClassListImportDeps{})
+	err := config.Update(context.Background(), 1, classListRow("Zoe", "Aalders", "1a"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nicht aktualisiert")
+}

--- a/backend/services/import/class_list_import_config_test.go
+++ b/backend/services/import/class_list_import_config_test.go
@@ -34,6 +34,20 @@ func (r stubClassListEntryRepo) FindByNameAndClass(ctx context.Context, firstNam
 	return r.findByNameAndClass(ctx, firstName, lastName, schoolClass)
 }
 
+// stubClassListStudentRepo only serves FindByNameAndClass.
+type stubClassListStudentRepo struct {
+	userModels.StudentRepository
+	findByNameAndClass func(ctx context.Context, firstName, lastName, schoolClass string) ([]*userModels.Student, error)
+}
+
+func (r stubClassListStudentRepo) FindByNameAndClass(ctx context.Context, firstName, lastName, schoolClass string) ([]*userModels.Student, error) {
+	return r.findByNameAndClass(ctx, firstName, lastName, schoolClass)
+}
+
+func noStudents(context.Context, string, string, string) ([]*userModels.Student, error) {
+	return nil, nil
+}
+
 func classListRow(firstName, lastName, schoolClass string) importModels.ClassListEntryImportRow {
 	return importModels.ClassListEntryImportRow{
 		FirstName:   firstName,
@@ -74,11 +88,11 @@ func TestClassListImportConfig_ValidateBatchFlagsInFileDuplicates(t *testing.T) 
 
 	result := config.ValidateBatch(context.Background(), rows)
 	require.Len(t, result, 1)
-	dup, ok := result[3]
-	require.True(t, ok, "the duplicate is reported on its own (1-based) row")
+	dup, ok := result[2]
+	require.True(t, ok, "the duplicate is keyed by its zero-based slice index — that is what the engine reads")
 	require.Len(t, dup, 1)
 	assert.Equal(t, "duplicate_in_file", dup[0].Code)
-	assert.Contains(t, dup[0].Message, "Zeile 1")
+	assert.Contains(t, dup[0].Message, "Zeile 2", "the message shows the 1-based file row including the header")
 }
 
 func TestClassListImportConfig_FindExisting(t *testing.T) {
@@ -92,6 +106,7 @@ func TestClassListImportConfig_FindExisting(t *testing.T) {
 			}
 			return nil, nil
 		}},
+		StudentRepo: stubClassListStudentRepo{findByNameAndClass: noStudents},
 	})
 
 	id, err := config.FindExisting(context.Background(), classListRow("Zoe", "Aalders", "1a"))
@@ -105,6 +120,46 @@ func TestClassListImportConfig_FindExisting(t *testing.T) {
 
 	failing := NewClassListImportConfig(ClassListImportDeps{
 		EntryRepo: stubClassListEntryRepo{findByNameAndClass: func(context.Context, string, string, string) ([]*userModels.ClassListEntry, error) {
+			return nil, errors.New("kaputt")
+		}},
+	})
+	_, err = failing.FindExisting(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	require.Error(t, err)
+}
+
+// A regular student with the entry's name and class IS the child's row on the
+// class list: the preview must report the row as already existing, not as
+// creatable (the actual create would fail on ErrClassListEntryStudentExists).
+func TestClassListImportConfig_FindExistingReportsMatchingStudent(t *testing.T) {
+	student := &userModels.Student{}
+	student.ID = 41
+
+	noEntries := func(context.Context, string, string, string) ([]*userModels.ClassListEntry, error) {
+		return nil, nil
+	}
+
+	config := NewClassListImportConfig(ClassListImportDeps{
+		EntryRepo: stubClassListEntryRepo{findByNameAndClass: noEntries},
+		StudentRepo: stubClassListStudentRepo{findByNameAndClass: func(_ context.Context, firstName, lastName, schoolClass string) ([]*userModels.Student, error) {
+			if firstName == "Zoe" && lastName == "Aalders" && schoolClass == "1a" {
+				return []*userModels.Student{student}, nil
+			}
+			return nil, nil
+		}},
+	})
+
+	id, err := config.FindExisting(context.Background(), classListRow("Zoe", "Aalders", "1a"))
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, student.ID, *id)
+
+	id, err = config.FindExisting(context.Background(), classListRow("Ben", "Zorn", "3c"))
+	require.NoError(t, err)
+	assert.Nil(t, id)
+
+	failing := NewClassListImportConfig(ClassListImportDeps{
+		EntryRepo: stubClassListEntryRepo{findByNameAndClass: noEntries},
+		StudentRepo: stubClassListStudentRepo{findByNameAndClass: func(context.Context, string, string, string) ([]*userModels.Student, error) {
 			return nil, errors.New("kaputt")
 		}},
 	})

--- a/backend/services/import/class_list_parser.go
+++ b/backend/services/import/class_list_parser.go
@@ -1,0 +1,140 @@
+package importpkg
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/xuri/excelize/v2"
+
+	importModels "github.com/moto-nrw/project-phoenix/models/import"
+)
+
+// classListRequiredColumns are the normalized header keys a class-list entry
+// import file must contain (#2382). All three are required — the entry IS
+// name + class.
+var classListRequiredColumns = []string{"vorname", "nachname", "klasse"}
+
+// MapClassListRow maps column values to a ClassListEntryImportRow.
+func MapClassListRow(mapper *ColumnMapper) importModels.ClassListEntryImportRow {
+	return importModels.ClassListEntryImportRow{
+		FirstName:   mapper.GetCol("vorname"),
+		LastName:    mapper.GetCol("nachname"),
+		SchoolClass: mapper.GetCol("klasse"),
+	}
+}
+
+// missingClassListColumns returns the required columns absent from the mapping.
+func missingClassListColumns(mapping map[string]int) []string {
+	var missing []string
+	for _, col := range classListRequiredColumns {
+		if _, ok := mapping[col]; !ok {
+			missing = append(missing, col)
+		}
+	}
+	return missing
+}
+
+// ParseClassListCSV parses a CSV file into class-list entry import rows.
+func ParseClassListCSV(reader io.Reader) ([]importModels.ClassListEntryImportRow, error) {
+	csvReader := csv.NewReader(reader)
+	csvReader.FieldsPerRecord = -1
+	csvReader.TrimLeadingSpace = true
+	csvReader.LazyQuotes = true
+
+	header, err := csvReader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+
+	mapping := make(map[string]int)
+	for i, col := range header {
+		mapping[normalizeHeaderKey(col)] = i
+	}
+	if missing := missingClassListColumns(mapping); len(missing) > 0 {
+		return nil, fmt.Errorf("fehlende erforderliche Spalten: %s", strings.Join(missing, ", "))
+	}
+
+	var rows []importModels.ClassListEntryImportRow
+	rowNum := 2
+	for {
+		values, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("row %d: %w", rowNum, err)
+		}
+
+		if isEmptyRow(values) {
+			rowNum++
+			continue
+		}
+
+		mapper := NewColumnMapper(mapping, values)
+		rows = append(rows, MapClassListRow(mapper))
+		rowNum++
+	}
+
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("die CSV-Datei enthält keine Datenzeilen. Möglicherweise haben Sie versehentlich die Vorlage hochgeladen")
+	}
+
+	return rows, nil
+}
+
+// ParseClassListXLSX parses an Excel (.xlsx) file into class-list entry
+// import rows.
+func ParseClassListXLSX(reader io.Reader) ([]importModels.ClassListEntryImportRow, error) {
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	f, err := excelize.OpenReader(buf)
+	if err != nil {
+		return nil, fmt.Errorf("open excel file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	sheetName := f.GetSheetName(0)
+	if sheetName == "" {
+		return nil, fmt.Errorf("no sheets found in Excel file")
+	}
+
+	sheetRows, err := f.GetRows(sheetName)
+	if err != nil {
+		return nil, fmt.Errorf("read rows: %w", err)
+	}
+	if len(sheetRows) == 0 {
+		return nil, fmt.Errorf("empty Excel file")
+	}
+
+	mapping := make(map[string]int)
+	for i, col := range sheetRows[0] {
+		mapping[normalizeHeaderKey(col)] = i
+	}
+	if missing := missingClassListColumns(mapping); len(missing) > 0 {
+		return nil, fmt.Errorf("fehlende erforderliche Spalten: %s", strings.Join(missing, ", "))
+	}
+
+	var rows []importModels.ClassListEntryImportRow
+	for rowNum := 2; rowNum <= len(sheetRows); rowNum++ {
+		values := sheetRows[rowNum-1]
+		if isEmptyRow(values) {
+			continue
+		}
+		mapper := NewColumnMapper(mapping, values)
+		rows = append(rows, MapClassListRow(mapper))
+	}
+
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("die Excel-Datei enthält keine Datenzeilen. Möglicherweise haben Sie versehentlich die Vorlage hochgeladen")
+	}
+
+	return rows, nil
+}

--- a/backend/services/import/class_list_parser.go
+++ b/backend/services/import/class_list_parser.go
@@ -17,6 +17,30 @@ import (
 // name + class.
 var classListRequiredColumns = []string{"vorname", "nachname", "klasse"}
 
+// ClassListTemplateExampleRows are the demo rows shipped in the import
+// template (the API's template download renders exactly these). An unchanged
+// template upload must not create these children as real tenant data, so the
+// parsers drop matching rows — a file consisting only of them then hits the
+// "keine Datenzeilen … Vorlage hochgeladen" error.
+var ClassListTemplateExampleRows = []importModels.ClassListEntryImportRow{
+	{FirstName: "Lena", LastName: "Beispiel", SchoolClass: "1a"},
+	{FirstName: "Jonas", LastName: "Muster", SchoolClass: "3b"},
+}
+
+// isClassListTemplateExample reports whether a parsed row is one of the
+// template's example rows (case-insensitive, trimmed — the template ships
+// them verbatim, but hand-copied variants should not slip through either).
+func isClassListTemplateExample(row importModels.ClassListEntryImportRow) bool {
+	for _, example := range ClassListTemplateExampleRows {
+		if strings.EqualFold(strings.TrimSpace(row.FirstName), example.FirstName) &&
+			strings.EqualFold(strings.TrimSpace(row.LastName), example.LastName) &&
+			strings.EqualFold(strings.TrimSpace(row.SchoolClass), example.SchoolClass) {
+			return true
+		}
+	}
+	return false
+}
+
 // MapClassListRow maps column values to a ClassListEntryImportRow.
 func MapClassListRow(mapper *ColumnMapper) importModels.ClassListEntryImportRow {
 	return importModels.ClassListEntryImportRow{
@@ -74,7 +98,10 @@ func ParseClassListCSV(reader io.Reader) ([]importModels.ClassListEntryImportRow
 		}
 
 		mapper := NewColumnMapper(mapping, values)
-		rows = append(rows, MapClassListRow(mapper))
+		row := MapClassListRow(mapper)
+		if !isClassListTemplateExample(row) {
+			rows = append(rows, row)
+		}
 		rowNum++
 	}
 
@@ -129,7 +156,10 @@ func ParseClassListXLSX(reader io.Reader) ([]importModels.ClassListEntryImportRo
 			continue
 		}
 		mapper := NewColumnMapper(mapping, values)
-		rows = append(rows, MapClassListRow(mapper))
+		row := MapClassListRow(mapper)
+		if !isClassListTemplateExample(row) {
+			rows = append(rows, row)
+		}
 	}
 
 	if len(rows) == 0 {

--- a/backend/services/import/class_list_parser.go
+++ b/backend/services/import/class_list_parser.go
@@ -17,29 +17,13 @@ import (
 // name + class.
 var classListRequiredColumns = []string{"vorname", "nachname", "klasse"}
 
-// ClassListTemplateExampleRows are the demo rows shipped in the import
-// template (the API's template download renders exactly these). An unchanged
-// template upload must not create these children as real tenant data, so the
-// parsers drop matching rows — a file consisting only of them then hits the
-// "keine Datenzeilen … Vorlage hochgeladen" error.
-var ClassListTemplateExampleRows = []importModels.ClassListEntryImportRow{
-	{FirstName: "Lena", LastName: "Beispiel", SchoolClass: "1a"},
-	{FirstName: "Jonas", LastName: "Muster", SchoolClass: "3b"},
-}
-
-// isClassListTemplateExample reports whether a parsed row is one of the
-// template's example rows (case-insensitive, trimmed — the template ships
-// them verbatim, but hand-copied variants should not slip through either).
-func isClassListTemplateExample(row importModels.ClassListEntryImportRow) bool {
-	for _, example := range ClassListTemplateExampleRows {
-		if strings.EqualFold(strings.TrimSpace(row.FirstName), example.FirstName) &&
-			strings.EqualFold(strings.TrimSpace(row.LastName), example.LastName) &&
-			strings.EqualFold(strings.TrimSpace(row.SchoolClass), example.SchoolClass) {
-			return true
-		}
-	}
-	return false
-}
+// The import template ships HEADERS ONLY (#2399 review round 10). Example
+// data rows would have to be recognized again on upload, and a class-list row
+// carries nothing but a name and a class — any recognition rule is a name
+// blocklist that silently drops a real child who happens to be called like
+// the example. The column meanings live in the template's "Hinweise" sheet
+// instead, and an unchanged template upload hits the "keine Datenzeilen …
+// Vorlage hochgeladen" error because it has no data rows at all.
 
 // MapClassListRow maps column values to a ClassListEntryImportRow.
 func MapClassListRow(mapper *ColumnMapper) importModels.ClassListEntryImportRow {
@@ -98,10 +82,7 @@ func ParseClassListCSV(reader io.Reader) ([]importModels.ClassListEntryImportRow
 		}
 
 		mapper := NewColumnMapper(mapping, values)
-		row := MapClassListRow(mapper)
-		if !isClassListTemplateExample(row) {
-			rows = append(rows, row)
-		}
+		rows = append(rows, MapClassListRow(mapper))
 		rowNum++
 	}
 
@@ -156,10 +137,7 @@ func ParseClassListXLSX(reader io.Reader) ([]importModels.ClassListEntryImportRo
 			continue
 		}
 		mapper := NewColumnMapper(mapping, values)
-		row := MapClassListRow(mapper)
-		if !isClassListTemplateExample(row) {
-			rows = append(rows, row)
-		}
+		rows = append(rows, MapClassListRow(mapper))
 	}
 
 	if len(rows) == 0 {

--- a/backend/services/import/class_list_parser_test.go
+++ b/backend/services/import/class_list_parser_test.go
@@ -130,3 +130,57 @@ func TestParseClassListXLSX_NotAnExcelFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "open excel file")
 }
+
+// The template ships example rows (Lena Beispiel, Jonas Muster); a template
+// uploaded with the examples left in must not import them as real tenant
+// data (#2399 review round 9). Only the exact name+class triple counts — a
+// real child who happens to share an example name in a DIFFERENT class stays.
+func TestParseClassListCSV_DropsTemplateExampleRows(t *testing.T) {
+	csvData := "Vorname,Nachname,Klasse\n" +
+		"Lena,Beispiel,1a\n" +
+		"jonas,muster,3b\n" +
+		"Lena,Beispiel,1b\n" +
+		"Zoe,Aalders,1a"
+
+	rows, err := ParseClassListCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "1b", rows[0].SchoolClass)
+	assert.Equal(t, "Zoe", rows[1].FirstName)
+}
+
+func TestParseClassListCSV_UnchangedTemplateOnlyExamples(t *testing.T) {
+	csvData := "Vorname,Nachname,Klasse\n" +
+		"Lena,Beispiel,1a\n" +
+		"Jonas,Muster,3b"
+
+	_, err := ParseClassListCSV(strings.NewReader(csvData))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keine Datenzeilen")
+}
+
+func TestParseClassListXLSX_DropsTemplateExampleRows(t *testing.T) {
+	reader := buildClassListXLSX(t, [][]string{
+		{"Vorname", "Nachname", "Klasse"},
+		{"Lena", "Beispiel", "1a"},
+		{"Jonas", "Muster", "3b"},
+		{"Ben", "Zorn", "3c"},
+	})
+
+	rows, err := ParseClassListXLSX(reader)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "Ben", rows[0].FirstName)
+}
+
+func TestParseClassListXLSX_UnchangedTemplateOnlyExamples(t *testing.T) {
+	reader := buildClassListXLSX(t, [][]string{
+		{"Vorname", "Nachname", "Klasse"},
+		{"Lena", "Beispiel", "1a"},
+		{"Jonas", "Muster", "3b"},
+	})
+
+	_, err := ParseClassListXLSX(reader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keine Datenzeilen")
+}

--- a/backend/services/import/class_list_parser_test.go
+++ b/backend/services/import/class_list_parser_test.go
@@ -1,0 +1,132 @@
+package importpkg
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xuri/excelize/v2"
+)
+
+// buildClassListXLSX builds an in-memory .xlsx from the given rows
+// (row 0 = header).
+func buildClassListXLSX(t *testing.T, rows [][]string) io.Reader {
+	t.Helper()
+	f := excelize.NewFile()
+	sheet := f.GetSheetName(0)
+	for r, row := range rows {
+		for c, val := range row {
+			cell, err := excelize.CoordinatesToCellName(c+1, r+1)
+			require.NoError(t, err)
+			require.NoError(t, f.SetCellStr(sheet, cell, val))
+		}
+	}
+	buf := new(bytes.Buffer)
+	require.NoError(t, f.Write(buf))
+	return buf
+}
+
+func TestParseClassListCSV_MapsColumns(t *testing.T) {
+	csvData := "Vorname,Nachname,Klasse\n" +
+		"Zoe,Aalders,1a\n" +
+		"Ben,Zorn,3c"
+
+	rows, err := ParseClassListCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	assert.Equal(t, "Zoe", rows[0].FirstName)
+	assert.Equal(t, "Aalders", rows[0].LastName)
+	assert.Equal(t, "1a", rows[0].SchoolClass)
+	assert.Equal(t, "Ben", rows[1].FirstName)
+	assert.Equal(t, "3c", rows[1].SchoolClass)
+}
+
+func TestParseClassListCSV_SkipsEmptyRowsAndLowercaseHeader(t *testing.T) {
+	csvData := "vorname,nachname,klasse\n" +
+		"Zoe,Aalders,1a\n" +
+		",,\n" +
+		"Ben,Zorn,3c"
+
+	rows, err := ParseClassListCSV(strings.NewReader(csvData))
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "Ben", rows[1].FirstName)
+}
+
+func TestParseClassListCSV_MissingColumn(t *testing.T) {
+	csvData := "Vorname,Nachname\nZoe,Aalders"
+
+	_, err := ParseClassListCSV(strings.NewReader(csvData))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fehlende erforderliche Spalten")
+	assert.Contains(t, err.Error(), "klasse")
+}
+
+func TestParseClassListCSV_TemplateOnly(t *testing.T) {
+	_, err := ParseClassListCSV(strings.NewReader("Vorname,Nachname,Klasse\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keine Datenzeilen")
+}
+
+func TestParseClassListCSV_EmptyFile(t *testing.T) {
+	_, err := ParseClassListCSV(strings.NewReader(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read header")
+}
+
+func TestParseClassListXLSX_MapsColumns(t *testing.T) {
+	reader := buildClassListXLSX(t, [][]string{
+		{"Vorname", "Nachname", "Klasse"},
+		{"Zoe", "Aalders", "1a"},
+		{"", "", ""},
+		{"Ben", "Zorn", "3c"},
+	})
+
+	rows, err := ParseClassListXLSX(reader)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "Zoe", rows[0].FirstName)
+	assert.Equal(t, "Aalders", rows[0].LastName)
+	assert.Equal(t, "1a", rows[0].SchoolClass)
+	assert.Equal(t, "3c", rows[1].SchoolClass)
+}
+
+func TestParseClassListXLSX_MissingColumn(t *testing.T) {
+	reader := buildClassListXLSX(t, [][]string{
+		{"Vorname", "Klasse"},
+		{"Zoe", "1a"},
+	})
+
+	_, err := ParseClassListXLSX(reader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fehlende erforderliche Spalten")
+	assert.Contains(t, err.Error(), "nachname")
+}
+
+func TestParseClassListXLSX_TemplateOnly(t *testing.T) {
+	reader := buildClassListXLSX(t, [][]string{
+		{"Vorname", "Nachname", "Klasse"},
+	})
+
+	_, err := ParseClassListXLSX(reader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keine Datenzeilen")
+}
+
+func TestParseClassListXLSX_NoRowsAtAll(t *testing.T) {
+	reader := buildClassListXLSX(t, [][]string{})
+
+	_, err := ParseClassListXLSX(reader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty Excel file")
+}
+
+func TestParseClassListXLSX_NotAnExcelFile(t *testing.T) {
+	_, err := ParseClassListXLSX(strings.NewReader("kein excel"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open excel file")
+}

--- a/backend/services/import/class_list_parser_test.go
+++ b/backend/services/import/class_list_parser_test.go
@@ -131,35 +131,25 @@ func TestParseClassListXLSX_NotAnExcelFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "open excel file")
 }
 
-// The template ships example rows (Lena Beispiel, Jonas Muster); a template
-// uploaded with the examples left in must not import them as real tenant
-// data (#2399 review round 9). Only the exact name+class triple counts — a
-// real child who happens to share an example name in a DIFFERENT class stays.
-func TestParseClassListCSV_DropsTemplateExampleRows(t *testing.T) {
+// The template ships headers only, so the parsers drop no data row for what
+// it is named (#2399 review round 10): a child really called "Lena Beispiel"
+// or "Jonas Muster" must import like any other.
+func TestParseClassListCSV_KeepsChildrenNamedLikeFormerTemplateExamples(t *testing.T) {
 	csvData := "Vorname,Nachname,Klasse\n" +
 		"Lena,Beispiel,1a\n" +
-		"jonas,muster,3b\n" +
-		"Lena,Beispiel,1b\n" +
+		"Jonas,Muster,3b\n" +
 		"Zoe,Aalders,1a"
 
 	rows, err := ParseClassListCSV(strings.NewReader(csvData))
 	require.NoError(t, err)
-	require.Len(t, rows, 2)
-	assert.Equal(t, "1b", rows[0].SchoolClass)
-	assert.Equal(t, "Zoe", rows[1].FirstName)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "Lena", rows[0].FirstName)
+	assert.Equal(t, "Beispiel", rows[0].LastName)
+	assert.Equal(t, "Muster", rows[1].LastName)
+	assert.Equal(t, "Zoe", rows[2].FirstName)
 }
 
-func TestParseClassListCSV_UnchangedTemplateOnlyExamples(t *testing.T) {
-	csvData := "Vorname,Nachname,Klasse\n" +
-		"Lena,Beispiel,1a\n" +
-		"Jonas,Muster,3b"
-
-	_, err := ParseClassListCSV(strings.NewReader(csvData))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "keine Datenzeilen")
-}
-
-func TestParseClassListXLSX_DropsTemplateExampleRows(t *testing.T) {
+func TestParseClassListXLSX_KeepsChildrenNamedLikeFormerTemplateExamples(t *testing.T) {
 	reader := buildClassListXLSX(t, [][]string{
 		{"Vorname", "Nachname", "Klasse"},
 		{"Lena", "Beispiel", "1a"},
@@ -169,18 +159,8 @@ func TestParseClassListXLSX_DropsTemplateExampleRows(t *testing.T) {
 
 	rows, err := ParseClassListXLSX(reader)
 	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	assert.Equal(t, "Ben", rows[0].FirstName)
-}
-
-func TestParseClassListXLSX_UnchangedTemplateOnlyExamples(t *testing.T) {
-	reader := buildClassListXLSX(t, [][]string{
-		{"Vorname", "Nachname", "Klasse"},
-		{"Lena", "Beispiel", "1a"},
-		{"Jonas", "Muster", "3b"},
-	})
-
-	_, err := ParseClassListXLSX(reader)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "keine Datenzeilen")
+	require.Len(t, rows, 3)
+	assert.Equal(t, "Beispiel", rows[0].LastName)
+	assert.Equal(t, "Muster", rows[1].LastName)
+	assert.Equal(t, "Ben", rows[2].FirstName)
 }

--- a/backend/services/users/class_list_entry_service.go
+++ b/backend/services/users/class_list_entry_service.go
@@ -1,0 +1,280 @@
+package users
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/internal/collation"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+)
+
+// Class-list entry errors (#2382). User-facing German messages by design —
+// the API renders them verbatim.
+var (
+	ErrClassListEntryNotFound = errors.New("Klassenlisteneintrag nicht gefunden") //nolint:staticcheck // ST1005: user-facing German message
+	// ErrClassListEntryDuplicate: an entry with the same name already exists
+	// in the same class (case-insensitive, backed by the DB unique index).
+	ErrClassListEntryDuplicate = errors.New("Ein Eintrag mit diesem Namen existiert in dieser Klasse bereits") //nolint:staticcheck // ST1005: user-facing German message
+	// ErrClassListEntryStudentExists: a regular student with the same name
+	// already exists in the same class — the child is already on the class
+	// list, a duplicate entry would list them twice.
+	ErrClassListEntryStudentExists = errors.New("Ein Kind mit diesem Namen ist in dieser Klasse bereits angelegt") //nolint:staticcheck // ST1005: user-facing German message
+	// ErrClassListEntryStudentNotFound: the assign target does not exist.
+	ErrClassListEntryStudentNotFound = errors.New("Das ausgewählte Kind wurde nicht gefunden") //nolint:staticcheck // ST1005: user-facing German message
+)
+
+// ClassListEntryInput carries the three fields an entry consists of.
+type ClassListEntryInput struct {
+	FirstName   string
+	LastName    string
+	SchoolClass string
+}
+
+// ClassListEntryWithMatches pairs an entry with the IDs of regular students
+// sharing its name and class — the candidates for a deliberate "Zuordnen"
+// resolution. Matching is a hint only: resolution is ALWAYS an explicit admin
+// action, never automatic (#2382: gleichnamige Kinder dürfen nicht
+// verwechselt werden).
+type ClassListEntryWithMatches struct {
+	Entry              *userModels.ClassListEntry
+	MatchingStudentIDs []int64
+}
+
+// ClassListEntryService manages the minimal class-list-only entries (#2382):
+// children of the class cohort without an OGS record. Every write records an
+// audit.class_list_entry_changes row in the same tenant transaction.
+type ClassListEntryService interface {
+	// List returns all entries of the tenant, class-then-name sorted, each
+	// with its matching-student hint.
+	List(ctx context.Context) ([]ClassListEntryWithMatches, error)
+	// ListAll returns all entries class-then-name sorted, without match
+	// hints — the cheap form for export surfaces.
+	ListAll(ctx context.Context) ([]*userModels.ClassListEntry, error)
+	Create(ctx context.Context, input ClassListEntryInput, changedBy int64) (*userModels.ClassListEntry, error)
+	Update(ctx context.Context, id int64, input ClassListEntryInput, changedBy int64) (*userModels.ClassListEntry, error)
+	Delete(ctx context.Context, id int64, changedBy int64) error
+	// Assign resolves the entry as a duplicate of an existing student: the
+	// entry is deleted, the audit row records which student it was attached
+	// to. The child keeps exactly one row on the class list — the student.
+	Assign(ctx context.Context, id int64, studentID int64, changedBy int64) error
+}
+
+type classListEntryService struct {
+	entryRepo   userModels.ClassListEntryRepository
+	studentRepo userModels.StudentRepository
+	auditRepo   auditModels.ClassListEntryChangeRepository
+}
+
+// NewClassListEntryService creates a ClassListEntryService.
+func NewClassListEntryService(
+	entryRepo userModels.ClassListEntryRepository,
+	studentRepo userModels.StudentRepository,
+	auditRepo auditModels.ClassListEntryChangeRepository,
+) ClassListEntryService {
+	return &classListEntryService{
+		entryRepo:   entryRepo,
+		studentRepo: studentRepo,
+		auditRepo:   auditRepo,
+	}
+}
+
+func (s *classListEntryService) ListAll(ctx context.Context) ([]*userModels.ClassListEntry, error) {
+	entries, err := s.entryRepo.List(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list class list entries: %w", err)
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if r := collation.CompareSchoolClasses(entries[i].SchoolClass, entries[j].SchoolClass); r != 0 {
+			return r < 0
+		}
+		if r := collation.CompareGermanNames(entries[i].LastName, entries[i].FirstName, entries[j].LastName, entries[j].FirstName); r != 0 {
+			return r < 0
+		}
+		return entries[i].ID < entries[j].ID
+	})
+	return entries, nil
+}
+
+func (s *classListEntryService) List(ctx context.Context) ([]ClassListEntryWithMatches, error) {
+	entries, err := s.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// One lookup per entry: the entry set is a hand-maintained handful per
+	// school, and FindByNameAndClass is an indexed point query — a bulk
+	// name-join variant would buy nothing but complexity here.
+	out := make([]ClassListEntryWithMatches, 0, len(entries))
+	for _, entry := range entries {
+		matches, err := s.studentRepo.FindByNameAndClass(ctx, entry.FirstName, entry.LastName, entry.SchoolClass)
+		if err != nil {
+			return nil, fmt.Errorf("match class list entry %d: %w", entry.ID, err)
+		}
+		ids := make([]int64, 0, len(matches))
+		for _, match := range matches {
+			if match != nil {
+				ids = append(ids, match.ID)
+			}
+		}
+		out = append(out, ClassListEntryWithMatches{Entry: entry, MatchingStudentIDs: ids})
+	}
+	return out, nil
+}
+
+// requireNoDuplicate rejects the name+class combination when another entry or
+// a regular student already carries it. ignoreEntryID skips the entry being
+// updated. The DB unique index backs the entry check race-safely; the student
+// check is advisory (a student created concurrently surfaces as a match hint
+// in List instead).
+func (s *classListEntryService) requireNoDuplicate(ctx context.Context, input ClassListEntryInput, ignoreEntryID int64) error {
+	existing, err := s.entryRepo.FindByNameAndClass(ctx, input.FirstName, input.LastName, input.SchoolClass)
+	if err != nil {
+		return fmt.Errorf("class list entry duplicate check: %w", err)
+	}
+	for _, entry := range existing {
+		if entry != nil && entry.ID != ignoreEntryID {
+			return ErrClassListEntryDuplicate
+		}
+	}
+	students, err := s.studentRepo.FindByNameAndClass(ctx, input.FirstName, input.LastName, input.SchoolClass)
+	if err != nil {
+		return fmt.Errorf("class list entry student check: %w", err)
+	}
+	if len(students) > 0 {
+		return ErrClassListEntryStudentExists
+	}
+	return nil
+}
+
+func trimClassListEntryInput(input ClassListEntryInput) ClassListEntryInput {
+	return ClassListEntryInput{
+		FirstName:   strings.TrimSpace(input.FirstName),
+		LastName:    strings.TrimSpace(input.LastName),
+		SchoolClass: strings.TrimSpace(input.SchoolClass),
+	}
+}
+
+func (s *classListEntryService) Create(ctx context.Context, input ClassListEntryInput, changedBy int64) (*userModels.ClassListEntry, error) {
+	input = trimClassListEntryInput(input)
+	entry := &userModels.ClassListEntry{
+		FirstName:   input.FirstName,
+		LastName:    input.LastName,
+		SchoolClass: input.SchoolClass,
+	}
+	if changedBy > 0 {
+		entry.CreatedBy = &changedBy
+	}
+	if err := entry.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.requireNoDuplicate(ctx, input, 0); err != nil {
+		return nil, err
+	}
+	if err := s.entryRepo.Create(ctx, entry); err != nil {
+		return nil, fmt.Errorf("create class list entry: %w", err)
+	}
+	if err := s.recordChange(ctx, entry.ID, auditModels.ClassListEntryActionCreated, "", entry.DisplayValue(), nil, changedBy); err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+func (s *classListEntryService) Update(ctx context.Context, id int64, input ClassListEntryInput, changedBy int64) (*userModels.ClassListEntry, error) {
+	entry, err := s.findEntry(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	input = trimClassListEntryInput(input)
+	oldValue := entry.DisplayValue()
+
+	entry.FirstName = input.FirstName
+	entry.LastName = input.LastName
+	entry.SchoolClass = input.SchoolClass
+	if err := entry.Validate(); err != nil {
+		return nil, err
+	}
+	if entry.DisplayValue() == oldValue {
+		return entry, nil
+	}
+	if err := s.requireNoDuplicate(ctx, input, entry.ID); err != nil {
+		return nil, err
+	}
+	if err := s.entryRepo.Update(ctx, entry); err != nil {
+		return nil, fmt.Errorf("update class list entry: %w", err)
+	}
+	if err := s.recordChange(ctx, entry.ID, auditModels.ClassListEntryActionUpdated, oldValue, entry.DisplayValue(), nil, changedBy); err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+func (s *classListEntryService) Delete(ctx context.Context, id int64, changedBy int64) error {
+	entry, err := s.findEntry(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := s.entryRepo.Delete(ctx, entry.ID); err != nil {
+		return fmt.Errorf("delete class list entry: %w", err)
+	}
+	return s.recordChange(ctx, entry.ID, auditModels.ClassListEntryActionDeleted, entry.DisplayValue(), "", nil, changedBy)
+}
+
+func (s *classListEntryService) Assign(ctx context.Context, id int64, studentID int64, changedBy int64) error {
+	entry, err := s.findEntry(ctx, id)
+	if err != nil {
+		return err
+	}
+	student, err := s.studentRepo.FindByID(ctx, studentID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrClassListEntryStudentNotFound
+		}
+		return fmt.Errorf("assign class list entry: load student: %w", err)
+	}
+	if student == nil || student.IsAlumnus() {
+		return ErrClassListEntryStudentNotFound
+	}
+	if err := s.entryRepo.Delete(ctx, entry.ID); err != nil {
+		return fmt.Errorf("assign class list entry: delete entry: %w", err)
+	}
+	return s.recordChange(ctx, entry.ID, auditModels.ClassListEntryActionAssigned, entry.DisplayValue(), "", &studentID, changedBy)
+}
+
+func (s *classListEntryService) findEntry(ctx context.Context, id int64) (*userModels.ClassListEntry, error) {
+	entry, err := s.entryRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrClassListEntryNotFound
+		}
+		return nil, fmt.Errorf("load class list entry %d: %w", id, err)
+	}
+	if entry == nil {
+		return nil, ErrClassListEntryNotFound
+	}
+	return entry, nil
+}
+
+// recordChange writes the audit row in the same tenant transaction as the
+// change. A nil audit repo (pure unit tests) disables the trail.
+func (s *classListEntryService) recordChange(ctx context.Context, entryID int64, action, oldValue, newValue string, matchedStudentID *int64, changedBy int64) error {
+	if s.auditRepo == nil {
+		return nil
+	}
+	change := &auditModels.ClassListEntryChange{
+		EntryID:          entryID,
+		Action:           action,
+		OldValue:         oldValue,
+		NewValue:         newValue,
+		MatchedStudentID: matchedStudentID,
+		ChangedBy:        changedBy,
+	}
+	if err := s.auditRepo.Create(ctx, change); err != nil {
+		return fmt.Errorf("record class list entry change: %w", err)
+	}
+	return nil
+}

--- a/backend/services/users/class_list_entry_service.go
+++ b/backend/services/users/class_list_entry_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/collation"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	userModels "github.com/moto-nrw/project-phoenix/models/users"
 )
 
@@ -180,6 +181,12 @@ func (s *classListEntryService) Create(ctx context.Context, input ClassListEntry
 		return nil, err
 	}
 	if err := s.entryRepo.Create(ctx, entry); err != nil {
+		if modelBase.IsUniqueViolationOn(err, userModels.ClassListEntryUniqueIndexName) {
+			// A concurrent create slipped past the advisory check above; the
+			// DB index is the race-safe backstop — report it as the duplicate
+			// it is, not as a server error.
+			return nil, ErrClassListEntryDuplicate
+		}
 		return nil, fmt.Errorf("create class list entry: %w", err)
 	}
 	if err := s.recordChange(ctx, entry.ID, auditModels.ClassListEntryActionCreated, "", entry.DisplayValue(), nil, changedBy); err != nil {
@@ -209,6 +216,9 @@ func (s *classListEntryService) Update(ctx context.Context, id int64, input Clas
 		return nil, err
 	}
 	if err := s.entryRepo.Update(ctx, entry); err != nil {
+		if modelBase.IsUniqueViolationOn(err, userModels.ClassListEntryUniqueIndexName) {
+			return nil, ErrClassListEntryDuplicate
+		}
 		return nil, fmt.Errorf("update class list entry: %w", err)
 	}
 	if err := s.recordChange(ctx, entry.ID, auditModels.ClassListEntryActionUpdated, oldValue, entry.DisplayValue(), nil, changedBy); err != nil {

--- a/backend/services/users/class_list_entry_service.go
+++ b/backend/services/users/class_list_entry_service.go
@@ -26,6 +26,10 @@ var (
 	ErrClassListEntryStudentExists = errors.New("Ein Kind mit diesem Namen ist in dieser Klasse bereits angelegt") //nolint:staticcheck // ST1005: user-facing German message
 	// ErrClassListEntryStudentNotFound: the assign target does not exist.
 	ErrClassListEntryStudentNotFound = errors.New("Das ausgewählte Kind wurde nicht gefunden") //nolint:staticcheck // ST1005: user-facing German message
+	// ErrClassListEntryAssignMismatch: the assign target is a real student but
+	// does not carry the entry's name and class — resolving the entry into it
+	// would delete one child's row in favor of a different child.
+	ErrClassListEntryAssignMismatch = errors.New("Das ausgewählte Kind stimmt nicht mit dem Eintrag überein: Name und Klasse müssen übereinstimmen") //nolint:staticcheck // ST1005: user-facing German message
 )
 
 // ClassListEntryInput carries the three fields an entry consists of.
@@ -238,6 +242,24 @@ func (s *classListEntryService) Assign(ctx context.Context, id int64, studentID 
 	}
 	if student == nil || student.IsAlumnus() {
 		return ErrClassListEntryStudentNotFound
+	}
+	// The target must BE the child the entry names: same name in the same
+	// class, matched exactly like the "Mögliche Dublette" hint (case-
+	// insensitive, trimmed). Anything else would resolve the entry into an
+	// unrelated child and silently drop the named child from the list.
+	matches, err := s.studentRepo.FindByNameAndClass(ctx, entry.FirstName, entry.LastName, entry.SchoolClass)
+	if err != nil {
+		return fmt.Errorf("assign class list entry: match student: %w", err)
+	}
+	matched := false
+	for _, match := range matches {
+		if match != nil && match.ID == student.ID {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return ErrClassListEntryAssignMismatch
 	}
 	if err := s.entryRepo.Delete(ctx, entry.ID); err != nil {
 		return fmt.Errorf("assign class list entry: delete entry: %w", err)

--- a/backend/services/users/class_list_entry_service_test.go
+++ b/backend/services/users/class_list_entry_service_test.go
@@ -2,6 +2,7 @@
 package users_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
@@ -155,6 +156,31 @@ func TestClassListEntryService_AssignResolvesDuplicate(t *testing.T) {
 		require.ErrorIs(t, err, usersService.ErrClassListEntryStudentNotFound)
 	})
 
+	t.Run("assign to a student with a different name or class is refused", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleAssignFremd", "Kind", "7y")
+		otherName := testpkg.CreateTestStudent(t, db, "CleAnders", "Kind", "7y")
+		otherClass := testpkg.CreateTestStudent(t, db, "CleAssignFremd", "Kind", "8y")
+		defer testpkg.CleanupActivityFixtures(t, db, otherName.ID, otherClass.ID)
+
+		require.ErrorIs(t, svc.Assign(ctx, entry.ID, otherName.ID, actor.ID),
+			usersService.ErrClassListEntryAssignMismatch,
+			"a student with another name must not swallow the entry")
+		require.ErrorIs(t, svc.Assign(ctx, entry.ID, otherClass.ID, actor.ID),
+			usersService.ErrClassListEntryAssignMismatch,
+			"a student in another class must not swallow the entry")
+
+		// The entry survives both refused attempts.
+		entries, err := svc.ListAll(ctx)
+		require.NoError(t, err)
+		var found bool
+		for _, remaining := range entries {
+			if remaining.ID == entry.ID {
+				found = true
+			}
+		}
+		assert.True(t, found, "the entry must still exist after refused assigns")
+	})
+
 	t.Run("list reports the matching student as a hint", func(t *testing.T) {
 		entry := testpkg.CreateTestClassListEntry(t, db, "CleMatch", "Kind", "7y")
 		// The student arrives AFTER the entry (enrollment approval, import) —
@@ -173,6 +199,177 @@ func TestClassListEntryService_AssignResolvesDuplicate(t *testing.T) {
 		}
 		require.True(t, found, "entry must be listed")
 	})
+}
+
+func TestClassListEntryService_ListAllSortsClassThenName(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, _ := setupClassListEntryService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	// Deliberately created out of order: 10x sorts AFTER 9x (numeric class
+	// collation), names sort by German collation within the class.
+	third := testpkg.CreateTestClassListEntry(t, db, "CleSortA", "Kind", "10x")
+	second := testpkg.CreateTestClassListEntry(t, db, "CleSortB", "Zorn", "9x")
+	first := testpkg.CreateTestClassListEntry(t, db, "CleSortC", "Aalders", "9x")
+	defer testpkg.CleanupClassListEntryFixtures(t, db, first.ID, second.ID, third.ID)
+
+	entries, err := svc.ListAll(ctx)
+	require.NoError(t, err)
+
+	positions := map[int64]int{}
+	for i, entry := range entries {
+		positions[entry.ID] = i
+	}
+	require.Contains(t, positions, first.ID)
+	assert.Less(t, positions[first.ID], positions[second.ID],
+		"within a class the names sort by German collation")
+	assert.Less(t, positions[second.ID], positions[third.ID],
+		"class 9x sorts before 10x")
+}
+
+func TestClassListEntryService_UpdateGuards(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, repos := setupClassListEntryService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	actor := testpkg.CreateTestAccount(t, db, "cle-update-actor@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, actor.ID)
+
+	t.Run("unchanged update writes nothing and records no audit", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleNoop", "Kind", "6v")
+		defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+
+		updated, err := svc.Update(ctx, entry.ID, usersService.ClassListEntryInput{
+			FirstName:   " CleNoop ",
+			LastName:    "Kind",
+			SchoolClass: "6v",
+		}, actor.ID)
+		require.NoError(t, err)
+		assert.Equal(t, entry.ID, updated.ID)
+
+		trail, err := repos.ClassListEntryChange.ListByEntryID(ctx, entry.ID)
+		require.NoError(t, err)
+		assert.Empty(t, trail, "a no-op update must not spam the audit trail")
+	})
+
+	t.Run("update into an existing entry's identity is refused", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleMoveDup", "Kind", "6v")
+		blocker := testpkg.CreateTestClassListEntry(t, db, "CleBlock", "Kind", "6v")
+		defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID, blocker.ID)
+
+		_, err := svc.Update(ctx, entry.ID, usersService.ClassListEntryInput{
+			FirstName:   "cleblock",
+			LastName:    "KIND",
+			SchoolClass: "6v",
+		}, actor.ID)
+		require.ErrorIs(t, err, usersService.ErrClassListEntryDuplicate)
+	})
+
+	t.Run("update to whitespace-only fields fails validation", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleLeer", "Kind", "6v")
+		defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+
+		_, err := svc.Update(ctx, entry.ID, usersService.ClassListEntryInput{
+			FirstName:   "  ",
+			LastName:    "Kind",
+			SchoolClass: "6v",
+		}, actor.ID)
+		require.Error(t, err)
+	})
+
+	t.Run("create with whitespace-only fields fails validation", func(t *testing.T) {
+		_, err := svc.Create(ctx, usersService.ClassListEntryInput{
+			FirstName:   "CleLeer2",
+			LastName:    " ",
+			SchoolClass: "6v",
+		}, actor.ID)
+		require.Error(t, err)
+	})
+}
+
+func TestClassListEntryService_MissingTargets(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, _ := setupClassListEntryService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	actor := testpkg.CreateTestAccount(t, db, "cle-missing-actor@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, actor.ID)
+
+	missingID := int64(987654321)
+
+	_, err := svc.Update(ctx, missingID, usersService.ClassListEntryInput{
+		FirstName: "Cle", LastName: "Weg", SchoolClass: "5u",
+	}, actor.ID)
+	require.ErrorIs(t, err, usersService.ErrClassListEntryNotFound)
+
+	require.ErrorIs(t, svc.Delete(ctx, missingID, actor.ID), usersService.ErrClassListEntryNotFound)
+	require.ErrorIs(t, svc.Assign(ctx, missingID, actor.ID, actor.ID), usersService.ErrClassListEntryNotFound)
+
+	t.Run("assign to an alumnus is refused", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleAlt", "Kind", "5u")
+		defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+		student := testpkg.CreateTestStudent(t, db, "CleAlt", "Kind", "5u")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		_, err := db.NewUpdate().TableExpr("users.students").
+			Set("status = ?", "alumnus").
+			Where("id = ?", student.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, svc.Assign(ctx, entry.ID, student.ID, actor.ID),
+			usersService.ErrClassListEntryStudentNotFound,
+			"an alumnus must not be an assign target")
+	})
+}
+
+// Errors from the storage layer must propagate, not vanish: a canceled
+// context fails the first repository call of every service path.
+func TestClassListEntryService_StorageErrorsPropagate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, repos := setupClassListEntryService(t, db)
+
+	entry := testpkg.CreateTestClassListEntry(t, db, "CleErr", "Kind", "4t")
+	defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+
+	canceled, cancel := context.WithCancel(testpkg.TenantContext(1))
+	cancel()
+
+	_, err := svc.ListAll(canceled)
+	require.Error(t, err)
+	_, err = svc.List(canceled)
+	require.Error(t, err)
+	_, err = svc.Create(canceled, usersService.ClassListEntryInput{
+		FirstName: "CleErr2", LastName: "Kind", SchoolClass: "4t",
+	}, 0)
+	require.Error(t, err)
+	_, err = svc.Update(canceled, entry.ID, usersService.ClassListEntryInput{
+		FirstName: "CleErr", LastName: "Kind", SchoolClass: "4u",
+	}, 0)
+	require.Error(t, err)
+	require.Error(t, svc.Delete(canceled, entry.ID, 0))
+	require.Error(t, svc.Assign(canceled, entry.ID, entry.ID, 0))
+
+	_, err = repos.ClassListEntry.FindBySchoolClass(canceled, "4t")
+	require.Error(t, err)
+	_, err = repos.ClassListEntry.FindByNameAndClass(canceled, "CleErr", "Kind", "4t")
+	require.Error(t, err)
+	_, err = repos.ClassListEntryChange.ListByEntryID(canceled, entry.ID)
+	require.Error(t, err)
+	require.Error(t, repos.ClassListEntryChange.Create(canceled, &auditModels.ClassListEntryChange{
+		EntryID: entry.ID, Action: auditModels.ClassListEntryActionCreated, ChangedBy: 1,
+	}))
+	require.Error(t, repos.ClassListEntryChange.Create(testpkg.TenantContext(1), &auditModels.ClassListEntryChange{
+		EntryID: entry.ID, Action: "renamed", ChangedBy: 1,
+	}), "an invalid audit row must be rejected by validation")
 }
 
 func TestClassListEntryService_TenantIsolation(t *testing.T) {

--- a/backend/services/users/class_list_entry_service_test.go
+++ b/backend/services/users/class_list_entry_service_test.go
@@ -1,0 +1,202 @@
+// Class-list entry service tests (#2382): hermetic pattern, real DB fixtures.
+package users_test
+
+import (
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func setupClassListEntryService(t *testing.T, db *bun.DB) (usersService.ClassListEntryService, *repositories.Factory) {
+	t.Helper()
+	repos := repositories.NewFactory(db)
+	svc := usersService.NewClassListEntryService(repos.ClassListEntry, repos.Student, repos.ClassListEntryChange)
+	return svc, repos
+}
+
+func TestClassListEntryService_CreateUpdateDelete(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, repos := setupClassListEntryService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	actor := testpkg.CreateTestAccount(t, db, "cle-actor@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, actor.ID)
+
+	t.Run("create records audit and trims input", func(t *testing.T) {
+		entry, err := svc.Create(ctx, usersService.ClassListEntryInput{
+			FirstName:   " CleVorname ",
+			LastName:    " CleNachname ",
+			SchoolClass: " 7z ",
+		}, actor.ID)
+		require.NoError(t, err)
+		defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+
+		assert.Equal(t, "CleVorname", entry.FirstName)
+		assert.Equal(t, "7z", entry.SchoolClass)
+		require.NotNil(t, entry.CreatedBy)
+		assert.Equal(t, actor.ID, *entry.CreatedBy)
+
+		trail, err := repos.ClassListEntryChange.ListByEntryID(ctx, entry.ID)
+		require.NoError(t, err)
+		require.Len(t, trail, 1)
+		assert.Equal(t, auditModels.ClassListEntryActionCreated, trail[0].Action)
+		assert.Equal(t, "CleVorname CleNachname (7z)", trail[0].NewValue)
+	})
+
+	t.Run("duplicate entry is rejected case-insensitively", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleDup", "Kind", "7z")
+		_ = entry
+
+		_, err := svc.Create(ctx, usersService.ClassListEntryInput{
+			FirstName:   "cledup",
+			LastName:    "KIND",
+			SchoolClass: " 7Z ",
+		}, actor.ID)
+		require.ErrorIs(t, err, usersService.ErrClassListEntryDuplicate)
+	})
+
+	t.Run("existing student with same name and class is rejected", func(t *testing.T) {
+		student := testpkg.CreateTestStudent(t, db, "CleStudent", "Kind", "7z")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		_, err := svc.Create(ctx, usersService.ClassListEntryInput{
+			FirstName:   "CleStudent",
+			LastName:    "Kind",
+			SchoolClass: "7z",
+		}, actor.ID)
+		require.ErrorIs(t, err, usersService.ErrClassListEntryStudentExists)
+	})
+
+	t.Run("update moves the entry to another class and records audit", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleMove", "Kind", "7z")
+
+		updated, err := svc.Update(ctx, entry.ID, usersService.ClassListEntryInput{
+			FirstName:   "CleMove",
+			LastName:    "Kind",
+			SchoolClass: "8z",
+		}, actor.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "8z", updated.SchoolClass)
+
+		trail, err := repos.ClassListEntryChange.ListByEntryID(ctx, entry.ID)
+		require.NoError(t, err)
+		require.Len(t, trail, 1)
+		assert.Equal(t, auditModels.ClassListEntryActionUpdated, trail[0].Action)
+		assert.Equal(t, "CleMove Kind (7z)", trail[0].OldValue)
+		assert.Equal(t, "CleMove Kind (8z)", trail[0].NewValue)
+	})
+
+	t.Run("delete removes the entry and records audit", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleDelete", "Kind", "7z")
+
+		require.NoError(t, svc.Delete(ctx, entry.ID, actor.ID))
+
+		entries, err := svc.ListAll(ctx)
+		require.NoError(t, err)
+		for _, remaining := range entries {
+			assert.NotEqual(t, entry.ID, remaining.ID)
+		}
+
+		trail, err := repos.ClassListEntryChange.ListByEntryID(ctx, entry.ID)
+		require.NoError(t, err)
+		require.Len(t, trail, 1)
+		assert.Equal(t, auditModels.ClassListEntryActionDeleted, trail[0].Action)
+	})
+
+	t.Run("missing entry yields not found", func(t *testing.T) {
+		err := svc.Delete(ctx, int64(987654321), actor.ID)
+		require.ErrorIs(t, err, usersService.ErrClassListEntryNotFound)
+	})
+}
+
+func TestClassListEntryService_AssignResolvesDuplicate(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, repos := setupClassListEntryService(t, db)
+	ctx := testpkg.TenantContext(1)
+
+	actor := testpkg.CreateTestAccount(t, db, "cle-assign-actor@test.local")
+	defer testpkg.CleanupAuthFixtures(t, db, actor.ID)
+
+	t.Run("assign deletes the entry and records the matched student", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleAssign", "Kind", "7y")
+		student := testpkg.CreateTestStudent(t, db, "CleAssign", "Kind", "7y")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		require.NoError(t, svc.Assign(ctx, entry.ID, student.ID, actor.ID))
+
+		entries, err := svc.ListAll(ctx)
+		require.NoError(t, err)
+		for _, remaining := range entries {
+			assert.NotEqual(t, entry.ID, remaining.ID)
+		}
+
+		trail, err := repos.ClassListEntryChange.ListByEntryID(ctx, entry.ID)
+		require.NoError(t, err)
+		require.Len(t, trail, 1)
+		assert.Equal(t, auditModels.ClassListEntryActionAssigned, trail[0].Action)
+		require.NotNil(t, trail[0].MatchedStudentID)
+		assert.Equal(t, student.ID, *trail[0].MatchedStudentID)
+	})
+
+	t.Run("assign to a missing student is refused", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleAssignMiss", "Kind", "7y")
+
+		err := svc.Assign(ctx, entry.ID, int64(987654321), actor.ID)
+		require.ErrorIs(t, err, usersService.ErrClassListEntryStudentNotFound)
+	})
+
+	t.Run("list reports the matching student as a hint", func(t *testing.T) {
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleMatch", "Kind", "7y")
+		// The student arrives AFTER the entry (enrollment approval, import) —
+		// exactly the Dubletten case the hint exists for.
+		student := testpkg.CreateTestStudent(t, db, "CleMatch", "Kind", "7y")
+		defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+
+		listed, err := svc.List(ctx)
+		require.NoError(t, err)
+		var found bool
+		for _, item := range listed {
+			if item.Entry.ID == entry.ID {
+				found = true
+				assert.Contains(t, item.MatchingStudentIDs, student.ID)
+			}
+		}
+		require.True(t, found, "entry must be listed")
+	})
+}
+
+func TestClassListEntryService_TenantIsolation(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	svc, _ := setupClassListEntryService(t, db)
+
+	testpkg.EnsureTestTenant(t, db, 42)
+	foreign := testpkg.CreateTestClassListEntryForTenant(t, db, 42, "CleForeign", "Kind", "9x")
+
+	t.Run("foreign tenant entries are invisible", func(t *testing.T) {
+		entries, err := svc.ListAll(testpkg.TenantContext(1))
+		require.NoError(t, err)
+		for _, entry := range entries {
+			assert.NotEqual(t, foreign.ID, entry.ID)
+		}
+	})
+
+	t.Run("foreign tenant entries cannot be deleted", func(t *testing.T) {
+		actor := testpkg.CreateTestAccount(t, db, "cle-iso-actor@test.local")
+		defer testpkg.CleanupAuthFixtures(t, db, actor.ID)
+
+		err := svc.Delete(testpkg.TenantContext(1), foreign.ID, actor.ID)
+		require.ErrorIs(t, err, usersService.ErrClassListEntryNotFound)
+	})
+}

--- a/backend/services/users/class_list_entry_service_test.go
+++ b/backend/services/users/class_list_entry_service_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
 	usersService "github.com/moto-nrw/project-phoenix/services/users"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
@@ -254,6 +256,24 @@ func TestClassListEntryService_UpdateGuards(t *testing.T) {
 		trail, err := repos.ClassListEntryChange.ListByEntryID(ctx, entry.ID)
 		require.NoError(t, err)
 		assert.Empty(t, trail, "a no-op update must not spam the audit trail")
+	})
+
+	t.Run("the unique index reports as the documented duplicate error", func(t *testing.T) {
+		// The advisory duplicate check cannot catch a concurrent create; the
+		// DB index is the backstop. Pin that a raw insert collision carries
+		// the index name the service maps to ErrClassListEntryDuplicate.
+		entry := testpkg.CreateTestClassListEntry(t, db, "CleRace", "Kind", "6v")
+		defer testpkg.CleanupClassListEntryFixtures(t, db, entry.ID)
+
+		clone := &userModels.ClassListEntry{
+			FirstName:   "clerace",
+			LastName:    "KIND",
+			SchoolClass: "6V",
+		}
+		err := repos.ClassListEntry.Create(testpkg.TenantContext(1), clone)
+		require.Error(t, err)
+		assert.True(t, modelBase.IsUniqueViolationOn(err, userModels.ClassListEntryUniqueIndexName),
+			"the collision must be recognizable via the pinned index name")
 	})
 
 	t.Run("update into an existing entry's identity is refused", func(t *testing.T) {

--- a/backend/test/class_list_entry_isolation_test.go
+++ b/backend/test/class_list_entry_isolation_test.go
@@ -3,7 +3,7 @@
 // Class-list-only entries are names of children — personal data — so the
 // acceptance criteria demand proof that one school can never read or write
 // another school's entries. What guarantees that is not a WHERE clause but the
-// RLS policy from migration 1.15.303, so these tests run through real
+// RLS policy from migration 1.15.304, so these tests run through real
 // phoenix_tenant transactions (tenant.WithTenantTx): a repository-level test
 // with a plain context would pass even if the policy were missing.
 package test

--- a/backend/test/class_list_entry_isolation_test.go
+++ b/backend/test/class_list_entry_isolation_test.go
@@ -3,7 +3,7 @@
 // Class-list-only entries are names of children — personal data — so the
 // acceptance criteria demand proof that one school can never read or write
 // another school's entries. What guarantees that is not a WHERE clause but the
-// RLS policy from migration 1.15.304, so these tests run through real
+// RLS policy from migration 1.15.306, so these tests run through real
 // phoenix_tenant transactions (tenant.WithTenantTx): a repository-level test
 // with a plain context would pass even if the policy were missing.
 package test

--- a/backend/test/class_list_entry_isolation_test.go
+++ b/backend/test/class_list_entry_isolation_test.go
@@ -1,0 +1,106 @@
+// Class-list entry tenant isolation (#2382).
+//
+// Class-list-only entries are names of children — personal data — so the
+// acceptance criteria demand proof that one school can never read or write
+// another school's entries. What guarantees that is not a WHERE clause but the
+// RLS policy from migration 1.15.301, so these tests run through real
+// phoenix_tenant transactions (tenant.WithTenantTx): a repository-level test
+// with a plain context would pass even if the policy were missing.
+package test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	repoUsers "github.com/moto-nrw/project-phoenix/database/repositories/users"
+	userModels "github.com/moto-nrw/project-phoenix/models/users"
+	"github.com/moto-nrw/project-phoenix/tenant"
+)
+
+// TestClassListEntryTenantIsolation pins the read side: a tenant transaction
+// sees only its own school's entries, on every query shape the repository
+// offers, including a point lookup by a foreign primary key.
+func TestClassListEntryTenantIsolation(t *testing.T) {
+	db := SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	tenantA := UniqueTestTenantID(t)
+	tenantB := UniqueTestTenantID(t)
+	EnsureTestTenant(t, db, tenantA)
+	EnsureTestTenant(t, db, tenantB)
+	defer CleanupTenantTestData(t, db, tenantA, tenantB)
+
+	// Same class name in both schools — the realistic collision: "1a" exists
+	// everywhere, and a leak would surface exactly here.
+	entryA := CreateTestClassListEntryForTenant(t, db, tenantA, "Ida", "IsolationA", "iso1a")
+	entryB := CreateTestClassListEntryForTenant(t, db, tenantB, "Ben", "IsolationB", "iso1a")
+
+	repo := repoUsers.NewClassListEntryRepository(db)
+
+	assertSeesOnly := func(t *testing.T, ownTenant int64, own, foreign *userModels.ClassListEntry) {
+		t.Helper()
+		err := tenant.WithTenantTx(context.Background(), db, ownTenant, func(txCtx context.Context, _ bun.Tx) error {
+			entries, err := repo.List(txCtx, nil)
+			require.NoError(t, err)
+			ids := make(map[int64]bool, len(entries))
+			for _, entry := range entries {
+				ids[entry.ID] = true
+			}
+			assert.True(t, ids[own.ID], "a school must see its own class-list entry")
+			assert.False(t, ids[foreign.ID], "a foreign school's class-list entry leaked into List")
+
+			byClass, err := repo.FindBySchoolClass(txCtx, "iso1a")
+			require.NoError(t, err)
+			for _, entry := range byClass {
+				assert.NotEqual(t, foreign.ID, entry.ID,
+					"a foreign school's entry leaked through the shared class name")
+			}
+
+			_, err = repo.FindByID(txCtx, foreign.ID)
+			require.Error(t, err, "a foreign entry must not be fetchable by id")
+			assert.ErrorIs(t, err, sql.ErrNoRows)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	assertSeesOnly(t, tenantA, entryA, entryB)
+	assertSeesOnly(t, tenantB, entryB, entryA)
+}
+
+// TestClassListEntryForeignTenantWriteRejected pins the fail-closed write
+// direction: a row stamped with another school's tenant_id must be refused by
+// the policy's WITH CHECK instead of silently landing in the foreign school.
+func TestClassListEntryForeignTenantWriteRejected(t *testing.T) {
+	db := SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	tenantA := UniqueTestTenantID(t)
+	tenantB := UniqueTestTenantID(t)
+	EnsureTestTenant(t, db, tenantA)
+	EnsureTestTenant(t, db, tenantB)
+	defer CleanupTenantTestData(t, db, tenantA, tenantB)
+
+	repo := repoUsers.NewClassListEntryRepository(db)
+	smuggled := &userModels.ClassListEntry{
+		FirstName:   "Fritz",
+		LastName:    "Fremdschule",
+		SchoolClass: "iso2b",
+	}
+	// EnsureTenantID only fills a zero tenant_id, so the preset foreign id
+	// survives to the INSERT — exactly the write WITH CHECK must reject.
+	smuggled.SetTenantID(tenantB)
+
+	err := tenant.WithTenantTx(context.Background(), db, tenantA, func(txCtx context.Context, _ bun.Tx) error {
+		return repo.Create(txCtx, smuggled)
+	})
+	require.Error(t, err, "the database must refuse an entry stamped with a foreign tenant_id")
+	if smuggled.ID != 0 {
+		CleanupClassListEntryFixtures(t, db, smuggled.ID)
+	}
+}

--- a/backend/test/class_list_entry_isolation_test.go
+++ b/backend/test/class_list_entry_isolation_test.go
@@ -3,7 +3,7 @@
 // Class-list-only entries are names of children — personal data — so the
 // acceptance criteria demand proof that one school can never read or write
 // another school's entries. What guarantees that is not a WHERE clause but the
-// RLS policy from migration 1.15.301, so these tests run through real
+// RLS policy from migration 1.15.303, so these tests run through real
 // phoenix_tenant transactions (tenant.WithTenantTx): a repository-level test
 // with a plain context would pass even if the policy were missing.
 package test

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -3604,6 +3604,6 @@ func CleanupClassListEntryFixtures(tb testing.TB, db *bun.DB, entryIDs ...int64)
 		return
 	}
 	ctx := context.Background()
-	_, _ = db.NewDelete().TableExpr("audit.class_list_entry_changes").Where("entry_id IN (?)", bun.In(entryIDs)).Exec(ctx)
-	_, _ = db.NewDelete().TableExpr("users.class_list_entries").Where("id IN (?)", bun.In(entryIDs)).Exec(ctx)
+	_, _ = db.NewDelete().TableExpr("audit.class_list_entry_changes").Where("entry_id IN (?)", bun.List(entryIDs)).Exec(ctx)
+	_, _ = db.NewDelete().TableExpr("users.class_list_entries").Where("id IN (?)", bun.List(entryIDs)).Exec(ctx)
 }

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -3567,3 +3567,43 @@ func CreateTestCareOffering(tb testing.TB, db *bun.DB, phaseID int64, name strin
 	})
 	return offering
 }
+
+// CreateTestClassListEntry creates a class-list-only entry (#2382) for the
+// default test tenant, with cleanup (entry + audit trail) registered.
+func CreateTestClassListEntry(tb testing.TB, db *bun.DB, firstName, lastName, schoolClass string) *users.ClassListEntry {
+	tb.Helper()
+	return CreateTestClassListEntryForTenant(tb, db, 1, firstName, lastName, schoolClass)
+}
+
+// CreateTestClassListEntryForTenant creates a class-list-only entry (#2382)
+// for a specific tenant, with cleanup (entry + audit trail) registered.
+func CreateTestClassListEntryForTenant(tb testing.TB, db *bun.DB, tenantID int64, firstName, lastName, schoolClass string) *users.ClassListEntry {
+	tb.Helper()
+	ctx := TenantContext(tenantID)
+	entry := &users.ClassListEntry{
+		FirstName:   firstName,
+		LastName:    lastName,
+		SchoolClass: schoolClass,
+	}
+	entry.SetTenantID(tenantID)
+	_, err := db.NewInsert().Model(entry).ModelTableExpr(`users.class_list_entries AS "class_list_entry"`).Returning("*").Exec(ctx)
+	if err != nil {
+		tb.Fatalf("create test class list entry: %v", err)
+	}
+	tb.Cleanup(func() {
+		CleanupClassListEntryFixtures(tb, db, entry.ID)
+	})
+	return entry
+}
+
+// CleanupClassListEntryFixtures removes class-list entries and their audit
+// trail rows. Safe to call for already-deleted entries.
+func CleanupClassListEntryFixtures(tb testing.TB, db *bun.DB, entryIDs ...int64) {
+	tb.Helper()
+	if len(entryIDs) == 0 {
+		return
+	}
+	ctx := context.Background()
+	_, _ = db.NewDelete().TableExpr("audit.class_list_entry_changes").Where("entry_id IN (?)", bun.In(entryIDs)).Exec(ctx)
+	_, _ = db.NewDelete().TableExpr("users.class_list_entries").Where("id IN (?)", bun.In(entryIDs)).Exec(ctx)
+}

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
@@ -495,23 +495,27 @@ export default function ClassListImportPage() {
 
           {/* Action Buttons */}
           <div className="sticky bottom-4 z-10 flex flex-col gap-2 rounded-xl border border-gray-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur-sm sm:flex-row sm:gap-3">
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="md"
+              className="flex-1"
               onClick={resetForm}
-              className="flex-1 rounded-lg bg-gray-200 px-3 py-2 text-xs font-medium text-gray-800 transition-all duration-200 hover:bg-gray-300 hover:shadow-md md:px-4 md:text-sm"
             >
               Abbrechen
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="primary"
+              size="md"
+              className="flex-1"
               onClick={() => void handleImport()}
               disabled={stats.new === 0 || isImporting}
-              className="bg-moto-green hover:bg-moto-green-hover flex-1 rounded-lg px-3 py-2 text-xs font-medium text-gray-950 transition-all duration-200 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm"
             >
               {isImporting
                 ? "Importiere..."
                 : `${stats.new} Einträge importieren`}
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
@@ -19,6 +19,7 @@ import { UploadSection } from "~/components/import/upload-section";
 import { StatsCards } from "~/components/import/stats-cards";
 import { StudentRowCard } from "~/components/import/student-row-card";
 import { useToast } from "~/contexts/ToastContext";
+import { useRequirePermission } from "~/lib/hooks/use-require-permission";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "ClassListImportPage" });
@@ -110,6 +111,10 @@ export default function ClassListImportPage() {
       redirect("/");
     },
   });
+  // Der Import legt Einträge an — dieselbe Hürde wie das Backend
+  // (/api/import/class-list-entries verlangt users:create). Wer sie nicht
+  // nimmt, wird zum Dashboard umgeleitet statt in einen 403 zu laufen.
+  const { isReady } = useRequirePermission("users:create");
 
   const toast = useToast();
 
@@ -339,7 +344,7 @@ export default function ClassListImportPage() {
     errors: (importResult?.ErrorCount ?? 0) - existingCount,
   };
 
-  if (status === "loading") {
+  if (status === "loading" || !isReady) {
     return (
       <SkeletonRegion label="Klassenlisten-Import wird geladen…">
         <FormSkeleton fields={2} />

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
@@ -199,8 +199,12 @@ export default function ClassListImportPage() {
         const result = (await response.json()) as Record<string, unknown>;
 
         if (!response.ok) {
+          // Failure responses carry the actionable text in `error`
+          // (api/common ErrResponse); `message` exists only on successes.
           throw new Error(
-            (result.message as string | undefined) ?? "Fehler bei der Vorschau",
+            (result.error as string | undefined) ??
+              (result.message as string | undefined) ??
+              "Fehler bei der Vorschau",
           );
         }
 
@@ -264,7 +268,9 @@ export default function ClassListImportPage() {
 
       if (!response.ok) {
         throw new Error(
-          (result.message as string | undefined) ?? "Fehler beim Import",
+          (result.error as string | undefined) ??
+            (result.message as string | undefined) ??
+            "Fehler beim Import",
         );
       }
 
@@ -366,7 +372,8 @@ export default function ClassListImportPage() {
           <li>Laden Sie die Vorlage herunter (siehe unten)</li>
           <li>
             Tragen Sie pro Kind nur Vorname, Nachname und Klasse ein — mehr
-            braucht ein Klassenlisteneintrag nicht
+            braucht ein Klassenlisteneintrag nicht (die Beispielzeilen der
+            Vorlage werden beim Import ignoriert)
           </li>
           <li>
             Kinder, die bereits in moto angelegt sind, werden übersprungen — sie

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
@@ -14,6 +14,7 @@ import { Button } from "~/components/ui/button";
 import { CustomSelect } from "~/components/ui/custom-select";
 import { Alert } from "~/components/ui/alert";
 import { BackButton } from "~/components/ui/back-button";
+import { SectionCard } from "~/components/ui/section-card";
 import { UploadSection } from "~/components/import/upload-section";
 import { StatsCards } from "~/components/import/stats-cards";
 import { StudentRowCard } from "~/components/import/student-row-card";
@@ -71,6 +72,14 @@ function rowStatusFor(errors: ImportError[]): RowStatus {
   if (errors.some((e) => e.severity === "error")) return "error";
   if (errors.some((e) => e.severity === "warning")) return "warning";
   return "new";
+}
+
+// The generic import engine records rows that are already on the class list
+// as already_exists row errors and never fills SkippedCount — the skipped
+// share has to be derived from the row results.
+function countAlreadyExists(rows: ImportRowResult[]): number {
+  return rows.filter((r) => r.Errors.some((e) => e.code === "already_exists"))
+    .length;
 }
 
 function toDisplayEntry(row: ImportRowResult): DisplayEntry {
@@ -261,8 +270,11 @@ export default function ClassListImportPage() {
         // Partial success: keep preview visible so the user sees which rows
         // were skipped (already on the class list) or failed.
         setPreviewData(importData.Errors.map(toDisplayEntry));
+        const skipped = countAlreadyExists(importData.Errors);
+        const failed = importData.ErrorCount - skipped;
         toast.warning(
-          `${importData.CreatedCount} angelegt, ${importData.ErrorCount} übersprungen`,
+          `${importData.CreatedCount} angelegt, ${skipped} übersprungen` +
+            (failed > 0 ? `, ${failed} fehlgeschlagen` : ""),
         );
       } else {
         setImportComplete(true);
@@ -319,11 +331,12 @@ export default function ClassListImportPage() {
     }
   };
 
+  const existingCount = countAlreadyExists(importResult?.Errors ?? []);
   const stats = {
     total: importResult?.TotalRows ?? 0,
     new: importResult?.CreatedCount ?? 0,
-    existing: importResult?.SkippedCount ?? 0,
-    errors: importResult?.ErrorCount ?? 0,
+    existing: existingCount,
+    errors: (importResult?.ErrorCount ?? 0) - existingCount,
   };
 
   if (status === "loading") {
@@ -339,58 +352,49 @@ export default function ClassListImportPage() {
       <BackButton referrer="/database/students/class-list" />
 
       {/* Info Section */}
-      <div className="border-moto-blue/20 bg-moto-blue-soft rounded-xl border p-6">
-        <div className="flex items-start gap-4">
-          <div className="flex-shrink-0">
-            <Info
-              className="text-moto-blue-strong h-6 w-6"
-              aria-hidden="true"
-            />
-          </div>
-          <div className="flex-1">
-            <h3 className="mb-2 text-sm font-semibold text-gray-900">
-              Sammelimport für Klassenlisteneinträge
-            </h3>
-            <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
-              <li>Laden Sie die Vorlage herunter (siehe unten)</li>
-              <li>
-                Tragen Sie pro Kind nur Vorname, Nachname und Klasse ein — mehr
-                braucht ein Klassenlisteneintrag nicht
-              </li>
-              <li>
-                Kinder, die bereits in moto angelegt sind, werden übersprungen —
-                sie stehen schon auf der Klassenliste
-              </li>
-              <li>
-                Laden Sie die Datei hier hoch und überprüfen Sie die Vorschau
-              </li>
-              <li>Bestätigen Sie den Import</li>
-            </ul>
-          </div>
-        </div>
-      </div>
+      <SectionCard
+        kicker="Klassenliste"
+        title="Sammelimport für Klassenlisteneinträge"
+        icon={Info}
+      >
+        <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
+          <li>Laden Sie die Vorlage herunter (siehe unten)</li>
+          <li>
+            Tragen Sie pro Kind nur Vorname, Nachname und Klasse ein — mehr
+            braucht ein Klassenlisteneintrag nicht
+          </li>
+          <li>
+            Kinder, die bereits in moto angelegt sind, werden übersprungen — sie
+            stehen schon auf der Klassenliste
+          </li>
+          <li>Laden Sie die Datei hier hoch und überprüfen Sie die Vorschau</li>
+          <li>Bestätigen Sie den Import</li>
+        </ul>
+      </SectionCard>
 
       {/* Error Display */}
       {error && (
         <div className="relative">
           <Alert type="error" message={error} />
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
             onClick={() => setError(null)}
-            className="text-moto-red hover:text-moto-red-strong absolute top-1/2 right-4 -translate-y-1/2"
+            className="text-moto-red hover:text-moto-red-strong absolute top-1/2 right-2 -translate-y-1/2"
             aria-label="Fehler schließen"
           >
             <X className="h-4 w-4" aria-hidden="true" />
-          </button>
+          </Button>
         </div>
       )}
 
       {/* Download Template */}
-      <div className="rounded-xl border border-gray-100 bg-white p-6">
-        <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900">
-          <Download className="h-5 w-5 text-gray-600" aria-hidden="true" />
-          Schritt 1: Vorlage herunterladen
-        </h3>
+      <SectionCard
+        kicker="Schritt 1"
+        title="Vorlage herunterladen"
+        icon={Download}
+      >
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
           <div className="flex-1">
             <label
@@ -437,7 +441,7 @@ export default function ClassListImportPage() {
             </Button>
           </div>
         </div>
-      </div>
+      </SectionCard>
 
       {/* Upload Section */}
       <UploadSection
@@ -461,18 +465,12 @@ export default function ClassListImportPage() {
             errors={stats.errors}
           />
 
-          <div className="overflow-hidden rounded-xl border border-gray-100 bg-white">
-            <div className="border-b border-gray-100 p-4">
-              <h3 className="flex items-center gap-2 text-sm font-semibold text-gray-900">
-                <ListChecks
-                  className="h-5 w-5 text-gray-600"
-                  aria-hidden="true"
-                />
-                Schritt 3: Datenvorschau
-              </h3>
-            </div>
-
-            <div className="space-y-2 p-3">
+          <SectionCard
+            kicker="Schritt 3"
+            title="Datenvorschau"
+            icon={ListChecks}
+          >
+            <div className="space-y-2">
               {previewData.map((entry, idx) => (
                 <StudentRowCard
                   key={entry.row}
@@ -488,7 +486,7 @@ export default function ClassListImportPage() {
                 />
               ))}
             </div>
-          </div>
+          </SectionCard>
 
           {/* Spacer for sticky action bar */}
           <div className="h-20" />

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+// Sammelimport für Klassenlisteneinträge (#2382): CSV/Excel mit genau drei
+// Spalten (Vorname, Nachname, Klasse). Bereits vorhandene Einträge und
+// bereits regulär angelegte Kinder werden übersprungen — sie stehen schon
+// auf der Klassenliste.
+
+import { useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+import { Download, Info, ListChecks, X } from "lucide-react";
+import { SkeletonRegion, FormSkeleton } from "~/components/ui/page-skeletons";
+import { Button } from "~/components/ui/button";
+import { CustomSelect } from "~/components/ui/custom-select";
+import { Alert } from "~/components/ui/alert";
+import { BackButton } from "~/components/ui/back-button";
+import { UploadSection } from "~/components/import/upload-section";
+import { StatsCards } from "~/components/import/stats-cards";
+import { StudentRowCard } from "~/components/import/student-row-card";
+import { useToast } from "~/contexts/ToastContext";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "ClassListImportPage" });
+
+interface ImportError {
+  field: string;
+  message: string;
+  code: string;
+  severity: "error" | "warning" | "info";
+}
+
+interface ImportRowResult {
+  RowNumber: number;
+  Data: {
+    first_name: string;
+    last_name: string;
+    school_class: string;
+  };
+  Errors: ImportError[];
+  Timestamp: string;
+}
+
+interface ImportResult {
+  StartedAt: string;
+  CompletedAt: string;
+  TotalRows: number;
+  CreatedCount: number;
+  UpdatedCount: number;
+  SkippedCount: number;
+  ErrorCount: number;
+  WarningCount: number;
+  Errors: ImportRowResult[];
+  BulkActions: string[];
+  DryRun: boolean;
+}
+
+type RowStatus = "new" | "existing" | "error" | "warning";
+
+interface DisplayEntry {
+  row: number;
+  status: RowStatus;
+  errors: string[];
+  first_name: string;
+  last_name: string;
+  school_class: string;
+}
+
+function rowStatusFor(errors: ImportError[]): RowStatus {
+  const isExisting = errors.some((e) => e.code === "already_exists");
+  if (isExisting) return "existing";
+  if (errors.some((e) => e.severity === "error")) return "error";
+  if (errors.some((e) => e.severity === "warning")) return "warning";
+  return "new";
+}
+
+function toDisplayEntry(row: ImportRowResult): DisplayEntry {
+  return {
+    row: row.RowNumber,
+    status: rowStatusFor(row.Errors),
+    errors: row.Errors.map((e) => e.message),
+    first_name: row.Data.first_name,
+    last_name: row.Data.last_name,
+    school_class: row.Data.school_class,
+  };
+}
+
+export default function ClassListImportPage() {
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [previewData, setPreviewData] = useState<DisplayEntry[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importComplete, setImportComplete] = useState(false);
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [templateFormat, setTemplateFormat] = useState<"csv" | "xlsx">("xlsx");
+
+  const { data: session, status } = useSession({
+    required: true,
+    onUnauthenticated() {
+      redirect("/");
+    },
+  });
+
+  const toast = useToast();
+
+  const resetForm = useCallback(() => {
+    setUploadedFile(null);
+    setPreviewData([]);
+    setIsDragging(false);
+    setIsLoading(false);
+    setIsImporting(false);
+    setImportComplete(false);
+    setImportResult(null);
+    setError(null);
+  }, []);
+
+  const handleDownloadTemplate = async () => {
+    try {
+      const token = session?.user?.token;
+      if (!token) {
+        setError("Keine Authentifizierung");
+        return;
+      }
+
+      const response = await fetch(
+        `/api/import/class-list-entries/template?format=${templateFormat}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Fehler beim Herunterladen der Vorlage");
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download =
+        templateFormat === "xlsx"
+          ? "klassenliste-import-vorlage.xlsx"
+          : "klassenliste-import-vorlage.csv";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      logger.error("template_download_failed", {
+        error: err instanceof Error ? err.message : String(err),
+        format: templateFormat,
+      });
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+    }
+  };
+
+  const handleFileUpload = useCallback(
+    async (file: File) => {
+      setUploadedFile(file);
+      setError(null);
+      setIsLoading(true);
+      setImportComplete(false);
+      setImportResult(null);
+
+      try {
+        const token = session?.user?.token;
+        if (!token) {
+          throw new Error("Keine Authentifizierung");
+        }
+
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const response = await fetch("/api/import/class-list-entries/preview", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          body: formData,
+        });
+
+        const result = (await response.json()) as Record<string, unknown>;
+
+        if (!response.ok) {
+          throw new Error(
+            (result.message as string | undefined) ?? "Fehler bei der Vorschau",
+          );
+        }
+
+        const importData = result.data as ImportResult;
+        const displayData: DisplayEntry[] = (importData.Errors ?? []).map(
+          toDisplayEntry,
+        );
+
+        // Rows without issues are not in the Errors array — summarise them.
+        const newCount = importData.TotalRows - displayData.length;
+        if (newCount > 0 && displayData.length === 0) {
+          displayData.push({
+            row: 0,
+            status: "new",
+            errors: [],
+            first_name: `${importData.TotalRows} Einträge`,
+            last_name: "bereit zum Import",
+            school_class: "",
+          });
+        }
+
+        setPreviewData(displayData);
+        setImportResult(importData);
+      } catch (err) {
+        logger.error("class_list_preview_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+        setPreviewData([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [session],
+  );
+
+  const handleImport = async () => {
+    if (!uploadedFile) return;
+
+    setIsImporting(true);
+    setError(null);
+
+    try {
+      const token = session?.user?.token;
+      if (!token) {
+        throw new Error("Keine Authentifizierung");
+      }
+
+      const formData = new FormData();
+      formData.append("file", uploadedFile);
+
+      const response = await fetch("/api/import/class-list-entries/import", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      });
+
+      const result = (await response.json()) as Record<string, unknown>;
+
+      if (!response.ok) {
+        throw new Error(
+          (result.message as string | undefined) ?? "Fehler beim Import",
+        );
+      }
+
+      const importData = result.data as ImportResult;
+      setImportResult(importData);
+
+      if (importData.ErrorCount > 0) {
+        // Partial success: keep preview visible so the user sees which rows
+        // were skipped (already on the class list) or failed.
+        setPreviewData(importData.Errors.map(toDisplayEntry));
+        toast.warning(
+          `${importData.CreatedCount} angelegt, ${importData.ErrorCount} übersprungen`,
+        );
+      } else {
+        setImportComplete(true);
+        toast.success(`${importData.CreatedCount} Einträge angelegt`);
+        resetForm();
+      }
+    } catch (err) {
+      logger.error("class_list_import_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      const file = files[0];
+      if (
+        file &&
+        (file.type === "text/csv" ||
+          file.type ===
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+          file.name.endsWith(".csv") ||
+          file.name.endsWith(".xlsx"))
+      ) {
+        handleFileUpload(file).catch(() => undefined);
+      } else {
+        setError("Bitte nur CSV- oder Excel-Dateien (.csv, .xlsx) hochladen");
+      }
+    }
+  };
+
+  const stats = {
+    total: importResult?.TotalRows ?? 0,
+    new: importResult?.CreatedCount ?? 0,
+    existing: importResult?.SkippedCount ?? 0,
+    errors: importResult?.ErrorCount ?? 0,
+  };
+
+  if (status === "loading") {
+    return (
+      <SkeletonRegion label="Klassenlisten-Import wird geladen…">
+        <FormSkeleton fields={2} />
+      </SkeletonRegion>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-6">
+      <BackButton referrer="/database/students/class-list" />
+
+      {/* Info Section */}
+      <div className="border-moto-blue/20 bg-moto-blue-soft rounded-xl border p-6">
+        <div className="flex items-start gap-4">
+          <div className="flex-shrink-0">
+            <Info
+              className="text-moto-blue-strong h-6 w-6"
+              aria-hidden="true"
+            />
+          </div>
+          <div className="flex-1">
+            <h3 className="mb-2 text-sm font-semibold text-gray-900">
+              Sammelimport für Klassenlisteneinträge
+            </h3>
+            <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
+              <li>Laden Sie die Vorlage herunter (siehe unten)</li>
+              <li>
+                Tragen Sie pro Kind nur Vorname, Nachname und Klasse ein — mehr
+                braucht ein Klassenlisteneintrag nicht
+              </li>
+              <li>
+                Kinder, die bereits in moto angelegt sind, werden übersprungen —
+                sie stehen schon auf der Klassenliste
+              </li>
+              <li>
+                Laden Sie die Datei hier hoch und überprüfen Sie die Vorschau
+              </li>
+              <li>Bestätigen Sie den Import</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <div className="relative">
+          <Alert type="error" message={error} />
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            className="text-moto-red hover:text-moto-red-strong absolute top-1/2 right-4 -translate-y-1/2"
+            aria-label="Fehler schließen"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+
+      {/* Download Template */}
+      <div className="rounded-xl border border-gray-100 bg-white p-6">
+        <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900">
+          <Download className="h-5 w-5 text-gray-600" aria-hidden="true" />
+          Schritt 1: Vorlage herunterladen
+        </h3>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+          <div className="flex-1">
+            <label
+              id="format-select-label"
+              htmlFor="format-select"
+              className="mb-2 block text-sm font-medium text-gray-700"
+            >
+              Format wählen
+            </label>
+            <CustomSelect
+              id="format-select"
+              ariaLabelledBy="format-select-label"
+              value={templateFormat}
+              options={[
+                { value: "csv", label: "CSV (Komma-getrennt)" },
+                { value: "xlsx", label: "Excel (.xlsx)" },
+              ]}
+              onChange={(next) => setTemplateFormat(next as "csv" | "xlsx")}
+            />
+            <p className="mt-2 text-sm text-gray-500">
+              Spalten: <span className="font-medium">Vorname</span>,{" "}
+              <span className="font-medium">Nachname</span>,{" "}
+              <span className="font-medium">Klasse</span>
+            </p>
+          </div>
+          <div className="flex-1">
+            {/* Spacer matches the format-select label height so the button
+                aligns with the dropdown on the sm+ row layout. */}
+            <span
+              aria-hidden="true"
+              className="mb-2 hidden text-sm font-medium text-gray-700 sm:block"
+            >
+              {"\u00A0"}
+            </span>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={() => handleDownloadTemplate().catch(() => undefined)}
+              className="h-10 w-full gap-2"
+            >
+              <Download className="h-5 w-5" aria-hidden="true" />
+              Vorlage herunterladen
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Upload Section */}
+      <UploadSection
+        isDragging={isDragging}
+        isLoading={isLoading}
+        uploadedFile={uploadedFile}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onFileSelect={(file) => handleFileUpload(file).catch(() => undefined)}
+      />
+
+      {/* Preview Section */}
+      {previewData.length > 0 && !importComplete && (
+        <>
+          <StatsCards
+            total={stats.total}
+            newCount={stats.new}
+            existing={stats.existing}
+            errors={stats.errors}
+          />
+
+          <div className="overflow-hidden rounded-xl border border-gray-100 bg-white">
+            <div className="border-b border-gray-100 p-4">
+              <h3 className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+                <ListChecks
+                  className="h-5 w-5 text-gray-600"
+                  aria-hidden="true"
+                />
+                Schritt 3: Datenvorschau
+              </h3>
+            </div>
+
+            <div className="space-y-2 p-3">
+              {previewData.map((entry, idx) => (
+                <StudentRowCard
+                  key={entry.row}
+                  student={{
+                    row: entry.row,
+                    status: entry.status,
+                    errors: entry.errors,
+                    first_name: entry.first_name,
+                    last_name: entry.last_name,
+                    meta: [entry.school_class],
+                  }}
+                  index={idx}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Spacer for sticky action bar */}
+          <div className="h-20" />
+
+          {/* Action Buttons */}
+          <div className="sticky bottom-4 z-10 flex flex-col gap-2 rounded-xl border border-gray-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur-sm sm:flex-row sm:gap-3">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="flex-1 rounded-lg bg-gray-200 px-3 py-2 text-xs font-medium text-gray-800 transition-all duration-200 hover:bg-gray-300 hover:shadow-md md:px-4 md:text-sm"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleImport()}
+              disabled={stats.new === 0 || isImporting}
+              className="bg-moto-green hover:bg-moto-green-hover flex-1 rounded-lg px-3 py-2 text-xs font-medium text-gray-950 transition-all duration-200 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50 md:px-4 md:text-sm"
+            >
+              {isImporting
+                ? "Importiere..."
+                : `${stats.new} Einträge importieren`}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/import/page.tsx
@@ -371,9 +371,8 @@ export default function ClassListImportPage() {
         <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
           <li>Laden Sie die Vorlage herunter (siehe unten)</li>
           <li>
-            Tragen Sie pro Kind nur Vorname, Nachname und Klasse ein — mehr
-            braucht ein Klassenlisteneintrag nicht (die Beispielzeilen der
-            Vorlage werden beim Import ignoriert)
+            Tragen Sie ab Zeile 2 pro Kind nur Vorname, Nachname und Klasse ein.
+            Mehr braucht ein Klassenlisteneintrag nicht
           </li>
           <li>
             Kinder, die bereits in moto angelegt sind, werden übersprungen — sie

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -34,6 +34,7 @@ import {
   type ClassListEntry,
 } from "~/lib/class-list-entries-api";
 import { hasPermission } from "~/lib/auth-utils";
+import { LOCATION_COLORS } from "~/lib/location-helper";
 import { createLogger } from "~/lib/logger";
 import type { Student } from "~/lib/student-helpers";
 import { useSWRAuth } from "~/lib/swr";
@@ -468,7 +469,10 @@ export default function ClassListEntriesPage() {
       <section className="moto-content-surface rounded-2xl border p-5 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
+            <p
+              className="text-xs font-semibold tracking-wide uppercase"
+              style={{ color: LOCATION_COLORS.OTHER_ROOM }}
+            >
               Klassenlisteneinträge
             </p>
             <h2 className="mt-1 text-base font-semibold text-gray-900">

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -447,7 +447,7 @@ export default function ClassListEntriesPage() {
                 type="button"
                 variant="ghost"
                 size="compact"
-                className="text-[#DC2626] hover:text-[#DC2626]"
+                className="text-moto-red hover:text-moto-red-hover"
                 onClick={() => {
                   setModalError(null);
                   setModal({ kind: "delete", entry });

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+// Klassenlisteneinträge (#2382): Kinder des Klassenverbands OHNE
+// OGS-Datensatz — nur Vorname, Nachname, Klasse. Sie erscheinen auf
+// Klassenlisten und in der Klassenansicht ("Keine Betreuung"), nie in
+// Kindersuche, Anwesenheit, Betreuungsplanung oder Elternportal. Diese Seite
+// ist die Verwaltung: anlegen, in andere Klasse verschieben, löschen und
+// Dubletten bewusst einem regulären Kind zuordnen.
+//
+// Design follows the Anmeldungen/Planung surface language: calm content
+// section, uppercase kicker, gray-50 stats, no colored dashboards.
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { Upload } from "lucide-react";
+import { Alert } from "~/components/ui/alert";
+import { BackButton } from "~/components/ui/back-button";
+import { Button } from "~/components/ui/button";
+import { ConfirmationModal, Modal } from "~/components/ui/modal";
+import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Input } from "~/components/ui/input";
+import { StatusBadge } from "~/components/ui/status-badge";
+import { useToast } from "~/contexts/ToastContext";
+import {
+  assignClassListEntry,
+  createClassListEntry,
+  deleteClassListEntry,
+  fetchClassListEntries,
+  updateClassListEntry,
+  type ClassListEntry,
+} from "~/lib/class-list-entries-api";
+import { createLogger } from "~/lib/logger";
+import { useSWRAuth } from "~/lib/swr";
+
+const logger = createLogger({ component: "ClassListEntriesPage" });
+
+const SWR_KEY = "class-list-entries";
+
+interface EntryFormState {
+  firstName: string;
+  lastName: string;
+  schoolClass: string;
+}
+
+const EMPTY_FORM: EntryFormState = {
+  firstName: "",
+  lastName: "",
+  schoolClass: "",
+};
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Unbekannter Fehler";
+}
+
+function EntryFormFields({
+  form,
+  onChange,
+  classSuggestions,
+}: Readonly<{
+  form: EntryFormState;
+  onChange: (next: EntryFormState) => void;
+  classSuggestions: string[];
+}>) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor="entry-first-name"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Vorname
+          </label>
+          <Input
+            id="entry-first-name"
+            value={form.firstName}
+            onChange={(e) => onChange({ ...form, firstName: e.target.value })}
+            placeholder="z.B. Lena"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="entry-last-name"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Nachname
+          </label>
+          <Input
+            id="entry-last-name"
+            value={form.lastName}
+            onChange={(e) => onChange({ ...form, lastName: e.target.value })}
+            placeholder="z.B. Beispiel"
+          />
+        </div>
+      </div>
+      <div>
+        <label
+          htmlFor="entry-school-class"
+          className="mb-1 block text-sm font-medium text-gray-700"
+        >
+          Klasse
+        </label>
+        <Input
+          id="entry-school-class"
+          value={form.schoolClass}
+          onChange={(e) => onChange({ ...form, schoolClass: e.target.value })}
+          placeholder="z.B. 1a"
+          list="class-list-class-suggestions"
+        />
+        <datalist id="class-list-class-suggestions">
+          {classSuggestions.map((klass) => (
+            <option key={klass} value={klass} />
+          ))}
+        </datalist>
+        <p className="mt-1 text-xs text-gray-500">
+          Genau wie bei den regulären Kindern geschrieben, damit der Eintrag in
+          derselben Klassenliste landet.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+async function fetchClassSuggestions(): Promise<string[]> {
+  const response = await fetch("/api/students/school-classes", {
+    credentials: "include",
+    cache: "no-store",
+  });
+  if (!response.ok) return [];
+  const payload = (await response.json()) as { data?: string[] };
+  return payload.data ?? [];
+}
+
+export default function ClassListEntriesPage() {
+  const toast = useToast();
+  const {
+    data: entries,
+    error: loadError,
+    isLoading,
+    mutate,
+  } = useSWRAuth(SWR_KEY, fetchClassListEntries);
+  const { data: classSuggestions } = useSWRAuth(
+    "class-list-class-suggestions",
+    fetchClassSuggestions,
+  );
+
+  const [modal, setModal] = useState<
+    | { kind: "create" }
+    | { kind: "edit"; entry: ClassListEntry }
+    | { kind: "delete"; entry: ClassListEntry }
+    | { kind: "assign"; entry: ClassListEntry }
+    | null
+  >(null);
+  const [form, setForm] = useState<EntryFormState>(EMPTY_FORM);
+  const [modalError, setModalError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const rows = useMemo(() => entries ?? [], [entries]);
+  const duplicateCount = useMemo(
+    () => rows.filter((entry) => entry.matchingStudentIds.length > 0).length,
+    [rows],
+  );
+  const classCount = useMemo(
+    () =>
+      new Set(rows.map((entry) => entry.schoolClass.toLowerCase().trim())).size,
+    [rows],
+  );
+
+  const closeModal = () => {
+    setModal(null);
+    setModalError(null);
+    setForm(EMPTY_FORM);
+  };
+
+  const openCreate = () => {
+    setForm(EMPTY_FORM);
+    setModalError(null);
+    setModal({ kind: "create" });
+  };
+
+  const openEdit = (entry: ClassListEntry) => {
+    setForm({
+      firstName: entry.firstName,
+      lastName: entry.lastName,
+      schoolClass: entry.schoolClass,
+    });
+    setModalError(null);
+    setModal({ kind: "edit", entry });
+  };
+
+  const submitForm = async () => {
+    if (modal?.kind !== "create" && modal?.kind !== "edit") return;
+    setSaving(true);
+    setModalError(null);
+    try {
+      if (modal.kind === "create") {
+        await createClassListEntry(form);
+        toast.success("Eintrag angelegt");
+      } else {
+        await updateClassListEntry(modal.entry.id, form);
+        toast.success("Eintrag gespeichert");
+      }
+      await mutate();
+      closeModal();
+    } catch (err) {
+      logger.error("class_list_entry_save_failed", {
+        error: errorMessage(err),
+      });
+      setModalError(errorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (modal?.kind !== "delete") return;
+    setSaving(true);
+    try {
+      await deleteClassListEntry(modal.entry.id);
+      toast.success("Eintrag gelöscht");
+      await mutate();
+      closeModal();
+    } catch (err) {
+      logger.error("class_list_entry_delete_failed", {
+        error: errorMessage(err),
+      });
+      setModalError(errorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmAssign = async () => {
+    if (modal?.kind !== "assign") return;
+    const studentId = modal.entry.matchingStudentIds[0];
+    if (!studentId) return;
+    setSaving(true);
+    try {
+      await assignClassListEntry(modal.entry.id, studentId);
+      toast.success("Eintrag zugeordnet und aus der Klassenliste entfernt");
+      await mutate();
+      closeModal();
+    } catch (err) {
+      logger.error("class_list_entry_assign_failed", {
+        error: errorMessage(err),
+      });
+      setModalError(errorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const columns: DataTableColumn<ClassListEntry>[] = [
+    {
+      key: "name",
+      header: "Name",
+      render: (entry) => (
+        <span className="font-medium text-gray-900">
+          {entry.lastName}, {entry.firstName}
+        </span>
+      ),
+      sortValue: (entry) =>
+        `${entry.lastName.toLowerCase()} ${entry.firstName.toLowerCase()}`,
+    },
+    {
+      key: "schoolClass",
+      header: "Klasse",
+      render: (entry) => (
+        <span className="text-gray-700">{entry.schoolClass}</span>
+      ),
+      sortValue: (entry) => entry.schoolClass.toLowerCase(),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (entry) =>
+        entry.matchingStudentIds.length > 0 ? (
+          <StatusBadge
+            tone="orange"
+            label="Mögliche Dublette"
+            title="Ein regulär angelegtes Kind trägt denselben Namen in derselben Klasse. Bitte prüfen und bewusst zuordnen."
+          />
+        ) : (
+          <StatusBadge tone="gray" label="Keine Betreuung" />
+        ),
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      render: (entry) => (
+        <div className="flex items-center justify-end gap-1">
+          {entry.matchingStudentIds.length > 0 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="compact"
+              onClick={() => {
+                setModalError(null);
+                setModal({ kind: "assign", entry });
+              }}
+            >
+              Zuordnen
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            onClick={() => openEdit(entry)}
+          >
+            Bearbeiten
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            className="text-[#DC2626] hover:text-[#DC2626]"
+            onClick={() => {
+              setModalError(null);
+              setModal({ kind: "delete", entry });
+            }}
+          >
+            Löschen
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="w-full space-y-4">
+      <BackButton referrer="/database/students" />
+
+      <section className="moto-content-surface rounded-2xl border p-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold tracking-wide text-[#5080D8] uppercase">
+              Klassenlisteneinträge
+            </p>
+            <h2 className="mt-1 text-base font-semibold text-gray-900">
+              Kinder ohne OGS-Betreuung
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-600">
+              Diese Einträge vervollständigen den Klassenverband auf
+              Klassenlisten und in der Klassenansicht. Sie bestehen nur aus Name
+              und Klasse — ohne Betreuung, Anwesenheit oder Kontaktdaten.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              href="/database/students/class-list/import"
+              className="flex h-9 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              <Upload className="h-4 w-4" aria-hidden="true" />
+              Sammelimport
+            </Link>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              className="h-9"
+              onClick={openCreate}
+            >
+              Eintrag anlegen
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-2 sm:max-w-md sm:grid-cols-3">
+          <div className="rounded-xl bg-gray-50 px-3 py-2">
+            <span className="block text-sm font-semibold text-gray-900">
+              {rows.length}
+            </span>
+            <span className="block text-[11px] font-medium text-gray-500">
+              Einträge
+            </span>
+          </div>
+          <div className="rounded-xl bg-gray-50 px-3 py-2">
+            <span className="block text-sm font-semibold text-gray-900">
+              {classCount}
+            </span>
+            <span className="block text-[11px] font-medium text-gray-500">
+              Klassen
+            </span>
+          </div>
+          <div className="rounded-xl bg-gray-50 px-3 py-2">
+            <span className="block text-sm font-semibold text-gray-900">
+              {duplicateCount}
+            </span>
+            <span className="block text-[11px] font-medium text-gray-500">
+              Mögliche Dubletten
+            </span>
+          </div>
+        </div>
+
+        {loadError ? (
+          <div className="mt-4">
+            <Alert
+              type="error"
+              message="Die Klassenlisteneinträge konnten nicht geladen werden."
+            />
+          </div>
+        ) : null}
+
+        <div className="mt-4">
+          <DataTable
+            columns={columns}
+            rows={rows}
+            getRowKey={(entry) => entry.id}
+            isLoading={isLoading && entries === undefined}
+            defaultSortKey="schoolClass"
+            emptyState={
+              <EmptyState
+                title="Noch keine Klassenlisteneinträge"
+                description="Legen Sie Kinder ohne OGS-Betreuung mit Name und Klasse an, damit Klassenlisten den vollständigen Klassenverband zeigen."
+                action={
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="md"
+                    onClick={openCreate}
+                  >
+                    Eintrag anlegen
+                  </Button>
+                }
+              />
+            }
+          />
+        </div>
+      </section>
+
+      <Modal
+        isOpen={modal?.kind === "create" || modal?.kind === "edit"}
+        onClose={closeModal}
+        title={
+          modal?.kind === "edit"
+            ? "Eintrag bearbeiten"
+            : "Klassenlisteneintrag anlegen"
+        }
+      >
+        <div className="space-y-4">
+          {modalError ? <Alert type="error" message={modalError} /> : null}
+          <EntryFormFields
+            form={form}
+            onChange={setForm}
+            classSuggestions={classSuggestions ?? []}
+          />
+          <div className="flex justify-end gap-2 border-t border-gray-100 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={closeModal}
+            >
+              Abbrechen
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              disabled={
+                saving ||
+                !form.firstName.trim() ||
+                !form.lastName.trim() ||
+                !form.schoolClass.trim()
+              }
+              onClick={() => void submitForm()}
+            >
+              {saving
+                ? "Speichern…"
+                : modal?.kind === "edit"
+                  ? "Speichern"
+                  : "Anlegen"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <ConfirmationModal
+        isOpen={modal?.kind === "delete"}
+        onClose={closeModal}
+        onConfirm={() => void confirmDelete()}
+        title="Eintrag löschen"
+        confirmText="Löschen"
+        isConfirmLoading={saving}
+      >
+        {modal?.kind === "delete" ? (
+          <div className="space-y-3">
+            {modalError ? <Alert type="error" message={modalError} /> : null}
+            <p className="text-sm text-gray-600">
+              Soll der Eintrag{" "}
+              <span className="font-medium text-gray-900">
+                {modal.entry.firstName} {modal.entry.lastName} (
+                {modal.entry.schoolClass})
+              </span>{" "}
+              gelöscht werden? Er verschwindet damit von allen Klassenlisten.
+            </p>
+          </div>
+        ) : null}
+      </ConfirmationModal>
+
+      <ConfirmationModal
+        isOpen={modal?.kind === "assign"}
+        onClose={closeModal}
+        onConfirm={() => void confirmAssign()}
+        title="Eintrag zuordnen"
+        confirmText="Zuordnen"
+        isConfirmLoading={saving}
+      >
+        {modal?.kind === "assign" ? (
+          <div className="space-y-3">
+            {modalError ? <Alert type="error" message={modalError} /> : null}
+            <p className="text-sm text-gray-600">
+              <span className="font-medium text-gray-900">
+                {modal.entry.firstName} {modal.entry.lastName} (
+                {modal.entry.schoolClass})
+              </span>{" "}
+              ist inzwischen als reguläres Kind angelegt. Beim Zuordnen wird der
+              Klassenlisteneintrag entfernt — das Kind steht dann nur noch über
+              seinen regulären Datensatz auf der Klassenliste.
+            </p>
+            <p className="text-xs text-gray-500">
+              Die Zuordnung passiert nie automatisch: Bitte nur bestätigen, wenn
+              es sich wirklich um dasselbe Kind handelt.
+            </p>
+          </div>
+        ) : null}
+      </ConfirmationModal>
+    </div>
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -33,6 +33,7 @@ import {
   type ClassListEntry,
 } from "~/lib/class-list-entries-api";
 import { createLogger } from "~/lib/logger";
+import type { Student } from "~/lib/student-helpers";
 import { useSWRAuth } from "~/lib/swr";
 
 const logger = createLogger({ component: "ClassListEntriesPage" });
@@ -144,31 +145,53 @@ interface RosterStudent {
   schoolClass: string;
 }
 
-interface RosterStudentWire {
-  id: number | string;
-  first_name?: string;
-  second_name?: string;
-  school_class?: string;
+// The /api/students route maps the backend rows through mapStudentResponse,
+// which emits the surname as `second_name` (see ~/lib/student-helpers) —
+// pinning the wire type to that mapper output keeps this page honest about
+// what actually arrives.
+type RosterStudentWire = Pick<
+  Student,
+  "id" | "first_name" | "second_name" | "school_class"
+>;
+
+interface RosterStudentsPage {
+  data?: {
+    data?: RosterStudentWire[];
+    pagination?: { total_pages?: number };
+  };
 }
 
+const ROSTER_PAGE_SIZE = 1000;
+
+// Loads EVERY student page: the /api/students route caps page_size at 1000,
+// so a larger school needs more than one request or the roster (and every
+// derived count) would silently stop at the first thousand children.
 async function fetchRosterStudents(): Promise<RosterStudent[]> {
-  const response = await fetch("/api/students?page=1&page_size=1000", {
-    credentials: "include",
-    cache: "no-store",
-  });
-  if (!response.ok) return [];
-  // The route wrapper wraps GET results, so the paginated list arrives as
-  // { data: { data: [...], pagination } }.
-  const payload = (await response.json()) as {
-    data?: { data?: RosterStudentWire[] };
-  };
-  const students = payload.data?.data ?? [];
-  return students.map((student) => ({
-    id: String(student.id),
-    firstName: student.first_name ?? "",
-    lastName: student.second_name ?? "",
-    schoolClass: student.school_class ?? "",
-  }));
+  const students: RosterStudent[] = [];
+  let page = 1;
+  let totalPages = 1;
+  while (page <= totalPages) {
+    const response = await fetch(
+      `/api/students?page=${page}&page_size=${ROSTER_PAGE_SIZE}`,
+      { credentials: "include", cache: "no-store" },
+    );
+    if (!response.ok) return students;
+    // The route wrapper wraps GET results, so the paginated list arrives as
+    // { data: { data: [...], pagination } }.
+    const payload = (await response.json()) as RosterStudentsPage;
+    const rows = payload.data?.data ?? [];
+    students.push(
+      ...rows.map((student) => ({
+        id: String(student.id),
+        firstName: student.first_name ?? "",
+        lastName: student.second_name ?? "",
+        schoolClass: student.school_class ?? "",
+      })),
+    );
+    totalPages = payload.data?.pagination?.total_pages ?? page;
+    page += 1;
+  }
+  return students;
 }
 
 // One row of the combined roster: a regular student (read-only) or a

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-// Klassenlisteneinträge (#2382): Kinder des Klassenverbands OHNE
-// OGS-Datensatz — nur Vorname, Nachname, Klasse. Sie erscheinen auf
-// Klassenlisten und in der Klassenansicht ("Keine Betreuung"), nie in
-// Kindersuche, Anwesenheit, Betreuungsplanung oder Elternportal. Diese Seite
-// ist die Verwaltung: anlegen, in andere Klasse verschieben, löschen und
-// Dubletten bewusst einem regulären Kind zuordnen.
+// Klassenlisten-Verwaltung (#2382): der vollständige Klassenverband aus
+// Admin-Sicht. Reguläre Kinder erscheinen read-only ("In moto angelegt",
+// gepflegt werden sie in der Kinder-Datenbank); Klassenlisteneinträge —
+// Kinder OHNE OGS-Datensatz, nur Vorname/Nachname/Klasse — werden hier
+// angelegt, verschoben, gelöscht und bei Dubletten bewusst einem regulären
+// Kind zugeordnet. Nur so sieht die Pflegekraft pro Klasse, welche Kinder
+// schon erfasst sind und welche noch fehlen.
 //
 // Design follows the Anmeldungen/Planung surface language: calm content
 // section, uppercase kicker, gray-50 stats, no colored dashboards.
@@ -17,6 +18,7 @@ import { Alert } from "~/components/ui/alert";
 import { BackButton } from "~/components/ui/back-button";
 import { Button } from "~/components/ui/button";
 import { ConfirmationModal, Modal } from "~/components/ui/modal";
+import { CustomSelect } from "~/components/ui/custom-select";
 import { DataTable, type DataTableColumn } from "~/components/ui/data-table";
 import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
@@ -132,6 +134,74 @@ async function fetchClassSuggestions(): Promise<string[]> {
   return payload.data ?? [];
 }
 
+// Minimal projection of a regular student for the roster view: this page
+// answers "wer ist schon in moto?", nicht mehr — alles Weitere gehört in die
+// Kinder-Datenbank.
+interface RosterStudent {
+  id: string;
+  firstName: string;
+  lastName: string;
+  schoolClass: string;
+}
+
+interface RosterStudentWire {
+  id: number | string;
+  first_name?: string;
+  second_name?: string;
+  school_class?: string;
+}
+
+async function fetchRosterStudents(): Promise<RosterStudent[]> {
+  const response = await fetch("/api/students?page=1&page_size=1000", {
+    credentials: "include",
+    cache: "no-store",
+  });
+  if (!response.ok) return [];
+  // The route wrapper wraps GET results, so the paginated list arrives as
+  // { data: { data: [...], pagination } }.
+  const payload = (await response.json()) as {
+    data?: { data?: RosterStudentWire[] };
+  };
+  const students = payload.data?.data ?? [];
+  return students.map((student) => ({
+    id: String(student.id),
+    firstName: student.first_name ?? "",
+    lastName: student.second_name ?? "",
+    schoolClass: student.school_class ?? "",
+  }));
+}
+
+// One row of the combined roster: a regular student (read-only) or a
+// class-list-only entry (editable).
+type RosterRow =
+  | { kind: "student"; student: RosterStudent }
+  | { kind: "entry"; entry: ClassListEntry };
+
+function rowName(row: RosterRow): { firstName: string; lastName: string } {
+  return row.kind === "student" ? row.student : row.entry;
+}
+
+function rowClass(row: RosterRow): string {
+  return row.kind === "student"
+    ? row.student.schoolClass
+    : row.entry.schoolClass;
+}
+
+// Sort key that keeps "Klasse 1a" ≡ "1a" together and orders grades
+// numerically (1a before 10a) — the same equivalence the exports use.
+function classSortKey(schoolClass: string): string {
+  const normalized = schoolClass
+    .trim()
+    .toLowerCase()
+    .replace(/^klasse\s+/, "");
+  return normalized.replace(/^\d+/, (digits) => digits.padStart(3, "0"));
+}
+
+function rowSortKey(row: RosterRow): string {
+  const { firstName, lastName } = rowName(row);
+  return `${classSortKey(rowClass(row))} ${lastName.toLowerCase()} ${firstName.toLowerCase()}`;
+}
+
 export default function ClassListEntriesPage() {
   const toast = useToast();
   const {
@@ -144,6 +214,15 @@ export default function ClassListEntriesPage() {
     "class-list-class-suggestions",
     fetchClassSuggestions,
   );
+  // Die regulären Kinder gehören mit auf diese Seite: ohne sie kann niemand
+  // beurteilen, welche Kinder einer Klasse schon erfasst sind und welche
+  // fehlen. Nach jeder Eintrags-Änderung mit-revalidiert (Zuordnen ersetzt
+  // einen Eintrag durch das reguläre Kind).
+  const { data: students, mutate: mutateStudents } = useSWRAuth(
+    "class-list-roster-students",
+    fetchRosterStudents,
+  );
+  const [classFilter, setClassFilter] = useState("all");
 
   const [modal, setModal] = useState<
     | { kind: "create" }
@@ -156,16 +235,49 @@ export default function ClassListEntriesPage() {
   const [modalError, setModalError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  const rows = useMemo(() => entries ?? [], [entries]);
+  const entryRows = useMemo(() => entries ?? [], [entries]);
   const duplicateCount = useMemo(
-    () => rows.filter((entry) => entry.matchingStudentIds.length > 0).length,
-    [rows],
-  );
-  const classCount = useMemo(
     () =>
-      new Set(rows.map((entry) => entry.schoolClass.toLowerCase().trim())).size,
-    [rows],
+      entryRows.filter((entry) => entry.matchingStudentIds.length > 0).length,
+    [entryRows],
   );
+
+  const allRows = useMemo<RosterRow[]>(
+    () => [
+      ...(students ?? []).map((student): RosterRow => ({
+        kind: "student",
+        student,
+      })),
+      ...entryRows.map((entry): RosterRow => ({ kind: "entry", entry })),
+    ],
+    [students, entryRows],
+  );
+
+  // Klassenoptionen aus BEIDEN Quellen, dedupliziert über dieselbe
+  // Normalisierung wie die Sortierung (erste Schreibweise gewinnt).
+  const classOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const row of allRows) {
+      const display = rowClass(row).trim();
+      if (display === "") continue;
+      const key = classSortKey(display);
+      if (!seen.has(key)) seen.set(key, display);
+    }
+    return [...seen.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, display]) => ({ key, display }));
+  }, [allRows]);
+
+  const rows = useMemo(
+    () =>
+      classFilter === "all"
+        ? allRows
+        : allRows.filter((row) => classSortKey(rowClass(row)) === classFilter),
+    [allRows, classFilter],
+  );
+
+  const classCount = classOptions.length;
+  const studentCount = students?.length ?? 0;
 
   const closeModal = () => {
     setModal(null);
@@ -239,7 +351,7 @@ export default function ClassListEntriesPage() {
     try {
       await assignClassListEntry(modal.entry.id, studentId);
       toast.success("Eintrag zugeordnet und aus der Klassenliste entfernt");
-      await mutate();
+      await Promise.all([mutate(), mutateStudents()]);
       closeModal();
     } catch (err) {
       logger.error("class_list_entry_assign_failed", {
@@ -251,31 +363,49 @@ export default function ClassListEntriesPage() {
     }
   };
 
-  const columns: DataTableColumn<ClassListEntry>[] = [
+  const columns: DataTableColumn<RosterRow>[] = [
     {
       key: "name",
       header: "Name",
-      render: (entry) => (
-        <span className="font-medium text-gray-900">
-          {entry.lastName}, {entry.firstName}
-        </span>
-      ),
-      sortValue: (entry) =>
-        `${entry.lastName.toLowerCase()} ${entry.firstName.toLowerCase()}`,
+      render: (row) => {
+        const { firstName, lastName } = rowName(row);
+        return (
+          <span
+            className={
+              row.kind === "student"
+                ? "text-gray-700"
+                : "font-medium text-gray-900"
+            }
+          >
+            {lastName}, {firstName}
+          </span>
+        );
+      },
+      sortValue: (row) => {
+        const { firstName, lastName } = rowName(row);
+        return `${lastName.toLowerCase()} ${firstName.toLowerCase()}`;
+      },
     },
     {
       key: "schoolClass",
       header: "Klasse",
-      render: (entry) => (
-        <span className="text-gray-700">{entry.schoolClass}</span>
-      ),
-      sortValue: (entry) => entry.schoolClass.toLowerCase(),
+      render: (row) => <span className="text-gray-700">{rowClass(row)}</span>,
+      sortValue: rowSortKey,
     },
     {
       key: "status",
       header: "Status",
-      render: (entry) =>
-        entry.matchingStudentIds.length > 0 ? (
+      render: (row) => {
+        if (row.kind === "student") {
+          return (
+            <StatusBadge
+              tone="green"
+              label="In moto angelegt"
+              title="Reguläres Kind mit vollständigem Datensatz. Gepflegt wird es in der Kinder-Datenbank."
+            />
+          );
+        }
+        return row.entry.matchingStudentIds.length > 0 ? (
           <StatusBadge
             tone="orange"
             label="Mögliche Dublette"
@@ -283,49 +413,65 @@ export default function ClassListEntriesPage() {
           />
         ) : (
           <StatusBadge tone="gray" label="Keine Betreuung" />
-        ),
+        );
+      },
     },
     {
       key: "actions",
       header: "",
       align: "right",
-      render: (entry) => (
-        <div className="flex items-center justify-end gap-1">
-          {entry.matchingStudentIds.length > 0 && (
+      render: (row) => {
+        if (row.kind === "student") {
+          return (
+            <div className="flex items-center justify-end">
+              <Link
+                href={`/students/${row.student.id}`}
+                className="rounded-md px-2.5 py-1 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+              >
+                Öffnen
+              </Link>
+            </div>
+          );
+        }
+        const entry = row.entry;
+        return (
+          <div className="flex items-center justify-end gap-1">
+            {entry.matchingStudentIds.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="compact"
+                onClick={() => {
+                  setModalError(null);
+                  setModal({ kind: "assign", entry });
+                }}
+              >
+                Zuordnen
+              </Button>
+            )}
             <Button
               type="button"
               variant="ghost"
               size="compact"
+              onClick={() => openEdit(entry)}
+            >
+              Bearbeiten
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="compact"
+              className="text-[#DC2626] hover:text-[#DC2626]"
               onClick={() => {
                 setModalError(null);
-                setModal({ kind: "assign", entry });
+                setModal({ kind: "delete", entry });
               }}
             >
-              Zuordnen
+              Löschen
             </Button>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="compact"
-            onClick={() => openEdit(entry)}
-          >
-            Bearbeiten
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="compact"
-            className="text-[#DC2626] hover:text-[#DC2626]"
-            onClick={() => {
-              setModalError(null);
-              setModal({ kind: "delete", entry });
-            }}
-          >
-            Löschen
-          </Button>
-        </div>
-      ),
+          </div>
+        );
+      },
     },
   ];
 
@@ -340,12 +486,14 @@ export default function ClassListEntriesPage() {
               Klassenlisteneinträge
             </p>
             <h2 className="mt-1 text-base font-semibold text-gray-900">
-              Kinder ohne OGS-Betreuung
+              Der vollständige Klassenverband
             </h2>
             <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-600">
-              Diese Einträge vervollständigen den Klassenverband auf
-              Klassenlisten und in der Klassenansicht. Sie bestehen nur aus Name
-              und Klasse — ohne Betreuung, Anwesenheit oder Kontaktdaten.
+              Alle Kinder pro Klasse auf einen Blick: regulär angelegte Kinder
+              und Klassenlisteneinträge (nur Name und Klasse, ohne Betreuung,
+              Anwesenheit oder Kontaktdaten). Wer hier fehlt, wird über{" "}
+              <span className="font-medium">Eintrag anlegen</span> oder den{" "}
+              <span className="font-medium">Sammelimport</span> ergänzt.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -368,13 +516,29 @@ export default function ClassListEntriesPage() {
           </div>
         </div>
 
-        <div className="mt-4 grid grid-cols-2 gap-2 sm:max-w-md sm:grid-cols-3">
+        <div className="mt-4 grid grid-cols-2 gap-2 sm:max-w-2xl sm:grid-cols-5">
           <div className="rounded-xl bg-gray-50 px-3 py-2">
             <span className="block text-sm font-semibold text-gray-900">
-              {rows.length}
+              {allRows.length}
             </span>
             <span className="block text-[11px] font-medium text-gray-500">
-              Einträge
+              Kinder gesamt
+            </span>
+          </div>
+          <div className="rounded-xl bg-gray-50 px-3 py-2">
+            <span className="block text-sm font-semibold text-gray-900">
+              {studentCount}
+            </span>
+            <span className="block text-[11px] font-medium text-gray-500">
+              In moto angelegt
+            </span>
+          </div>
+          <div className="rounded-xl bg-gray-50 px-3 py-2">
+            <span className="block text-sm font-semibold text-gray-900">
+              {entryRows.length}
+            </span>
+            <span className="block text-[11px] font-medium text-gray-500">
+              Ohne Betreuung
             </span>
           </div>
           <div className="rounded-xl bg-gray-50 px-3 py-2">
@@ -404,16 +568,50 @@ export default function ClassListEntriesPage() {
           </div>
         ) : null}
 
-        <div className="mt-4">
+        <div className="mt-4 flex items-center gap-2">
+          <span
+            id="class-list-filter-label"
+            className="text-sm font-medium text-gray-700"
+          >
+            Klasse
+          </span>
+          <div className="w-48">
+            <CustomSelect
+              id="class-list-filter"
+              ariaLabelledBy="class-list-filter-label"
+              value={classFilter}
+              options={[
+                { value: "all", label: "Alle Klassen" },
+                ...classOptions.map((option) => ({
+                  value: option.key,
+                  label: option.display,
+                })),
+              ]}
+              onChange={setClassFilter}
+            />
+          </div>
+        </div>
+
+        <div className="mt-3">
           <DataTable
             columns={columns}
             rows={rows}
-            getRowKey={(entry) => entry.id}
+            getRowKey={(row) =>
+              row.kind === "student"
+                ? `student-${row.student.id}`
+                : `entry-${row.entry.id}`
+            }
             isLoading={isLoading && entries === undefined}
             defaultSortKey="schoolClass"
+            pageSize={50}
+            paginationResetKey={classFilter}
             emptyState={
               <EmptyState
-                title="Noch keine Klassenlisteneinträge"
+                title={
+                  classFilter === "all"
+                    ? "Noch keine Kinder erfasst"
+                    : "Keine Kinder in dieser Klasse"
+                }
                 description="Legen Sie Kinder ohne OGS-Betreuung mit Name und Klasse an, damit Klassenlisten den vollständigen Klassenverband zeigen."
                 action={
                   <Button

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -165,7 +165,9 @@ const ROSTER_PAGE_SIZE = 1000;
 
 // Loads EVERY student page: the /api/students route caps page_size at 1000,
 // so a larger school needs more than one request or the roster (and every
-// derived count) would silently stop at the first thousand children.
+// derived count) would silently stop at the first thousand children. A failed
+// page THROWS — a partial roster rendered as if complete would misreport who
+// is already in moto.
 async function fetchRosterStudents(): Promise<RosterStudent[]> {
   const students: RosterStudent[] = [];
   let page = 1;
@@ -175,7 +177,11 @@ async function fetchRosterStudents(): Promise<RosterStudent[]> {
       `/api/students?page=${page}&page_size=${ROSTER_PAGE_SIZE}`,
       { credentials: "include", cache: "no-store" },
     );
-    if (!response.ok) return students;
+    if (!response.ok) {
+      throw new Error(
+        `Kinderliste konnte nicht geladen werden (Seite ${page}, Status ${response.status})`,
+      );
+    }
     // The route wrapper wraps GET results, so the paginated list arrives as
     // { data: { data: [...], pagination } }.
     const payload = (await response.json()) as RosterStudentsPage;
@@ -241,10 +247,11 @@ export default function ClassListEntriesPage() {
   // beurteilen, welche Kinder einer Klasse schon erfasst sind und welche
   // fehlen. Nach jeder Eintrags-Änderung mit-revalidiert (Zuordnen ersetzt
   // einen Eintrag durch das reguläre Kind).
-  const { data: students, mutate: mutateStudents } = useSWRAuth(
-    "class-list-roster-students",
-    fetchRosterStudents,
-  );
+  const {
+    data: students,
+    error: studentsError,
+    mutate: mutateStudents,
+  } = useSWRAuth("class-list-roster-students", fetchRosterStudents);
   const [classFilter, setClassFilter] = useState("all");
 
   const [modal, setModal] = useState<
@@ -257,6 +264,10 @@ export default function ClassListEntriesPage() {
   const [form, setForm] = useState<EntryFormState>(EMPTY_FORM);
   const [modalError, setModalError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Das Zuordnungs-Ziel: bei genau einem Kandidaten vorbelegt, bei mehreren
+  // gleichnamigen Kindern MUSS die Person bewusst wählen — sonst könnte der
+  // Eintrag dem falschen Kind zugeschlagen und dabei gelöscht werden.
+  const [assignTarget, setAssignTarget] = useState<string | null>(null);
 
   const entryRows = useMemo(() => entries ?? [], [entries]);
   const duplicateCount = useMemo(
@@ -306,6 +317,7 @@ export default function ClassListEntriesPage() {
     setModal(null);
     setModalError(null);
     setForm(EMPTY_FORM);
+    setAssignTarget(null);
   };
 
   const openCreate = () => {
@@ -368,7 +380,7 @@ export default function ClassListEntriesPage() {
 
   const confirmAssign = async () => {
     if (modal?.kind !== "assign") return;
-    const studentId = modal.entry.matchingStudentIds[0];
+    const studentId = assignTarget;
     if (!studentId) return;
     setSaving(true);
     try {
@@ -466,6 +478,11 @@ export default function ClassListEntriesPage() {
                 size="compact"
                 onClick={() => {
                   setModalError(null);
+                  setAssignTarget(
+                    entry.matchingStudentIds.length === 1
+                      ? (entry.matchingStudentIds[0] ?? null)
+                      : null,
+                  );
                   setModal({ kind: "assign", entry });
                 }}
               >
@@ -587,6 +604,15 @@ export default function ClassListEntriesPage() {
             <Alert
               type="error"
               message="Die Klassenlisteneinträge konnten nicht geladen werden."
+            />
+          </div>
+        ) : null}
+
+        {studentsError ? (
+          <div className="mt-4">
+            <Alert
+              type="error"
+              message="Die regulär angelegten Kinder konnten nicht vollständig geladen werden. Die Liste ist unvollständig, bitte laden Sie die Seite neu."
             />
           </div>
         ) : null}
@@ -729,6 +755,7 @@ export default function ClassListEntriesPage() {
         title="Eintrag zuordnen"
         confirmText="Zuordnen"
         isConfirmLoading={saving}
+        isConfirmDisabled={!assignTarget}
       >
         {modal?.kind === "assign" ? (
           <div className="space-y-3">
@@ -742,6 +769,38 @@ export default function ClassListEntriesPage() {
               Klassenlisteneintrag entfernt — das Kind steht dann nur noch über
               seinen regulären Datensatz auf der Klassenliste.
             </p>
+            {modal.entry.matchingStudentIds.length > 1 ? (
+              <fieldset className="space-y-2">
+                <legend className="text-sm font-medium text-gray-900">
+                  Mehrere Kinder tragen diesen Namen in dieser Klasse. Bitte den
+                  richtigen Datensatz auswählen:
+                </legend>
+                {modal.entry.matchingStudentIds.map((studentId) => (
+                  <label
+                    key={studentId}
+                    className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700"
+                  >
+                    <span className="flex items-center gap-2">
+                      <input
+                        type="radio"
+                        name="assign-target"
+                        className="accent-moto-green"
+                        checked={assignTarget === studentId}
+                        onChange={() => setAssignTarget(studentId)}
+                      />
+                      Kind-Datensatz #{studentId}
+                    </span>
+                    <Link
+                      href={`/students/${studentId}`}
+                      target="_blank"
+                      className="text-xs font-medium text-gray-600 underline hover:text-gray-900"
+                    >
+                      Öffnen
+                    </Link>
+                  </label>
+                ))}
+              </fieldset>
+            ) : null}
             <p className="text-xs text-gray-500">
               Die Zuordnung passiert nie automatisch: Bitte nur bestätigen, wenn
               es sich wirklich um dasselbe Kind handelt.

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -13,6 +13,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
 import { Upload } from "lucide-react";
 import { Alert } from "~/components/ui/alert";
 import { BackButton } from "~/components/ui/back-button";
@@ -32,6 +33,7 @@ import {
   updateClassListEntry,
   type ClassListEntry,
 } from "~/lib/class-list-entries-api";
+import { hasPermission } from "~/lib/auth-utils";
 import { createLogger } from "~/lib/logger";
 import type { Student } from "~/lib/student-helpers";
 import { useSWRAuth } from "~/lib/swr";
@@ -164,6 +166,14 @@ function rowSortKey(row: RosterRow): string {
 
 export default function ClassListEntriesPage() {
   const toast = useToast();
+  const { data: session } = useSession();
+  // Mirror the backend route gates (api/classlistentries): create needs
+  // users:create (der Sammelimport ebenso), edit users:update, delete und
+  // Zuordnen users:delete. Ohne das Recht gibt es keinen Einstieg in den
+  // Dialog — der Backend-403 bleibt Defense-in-Depth, keine UX.
+  const canCreate = hasPermission(session, "users:create");
+  const canUpdate = hasPermission(session, "users:update");
+  const canDelete = hasPermission(session, "users:delete");
   const {
     data: entries,
     error: loadError,
@@ -399,10 +409,11 @@ export default function ClassListEntriesPage() {
             </div>
           );
         }
+        if (!canUpdate && !canDelete) return null;
         const entry = row.entry;
         return (
           <div className="flex items-center justify-end gap-1">
-            {entry.matchingStudentIds.length > 0 && (
+            {canDelete && entry.matchingStudentIds.length > 0 && (
               <Button
                 type="button"
                 variant="ghost"
@@ -420,26 +431,30 @@ export default function ClassListEntriesPage() {
                 Zuordnen
               </Button>
             )}
-            <Button
-              type="button"
-              variant="ghost"
-              size="compact"
-              onClick={() => openEdit(entry)}
-            >
-              Bearbeiten
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="compact"
-              className="text-[#DC2626] hover:text-[#DC2626]"
-              onClick={() => {
-                setModalError(null);
-                setModal({ kind: "delete", entry });
-              }}
-            >
-              Löschen
-            </Button>
+            {canUpdate && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="compact"
+                onClick={() => openEdit(entry)}
+              >
+                Bearbeiten
+              </Button>
+            )}
+            {canDelete && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="compact"
+                className="text-[#DC2626] hover:text-[#DC2626]"
+                onClick={() => {
+                  setModalError(null);
+                  setModal({ kind: "delete", entry });
+                }}
+              >
+                Löschen
+              </Button>
+            )}
           </div>
         );
       },
@@ -467,24 +482,26 @@ export default function ClassListEntriesPage() {
               <span className="font-medium">Sammelimport</span> ergänzt.
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Link
-              href="/database/students/class-list/import"
-              className="flex h-9 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            >
-              <Upload className="h-4 w-4" aria-hidden="true" />
-              Sammelimport
-            </Link>
-            <Button
-              type="button"
-              variant="primary"
-              size="md"
-              className="h-9"
-              onClick={openCreate}
-            >
-              Eintrag anlegen
-            </Button>
-          </div>
+          {canCreate && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Link
+                href="/database/students/class-list/import"
+                className="flex h-9 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                <Upload className="h-4 w-4" aria-hidden="true" />
+                Sammelimport
+              </Link>
+              <Button
+                type="button"
+                variant="primary"
+                size="md"
+                className="h-9"
+                onClick={openCreate}
+              >
+                Eintrag anlegen
+              </Button>
+            </div>
+          )}
         </div>
 
         <div className="mt-4 grid grid-cols-2 gap-2 sm:max-w-2xl sm:grid-cols-5">
@@ -594,14 +611,16 @@ export default function ClassListEntriesPage() {
                 }
                 description="Legen Sie Kinder ohne OGS-Betreuung mit Name und Klasse an, damit Klassenlisten den vollständigen Klassenverband zeigen."
                 action={
-                  <Button
-                    type="button"
-                    variant="primary"
-                    size="md"
-                    onClick={openCreate}
-                  >
-                    Eintrag anlegen
-                  </Button>
+                  canCreate ? (
+                    <Button
+                      type="button"
+                      variant="primary"
+                      size="md"
+                      onClick={openCreate}
+                    >
+                      Eintrag anlegen
+                    </Button>
+                  ) : undefined
                 }
               />
             }

--- a/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/class-list/page.tsx
@@ -56,75 +56,6 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : "Unbekannter Fehler";
 }
 
-function EntryFormFields({
-  form,
-  onChange,
-  classSuggestions,
-}: Readonly<{
-  form: EntryFormState;
-  onChange: (next: EntryFormState) => void;
-  classSuggestions: string[];
-}>) {
-  return (
-    <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div>
-          <label
-            htmlFor="entry-first-name"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            Vorname
-          </label>
-          <Input
-            id="entry-first-name"
-            value={form.firstName}
-            onChange={(e) => onChange({ ...form, firstName: e.target.value })}
-            placeholder="z.B. Lena"
-          />
-        </div>
-        <div>
-          <label
-            htmlFor="entry-last-name"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            Nachname
-          </label>
-          <Input
-            id="entry-last-name"
-            value={form.lastName}
-            onChange={(e) => onChange({ ...form, lastName: e.target.value })}
-            placeholder="z.B. Beispiel"
-          />
-        </div>
-      </div>
-      <div>
-        <label
-          htmlFor="entry-school-class"
-          className="mb-1 block text-sm font-medium text-gray-700"
-        >
-          Klasse
-        </label>
-        <Input
-          id="entry-school-class"
-          value={form.schoolClass}
-          onChange={(e) => onChange({ ...form, schoolClass: e.target.value })}
-          placeholder="z.B. 1a"
-          list="class-list-class-suggestions"
-        />
-        <datalist id="class-list-class-suggestions">
-          {classSuggestions.map((klass) => (
-            <option key={klass} value={klass} />
-          ))}
-        </datalist>
-        <p className="mt-1 text-xs text-gray-500">
-          Genau wie bei den regulären Kindern geschrieben, damit der Eintrag in
-          derselben Klassenliste landet.
-        </p>
-      </div>
-    </div>
-  );
-}
-
 async function fetchClassSuggestions(): Promise<string[]> {
   const response = await fetch("/api/students/school-classes", {
     credentials: "include",
@@ -689,11 +620,66 @@ export default function ClassListEntriesPage() {
       >
         <div className="space-y-4">
           {modalError ? <Alert type="error" message={modalError} /> : null}
-          <EntryFormFields
-            form={form}
-            onChange={setForm}
-            classSuggestions={classSuggestions ?? []}
-          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label
+                htmlFor="entry-first-name"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Vorname
+              </label>
+              <Input
+                id="entry-first-name"
+                value={form.firstName}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, firstName: e.target.value }))
+                }
+                placeholder="z.B. Lena"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="entry-last-name"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Nachname
+              </label>
+              <Input
+                id="entry-last-name"
+                value={form.lastName}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, lastName: e.target.value }))
+                }
+                placeholder="z.B. Beispiel"
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="entry-school-class"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              Klasse
+            </label>
+            <Input
+              id="entry-school-class"
+              value={form.schoolClass}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, schoolClass: e.target.value }))
+              }
+              placeholder="z.B. 1a"
+              list="class-list-class-suggestions"
+            />
+            <datalist id="class-list-class-suggestions">
+              {(classSuggestions ?? []).map((klass) => (
+                <option key={klass} value={klass} />
+              ))}
+            </datalist>
+            <p className="mt-1 text-xs text-gray-500">
+              Genau wie bei den regulären Kindern geschrieben, damit der Eintrag
+              in derselben Klassenliste landet.
+            </p>
+          </div>
           <div className="flex justify-end gap-2 border-t border-gray-100 pt-4">
             <Button
               type="button"

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -417,6 +417,7 @@ function StudentsPageContent() {
 
   const canShowDetail = !loading && filteredStudents.length > 0;
   const canViewEnrollments = hasPermission(session, "config:manage");
+  const canCreateStudents = hasPermission(session, "users:create");
   const canDeleteStudents = hasPermission(session, "users:delete");
   const canUpdateStudents = hasPermission(session, "users:update");
 
@@ -590,7 +591,11 @@ function StudentsPageContent() {
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
         onCreate={handleCreateStudent}
-        onCreateListEntry={handleCreateListEntry}
+        // Same gate as POST /api/class-list-entries (users:create) — without
+        // the permission the modal must not offer the "Nur Klassenliste" mode.
+        onCreateListEntry={
+          canCreateStudents ? handleCreateListEntry : undefined
+        }
         groups={allGroups}
       />
 

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -36,6 +36,7 @@ import type { StudentGuardianPayload } from "@/lib/guardian-helpers";
 import { useSWRAuth, useTenantMutate } from "~/lib/swr";
 import { createLogger } from "~/lib/logger";
 import { hasPermission } from "~/lib/auth-utils";
+import { createClassListEntry } from "~/lib/class-list-entries-api";
 import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils";
 import { MasterDetailSkeleton } from "~/components/database/master-detail-skeleton";
@@ -276,6 +277,23 @@ function StudentsPageContent() {
     }
     return chips;
   }, [searchTerm, groupFilter, allGroups]);
+
+  // Class-list-only entry (#2382): created straight from the "+ Kinder"
+  // modal's "Nur Klassenliste" mode. The entry does NOT appear in this list
+  // (it is no student) — the toast says where it lives instead.
+  const handleCreateListEntry = useCallback(
+    async (input: {
+      firstName: string;
+      lastName: string;
+      schoolClass: string;
+    }) => {
+      await createClassListEntry(input);
+      toastSuccess(
+        "Klassenlisteneintrag angelegt — zu finden im Menü oben rechts unter Klassenliste",
+      );
+    },
+    [toastSuccess],
+  );
 
   const handleCreateStudent = useCallback(
     async (
@@ -572,6 +590,7 @@ function StudentsPageContent() {
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
         onCreate={handleCreateStudent}
+        onCreateListEntry={handleCreateListEntry}
         groups={allGroups}
       />
 

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { redirect, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { ListChecks, Trash2 } from "lucide-react";
+import { ClipboardList, GraduationCap, ListChecks, Trash2 } from "lucide-react";
 import { DatabaseCreateAction } from "~/components/database/database-create-action";
 import { DatabaseEmptyState } from "~/components/database/database-empty-state";
 import { DatabaseGroupingToggle } from "~/components/database/database-grouping-toggle";
@@ -445,6 +445,28 @@ function StudentsPageContent() {
             setSearchTerm("");
             setGroupFilter("all");
           }}
+          // Sekundäre Navigationsziele (Jahrgangswechsel, Klassenliste) liegen
+          // im Kebab-Menü: als vierter und fünfter Textbutton sprengten sie
+          // die Aktionszeile auf üblichen Laptop-Breiten (#2382 Review).
+          overflowMenu={[
+            ...(hasPermission(session, "grade_transitions:read")
+              ? [
+                  {
+                    label: "Jahrgangswechsel",
+                    icon: <GraduationCap className="h-4 w-4" aria-hidden />,
+                    href: "/database/grade-transitions",
+                    // Navigation only — OverflowMenu verlangt onClick auch bei href.
+                    onClick: () => undefined,
+                  },
+                ]
+              : []),
+            {
+              label: "Klassenliste",
+              icon: <ClipboardList className="h-4 w-4" aria-hidden />,
+              href: "/database/students/class-list",
+              onClick: () => undefined,
+            },
+          ]}
           actionButton={
             <div className="flex items-center gap-2">
               {!isMobile ? (
@@ -454,20 +476,6 @@ function StudentsPageContent() {
                     options={STUDENTS_GROUPING_OPTIONS}
                     onChange={handleGroupingChange}
                   />
-                  {hasPermission(session, "grade_transitions:read") && (
-                    <Link
-                      href="/database/grade-transitions"
-                      className="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                    >
-                      Jahrgangswechsel
-                    </Link>
-                  )}
-                  <Link
-                    href="/database/students/class-list"
-                    className="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                  >
-                    Klassenliste
-                  </Link>
                   <Link
                     href="/database/students/import"
                     className="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"

--- a/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/database/students/page.tsx
@@ -463,6 +463,12 @@ function StudentsPageContent() {
                     </Link>
                   )}
                   <Link
+                    href="/database/students/class-list"
+                    className="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    Klassenliste
+                  </Link>
+                  <Link
                     href="/database/students/import"
                     className="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
                   >

--- a/frontend/src/app/[tenant]/(protected)/klassen/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/klassen/page.tsx
@@ -231,6 +231,9 @@ function ClassCard({
             <>
               <Stat label="Bleiben" value={totals.staying} />
               <Stat label="Gehen heim" value={totals.leaving} />
+              {totals.list_entries > 0 && (
+                <Stat label="Keine Betreuung" value={totals.list_entries} />
+              )}
               <Stat label="Abgemeldet" value={totals.absent} />
             </>
           )}
@@ -370,7 +373,17 @@ export default function KlassenPage() {
     [report],
   );
   const leaving = useMemo(
-    () => report?.rows.filter((row) => !row.stays_today && !row.status) ?? [],
+    () =>
+      report?.rows.filter(
+        (row) => !row.stays_today && !row.status && !row.list_entry,
+      ) ?? [],
+    [report],
+  );
+  // Klassenlisteneinträge (#2382): "Keine Betreuung" ist eine neutrale
+  // Verbands-Aussage, kein "geht nach Hause" — eigene Sektion statt der
+  // Übergabe-Kategorien.
+  const noCare = useMemo(
+    () => report?.rows.filter((row) => row.list_entry) ?? [],
     [report],
   );
   const absent = useMemo(
@@ -568,6 +581,13 @@ export default function KlassenPage() {
                       count={leaving.length}
                       rows={leaving}
                     />
+                    {noCare.length > 0 && (
+                      <Section
+                        title="Keine Betreuung"
+                        count={noCare.length}
+                        rows={noCare}
+                      />
+                    )}
                     <Section
                       title="Abgemeldet"
                       count={absent.length}

--- a/frontend/src/app/[tenant]/(protected)/klassen/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/klassen/page.tsx
@@ -75,6 +75,10 @@ function Stat({ label, value }: Readonly<{ label: string; value: number }>) {
 }
 
 function rowDetailLine(row: ClassDayRow, enrollmentKnown: boolean): string {
+  // Klassenlisteneintrag (#2382): "Keine Betreuung" ist die ganze Aussage —
+  // das Badge rechts trägt sie, die Detailzeile bleibt leer (keine erfundene
+  // Gehregel, keine Abholzeit).
+  if (row.list_entry) return "";
   const parts: string[] = [];
   if (row.stays_today && row.offerings.length > 0) {
     parts.push(row.offerings.join(", "));
@@ -111,6 +115,14 @@ function StudentRow({
           <span className="text-xs font-medium text-gray-600 tabular-nums">
             bis {row.pickup}
           </span>
+        ) : null}
+        {/* Klassenlisteneintrag (#2382): Kind ohne OGS-Datensatz — eindeutig
+            als "Keine Betreuung" gekennzeichnet, unabhängig von Anmeldephasen. */}
+        {row.list_entry ? (
+          <StatusDotBadge
+            label="Keine Betreuung"
+            color={LOCATION_COLORS.HOME}
+          />
         ) : null}
         {row.status ? (
           <StatusDotBadge
@@ -149,7 +161,8 @@ function Section({
       <ul className="grid gap-1.5 lg:grid-cols-2">
         {rows.map((row) => (
           <StudentRow
-            key={row.student_id}
+            // Klassenlisteneinträge haben student_id 0 — eigener Key-Raum.
+            key={row.list_entry ? `entry-${row.list_entry_id}` : row.student_id}
             row={row}
             enrollmentKnown={enrollmentKnown}
           />

--- a/frontend/src/app/api/class-list-entries/[id]/assign/route.ts
+++ b/frontend/src/app/api/class-list-entries/[id]/assign/route.ts
@@ -1,0 +1,8 @@
+import { proxyPost } from "~/lib/route-proxy.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+// Klassenlisteneintrag bewusst einem regulären Kind zuordnen (#2382): löscht
+// die Dublette aus der Klassenliste. users:delete — erzwingt das Backend.
+export const POST = proxyPost(
+  (p) => `/api/class-list-entries/${requirePathSegmentParam(p)}/assign`,
+);

--- a/frontend/src/app/api/class-list-entries/[id]/route.ts
+++ b/frontend/src/app/api/class-list-entries/[id]/route.ts
@@ -1,0 +1,12 @@
+import { proxyDelete, proxyPut } from "~/lib/route-proxy.server";
+import { requirePathSegmentParam } from "~/lib/route-wrapper-utils.server";
+
+// Klassenlisteneintrag bearbeiten/löschen (#2382): Ändern users:update,
+// Löschen users:delete — beides erzwingt das Backend.
+export const PUT = proxyPut(
+  (p) => `/api/class-list-entries/${requirePathSegmentParam(p)}`,
+);
+
+export const DELETE = proxyDelete(
+  (p) => `/api/class-list-entries/${requirePathSegmentParam(p)}`,
+);

--- a/frontend/src/app/api/class-list-entries/route.ts
+++ b/frontend/src/app/api/class-list-entries/route.ts
@@ -1,0 +1,7 @@
+import { proxyGet, proxyPost } from "~/lib/route-proxy.server";
+
+// Klassenlisteneinträge (#2382): Kinder ohne OGS-Datensatz, nur Name +
+// Klasse. Lesen users:read, Anlegen users:create — beides erzwingt das
+// Backend.
+export const GET = proxyGet("/api/class-list-entries/");
+export const POST = proxyPost("/api/class-list-entries/");

--- a/frontend/src/app/api/import/class-list-entries/import/route.ts
+++ b/frontend/src/app/api/import/class-list-entries/import/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "ClassListImportRoute" });
+
+async function POSTHandler(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await request.formData();
+
+    const response = await fetch(
+      `${getServerApiUrl()}/api/import/class-list-entries/import`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.user.token}`,
+        },
+        body: formData,
+      },
+    );
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    logger.error("class_list_import_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const POST = withTenantAuth(POSTHandler);

--- a/frontend/src/app/api/import/class-list-entries/preview/route.ts
+++ b/frontend/src/app/api/import/class-list-entries/preview/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "ClassListPreviewRoute" });
+
+async function POSTHandler(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await request.formData();
+
+    const response = await fetch(
+      `${getServerApiUrl()}/api/import/class-list-entries/preview`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.user.token}`,
+        },
+        body: formData,
+      },
+    );
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    logger.error("class_list_preview_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const POST = withTenantAuth(POSTHandler);

--- a/frontend/src/app/api/import/class-list-entries/template/route.ts
+++ b/frontend/src/app/api/import/class-list-entries/template/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { auth } from "~/server/auth";
+import { withTenantAuth } from "~/server/auth/tenant-route";
+import { getServerApiUrl } from "~/lib/server-api-url";
+import { createLogger } from "~/lib/logger";
+
+const logger = createLogger({ component: "ClassListTemplateRoute" });
+
+async function GETHandler(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const format = searchParams.get("format") ?? "csv";
+
+    const response = await fetch(
+      `${getServerApiUrl()}/api/import/class-list-entries/template?format=${format}`,
+      {
+        headers: {
+          Authorization: `Bearer ${session.user.token}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      return NextResponse.json(
+        { error: error || "Failed to download template" },
+        { status: response.status },
+      );
+    }
+
+    const contentType =
+      response.headers.get("Content-Type") ?? "text/csv; charset=utf-8";
+    const contentDisposition =
+      response.headers.get("Content-Disposition") ??
+      'attachment; filename="klassenliste-import-vorlage.csv"';
+
+    const blob = await response.blob();
+    return new NextResponse(blob, {
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": contentDisposition,
+      },
+    });
+  } catch (error) {
+    logger.error("template_download_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = withTenantAuth(GETHandler);

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.ts
@@ -99,6 +99,8 @@ const subPageLabels: Record<string, string> = {
   details: "Details",
   permissions: "Berechtigungen",
   "opening-balances": "Eröffnungssalden",
+  // Klassenlisteneinträge (#2382): Kinder ohne OGS-Datensatz.
+  "class-list": "Klassenliste",
 };
 
 /**

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1325,9 +1325,9 @@ export const appChapters: readonly GuideChapter[] = [
         summary:
           "Kinder, die nicht im Ganztag sind, fehlen sonst auf Klassenlisten. Ein Klassenlisteneintrag besteht nur aus Name und Klasse und vervollständigt den Klassenverband — ohne Betreuung, Anwesenheit oder Kontaktdaten.",
         steps: [
-          "`Datenverwaltung` -> `Kinder` öffnen und oben rechts im Menü mit den drei Punkten `Klassenliste` wählen.",
-          "`Eintrag anlegen` wählen und Vorname, Nachname und Klasse eintragen. Die Klasse genauso schreiben wie bei den regulären Kindern, damit der Eintrag in derselben Klassenliste landet.",
-          "Für ganze Klassen den `Sammelimport` nutzen: Vorlage mit den Spalten `Vorname`, `Nachname`, `Klasse` herunterladen, ausfüllen und hochladen. Bereits angelegte Kinder werden übersprungen.",
+          "`Datenverwaltung` -> `Kinder` -> `+ Kinder` wählen und oben im Fenster auf `Nur Klassenliste` umschalten. Vorname, Nachname und Klasse eintragen — die Klasse genauso schreiben wie bei den regulären Kindern, damit der Eintrag in derselben Klassenliste landet.",
+          "Alle Einträge verwalten: auf der Kinder-Seite oben rechts im Menü mit den drei Punkten `Klassenliste` wählen.",
+          "Für ganze Klassen dort den `Sammelimport` nutzen: Vorlage mit den Spalten `Vorname`, `Nachname`, `Klasse` herunterladen, ausfüllen und hochladen. Bereits angelegte Kinder werden übersprungen.",
           "Die Einträge erscheinen auf den Klassenlisten-Exporten und in der `Klassenansicht` der Lehrkräfte, deutlich gekennzeichnet als `Keine Betreuung`. In Kindersuche, Anwesenheit, Betreuungsplanung und Elternportal tauchen sie nicht auf.",
           "Über `Bearbeiten` lässt sich ein Eintrag in eine andere Klasse verschieben, über `Löschen` entfernen.",
           "Wird das Kind später regulär angelegt (z. B. über eine Anmeldung oder den Import), zeigt die Liste `Mögliche Dublette`. Mit `Zuordnen` bestätigen Sie, dass es dasselbe Kind ist — der Eintrag wird entfernt, das Kind steht nur noch über seinen regulären Datensatz auf der Liste. Das passiert nie automatisch, damit gleichnamige Kinder nicht verwechselt werden.",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1326,7 +1326,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Kinder, die nicht im Ganztag sind, fehlen sonst auf Klassenlisten. Ein Klassenlisteneintrag besteht nur aus Name und Klasse und vervollständigt den Klassenverband — ohne Betreuung, Anwesenheit oder Kontaktdaten.",
         steps: [
           "`Datenverwaltung` -> `Kinder` -> `+ Kinder` wählen und oben im Fenster auf `Nur Klassenliste` umschalten. Vorname, Nachname und Klasse eintragen — die Klasse genauso schreiben wie bei den regulären Kindern, damit der Eintrag in derselben Klassenliste landet.",
-          "Alle Einträge verwalten: auf der Kinder-Seite oben rechts im Menü mit den drei Punkten `Klassenliste` wählen.",
+          "Den Überblick gibt die Klassenlisten-Seite: auf der Kinder-Seite oben rechts im Menü mit den drei Punkten `Klassenliste` wählen. Sie zeigt den vollständigen Klassenverband — regulär angelegte Kinder (`In moto angelegt`) und Klassenlisteneinträge (`Keine Betreuung`) — und über den Klassenfilter ist sofort sichtbar, wer in einer Klasse noch fehlt.",
           "Für ganze Klassen dort den `Sammelimport` nutzen: Vorlage mit den Spalten `Vorname`, `Nachname`, `Klasse` herunterladen, ausfüllen und hochladen. Bereits angelegte Kinder werden übersprungen.",
           "Die Einträge erscheinen auf den Klassenlisten-Exporten und in der `Klassenansicht` der Lehrkräfte, deutlich gekennzeichnet als `Keine Betreuung`. In Kindersuche, Anwesenheit, Betreuungsplanung und Elternportal tauchen sie nicht auf.",
           "Über `Bearbeiten` lässt sich ein Eintrag in eine andere Klasse verschieben, über `Löschen` entfernen.",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -959,7 +959,7 @@ export const appChapters: readonly GuideChapter[] = [
         steps: [
           "In der Datenverwaltung unter `Personal` die Lehrkraft mit der System-Rolle `Lehrkraft` anlegen bzw. einladen.",
           "Unter `Mitarbeiter` das Profil der Lehrkraft öffnen und im Reiter `Klassen` die betreuten Schulklassen zuweisen (z. B. `1a`). Die Schreibweise muss zur Klasse der Kinder passen; Groß-/Kleinschreibung spielt keine Rolle.",
-          "Die Lehrkraft meldet sich mit ihrem eigenen Konto an und landet direkt in der `Klassenansicht`: pro Tag der volle Klassenverband mit Kennzeichnung, wer in Randstunde oder Ganztag bleibt, wer nach Hause geht (und wie) und wer krank oder entschuldigt gemeldet ist.",
+          "Die Lehrkraft meldet sich mit ihrem eigenen Konto an und landet direkt in der `Klassenansicht`: pro Tag der volle Klassenverband mit Kennzeichnung, wer in Randstunde oder Ganztag bleibt, wer nach Hause geht (und wie) und wer krank oder entschuldigt gemeldet ist. Kinder ohne OGS-Datensatz erscheinen als Klassenlisteneinträge mit dem Vermerk `Keine Betreuung` (siehe `Datenverwaltung`).",
           "Mehr sieht die Lehrkraft nicht: keinen Bereich Alle Kinder, keine Stammdaten, keine Kontaktdaten der Sorgeberechtigten. Zugriffe auf die Ansicht werden im Zugriffsprotokoll vermerkt.",
         ],
         callout: {
@@ -1320,6 +1320,27 @@ export const appChapters: readonly GuideChapter[] = [
         image: "/help/screens/datenverwaltung.webp",
       },
       {
+        id: "klassenlisteneintraege",
+        title: "Klassenlisteneinträge: Kinder ohne OGS-Betreuung",
+        summary:
+          "Kinder, die nicht im Ganztag sind, fehlen sonst auf Klassenlisten. Ein Klassenlisteneintrag besteht nur aus Name und Klasse und vervollständigt den Klassenverband — ohne Betreuung, Anwesenheit oder Kontaktdaten.",
+        steps: [
+          "`Datenverwaltung` -> `Kinder` -> `Klassenliste` öffnen.",
+          "`Eintrag anlegen` wählen und Vorname, Nachname und Klasse eintragen. Die Klasse genauso schreiben wie bei den regulären Kindern, damit der Eintrag in derselben Klassenliste landet.",
+          "Für ganze Klassen den `Sammelimport` nutzen: Vorlage mit den Spalten `Vorname`, `Nachname`, `Klasse` herunterladen, ausfüllen und hochladen. Bereits angelegte Kinder werden übersprungen.",
+          "Die Einträge erscheinen auf den Klassenlisten-Exporten und in der `Klassenansicht` der Lehrkräfte, deutlich gekennzeichnet als `Keine Betreuung`. In Kindersuche, Anwesenheit, Betreuungsplanung und Elternportal tauchen sie nicht auf.",
+          "Über `Bearbeiten` lässt sich ein Eintrag in eine andere Klasse verschieben, über `Löschen` entfernen.",
+          "Wird das Kind später regulär angelegt (z. B. über eine Anmeldung oder den Import), zeigt die Liste `Mögliche Dublette`. Mit `Zuordnen` bestätigen Sie, dass es dasselbe Kind ist — der Eintrag wird entfernt, das Kind steht nur noch über seinen regulären Datensatz auf der Liste. Das passiert nie automatisch, damit gleichnamige Kinder nicht verwechselt werden.",
+        ],
+        callout: {
+          title: "Kein zweiter Kinder-Datensatz",
+          body: "Ein Klassenlisteneintrag ist bewusst kein Kind-Datensatz: Er kann nicht eingecheckt, nicht verplant und nicht mit Sorgeberechtigten verknüpft werden. Braucht das Kind Betreuung, legen Sie es regulär unter `Kinder` an.",
+          tone: "blue",
+        },
+        screenshot:
+          "Verwaltung der Klassenlisteneinträge mit Tabelle nach Klassen, Kennzeichnung Keine Betreuung und Hinweis auf mögliche Dubletten.",
+      },
+      {
         id: "kind-dauerhaft-loeschen",
         title: "Kind dauerhaft löschen",
         summary:
@@ -1418,7 +1439,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Bei einer Phase auf `Anmeldungen ansehen` klicken, um die eingegangenen Anmeldungen zu prüfen.",
           "Mit `Status`, `Berücksichtigte Angebote`, `Anzahl Betreuungstage`, `Zielklasse`, `Wochentag`, `Gehzeit` oder der Suche die Tabelle auf die Kinder eingrenzen, die du brauchst.",
           "Die Kennzahlen über der Tabelle zeigen, wie viele Kinder an einem, zwei, drei, vier oder fünf Tagen betreut werden. Die Karte `Einsatzplanung` zeigt zusätzlich, wie viele Kinder je Wochentag bis zu welcher Gehzeit bleiben.",
-          "Für Klassenlehrkräfte unter `Klasse für Klassenliste` den Klassenverband wählen und `Klassenliste exportieren` nutzen. Mit `Alle Klassen` erhältst du alle Klassenlisten in einer Datei, sauber getrennt mit eigener Überschrift je Klasse (im PDF auf einer neuen Seite). Die Liste enthält den gesamten Klassenverband, auch Kinder ohne bestätigte Anmeldung, und zeigt pro Wochentag die Gehzeit des Kindes (aus dem Gehplan, einschließlich einer am Betreuungsangebot hinterlegten Gehzeit), ersatzweise die Abholzeit aus dem Anmeldeformular oder das gebuchte Betreuungsangebot (sonst `Keine Abholzeit`), jeweils zusammen mit der Geh-/Abholregelung des Tages (z. B. `14:30 Uhr, wird abgeholt`), und `—` ohne Betreuung, plus Kontaktdaten der Erziehungsberechtigten.",
+          "Für Klassenlehrkräfte unter `Klasse für Klassenliste` den Klassenverband wählen und `Klassenliste exportieren` nutzen. Mit `Alle Klassen` erhältst du alle Klassenlisten in einer Datei, sauber getrennt mit eigener Überschrift je Klasse (im PDF auf einer neuen Seite). Die Liste enthält den gesamten Klassenverband, auch Kinder ohne bestätigte Anmeldung, und zeigt pro Wochentag die Gehzeit des Kindes (aus dem Gehplan, einschließlich einer am Betreuungsangebot hinterlegten Gehzeit), ersatzweise die Abholzeit aus dem Anmeldeformular oder das gebuchte Betreuungsangebot (sonst `Keine Abholzeit`), jeweils zusammen mit der Geh-/Abholregelung des Tages (z. B. `14:30 Uhr, wird abgeholt`), und `—` ohne Betreuung, plus Kontaktdaten der Erziehungsberechtigten. Auch Klassenlisteneinträge (Kinder ohne OGS-Datensatz, siehe `Datenverwaltung`) stehen mit dem Zusatz `Keine Betreuung` in ihrer Klasse.",
           "Eine Anmeldung öffnen und Kind, erziehungsberechtigte Personen (Hauptkontakt und weitere erziehungsberechtigte Personen), gewähltes Betreuungsangebot und Formularangaben prüfen.",
           "Wenn eine Familie nach der Frist nachgereicht hat, erscheint die Anmeldung nach Nutzung des Nachzügler-Links ganz normal in dieser Liste. Bei der manuellen Freigabe ist das Kind bereits bestätigt; prüfe anschließend bei Bedarf den Statuslink oder die Kinddetailseite.",
           "Mit `Bestätigen`, `Warteliste` oder `Ablehnen` entscheiden; mit `Zur Prüfung` für später vormerken. Ist die Warteliste in den Einstellungen deaktiviert, wird diese Aktion nicht angeboten. Nach einer Bestätigung lässt sich eine erziehungsberechtigte Person bei Bedarf in der Kinddetailseite manuell einladen oder erneut einladen.",

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1325,7 +1325,7 @@ export const appChapters: readonly GuideChapter[] = [
         summary:
           "Kinder, die nicht im Ganztag sind, fehlen sonst auf Klassenlisten. Ein Klassenlisteneintrag besteht nur aus Name und Klasse und vervollständigt den Klassenverband — ohne Betreuung, Anwesenheit oder Kontaktdaten.",
         steps: [
-          "`Datenverwaltung` -> `Kinder` -> `Klassenliste` öffnen.",
+          "`Datenverwaltung` -> `Kinder` öffnen und oben rechts im Menü mit den drei Punkten `Klassenliste` wählen.",
           "`Eintrag anlegen` wählen und Vorname, Nachname und Klasse eintragen. Die Klasse genauso schreiben wie bei den regulären Kindern, damit der Eintrag in derselben Klassenliste landet.",
           "Für ganze Klassen den `Sammelimport` nutzen: Vorlage mit den Spalten `Vorname`, `Nachname`, `Klasse` herunterladen, ausfüllen und hochladen. Bereits angelegte Kinder werden übersprungen.",
           "Die Einträge erscheinen auf den Klassenlisten-Exporten und in der `Klassenansicht` der Lehrkräfte, deutlich gekennzeichnet als `Keine Betreuung`. In Kindersuche, Anwesenheit, Betreuungsplanung und Elternportal tauchen sie nicht auf.",

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -446,7 +446,7 @@ export function StudentCreateModal({
                       htmlFor="list-entry-first-name"
                       className="mb-1 block text-xs font-medium text-gray-700 md:text-sm"
                     >
-                      Vorname <span className="text-[#DC2626]">*</span>
+                      Vorname <span className="text-moto-red">*</span>
                     </label>
                     <Input
                       id="list-entry-first-name"
@@ -457,7 +457,7 @@ export function StudentCreateModal({
                       placeholder="Max"
                     />
                     {errors.first_name ? (
-                      <p className="mt-1 text-xs text-[#DC2626]">
+                      <p className="text-moto-red mt-1 text-xs">
                         {errors.first_name}
                       </p>
                     ) : null}
@@ -467,7 +467,7 @@ export function StudentCreateModal({
                       htmlFor="list-entry-last-name"
                       className="mb-1 block text-xs font-medium text-gray-700 md:text-sm"
                     >
-                      Nachname <span className="text-[#DC2626]">*</span>
+                      Nachname <span className="text-moto-red">*</span>
                     </label>
                     <Input
                       id="list-entry-last-name"
@@ -478,7 +478,7 @@ export function StudentCreateModal({
                       placeholder="Mustermann"
                     />
                     {errors.second_name ? (
-                      <p className="mt-1 text-xs text-[#DC2626]">
+                      <p className="text-moto-red mt-1 text-xs">
                         {errors.second_name}
                       </p>
                     ) : null}
@@ -488,7 +488,7 @@ export function StudentCreateModal({
                       htmlFor="list-entry-school-class"
                       className="mb-1 block text-xs font-medium text-gray-700 md:text-sm"
                     >
-                      Klasse <span className="text-[#DC2626]">*</span>
+                      Klasse <span className="text-moto-red">*</span>
                     </label>
                     <Input
                       id="list-entry-school-class"
@@ -499,7 +499,7 @@ export function StudentCreateModal({
                       placeholder="5A"
                     />
                     {errors.school_class ? (
-                      <p className="mt-1 text-xs text-[#DC2626]">
+                      <p className="text-moto-red mt-1 text-xs">
                         {errors.school_class}
                       </p>
                     ) : (

--- a/frontend/src/components/students/student-create-modal.tsx
+++ b/frontend/src/components/students/student-create-modal.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useRef } from "react";
 import { Plus, Search, Trash2 } from "lucide-react";
 import { MotoConceptIcon } from "~/components/ui/moto-concept-icon";
 import { Modal } from "~/components/ui/modal";
+import { Input } from "~/components/ui/input";
+import { SegmentedControl } from "~/components/ui/segmented-control";
 import { useScrollToFirstError } from "~/lib/hooks/use-scroll-to-error";
 import type { Student } from "@/lib/api";
 import { PersonalInfoSection, DepartureSection } from "./student-form-fields";
@@ -132,6 +134,10 @@ export type CreateStudentSchedules = {
   pickup_schedules?: BackendPickupScheduleRequest[];
 };
 
+// The two things "+ Kinder" can create (#2382): a regular OGS child, or a
+// minimal class-list-only entry (Name + Klasse, "Keine Betreuung").
+type CreateMode = "student" | "list-entry";
+
 interface StudentCreateModalProps {
   readonly isOpen: boolean;
   readonly onClose: () => void;
@@ -140,6 +146,18 @@ interface StudentCreateModalProps {
       guardians?: StudentGuardianPayload[];
     } & CreateStudentSchedules,
   ) => Promise<void>;
+  /**
+   * Creates a class-list-only entry (#2382). When set, the modal offers the
+   * "Nur Klassenliste" mode switch — the admin's mental model is one entry
+   * point for "Kind erfassen", so the choice lives HERE, not on a page the
+   * user must know about beforehand. Optional: callers without the feature
+   * get the unchanged student form.
+   */
+  readonly onCreateListEntry?: (input: {
+    firstName: string;
+    lastName: string;
+    schoolClass: string;
+  }) => Promise<void>;
   readonly groups?: Array<{ readonly value: string; readonly label: string }>;
 }
 
@@ -149,8 +167,10 @@ export function StudentCreateModal({
   isOpen,
   onClose,
   onCreate,
+  onCreateListEntry,
   groups = EMPTY_GROUPS,
 }: StudentCreateModalProps) {
+  const [mode, setMode] = useState<CreateMode>("student");
   const [formData, setFormData] = useState<Partial<Student>>({
     first_name: "",
     second_name: "",
@@ -201,6 +221,7 @@ export function StudentCreateModal({
   // Reset form when modal opens/closes
   useEffect(() => {
     if (isOpen) {
+      setMode("student");
       setFormData({
         first_name: "",
         second_name: "",
@@ -293,6 +314,31 @@ export function StudentCreateModal({
   };
 
   const handleSubmit = (e: React.FormEvent) => {
+    // Class-list-only entry (#2382): three fields, one call — the same
+    // validation flags the student path uses (Vorname/Nachname/Klasse).
+    if (mode === "list-entry" && onCreateListEntry) {
+      e.preventDefault();
+      if (!validateForm()) {
+        scrollToError();
+        return;
+      }
+      setSaveLoading(true);
+      return onCreateListEntry({
+        firstName: (formData.first_name ?? "").trim(),
+        lastName: (formData.second_name ?? "").trim(),
+        schoolClass: (formData.school_class ?? "").trim(),
+      })
+        .then(() => onClose())
+        .catch((error: unknown) => {
+          setErrors({
+            submit:
+              error instanceof Error
+                ? error.message
+                : "Eintrag konnte nicht angelegt werden",
+          });
+        })
+        .finally(() => setSaveLoading(false));
+    }
     const payload: Partial<Student> & {
       guardians?: StudentGuardianPayload[];
     } & CreateStudentSchedules = { ...formData };
@@ -363,199 +409,313 @@ export function StudentCreateModal({
             </div>
           )}
 
-          {/* Personal Information */}
-          <PersonalInfoSection
-            formData={formData}
-            onChange={handleChange}
-            errors={errors}
-            groups={groups}
-          />
+          {/* Art des Eintrags (#2382): reguläres OGS-Kind oder minimaler
+              Klassenlisteneintrag. Die Weiche sitzt im Erstell-Modal, weil
+              "Kind erfassen" der eine Einstieg ist, den alle kennen. */}
+          {onCreateListEntry ? (
+            <SegmentedControl
+              ariaLabel="Art des Eintrags"
+              fullWidth
+              items={[
+                { value: "student", label: "Mit OGS-Betreuung" },
+                { value: "list-entry", label: "Nur Klassenliste" },
+              ]}
+              value={mode}
+              onChange={(next) => {
+                setMode(next);
+                setErrors({});
+              }}
+            />
+          ) : null}
 
-          {/* Guardian Information: add directly during creation. Styling
+          {mode === "list-entry" ? (
+            <div className="space-y-4">
+              <div className="border-moto-blue/20 bg-moto-blue-soft rounded-xl border p-3 text-xs leading-5 text-gray-700 md:p-4 md:text-sm">
+                Für Kinder, die nicht im Ganztag sind: Der Eintrag besteht nur
+                aus Name und Klasse und erscheint ausschließlich auf
+                Klassenlisten und in der Klassenansicht (
+                <span className="font-medium">Keine Betreuung</span>). Keine
+                Anwesenheit, keine Betreuungsplanung, keine Kontaktdaten.
+                Verwalten lässt sich die Liste über das Menü oben rechts unter{" "}
+                <span className="font-medium">Klassenliste</span>.
+              </div>
+              <div className="rounded-xl border border-gray-100 bg-gray-50 p-3 md:p-4">
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
+                  <div>
+                    <label
+                      htmlFor="list-entry-first-name"
+                      className="mb-1 block text-xs font-medium text-gray-700 md:text-sm"
+                    >
+                      Vorname <span className="text-[#DC2626]">*</span>
+                    </label>
+                    <Input
+                      id="list-entry-first-name"
+                      value={formData.first_name ?? ""}
+                      onChange={(e) =>
+                        handleChange("first_name", e.target.value)
+                      }
+                      placeholder="Max"
+                    />
+                    {errors.first_name ? (
+                      <p className="mt-1 text-xs text-[#DC2626]">
+                        {errors.first_name}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="list-entry-last-name"
+                      className="mb-1 block text-xs font-medium text-gray-700 md:text-sm"
+                    >
+                      Nachname <span className="text-[#DC2626]">*</span>
+                    </label>
+                    <Input
+                      id="list-entry-last-name"
+                      value={formData.second_name ?? ""}
+                      onChange={(e) =>
+                        handleChange("second_name", e.target.value)
+                      }
+                      placeholder="Mustermann"
+                    />
+                    {errors.second_name ? (
+                      <p className="mt-1 text-xs text-[#DC2626]">
+                        {errors.second_name}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="list-entry-school-class"
+                      className="mb-1 block text-xs font-medium text-gray-700 md:text-sm"
+                    >
+                      Klasse <span className="text-[#DC2626]">*</span>
+                    </label>
+                    <Input
+                      id="list-entry-school-class"
+                      value={formData.school_class ?? ""}
+                      onChange={(e) =>
+                        handleChange("school_class", e.target.value)
+                      }
+                      placeholder="5A"
+                    />
+                    {errors.school_class ? (
+                      <p className="mt-1 text-xs text-[#DC2626]">
+                        {errors.school_class}
+                      </p>
+                    ) : (
+                      <p className="mt-1 text-xs text-gray-500">
+                        Genau wie bei den regulären Kindern geschrieben.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {/* Personal Information */}
+          {mode === "student" ? (
+            <PersonalInfoSection
+              formData={formData}
+              onChange={handleChange}
+              errors={errors}
+              groups={groups}
+            />
+          ) : null}
+
+          {mode === "student" ? (
+            <>
+              {/* Guardian Information: add directly during creation. Styling
               matches the other modal sections (border-gray-100 + neutral
               surface) and reuses the guardian modal's own dashed add-button
               and red remove patterns. */}
-          <section
-            ref={guardianSectionRef}
-            aria-label="Erziehungsberechtigte"
-            className="scroll-mt-4 rounded-xl border border-gray-100 bg-gray-50 p-3 md:p-4"
-          >
-            <div className="mb-3 flex items-center justify-between md:mb-4">
-              <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
-                <MotoConceptIcon concept="groups" size={18} />
-                Erziehungsberechtigte
-              </h3>
-              <span className="text-xs text-gray-500">
-                {guardians.length > 0
-                  ? `${guardians.length} hinzugefügt`
-                  : "Optional"}
-              </span>
-            </div>
+              <section
+                ref={guardianSectionRef}
+                aria-label="Erziehungsberechtigte"
+                className="scroll-mt-4 rounded-xl border border-gray-100 bg-gray-50 p-3 md:p-4"
+              >
+                <div className="mb-3 flex items-center justify-between md:mb-4">
+                  <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
+                    <MotoConceptIcon concept="groups" size={18} />
+                    Erziehungsberechtigte
+                  </h3>
+                  <span className="text-xs text-gray-500">
+                    {guardians.length > 0
+                      ? `${guardians.length} hinzugefügt`
+                      : "Optional"}
+                  </span>
+                </div>
 
-            {guardians.length > 0 && (
-              <ul className="mb-3 space-y-2">
-                {guardians.map((guardian, index) => {
-                  const flags = [
-                    guardian.can_pickup ? "Abholberechtigt" : null,
-                    guardian.is_emergency_contact ? "Notfallkontakt" : null,
-                    guardian.is_primary ? "Primär" : null,
-                  ].filter(Boolean);
-                  return (
-                    <li
-                      key={`${guardian.first_name}-${guardian.last_name}-${guardian.email ?? ""}`}
-                      className="flex items-start justify-between gap-2 rounded-lg border border-gray-100 bg-white p-2 md:p-3"
+                {guardians.length > 0 && (
+                  <ul className="mb-3 space-y-2">
+                    {guardians.map((guardian, index) => {
+                      const flags = [
+                        guardian.can_pickup ? "Abholberechtigt" : null,
+                        guardian.is_emergency_contact ? "Notfallkontakt" : null,
+                        guardian.is_primary ? "Primär" : null,
+                      ].filter(Boolean);
+                      return (
+                        <li
+                          key={`${guardian.first_name}-${guardian.last_name}-${guardian.email ?? ""}`}
+                          className="flex items-start justify-between gap-2 rounded-lg border border-gray-100 bg-white p-2 md:p-3"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
+                              {`${guardian.first_name} ${guardian.last_name}`.trim() ||
+                                "Erziehungsberechtigte/r"}
+                              <span className="ml-2 font-normal text-gray-500">
+                                {relationshipLabel(guardian.relationship_type)}
+                              </span>
+                            </p>
+                            {flags.length > 0 && (
+                              <p className="mt-0.5 truncate text-xs text-gray-500">
+                                {flags.join(" · ")}
+                              </p>
+                            )}
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => removeGuardian(index)}
+                            disabled={saveLoading}
+                            aria-label="Erziehungsberechtigte/n entfernen"
+                            className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+
+                {guardianPickerOpen ? (
+                  // Existing-guardian path is inline (not a second modal): a search
+                  // is a light lookup, so it expands here in place. "Neu anlegen"
+                  // stays a full modal because the new-guardian form is heavy.
+                  <GuardianPickerPanel
+                    onSelect={handleGuardianPick}
+                    onCancel={handlePickerCancel}
+                    excludeProfileIds={addedProfileIds}
+                  />
+                ) : (
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => setGuardianModalOpen(true)}
+                      disabled={saveLoading}
+                      className="flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                     >
-                      <div className="min-w-0">
-                        <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
-                          {`${guardian.first_name} ${guardian.last_name}`.trim() ||
-                            "Erziehungsberechtigte/r"}
-                          <span className="ml-2 font-normal text-gray-500">
-                            {relationshipLabel(guardian.relationship_type)}
-                          </span>
-                        </p>
-                        {flags.length > 0 && (
-                          <p className="mt-0.5 truncate text-xs text-gray-500">
-                            {flags.join(" · ")}
-                          </p>
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => removeGuardian(index)}
-                        disabled={saveLoading}
-                        aria-label="Erziehungsberechtigte/n entfernen"
-                        className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
+                      <Plus className="h-4 w-4" />
+                      Neu anlegen
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setGuardianPickerOpen(true)}
+                      disabled={saveLoading}
+                      className="flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                    >
+                      <Search className="h-4 w-4" />
+                      Vorhandene/n suchen
+                    </button>
+                  </div>
+                )}
+              </section>
 
-            {guardianPickerOpen ? (
-              // Existing-guardian path is inline (not a second modal): a search
-              // is a light lookup, so it expands here in place. "Neu anlegen"
-              // stays a full modal because the new-guardian form is heavy.
-              <GuardianPickerPanel
-                onSelect={handleGuardianPick}
-                onCancel={handlePickerCancel}
-                excludeProfileIds={addedProfileIds}
-              />
-            ) : (
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <button
-                  type="button"
-                  onClick={() => setGuardianModalOpen(true)}
-                  disabled={saveLoading}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                >
-                  <Plus className="h-4 w-4" />
-                  Neu anlegen
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setGuardianPickerOpen(true)}
-                  disabled={saveLoading}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                >
-                  <Search className="h-4 w-4" />
-                  Vorhandene/n suchen
-                </button>
-              </div>
-            )}
-          </section>
-
-          {/* Betreuungszeiten — weekly arrival/pickup times staged here and
+              {/* Betreuungszeiten — weekly arrival/pickup times staged here and
               persisted atomically with the student, mirroring the guardian
               section above. Reuses the existing CareWeeklyPlanModal editor. */}
-          <section
-            aria-label="Betreuungszeiten"
-            className="rounded-xl border border-gray-100 bg-gray-50 p-3 md:p-4"
-          >
-            <div className="mb-3 flex items-center justify-between md:mb-4">
-              <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
-                <MotoConceptIcon concept="careTimes" size={16} />
-                Betreuungszeiten
-              </h3>
-              <span className="text-xs text-gray-500">
-                {hasCarePlan ? `${scheduledWeekdays.length} Tage` : "Optional"}
-              </span>
-            </div>
-
-            {hasCarePlan && (
-              <div className="mb-3 flex items-start justify-between gap-2 rounded-lg border border-gray-100 bg-white p-2 md:p-3">
-                <div className="min-w-0">
-                  <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
-                    {scheduledWeekdays.map(weekdayShort).join(" · ")}
-                  </p>
-                  <p className="mt-0.5 truncate text-xs text-gray-500">
-                    {`${arrivalSchedules.length}× Ankunft · ${pickupSchedules.length}× Abholung`}
-                  </p>
+              <section
+                aria-label="Betreuungszeiten"
+                className="rounded-xl border border-gray-100 bg-gray-50 p-3 md:p-4"
+              >
+                <div className="mb-3 flex items-center justify-between md:mb-4">
+                  <h3 className="flex items-center gap-2 text-xs font-semibold text-gray-900 md:text-sm">
+                    <MotoConceptIcon concept="careTimes" size={16} />
+                    Betreuungszeiten
+                  </h3>
+                  <span className="text-xs text-gray-500">
+                    {hasCarePlan
+                      ? `${scheduledWeekdays.length} Tage`
+                      : "Optional"}
+                  </span>
                 </div>
+
+                {hasCarePlan && (
+                  <div className="mb-3 flex items-start justify-between gap-2 rounded-lg border border-gray-100 bg-white p-2 md:p-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-xs font-medium text-gray-900 md:text-sm">
+                        {scheduledWeekdays.map(weekdayShort).join(" · ")}
+                      </p>
+                      <p className="mt-0.5 truncate text-xs text-gray-500">
+                        {`${arrivalSchedules.length}× Ankunft · ${pickupSchedules.length}× Abholung`}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setArrivalSchedules([]);
+                        setPickupSchedules([]);
+                      }}
+                      disabled={saveLoading}
+                      aria-label="Betreuungszeiten entfernen"
+                      className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                )}
+
                 <button
                   type="button"
-                  onClick={() => {
-                    setArrivalSchedules([]);
-                    setPickupSchedules([]);
-                  }}
+                  onClick={() => setCarePlanModalOpen(true)}
                   disabled={saveLoading}
-                  aria-label="Betreuungszeiten entfernen"
-                  className="flex flex-shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                 >
-                  <Trash2 className="h-3.5 w-3.5" />
+                  <Plus className="h-4 w-4" />
+                  {hasCarePlan
+                    ? "Wochenplan bearbeiten"
+                    : "Wochenplan hinzufügen"}
                 </button>
-              </div>
-            )}
+              </section>
 
-            <button
-              type="button"
-              onClick={() => setCarePlanModalOpen(true)}
-              disabled={saveLoading}
-              className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 bg-gray-50 py-2 text-xs font-medium text-gray-600 transition-all duration-200 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-            >
-              <Plus className="h-4 w-4" />
-              {hasCarePlan ? "Wochenplan bearbeiten" : "Wochenplan hinzufügen"}
-            </button>
-          </section>
+              {/* Common Form Sections */}
+              <StudentCommonFormSections
+                formData={formData}
+                errors={errors}
+                onChange={handleChange}
+              />
 
-          {/* Common Form Sections */}
-          <StudentCommonFormSections
-            formData={formData}
-            errors={errors}
-            onChange={handleChange}
-          />
-
-          {/* How the child leaves each weekday (alleine / Bus / Abholung) */}
-          <DepartureSection
-            days={formData.allowed_departure_modes}
-            onChange={(value) => {
-              const allowed = normalizeAllowedDepartureModes(value);
-              const departure = allowedDepartureToDepartureDays(allowed);
-              const busDays = allowedDepartureToBusDays(allowed);
-              const pickupDays = allowedDepartureToPickupDays(allowed);
-              setFormData((prev) => ({
-                ...prev,
-                allowed_departure_modes: allowed,
-                departure_days: departure,
-                bus_days: busDays,
-                bus: busDaysHaveAny(busDays),
-                pickup_days: pickupDays,
-                pickup_status: pickupDaysHaveAny(pickupDays)
-                  ? "Wird abgeholt"
-                  : "Geht alleine nach Hause",
-              }));
-            }}
-            companionNote={formData.departure_companion_note}
-            onCompanionNoteChange={(value) =>
-              setFormData((prev) => ({
-                ...prev,
-                departure_companion_note: value,
-              }))
-            }
-            companionNoteError={errors.departure_companion_note}
-          />
+              {/* How the child leaves each weekday (alleine / Bus / Abholung) */}
+              <DepartureSection
+                days={formData.allowed_departure_modes}
+                onChange={(value) => {
+                  const allowed = normalizeAllowedDepartureModes(value);
+                  const departure = allowedDepartureToDepartureDays(allowed);
+                  const busDays = allowedDepartureToBusDays(allowed);
+                  const pickupDays = allowedDepartureToPickupDays(allowed);
+                  setFormData((prev) => ({
+                    ...prev,
+                    allowed_departure_modes: allowed,
+                    departure_days: departure,
+                    bus_days: busDays,
+                    bus: busDaysHaveAny(busDays),
+                    pickup_days: pickupDays,
+                    pickup_status: pickupDaysHaveAny(pickupDays)
+                      ? "Wird abgeholt"
+                      : "Geht alleine nach Hause",
+                  }));
+                }}
+                companionNote={formData.departure_companion_note}
+                onCompanionNoteChange={(value) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    departure_companion_note: value,
+                  }))
+                }
+                companionNoteError={errors.departure_companion_note}
+              />
+            </>
+          ) : null}
 
           {/* Action Buttons */}
           <div className="sticky bottom-0 -mx-4 mt-4 -mb-4 flex gap-2 border-t border-gray-100 bg-white/95 px-4 py-3 backdrop-blur-sm md:-mx-6 md:mt-6 md:-mb-6 md:gap-3 md:px-6 md:py-4">

--- a/frontend/src/lib/analytics-routes.ts
+++ b/frontend/src/lib/analytics-routes.ts
@@ -32,6 +32,8 @@ export const TRACKED_TENANT_ROUTE_TEMPLATES = [
   "/database/roles",
   "/database/rooms",
   "/database/students",
+  "/database/students/class-list",
+  "/database/students/class-list/import",
   "/database/students/import",
   "/day-log",
   "/dienstplan",

--- a/frontend/src/lib/class-day-api.ts
+++ b/frontend/src/lib/class-day-api.ts
@@ -8,6 +8,10 @@ export interface ClassDayRow {
   student_id: number;
   first_name: string;
   last_name: string;
+  // Klassenlisteneintrag (#2382): Kind des Klassenverbands OHNE OGS-Datensatz
+  // ("Keine Betreuung"). student_id ist dann 0, list_entry_id trägt die ID.
+  list_entry?: boolean;
+  list_entry_id?: number;
   group_name?: string;
   registered: boolean;
   stays_today: boolean;

--- a/frontend/src/lib/class-day-api.ts
+++ b/frontend/src/lib/class-day-api.ts
@@ -27,6 +27,9 @@ interface ClassDayTotals {
   staying: number;
   leaving: number;
   absent: number;
+  // Klassenlisteneinträge (#2382) unter students: weder "bleiben" noch
+  // "gehen", sondern der neutrale "Keine Betreuung"-Anteil des Verbands.
+  list_entries: number;
 }
 
 export interface ClassDayReport {

--- a/frontend/src/lib/class-day-api.ts
+++ b/frontend/src/lib/class-day-api.ts
@@ -9,9 +9,10 @@ export interface ClassDayRow {
   first_name: string;
   last_name: string;
   // Klassenlisteneintrag (#2382): Kind des Klassenverbands OHNE OGS-Datensatz
-  // ("Keine Betreuung"). student_id ist dann 0, list_entry_id trägt die ID.
+  // ("Keine Betreuung"). student_id ist dann 0, list_entry_id trägt die ID —
+  // als String, weil JSON-Zahlen oberhalb von 2^53 im Client runden würden.
   list_entry?: boolean;
-  list_entry_id?: number;
+  list_entry_id?: string;
   group_name?: string;
   registered: boolean;
   stays_today: boolean;

--- a/frontend/src/lib/class-list-entries-api.test.ts
+++ b/frontend/src/lib/class-list-entries-api.test.ts
@@ -1,0 +1,168 @@
+// Tests for the Klassenlisteneinträge API client (#2382): wire mapping,
+// trimming, and the German error-message passthrough.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assignClassListEntry,
+  createClassListEntry,
+  deleteClassListEntry,
+  fetchClassListEntries,
+  updateClassListEntry,
+} from "./class-list-entries-api";
+
+const mockFetch = vi.fn();
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+const wireEntry = {
+  id: 12,
+  first_name: "Zoe",
+  last_name: "Aalders",
+  school_class: "1a",
+  created_at: "2026-08-18T10:00:00Z",
+  matching_student_ids: [7, 8],
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+describe("fetchClassListEntries", () => {
+  it("maps the wire entries to string IDs", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: [wireEntry] }));
+
+    const entries = await fetchClassListEntries();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/class-list-entries",
+      expect.objectContaining({ method: "GET", credentials: "include" }),
+    );
+    expect(entries).toEqual([
+      {
+        id: "12",
+        firstName: "Zoe",
+        lastName: "Aalders",
+        schoolClass: "1a",
+        createdAt: "2026-08-18T10:00:00Z",
+        matchingStudentIds: ["7", "8"],
+      },
+    ]);
+  });
+
+  it("tolerates a missing data array and missing match hints", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    expect(await fetchClassListEntries()).toEqual([]);
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ ...wireEntry, matching_student_ids: undefined }],
+      }),
+    );
+    const entries = await fetchClassListEntries();
+    expect(entries[0]?.matchingStudentIds).toEqual([]);
+  });
+
+  it("surfaces the backend error field verbatim", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ error: "Ein Eintrag existiert bereits" }, false, 400),
+    );
+    await expect(fetchClassListEntries()).rejects.toThrow(
+      "Ein Eintrag existiert bereits",
+    );
+  });
+
+  it("falls back to message, then to the status code", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ message: "Nicht gefunden" }, false, 404),
+    );
+    await expect(fetchClassListEntries()).rejects.toThrow("Nicht gefunden");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error("no body")),
+    } as unknown as Response);
+    await expect(fetchClassListEntries()).rejects.toThrow("API error (500)");
+  });
+});
+
+describe("createClassListEntry", () => {
+  it("trims the input and maps the created entry", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: wireEntry }));
+
+    const entry = await createClassListEntry({
+      firstName: " Zoe ",
+      lastName: " Aalders ",
+      schoolClass: " 1a ",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/class-list-entries",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          first_name: "Zoe",
+          last_name: "Aalders",
+          school_class: "1a",
+        }),
+      }),
+    );
+    expect(entry.id).toBe("12");
+  });
+});
+
+describe("updateClassListEntry", () => {
+  it("PUTs the trimmed input to the entry URL", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: wireEntry }));
+
+    const entry = await updateClassListEntry("12", {
+      firstName: "Zoe",
+      lastName: "Aalders",
+      schoolClass: "1b",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/class-list-entries/12",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(entry.firstName).toBe("Zoe");
+  });
+});
+
+describe("deleteClassListEntry", () => {
+  it("DELETEs the entry URL without a body", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: null }));
+
+    await deleteClassListEntry("12");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/class-list-entries/12",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    expect(init.body).toBeUndefined();
+  });
+});
+
+describe("assignClassListEntry", () => {
+  it("POSTs the numeric student ID to the assign URL", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: null }));
+
+    await assignClassListEntry("12", "77");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/class-list-entries/12/assign",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ student_id: 77 }),
+      }),
+    );
+  });
+});

--- a/frontend/src/lib/class-list-entries-api.test.ts
+++ b/frontend/src/lib/class-list-entries-api.test.ts
@@ -20,13 +20,14 @@ function jsonResponse(body: unknown, ok = true, status = 200) {
   } as unknown as Response;
 }
 
+// IDs kommen als JSON-Strings vom Backend (verlustfrei jenseits von 2^53).
 const wireEntry = {
-  id: 12,
+  id: "12",
   first_name: "Zoe",
   last_name: "Aalders",
   school_class: "1a",
   created_at: "2026-08-18T10:00:00Z",
-  matching_student_ids: [7, 8],
+  matching_student_ids: ["7", "8"],
 };
 
 beforeEach(() => {
@@ -35,7 +36,7 @@ beforeEach(() => {
 });
 
 describe("fetchClassListEntries", () => {
-  it("maps the wire entries to string IDs", async () => {
+  it("maps the wire entries", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ data: [wireEntry] }));
 
     const entries = await fetchClassListEntries();
@@ -152,7 +153,7 @@ describe("deleteClassListEntry", () => {
 });
 
 describe("assignClassListEntry", () => {
-  it("POSTs the numeric student ID to the assign URL", async () => {
+  it("POSTs the student ID as a JSON string to the assign URL", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ data: null }));
 
     await assignClassListEntry("12", "77");
@@ -161,7 +162,7 @@ describe("assignClassListEntry", () => {
       "/api/class-list-entries/12/assign",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ student_id: 77 }),
+        body: JSON.stringify({ student_id: "77" }),
       }),
     );
   });

--- a/frontend/src/lib/class-list-entries-api.ts
+++ b/frontend/src/lib/class-list-entries-api.ts
@@ -1,0 +1,135 @@
+// Client-side API for Klassenlisteneinträge (#2382): Kinder des
+// Klassenverbands OHNE OGS-Datensatz — nur Name + Klasse. Die Einträge
+// erscheinen ausschließlich auf Klassenlisten und in der Klassenansicht
+// ("Keine Betreuung"); Anwesenheit, Betreuungsplanung und Elternportal
+// kennen sie strukturell nicht.
+
+export interface ClassListEntry {
+  id: string;
+  firstName: string;
+  lastName: string;
+  schoolClass: string;
+  createdAt: string;
+  // IDs regulärer Kinder mit gleichem Namen in derselben Klasse — der
+  // Hinweis für die bewusste Zuordnung. Nie automatisch zusammengeführt.
+  matchingStudentIds: string[];
+}
+
+export interface ClassListEntryInput {
+  firstName: string;
+  lastName: string;
+  schoolClass: string;
+}
+
+interface WireEntry {
+  id: number;
+  first_name: string;
+  last_name: string;
+  school_class: string;
+  created_at: string;
+  matching_student_ids?: number[];
+}
+
+interface Envelope<T> {
+  data: T;
+  error?: string;
+  message?: string;
+}
+
+function mapEntry(wire: WireEntry): ClassListEntry {
+  return {
+    id: wire.id.toString(),
+    firstName: wire.first_name,
+    lastName: wire.last_name,
+    schoolClass: wire.school_class,
+    createdAt: wire.created_at,
+    matchingStudentIds: (wire.matching_student_ids ?? []).map((id) =>
+      id.toString(),
+    ),
+  };
+}
+
+// Eigener Fetch statt authFetch: die Backend-Fehlermeldungen (z.B. "existiert
+// in dieser Klasse bereits") sind deutschsprachige Nutzertexte und müssen die
+// aufrufende UI erreichen — authFetch wirft nur den generischen Statustext.
+async function request<T>(
+  url: string,
+  method: "GET" | "POST" | "PUT" | "DELETE",
+  body?: unknown,
+): Promise<T> {
+  const response = await fetch(url, {
+    method,
+    credentials: "include",
+    cache: "no-store",
+    ...(body !== undefined && {
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  });
+  const payload = (await response.json().catch(() => null)) as
+    (Envelope<unknown> & Record<string, unknown>) | null;
+  if (!response.ok) {
+    const message =
+      (typeof payload?.error === "string" && payload.error) ||
+      (typeof payload?.message === "string" && payload.message) ||
+      `API error (${response.status})`;
+    throw new Error(message);
+  }
+  return payload as T;
+}
+
+function toWireInput(input: ClassListEntryInput) {
+  return {
+    first_name: input.firstName.trim(),
+    last_name: input.lastName.trim(),
+    school_class: input.schoolClass.trim(),
+  };
+}
+
+export async function fetchClassListEntries(): Promise<ClassListEntry[]> {
+  const envelope = await request<Envelope<WireEntry[]>>(
+    "/api/class-list-entries",
+    "GET",
+  );
+  return (envelope.data ?? []).map(mapEntry);
+}
+
+export async function createClassListEntry(
+  input: ClassListEntryInput,
+): Promise<ClassListEntry> {
+  const envelope = await request<Envelope<WireEntry>>(
+    "/api/class-list-entries",
+    "POST",
+    toWireInput(input),
+  );
+  return mapEntry(envelope.data);
+}
+
+export async function updateClassListEntry(
+  id: string,
+  input: ClassListEntryInput,
+): Promise<ClassListEntry> {
+  const envelope = await request<Envelope<WireEntry>>(
+    `/api/class-list-entries/${id}`,
+    "PUT",
+    toWireInput(input),
+  );
+  return mapEntry(envelope.data);
+}
+
+export async function deleteClassListEntry(id: string): Promise<void> {
+  await request<Envelope<null>>(`/api/class-list-entries/${id}`, "DELETE");
+}
+
+export async function assignClassListEntry(
+  id: string,
+  studentId: string,
+): Promise<void> {
+  await request<Envelope<null>>(
+    `/api/class-list-entries/${id}/assign`,
+    "POST",
+    {
+      student_id: Number(studentId),
+    },
+  );
+}

--- a/frontend/src/lib/class-list-entries-api.ts
+++ b/frontend/src/lib/class-list-entries-api.ts
@@ -21,13 +21,15 @@ export interface ClassListEntryInput {
   schoolClass: string;
 }
 
+// Alle IDs reisen als JSON-Strings: als JSON-Zahl würden int64-IDs oberhalb
+// von 2^53 beim Parsen (Browser wie Next.js-Proxy) gerundet.
 interface WireEntry {
-  id: number;
+  id: string;
   first_name: string;
   last_name: string;
   school_class: string;
   created_at: string;
-  matching_student_ids?: number[];
+  matching_student_ids?: string[];
 }
 
 interface Envelope<T> {
@@ -38,14 +40,12 @@ interface Envelope<T> {
 
 function mapEntry(wire: WireEntry): ClassListEntry {
   return {
-    id: wire.id.toString(),
+    id: wire.id,
     firstName: wire.first_name,
     lastName: wire.last_name,
     schoolClass: wire.school_class,
     createdAt: wire.created_at,
-    matchingStudentIds: (wire.matching_student_ids ?? []).map((id) =>
-      id.toString(),
-    ),
+    matchingStudentIds: wire.matching_student_ids ?? [],
   };
 }
 

--- a/frontend/src/lib/class-list-entries-api.ts
+++ b/frontend/src/lib/class-list-entries-api.ts
@@ -128,8 +128,10 @@ export async function assignClassListEntry(
   await request<Envelope<null>>(
     `/api/class-list-entries/${id}/assign`,
     "POST",
+    // int64-IDs reisen als JSON-String (Backend bindet mit `,string`): als
+    // JSON-Zahl würden IDs oberhalb von 2^53 beim Parsen gerundet.
     {
-      student_id: Number(studentId),
+      student_id: studentId,
     },
   );
 }


### PR DESCRIPTION
## Worum geht es

Der Klassenlisten-Export enthält bisher nur Kinder, die als Schüler in moto existieren. Für die Übergabe an Klassenlehrkräfte fehlt damit der Teil des Klassenverbands, der nicht im Ganztag ist: die Lehrkraft kann auf der Liste nicht erkennen, wer nach dem Unterricht betreut wird und wer nach Hause geht.

Dieser PR führt minimale, mandantenbezogene **Klassenlisteneinträge** ein: nur Vorname, Nachname und Schulklasse, ohne Betreuung, Sorgeberechtigte, Anwesenheit oder sonstige Stammdaten.

## Kernentscheidung: eigene Tabelle statt Student-Flag

Einträge leben in `users.class_list_entries` (Migration 1.15.304), nicht als Sonderstatus auf `users.students`. Damit ist die Anforderung "erscheint nicht in Kindersuche, Anwesenheit, Betreuungsplanung, Elternportal oder Abrechnung" **strukturell garantiert**: es existiert keine Student-Zeile, auf die diese Systeme zeigen könnten, ein vergessener Filter kann nichts leaken.

## Was der PR umsetzt

**Oberflächen, die Einträge mitführen**
- Klassenlisten-Export (Phasen-Klassenliste): Einträge sortieren alphabetisch in ihre Klasse, markiert mit **"Keine Betreuung"** (bewusst abgegrenzt von "Keine Anmeldung"), Subtitle zeigt "+N ohne Betreuung". Eine Klasse, die nur durch Einträge existiert, bekommt automatisch ihre eigene Sektion.
- Klassenansicht der Lehrkraft (class-day): Einträge erscheinen mit Badge, ohne Gehregel, ohne Aktionen (`list_entry`-Flag auf dem Wire).
- Kinderdatenbank-Export: das `class_roster`-Preset nimmt Einträge mit, solange keine Eigenschafts-Filter aktiv sind.
- Klassen-Dropdown: Union aus Schülerklassen und Eintragsklassen.

**Verwaltung und Einstiege**
- Die Klassenlisten-Seite zeigt den **vollständigen Klassenverband**: reguläre Kinder read-only ("In moto angelegt", Link zum Datensatz), Einträge editierbar, Klassenfilter über normalisierte Klassen-Identität, Statistik-Kacheln.
- Primärer Einstieg ist die Weiche im "+ Kinder"-Erstell-Modal (SegmentedControl "Mit OGS-Betreuung" / "Nur Klassenliste", Formular schrumpft auf drei Felder). Verwaltung, Sammelimport und Zuordnen erreichbar über das Kebab-Menü "Klassenliste" auf der Kinder-Seite (der Jahrgangswechsel wanderte mit ins Kebab, die Aktionszeile lief sonst über).
- Sammelerfassung über die generische Import-Engine (`/api/import/class-list-entries`, Vorlage Vorname/Nachname/Klasse).

**Dubletten und Zuordnen**
- Kein automatischer Merge anhand des Namens: gleichnamige reguläre Kinder werden als Hinweis ("Mögliche Dublette") angezeigt, die Auflösung ist immer eine bewusste Admin-Aktion.
- **Zuordnen** löscht den Eintrag und protokolliert `matched_student_id` im Audit, das Kind steht danach genau einmal auf der Liste. Alumni sind als Ziel ausgeschlossen.
- Eintrag anlegen bei existierendem gleichnamigem Schüler ist blockiert (das Kind steht schon auf der Liste); Schüler anlegen trotz gleichnamigem Eintrag ist erlaubt und zeigt den Dubletten-Hinweis.
- Race-sicherer Unique-Index (tenant, Name, Klasse, case-insensitiv) als Backstop hinter dem Service-Guard.

**Sicherheit und Datenschutz**
- RLS inkl. `FORCE ROW LEVEL SECURITY` auf Eintrags- und Audit-Tabelle; Cross-Tenant-Isolationstests pinnen Lese- und Schreibrichtung über echte `phoenix_tenant`-Transaktionen.
- CRUD hinter `users:create/update/delete`, Lesen hinter `users:read`; 403-Test vorhanden.
- Append-only Audit-Trail `audit.class_list_entry_changes` (created/updated/deleted/assigned) in derselben Tenant-Transaktion wie die Änderung.

**Jahrgangswechsel**
- Einträge werden beim Jahrgangswechsel mit umbenannt (remap). Jede Umbenennung landet im Ledger `education.grade_transition_class_list_entries` (Spiegel des Klassenlehrer-Ledgers), und der Revert spielt exakt dieses Ledger zurück: unbeteiligte oder zwischenzeitlich angelegte Einträge bleiben unangetastet, von Admins gelöschte Einträge bleiben gelöscht.
- Abgänger-Einträge (4. Klasse) werden beim Revert aus dem Ledger wiederhergestellt, genau wie die Abgänger-Schüler selbst reaktiviert werden.

**Sonstiges**
- Hilfe-Guide um das Kapitel Klassenlisteneinträge ergänzt.
- Noch keine Retention-Cleanup-Anbindung für die Audit-Tabelle (gleicher Stand wie `audit.staff_master_data_changes`), im Migrationskommentar dokumentiert.

## Nicht im Scope

IServ-Synchronisierung (#1322), Sorgeberechtigte/Kontaktdaten für reine Einträge, eine zweite Schülerverwaltung.

## Tests

- Router-Tests: Berechtigungs-Gates, CRUD + Zuordnen, Dubletten-400, class-day-Merge
- Cross-Tenant-Isolationstests (RLS-Lese- und Schreibrichtung)
- Service-Tests (Validierung, Dubletten-Guards, Audit)
- Report-Tests (Klassenlisten-Merge, Marker, Sortierung), Import-Parser-Tests
- Frontend: `pnpm run check` grün

## Screenshots

<details>
<summary>Screenshots</summary>
<img width="1440" height="1000" alt="01-einstieg-kinder-datenbank" src="https://github.com/user-attachments/assets/cc6aa25e-04b3-4111-8591-cd94b76d3f7c" />
<img width="1440" height="1000" alt="02-create-modal-mit-ogs" src="https://github.com/user-attachments/assets/6c120ec5-236b-4cdc-aabb-79bb7018c375" />
<img width="1440" height="1000" alt="03-create-modal-nur-klassenliste" src="https://github.com/user-attachments/assets/d8f45b71-a565-453e-9cb8-784996b0355e" />
<img width="1440" height="1000" alt="04-kebab-menu-klassenliste" src="https://github.com/user-attachments/assets/996c4353-1d5f-4ee7-9eac-0a3b1ebdb148" />
<img width="1440" height="1000" alt="05-klassenliste-uebersicht" src="https://github.com/user-attachments/assets/61ddc003-f595-49bf-97d8-3dc6b5b81066" />
<img width="1440" height="1000" alt="06-sammelimport-seite" src="https://github.com/user-attachments/assets/efa5602e-a12f-406a-b826-178004e53cff" />
<img width="1440" height="1000" alt="07-sammelimport-vorschau" src="https://github.com/user-attachments/assets/01fe8dc9-a2d3-4631-bd31-6477f0257276" />
<img width="1440" height="1000" alt="08-klassenliste-nach-import" src="https://github.com/user-attachments/assets/5df5ff1c-5460-430b-9552-cde1af9800b4" />
<img width="1440" height="1000" alt="09-klassenliste-gefiltert-2b" src="https://github.com/user-attachments/assets/982edcb6-b2d3-47a4-8493-97cc3958f33e" />
<img width="1440" height="1000" alt="10-kindersuche-ohne-eintraege" src="https://github.com/user-attachments/assets/b92778ee-f917-48d1-a00d-8245f5a11518" />
<img width="1440" height="1000" alt="11-klassenansicht-lehrkraft" src="https://github.com/user-attachments/assets/4e4cb5b6-f38b-4079-9bd9-4f6c746602c8" />
<img width="1400" height="989" alt="12-klassenliste-export-pdf" src="https://github.com/user-attachments/assets/a33b5029-2e52-47cf-b0ad-2d2e77d95dfd" />
<img width="1440" height="1000" alt="13-dubletten-hinweis" src="https://github.com/user-attachments/assets/7787a843-9bdf-4879-9f1c-a3557474d7dc" />
<img width="1440" height="1000" alt="14-zuordnen-modal" src="https://github.com/user-attachments/assets/ca3750d9-943f-4456-8e06-92bae9ce6615" />
<img width="1440" height="1000" alt="15-nach-zuordnung" src="https://github.com/user-attachments/assets/11450d46-dba8-4bf7-b7de-72a35a135940" />
[klassenliste-klasse-1a.pdf](https://github.com/user-attachments/files/31185820/klassenliste-klasse-1a.pdf)

</details>

Closes #2382


