### PR TITLE
fix(schedule): is_spontaneous misst Entstehungsart statt Angebots-Verknüpfung

### DIFF
--- a/backend/api/timetable/instances_create_test.go
+++ b/backend/api/timetable/instances_create_test.go
@@ -150,7 +150,7 @@ func TestCreateInstance_Spontaneous(t *testing.T) {
 	assert.Equal(t, "14:00", got.StartTime)
 	assert.Equal(t, "15:00", got.EndTime)
 	assert.Equal(t, scheduleModel.InstanceStatusPlanned, got.Status)
-	assert.True(t, got.IsSpontaneous, "no activity_group_id ⇒ spontaneous")
+	assert.True(t, got.IsSpontaneous, "is_spontaneous is serialized from the service result")
 	assert.False(t, got.IsLive)
 	assert.Equal(t, s.roomID, got.RoomID)
 	assert.NotEmpty(t, got.RoomName, "room name should resolve via RoomRepo")

--- a/backend/database/migrations/001015303_reclassify_planned_spontaneous_instances.go
+++ b/backend/database/migrations/001015303_reclassify_planned_spontaneous_instances.go
@@ -1,0 +1,52 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	reclassifyPlannedSpontaneousInstancesVersion     = "1.15.303"
+	reclassifyPlannedSpontaneousInstancesDescription = "Reclassify planned spontaneous activity instances as planned blocks"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     reclassifyPlannedSpontaneousInstancesVersion,
+		Description: reclassifyPlannedSpontaneousInstancesDescription,
+		DependsOn:   []string{createActivityInstancesVersion},
+	})
+	Migrations.MustRegister(reclassifyPlannedSpontaneousInstancesUp, reclassifyPlannedSpontaneousInstancesDown)
+}
+
+// is_spontaneous now records the creation origin, not the offering link
+// (#2299). Genuinely spontaneous instances are created ad-hoc AT START — the
+// web spontaneous flow creates and starts in one transaction and the kiosk
+// mirror inserts status='active' directly — so no persisted row is ever both
+// spontaneous and still 'planned'. Every planned row flagged spontaneous is
+// therefore a planning-module block that only lacked an offering link; flip it
+// so the lifecycle time guards apply. Started/completed/cancelled rows keep
+// their flag: their origin is ambiguous and no start guard applies to them.
+func reclassifyPlannedSpontaneousInstancesUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.303: Reclassifying planned spontaneous activity instances as planned blocks...")
+	res, err := db.NewRaw(`
+		UPDATE schedule.activity_instances
+		SET is_spontaneous = FALSE
+		WHERE is_spontaneous = TRUE
+		  AND status = 'planned'
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("reclassify planned spontaneous instances: %w", err)
+	}
+	if rows, err := res.RowsAffected(); err == nil {
+		fmt.Printf("Migration 1.15.303: reclassified %d instance(s)\n", rows)
+	}
+	return nil
+}
+
+func reclassifyPlannedSpontaneousInstancesDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.303: nothing to restore (the pre-#2299 flag values are not recoverable)")
+	return nil
+}

--- a/backend/database/migrations/001015303_reclassify_planned_spontaneous_instances_test.go
+++ b/backend/database/migrations/001015303_reclassify_planned_spontaneous_instances_test.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2299: only rows that are BOTH spontaneous and still 'planned' are
+// reclassified — those are planning-module blocks that merely lacked an
+// offering link. Ad-hoc rows (created at start, so never persisted as
+// planned+spontaneous) keep their flag.
+func TestReclassifyPlannedSpontaneousInstances(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	room := testpkg.CreateTestRoom(t, db, "Migration-2299-Room")
+	date := timezone.NewDate(2026, 9, 1)
+	plannedSpont := testpkg.CreateTestActivityInstance(t, db, date, room.ID, testpkg.ActivityInstanceOpts{
+		Status:        schedule.InstanceStatusPlanned,
+		IsSpontaneous: true,
+	})
+	activeSpont := testpkg.CreateTestActivityInstance(t, db, date, room.ID, testpkg.ActivityInstanceOpts{
+		Status:        schedule.InstanceStatusActive,
+		IsSpontaneous: true,
+	})
+	completedSpont := testpkg.CreateTestActivityInstance(t, db, date, room.ID, testpkg.ActivityInstanceOpts{
+		Status:        schedule.InstanceStatusCompleted,
+		IsSpontaneous: true,
+	})
+	plannedNormal := testpkg.CreateTestActivityInstance(t, db, date, room.ID, testpkg.ActivityInstanceOpts{
+		Status: schedule.InstanceStatusPlanned,
+	})
+	t.Cleanup(func() {
+		testpkg.CleanupTableRecords(t, db, "schedule.activity_instances",
+			plannedSpont.ID, activeSpont.ID, completedSpont.ID, plannedNormal.ID)
+		testpkg.CleanupTableRecords(t, db, "facilities.rooms", room.ID)
+	})
+
+	require.NoError(t, reclassifyPlannedSpontaneousInstancesUp(ctx, db))
+
+	flags := map[int64]bool{}
+	var rows []struct {
+		ID            int64 `bun:"id"`
+		IsSpontaneous bool  `bun:"is_spontaneous"`
+	}
+	require.NoError(t, db.NewRaw(`
+		SELECT id, is_spontaneous
+		FROM schedule.activity_instances
+		WHERE id IN (?, ?, ?, ?)
+	`, plannedSpont.ID, activeSpont.ID, completedSpont.ID, plannedNormal.ID).Scan(ctx, &rows))
+	require.Len(t, rows, 4)
+	for _, r := range rows {
+		flags[r.ID] = r.IsSpontaneous
+	}
+
+	assert.False(t, flags[plannedSpont.ID], "planned spontaneous row must be reclassified as a planned block")
+	assert.True(t, flags[activeSpont.ID], "active ad-hoc row keeps its spontaneous origin")
+	assert.True(t, flags[completedSpont.ID], "completed ad-hoc row keeps its spontaneous origin")
+	assert.False(t, flags[plannedNormal.ID], "already-planned row stays planned")
+}

--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -424,7 +424,13 @@ func (r *ActivityInstanceRepository) DeletePlannedNonSpontaneousInWindow(ctx con
 		ModelTableExpr(modelTblActivityInstance).
 		Where(`"activity_instance".date >= ?`, from).
 		Where(`"activity_instance".status = ?`, schedule.InstanceStatusPlanned).
-		Where(`"activity_instance".is_spontaneous = ?`, false)
+		Where(`"activity_instance".is_spontaneous = ?`, false).
+		// Re-plan deletes only what materialization can recreate. Since
+		// is_spontaneous became a creation-origin flag (#2299), a manual
+		// planning-module block WITHOUT an offering is non-spontaneous too —
+		// but it has no template, so a whole-grid re-plan (activityGroupID
+		// nil) must never delete it: nothing would ever bring it back.
+		Where(`"activity_instance".activity_group_id IS NOT NULL`)
 
 	if preserveDeviations {
 		// Keep deviated instances (#1840, re-plan only). RLS already scopes

--- a/backend/services/schedule/instance_service.go
+++ b/backend/services/schedule/instance_service.go
@@ -229,11 +229,12 @@ type InstanceService interface {
 // CreateInstanceInput bundles the fields needed to insert a fresh instance
 // (spontaneous or scheduled) outside the materialization flow.
 //
-// By default, IsSpontaneous is computed from ActivityGroupID: when nil the
-// instance is purely free-form; when set it is bound to a template (e.g. an
-// admin-scheduled extra Yoga slot using the existing Yoga template's metadata,
-// but on a date that materialization would not have emitted). Operational
-// spontaneous starts may override this while still linking template metadata.
+// IsSpontaneous records the creation origin (#2299), not the template
+// binding: nil defaults to false — a planned block created in the planning
+// module, with or without a linked offering, so the lifecycle time guards
+// apply. Ad-hoc start flows (web spontaneous start, kiosk sessions) pass an
+// explicit true and stay exempt from the time policy; they may still link
+// template metadata via ActivityGroupID.
 type CreateInstanceInput struct {
 	Date             timezone.Date
 	StartTime        time.Time // 2000-01-01 HH:MM in UTC
@@ -1458,9 +1459,10 @@ func (s *instanceService) rejectAmbiguousTemplateDelete(ctx context.Context, act
 }
 
 // Create inserts a new activity instance and optionally pre-assigns staff.
-// Spontaneity is derived from the absence of an ActivityGroupID — a value
-// of nil means there is no template binding, so is_spontaneous is set to
-// true. Conflict detection is intentionally not run here; the read-side
+// is_spontaneous records the creation origin (#2299): the default is a
+// planned block (planning module), and only ad-hoc start flows pass an
+// explicit IsSpontaneous=true. Conflict detection is intentionally not run
+// here; the read-side
 // of the planner surfaces conflicts on the response, and surfacing them
 // in the create path would block admins from creating overlapping rows
 // they may explicitly want (e.g. parallel offers in different rooms).
@@ -1485,7 +1487,7 @@ func (s *instanceService) Create(ctx context.Context, req CreateInstanceInput) (
 		return nil, &ScheduleError{Op: "create instance: validate references", Err: err}
 	}
 
-	isSpontaneous := req.ActivityGroupID == nil
+	isSpontaneous := false
 	if req.IsSpontaneous != nil {
 		isSpontaneous = *req.IsSpontaneous
 	}
@@ -1650,7 +1652,6 @@ func (s *instanceService) UpdatePlanned(ctx context.Context, instanceID int64, r
 	instance.ActivityGroupID = req.ActivityGroupID
 	instance.RequiredStaff = req.RequiredStaff
 	instance.ListKind = req.ListKind
-	instance.IsSpontaneous = req.ActivityGroupID == nil
 	columns := []string{
 		"date",
 		"start_time",
@@ -1662,11 +1663,17 @@ func (s *instanceService) UpdatePlanned(ctx context.Context, instanceID int64, r
 		"activity_group_id",
 		"required_staff",
 		"list_kind",
-		"is_spontaneous",
 	}
+	// is_spontaneous records the creation origin (#2299) and is never
+	// recomputed from the offering link: linking or unlinking an Angebot must
+	// not toggle the lifecycle time guards. The one exception is
+	// convert-to-series (the only caller passing CalendarPeriodID), which
+	// stamps the full materializer marker — activity_group_id + period +
+	// is_spontaneous=false — so the seed behaves like a materialized row.
 	if req.CalendarPeriodID != nil {
 		instance.CalendarPeriodID = req.CalendarPeriodID
-		columns = append(columns, "calendar_period_id")
+		instance.IsSpontaneous = false
+		columns = append(columns, "calendar_period_id", "is_spontaneous")
 	}
 
 	if err := s.updateLifecycleColumns(ctx, instance, columns...); err != nil {

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -1256,25 +1256,40 @@ func TestInstance_ReplanWeek_OnlyDeletesPlannedNonSpontaneous(t *testing.T) {
 	from := timezone.NewDate(2026, 4, 20)
 	to := from.AddDays(6)
 
-	// Five seeded rows inside the window — one of each protected kind.
+	// Six seeded rows inside the window — one of each protected kind.
 	plannedNormal := insertInstance(t, s, from, scheduleModels.InstanceStatusPlanned, false)
 	plannedSpont := insertInstance(t, s, from.AddDays(1), scheduleModels.InstanceStatusPlanned, true)
 	active := insertInstance(t, s, from.AddDays(2), scheduleModels.InstanceStatusActive, false)
 	completed := insertInstance(t, s, from.AddDays(3), scheduleModels.InstanceStatusCompleted, false)
 	cancelled := insertInstance(t, s, from.AddDays(4), scheduleModels.InstanceStatusCancelled, false)
+	// #2299: a manual planning-module block without an offering is planned
+	// (is_spontaneous=false) but has no template — materialization could never
+	// recreate it, so a whole-grid re-plan must not delete it.
+	plannedManual := &scheduleModels.ActivityInstance{
+		Date:      from.AddDays(1),
+		Title:     fmt.Sprintf("Row-manual-%d", time.Now().UnixNano()),
+		StartTime: time.Date(1, 1, 1, 9, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(1, 1, 1, 10, 0, 0, 0, time.UTC),
+		RoomID:    s.roomID,
+		Status:    scheduleModels.InstanceStatusPlanned,
+	}
+	plannedManual.SetTenantID(1)
+	_, err := s.db.NewInsert().Model(plannedManual).ModelTableExpr(`schedule.activity_instances`).Exec(s.ctx)
+	require.NoError(t, err)
 
 	// Manual cleanup for the survivors (the planned-normal row may be deleted
 	// by ReplanWeek; if so, the cleanup becomes a no-op).
 	t.Cleanup(func() {
 		testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances",
-			plannedNormal, plannedSpont, active, completed, cancelled)
+			plannedNormal, plannedSpont, active, completed, cancelled, plannedManual.ID)
 	})
 
-	_, err := s.svc.ReplanWeek(s.ctx, from, to, nil, nil)
+	_, err = s.svc.ReplanWeek(s.ctx, from, to, nil, nil)
 	require.NoError(t, err)
 
 	assert.False(t, instanceExists(t, s, plannedNormal), "planned non-spontaneous must be deleted")
 	assert.True(t, instanceExists(t, s, plannedSpont), "spontaneous planned must survive")
+	assert.True(t, instanceExists(t, s, plannedManual.ID), "manual no-offering planned block must survive a whole-grid re-plan")
 	assert.True(t, instanceExists(t, s, active), "active must survive")
 	assert.True(t, instanceExists(t, s, completed), "completed must survive")
 	assert.True(t, instanceExists(t, s, cancelled), "cancelled must survive")
@@ -1489,7 +1504,10 @@ func TestInstance_Create_SpontaneousAndMissingTenant(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", inst.ID) })
-	assert.True(t, inst.IsSpontaneous)
+	// #2299: is_spontaneous records the creation origin. A planning-module
+	// create without an explicit flag is a planned block even without an
+	// offering link — the lifecycle time guards must apply.
+	assert.False(t, inst.IsSpontaneous)
 	assert.Nil(t, inst.ActivityGroupID)
 
 	isSpontaneous := true
@@ -1536,13 +1554,36 @@ func TestInstance_UpdatePlanned_ReplacesAssignmentsAndFields(t *testing.T) {
 
 	assert.Equal(t, "Updated planned instance", updated.Title)
 	assert.Equal(t, "16:00", updated.StartTime.Format("15:04"))
-	assert.True(t, updated.IsSpontaneous, "nil ActivityGroupID should toggle to spontaneous")
+	// #2299: unlinking the offering must NOT flip the block to spontaneous —
+	// is_spontaneous keeps recording the creation origin.
+	assert.False(t, updated.IsSpontaneous, "removing the offering link must not toggle is_spontaneous")
 	assert.Nil(t, updated.ActivityGroupID)
 	assert.Equal(t, 1, countRowsWhere(t, s, "schedule.instance_staff", "instance_id", ai.ID))
 	assert.Equal(t, 1, countRowsWhere(t, s, "schedule.instance_students", "instance_id", ai.ID))
 
 	row := fetchAttendance(t, s, ai.ID, s.student2)
 	assert.Equal(t, scheduleModels.AttendanceStatusExpected, row.Status)
+}
+
+// #2299: is_spontaneous records the creation origin, so an edit that links an
+// offering to a spontaneous block must not reclassify it as planned either.
+func TestInstance_UpdatePlanned_KeepsSpontaneousOriginWhenLinkingOffering(t *testing.T) {
+	s := buildLifecycle(t)
+	ai := seedSpontaneousInstance(t, s, false)
+
+	updated, err := s.svc.UpdatePlanned(s.ctx, ai.ID, scheduleSvc.UpdateInstanceInput{
+		Date:            ai.Date,
+		StartTime:       ai.StartTime,
+		EndTime:         ai.EndTime,
+		Title:           ai.Title,
+		RoomID:          s.roomID,
+		ActivityGroupID: &s.tmplID,
+	}, nil)
+	require.NoError(t, err)
+
+	assert.True(t, updated.IsSpontaneous, "linking an offering must not toggle is_spontaneous")
+	require.NotNil(t, updated.ActivityGroupID)
+	assert.Equal(t, s.tmplID, *updated.ActivityGroupID)
 }
 
 func TestInstance_UpdatePlanned_RejectsCrossTenantReferencesBeforeMutation(t *testing.T) {

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -1287,7 +1287,7 @@ func TestInstance_ReplanWeek_OnlyDeletesPlannedNonSpontaneous(t *testing.T) {
 		RoomID:    s.roomID,
 		Status:    scheduleModels.InstanceStatusPlanned,
 	}
-	plannedManual.SetTenantID(1)
+	plannedManual.SetTenantID(tenant.FromContext(s.ctx))
 	_, err := s.db.NewInsert().Model(plannedManual).ModelTableExpr(`schedule.activity_instances`).Exec(s.ctx)
 	require.NoError(t, err)
 

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -780,10 +780,24 @@ func TestInstance_Reopen_RejectsSupervisorChangedAfterComplete(t *testing.T) {
 	_, err = s.svc.Complete(s.ctx, ai.ID)
 	require.NoError(t, err)
 
+	// active.group_supervisors carries a BEFORE UPDATE trigger
+	// (update_modified_column) that overwrites updated_at with the DB clock's
+	// now(), so an explicit future timestamp cannot be written. Bump the row
+	// (the trigger stamps it "now") and move the recorded completion instant
+	// two minutes into the past instead: the conflict predicate
+	// updated_at > completed_at then holds regardless of Go-vs-Postgres clock
+	// skew. Comparing the trigger stamp against the Go-clock completed_at
+	// directly is a sub-millisecond race that made this test flaky.
 	_, err = s.db.NewUpdate().
 		Table("active.group_supervisors").
-		Set("updated_at = ?", time.Now().Add(time.Minute)).
+		Set("updated_at = now()").
 		Where("group_id = ?", started.ActiveGroupID).
+		Exec(s.ctx)
+	require.NoError(t, err)
+	_, err = s.db.NewUpdate().
+		Table("schedule.activity_instances").
+		Set("completed_at = completed_at - interval '2 minutes'").
+		Where("id = ?", ai.ID).
 		Exec(s.ctx)
 	require.NoError(t, err)
 

--- a/backend/services/schedule/instance_service_integration_test.go
+++ b/backend/services/schedule/instance_service_integration_test.go
@@ -1565,6 +1565,84 @@ func TestInstance_UpdatePlanned_ReplacesAssignmentsAndFields(t *testing.T) {
 	assert.Equal(t, scheduleModels.AttendanceStatusExpected, row.Status)
 }
 
+// guardedLifecycleSettings satisfies scheduleSvc.LifecycleSettings for the
+// time-policy pass-through test below.
+type guardedLifecycleSettings struct {
+	leadMinutes       int
+	enforcePlannedEnd bool
+}
+
+func (s guardedLifecycleSettings) ResolveInt(context.Context, string) (int, error) {
+	return s.leadMinutes, nil
+}
+
+func (s guardedLifecycleSettings) ResolveBool(context.Context, string) (bool, error) {
+	return s.enforcePlannedEnd, nil
+}
+
+// #2299 guard pass-through: a block created in the planning module WITHOUT an
+// offering link is subject to the lead-time guard, while an ad-hoc block
+// (explicit IsSpontaneous=true) stays exempt at the same clock.
+func TestInstance_Start_TimePolicyAppliesToNoOfferingPlannedBlock(t *testing.T) {
+	s := buildLifecycle(t)
+	date := timezone.NewDate(2026, 4, 22)
+	// 08:00 Berlin — far before the 14:00 start minus the 15-minute lead.
+	now := time.Date(2026, 4, 22, 8, 0, 0, 0, timezone.Berlin)
+	guarded := scheduleSvc.NewInstanceService(scheduleSvc.InstanceServiceDependencies{
+		InstanceRepo:       s.repos.ActivityInstance,
+		InstanceStaffRepo:  s.repos.InstanceStaff,
+		InstanceStudents:   s.repos.InstanceStudent,
+		ExceptionRepo:      s.repos.ActivityException,
+		ActiveGroupRepo:    s.repos.ActiveGroup,
+		SupervisorRepo:     s.repos.GroupSupervisor,
+		VisitRepo:          s.repos.ActiveVisit,
+		RoomRepo:           s.repos.Room,
+		ActivityGroupRepo:  s.repos.ActivityGroup,
+		StaffRepo:          s.repos.Staff,
+		StudentRepo:        s.repos.Student,
+		ActiveService:      s.factory.Active,
+		Materialization:    s.factory.Materialization,
+		CareDayService:     s.factory.CareDay,
+		DeviationEventRepo: s.repos.DeviationEvent,
+		DB:                 s.db,
+		Logger:             slog.Default(),
+		RecoveryRepo:       scheduleRepo.NewActivityRecoveryRepository(s.db),
+		Settings:           guardedLifecycleSettings{leadMinutes: 15, enforcePlannedEnd: true},
+		Now:                func() time.Time { return now },
+		EnforceTimePolicy:  true,
+	})
+
+	planned, err := guarded.Create(s.ctx, scheduleSvc.CreateInstanceInput{
+		Date:      date,
+		StartTime: time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		Title:     "Guarded no-offering block",
+		RoomID:    s.roomID,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", planned.ID) })
+
+	_, err = guarded.Start(s.ctx, planned.ID, s.staffID)
+	require.ErrorIs(t, err, scheduleSvc.ErrInstanceStartTooEarly,
+		"planning-module block without offering must hit the lead-time guard")
+
+	isSpontaneous := true
+	adhoc, err := guarded.Create(s.ctx, scheduleSvc.CreateInstanceInput{
+		Date:          date,
+		StartTime:     time.Date(1, 1, 1, 14, 0, 0, 0, time.UTC),
+		EndTime:       time.Date(1, 1, 1, 15, 0, 0, 0, time.UTC),
+		Title:         "Ad-hoc block",
+		RoomID:        s.roomID,
+		IsSpontaneous: &isSpontaneous,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "schedule.activity_instances", adhoc.ID) })
+
+	started, err := guarded.Start(s.ctx, adhoc.ID, s.staffID)
+	require.NoError(t, err, "ad-hoc block stays exempt from the time policy")
+	t.Cleanup(func() { testpkg.CleanupTableRecords(t, s.db, "active.groups", started.ActiveGroupID) })
+}
+
 // #2299: is_spontaneous records the creation origin, so an edit that links an
 // offering to a spontaneous block must not reclassify it as planned either.
 func TestInstance_UpdatePlanned_KeepsSpontaneousOriginWhenLinkingOffering(t *testing.T) {


### PR DESCRIPTION
Closes #2299

## Problem

`is_spontaneous` wurde bisher aus der Angebots-Verknüpfung abgeleitet. Dadurch galten geplante Blöcke ohne Angebot als spontan und umgingen die Lifecycle-Zeitprüfungen aus #2269.

## Änderungen

- **`Create`** setzt `is_spontaneous` standardmäßig auf `false`. Ad-hoc-Pfade übergeben weiterhin explizit `true` und bleiben von der Zeitprüfung ausgenommen.
- **`UpdatePlanned`** ändert `is_spontaneous` nicht mehr beim Verknüpfen oder Entfernen eines Angebots. Beim Convert-to-Series wird das Flag zusammen mit `calendar_period_id` weiterhin auf `false` gesetzt.
- **Re-Plan-Schutz:** Manuelle geplante Blöcke ohne Angebot werden bei einem Grid-weiten Re-Plan nicht gelöscht, da sie nicht durch Materialisierung wiederhergestellt werden können.
- **Migration 1.15.303:** Setzt `is_spontaneous` für bestehende Datensätze mit Status `planned` auf `false`. Aktive und abgeschlossene Datensätze bleiben unverändert.

## Akzeptanzkriterien

- [x] Geplante Blöcke ohne Angebot unterliegen der Lead- und Planende-Prüfung.
- [x] Ad-hoc-Blöcke bleiben von der Zeitprüfung ausgenommen.
- [x] Änderungen an der Angebots-Verknüpfung ändern `is_spontaneous` nicht.
- [x] Bestandsdaten werden durch Migration 1.15.303 korrekt klassifiziert.
- [x] Re-Plans löschen keine manuellen Blöcke ohne Angebot.
- [x] Tests decken beide Entstehungsarten und die Lifecycle-Guards ab.

## Geänderte Bestandstests

- `TestInstance_Create_SpontaneousAndMissingTenant`
- `TestInstance_UpdatePlanned_ReplacesAssignmentsAndFields`

Beide Tests bilden jetzt die Entstehungsart statt der Angebots-Verknüpfung ab.

## Verifikation

- `go test ./...` grün nach `migrate reset` auf der Test-DB
- `golangci-lint run` auf den geänderten Paketen: 0 Issues
- `migrate validate` grün für Migration 1.15.303

## Bonus: Stabilisierung eines Flaky-Tests

`TestInstance_Reopen_RejectsSupervisorChangedAfterComplete` verwendet jetzt einen durch den Datenbank-Trigger gesetzten Supervisor-Zeitstempel und verschiebt `completed_at` um zwei Minuten in die Vergangenheit. Damit ist der Konflikt unabhängig von kleinen Abweichungen zwischen Go- und PostgreSQL-Uhr. 15 aufeinanderfolgende Läufe waren erfolgreich.
