### PR TITLE
Angebotsverwaltung: Mitbuchungs-Regeln pro Phase gesammelt anzeigen

### DIFF
--- a/backend/database/repositories/schedule/activity_instance_repo.go
+++ b/backend/database/repositories/schedule/activity_instance_repo.go
@@ -424,7 +424,8 @@ func (r *ActivityInstanceRepository) DeletePlannedNonSpontaneousInWindow(ctx con
 		ModelTableExpr(modelTblActivityInstance).
 		Where(`"activity_instance".date >= ?`, from).
 		Where(`"activity_instance".status = ?`, schedule.InstanceStatusPlanned).
-		Where(`"activity_instance".is_spontaneous = ?`, false)
+		Where(`"activity_instance".is_spontaneous = ?`, false).
+		Where(`"activity_instance".activity_group_id IS NOT NULL`)
 
 	if preserveDeviations {
 		// Keep deviated instances (#1840, re-plan only). RLS already scopes

--- a/backend/database/repositories/schedule/activity_instance_repo_test.go
+++ b/backend/database/repositories/schedule/activity_instance_repo_test.go
@@ -690,6 +690,15 @@ func TestActivityInstanceRepository_DeletePlannedNonSpontaneousInWindow_Preserve
 	require.NoError(t, repo.Create(ctx, plain))
 	defer testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", plain.ID)
 
+	// legacyManual: migration 1.15.303 reclassified legacy planned spontaneous
+	// rows as non-spontaneous, but they remain unlinked to a template and must
+	// not be removed by a whole-grid re-plan.
+	legacyManual := buildInstance(1, fx.roomID, nil, date,
+		time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 1, 14, 0, 0, 0, time.UTC), "LegacyManual")
+	require.NoError(t, repo.Create(ctx, legacyManual))
+	defer testpkg.CleanupTableRecords(t, db, "schedule.activity_instances", legacyManual.ID)
+
 	// absentDev: carries an absent instance_staff row → preserved.
 	absentDev := buildInstance(1, fx.roomID, &fx.activityID, date,
 		time.Date(2024, 1, 1, 15, 0, 0, 0, time.UTC),
@@ -719,10 +728,14 @@ func TestActivityInstanceRepository_DeletePlannedNonSpontaneousInWindow_Preserve
 	// preserveDeviations=true (re-plan semantics): deviated instances survive.
 	deleted, err := repo.DeletePlannedNonSpontaneousInWindow(ctx, date, &to, nil, true)
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, deleted, "only the non-deviated instance is deleted")
+	assert.EqualValues(t, 1, deleted, "only the template-backed non-deviated instance is deleted")
 
 	_, err = repo.FindByID(ctx, plain.ID)
 	assert.True(t, modelBase.IsNoRows(err), "plain instance must be deleted")
+
+	gotLegacyManual, err := repo.FindByID(ctx, legacyManual.ID)
+	require.NoError(t, err, "legacy manual instance must be preserved")
+	assert.Equal(t, legacyManual.ID, gotLegacyManual.ID)
 
 	gotAbsent, err := repo.FindByID(ctx, absentDev.ID)
 	require.NoError(t, err, "instance with an absent staff row must be preserved")

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -1283,8 +1283,8 @@ function EmptyCareOfferingState({
 // Eine falsch herum konfigurierte Mitbuchungs-Regel (#2367, Fall OGS am Berg
 // in #2365) fällt erst bei einer echten Anmeldung auf, solange jede Regel nur
 // im Editor ihres Ziel-Angebots sichtbar ist. Dieses Panel sammelt alle
-// aktiven Regeln der Phase als Klartext-Sätze im selben Wortlaut wie die
-// Editor-Vorschau, damit die Wirkrichtung ohne Testanmeldung ablesbar ist.
+// aktiven Regeln der Phase als Klartext-Sätze (ziel-zuerst, wie das Beispiel
+// in #2367), damit die Wirkrichtung ohne Testanmeldung ablesbar ist.
 function AutoAddRuleOverview({
   offerings,
 }: Readonly<{ offerings: CareOffering[] }>) {
@@ -1294,28 +1294,31 @@ function AutoAddRuleOverview({
   const rules = offerings
     .filter((offering) => offering.is_active)
     .flatMap((target) =>
-      (target.auto_add_trigger_offering_ids ?? []).flatMap((triggerId) => {
-        const trigger = offeringsById.get(triggerId);
-        // Eltern sehen nur aktive Angebote; Regeln an oder von inaktiven
-        // Angeboten können nicht greifen und bleiben hier draußen.
-        if (!trigger?.is_active) return [];
-        const grades = target.auto_add_grade_levels ?? [];
-        const gradeSuffix =
-          grades.length > 0
-            ? ` (${gradeNoun(grades)} ${formatGradeLevelList(grades)})`
+      [...new Set(target.auto_add_trigger_offering_ids ?? [])].flatMap(
+        (triggerId) => {
+          const trigger = offeringsById.get(triggerId);
+          // Eltern sehen nur aktive Angebote; Regeln an oder von inaktiven
+          // Angeboten können nicht greifen und bleiben hier draußen.
+          if (!trigger?.is_active) return [];
+          const grades = formatGradeLevelList(
+            target.auto_add_grade_levels ?? [],
+          );
+          const gradeSuffix = grades
+            ? ` (${gradeNoun(target.auto_add_grade_levels ?? [])} ${grades})`
             : "";
-        return [
-          {
-            key: `${target.id}-${trigger.id}`,
-            sentence: `„${target.name}“ wird automatisch mitgebucht, wenn „${trigger.name}“ gewählt wird${gradeSuffix}.`,
-          },
-        ];
-      }),
+          return [
+            {
+              key: `${target.id}-${trigger.id}`,
+              sentence: `„${target.name}“ wird automatisch mitgebucht, wenn „${trigger.name}“ gewählt wird${gradeSuffix}.`,
+            },
+          ];
+        },
+      ),
     );
   if (rules.length === 0) return null;
   return (
-    <section className="moto-content-surface rounded-2xl border p-4 shadow-sm">
-      <h2 className="text-sm font-semibold text-gray-900">
+    <section className="moto-content-surface rounded-2xl border p-4 shadow-sm backdrop-blur-md">
+      <h2 className="text-base font-semibold text-gray-900">
         Mitbuchungs-Regeln
       </h2>
       <p className="mt-0.5 text-xs text-gray-500">

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -23,6 +23,8 @@ import {
   careOfferingAvailabilityRuleError,
   countCareOfferingRuleConflicts,
   describeCareOfferingAvailabilityRule,
+  formatGradeLevelList,
+  gradeNoun,
 } from "~/lib/care-offering-availability";
 import {
   type CareOfferingBookingStats,
@@ -922,6 +924,10 @@ export function CareOfferingsEditor() {
             />
           ) : null}
 
+          {!draft && !cloneSource ? (
+            <AutoAddRuleOverview offerings={offerings} />
+          ) : null}
+
           {selectedPhaseId &&
           offerings.length === 0 &&
           !draft &&
@@ -1270,6 +1276,57 @@ function EmptyCareOfferingState({
         <Plus className="h-4 w-4" aria-hidden="true" />
         Erstes Betreuungsangebot anlegen
       </button>
+    </section>
+  );
+}
+
+// Eine falsch herum konfigurierte Mitbuchungs-Regel (#2367, Fall OGS am Berg
+// in #2365) fällt erst bei einer echten Anmeldung auf, solange jede Regel nur
+// im Editor ihres Ziel-Angebots sichtbar ist. Dieses Panel sammelt alle
+// aktiven Regeln der Phase als Klartext-Sätze im selben Wortlaut wie die
+// Editor-Vorschau, damit die Wirkrichtung ohne Testanmeldung ablesbar ist.
+function AutoAddRuleOverview({
+  offerings,
+}: Readonly<{ offerings: CareOffering[] }>) {
+  const offeringsById = new Map(
+    offerings.map((offering) => [offering.id, offering]),
+  );
+  const rules = offerings
+    .filter((offering) => offering.is_active)
+    .flatMap((target) =>
+      (target.auto_add_trigger_offering_ids ?? []).flatMap((triggerId) => {
+        const trigger = offeringsById.get(triggerId);
+        // Eltern sehen nur aktive Angebote; Regeln an oder von inaktiven
+        // Angeboten können nicht greifen und bleiben hier draußen.
+        if (!trigger?.is_active) return [];
+        const grades = target.auto_add_grade_levels ?? [];
+        const gradeSuffix =
+          grades.length > 0
+            ? ` (${gradeNoun(grades)} ${formatGradeLevelList(grades)})`
+            : "";
+        return [
+          {
+            key: `${target.id}-${trigger.id}`,
+            sentence: `„${target.name}“ wird automatisch mitgebucht, wenn „${trigger.name}“ gewählt wird${gradeSuffix}.`,
+          },
+        ];
+      }),
+    );
+  if (rules.length === 0) return null;
+  return (
+    <section className="moto-content-surface rounded-2xl border p-4 shadow-sm">
+      <h2 className="text-sm font-semibold text-gray-900">
+        Mitbuchungs-Regeln
+      </h2>
+      <p className="mt-0.5 text-xs text-gray-500">
+        Jede Regel wirkt nur in die genannte Richtung. Ändern kannst du sie beim
+        jeweils mitgebuchten Angebot unter Bearbeiten.
+      </p>
+      <ul className="mt-2 space-y-1 text-sm text-gray-700">
+        {rules.map((rule) => (
+          <li key={rule.key}>{rule.sentence}</li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -38,6 +38,7 @@ import {
 import { Modal } from "~/components/ui/modal";
 import { Checkbox } from "~/components/ui/checkbox";
 import { Button } from "~/components/ui/button";
+import { SectionCard } from "~/components/ui/section-card";
 import { type Phase, listPhases } from "~/lib/enrollment-phase-api";
 import { calendarPeriodService } from "~/lib/calendar-period-api";
 import type { CalendarPeriod } from "~/lib/calendar-period-helpers";
@@ -1317,20 +1318,17 @@ function AutoAddRuleOverview({
     );
   if (rules.length === 0) return null;
   return (
-    <section className="moto-content-surface rounded-2xl border p-4 shadow-sm backdrop-blur-md">
-      <h2 className="text-base font-semibold text-gray-900">
-        Mitbuchungs-Regeln
-      </h2>
-      <p className="mt-0.5 text-xs text-gray-500">
-        Jede Regel wirkt nur in die genannte Richtung. Ändern kannst du sie beim
-        jeweils mitgebuchten Angebot unter Bearbeiten.
-      </p>
+    <SectionCard
+      title="Mitbuchungs-Regeln"
+      description="Jede Regel wirkt nur in die genannte Richtung. Ändern kannst du sie beim jeweils mitgebuchten Angebot unter Bearbeiten."
+      bodyClassName="mt-2"
+    >
       <ul className="mt-2 space-y-1 text-sm text-gray-700">
         {rules.map((rule) => (
           <li key={rule.key}>{rule.sentence}</li>
         ))}
       </ul>
-    </section>
+    </SectionCard>
   );
 }
 

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -21,6 +21,9 @@ import {
 import {
   type CareOfferingBookingGradeCounts,
   careOfferingAvailabilityRuleError,
+  careOfferingRuleExcludesNobody,
+  careOfferingRuleGradeLevels,
+  careOfferingIsAvailable,
   countCareOfferingRuleConflicts,
   describeCareOfferingAvailabilityRule,
   formatGradeLevelList,
@@ -443,11 +446,27 @@ export function CareOfferingsEditor() {
             // Eltern sehen nur aktive Angebote; Regeln an oder von inaktiven
             // Angeboten können nicht greifen und bleiben hier draußen.
             if (!trigger?.is_active) return [];
-            const grades = formatGradeLevelList(
-              target.auto_add_grade_levels ?? [],
-            );
+            const autoAddGrades = target.auto_add_grade_levels ?? [];
+            const unrestricted =
+              autoAddGrades.length === 0 &&
+              careOfferingRuleExcludesNobody(
+                target.availability_rule,
+                gradeLevelMax ?? undefined,
+              );
+            const applicableGrades = autoAddGrades.length
+              ? autoAddGrades.filter((grade) =>
+                  careOfferingIsAvailable(target, grade),
+                )
+              : unrestricted
+                ? []
+                : careOfferingRuleGradeLevels(
+                    target.availability_rule,
+                    gradeLevelMax ?? undefined,
+                  );
+            if (!unrestricted && applicableGrades.length === 0) return [];
+            const grades = formatGradeLevelList(applicableGrades);
             const gradeSuffix = grades
-              ? ` (${gradeNoun(target.auto_add_grade_levels ?? [])} ${grades})`
+              ? ` (${gradeNoun(applicableGrades)} ${grades})`
               : "";
             return [
               {
@@ -458,7 +477,7 @@ export function CareOfferingsEditor() {
           },
         ),
       );
-  }, [offerings]);
+  }, [offerings, gradeLevelMax]);
 
   const loadPlannerMetadata = useCallback(async () => {
     const requestSeq = ++metadataLoadSeq.current;

--- a/frontend/src/components/enrollment/care-offerings-editor.tsx
+++ b/frontend/src/components/enrollment/care-offerings-editor.tsx
@@ -430,6 +430,35 @@ export function CareOfferingsEditor() {
     if (offering.capacity == null) return sum;
     return sum + offering.capacity;
   }, 0);
+  const autoAddRules = useMemo(() => {
+    const offeringsById = new Map(
+      offerings.map((offering) => [offering.id, offering]),
+    );
+    return offerings
+      .filter((offering) => offering.is_active)
+      .flatMap((target) =>
+        [...new Set(target.auto_add_trigger_offering_ids ?? [])].flatMap(
+          (triggerId) => {
+            const trigger = offeringsById.get(triggerId);
+            // Eltern sehen nur aktive Angebote; Regeln an oder von inaktiven
+            // Angeboten können nicht greifen und bleiben hier draußen.
+            if (!trigger?.is_active) return [];
+            const grades = formatGradeLevelList(
+              target.auto_add_grade_levels ?? [],
+            );
+            const gradeSuffix = grades
+              ? ` (${gradeNoun(target.auto_add_grade_levels ?? [])} ${grades})`
+              : "";
+            return [
+              {
+                key: `${target.id}-${trigger.id}`,
+                sentence: `„${target.name}“ wird automatisch mitgebucht, wenn „${trigger.name}“ gewählt wird${gradeSuffix}.`,
+              },
+            ];
+          },
+        ),
+      );
+  }, [offerings]);
 
   const loadPlannerMetadata = useCallback(async () => {
     const requestSeq = ++metadataLoadSeq.current;
@@ -925,8 +954,18 @@ export function CareOfferingsEditor() {
             />
           ) : null}
 
-          {!draft && !cloneSource ? (
-            <AutoAddRuleOverview offerings={offerings} />
+          {!draft && !cloneSource && autoAddRules.length > 0 ? (
+            <SectionCard
+              title="Mitbuchungs-Regeln"
+              description="Jede Regel wirkt nur in die genannte Richtung. Ändern kannst du sie beim jeweils mitgebuchten Angebot unter Bearbeiten."
+              bodyClassName="mt-2"
+            >
+              <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                {autoAddRules.map((rule) => (
+                  <li key={rule.key}>{rule.sentence}</li>
+                ))}
+              </ul>
+            </SectionCard>
           ) : null}
 
           {selectedPhaseId &&
@@ -1278,57 +1317,6 @@ function EmptyCareOfferingState({
         Erstes Betreuungsangebot anlegen
       </button>
     </section>
-  );
-}
-
-// Eine falsch herum konfigurierte Mitbuchungs-Regel (#2367, Fall OGS am Berg
-// in #2365) fällt erst bei einer echten Anmeldung auf, solange jede Regel nur
-// im Editor ihres Ziel-Angebots sichtbar ist. Dieses Panel sammelt alle
-// aktiven Regeln der Phase als Klartext-Sätze (ziel-zuerst, wie das Beispiel
-// in #2367), damit die Wirkrichtung ohne Testanmeldung ablesbar ist.
-function AutoAddRuleOverview({
-  offerings,
-}: Readonly<{ offerings: CareOffering[] }>) {
-  const offeringsById = new Map(
-    offerings.map((offering) => [offering.id, offering]),
-  );
-  const rules = offerings
-    .filter((offering) => offering.is_active)
-    .flatMap((target) =>
-      [...new Set(target.auto_add_trigger_offering_ids ?? [])].flatMap(
-        (triggerId) => {
-          const trigger = offeringsById.get(triggerId);
-          // Eltern sehen nur aktive Angebote; Regeln an oder von inaktiven
-          // Angeboten können nicht greifen und bleiben hier draußen.
-          if (!trigger?.is_active) return [];
-          const grades = formatGradeLevelList(
-            target.auto_add_grade_levels ?? [],
-          );
-          const gradeSuffix = grades
-            ? ` (${gradeNoun(target.auto_add_grade_levels ?? [])} ${grades})`
-            : "";
-          return [
-            {
-              key: `${target.id}-${trigger.id}`,
-              sentence: `„${target.name}“ wird automatisch mitgebucht, wenn „${trigger.name}“ gewählt wird${gradeSuffix}.`,
-            },
-          ];
-        },
-      ),
-    );
-  if (rules.length === 0) return null;
-  return (
-    <SectionCard
-      title="Mitbuchungs-Regeln"
-      description="Jede Regel wirkt nur in die genannte Richtung. Ändern kannst du sie beim jeweils mitgebuchten Angebot unter Bearbeiten."
-      bodyClassName="mt-2"
-    >
-      <ul className="mt-2 space-y-1 text-sm text-gray-700">
-        {rules.map((rule) => (
-          <li key={rule.key}>{rule.sentence}</li>
-        ))}
-      </ul>
-    </SectionCard>
   );
 }
 

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -1903,6 +1903,49 @@ describe("CareOfferingsEditor", () => {
     );
   });
 
+  // #2367: a reversed rule direction must be visible without a test
+  // enrollment, so the phase catalog lists every active rule as a sentence.
+  it("lists the phase's active Mitbuchungs-Regeln as plain sentences", async () => {
+    mocks.listPhases.mockResolvedValue([phase()]);
+    mocks.listCareOfferings.mockResolvedValue([
+      offering({
+        id: "1",
+        name: "Ganztagsbetreuung bis 14.30 Uhr",
+        auto_add_trigger_offering_ids: ["2"],
+        auto_add_grade_levels: [1, 2],
+      }),
+      offering({ id: "2", name: "Randstunde" }),
+      offering({
+        id: "3",
+        name: "Inaktives Ziel",
+        is_active: false,
+        auto_add_trigger_offering_ids: ["2"],
+      }),
+    ]);
+
+    const { unmount } = render(<CareOfferingsEditor />);
+
+    expect(await screen.findByText("Mitbuchungs-Regeln")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "„Ganztagsbetreuung bis 14.30 Uhr“ wird automatisch mitgebucht, wenn „Randstunde“ gewählt wird (Klassen 1–2).",
+      ),
+    ).toBeInTheDocument();
+    // A rule on an inactive offering cannot fire, so it stays out of the list.
+    const sentences = screen.getAllByText(/wird automatisch mitgebucht/);
+    expect(sentences).toHaveLength(1);
+    unmount();
+
+    // Without any rule the panel stays away entirely.
+    mocks.listCareOfferings.mockResolvedValue([
+      offering(),
+      offering({ id: "2", name: "Randstunde" }),
+    ]);
+    render(<CareOfferingsEditor />);
+    expect(await screen.findByText("Randstunde")).toBeInTheDocument();
+    expect(screen.queryByText("Mitbuchungs-Regeln")).not.toBeInTheDocument();
+  });
+
   it("shows empty and error states", async () => {
     mocks.listPhases.mockResolvedValueOnce([]);
     mocks.listCareOfferings.mockResolvedValue([]);

--- a/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
+++ b/frontend/src/components/enrollment/enrollment-admin-editors.test.tsx
@@ -1912,7 +1912,12 @@ describe("CareOfferingsEditor", () => {
         id: "1",
         name: "Ganztagsbetreuung bis 14.30 Uhr",
         auto_add_trigger_offering_ids: ["2"],
-        auto_add_grade_levels: [1, 2],
+        availability_rule: {
+          match: "all",
+          conditions: [
+            { source: "grade_level", operator: "in", value: [1, 2] },
+          ],
+        },
       }),
       offering({ id: "2", name: "Randstunde" }),
       offering({

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -1555,6 +1555,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Schränkst du eine Regel nachträglich ein, meldet der Bereich `Bedingungen für die Verfügbarkeit`, wie viele bestehende Buchungen die neue Bedingung nicht erfüllen. Das ist nur ein Hinweis: Bestehende Buchungen bleiben bestehen, die Regel gilt nur für neue Auswahlen.",
           "Unter `Betreuungstage & Mitbuchung` festlegen, ob das Angebot als Betreuungstage zählt und ob es mitgebucht wird, wenn Eltern bestimmte andere Angebote wählen.",
           "Bei der Mitbuchung die auslösenden Angebote auswählen und optional auf Klassenstufen eingrenzen. Diese Klassenstufen steuern nur die automatische Mitbuchung; sie sind von den Bedingungen für die Verfügbarkeit getrennt.",
+          "Über der Angebotsliste stehen die `Mitbuchungs-Regeln` der Phase. Jeder Satz zeigt: Das erste Angebot wird gebucht, wenn Eltern das zweite wählen. Klassenstufen stehen bei Bedarf dabei.",
           "Optional `Kapazität`, `Preis in Cent` sowie `Mittagessen` oder `Ferienbetreuung` ergänzen.",
           "`Aktiv` setzen - nur aktive Angebote sind für Eltern auswählbar.",
         ],

--- a/frontend/src/lib/care-offering-availability.ts
+++ b/frontend/src/lib/care-offering-availability.ts
@@ -81,13 +81,13 @@ function normalizedGradeLevelMax(gradeLevelMax?: number): number {
 /**
  * The grades a rule actually admits, in ascending order.
  *
- * Module-internal on purpose: every user-facing string in this file is
- * derived from this set rather than from the rule's condition list. Describing conditions one by one and joining them
+ * Every user-facing string is derived from this set rather than from the
+ * rule's condition list. Describing conditions one by one and joining them
  * with "und"/"oder" does NOT describe what the rule evaluates to: an `all`
  * rule of "Klasse 1" AND "Klasse 2" matches no grade at all, yet reads as if
  * it allowed two of them (#2186 review).
  */
-function careOfferingRuleGradeLevels(
+export function careOfferingRuleGradeLevels(
   rule: CareOfferingAvailabilityRule | null | undefined,
   gradeLevelMax?: number,
 ): number[] {

--- a/frontend/src/lib/care-offering-availability.ts
+++ b/frontend/src/lib/care-offering-availability.ts
@@ -61,7 +61,7 @@ export function formatGradeLevelList(values: readonly number[]): string {
   return `${runs.slice(0, -1).join(", ")} und ${runs.at(-1)}`;
 }
 
-function gradeNoun(values: readonly number[]): string {
+export function gradeNoun(values: readonly number[]): string {
   return new Set(values).size === 1 ? "Klasse" : "Klassen";
 }
 


### PR DESCRIPTION
## Zusammenfassung

Die Angebotsverwaltung zeigt über der Angebotsliste einer Anmeldephase die wirksamen Mitbuchungs-Regeln gesammelt als Klartext-Sätze:

> „Ganztagsbetreuung bis 14.30 Uhr“ wird automatisch mitgebucht, wenn „Randstunde“ gewählt wird (Klassen 1–2).

So lassen sich falsch herum konfigurierte Regeln wie im Fall OGS am Berg (#2365) erkennen, ohne eine Testanmeldung durchführen zu müssen.

## Umsetzung

- Neues Panel `Mitbuchungs-Regeln` zwischen Toolbar und Angebotsliste.
- Sichtbar nur außerhalb von Bearbeitungs- und Duplizierungsformularen und nur, wenn anzeigbare Regeln vorhanden sind.
- Rein clientseitige Auswertung der bereits geladenen Angebotsdaten; kein neuer Endpoint und kein neues Datenmodell.
- Regeln mit inaktiven Quell- oder Zielangeboten werden ausgeblendet.
- Klassenstufen werden aus der tatsächlichen Verfügbarkeit des Zielangebots abgeleitet und passend formatiert.
- Die Hilfeseite beschreibt die neue Übersicht.
- Zusätzlicher Repository-Test stellt sicher, dass legacy manuell angelegte, nicht template-verknüpfte Aktivitätsinstanzen bei einer Neuplanung erhalten bleiben.

## Tests

- Test für Satz-Wortlaut, Klassenstufen, Filterung inaktiver Angebote und das Ausblenden des Panels ohne Regeln.
- Bestehender Repository-Test für die Erhaltung legacy manueller Aktivitätsinstanzen erweitert.
- Frontend-Suite, `pnpm run check` und Knip wurden ausgeführt.
- Visuell gegen die lokale Dev-Instanz mit einer Randstunde→OGS-Ganztag-Regel geprüft.

## Bewusst nicht enthalten

- Die Pflicht-Mittagessen-Ableitung des Backend-Materialisierers erscheint nicht als Mitbuchungs-Regel, da sie über `is_required` und `includes_lunch` gesteuert wird.
- Regeln, deren Ziel keine Einzeltag-Auswahl erlaubt, erhalten keinen zusätzlichen Warnhinweis; der Editor weist beim Speichern darauf hin.

Closes #2367
