### PR TITLE
fix(logging): Query-String-Werte aus Zugriffslogs redigieren

### DIFF
--- a/backend/api/access_log_redaction_test.go
+++ b/backend/api/access_log_redaction_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #2105: slog-chi writes slog.String("query", r.URL.RawQuery) into every
+// access line at Info level. Staff-UI search endpoints pass student names and
+// e-mail addresses as query parameters (?search=, ?first_name=, ?email=, ?q=),
+// so every search wrote personal data into Loki. The request logger is wrapped
+// in NewQueryValueRedactor; this test drives the real setupBasicMiddleware
+// chain and pins that query VALUES never reach the log while method, path,
+// status, and duration survive.
+func TestAccessLogOmitsQueryValues(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	router := chi.NewRouter()
+	setupBasicMiddleware(router, logger, nil)
+	router.Get("/api/students", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/students?search=Mustermann&first_name=Erika&email=erika%40example.com", nil)
+	// The browser sends the staff-UI page URL — including its search box query —
+	// as the Referer on same-origin API calls.
+	req.Header.Set("Referer", "https://schule.example.com/students/search?search=Mustermann")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	out := logs.String()
+	require.NotEmpty(t, out, "expected the request to emit an access log line")
+
+	for _, forbidden := range []string{"Mustermann", "Erika", "erika%40example.com", "erika@example.com"} {
+		assert.NotContainsf(t, out, forbidden, "access log must not carry query value %q:\n%s", forbidden, out)
+	}
+
+	// Diagnostic value stays: method, path, status, duration, and the query
+	// parameter NAMES.
+	assert.Contains(t, out, `"method":"GET"`)
+	assert.Contains(t, out, `"path":"/api/students"`)
+	assert.Contains(t, out, `"status":200`)
+	assert.Contains(t, out, `"latency"`)
+	assert.Contains(t, out, `"query":"search&first_name&email"`)
+}

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -218,9 +218,12 @@ func setupBasicMiddleware(router chi.Router, logger *slog.Logger, httpMetrics *o
 		router.Use(httpMetrics.Middleware)
 	}
 	// Redact the parent calendar-feed token (the sole credential for the public
-	// /public/calendar/{token} feed) from the per-request "path" attribute so it
-	// never lands in access logs.
-	requestLogger := slog.New(customMiddleware.NewFeedTokenRedactor(logger.Handler()))
+	// /public/calendar/{token} feed) from the per-request "path" attribute, and
+	// strip query-string values (staff-UI searches carry student names and
+	// e-mail addresses as query parameters, issue #2105) so neither lands in
+	// access logs.
+	requestLogger := slog.New(customMiddleware.NewQueryValueRedactor(
+		customMiddleware.NewFeedTokenRedactor(logger.Handler())))
 	router.Use(slogchi.NewWithConfig(requestLogger, slogchi.Config{
 		DefaultLevel:     slog.LevelInfo,
 		ClientErrorLevel: slog.LevelWarn,

--- a/backend/middleware/log_redaction.go
+++ b/backend/middleware/log_redaction.go
@@ -12,55 +12,81 @@ import (
 // replayed.
 const feedCalendarPathMarker = "/public/calendar/"
 
-// feedTokenRedactor wraps a slog.Handler and rewrites the calendar-feed
-// subscription token in any log record (message, string attributes, and nested
-// groups) to "[REDACTED]". It is applied to both the HTTP request logger and the
-// security logger, whose "path" attribute would otherwise capture the token
-// verbatim (the security logger records it on rate-limited requests).
-type feedTokenRedactor struct {
-	inner slog.Handler
+// attrRedactor wraps a slog.Handler and rewrites the message and every string
+// attribute (including nested groups) through transform. transform receives the
+// attribute key ("" for the record message) so implementations can redact
+// selectively.
+type attrRedactor struct {
+	inner     slog.Handler
+	transform func(key, value string) string
 }
 
 // NewFeedTokenRedactor wraps inner so calendar-feed tokens are redacted from
-// every emitted log record.
+// every emitted log record (message, string attributes, and nested groups). It
+// is applied to both the HTTP request logger and the security logger, whose
+// "path" attribute would otherwise capture the token verbatim (the security
+// logger records it on rate-limited requests).
 func NewFeedTokenRedactor(inner slog.Handler) slog.Handler {
-	return &feedTokenRedactor{inner: inner}
+	return &attrRedactor{inner: inner, transform: func(_, value string) string {
+		return RedactFeedToken(value)
+	}}
 }
 
-func (h *feedTokenRedactor) Enabled(ctx context.Context, level slog.Level) bool {
+// NewQueryValueRedactor wraps inner so query-string values never reach the
+// access log (issue #2105): staff-UI search endpoints carry student names and
+// e-mail addresses as query parameters. The "query" attribute keeps only the
+// parameter names; the "referer" attribute keeps its path but loses its query
+// values the same way. Method, path, status, and duration stay intact.
+func NewQueryValueRedactor(inner slog.Handler) slog.Handler {
+	return &attrRedactor{inner: inner, transform: func(key, value string) string {
+		switch key {
+		case "query":
+			return RedactQueryValues(value)
+		case "referer":
+			if path, query, found := strings.Cut(value, "?"); found {
+				return path + "?" + RedactQueryValues(query)
+			}
+			return value
+		default:
+			return value
+		}
+	}}
+}
+
+func (h *attrRedactor) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.inner.Enabled(ctx, level)
 }
 
-func (h *feedTokenRedactor) Handle(ctx context.Context, rec slog.Record) error {
-	out := slog.NewRecord(rec.Time, rec.Level, RedactFeedToken(rec.Message), rec.PC)
+func (h *attrRedactor) Handle(ctx context.Context, rec slog.Record) error {
+	out := slog.NewRecord(rec.Time, rec.Level, h.transform("", rec.Message), rec.PC)
 	rec.Attrs(func(a slog.Attr) bool {
-		out.AddAttrs(redactFeedTokenAttr(a))
+		out.AddAttrs(h.redactAttr(a))
 		return true
 	})
 	return h.inner.Handle(ctx, out)
 }
 
-func (h *feedTokenRedactor) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (h *attrRedactor) WithAttrs(attrs []slog.Attr) slog.Handler {
 	redacted := make([]slog.Attr, len(attrs))
 	for i, a := range attrs {
-		redacted[i] = redactFeedTokenAttr(a)
+		redacted[i] = h.redactAttr(a)
 	}
-	return &feedTokenRedactor{inner: h.inner.WithAttrs(redacted)}
+	return &attrRedactor{inner: h.inner.WithAttrs(redacted), transform: h.transform}
 }
 
-func (h *feedTokenRedactor) WithGroup(name string) slog.Handler {
-	return &feedTokenRedactor{inner: h.inner.WithGroup(name)}
+func (h *attrRedactor) WithGroup(name string) slog.Handler {
+	return &attrRedactor{inner: h.inner.WithGroup(name), transform: h.transform}
 }
 
-func redactFeedTokenAttr(a slog.Attr) slog.Attr {
+func (h *attrRedactor) redactAttr(a slog.Attr) slog.Attr {
 	switch a.Value.Kind() {
 	case slog.KindString:
-		return slog.String(a.Key, RedactFeedToken(a.Value.String()))
+		return slog.String(a.Key, h.transform(a.Key, a.Value.String()))
 	case slog.KindGroup:
 		group := a.Value.Group()
 		redacted := make([]slog.Attr, len(group))
 		for i, ga := range group {
-			redacted[i] = redactFeedTokenAttr(ga)
+			redacted[i] = h.redactAttr(ga)
 		}
 		return slog.Attr{Key: a.Key, Value: slog.GroupValue(redacted...)}
 	default:
@@ -87,4 +113,20 @@ func RedactFeedToken(s string) string {
 		return s
 	}
 	return s[:start] + "[REDACTED]" + s[end:]
+}
+
+// RedactQueryValues strips the values from a raw query string, keeping only
+// the parameter names: "search=Mustermann&page=2" becomes "search&page". Names
+// alone are enough for diagnosis; values may contain personal data.
+func RedactQueryValues(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	parts := strings.Split(rawQuery, "&")
+	for i, p := range parts {
+		if name, _, found := strings.Cut(p, "="); found {
+			parts[i] = name
+		}
+	}
+	return strings.Join(parts, "&")
 }

--- a/backend/middleware/log_redaction_test.go
+++ b/backend/middleware/log_redaction_test.go
@@ -72,7 +72,57 @@ func TestSecurityLoggerRedactsFeedToken(t *testing.T) {
 	}
 }
 
-var _ slog.Handler = (*feedTokenRedactor)(nil)
+func TestRedactQueryValues(t *testing.T) {
+	cases := map[string]string{
+		"search=Mustermann":               "search",
+		"search=Mustermann&page=2":        "search&page",
+		"first_name=Max&last_name=Muster": "first_name&last_name",
+		"email=max%40example.com":         "email",
+		"flag":                            "flag", // valueless parameter stays
+		"":                                "",
+		"a=1&b&c=x=y":                     "a&b&c", // value containing '=' is dropped entirely
+	}
+	for in, want := range cases {
+		if got := RedactQueryValues(in); got != want {
+			t.Errorf("RedactQueryValues(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Issue #2105: the access-log "query" attribute (nested in slog-chi's
+// "request" group) and the "referer" attribute must lose their query values
+// while other attributes stay intact.
+func TestQueryValueRedactorHandler(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewQueryValueRedactor(slog.NewTextHandler(&buf, nil)))
+
+	logger.Info("request",
+		slog.Group("request",
+			slog.String("method", "GET"),
+			slog.String("path", "/api/students"),
+			slog.String("query", "search=Mustermann&page=2"),
+			slog.String("referer", "https://schule.example.com/students/search?search=Mustermann"),
+		),
+	)
+
+	out := buf.String()
+	if strings.Contains(out, "Mustermann") {
+		t.Errorf("query value leaked into logs:\n%s", out)
+	}
+	for _, want := range []string{"query=search&page", "/api/students", "method=GET", "referer=https://schule.example.com/students/search?search"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in logs:\n%s", want, out)
+		}
+	}
+	// Non-query attributes containing '=' or '&' are untouched.
+	buf.Reset()
+	logger.Info("other", slog.String("detail", "a=1&b=2"))
+	if !strings.Contains(buf.String(), "a=1&b=2") {
+		t.Errorf("non-query attribute should be preserved:\n%s", buf.String())
+	}
+}
+
+var _ slog.Handler = (*attrRedactor)(nil)
 
 func TestFeedTokenRedactorEnabled(t *testing.T) {
 	h := NewFeedTokenRedactor(slog.NewTextHandler(&bytes.Buffer{}, nil))

--- a/frontend/src/lib/api-helpers.server.ts
+++ b/frontend/src/lib/api-helpers.server.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { recordBackendProxyMetric } from "./backend-proxy-metrics";
 import { canonicalForwardedFor } from "./client-headers.server";
+import { sanitizeEndpoint } from "./log-sanitize";
 import { createLogger } from "~/lib/logger";
 
 // Logger instance for API helpers
@@ -251,20 +252,6 @@ function parseContentLength(value: string | null): number | null {
 
 function parseResponseContentLength(response: Response): number | null {
   return parseContentLength(response.headers?.get?.("content-length") ?? null);
-}
-
-function sanitizeEndpoint(endpoint: string): string {
-  const [path = ""] = endpoint.split("?");
-  return path
-    .split("/")
-    .map((segment) => {
-      if (!segment) return segment;
-      if (/^\d+$/.test(segment)) return "{id}";
-      if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(segment)) return "{uuid}";
-      if (/^[A-Za-z0-9_-]{16,}$/.test(segment)) return "{token}";
-      return segment;
-    })
-    .join("/");
 }
 
 function extractTokenContext(token: string): {

--- a/frontend/src/lib/api-helpers.test.ts
+++ b/frontend/src/lib/api-helpers.test.ts
@@ -749,6 +749,50 @@ describe("fetchWithRetry", () => {
     expect(consoleSpies.warn).toHaveBeenCalled();
   });
 
+  // Issue #2105: these log lines are shipped to /api/logs and land in Loki,
+  // so query values (student names, e-mail addresses from staff-UI searches)
+  // must never appear in them.
+  it("strips query values from logged URLs", async () => {
+    mockFetchRetry.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve("Forbidden"),
+    } as Response);
+
+    await fetchWithRetry(
+      "http://api.test/api/students?search=Mustermann&first_name=Erika",
+      "test-token",
+    );
+
+    expect(consoleSpies.warn).toHaveBeenCalledWith(
+      "api access denied",
+      expect.objectContaining({ url: "http://api.test/api/students" }),
+    );
+    expect(JSON.stringify(consoleSpies.warn.mock.calls)).not.toContain(
+      "Mustermann",
+    );
+  });
+
+  it("strips query values from error-level logs", async () => {
+    mockFetchRetry.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("boom"),
+    } as Response);
+
+    await expect(
+      fetchWithRetry("http://api.test/api/students?search=Mustermann", "t"),
+    ).rejects.toThrow("API error: 500");
+
+    expect(consoleSpies.error).toHaveBeenCalledWith(
+      "api error",
+      expect.objectContaining({ url: "http://api.test/api/students" }),
+    );
+    expect(JSON.stringify(consoleSpies.error.mock.calls)).not.toContain(
+      "Mustermann",
+    );
+  });
+
   it("throws error for non-access-denied errors (4xx bugs)", async () => {
     mockFetchRetry.mockResolvedValueOnce({
       ok: false,

--- a/frontend/src/lib/api-helpers.ts
+++ b/frontend/src/lib/api-helpers.ts
@@ -1,5 +1,6 @@
 // lib/api-helpers.ts
 import { isBrowserContext } from "./api-url";
+import { sanitizeEndpoint } from "./log-sanitize";
 import { createLogger } from "~/lib/logger";
 
 // Logger instance for API helpers
@@ -238,7 +239,7 @@ export async function fetchWithRetry<T>(
   if (response.status === 401 && onAuthFailure && getNewToken) {
     const errorText = await response.text();
     logger.info("token expired, attempting refresh", {
-      url,
+      url: sanitizeEndpoint(url),
       method,
       status: response.status,
       error_text: errorText,
@@ -266,7 +267,7 @@ export async function fetchWithRetry<T>(
     const accessDeniedStatuses = [401, 403];
     if (accessDeniedStatuses.includes(response.status)) {
       logger.warn("api access denied", {
-        url,
+        url: sanitizeEndpoint(url),
         method,
         status: response.status,
         error_text: errorText.substring(0, 200),
@@ -275,7 +276,7 @@ export async function fetchWithRetry<T>(
     }
     // All other errors (4xx bugs, 5xx server errors) should throw
     const logContext = {
-      url,
+      url: sanitizeEndpoint(url),
       method,
       status: response.status,
       error_text: errorText.substring(0, 200),

--- a/frontend/src/lib/api-interceptor.test.ts
+++ b/frontend/src/lib/api-interceptor.test.ts
@@ -209,12 +209,15 @@ describe("response interceptor token refresh queue", () => {
 
   it("request interceptor injects auth token in browser context", async () => {
     const restore = setupBrowserEnv();
+    const consoleDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => {});
     try {
       mockGetSession.mockResolvedValue({ user: { token: "browser-token" } });
 
       const result = await requestInterceptorFulfilled({
         method: "get",
-        url: "/api/test",
+        url: "/api/students?search=Mustermann",
         headers: {},
       });
 
@@ -222,27 +225,44 @@ describe("response interceptor token refresh queue", () => {
       expect(result.headers).toMatchObject({
         Authorization: "Bearer browser-token",
       });
+      expect(consoleDebug).toHaveBeenCalledWith("token injected in request", {
+        method: "GET",
+        url: "/api/students",
+        has_token: true,
+      });
     } finally {
+      consoleDebug.mockRestore();
       restore();
     }
   });
 
   it("request interceptor leaves headers unchanged when browser session has no token", async () => {
     const restore = setupBrowserEnv();
+    const consoleDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => {});
     try {
       mockGetSession.mockResolvedValue({ user: {} });
       const headers = {};
 
       const result = await requestInterceptorFulfilled({
         method: "get",
-        url: "/api/test",
+        url: "/api/students?email=erika%40example.com",
         headers,
       });
 
       expect(mockGetSession).toHaveBeenCalledTimes(1);
       expect(result.headers).toBe(headers);
       expect(result.headers).not.toHaveProperty("Authorization");
+      expect(consoleDebug).toHaveBeenCalledWith(
+        "no token available for request",
+        {
+          method: "GET",
+          url: "/api/students",
+        },
+      );
     } finally {
+      consoleDebug.mockRestore();
       restore();
     }
   });
@@ -461,6 +481,9 @@ describe("response interceptor token refresh queue", () => {
 
   it("multiple concurrent 401s: all queued requests reject on failure", async () => {
     const restore = setupBrowserEnv();
+    const consoleDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => {});
     try {
       // Create a deferred promise so we can control when handleAuthFailure resolves
       let rejectAuthFailure!: () => void;
@@ -482,7 +505,7 @@ describe("response interceptor token refresh queue", () => {
 
       // Second and third 401s: should get queued (isRefreshing is true)
       const error2 = make401Error({
-        url: "/api/request-2",
+        url: "/api/students?first_name=Erika",
         method: "get",
         headers: {},
       });
@@ -494,6 +517,11 @@ describe("response interceptor token refresh queue", () => {
       const promise2 = responseInterceptorRejected(error2);
       const promise3 = responseInterceptorRejected(error3);
 
+      expect(consoleDebug).toHaveBeenCalledWith(
+        "token refresh in progress, queueing request",
+        expect.objectContaining({ url: "/api/students" }),
+      );
+
       // Now fail the refresh
       rejectAuthFailure();
 
@@ -502,6 +530,7 @@ describe("response interceptor token refresh queue", () => {
       await expect(promise2).rejects.toThrow("Token refresh failed");
       await expect(promise3).rejects.toThrow("Token refresh failed");
     } finally {
+      consoleDebug.mockRestore();
       restore();
     }
   });

--- a/frontend/src/lib/api-transport.ts
+++ b/frontend/src/lib/api-transport.ts
@@ -43,13 +43,13 @@ api.interceptors.request.use(
         config.headers.Authorization = `Bearer ${session.user.token}`;
         logger.debug("token injected in request", {
           method: config.method?.toUpperCase(),
-          url: config.url,
+          url: sanitizeEndpoint(config.url ?? ""),
           has_token: true,
         });
       } else {
         logger.debug("no token available for request", {
           method: config.method?.toUpperCase(),
-          url: config.url,
+          url: sanitizeEndpoint(config.url ?? ""),
         });
       }
     }
@@ -194,7 +194,7 @@ api.interceptors.response.use(
     if (isRefreshing) {
       logger.debug("token refresh in progress, queueing request", {
         caller_id: callerId,
-        url: originalRequest.url,
+        url: sanitizeEndpoint(originalRequest.url ?? ""),
       });
       return queueRequestForRefresh(originalRequest, callerId);
     }

--- a/frontend/src/lib/api-transport.ts
+++ b/frontend/src/lib/api-transport.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { env } from "~/env";
+import { sanitizeEndpoint } from "~/lib/log-sanitize";
 import { createLogger } from "~/lib/logger";
 import { clearSessionCache, getCachedSession } from "~/lib/session-cache";
 
@@ -154,7 +155,7 @@ api.interceptors.response.use(
     if (error.response?.status !== 401) {
       logger.error("api request failed", {
         method: originalRequest?.method?.toUpperCase(),
-        url: originalRequest?.url,
+        url: sanitizeEndpoint(originalRequest?.url ?? ""),
         status: error.response?.status,
         error: error.message,
       });
@@ -172,7 +173,7 @@ api.interceptors.response.use(
 
     logger.info("token expired, attempting refresh", {
       method: originalRequest.method?.toUpperCase(),
-      url: originalRequest.url,
+      url: sanitizeEndpoint(originalRequest.url ?? ""),
       retry_count: originalRequest._retryCount,
       caller_id: callerId,
     });
@@ -181,7 +182,7 @@ api.interceptors.response.use(
     if (originalRequest._retryCount > 3) {
       logger.warn("max token refresh retries reached", {
         method: originalRequest.method?.toUpperCase(),
-        url: originalRequest.url,
+        url: sanitizeEndpoint(originalRequest.url ?? ""),
         retry_count: originalRequest._retryCount,
         action: "redirecting to login",
       });

--- a/frontend/src/lib/fetch-with-auth.ts
+++ b/frontend/src/lib/fetch-with-auth.ts
@@ -1,4 +1,5 @@
 import { handleAuthFailure } from "./auth-failure";
+import { sanitizeEndpoint } from "~/lib/log-sanitize";
 import { createLogger } from "~/lib/logger";
 
 const logger = createLogger({ component: "FetchWithAuth" });
@@ -33,7 +34,10 @@ export async function fetchWithAuth(
           return fetchWithAuth(url, { ...fetchOptions, retry: false });
         }
       } catch (error) {
-        logger.error("token refresh failed", { url, error: String(error) });
+        logger.error("token refresh failed", {
+          url: sanitizeEndpoint(url),
+          error: String(error),
+        });
       }
     }
   }

--- a/frontend/src/lib/log-sanitize.test.ts
+++ b/frontend/src/lib/log-sanitize.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeEndpoint } from "./log-sanitize";
+
+describe("sanitizeEndpoint", () => {
+  it("removes the query string entirely (issue #2105)", () => {
+    expect(
+      sanitizeEndpoint("/api/students?search=Mustermann&first_name=Erika"),
+    ).toBe("/api/students");
+    expect(
+      sanitizeEndpoint(
+        "http://api.test/api/students?email=erika%40example.com",
+      ),
+    ).toBe("http://api.test/api/students");
+  });
+
+  it("masks numeric IDs, UUIDs, and token-like segments", () => {
+    expect(sanitizeEndpoint("/api/students/12345/visits")).toBe(
+      "/api/students/{id}/visits",
+    );
+    expect(
+      sanitizeEndpoint("/api/x/0d1f3c62-9a7b-4c1d-8e2f-aa55bb66cc77"),
+    ).toBe("/api/x/{uuid}");
+    expect(sanitizeEndpoint("/invite/AbCdEfGhIjKlMnOp123")).toBe(
+      "/invite/{token}",
+    );
+  });
+
+  it("leaves plain paths untouched", () => {
+    expect(sanitizeEndpoint("/api/staff")).toBe("/api/staff");
+    expect(sanitizeEndpoint("")).toBe("");
+  });
+});

--- a/frontend/src/lib/log-sanitize.ts
+++ b/frontend/src/lib/log-sanitize.ts
@@ -1,0 +1,21 @@
+/**
+ * Strips a URL or endpoint down to a log-safe form: the query string is
+ * removed entirely (staff-UI searches carry student names and e-mail
+ * addresses as query parameters — issue #2105) and path segments that look
+ * like numeric IDs, UUIDs, or tokens are masked. Browser logs are shipped to
+ * /api/logs and land in Loki, so this applies to client and server logging
+ * alike.
+ */
+export function sanitizeEndpoint(endpoint: string): string {
+  const [path = ""] = endpoint.split("?");
+  return path
+    .split("/")
+    .map((segment) => {
+      if (!segment) return segment;
+      if (/^\d+$/.test(segment)) return "{id}";
+      if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(segment)) return "{uuid}";
+      if (/^[A-Za-z0-9_-]{16,}$/.test(segment)) return "{token}";
+      return segment;
+    })
+    .join("/");
+}

--- a/frontend/src/lib/operator/route-wrapper.server.ts
+++ b/frontend/src/lib/operator/route-wrapper.server.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { withOperatorAuth } from "~/server/auth/operator-route";
 import { handleApiError } from "../api-helpers.server";
 import { recordBackendProxyMetric } from "../backend-proxy-metrics";
+import { sanitizeEndpoint } from "../log-sanitize";
 import { makeProxyFactories } from "../route-proxy-factory.server";
 import {
   extractParams,
@@ -109,20 +110,6 @@ async function recordOperatorBackendProxyMetric(args: {
   } catch {
     // Metrics must never alter request behavior.
   }
-}
-
-function sanitizeEndpoint(endpoint: string): string {
-  const [path = ""] = endpoint.split("?");
-  return path
-    .split("/")
-    .map((segment) => {
-      if (!segment) return segment;
-      if (/^\d+$/.test(segment)) return "{id}";
-      if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(segment)) return "{uuid}";
-      if (/^[A-Za-z0-9_-]{16,}$/.test(segment)) return "{token}";
-      return segment;
-    })
-    .join("/");
 }
 
 function parseResponse<T>(response: Response): Promise<T> {


### PR DESCRIPTION
Closes #2105

## Problem

Zugriffslogs schreiben Query-Strings auf Info-Ebene nach Loki. Suchfelder der Staff-UI können dadurch Kindernamen und E-Mail-Adressen protokollieren. Auch Frontend- und Browser-Logs über `/api/logs` enthielten vollständige URLs mit Query-Werten.

## Änderungen

**Backend**

- `NewQueryValueRedactor` redigiert Query-Werte im Access-Log. Parameternamen bleiben zur Diagnose erhalten: `search=Mustermann&page=2` wird zu `search&page`.
- Query-Werte im `referer` werden ebenfalls entfernt, während der Pfad erhalten bleibt.
- Methode, Pfad, Status und Dauer bleiben unverändert.
- Der Feed-Token-Redaktor und die Query-Redaktion verwenden denselben generischen Handler für Attribut-Walks.

**Frontend**

- `sanitizeEndpoint` liegt jetzt in `lib/log-sanitize.ts` und wird von Client- und Server-Code gemeinsam verwendet.
- Query-Strings werden aus geloggten URLs vollständig entfernt.
- Numerische IDs, UUIDs und tokenartige Pfadsegmente werden weiterhin maskiert.
- Die Sanitisierung greift in den API-Helper-Warn- und Error-Pfaden, Axios-Request- und Response-Interceptor-Logs sowie bei `fetch-with-auth`.
- Die serverseitigen Proxy- und Operator-Logger verwenden ebenfalls die gemeinsame Funktion.

## Tests

- Backend-Integrationstest über die echte `setupBasicMiddleware`-Kette für Query- und Referer-Redaktion.
- Unit-Tests für `RedactQueryValues` und den generischen Redaktions-Handler.
- Frontend-Regressionstests für API-Helper und Axios-Interceptor.
- Direkte Unit-Tests für `sanitizeEndpoint`.
- Qualitätsprüfungen:
  - `cd backend && go test ./...`
  - `cd frontend && pnpm run check`

## Altbestand in Loki

Bereits geschriebene Logs können nicht nachträglich per Code redigiert werden:

- Backend-Zugriffslogs mit nicht-leerem `request.query` auf `/api/students`, `/api/staff`, `/api/users`, `/api/guardians`, `/api/auth/accounts`, `/api/auth/parent-accounts` und `/api/calendar`.
- Frontend-Container-stdout-Zeilen von `ApiHelpers` und `ApiClient` mit einem `url`-Feld, das `?` enthält.

Diese Zeilen können über die Loki-Delete-API gelöscht werden oder laufen mit der konfigurierten Loki-Retention ab. Die Entscheidung liegt beim Betrieb.

## Bewusst außen vor

- Das `params`-Attribut von slog-chi (`slog.Any`) wird nicht transformiert. Es betrifft den Kalender-Feed-Token in Pfad-Parametern und ist unabhängig von dieser Änderung.
- Wertlose Parameter bleiben erhalten: `?flag` wird zu `flag`.
