### PR TITLE
Aktuelle Aufsicht: BFF-Fan-out durch aggregierte Projektion ersetzen

### DIFF
--- a/backend/api/active/api.go
+++ b/backend/api/active/api.go
@@ -13,6 +13,7 @@ import (
 	configSvc "github.com/moto-nrw/project-phoenix/services/config"
 	educationSvc "github.com/moto-nrw/project-phoenix/services/education"
 	"github.com/moto-nrw/project-phoenix/services/facilities"
+	"github.com/moto-nrw/project-phoenix/services/supervisiondashboard"
 	"github.com/moto-nrw/project-phoenix/services/usercontext"
 	userSvc "github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/uptrace/bun"
@@ -26,8 +27,12 @@ type Resource struct {
 	SchulhofService    facilities.SchulhofService
 	UserContextService usercontext.UserContextService
 	SettingsService    configSvc.SettingsService
-	db                 *bun.DB
-	logger             *slog.Logger
+	// SupervisionDashboardService backs the aggregated supervision dashboard
+	// endpoint (#2096); assigned after construction to keep the positional
+	// constructor's existing call sites unchanged.
+	SupervisionDashboardService supervisiondashboard.Getter
+	db                          *bun.DB
+	logger                      *slog.Logger
 }
 
 // getLogger returns a nil-safe logger, falling back to slog.Default() if logger is nil
@@ -104,6 +109,13 @@ func (rs *Resource) Router() chi.Router {
 			r.With(authorize.RequiresPermission(permissions.VisitsUpdate), withTx, common.RequireWebAttendanceEnabled(rs.SettingsService)).Post("/move-to-group", rs.moveStudentsToActiveGroup)
 			r.With(authorize.RequiresPermission(permissions.VisitsUpdate), withTx, common.RequireWebAttendanceEnabled(rs.SettingsService)).Post("/move-to-transit", rs.moveStudentsToTransit)
 		})
+
+		// Aggregated projection for the "Aktuelle Aufsicht" page (#2096):
+		// replaces the former Next.js BFF fan-out. Gated on groups:read (the
+		// widest common permission of the replaced endpoints); sections that
+		// required schedules:read or users:read are redacted deterministically
+		// inside the service for callers missing them.
+		r.With(authorize.RequiresPermission(permissions.GroupsRead), withTx).Get("/supervision-dashboard", rs.getSupervisionDashboard)
 
 		// Supervisors
 		r.Route("/supervisors", func(r chi.Router) {

--- a/backend/api/active/supervision_dashboard_handlers.go
+++ b/backend/api/active/supervision_dashboard_handlers.go
@@ -1,0 +1,54 @@
+package active
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/moto-nrw/project-phoenix/api/common"
+	supervisionDashboardService "github.com/moto-nrw/project-phoenix/services/supervisiondashboard"
+)
+
+// Compatibility alias: the projection and its error contract live in the
+// service layer (#2096), mirroring the OGS group live endpoint (#2056).
+type SupervisionDashboardResponse = supervisionDashboardService.Projection
+
+// getSupervisionDashboard handles GET /active/supervision-dashboard?group_id={id}.
+// The service owns scope authorization, projection shaping, and the
+// all-or-nothing sub-load contract; this boundary only parses input and maps
+// domain errors.
+func (rs *Resource) getSupervisionDashboard(w http.ResponseWriter, r *http.Request) {
+	requestedGroupID, ok := parseOptionalDashboardGroupID(w, r)
+	if !ok {
+		return
+	}
+	if rs.SupervisionDashboardService == nil {
+		common.RenderError(w, r, common.ErrorInternalServer(errors.New("supervision dashboard service is not configured")))
+		return
+	}
+
+	response, err := rs.SupervisionDashboardService.Get(r.Context(), requestedGroupID)
+	if errors.Is(err, supervisionDashboardService.ErrForbiddenGroup) {
+		common.RenderError(w, r, common.ErrorForbidden(errors.New("you do not supervise this active group")))
+		return
+	}
+	if err != nil {
+		common.RenderError(w, r, common.ErrorInternalServerWrap("failed to build supervision dashboard projection", err))
+		return
+	}
+	common.Respond(w, r, http.StatusOK, response, "Supervision dashboard retrieved successfully")
+}
+
+func parseOptionalDashboardGroupID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := strings.TrimSpace(r.URL.Query().Get("group_id"))
+	if raw == "" {
+		return 0, true
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		common.RenderError(w, r, common.ErrorInvalidRequest(errors.New("invalid group_id")))
+		return 0, false
+	}
+	return id, true
+}

--- a/backend/api/active/supervision_dashboard_test.go
+++ b/backend/api/active/supervision_dashboard_test.go
@@ -1,0 +1,437 @@
+package active_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// dashboardPerms is the permission set the aggregated endpoint serves fully —
+// the union of what its constituent single endpoints required (#2096).
+var dashboardPerms = []string{"groups:read", "schedules:read", "users:read"}
+
+type dashboardEnvelope struct {
+	Data struct {
+		Groups []struct {
+			ID        string  `json:"id"`
+			RoomID    *string `json:"room_id"`
+			RoomName  string  `json:"room_name"`
+			RoomColor *string `json:"room_color"`
+		} `json:"groups"`
+		SelectedGroupID *string `json:"selected_group_id"`
+		UnclaimedGroups []struct {
+			ID       string `json:"id"`
+			RoomName string `json:"room_name"`
+		} `json:"unclaimed_groups"`
+		CurrentStaffID    *string `json:"current_staff_id"`
+		EducationalGroups []struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			RoomName string `json:"room_name"`
+		} `json:"educational_groups"`
+		Schulhof *struct {
+			Exists bool `json:"exists"`
+		} `json:"schulhof_status"`
+		Capabilities struct {
+			WebSpontaneousActivitiesEnabled bool `json:"web_spontaneous_activities_enabled"`
+		} `json:"capabilities"`
+		ActiveSessions []map[string]any `json:"active_sessions"`
+		PlannedNow     []map[string]any `json:"planned_now"`
+		Visits         []struct {
+			StudentID         string  `json:"student_id"`
+			StudentName       string  `json:"student_name"`
+			SchoolClass       string  `json:"school_class"`
+			GroupName         string  `json:"group_name"`
+			ActiveGroupID     string  `json:"active_group_id"`
+			ActualArrivalTime *string `json:"actual_arrival_time"`
+			Sick              bool    `json:"sick"`
+		} `json:"visits"`
+		TrackingIndicators struct {
+			Labels  []string          `json:"labels"`
+			Results map[string][]bool `json:"results"`
+		} `json:"tracking_indicators"`
+		PickupTimes []struct {
+			StudentID  string  `json:"student_id"`
+			PickupTime *string `json:"pickup_time"`
+		} `json:"pickup_times"`
+		ArrivalTimes []struct {
+			StudentID       string  `json:"student_id"`
+			ExpectedArrival *string `json:"expected_arrival"`
+		} `json:"arrival_times"`
+	} `json:"data"`
+}
+
+func decodeDashboard(t *testing.T, body []byte) *dashboardEnvelope {
+	t.Helper()
+	var envelope dashboardEnvelope
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	return &envelope
+}
+
+// setupDashboardContext wires the production active router with the real
+// supervision dashboard service (assigned post-construction, as api/base.go
+// does).
+func setupDashboardContext(t *testing.T) (*testContext, chi.Router) {
+	t.Helper()
+	tc := setupTestContext(t)
+	tc.resource.SupervisionDashboardService = tc.services.SupervisionDashboard
+	return tc, mountActiveRouter(tc)
+}
+
+func dashboardExec(t *testing.T, router chi.Router, path string, accountID int64, perms []string) *dashboardEnvelope {
+	t.Helper()
+	rr := dashboardExecRaw(t, router, path, accountID, perms)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	return decodeDashboard(t, rr.Body.Bytes())
+}
+
+func dashboardExecRaw(t *testing.T, router chi.Router, path string, accountID int64, perms []string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := testutil.NewRequest("GET", path, nil)
+	return testutil.ExecuteWithAuthPermissions(t, router, req, testutil.TeacherTestClaims(int(accountID)), perms)
+}
+
+func TestSupervisionDashboard_Aggregates(t *testing.T) {
+	tc, router := setupDashboardContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashAgg", "Leader")
+	room := testpkg.CreateTestRoom(t, tc.db, "DashAggRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashAggActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activityGroup.ID, room.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, teacher.Staff.ID, activeGroup.ID, "supervisor")
+
+	eduGroup := testpkg.CreateTestEducationGroup(t, tc.db, "DashAggEdu")
+	testpkg.CreateTestGroupTeacher(t, tc.db, eduGroup.ID, teacher.ID)
+
+	student := testpkg.CreateTestStudent(t, tc.db, "DashAgg", "Kind", "DA1")
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, eduGroup.ID)
+
+	device := testpkg.CreateTestDevice(t, tc.db, "DashAggDevice")
+	checkIn := time.Now().Add(-1 * time.Hour)
+	testpkg.CreateTestAttendance(t, tc.db, student.ID, teacher.Staff.ID, device.ID, checkIn, nil)
+	testpkg.CreateTestVisit(t, tc.db, student.ID, activeGroup.ID, checkIn, nil)
+
+	today := timezone.TodayDate()
+	pickupException := testpkg.CreateTestPickupException(t, tc.db, student.ID, today, teacher.Staff.ID, "15:30", "Test")
+	defer testpkg.CleanupScheduleFixturesB11(t, tc.db, nil, nil, nil, []int64{pickupException.ID}, nil, nil)
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, eduGroup.ID, activeGroup.ID, activityGroup.ID, device.ID, room.ID, teacher.ID)
+
+	settingsCtx := testpkg.TenantContext(1)
+	require.NoError(t, tc.services.Settings.SetValue(settingsCtx, configModel.KeyTrackingIndicatorsEnabled, true, nil, nil))
+	require.NoError(t, tc.services.Settings.SetValue(settingsCtx, configModel.KeyTrackingIndicator1, "Hausaufgaben", nil, nil))
+	t.Cleanup(func() {
+		_ = tc.services.Settings.ResetValue(settingsCtx, configModel.KeyTrackingIndicatorsEnabled, nil, nil)
+		_ = tc.services.Settings.ResetValue(settingsCtx, configModel.KeyTrackingIndicator1, nil, nil)
+	})
+
+	envelope := dashboardExec(t, router, "/active/supervision-dashboard", account.ID, dashboardPerms)
+	data := envelope.Data
+
+	// Supervised session with bulk-loaded room info.
+	require.Len(t, data.Groups, 1)
+	assert.Equal(t, strconv.FormatInt(activeGroup.ID, 10), data.Groups[0].ID)
+	require.NotNil(t, data.Groups[0].RoomID)
+	assert.Equal(t, strconv.FormatInt(room.ID, 10), *data.Groups[0].RoomID)
+	assert.Equal(t, room.Name, data.Groups[0].RoomName)
+
+	require.NotNil(t, data.SelectedGroupID)
+	assert.Equal(t, strconv.FormatInt(activeGroup.ID, 10), *data.SelectedGroupID)
+
+	require.NotNil(t, data.CurrentStaffID)
+	assert.Equal(t, strconv.FormatInt(teacher.Staff.ID, 10), *data.CurrentStaffID)
+
+	foundEdu := false
+	for _, group := range data.EducationalGroups {
+		if group.ID == strconv.FormatInt(eduGroup.ID, 10) {
+			foundEdu = true
+			assert.Equal(t, eduGroup.Name, group.Name)
+		}
+	}
+	assert.True(t, foundEdu, "educational groups must include the teacher's group")
+
+	// Schulhof status is present (deterministic exists flag, no silent null).
+	require.NotNil(t, data.Schulhof)
+
+	// Open visit for the selected session with display fields and the
+	// full-access actual arrival clock.
+	require.Len(t, data.Visits, 1)
+	visit := data.Visits[0]
+	assert.Equal(t, strconv.FormatInt(student.ID, 10), visit.StudentID)
+	assert.Equal(t, "DashAgg Kind", visit.StudentName)
+	assert.Equal(t, "DA1", visit.SchoolClass)
+	assert.Equal(t, eduGroup.Name, visit.GroupName)
+	assert.Equal(t, strconv.FormatInt(activeGroup.ID, 10), visit.ActiveGroupID)
+	assert.NotNil(t, visit.ActualArrivalTime)
+
+	// Tracking indicators for the visit students.
+	assert.Equal(t, []string{"Hausaufgaben"}, data.TrackingIndicators.Labels)
+
+	// Today's pickup exception surfaces in the folded-in pickup times.
+	require.Len(t, data.PickupTimes, 1)
+	assert.Equal(t, strconv.FormatInt(student.ID, 10), data.PickupTimes[0].StudentID)
+	require.NotNil(t, data.PickupTimes[0].PickupTime)
+	assert.Equal(t, "15:30", *data.PickupTimes[0].PickupTime)
+
+	// Full permission set resolves capabilities from settings defaults.
+	assert.True(t, data.Capabilities.WebSpontaneousActivitiesEnabled)
+}
+
+// TestSupervisionDashboard_MinimalProjection pins the GDPR/payload contract:
+// the aggregate must never carry the wide personal fields the supervision
+// page does not render.
+func TestSupervisionDashboard_MinimalProjection(t *testing.T) {
+	tc, router := setupDashboardContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashSlim", "Leader")
+	room := testpkg.CreateTestRoom(t, tc.db, "DashSlimRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashSlimActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activityGroup.ID, room.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, teacher.Staff.ID, activeGroup.ID, "supervisor")
+
+	student := testpkg.CreateTestStudent(t, tc.db, "DashSlim", "Kind", "DS1")
+	testpkg.CreateTestVisit(t, tc.db, student.ID, activeGroup.ID, time.Now().Add(-30*time.Minute), nil)
+	defer testpkg.CleanupActivityFixtures(t, tc.db, student.ID, activeGroup.ID, activityGroup.ID, room.ID, teacher.ID)
+
+	rr := dashboardExecRaw(t, router, "/active/supervision-dashboard", account.ID, dashboardPerms)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	body := rr.Body.String()
+	for _, forbidden := range []string{
+		"guardian_name", "guardian_contact", "guardian_email", "guardian_phone",
+		"address_street", "address_city", "address_postal_code",
+		"health_info", "supervisor_notes", "extra_info", "birthday", "tag_id",
+		"bus_days", "pickup_days", "departure_days", "allowed_departure_modes",
+		"companion", "privacy", "person_id",
+	} {
+		assert.NotContains(t, body, forbidden,
+			"aggregated dashboard response must not ship unrendered personal/internal field %q", forbidden)
+	}
+}
+
+// dashboardQueryCounter counts every SQL statement issued through the hooked
+// *bun.DB, including statements inside tenant transactions.
+type dashboardQueryCounter struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+func (h *dashboardQueryCounter) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	h.mu.Lock()
+	h.queries = append(h.queries, event.Query)
+	h.mu.Unlock()
+	return ctx
+}
+
+func (h *dashboardQueryCounter) AfterQuery(context.Context, *bun.QueryEvent) {}
+
+func (h *dashboardQueryCounter) reset() {
+	h.mu.Lock()
+	h.queries = nil
+	h.mu.Unlock()
+}
+
+func (h *dashboardQueryCounter) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.queries)
+}
+
+// TestSupervisionDashboard_QueryBudget guards the aggregate against
+// per-student N+1 regressions: the query count must not grow with the number
+// of checked-in students, and the total per request stays under a fixed
+// budget.
+func TestSupervisionDashboard_QueryBudget(t *testing.T) {
+	tc, router := setupDashboardContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashBudget", "Leader")
+	room := testpkg.CreateTestRoom(t, tc.db, "DashBudgetRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashBudgetActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activityGroup.ID, room.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, teacher.Staff.ID, activeGroup.ID, "supervisor")
+
+	var studentIDs []int64
+	addStudents := func(n int) {
+		for i := range n {
+			student := testpkg.CreateTestStudent(t, tc.db, "DashBudget", fmt.Sprintf("Kind%d", len(studentIDs)+i), "DB1")
+			testpkg.CreateTestVisit(t, tc.db, student.ID, activeGroup.ID, time.Now().Add(-30*time.Minute), nil)
+			studentIDs = append(studentIDs, student.ID)
+		}
+	}
+	defer func() {
+		testpkg.CleanupActivityFixtures(t, tc.db, append(studentIDs, activeGroup.ID, activityGroup.ID, room.ID, teacher.ID)...)
+	}()
+
+	counter := &dashboardQueryCounter{}
+	tc.db.AddQueryHook(counter)
+
+	run := func() int {
+		counter.reset()
+		rr := dashboardExecRaw(t, router, "/active/supervision-dashboard", account.ID, dashboardPerms)
+		require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+		return counter.count()
+	}
+
+	addStudents(3)
+	smallCount := run()
+
+	addStudents(7)
+	largeCount := run()
+
+	t.Logf("query budget: 3 students → %d queries, 10 students → %d queries", smallCount, largeCount)
+
+	assert.Equal(t, smallCount, largeCount,
+		"query count must be independent of the checked-in student count (no per-student N+1)")
+
+	// Fixed budget for the whole aggregate: identity resolution, session +
+	// room bulk loads, schulhof status, unclaimed groups, educational groups,
+	// planned-now + active sessions, visits + attendance, tracking, pickup /
+	// arrival bulk loads, settings snapshot, tenant tx overhead. Raise only
+	// with a written justification.
+	// Measured at 29 flat; the cap leaves headroom for benign changes only.
+	const maxQueries = 40
+	assert.LessOrEqual(t, largeCount, maxQueries,
+		"aggregated supervision dashboard request exceeded its query budget")
+}
+
+// TestSupervisionDashboard_PayloadBudget bounds the wire size for a
+// production-sized session so the aggregate stays a fraction of the ~11
+// responses it replaces.
+func TestSupervisionDashboard_PayloadBudget(t *testing.T) {
+	tc, router := setupDashboardContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashPayload", "Leader")
+	room := testpkg.CreateTestRoom(t, tc.db, "DashPayloadRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashPayloadActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activityGroup.ID, room.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, teacher.Staff.ID, activeGroup.ID, "supervisor")
+
+	var studentIDs []int64
+	const groupSize = 30
+	for i := range groupSize {
+		student := testpkg.CreateTestStudent(t, tc.db, "DashPayload", fmt.Sprintf("Produktionskind%02d", i), "DP1")
+		testpkg.CreateTestVisit(t, tc.db, student.ID, activeGroup.ID, time.Now().Add(-30*time.Minute), nil)
+		studentIDs = append(studentIDs, student.ID)
+	}
+	defer func() {
+		testpkg.CleanupActivityFixtures(t, tc.db, append(studentIDs, activeGroup.ID, activityGroup.ID, room.ID, teacher.ID)...)
+	}()
+
+	rr := dashboardExecRaw(t, router, "/active/supervision-dashboard", account.ID, dashboardPerms)
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	size := rr.Body.Len()
+	t.Logf("payload budget: %d students → %d bytes (%.0f bytes/student)", groupSize, size, float64(size)/groupSize)
+
+	// Budget: ≤ 700 bytes per checked-in student (visit projection, tracking
+	// row, pickup/arrival rows) plus 4 KB envelope/session/schulhof overhead.
+	const maxBytes = 4096 + groupSize*700
+	assert.LessOrEqual(t, size, maxBytes, "aggregated supervision dashboard payload exceeded its budget")
+}
+
+func TestSupervisionDashboard_ErrorContract(t *testing.T) {
+	tc, router := setupDashboardContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashErr", "Leader")
+	room := testpkg.CreateTestRoom(t, tc.db, "DashErrRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashErrActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activityGroup.ID, room.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, teacher.Staff.ID, activeGroup.ID, "supervisor")
+
+	otherTeacher, _ := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashErr", "Other")
+	foreignRoom := testpkg.CreateTestRoom(t, tc.db, "DashErrForeignRoom")
+	foreignActivityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashErrForeignActivity")
+	foreignActiveGroup := testpkg.CreateTestActiveGroup(t, tc.db, foreignActivityGroup.ID, foreignRoom.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, otherTeacher.Staff.ID, foreignActiveGroup.ID, "supervisor")
+
+	student := testpkg.CreateTestStudent(t, tc.db, "DashErr", "Kind", "DE1")
+	testpkg.CreateTestVisit(t, tc.db, student.ID, activeGroup.ID, time.Now().Add(-30*time.Minute), nil)
+
+	today := timezone.TodayDate()
+	pickupException := testpkg.CreateTestPickupException(t, tc.db, student.ID, today, teacher.Staff.ID, "15:45", "Test")
+	defer testpkg.CleanupScheduleFixturesB11(t, tc.db, nil, nil, nil, []int64{pickupException.ID}, nil, nil)
+	defer testpkg.CleanupActivityFixtures(t, tc.db,
+		student.ID, activeGroup.ID, activityGroup.ID, room.ID, teacher.ID,
+		foreignActiveGroup.ID, foreignActivityGroup.ID, foreignRoom.ID, otherTeacher.ID)
+
+	t.Run("invalid group_id is a 400", func(t *testing.T) {
+		rr := dashboardExecRaw(t, router, "/active/supervision-dashboard?group_id=abc", account.ID, dashboardPerms)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("unsupervised group is a 403", func(t *testing.T) {
+		rr := dashboardExecRaw(t, router, fmt.Sprintf("/active/supervision-dashboard?group_id=%d", foreignActiveGroup.ID), account.ID, dashboardPerms)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("missing schedules:read redacts the timetable sections", func(t *testing.T) {
+		envelope := dashboardExec(t, router, "/active/supervision-dashboard", account.ID, []string{"groups:read", "users:read"})
+		assert.Empty(t, envelope.Data.PlannedNow)
+		assert.Empty(t, envelope.Data.ActiveSessions)
+		assert.False(t, envelope.Data.Capabilities.WebSpontaneousActivitiesEnabled)
+		// The roster itself stays complete.
+		assert.NotEmpty(t, envelope.Data.Groups)
+		assert.NotEmpty(t, envelope.Data.Visits)
+	})
+
+	t.Run("missing users:read redacts pickup and arrival times", func(t *testing.T) {
+		envelope := dashboardExec(t, router, "/active/supervision-dashboard", account.ID, []string{"groups:read", "schedules:read"})
+		assert.Empty(t, envelope.Data.PickupTimes)
+		assert.Empty(t, envelope.Data.ArrivalTimes)
+		assert.NotEmpty(t, envelope.Data.Visits)
+	})
+
+	t.Run("full permissions include the pickup exception", func(t *testing.T) {
+		envelope := dashboardExec(t, router, "/active/supervision-dashboard", account.ID, dashboardPerms)
+		require.Len(t, envelope.Data.PickupTimes, 1)
+	})
+
+	t.Run("no supervised groups is an explicit empty 200", func(t *testing.T) {
+		lonely, lonelyAccount := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashErr", "Gruppenlos")
+		defer testpkg.CleanupActivityFixtures(t, tc.db, lonely.ID)
+
+		envelope := dashboardExec(t, router, "/active/supervision-dashboard", lonelyAccount.ID, dashboardPerms)
+		assert.Empty(t, envelope.Data.Groups)
+		assert.Nil(t, envelope.Data.SelectedGroupID)
+		assert.Empty(t, envelope.Data.Visits)
+		require.NotNil(t, envelope.Data.CurrentStaffID)
+	})
+}
+
+func TestSupervisionDashboard_TenantIsolation(t *testing.T) {
+	tc, router := setupDashboardContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "DashIso", "Leader")
+	room := testpkg.CreateTestRoom(t, tc.db, "DashIsoRoom")
+	activityGroup := testpkg.CreateTestActivityGroup(t, tc.db, "DashIsoActivity")
+	activeGroup := testpkg.CreateTestActiveGroup(t, tc.db, activityGroup.ID, room.ID)
+	testpkg.CreateTestGroupSupervisor(t, tc.db, teacher.Staff.ID, activeGroup.ID, "supervisor")
+
+	testpkg.EnsureTestTenant(t, tc.db, 2)
+	foreignRoom := testpkg.CreateTestRoomForTenant(t, tc.db, 2, "DashIsoForeignRoom")
+	foreignActivityGroup := testpkg.CreateTestActivityGroupForTenant(t, tc.db, 2, "DashIsoForeignActivity")
+	foreignActiveGroup := testpkg.CreateTestActiveGroupWithIDsForTenant(t, tc.db, 2, foreignActivityGroup.ID, foreignRoom.ID)
+
+	defer testpkg.CleanupActivityFixtures(t, tc.db,
+		activeGroup.ID, activityGroup.ID, room.ID, teacher.ID,
+		foreignActiveGroup.ID, foreignActivityGroup.ID, foreignRoom.ID)
+
+	rr := dashboardExecRaw(t, router, fmt.Sprintf("/active/supervision-dashboard?group_id=%d", foreignActiveGroup.ID), account.ID, dashboardPerms)
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"a tenant-1 supervisor must never resolve a tenant-2 active group through the aggregate")
+}

--- a/backend/api/base.go
+++ b/backend/api/base.go
@@ -564,6 +564,7 @@ func initializeAPIResources(api *API, repoFactory *repositories.Factory, db *bun
 	api.Settings.SetPayrollStatusService(api.Services.PayrollStatus)
 	api.Settings.OnValueSet(api.Services.SettingsSideEffects.Dispatch)
 	api.Active = activeAPI.NewResource(api.Services.Active, api.Services.Users, api.Services.Education, api.Services.Schulhof, api.Services.UserContext, api.Services.Settings, db, logger.With("handler", "active"))
+	api.Active.SupervisionDashboardService = api.Services.SupervisionDashboard
 	api.IoT = iotAPI.NewResource(iotAPI.ServiceDependencies{
 		IoTService:            api.Services.IoT,
 		StaffPINAuthenticator: api.Services.StaffPINAuth,

--- a/backend/api/testdata/route_table.golden
+++ b/backend/api/testdata/route_table.golden
@@ -123,6 +123,7 @@ GET /api/active/groups/{id}/visits/display
 GET /api/active/mappings/combined/{combinedId}
 GET /api/active/mappings/group/{groupId}
 GET /api/active/schulhof/status
+GET /api/active/supervision-dashboard
 GET /api/active/supervisors/
 GET /api/active/supervisors/all
 GET /api/active/supervisors/group/{groupId}

--- a/backend/database/repositories/active/group.go
+++ b/backend/database/repositories/active/group.go
@@ -579,6 +579,10 @@ func (r *GroupRepository) FindByIDs(ctx context.Context, ids []int64) (map[int64
 	if err := r.loadRoomsForGroups(ctx, groups); err != nil {
 		return nil, err
 	}
+	_, activityGroupIDs := collectRelationIDs(groups)
+	if err := r.loadAndAssignActivityGroups(ctx, groups, activityGroupIDs); err != nil {
+		return nil, err
+	}
 
 	return groupsToMap(groups), nil
 }

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -61,6 +61,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/services/schedule"
 	"github.com/moto-nrw/project-phoenix/services/slotlists"
 	"github.com/moto-nrw/project-phoenix/services/suggestions"
+	"github.com/moto-nrw/project-phoenix/services/supervisiondashboard"
 	"github.com/moto-nrw/project-phoenix/services/usercontext"
 	"github.com/moto-nrw/project-phoenix/services/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
@@ -171,6 +172,7 @@ type Factory struct {
 	AbsenceOverview         *active.StudentStatusDayOverviewService
 	StudentHistory          active.StudentHistoryService
 	OGSGroupLive            ogsgrouplive.Getter
+	SupervisionDashboard    supervisiondashboard.Getter
 	TimetableData           *schedule.TimetableDataService
 	InstanceSeriesConverter schedule.InstanceSeriesConverter
 	OperatorSuggestions     platform.OperatorSuggestionsService
@@ -2185,6 +2187,18 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Logger:          logger.With("service", "ogs-group-live"),
 	})
 
+	supervisionDashboardService := supervisiondashboard.NewService(supervisiondashboard.Dependencies{
+		Active:      activeService,
+		UserContext: userContextService,
+		Education:   educationService,
+		Schulhof:    schulhofService,
+		Operations:  timetableOperationsService,
+		Settings:    settingsService,
+		Pickups:     pickupScheduleService,
+		Arrivals:    arrivalScheduleService,
+		Logger:      logger.With("service", "supervision-dashboard"),
+	})
+
 	timetableDataService := schedule.NewTimetableDataService(schedule.TimetableDataDependencies{
 		InstanceStudentRepo:        repos.InstanceStudent,
 		ActivityInstanceRepo:       repos.ActivityInstance,
@@ -2333,6 +2347,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		AbsenceOverview:         studentStatusDayOverviewService,
 		StudentHistory:          active.NewStudentHistoryService(repos.Attendance, repos.ActiveVisit, repos.DataAccessLog, repos.InstanceStudent),
 		OGSGroupLive:            ogsGroupLiveService,
+		SupervisionDashboard:    supervisionDashboardService,
 		TimetableData:           timetableDataService,
 		InstanceSeriesConverter: instanceSeriesConverter,
 		OperatorSuggestions:     operatorSuggestionsService,

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -2196,7 +2196,6 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		Settings:    settingsService,
 		Pickups:     pickupScheduleService,
 		Arrivals:    arrivalScheduleService,
-		Logger:      logger.With("service", "supervision-dashboard"),
 	})
 
 	timetableDataService := schedule.NewTimetableDataService(schedule.TimetableDataDependencies{

--- a/backend/services/supervisiondashboard/service.go
+++ b/backend/services/supervisiondashboard/service.go
@@ -656,33 +656,41 @@ func (s *service) loadPlanningTimes(ctx context.Context, projection *Projection,
 
 	for _, id := range studentIDs {
 		if effective := pickups[id]; effective != nil {
-			item := PickupTime{
-				StudentID: id, Date: effective.Date.String(), WeekdayName: effective.WeekdayName,
-				IsException: effective.IsException, Notes: effective.Notes,
-			}
-			if effective.PickupTime != nil {
-				formatted := effective.PickupTime.Format("15:04")
-				item.PickupTime = &formatted
-			}
-			for _, note := range effective.DayNotes {
-				item.DayNotes = append(item.DayNotes, DayNote{ID: note.ID, Content: note.Content})
-			}
-			projection.PickupTimes = append(projection.PickupTimes, item)
+			projection.PickupTimes = append(projection.PickupTimes, pickupTimeFromEffective(id, effective))
 		}
 		if effective := arrivals[id]; effective != nil {
-			item := ArrivalTime{
-				StudentID: id, Date: effective.Date.String(), WeekdayName: effective.WeekdayName,
-				IsException: effective.IsException, Notes: effective.Notes,
-			}
-			if effective.ArrivalTime != nil {
-				formatted := effective.ArrivalTime.Format("15:04")
-				item.ExpectedArrival = &formatted
-			}
-			for _, note := range effective.DayNotes {
-				item.DayNotes = append(item.DayNotes, DayNote{ID: note.ID, Content: note.Content})
-			}
-			projection.ArrivalTimes = append(projection.ArrivalTimes, item)
+			projection.ArrivalTimes = append(projection.ArrivalTimes, arrivalTimeFromEffective(id, effective))
 		}
 	}
 	return nil
+}
+
+func pickupTimeFromEffective(studentID int64, effective *scheduleService.EffectivePickupTime) PickupTime {
+	item := PickupTime{
+		StudentID: studentID, Date: effective.Date.String(), WeekdayName: effective.WeekdayName,
+		IsException: effective.IsException, Notes: effective.Notes,
+	}
+	if effective.PickupTime != nil {
+		formatted := effective.PickupTime.Format("15:04")
+		item.PickupTime = &formatted
+	}
+	for _, note := range effective.DayNotes {
+		item.DayNotes = append(item.DayNotes, DayNote{ID: note.ID, Content: note.Content})
+	}
+	return item
+}
+
+func arrivalTimeFromEffective(studentID int64, effective *scheduleService.EffectiveArrivalTime) ArrivalTime {
+	item := ArrivalTime{
+		StudentID: studentID, Date: effective.Date.String(), WeekdayName: effective.WeekdayName,
+		IsException: effective.IsException, Notes: effective.Notes,
+	}
+	if effective.ArrivalTime != nil {
+		formatted := effective.ArrivalTime.Format("15:04")
+		item.ExpectedArrival = &formatted
+	}
+	for _, note := range effective.DayNotes {
+		item.DayNotes = append(item.DayNotes, DayNote{ID: note.ID, Content: note.Content})
+	}
+	return item
 }

--- a/backend/services/supervisiondashboard/service.go
+++ b/backend/services/supervisiondashboard/service.go
@@ -63,10 +63,11 @@ func NewService(deps Dependencies) Getter {
 }
 
 // Group is one supervised (or, under admin overview / open care, any active)
-// session tab. The wire shape carries only what the page renders: room label,
-// color, and ids for selection.
+// session tab. The wire shape carries only what the page renders: the session
+// label, room label, color, and ids for selection.
 type Group struct {
 	ID        int64   `json:"id,string"`
+	Name      string  `json:"name"`
 	RoomID    *int64  `json:"room_id,string,omitempty"`
 	RoomName  string  `json:"room_name,omitempty"`
 	RoomColor *string `json:"room_color,omitempty"`
@@ -295,6 +296,10 @@ func (s *service) resolveGroups(ctx context.Context) ([]Group, error) {
 				groups = append(groups, group)
 			}
 		}
+		groups, err = s.loadGroupsWithRelations(ctx, groups)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		supervised, err := s.deps.UserContext.GetMySupervisedGroups(ctx)
 		if err != nil {
@@ -311,12 +316,18 @@ func (s *service) resolveGroups(ctx context.Context) ([]Group, error) {
 	result := make([]Group, 0, len(groups))
 	for _, group := range groups {
 		item := Group{ID: group.ID}
+		if group.ActualGroup != nil {
+			item.Name = group.ActualGroup.Name
+		}
 		if group.RoomID > 0 {
 			roomID := group.RoomID
 			item.RoomID = &roomID
 			if room := rooms[group.RoomID]; room != nil {
 				item.RoomName = room.Name
 				item.RoomColor = room.Color
+				if item.Name == "" {
+					item.Name = room.Name
+				}
 			}
 		}
 		result = append(result, item)
@@ -324,6 +335,28 @@ func (s *service) resolveGroups(ctx context.Context) ([]Group, error) {
 	sort.SliceStable(result, func(i, j int) bool {
 		return collation.CompareGerman(result[i].RoomName, result[j].RoomName) < 0
 	})
+	return result, nil
+}
+
+// loadGroupsWithRelations fills the template activity relation for the broad
+// overview path, whose list query intentionally returns only active-group
+// columns. The supervised path already uses the same bulk lookup internally.
+func (s *service) loadGroupsWithRelations(ctx context.Context, groups []*activeModels.Group) ([]*activeModels.Group, error) {
+	ids := make([]int64, 0, len(groups))
+	for _, group := range groups {
+		ids = append(ids, group.ID)
+	}
+	loaded, err := s.deps.Active.GetActiveGroupsByIDs(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("load active group relations: %w", err)
+	}
+
+	result := make([]*activeModels.Group, 0, len(groups))
+	for _, group := range groups {
+		if loadedGroup := loaded[group.ID]; loadedGroup != nil {
+			result = append(result, loadedGroup)
+		}
+	}
 	return result, nil
 }
 

--- a/backend/services/supervisiondashboard/service.go
+++ b/backend/services/supervisiondashboard/service.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -51,16 +50,12 @@ type Dependencies struct {
 	Settings    configService.SettingsService
 	Pickups     scheduleService.PickupScheduleService
 	Arrivals    scheduleService.ArrivalScheduleService
-	Logger      *slog.Logger
 	Now         func() time.Time
 }
 
 type service struct{ deps Dependencies }
 
 func NewService(deps Dependencies) Getter {
-	if deps.Logger == nil {
-		deps.Logger = slog.Default()
-	}
 	if deps.Now == nil {
 		deps.Now = time.Now
 	}

--- a/backend/services/supervisiondashboard/service.go
+++ b/backend/services/supervisiondashboard/service.go
@@ -1,0 +1,693 @@
+// Package supervisiondashboard builds the complete live projection for the
+// "Aktuelle Aufsicht" (active supervision) page in one request (#2096). It
+// replaces the Next.js BFF fan-out of ~11 backend calls and owns the
+// projection's authorization and strict error contract: mandatory sub-loads
+// fail the whole request instead of degrading to silently-empty sections.
+package supervisiondashboard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/internal/collation"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	facilitiesModels "github.com/moto-nrw/project-phoenix/models/facilities"
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	educationService "github.com/moto-nrw/project-phoenix/services/education"
+	facilitiesService "github.com/moto-nrw/project-phoenix/services/facilities"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+	userContextService "github.com/moto-nrw/project-phoenix/services/usercontext"
+)
+
+// ErrForbiddenGroup indicates that the requested active group is outside the
+// caller's operational scope (supervised sessions, or all sessions under
+// admin overview / open care, plus a supervised Schulhof session).
+var ErrForbiddenGroup = errors.New("caller does not supervise the requested active group")
+
+const studentPhotoStoredURLPrefix = "/uploads/student-photos/"
+
+type Getter interface {
+	Get(ctx context.Context, requestedGroupID int64) (*Projection, error)
+}
+
+type Dependencies struct {
+	Active      activeService.Service
+	UserContext userContextService.UserContextService
+	Education   educationService.Service
+	Schulhof    facilitiesService.SchulhofService
+	Operations  scheduleService.TimetableOperationsService
+	Settings    configService.SettingsService
+	Pickups     scheduleService.PickupScheduleService
+	Arrivals    scheduleService.ArrivalScheduleService
+	Logger      *slog.Logger
+	Now         func() time.Time
+}
+
+type service struct{ deps Dependencies }
+
+func NewService(deps Dependencies) Getter {
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	return &service{deps: deps}
+}
+
+// Group is one supervised (or, under admin overview / open care, any active)
+// session tab. The wire shape carries only what the page renders: room label,
+// color, and ids for selection.
+type Group struct {
+	ID        int64   `json:"id,string"`
+	RoomID    *int64  `json:"room_id,string,omitempty"`
+	RoomName  string  `json:"room_name,omitempty"`
+	RoomColor *string `json:"room_color,omitempty"`
+}
+
+type UnclaimedGroup struct {
+	ID       int64  `json:"id,string"`
+	RoomName string `json:"room_name,omitempty"`
+}
+
+type EducationalGroup struct {
+	ID       int64  `json:"id,string"`
+	Name     string `json:"name"`
+	RoomName string `json:"room_name,omitempty"`
+}
+
+// Visit mirrors the fields the page renders from the former per-group
+// /active/groups/{id}/visits/display endpoint, restricted to open visits.
+type Visit struct {
+	StudentID         int64      `json:"student_id,string"`
+	StudentName       string     `json:"student_name"`
+	SchoolClass       string     `json:"school_class"`
+	GroupName         string     `json:"group_name"`
+	ActiveGroupID     int64      `json:"active_group_id,string"`
+	CheckInTime       time.Time  `json:"check_in_time"`
+	ActualArrivalTime *string    `json:"actual_arrival_time,omitempty"`
+	ActualPickupTime  *string    `json:"actual_pickup_time,omitempty"`
+	Sick              bool       `json:"sick"`
+	SickSince         *time.Time `json:"sick_since,omitempty"`
+	Excused           bool       `json:"excused"`
+	ExcusedSince      *time.Time `json:"excused_since,omitempty"`
+	PhotoURL          string     `json:"photo_url,omitempty"`
+}
+
+type TrackingIndicators struct {
+	Labels  []string         `json:"labels"`
+	Results map[int64][]bool `json:"results"`
+}
+
+type DayNote struct {
+	ID      int64  `json:"id,string"`
+	Content string `json:"content"`
+}
+
+// PickupTime / ArrivalTime keep the field names of the bulk endpoints they
+// replace so the frontend mapping stays identical.
+type PickupTime struct {
+	StudentID   int64     `json:"student_id,string"`
+	Date        string    `json:"date"`
+	WeekdayName string    `json:"weekday_name"`
+	PickupTime  *string   `json:"pickup_time,omitempty"`
+	IsException bool      `json:"is_exception"`
+	Notes       string    `json:"notes,omitempty"`
+	DayNotes    []DayNote `json:"day_notes,omitempty"`
+}
+
+type ArrivalTime struct {
+	StudentID       int64     `json:"student_id,string"`
+	Date            string    `json:"date"`
+	WeekdayName     string    `json:"weekday_name"`
+	ExpectedArrival *string   `json:"expected_arrival,omitempty"`
+	IsException     bool      `json:"is_exception"`
+	Notes           string    `json:"notes,omitempty"`
+	DayNotes        []DayNote `json:"day_notes,omitempty"`
+}
+
+type Capabilities struct {
+	WebSpontaneousActivitiesEnabled bool `json:"web_spontaneous_activities_enabled"`
+}
+
+type Projection struct {
+	Groups            []Group            `json:"groups"`
+	SelectedGroupID   *int64             `json:"selected_group_id,string,omitempty"`
+	UnclaimedGroups   []UnclaimedGroup   `json:"unclaimed_groups"`
+	CurrentStaffID    *int64             `json:"current_staff_id,string,omitempty"`
+	EducationalGroups []EducationalGroup `json:"educational_groups"`
+	// Schulhof is nil only when the caller has no staff identity (and thus no
+	// Schulhof workflow) — never because a sub-load failed.
+	Schulhof           *facilitiesService.SchulhofStatus          `json:"schulhof_status"`
+	Capabilities       Capabilities                               `json:"capabilities"`
+	ActiveSessions     []scheduleService.OperationActiveSession   `json:"active_sessions"`
+	PlannedNow         []scheduleService.OperationPlannedInstance `json:"planned_now"`
+	Visits             []Visit                                    `json:"visits"`
+	TrackingIndicators TrackingIndicators                         `json:"tracking_indicators"`
+	PickupTimes        []PickupTime                               `json:"pickup_times"`
+	ArrivalTimes       []ArrivalTime                              `json:"arrival_times"`
+}
+
+func emptyProjection() *Projection {
+	return &Projection{
+		Groups:             []Group{},
+		UnclaimedGroups:    []UnclaimedGroup{},
+		EducationalGroups:  []EducationalGroup{},
+		ActiveSessions:     []scheduleService.OperationActiveSession{},
+		PlannedNow:         []scheduleService.OperationPlannedInstance{},
+		Visits:             []Visit{},
+		TrackingIndicators: TrackingIndicators{Labels: []string{}, Results: map[int64][]bool{}},
+		PickupTimes:        []PickupTime{},
+		ArrivalTimes:       []ArrivalTime{},
+	}
+}
+
+// plannedNow parameters are the page contract the former BFF hardcoded.
+const (
+	plannedNowHorizonMinutes = 480
+	plannedNowLimit          = 5
+)
+
+func (s *service) Get(ctx context.Context, requestedGroupID int64) (*Projection, error) {
+	if err := s.validateDependencies(); err != nil {
+		return nil, err
+	}
+	ctx, err := s.prefetchSettings(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve dashboard settings: %w", err)
+	}
+
+	projection := emptyProjection()
+
+	staffID, err := s.loadCurrentStaffID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	projection.CurrentStaffID = staffID
+
+	groups, err := s.resolveGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+	projection.Groups = groups
+
+	if staffID != nil {
+		schulhof, err := s.deps.Schulhof.GetSchulhofStatus(ctx, *staffID)
+		if err != nil {
+			return nil, fmt.Errorf("load schulhof status: %w", err)
+		}
+		projection.Schulhof = schulhof
+	}
+
+	selected, err := selectGroup(groups, projection.Schulhof, requestedGroupID)
+	if err != nil {
+		return nil, err
+	}
+	projection.SelectedGroupID = selected
+
+	if err := s.loadStaticSections(ctx, projection); err != nil {
+		return nil, err
+	}
+	if err := s.loadScheduleSections(ctx, projection); err != nil {
+		return nil, err
+	}
+	if selected != nil {
+		if err := s.loadSelectedGroupSections(ctx, projection, *selected); err != nil {
+			return nil, err
+		}
+	}
+	return projection, nil
+}
+
+func (s *service) validateDependencies() error {
+	if s.deps.Active == nil || s.deps.UserContext == nil || s.deps.Education == nil ||
+		s.deps.Schulhof == nil || s.deps.Operations == nil || s.deps.Settings == nil ||
+		s.deps.Pickups == nil || s.deps.Arrivals == nil {
+		return errors.New("supervision dashboard service is not fully configured")
+	}
+	return nil
+}
+
+func (s *service) prefetchSettings(ctx context.Context) (context.Context, error) {
+	batch, ok := s.deps.Settings.(configService.BatchSettingsService)
+	if !ok {
+		return ctx, nil
+	}
+	snapshot, err := batch.ResolveMany(ctx, []string{
+		configModel.KeyAdminSupervisionOverview,
+		configModel.KeyGroupMode,
+		configModel.KeyStudentPhotosEnabled,
+		configModel.KeyCareConcept,
+		configModel.KeyWebSpontaneousActivities,
+		configModel.KeyTrackingIndicatorsEnabled,
+		configModel.KeyTrackingIndicator1,
+		configModel.KeyTrackingIndicator2,
+		configModel.KeyTrackingIndicator3,
+	})
+	if err != nil {
+		return ctx, err
+	}
+	return configService.WithSettingsSnapshot(ctx, snapshot), nil
+}
+
+func (s *service) loadCurrentStaffID(ctx context.Context) (*int64, error) {
+	staff, err := s.deps.UserContext.GetCurrentStaff(ctx)
+	if err != nil {
+		if errors.Is(err, userContextService.ErrUserNotLinkedToStaff) ||
+			errors.Is(err, userContextService.ErrUserNotLinkedToPerson) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load current staff: %w", err)
+	}
+	if staff == nil {
+		return nil, nil
+	}
+	id := staff.ID
+	return &id, nil
+}
+
+// resolveGroups mirrors the scope split of the former fan-out: admins with the
+// supervision overview setting and everyone under open care see all running
+// sessions; otherwise the caller's own supervised sessions. Errors propagate —
+// the former BFF's silent 403→fallback chain is replaced by one deterministic
+// decision here.
+func (s *service) resolveGroups(ctx context.Context) ([]Group, error) {
+	broad, err := s.hasOperationalOverview(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var groups []*activeModels.Group
+	if broad {
+		all, err := s.deps.Active.ListActiveGroups(ctx, base.NewQueryOptions())
+		if err != nil {
+			return nil, fmt.Errorf("load active groups: %w", err)
+		}
+		for _, group := range all {
+			if group.IsActive() {
+				groups = append(groups, group)
+			}
+		}
+	} else {
+		supervised, err := s.deps.UserContext.GetMySupervisedGroups(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("load supervised groups: %w", err)
+		}
+		groups = supervised
+	}
+
+	rooms, err := s.loadRooms(ctx, groups)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Group, 0, len(groups))
+	for _, group := range groups {
+		item := Group{ID: group.ID}
+		if group.RoomID > 0 {
+			roomID := group.RoomID
+			item.RoomID = &roomID
+			if room := rooms[group.RoomID]; room != nil {
+				item.RoomName = room.Name
+				item.RoomColor = room.Color
+			}
+		}
+		result = append(result, item)
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		return collation.CompareGerman(result[i].RoomName, result[j].RoomName) < 0
+	})
+	return result, nil
+}
+
+func (s *service) hasOperationalOverview(ctx context.Context) (bool, error) {
+	claims := jwt.ClaimsFromCtx(ctx)
+	if claims.IsAdmin {
+		enabled, err := s.deps.Settings.ResolveBool(ctx, configModel.KeyAdminSupervisionOverview)
+		if err != nil {
+			return false, fmt.Errorf("resolve admin supervision overview setting: %w", err)
+		}
+		if enabled {
+			return true, nil
+		}
+	}
+	mode, err := s.deps.Settings.ResolveString(ctx, configModel.KeyGroupMode)
+	if err != nil {
+		return false, fmt.Errorf("resolve group mode setting: %w", err)
+	}
+	return mode == configModel.GroupModeOpenCare, nil
+}
+
+// loadRooms bulk-resolves rooms for groups whose relation is not preloaded —
+// this replaces the former per-group GET /api/rooms/{id} N+1.
+func (s *service) loadRooms(ctx context.Context, groups []*activeModels.Group) (map[int64]*facilitiesModels.Room, error) {
+	missing := make([]int64, 0, len(groups))
+	seen := map[int64]struct{}{}
+	result := map[int64]*facilitiesModels.Room{}
+	for _, group := range groups {
+		if group.RoomID <= 0 {
+			continue
+		}
+		if group.Room != nil {
+			result[group.RoomID] = group.Room
+			continue
+		}
+		if _, ok := seen[group.RoomID]; ok {
+			continue
+		}
+		seen[group.RoomID] = struct{}{}
+		missing = append(missing, group.RoomID)
+	}
+	if len(missing) == 0 {
+		return result, nil
+	}
+	rooms, err := s.deps.Active.GetRoomsByIDs(ctx, missing)
+	if err != nil {
+		return nil, fmt.Errorf("bulk load rooms: %w", err)
+	}
+	for _, room := range rooms {
+		result[room.ID] = room
+	}
+	return result, nil
+}
+
+// selectGroup resolves the caller-requested session against the operational
+// scope. An unknown id is a hard 403 (ErrForbiddenGroup) — the caller retries
+// without group_id when its selection went stale.
+func selectGroup(groups []Group, schulhof *facilitiesService.SchulhofStatus, requestedGroupID int64) (*int64, error) {
+	if requestedGroupID <= 0 {
+		if len(groups) == 0 {
+			return nil, nil
+		}
+		id := groups[0].ID
+		return &id, nil
+	}
+	for _, group := range groups {
+		if group.ID == requestedGroupID {
+			id := group.ID
+			return &id, nil
+		}
+	}
+	if schulhof != nil && schulhof.IsUserSupervising &&
+		schulhof.ActiveGroupID != nil && *schulhof.ActiveGroupID == requestedGroupID {
+		id := requestedGroupID
+		return &id, nil
+	}
+	return nil, ErrForbiddenGroup
+}
+
+func (s *service) loadStaticSections(ctx context.Context, projection *Projection) error {
+	unclaimed, err := s.deps.Active.GetUnclaimedActiveGroups(ctx)
+	if err != nil {
+		return fmt.Errorf("load unclaimed groups: %w", err)
+	}
+	for _, group := range unclaimed {
+		item := UnclaimedGroup{ID: group.ID}
+		if group.Room != nil {
+			item.RoomName = group.Room.Name
+		}
+		projection.UnclaimedGroups = append(projection.UnclaimedGroups, item)
+	}
+
+	myGroups, err := s.deps.UserContext.GetMyGroups(ctx)
+	if err != nil {
+		return fmt.Errorf("load educational groups: %w", err)
+	}
+	roomGroupIDs := make([]int64, 0, len(myGroups))
+	for _, group := range myGroups {
+		if group.RoomID != nil {
+			roomGroupIDs = append(roomGroupIDs, group.ID)
+		}
+	}
+	loaded, err := s.loadEducationRooms(ctx, roomGroupIDs)
+	if err != nil {
+		return err
+	}
+	for _, group := range myGroups {
+		item := EducationalGroup{ID: group.ID, Name: group.Name}
+		if withRoom := loaded[group.ID]; withRoom != "" {
+			item.RoomName = withRoom
+		}
+		projection.EducationalGroups = append(projection.EducationalGroups, item)
+	}
+	return nil
+}
+
+func (s *service) loadEducationRooms(ctx context.Context, groupIDs []int64) (map[int64]string, error) {
+	result := map[int64]string{}
+	if len(groupIDs) == 0 {
+		return result, nil
+	}
+	loaded, err := s.deps.Education.GetGroupsWithRoomsByIDs(ctx, groupIDs)
+	if err != nil {
+		return nil, fmt.Errorf("load education group rooms: %w", err)
+	}
+	for id, group := range loaded {
+		if group != nil && group.Room != nil {
+			result[id] = group.Room.Name
+		}
+	}
+	return result, nil
+}
+
+// loadScheduleSections fills planned-now, active sessions, and capabilities.
+// These mirror the former /timetable/operations/* endpoints, which were gated
+// on schedules:read — a caller without it gets them deterministically empty
+// (permission-based redaction), never a swallowed error.
+func (s *service) loadScheduleSections(ctx context.Context, projection *Projection) error {
+	if !authorize.HasPermission(permissions.SchedulesRead, jwt.PermissionsFromCtx(ctx)) {
+		return nil
+	}
+	claims := jwt.ClaimsFromCtx(ctx)
+	now := s.deps.Now()
+	today := timezone.DateFromTime(now)
+
+	planned, err := s.deps.Operations.PlannedNow(ctx, int64(claims.ID), claims.IsAdmin, today, now, scheduleService.PlannedNowOptions{
+		HorizonMinutes: plannedNowHorizonMinutes,
+		Limit:          plannedNowLimit,
+		IncludeRoster:  true,
+	})
+	if err != nil {
+		return fmt.Errorf("load planned instances: %w", err)
+	}
+	if planned != nil {
+		projection.PlannedNow = planned
+	}
+
+	sessions, err := s.deps.Operations.ActiveSessions(ctx, today)
+	if err != nil {
+		return fmt.Errorf("load active sessions: %w", err)
+	}
+	if sessions != nil {
+		projection.ActiveSessions = sessions
+	}
+
+	capabilities, err := s.resolveCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	projection.Capabilities = capabilities
+	return nil
+}
+
+func (s *service) resolveCapabilities(ctx context.Context) (Capabilities, error) {
+	careConcept, err := s.deps.Settings.ResolveString(ctx, configModel.KeyCareConcept)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("resolve care concept setting: %w", err)
+	}
+	if careConcept != configModel.CareConceptOpenRooms {
+		return Capabilities{}, nil
+	}
+	enabled, err := s.deps.Settings.ResolveBool(ctx, configModel.KeyWebSpontaneousActivities)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("resolve spontaneous activities setting: %w", err)
+	}
+	return Capabilities{WebSpontaneousActivitiesEnabled: enabled}, nil
+}
+
+// loadSelectedGroupSections fills visits, tracking indicators, and pickup /
+// arrival times for the selected session's students.
+func (s *service) loadSelectedGroupSections(ctx context.Context, projection *Projection, selectedGroupID int64) error {
+	rows, err := s.deps.Active.GetActiveGroupVisitsWithDisplay(ctx, selectedGroupID)
+	if err != nil {
+		return fmt.Errorf("load group visits: %w", err)
+	}
+
+	access := userContextService.ResolveStudentAccess(ctx, s.deps.UserContext)
+	fullAccess := access.HasFullAccess()
+
+	openVisits := make([]*activeModels.VisitWithStudentDisplay, 0, len(rows))
+	studentIDs := make([]int64, 0, len(rows))
+	seen := map[int64]struct{}{}
+	for _, row := range rows {
+		if row.ExitTime != nil {
+			continue
+		}
+		openVisits = append(openVisits, row)
+		if _, ok := seen[row.StudentID]; !ok {
+			seen[row.StudentID] = struct{}{}
+			studentIDs = append(studentIDs, row.StudentID)
+		}
+	}
+
+	attendance := map[int64]*activeService.AttendanceStatus{}
+	if fullAccess && len(studentIDs) > 0 {
+		loaded, err := s.deps.Active.GetStudentsAttendanceStatuses(ctx, studentIDs)
+		if err != nil {
+			return fmt.Errorf("load attendance statuses: %w", err)
+		}
+		if loaded != nil {
+			attendance = loaded
+		}
+	}
+
+	photosEnabled, err := s.deps.Settings.ResolveBool(ctx, configModel.KeyStudentPhotosEnabled)
+	if err != nil {
+		return fmt.Errorf("resolve student photos setting: %w", err)
+	}
+	projection.Visits = buildVisits(openVisits, attendance, fullAccess, photosEnabled)
+
+	tracking, err := s.loadTracking(ctx, studentIDs)
+	if err != nil {
+		return fmt.Errorf("load tracking indicators: %w", err)
+	}
+	projection.TrackingIndicators = tracking
+
+	return s.loadPlanningTimes(ctx, projection, studentIDs, fullAccess)
+}
+
+func buildVisits(rows []*activeModels.VisitWithStudentDisplay, attendance map[int64]*activeService.AttendanceStatus, fullAccess, photosEnabled bool) []Visit {
+	result := make([]Visit, 0, len(rows))
+	for _, row := range rows {
+		visit := Visit{
+			StudentID:     row.StudentID,
+			StudentName:   strings.TrimSpace(row.FirstName + " " + row.LastName),
+			SchoolClass:   row.SchoolClass,
+			GroupName:     row.OGSGroupName,
+			ActiveGroupID: row.ActiveGroupID,
+			CheckInTime:   row.EntryTime,
+		}
+		if row.Sick != nil {
+			visit.Sick = *row.Sick
+		}
+		visit.SickSince = row.SickSince
+		if row.Excused != nil {
+			visit.Excused = *row.Excused
+		}
+		visit.ExcusedSince = row.ExcusedSince
+		if fullAccess {
+			if status := attendance[row.StudentID]; status != nil {
+				visit.ActualArrivalTime = timezone.FormatBerlinClock(status.CheckInTime)
+				visit.ActualPickupTime = timezone.FormatBerlinClock(status.CheckOutTime)
+			}
+		}
+		// Same full-access gate the single endpoint used: without it, avatar
+		// requests for out-of-scope students would 403 in the byte-serve path.
+		if photosEnabled && fullAccess && row.PhotoPath != nil {
+			visit.PhotoURL = buildPhotoURL(row.StudentID, *row.PhotoPath)
+		}
+		result = append(result, visit)
+	}
+	return result
+}
+
+func buildPhotoURL(studentID int64, storedURL string) string {
+	if storedURL == "" || !strings.HasPrefix(storedURL, studentPhotoStoredURLPrefix) {
+		return storedURL
+	}
+	return fmt.Sprintf("/api/students/%d/photo/%s", studentID, strings.TrimPrefix(storedURL, studentPhotoStoredURLPrefix))
+}
+
+func (s *service) loadTracking(ctx context.Context, studentIDs []int64) (TrackingIndicators, error) {
+	empty := TrackingIndicators{Labels: []string{}, Results: map[int64][]bool{}}
+	if len(studentIDs) == 0 {
+		return empty, nil
+	}
+	enabled, err := s.deps.Settings.ResolveBool(ctx, configModel.KeyTrackingIndicatorsEnabled)
+	if err != nil || !enabled {
+		return empty, err
+	}
+	labels := make([]string, 0, 3)
+	for _, key := range []string{configModel.KeyTrackingIndicator1, configModel.KeyTrackingIndicator2, configModel.KeyTrackingIndicator3} {
+		value, err := s.deps.Settings.ResolveString(ctx, key)
+		if err != nil {
+			return empty, err
+		}
+		if value = strings.TrimSpace(value); value != "" {
+			labels = append(labels, value)
+		}
+	}
+	if len(labels) == 0 {
+		return empty, nil
+	}
+	results, err := s.deps.Active.GetTrackingIndicators(ctx, studentIDs, labels)
+	if err != nil {
+		return empty, err
+	}
+	return TrackingIndicators{Labels: labels, Results: results}, nil
+}
+
+// loadPlanningTimes mirrors the former bulk pickup/arrival endpoints, which
+// were gated on users:read; without it the sections stay deterministically
+// empty. Times are additionally scoped to full-access callers, matching the
+// actual arrival/pickup gate on the visit rows.
+func (s *service) loadPlanningTimes(ctx context.Context, projection *Projection, studentIDs []int64, fullAccess bool) error {
+	if len(studentIDs) == 0 || !fullAccess ||
+		!authorize.HasPermission(permissions.UsersRead, jwt.PermissionsFromCtx(ctx)) {
+		return nil
+	}
+	today := timezone.DateFromTime(s.deps.Now())
+
+	pickups, err := s.deps.Pickups.GetBulkEffectivePickupTimesForDate(ctx, studentIDs, today)
+	if err != nil {
+		return fmt.Errorf("load pickup times: %w", err)
+	}
+	arrivals, err := s.deps.Arrivals.GetBulkEffectiveArrivalTimesForDate(ctx, studentIDs, today)
+	if err != nil {
+		return fmt.Errorf("load arrival times: %w", err)
+	}
+
+	for _, id := range studentIDs {
+		if effective := pickups[id]; effective != nil {
+			item := PickupTime{
+				StudentID: id, Date: effective.Date.String(), WeekdayName: effective.WeekdayName,
+				IsException: effective.IsException, Notes: effective.Notes,
+			}
+			if effective.PickupTime != nil {
+				formatted := effective.PickupTime.Format("15:04")
+				item.PickupTime = &formatted
+			}
+			for _, note := range effective.DayNotes {
+				item.DayNotes = append(item.DayNotes, DayNote{ID: note.ID, Content: note.Content})
+			}
+			projection.PickupTimes = append(projection.PickupTimes, item)
+		}
+		if effective := arrivals[id]; effective != nil {
+			item := ArrivalTime{
+				StudentID: id, Date: effective.Date.String(), WeekdayName: effective.WeekdayName,
+				IsException: effective.IsException, Notes: effective.Notes,
+			}
+			if effective.ArrivalTime != nil {
+				formatted := effective.ArrivalTime.Format("15:04")
+				item.ExpectedArrival = &formatted
+			}
+			for _, note := range effective.DayNotes {
+				item.DayNotes = append(item.DayNotes, DayNote{ID: note.ID, Content: note.Content})
+			}
+			projection.ArrivalTimes = append(projection.ArrivalTimes, item)
+		}
+	}
+	return nil
+}

--- a/backend/services/supervisiondashboard/service_mock_test.go
+++ b/backend/services/supervisiondashboard/service_mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	activityModels "github.com/moto-nrw/project-phoenix/models/activities"
 	"github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	educationModels "github.com/moto-nrw/project-phoenix/models/education"
@@ -30,6 +31,7 @@ import (
 type mockActiveService struct {
 	activeService.Service
 	listActiveGroupsFn         func() ([]*activeModels.Group, error)
+	getActiveGroupsByIDsFn     func(ids []int64) (map[int64]*activeModels.Group, error)
 	getRoomsByIDsFn            func(ids []int64) ([]*facilitiesModels.Room, error)
 	getUnclaimedActiveGroupsFn func() ([]*activeModels.Group, error)
 	getTrackingIndicatorsFn    func(studentIDs []int64, labels []string) (map[int64][]bool, error)
@@ -37,6 +39,10 @@ type mockActiveService struct {
 
 func (m *mockActiveService) ListActiveGroups(_ context.Context, _ *base.QueryOptions) ([]*activeModels.Group, error) {
 	return m.listActiveGroupsFn()
+}
+
+func (m *mockActiveService) GetActiveGroupsByIDs(_ context.Context, ids []int64) (map[int64]*activeModels.Group, error) {
+	return m.getActiveGroupsByIDsFn(ids)
 }
 
 func (m *mockActiveService) GetRoomsByIDs(_ context.Context, ids []int64) ([]*facilitiesModels.Room, error) {
@@ -193,7 +199,7 @@ func TestResolveGroupsBroadScope(t *testing.T) {
 	active := &mockActiveService{
 		listActiveGroupsFn: func() ([]*activeModels.Group, error) {
 			return []*activeModels.Group{
-				{Model: base.Model{ID: 11}, RoomID: 21, Room: &facilitiesModels.Room{Model: base.Model{ID: 21}, Name: "Zebra", Color: &color}},
+				{Model: base.Model{ID: 11}, RoomID: 21, ActualGroup: &activityModels.Group{Name: "Malen"}, Room: &facilitiesModels.Room{Model: base.Model{ID: 21}, Name: "Zebra", Color: &color}},
 				{Model: base.Model{ID: 12}, RoomID: 22},
 				{Model: base.Model{ID: 13}, RoomID: 22},
 				{Model: base.Model{ID: 14}, RoomID: 23, EndTime: &endedAt},
@@ -202,6 +208,14 @@ func TestResolveGroupsBroadScope(t *testing.T) {
 		getRoomsByIDsFn: func(ids []int64) ([]*facilitiesModels.Room, error) {
 			assert.Equal(t, []int64{22}, ids)
 			return []*facilitiesModels.Room{{Model: base.Model{ID: 22}, Name: "Adler"}}, nil
+		},
+		getActiveGroupsByIDsFn: func(ids []int64) (map[int64]*activeModels.Group, error) {
+			assert.Equal(t, []int64{11, 12, 13}, ids)
+			return map[int64]*activeModels.Group{
+				11: {Model: base.Model{ID: 11}, RoomID: 21, ActualGroup: &activityModels.Group{Name: "Malen"}, Room: &facilitiesModels.Room{Model: base.Model{ID: 21}, Name: "Zebra", Color: &color}},
+				12: {Model: base.Model{ID: 12}, RoomID: 22, Room: &facilitiesModels.Room{Model: base.Model{ID: 22}, Name: "Adler"}},
+				13: {Model: base.Model{ID: 13}, RoomID: 22, Room: &facilitiesModels.Room{Model: base.Model{ID: 22}, Name: "Adler"}},
+			}, nil
 		},
 	}
 	settings := &configtest.Mock{ResolveBoolFn: func(context.Context, string) (bool, error) { return true, nil }}
@@ -214,6 +228,8 @@ func TestResolveGroupsBroadScope(t *testing.T) {
 	assert.Equal(t, "Adler", groups[1].RoomName)
 	assert.Equal(t, "Zebra", groups[2].RoomName)
 	assert.Equal(t, &color, groups[2].RoomColor)
+	assert.Equal(t, "Malen", groups[2].Name)
+	assert.Equal(t, "Adler", groups[0].Name)
 
 	active.listActiveGroupsFn = func() ([]*activeModels.Group, error) { return nil, errors.New("boom") }
 	_, err = svc.resolveGroups(ctx)

--- a/backend/services/supervisiondashboard/service_mock_test.go
+++ b/backend/services/supervisiondashboard/service_mock_test.go
@@ -1,0 +1,337 @@
+package supervisiondashboard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	"github.com/moto-nrw/project-phoenix/models/base"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
+	educationModels "github.com/moto-nrw/project-phoenix/models/education"
+	facilitiesModels "github.com/moto-nrw/project-phoenix/models/facilities"
+	usersModels "github.com/moto-nrw/project-phoenix/models/users"
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	configService "github.com/moto-nrw/project-phoenix/services/config"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
+	educationService "github.com/moto-nrw/project-phoenix/services/education"
+	facilitiesService "github.com/moto-nrw/project-phoenix/services/facilities"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+	userContextService "github.com/moto-nrw/project-phoenix/services/usercontext"
+)
+
+// The dependency interfaces are wide; the mocks embed them and override only
+// what a test calls — an unexpected call panics on the nil embedded interface.
+type mockActiveService struct {
+	activeService.Service
+	listActiveGroupsFn         func() ([]*activeModels.Group, error)
+	getRoomsByIDsFn            func(ids []int64) ([]*facilitiesModels.Room, error)
+	getUnclaimedActiveGroupsFn func() ([]*activeModels.Group, error)
+	getTrackingIndicatorsFn    func(studentIDs []int64, labels []string) (map[int64][]bool, error)
+}
+
+func (m *mockActiveService) ListActiveGroups(_ context.Context, _ *base.QueryOptions) ([]*activeModels.Group, error) {
+	return m.listActiveGroupsFn()
+}
+
+func (m *mockActiveService) GetRoomsByIDs(_ context.Context, ids []int64) ([]*facilitiesModels.Room, error) {
+	return m.getRoomsByIDsFn(ids)
+}
+
+func (m *mockActiveService) GetUnclaimedActiveGroups(_ context.Context) ([]*activeModels.Group, error) {
+	return m.getUnclaimedActiveGroupsFn()
+}
+
+func (m *mockActiveService) GetTrackingIndicators(_ context.Context, studentIDs []int64, labels []string) (map[int64][]bool, error) {
+	return m.getTrackingIndicatorsFn(studentIDs, labels)
+}
+
+type mockUserContextService struct {
+	userContextService.UserContextService
+	getCurrentStaffFn       func() (*usersModels.Staff, error)
+	getMySupervisedGroupsFn func() ([]*activeModels.Group, error)
+	getMyGroupsFn           func() ([]*educationModels.Group, error)
+}
+
+func (m *mockUserContextService) GetCurrentStaff(_ context.Context) (*usersModels.Staff, error) {
+	return m.getCurrentStaffFn()
+}
+
+func (m *mockUserContextService) GetMySupervisedGroups(_ context.Context) ([]*activeModels.Group, error) {
+	return m.getMySupervisedGroupsFn()
+}
+
+func (m *mockUserContextService) GetMyGroups(_ context.Context) ([]*educationModels.Group, error) {
+	return m.getMyGroupsFn()
+}
+
+type mockEducationService struct {
+	educationService.Service
+	getGroupsWithRoomsByIDsFn func(ids []int64) (map[int64]*educationModels.Group, error)
+}
+
+func (m *mockEducationService) GetGroupsWithRoomsByIDs(_ context.Context, ids []int64) (map[int64]*educationModels.Group, error) {
+	return m.getGroupsWithRoomsByIDsFn(ids)
+}
+
+type mockSchulhofService struct {
+	facilitiesService.SchulhofService
+}
+type mockOperationsService struct {
+	scheduleService.TimetableOperationsService
+}
+type mockPickupService struct {
+	scheduleService.PickupScheduleService
+}
+type mockArrivalService struct {
+	scheduleService.ArrivalScheduleService
+}
+
+func fullDependencies() Dependencies {
+	return Dependencies{
+		Active:      &mockActiveService{},
+		UserContext: &mockUserContextService{},
+		Education:   &mockEducationService{},
+		Schulhof:    &mockSchulhofService{},
+		Operations:  &mockOperationsService{},
+		Settings:    &configtest.Mock{},
+		Pickups:     &mockPickupService{},
+		Arrivals:    &mockArrivalService{},
+	}
+}
+
+func adminContext() context.Context {
+	return context.WithValue(context.Background(), jwt.CtxClaims, jwt.AppClaims{ID: 99, IsAdmin: true})
+}
+
+func TestGetFailsFast(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := NewService(Dependencies{}).Get(ctx, 0)
+	require.ErrorContains(t, err, "not fully configured")
+
+	deps := fullDependencies()
+	deps.Settings = &configtest.Mock{ResolveManyFn: func(context.Context, []string) (*configService.SettingsSnapshot, error) {
+		return nil, errors.New("settings down")
+	}}
+	_, err = NewService(deps).Get(ctx, 0)
+	require.ErrorContains(t, err, "resolve dashboard settings")
+
+	deps = fullDependencies()
+	deps.UserContext = &mockUserContextService{getCurrentStaffFn: func() (*usersModels.Staff, error) {
+		return nil, errors.New("staff lookup failed")
+	}}
+	_, err = NewService(deps).Get(ctx, 0)
+	require.ErrorContains(t, err, "load current staff")
+}
+
+func TestLoadCurrentStaffIDBranches(t *testing.T) {
+	ctx := context.Background()
+	staff := &usersModels.Staff{Model: base.Model{ID: 42}}
+
+	tests := []struct {
+		name    string
+		result  *usersModels.Staff
+		err     error
+		want    *int64
+		wantErr bool
+	}{
+		{name: "not linked to staff", err: userContextService.ErrUserNotLinkedToStaff},
+		{name: "not linked to person", err: userContextService.ErrUserNotLinkedToPerson},
+		{name: "lookup error", err: errors.New("db down"), wantErr: true},
+		{name: "nil staff", result: nil},
+		{name: "staff found", result: staff, want: int64Ptr(42)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{deps: Dependencies{UserContext: &mockUserContextService{
+				getCurrentStaffFn: func() (*usersModels.Staff, error) { return tt.result, tt.err },
+			}}}
+			got, err := svc.loadCurrentStaffID(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHasOperationalOverviewAdmin(t *testing.T) {
+	ctx := adminContext()
+
+	settings := &configtest.Mock{ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+		return key == configModel.KeyAdminSupervisionOverview, nil
+	}}
+	svc := &service{deps: Dependencies{Settings: settings}}
+	broad, err := svc.hasOperationalOverview(ctx)
+	require.NoError(t, err)
+	assert.True(t, broad)
+
+	settings.ResolveBoolFn = func(context.Context, string) (bool, error) { return false, errors.New("boom") }
+	_, err = svc.hasOperationalOverview(ctx)
+	require.ErrorContains(t, err, "admin supervision overview")
+
+	settings.ResolveBoolFn = func(context.Context, string) (bool, error) { return false, nil }
+	settings.ResolveStringFn = func(context.Context, string) (string, error) { return "", errors.New("boom") }
+	_, err = svc.hasOperationalOverview(ctx)
+	require.ErrorContains(t, err, "group mode")
+}
+
+func TestResolveGroupsBroadScope(t *testing.T) {
+	ctx := adminContext()
+	color := "#83CD2D"
+	endedAt := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+
+	active := &mockActiveService{
+		listActiveGroupsFn: func() ([]*activeModels.Group, error) {
+			return []*activeModels.Group{
+				{Model: base.Model{ID: 11}, RoomID: 21, Room: &facilitiesModels.Room{Model: base.Model{ID: 21}, Name: "Zebra", Color: &color}},
+				{Model: base.Model{ID: 12}, RoomID: 22},
+				{Model: base.Model{ID: 13}, RoomID: 22},
+				{Model: base.Model{ID: 14}, RoomID: 23, EndTime: &endedAt},
+			}, nil
+		},
+		getRoomsByIDsFn: func(ids []int64) ([]*facilitiesModels.Room, error) {
+			assert.Equal(t, []int64{22}, ids)
+			return []*facilitiesModels.Room{{Model: base.Model{ID: 22}, Name: "Adler"}}, nil
+		},
+	}
+	settings := &configtest.Mock{ResolveBoolFn: func(context.Context, string) (bool, error) { return true, nil }}
+	svc := &service{deps: Dependencies{Active: active, Settings: settings}}
+
+	groups, err := svc.resolveGroups(ctx)
+	require.NoError(t, err)
+	require.Len(t, groups, 3)
+	assert.Equal(t, "Adler", groups[0].RoomName)
+	assert.Equal(t, "Adler", groups[1].RoomName)
+	assert.Equal(t, "Zebra", groups[2].RoomName)
+	assert.Equal(t, &color, groups[2].RoomColor)
+
+	active.listActiveGroupsFn = func() ([]*activeModels.Group, error) { return nil, errors.New("boom") }
+	_, err = svc.resolveGroups(ctx)
+	require.ErrorContains(t, err, "load active groups")
+}
+
+func TestResolveGroupsSupervisedErrors(t *testing.T) {
+	ctx := context.Background()
+	settings := &configtest.Mock{}
+
+	userContext := &mockUserContextService{getMySupervisedGroupsFn: func() ([]*activeModels.Group, error) {
+		return nil, errors.New("boom")
+	}}
+	svc := &service{deps: Dependencies{UserContext: userContext, Settings: settings}}
+	_, err := svc.resolveGroups(ctx)
+	require.ErrorContains(t, err, "load supervised groups")
+
+	userContext.getMySupervisedGroupsFn = func() ([]*activeModels.Group, error) {
+		return []*activeModels.Group{{Model: base.Model{ID: 11}, RoomID: 21}}, nil
+	}
+	svc.deps.Active = &mockActiveService{getRoomsByIDsFn: func([]int64) ([]*facilitiesModels.Room, error) {
+		return nil, errors.New("boom")
+	}}
+	_, err = svc.resolveGroups(ctx)
+	require.ErrorContains(t, err, "bulk load rooms")
+}
+
+func TestLoadStaticSectionsBranches(t *testing.T) {
+	ctx := context.Background()
+	roomID := int64(31)
+
+	active := &mockActiveService{getUnclaimedActiveGroupsFn: func() ([]*activeModels.Group, error) {
+		return []*activeModels.Group{
+			{Model: base.Model{ID: 11}, Room: &facilitiesModels.Room{Model: base.Model{ID: 21}, Name: "Adler"}},
+			{Model: base.Model{ID: 12}},
+		}, nil
+	}}
+	userContext := &mockUserContextService{getMyGroupsFn: func() ([]*educationModels.Group, error) {
+		return []*educationModels.Group{
+			{Model: base.Model{ID: 41}, Name: "Bären", RoomID: &roomID},
+			{Model: base.Model{ID: 42}, Name: "Füchse"},
+		}, nil
+	}}
+	education := &mockEducationService{getGroupsWithRoomsByIDsFn: func(ids []int64) (map[int64]*educationModels.Group, error) {
+		assert.Equal(t, []int64{41}, ids)
+		return map[int64]*educationModels.Group{
+			41: {Model: base.Model{ID: 41}, Room: &facilitiesModels.Room{Model: base.Model{ID: 31}, Name: "Igel"}},
+			42: nil,
+		}, nil
+	}}
+	svc := &service{deps: Dependencies{Active: active, UserContext: userContext, Education: education}}
+
+	projection := emptyProjection()
+	require.NoError(t, svc.loadStaticSections(ctx, projection))
+	assert.Equal(t, []UnclaimedGroup{{ID: 11, RoomName: "Adler"}, {ID: 12}}, projection.UnclaimedGroups)
+	assert.Equal(t, []EducationalGroup{{ID: 41, Name: "Bären", RoomName: "Igel"}, {ID: 42, Name: "Füchse"}}, projection.EducationalGroups)
+
+	education.getGroupsWithRoomsByIDsFn = func([]int64) (map[int64]*educationModels.Group, error) { return nil, errors.New("boom") }
+	require.ErrorContains(t, svc.loadStaticSections(ctx, emptyProjection()), "load education group rooms")
+
+	userContext.getMyGroupsFn = func() ([]*educationModels.Group, error) { return nil, errors.New("boom") }
+	require.ErrorContains(t, svc.loadStaticSections(ctx, emptyProjection()), "load educational groups")
+
+	active.getUnclaimedActiveGroupsFn = func() ([]*activeModels.Group, error) { return nil, errors.New("boom") }
+	require.ErrorContains(t, svc.loadStaticSections(ctx, emptyProjection()), "load unclaimed groups")
+}
+
+func TestLoadTrackingBranches(t *testing.T) {
+	ctx := context.Background()
+	studentIDs := []int64{11}
+
+	settings := &configtest.Mock{
+		ResolveBoolFn:   func(context.Context, string) (bool, error) { return true, nil },
+		ResolveStringFn: func(context.Context, string) (string, error) { return "", errors.New("boom") },
+	}
+	svc := &service{deps: Dependencies{Settings: settings}}
+	_, err := svc.loadTracking(ctx, studentIDs)
+	require.Error(t, err)
+
+	settings.ResolveStringFn = func(context.Context, string) (string, error) { return "  ", nil }
+	tracking, err := svc.loadTracking(ctx, studentIDs)
+	require.NoError(t, err)
+	assert.Empty(t, tracking.Labels)
+
+	settings.ResolveStringFn = func(_ context.Context, key string) (string, error) {
+		if key == configModel.KeyTrackingIndicator1 {
+			return "Hausaufgaben", nil
+		}
+		return "", nil
+	}
+	svc.deps.Active = &mockActiveService{getTrackingIndicatorsFn: func([]int64, []string) (map[int64][]bool, error) {
+		return nil, errors.New("boom")
+	}}
+	_, err = svc.loadTracking(ctx, studentIDs)
+	require.Error(t, err)
+
+	svc.deps.Active = &mockActiveService{getTrackingIndicatorsFn: func(ids []int64, labels []string) (map[int64][]bool, error) {
+		assert.Equal(t, studentIDs, ids)
+		assert.Equal(t, []string{"Hausaufgaben"}, labels)
+		return map[int64][]bool{11: {true}}, nil
+	}}
+	tracking, err = svc.loadTracking(ctx, studentIDs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Hausaufgaben"}, tracking.Labels)
+	assert.Equal(t, map[int64][]bool{11: {true}}, tracking.Results)
+}
+
+func TestResolveCapabilitiesClosedConcept(t *testing.T) {
+	ctx := context.Background()
+
+	settings := &configtest.Mock{ResolveStringFn: func(context.Context, string) (string, error) { return "standard", nil }}
+	svc := &service{deps: Dependencies{Settings: settings}}
+	capabilities, err := svc.resolveCapabilities(ctx)
+	require.NoError(t, err)
+	assert.False(t, capabilities.WebSpontaneousActivitiesEnabled)
+
+	settings.ResolveStringFn = func(context.Context, string) (string, error) { return configModel.CareConceptOpenRooms, nil }
+	settings.ResolveBoolFn = func(context.Context, string) (bool, error) { return false, errors.New("boom") }
+	_, err = svc.resolveCapabilities(ctx)
+	require.ErrorContains(t, err, "spontaneous activities")
+}

--- a/backend/services/supervisiondashboard/service_test.go
+++ b/backend/services/supervisiondashboard/service_test.go
@@ -1,0 +1,95 @@
+package supervisiondashboard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	facilitiesService "github.com/moto-nrw/project-phoenix/services/facilities"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+func TestSelectGroup(t *testing.T) {
+	groups := []Group{{ID: 10}, {ID: 20}}
+	yardGroupID := int64(30)
+
+	tests := []struct {
+		name      string
+		requested int64
+		yard      *facilitiesService.SchulhofStatus
+		want      *int64
+		wantErr   error
+	}{
+		{name: "defaults to the first group", want: int64Ptr(10)},
+		{name: "uses a requested group", requested: 20, want: int64Ptr(20)},
+		{name: "permits the supervised yard group", requested: 30, yard: &facilitiesService.SchulhofStatus{IsUserSupervising: true, ActiveGroupID: &yardGroupID}, want: int64Ptr(30)},
+		{name: "rejects an unsupervised group", requested: 40, wantErr: ErrForbiddenGroup},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectGroup(groups, tt.yard, tt.requested)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	got, err := selectGroup(nil, nil, 0)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestBuildVisitsAndEffectiveTimes(t *testing.T) {
+	checkedIn := time.Date(2026, time.August, 19, 10, 0, 0, 0, time.UTC)
+	checkedOut := checkedIn.Add(time.Hour)
+	sick, excused := true, true
+	storedPhoto := studentPhotoStoredURLPrefix + "portrait.jpg"
+	rows := []*activeModels.VisitWithStudentDisplay{{
+		StudentID: 1, ActiveGroupID: 2, EntryTime: checkedIn,
+		FirstName: "  Erika", LastName: "Mustermann ", SchoolClass: "4a", OGSGroupName: "Bären",
+		Sick: &sick, SickSince: &checkedIn, Excused: &excused, ExcusedSince: &checkedOut, PhotoPath: &storedPhoto,
+	}}
+
+	visits := buildVisits(rows, map[int64]*activeService.AttendanceStatus{1: {CheckInTime: &checkedIn, CheckOutTime: &checkedOut}}, true, true)
+	require.Len(t, visits, 1)
+	assert.Equal(t, "Erika Mustermann", visits[0].StudentName)
+	assert.True(t, visits[0].Sick)
+	assert.True(t, visits[0].Excused)
+	assert.Equal(t, "/api/students/1/photo/portrait.jpg", visits[0].PhotoURL)
+	assert.Equal(t, timezone.FormatBerlinClock(&checkedIn), visits[0].ActualArrivalTime)
+	assert.Equal(t, timezone.FormatBerlinClock(&checkedOut), visits[0].ActualPickupTime)
+
+	privateVisits := buildVisits(rows, nil, false, true)
+	assert.Nil(t, privateVisits[0].ActualArrivalTime)
+	assert.Empty(t, privateVisits[0].PhotoURL)
+
+	pickup := time.Date(2026, time.August, 19, 15, 30, 0, 0, time.UTC)
+	arrival := time.Date(2026, time.August, 19, 11, 45, 0, 0, time.UTC)
+	pickupItem := pickupTimeFromEffective(1, &scheduleService.EffectivePickupTime{
+		Date: timezone.DateFromTime(checkedIn), PickupTime: &pickup, WeekdayName: "Mittwoch", IsException: true, Notes: "Oma", DayNotes: []scheduleService.NoteData{{ID: 3, Content: "Klingeln"}},
+	})
+	assert.Equal(t, "15:30", *pickupItem.PickupTime)
+	assert.Equal(t, []DayNote{{ID: 3, Content: "Klingeln"}}, pickupItem.DayNotes)
+
+	arrivalItem := arrivalTimeFromEffective(1, &scheduleService.EffectiveArrivalTime{
+		Date: timezone.DateFromTime(checkedIn), ArrivalTime: &arrival, WeekdayName: "Mittwoch", Notes: "Bus", DayNotes: []scheduleService.ArrivalNoteData{{ID: 4, Content: "Verspätung"}},
+	})
+	assert.Equal(t, "11:45", *arrivalItem.ExpectedArrival)
+	assert.Equal(t, []DayNote{{ID: 4, Content: "Verspätung"}}, arrivalItem.DayNotes)
+}
+
+func TestBuildPhotoURL(t *testing.T) {
+	assert.Empty(t, buildPhotoURL(1, ""))
+	assert.Equal(t, "https://example.test/photo.jpg", buildPhotoURL(1, "https://example.test/photo.jpg"))
+}
+
+func int64Ptr(value int64) *int64 { return &value }

--- a/backend/services/supervisiondashboard/service_test.go
+++ b/backend/services/supervisiondashboard/service_test.go
@@ -1,6 +1,7 @@
 package supervisiondashboard
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -90,6 +91,43 @@ func TestBuildVisitsAndEffectiveTimes(t *testing.T) {
 func TestBuildPhotoURL(t *testing.T) {
 	assert.Empty(t, buildPhotoURL(1, ""))
 	assert.Equal(t, "https://example.test/photo.jpg", buildPhotoURL(1, "https://example.test/photo.jpg"))
+}
+
+func TestEmptyAndPermissionRedactedProjection(t *testing.T) {
+	projection := emptyProjection()
+	assert.Empty(t, projection.Groups)
+	assert.Empty(t, projection.UnclaimedGroups)
+	assert.Empty(t, projection.EducationalGroups)
+	assert.Empty(t, projection.ActiveSessions)
+	assert.Empty(t, projection.PlannedNow)
+	assert.Empty(t, projection.Visits)
+	assert.Empty(t, projection.TrackingIndicators.Labels)
+	assert.Empty(t, projection.TrackingIndicators.Results)
+	assert.Empty(t, projection.PickupTimes)
+	assert.Empty(t, projection.ArrivalTimes)
+
+	service := &service{}
+	ctx := context.Background()
+	require.NoError(t, service.loadScheduleSections(ctx, projection))
+	require.NoError(t, service.loadPlanningTimes(ctx, projection, nil, false))
+	tracking, err := service.loadTracking(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, tracking.Labels)
+	assert.Empty(t, tracking.Results)
+
+	rooms, err := service.loadEducationRooms(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, rooms)
+}
+
+func TestServiceDefaults(t *testing.T) {
+	service := NewService(Dependencies{}).(*service)
+	assert.NotNil(t, service.deps.Now)
+	assert.Error(t, service.validateDependencies())
+
+	ctx, err := service.prefetchSettings(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, ctx)
 }
 
 func int64Ptr(value int64) *int64 { return &value }

--- a/backend/services/supervisiondashboard/service_test.go
+++ b/backend/services/supervisiondashboard/service_test.go
@@ -2,6 +2,7 @@ package supervisiondashboard
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,7 +11,9 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	facilitiesService "github.com/moto-nrw/project-phoenix/services/facilities"
 	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
 )
@@ -128,6 +131,41 @@ func TestServiceDefaults(t *testing.T) {
 	ctx, err := service.prefetchSettings(context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, ctx)
+}
+
+func TestSettingsDrivenProjectionBranches(t *testing.T) {
+	settings := &configtest.Mock{
+		ResolveStringFn: func(_ context.Context, key string) (string, error) {
+			switch key {
+			case configModel.KeyGroupMode:
+				return configModel.GroupModeOpenCare, nil
+			case configModel.KeyCareConcept:
+				return configModel.CareConceptOpenRooms, nil
+			default:
+				return "", nil
+			}
+		},
+		ResolveBoolFn: func(_ context.Context, key string) (bool, error) {
+			return key == configModel.KeyWebSpontaneousActivities, nil
+		},
+	}
+	service := &service{deps: Dependencies{Settings: settings}}
+
+	overview, err := service.hasOperationalOverview(context.Background())
+	require.NoError(t, err)
+	assert.True(t, overview)
+
+	capabilities, err := service.resolveCapabilities(context.Background())
+	require.NoError(t, err)
+	assert.True(t, capabilities.WebSpontaneousActivitiesEnabled)
+
+	rooms, err := service.loadRooms(context.Background(), []*activeModels.Group{{}})
+	require.NoError(t, err)
+	assert.Empty(t, rooms)
+
+	settings.ResolveStringFn = func(_ context.Context, _ string) (string, error) { return "", errors.New("settings unavailable") }
+	_, err = service.resolveCapabilities(context.Background())
+	require.Error(t, err)
 }
 
 func int64Ptr(value int64) *int64 { return &value }

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,8 +1,10 @@
 <!-- BEGIN:nextjs-agent-rules -->
 
-# Next.js: ALWAYS read docs before coding
+# This is NOT the Next.js you know
 
-Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->
 

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
@@ -634,6 +634,7 @@ describe("Schulhof tab onTabChange callback", () => {
       educationalGroups: [],
       firstRoomVisits: [],
       firstRoomId: "room-1",
+      selectedGroupId: "room-1",
       capabilities: { webSpontaneousActivitiesEnabled: true },
       schulhofStatus: {
         exists: true,
@@ -656,21 +657,25 @@ describe("Schulhof tab onTabChange callback", () => {
       },
     };
 
-    vi.mocked(useSWRAuth)
-      .mockReturnValueOnce({
-        data: dashboardData,
-        isLoading: false,
-        error: null,
-        mutate: mockMutate,
-        isValidating: false,
-      } as never)
-      .mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: null,
-        mutate: mockMutate,
-        isValidating: false,
-      } as never);
+    // Key-aware mock: the dashboard data must stay available across
+    // re-renders so the selection-reconciliation effect (#2096) can compare
+    // the cached selectedGroupId against the Schulhof session.
+    vi.mocked(useSWRAuth).mockImplementation(((key: unknown) =>
+      typeof key === "string" && key.startsWith("active-supervision-dashboard")
+        ? ({
+            data: dashboardData,
+            isLoading: false,
+            error: null,
+            mutate: mockMutate,
+            isValidating: false,
+          } as never)
+        : ({
+            data: null,
+            isLoading: false,
+            error: null,
+            mutate: mockMutate,
+            isValidating: false,
+          } as never)) as never);
 
     render(<MeinRaumPage />);
 
@@ -690,27 +695,22 @@ describe("Schulhof tab onTabChange callback", () => {
       );
     });
 
-    // The tab callback itself must not start a duplicate request.
+    // The tab callback itself must not start a separate visits request —
+    // the Schulhof session's visits arrive via the aggregate re-run (#2096).
     expect(
       activeService.getActiveGroupVisitsWithDisplay,
     ).not.toHaveBeenCalled();
-
-    // The keyed SWR subscription owns exactly one Schulhof request and must
-    // not carry another room's previous data across the key change.
-    const visitCall = vi
-      .mocked(useSWRAuth)
-      .mock.calls.find(([key]) => key === "supervision-visits-active-schulhof");
-    expect(visitCall).toBeDefined();
-    expect(visitCall?.[2]).toMatchObject({ keepPreviousData: false });
-    const visitFetcher = visitCall?.[1] as (() => Promise<unknown>) | undefined;
-    expect(visitFetcher).toBeTypeOf("function");
-    await visitFetcher?.();
-    expect(activeService.getActiveGroupVisitsWithDisplay).toHaveBeenCalledTimes(
-      1,
-    );
-    expect(activeService.getActiveGroupVisitsWithDisplay).toHaveBeenCalledWith(
-      "active-schulhof",
-    );
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
+    expect(
+      vi
+        .mocked(useSWRAuth)
+        .mock.calls.some(
+          ([key]) =>
+            typeof key === "string" && key.startsWith("supervision-visits-"),
+        ),
+    ).toBe(false);
   });
 
   it("clicking Schulhof tab when not supervising sets empty students", async () => {
@@ -730,6 +730,7 @@ describe("Schulhof tab onTabChange callback", () => {
       educationalGroups: [],
       firstRoomVisits: [],
       firstRoomId: "room-1",
+      selectedGroupId: "room-1",
       capabilities: { webSpontaneousActivitiesEnabled: true },
       schulhofStatus: {
         exists: true,
@@ -803,6 +804,7 @@ describe("Schulhof tab onTabChange callback", () => {
       educationalGroups: [],
       firstRoomVisits: [],
       firstRoomId: "room-1",
+      selectedGroupId: "room-1",
       capabilities: { webSpontaneousActivitiesEnabled: true },
       schulhofStatus: {
         exists: true,
@@ -850,12 +852,11 @@ describe("Schulhof tab onTabChange callback", () => {
       );
     });
 
-    // Should have called loadRoomVisits for the room
-    await waitFor(() => {
-      expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("room-1");
-    });
+    // The room's visits ride in the aggregate (#2096) — no separate
+    // per-room request is issued by the switch.
+    expect(
+      activeService.getActiveGroupVisitsWithDisplay,
+    ).not.toHaveBeenCalled();
   });
 });
 
@@ -1222,7 +1223,7 @@ describe("Tracking indicators rendering", () => {
 
   afterEach(() => cleanup());
 
-  it("subscribes to the tracking hook once a room has students", async () => {
+  it("renders tracking indicators from the aggregate without a separate fetch", async () => {
     const dashboardData = {
       supervisedGroups: [
         { id: "1", name: "Raum 101", room: { id: "10", name: "Raum 101" } },
@@ -1242,19 +1243,16 @@ describe("Tracking indicators rendering", () => {
         },
       ],
       firstRoomId: "1",
+      selectedGroupId: "1",
+      // Tracking indicators ride in the aggregate since #2096.
+      trackingIndicators: {
+        labels: ["Hausaufgaben"],
+        results: { "100": [true] },
+      },
       schulhofStatus: null,
     };
 
-    vi.mocked(useSWRAuth).mockImplementation((key) => {
-      if (typeof key === "string" && key.startsWith("tracking-supervisions")) {
-        return {
-          data: { labels: ["Hausaufgaben"], results: { "100": [true] } },
-          isLoading: false,
-          error: null,
-          mutate: mockMutate,
-          isValidating: false,
-        } as never;
-      }
+    vi.mocked(useSWRAuth).mockImplementation(((key: unknown) => {
       if (
         typeof key === "string" &&
         key.startsWith("active-supervision-dashboard")
@@ -1274,7 +1272,7 @@ describe("Tracking indicators rendering", () => {
         mutate: mockMutate,
         isValidating: false,
       } as never;
-    });
+    }) as never);
 
     render(<MeinRaumPage />);
 
@@ -1282,15 +1280,15 @@ describe("Tracking indicators rendering", () => {
       expect(screen.getByTestId("student-card")).toBeInTheDocument();
     });
 
-    const trackingCall = vi
-      .mocked(useSWRAuth)
-      .mock.calls.find(
-        (args) =>
-          typeof args[0] === "string" &&
-          args[0].startsWith("tracking-supervisions"),
-      );
-    expect(trackingCall).toBeDefined();
-    expect(trackingCall?.[0]).toContain("tracking-supervisions-");
-    expect(trackingCall?.[0]).toContain("100");
+    // The former separate tracking subscription must be gone (#2096).
+    expect(
+      vi
+        .mocked(useSWRAuth)
+        .mock.calls.some(
+          (args) =>
+            typeof args[0] === "string" &&
+            args[0].startsWith("tracking-supervisions"),
+        ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
@@ -980,7 +980,7 @@ describe("RoleGuard integration", () => {
   });
 });
 
-describe("Admin fallback dashboard fetcher", () => {
+describe("Aggregate fetcher error contract", () => {
   const mockMutate = vi.fn();
 
   beforeEach(async () => {
@@ -1006,184 +1006,11 @@ describe("Admin fallback dashboard fetcher", () => {
 
   afterEach(() => cleanup());
 
-  // Helper: mock useSWRAuth so the dashboard fetcher actually runs
+  // Capture the dashboard fetcher without invoking it — invoked manually so
+  // rejections stay contained in the test instead of escaping to vitest.
   function captureFetcher(): {
-    getPromise: () => Promise<unknown> | undefined;
+    getFetcher: () => (() => Promise<unknown>) | undefined;
   } {
-    let dashboardPromise: Promise<unknown> | undefined;
-    vi.mocked(useSWRAuth).mockImplementation(((
-      key: string | null,
-      fetcher: (() => Promise<unknown>) | undefined,
-    ) => {
-      if (
-        key?.startsWith("active-supervision-dashboard") &&
-        fetcher &&
-        !dashboardPromise
-      ) {
-        dashboardPromise = fetcher();
-      }
-      return {
-        data: null,
-        isLoading: true,
-        error: null,
-        mutate: mockMutate,
-        isValidating: false,
-      } as never;
-    }) as never);
-    return { getPromise: () => dashboardPromise };
-  }
-
-  it("populates supervisedGroups and schulhofStatus from fallback endpoints", async () => {
-    global.fetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes("/api/active-supervision-dashboard")) {
-        return Promise.resolve({ ok: false, status: 500 });
-      }
-      if (url.includes("/api/active/supervisors/all")) {
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: [
-                {
-                  id: 1,
-                  name: "Group 1",
-                  room_id: 10,
-                  room: { id: 10, name: "Kunstraum" },
-                },
-              ],
-            }),
-        });
-      }
-      if (url.includes("/api/active/schulhof/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                data: {
-                  exists: true,
-                  room_id: 99,
-                  room_name: "Schulhof",
-                  active_group_id: 42,
-                  is_user_supervising: true,
-                  supervision_id: 123,
-                  supervisor_count: 1,
-                  student_count: 5,
-                  supervisors: [
-                    {
-                      id: 1,
-                      staff_id: 2,
-                      name: "Super",
-                      is_current_user: true,
-                    },
-                  ],
-                },
-              },
-            }),
-        });
-      }
-      return Promise.reject(new Error(`unexpected: ${url}`));
-    });
-
-    const { getPromise } = captureFetcher();
-    render(<MeinRaumPage />);
-    await waitFor(() => expect(getPromise()).toBeDefined());
-
-    const result = (await getPromise()) as {
-      supervisedGroups: Array<{ id: string; room_id?: string }>;
-      schulhofStatus: { exists: boolean; supervisorCount: number } | null;
-      firstRoomId: string | null;
-    };
-    expect(result.supervisedGroups).toHaveLength(1);
-    expect(result.supervisedGroups[0]?.room_id).toBe("10");
-    expect(result.firstRoomId).toBe("10");
-    expect(result.schulhofStatus?.exists).toBe(true);
-    expect(result.schulhofStatus?.supervisorCount).toBe(1);
-  });
-
-  it("returns empty supervisedGroups when supervisors endpoint fails", async () => {
-    global.fetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes("/api/active-supervision-dashboard")) {
-        return Promise.resolve({ ok: false, status: 403 });
-      }
-      if (url.includes("/api/active/supervisors/all")) {
-        return Promise.resolve({ ok: false });
-      }
-      if (url.includes("/api/active/schulhof/status")) {
-        return Promise.reject(new Error("network"));
-      }
-      return Promise.reject(new Error("unexpected"));
-    });
-
-    const { getPromise } = captureFetcher();
-    render(<MeinRaumPage />);
-    await waitFor(() => expect(getPromise()).toBeDefined());
-
-    const result = (await getPromise()) as {
-      supervisedGroups: unknown[];
-      schulhofStatus: unknown;
-      firstRoomId: string | null;
-    };
-    expect(result.supervisedGroups).toEqual([]);
-    expect(result.schulhofStatus).toBeNull();
-    expect(result.firstRoomId).toBeNull();
-  });
-
-  it("omits schulhofStatus when schulhof.exists is false", async () => {
-    global.fetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes("/api/active-supervision-dashboard")) {
-        return Promise.resolve({ ok: false, status: 500 });
-      }
-      if (url.includes("/api/active/supervisors/all")) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ data: [] }),
-        });
-      }
-      if (url.includes("/api/active/schulhof/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              data: {
-                data: {
-                  exists: false,
-                  room_name: "",
-                  is_user_supervising: false,
-                  supervisor_count: 0,
-                  student_count: 0,
-                },
-              },
-            }),
-        });
-      }
-      return Promise.reject(new Error("unexpected"));
-    });
-
-    const { getPromise } = captureFetcher();
-    render(<MeinRaumPage />);
-    await waitFor(() => expect(getPromise()).toBeDefined());
-
-    const result = (await getPromise()) as { schulhofStatus: unknown };
-    expect(result.schulhofStatus).toBeNull();
-  });
-
-  it("skips fallback entirely for non-admin and throws on BFF failure", async () => {
-    const { useSession } = await import("next-auth/react");
-    vi.mocked(useSession).mockReturnValue({
-      data: { user: { token: "test-token", isAdmin: false } },
-      status: "authenticated",
-    } as never);
-
-    global.fetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes("/api/active-supervision-dashboard")) {
-        return Promise.resolve({ ok: false, status: 500 });
-      }
-      return Promise.reject(new Error("should not be called"));
-    });
-
-    // Capture the fetcher without invoking — invoke manually below to contain
-    // the rejection inside the test instead of letting it escape to vitest.
     let capturedFetcher: (() => Promise<unknown>) | undefined;
     vi.mocked(useSWRAuth).mockImplementation(((
       key: string | null,
@@ -1204,11 +1031,54 @@ describe("Admin fallback dashboard fetcher", () => {
         isValidating: false,
       } as never;
     }) as never);
+    return { getFetcher: () => capturedFetcher };
+  }
 
+  it("throws on aggregate failure for admins too — no silent fallback fan-out (#2096)", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/active-supervision-dashboard")) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.reject(new Error(`unexpected: ${url}`));
+    });
+    global.fetch = fetchMock;
+
+    const { getFetcher } = captureFetcher();
     render(<MeinRaumPage />);
-    await waitFor(() => expect(capturedFetcher).toBeDefined());
+    await waitFor(() => expect(getFetcher()).toBeDefined());
 
-    await expect(capturedFetcher!()).rejects.toThrow("BFF request failed: 500");
+    await expect(getFetcher()!()).rejects.toThrow("BFF request failed: 500");
+
+    // The former admin fallback fan-out endpoints must never be contacted:
+    // silently-empty partial payloads are the failure mode #2096 removed.
+    const urls = fetchMock.mock.calls.map(([u]) => String(u));
+    expect(urls.some((u) => u.includes("/api/active/supervisors/all"))).toBe(
+      false,
+    );
+    expect(urls.some((u) => u.includes("/api/active/schulhof/status"))).toBe(
+      false,
+    );
+  });
+
+  it("throws on aggregate failure for non-admins", async () => {
+    const { useSession } = await import("next-auth/react");
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { token: "test-token", isAdmin: false } },
+      status: "authenticated",
+    } as never);
+
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("/api/active-supervision-dashboard")) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.reject(new Error("should not be called"));
+    });
+
+    const { getFetcher } = captureFetcher();
+    render(<MeinRaumPage />);
+    await waitFor(() => expect(getFetcher()).toBeDefined());
+
+    await expect(getFetcher()!()).rejects.toThrow("BFF request failed: 500");
   });
 });
 

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part6.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part6.test.tsx
@@ -580,10 +580,10 @@ describe("MeinRaumPage (Active Supervisions) (5/5)", () => {
 
   it("does not flash first-room students while a direct room URL is syncing", async () => {
     navigationMockState.roomParam = "11";
-    const { activeService } = await import("~/lib/active-api");
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockReturnValue(
-      new Promise(() => undefined) as never,
-    );
+    // The aggregate re-run for the URL-targeted session never resolves in
+    // this test — the point is that the first room's visits from the stale
+    // payload must not be shown meanwhile (#2096).
+    mockMutate.mockReturnValue(new Promise(() => undefined) as never);
     const dashboardData = {
       supervisedGroups: [
         {
@@ -639,9 +639,9 @@ describe("MeinRaumPage (Active Supervisions) (5/5)", () => {
     render(<MeinRaumPage />);
 
     await waitFor(() => {
-      expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("2");
+      // The URL target resolves to session "2" and triggers the aggregate
+      // re-run; the first room's students never appear meanwhile.
+      expect(mockMutate).toHaveBeenCalled();
       expect(screen.queryByTestId("student-card")).not.toBeInTheDocument();
       expect(screen.queryByText("Max Mustermann")).not.toBeInTheDocument();
     });

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part9.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part9.test.tsx
@@ -653,21 +653,6 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
   });
 
   it("switches to a different room when tab is clicked and loads visits", async () => {
-    const { activeService } = await import("~/lib/active-api");
-
-    // Mock loadRoomVisits to return visit data for the second room
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockResolvedValue([
-      {
-        studentId: "s10",
-        studentName: "Room B Student",
-        schoolClass: "4a",
-        groupName: "Gruppe B",
-        activeGroupId: "room-2",
-        checkInTime: new Date(),
-        isActive: true,
-      },
-    ] as never);
-
     const dashboardData = {
       supervisedGroups: [
         {
@@ -709,15 +694,37 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
       isValidating: false,
     } as never;
 
-    vi.mocked(useSWRAuth)
-      .mockReturnValueOnce({
-        data: dashboardData,
-        isLoading: false,
-        error: null,
-        mutate: mockMutate,
-        isValidating: false,
-      } as never)
-      .mockReturnValue(swrNull);
+    // The aggregate carries the selected session's visits (#2096): a room
+    // switch re-runs the dashboard fetch via mutate, whose next response is
+    // scoped to room-2.
+    const dashboardRef: { current: unknown } = { current: dashboardData };
+    mockMutate.mockImplementation(async () => {
+      dashboardRef.current = {
+        ...dashboardData,
+        selectedGroupId: "room-2",
+        firstRoomVisits: [
+          {
+            studentId: "s10",
+            studentName: "Room B Student",
+            schoolClass: "4a",
+            groupName: "Gruppe B",
+            activeGroupId: "room-2",
+            checkInTime: new Date().toISOString(),
+            isActive: true,
+          },
+        ],
+      };
+    });
+    vi.mocked(useSWRAuth).mockImplementation(((key: unknown) =>
+      typeof key === "string" && key.startsWith("active-supervision-dashboard")
+        ? ({
+            data: dashboardRef.current,
+            isLoading: false,
+            error: null,
+            mutate: mockMutate,
+            isValidating: false,
+          } as never)
+        : swrNull) as never);
 
     render(<MeinRaumPage />);
 
@@ -726,46 +733,21 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
       expect(screen.getByText("Room A Student")).toBeInTheDocument();
     });
 
-    // Click the second room's tab - triggers switchToRoom and loadRoomVisits
+    // Click the second room's tab - triggers switchToRoom -> mutateDashboard
     const tabB = screen.getByTestId("tab-room-2");
     fireEvent.click(tabB);
 
-    // After switching, the second room's student should appear
     await waitFor(() => {
-      expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("room-2");
+      expect(mockMutate).toHaveBeenCalled();
     });
 
+    // After switching, the second room's student should appear
     await waitFor(() => {
       expect(screen.getByText("Room B Student")).toBeInTheDocument();
     });
   });
 
   it("shows the selected parallel Schulhof group's student count", async () => {
-    const { activeService } = await import("~/lib/active-api");
-
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockResolvedValue([
-      {
-        studentId: "s10",
-        studentName: "Parallel Student A",
-        schoolClass: "4a",
-        groupName: "Gruppe A",
-        activeGroupId: "yard-parallel",
-        checkInTime: new Date(),
-        isActive: true,
-      },
-      {
-        studentId: "s11",
-        studentName: "Parallel Student B",
-        schoolClass: "4b",
-        groupName: "Gruppe B",
-        activeGroupId: "yard-parallel",
-        checkInTime: new Date(),
-        isActive: true,
-      },
-    ] as never);
-
     const dashboardData = {
       supervisedGroups: [
         {
@@ -815,15 +797,45 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
       isValidating: false,
     } as never;
 
-    vi.mocked(useSWRAuth)
-      .mockReturnValueOnce({
-        data: dashboardData,
-        isLoading: false,
-        error: null,
-        mutate: mockMutate,
-        isValidating: false,
-      } as never)
-      .mockReturnValue(swrNull);
+    // Switching to the parallel yard session re-runs the aggregate; its next
+    // response carries that session's two visits (#2096).
+    const dashboardRef: { current: unknown } = { current: dashboardData };
+    mockMutate.mockImplementation(async () => {
+      dashboardRef.current = {
+        ...dashboardData,
+        selectedGroupId: "yard-parallel",
+        firstRoomVisits: [
+          {
+            studentId: "s10",
+            studentName: "Parallel Student A",
+            schoolClass: "4a",
+            groupName: "Gruppe A",
+            activeGroupId: "yard-parallel",
+            checkInTime: new Date().toISOString(),
+            isActive: true,
+          },
+          {
+            studentId: "s11",
+            studentName: "Parallel Student B",
+            schoolClass: "4b",
+            groupName: "Gruppe B",
+            activeGroupId: "yard-parallel",
+            checkInTime: new Date().toISOString(),
+            isActive: true,
+          },
+        ],
+      };
+    });
+    vi.mocked(useSWRAuth).mockImplementation(((key: unknown) =>
+      typeof key === "string" && key.startsWith("active-supervision-dashboard")
+        ? ({
+            data: dashboardRef.current,
+            isLoading: false,
+            error: null,
+            mutate: mockMutate,
+            isValidating: false,
+          } as never)
+        : swrNull) as never);
 
     render(<MeinRaumPage />);
 
@@ -831,9 +843,7 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
     fireEvent.click(parallelTab);
 
     await waitFor(() => {
-      expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("yard-parallel");
+      expect(mockMutate).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(screen.getByTestId("page-header")).toHaveAttribute(
@@ -912,15 +922,12 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
     );
   });
 
-  it("handles 403 error from loadRoomVisits gracefully when switching rooms", async () => {
-    const { activeService } = await import("~/lib/active-api");
-
-    // Mock getActiveGroupVisitsWithDisplay to throw a 403 error.
-    // loadRoomVisits catches 403 internally and returns [] (lines 473-480),
-    // so switchToRoom receives empty students without throwing.
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockRejectedValue(
-      new Error("Request failed: 403"),
-    );
+  it("shows the permission notice when switching to a forbidden session", async () => {
+    // The aggregate answers 403 for a session outside the caller's scope;
+    // the fetcher's group_id retry failed too, so mutate rejects. Unlike the
+    // former silently-swallowed per-room 403 (#2096), the page now surfaces
+    // the permission problem.
+    mockMutate.mockRejectedValue(new Error("Request failed: 403"));
 
     const dashboardData = {
       supervisedGroups: [
@@ -979,35 +986,25 @@ describe("ID-based selection coverage: switchToRoom via tab click", () => {
       expect(screen.getByText("Initial Student")).toBeInTheDocument();
     });
 
-    // Click the second room's tab - triggers switchToRoom -> loadRoomVisits
+    // Click the second room's tab - triggers switchToRoom -> mutateDashboard
     const tabB = screen.getByTestId("tab-room-2");
     fireEvent.click(tabB);
 
-    // loadRoomVisits catches 403 and returns empty - no error alert shown
+    // The permission notice appears and the previous room's students are
+    // cleared instead of lingering under the wrong heading.
     await waitFor(() => {
       expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("room-2");
-    });
-
-    // Room shows empty students state (no crash, graceful degradation)
-    await waitFor(() => {
-      expect(
-        screen.getByText("Keine Kinder in diesem Raum"),
+        screen.getByText(
+          'Keine Berechtigung für "Raum B". Kontaktieren Sie einen Administrator.',
+        ),
       ).toBeInTheDocument();
     });
-
-    // No error alert should be shown (403 is handled silently in loadRoomVisits)
-    expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
+    expect(screen.queryByText("Initial Student")).not.toBeInTheDocument();
   });
 
-  it("handles non-403 error from loadRoomVisits", async () => {
-    const { activeService } = await import("~/lib/active-api");
-
-    // Mock loadRoomVisits to throw a generic error
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockRejectedValue(
-      new Error("Network timeout"),
-    );
+  it("handles non-403 error when switching rooms", async () => {
+    // A generic aggregate failure while switching surfaces the load error.
+    mockMutate.mockRejectedValue(new Error("Network timeout"));
 
     const dashboardData = {
       supervisedGroups: [
@@ -1186,22 +1183,8 @@ describe("ID-based selection coverage: localStorage room restore", () => {
   });
 
   it("restores room from localStorage when no URL param is present", async () => {
-    const { activeService } = await import("~/lib/active-api");
-
     // Set localStorage to point to room r2 (the second room)
     localStorage.setItem("sidebar-last-room", "r2");
-
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockResolvedValue([
-      {
-        studentId: "s20",
-        studentName: "Restored Student",
-        schoolClass: "2a",
-        groupName: "G2",
-        activeGroupId: "room-2",
-        checkInTime: new Date(),
-        isActive: true,
-      },
-    ] as never);
 
     const dashboardData = {
       supervisedGroups: [
@@ -1244,24 +1227,43 @@ describe("ID-based selection coverage: localStorage room restore", () => {
       isValidating: false,
     } as never;
 
-    vi.mocked(useSWRAuth)
-      .mockReturnValueOnce({
-        data: dashboardData,
-        isLoading: false,
-        error: null,
-        mutate: mockMutate,
-        isValidating: false,
-      } as never)
-      .mockReturnValue(swrNull);
+    // The restore path calls switchToRoom, which re-runs the aggregate; its
+    // next response is scoped to the restored session (#2096).
+    const dashboardRef: { current: unknown } = { current: dashboardData };
+    mockMutate.mockImplementation(async () => {
+      dashboardRef.current = {
+        ...dashboardData,
+        selectedGroupId: "room-2",
+        firstRoomVisits: [
+          {
+            studentId: "s20",
+            studentName: "Restored Student",
+            schoolClass: "2a",
+            groupName: "G2",
+            activeGroupId: "room-2",
+            checkInTime: new Date().toISOString(),
+            isActive: true,
+          },
+        ],
+      };
+    });
+    vi.mocked(useSWRAuth).mockImplementation(((key: unknown) =>
+      typeof key === "string" && key.startsWith("active-supervision-dashboard")
+        ? ({
+            data: dashboardRef.current,
+            isLoading: false,
+            error: null,
+            mutate: mockMutate,
+            isValidating: false,
+          } as never)
+        : swrNull) as never);
 
     render(<MeinRaumPage />);
 
-    // The URL sync effect should find savedRoom via allRooms.find(r => r.room_id === "r2")
-    // and call switchToRoom, which calls loadRoomVisits
+    // The URL sync effect should find savedRoom via allRooms.find(r =>
+    // r.room_id === "r2") and call switchToRoom -> mutateDashboard
     await waitFor(() => {
-      expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("room-2");
+      expect(mockMutate).toHaveBeenCalled();
     });
 
     await waitFor(() => {
@@ -1642,7 +1644,7 @@ describe("ID-based selection coverage: currentRoom useMemo", () => {
   });
 });
 
-describe("ID-based selection coverage: loadRoomVisits 403 handling", () => {
+describe("ID-based selection coverage: forbidden-session 403 handling", () => {
   const mockMutate = vi.fn();
   const originalInnerWidth = window.innerWidth;
 
@@ -1703,13 +1705,9 @@ describe("ID-based selection coverage: loadRoomVisits 403 handling", () => {
   });
 
   it("shows permission error for 403 and clears students", async () => {
-    const { activeService } = await import("~/lib/active-api");
-
-    // loadRoomVisits catches 403 and returns empty, but switchToRoom re-throws
-    // other errors. Let's test the 403 path in switchToRoom (lines 991-996)
-    vi.mocked(activeService.getActiveGroupVisitsWithDisplay).mockRejectedValue(
-      new Error("Request failed: 403"),
-    );
+    // The aggregate's mutate rejects with 403 for a session outside the
+    // caller's scope (#2096) — switchToRoom shows the permission notice.
+    mockMutate.mockRejectedValue(new Error("Request failed: 403"));
 
     const dashboardData = {
       supervisedGroups: [
@@ -1772,13 +1770,16 @@ describe("ID-based selection coverage: loadRoomVisits 403 handling", () => {
     const restrictedTab = screen.getByTestId("tab-room-no-access");
     fireEvent.click(restrictedTab);
 
-    // loadRoomVisits internally catches 403 and returns [], but the code
-    // in switchToRoom proceeds normally with empty students
+    // switchToRoom surfaces the permission notice and clears the previous
+    // room's students.
     await waitFor(() => {
       expect(
-        activeService.getActiveGroupVisitsWithDisplay,
-      ).toHaveBeenCalledWith("room-no-access");
+        screen.getByText(
+          'Keine Berechtigung für "Restricted Room". Kontaktieren Sie einen Administrator.',
+        ),
+      ).toBeInTheDocument();
     });
+    expect(screen.queryByText("Allowed Student")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -48,12 +48,9 @@ import {
   StudentAbsenceRow,
   StudentPendingExcusedRow,
 } from "~/components/students/student-card";
-import { fetchBulkPickupTimes } from "~/lib/pickup-schedule-api";
 import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
-import { fetchBulkArrivalTimes } from "~/lib/student-arrival-api";
 import type { BulkArrivalTime } from "~/lib/student-arrival-api";
 import { useMinuteClock } from "~/lib/pickup-helpers";
-import { toISODate } from "~/lib/date-helpers";
 import { canCompleteInstance } from "~/lib/timetable-lifecycle";
 import { createLogger } from "~/lib/logger";
 import { activeService } from "~/lib/active-api";
@@ -251,6 +248,30 @@ interface BFFDashboardResponse {
     endTime: string;
   }>;
   plannedNow: PlannedTimetableInstance[];
+  // Folded-in sections of the selected session (#2096): the aggregate
+  // resolves group_id (or the first supervised session) and ships its
+  // visits, tracking indicators, and pickup/arrival times in the same
+  // response. Optional so the admin fallback payload stays minimal.
+  selectedGroupId?: string | null;
+  trackingIndicators?: TrackingIndicatorsResponse;
+  pickupTimes?: Array<{
+    studentId: string;
+    date: string;
+    weekdayName: string;
+    pickupTime: string | null;
+    isException: boolean;
+    notes: string;
+    dayNotes: Array<{ id: string; content: string }>;
+  }>;
+  arrivalTimes?: Array<{
+    studentId: string;
+    date: string;
+    weekdayName: string;
+    expectedArrival: string | null;
+    isException: boolean;
+    notes: string;
+    dayNotes: Array<{ id: string; content: string }>;
+  }>;
 }
 
 /** Check if a student matches the current search, group, and year filters */
@@ -1042,37 +1063,6 @@ function MeinRaumPageContent() {
       : (currentRoom?.name ?? currentRoom?.room_name),
   });
 
-  // Helper function to load visits for a specific room
-  const loadRoomVisits = useCallback(
-    async (
-      roomId: string,
-      roomName?: string,
-      groupNameToId?: Map<string, string>,
-      roomColor?: string | null,
-    ): Promise<StudentWithVisit[]> => {
-      try {
-        // Use bulk endpoint to fetch visits with display data for specific room
-        const visits =
-          await activeService.getActiveGroupVisitsWithDisplay(roomId);
-
-        return mapVisitsToSupervisionStudents(visits, {
-          roomName,
-          roomColor,
-          groupNameToId,
-        });
-      } catch (error) {
-        // Handle 403 Forbidden gracefully - user might not have group access
-        if (error instanceof Error && error.message.includes("403")) {
-          logger.warn("no permission to view group", { group_id: roomId });
-          return []; // Return empty array instead of throwing
-        }
-        // Re-throw other errors
-        throw error;
-      }
-    },
-    [],
-  );
-
   const currentRoomRef = useRef<ActiveRoom | null>(null);
   const hasSupervisionRef = useRef(false);
   const groupNameToIdMapRef = useRef<Map<string, string>>(new Map());
@@ -1196,10 +1186,17 @@ function MeinRaumPageContent() {
       };
     }, []);
 
-  // Get current room ID for per-room SWR subscription
+  // Get current room ID (the selected session's active group id)
   const currentRoomId = currentRoom?.id;
 
-  // SWR-based BFF data fetching with caching
+  // The aggregate is parameterized by the selected session (#2096). The SWR
+  // key stays `active-supervision-dashboard-${refreshKey}` — the global SSE
+  // invalidation contract and the page tests match on that prefix — so the
+  // fetcher reads the selection from a ref; room switches re-run it via
+  // mutateDashboard() instead of spawning per-room cache keys.
+  const requestedGroupIdRef = useRef<string | null>(null);
+
+  // SWR-based aggregate fetching with caching
   // Cache key "active-supervision-dashboard" will be invalidated by global SSE on relevant events
   const {
     data: dashboardData,
@@ -1209,15 +1206,31 @@ function MeinRaumPageContent() {
   } = useSWRAuth<BFFDashboardResponse>(
     session?.user?.token ? `active-supervision-dashboard-${refreshKey}` : null,
     async () => {
-      logger.debug("SWR fetching BFF data");
+      logger.debug("SWR fetching dashboard data");
       const start = performance.now();
 
-      const response = await fetch("/api/active-supervision-dashboard", {
-        headers: {
-          Authorization: `Bearer ${session?.user?.token}`,
-          "Content-Type": "application/json",
-        },
-      });
+      const fetchDashboard = async (groupId: string | null) => {
+        const query =
+          groupId && /^[1-9]\d{0,18}$/.test(groupId)
+            ? `?group_id=${encodeURIComponent(groupId)}`
+            : "";
+        return fetch(`/api/active-supervision-dashboard${query}`, {
+          headers: {
+            Authorization: `Bearer ${session?.user?.token}`,
+            "Content-Type": "application/json",
+          },
+        });
+      };
+
+      const requestedGroupId = requestedGroupIdRef.current;
+      let response = await fetchDashboard(requestedGroupId);
+      // A stale selection (supervision revoked, session ended) is a backend
+      // 403 — retry once without group_id so the backend resolves the
+      // caller's first supervised session; the sync effect then re-aligns
+      // the selection from the response.
+      if (!response.ok && response.status === 403 && requestedGroupId) {
+        response = await fetchDashboard(null);
+      }
 
       if (!response.ok) {
         // Admin fallback: load data directly from individual endpoints
@@ -1244,6 +1257,20 @@ function MeinRaumPageContent() {
       revalidateOnFocus: false,
     },
   );
+
+  // Reconcile selection and aggregate: whenever the visible session changes
+  // through any path (tab click, Schulhof open, URL/localStorage restore)
+  // and the cached aggregate belongs to another session, re-run the fetch.
+  // Payloads without selectedGroupId (admin fallback) never trigger this.
+  useEffect(() => {
+    requestedGroupIdRef.current = currentRoomId ?? null;
+    if (!currentRoomId || !dashboardData) return;
+    const resolved = dashboardData.selectedGroupId;
+    if (resolved == null || resolved === currentRoomId) return;
+    void Promise.resolve(mutateDashboard()).catch(() => {
+      // Errors surface via dashboardError handling
+    });
+  }, [currentRoomId, dashboardData, mutateDashboard]);
 
   // Title + plan window per running session, so tab labels can show
   // "Aktivitätsname · Planzeit" (#2265). Sessions without a timetable
@@ -1347,17 +1374,23 @@ function MeinRaumPageContent() {
 
     setAllRooms(activeRooms);
 
-    // Use pre-loaded visits from BFF for the first room
-    // IMPORTANT: Only apply first room visits when the first room is selected.
-    // When SSE triggers revalidation while user views another room, we must NOT
-    // overwrite their current view with the first room's data.
+    // The aggregate carries the visits of the session the backend resolved
+    // (requested group_id, or the first supervised session). Apply them only
+    // when that session is the one the user is looking at — an SSE
+    // revalidation while the user views another room must NOT overwrite
+    // their current view.
     const firstRoom = activeRooms[0];
+    // A payload without selectedGroupId (admin fallback) keeps the former
+    // semantics: its visits belong to the first room.
+    const selectedRoom = data.selectedGroupId
+      ? activeRooms.find((r) => r.id === data.selectedGroupId)
+      : firstRoom;
 
     // If the previously selected room no longer exists in the refreshed list
-    // (e.g., supervision revoked, session ended), reset to the first room so
-    // the student data stays in sync with what the UI displays.
+    // (e.g., supervision revoked, session ended), reset to the session the
+    // backend resolved so the student data stays in sync with the UI.
     if (selectedRoomId && !activeRooms.some((r) => r.id === selectedRoomId)) {
-      setSelectedRoomId(firstRoom?.id ?? null);
+      setSelectedRoomId(selectedRoom?.id ?? firstRoom?.id ?? null);
     }
 
     // Skip first-room preload when Schulhof tab is active — Schulhof uses
@@ -1375,29 +1408,42 @@ function MeinRaumPageContent() {
     if (
       !isSchulhofTabSelected &&
       !isUrlTargetingDifferentRoom &&
-      (!selectedRoomId || selectedRoomId === firstRoom?.id)
+      selectedRoom &&
+      (!selectedRoomId || selectedRoomId === selectedRoom.id)
     ) {
-      // When no room is explicitly selected yet, lock in the first room's ID
-      // so the URL-sync effect won't try to "switch" to it via localStorage.
-      if (!selectedRoomId && firstRoom) {
-        setSelectedRoomId(firstRoom.id);
+      // When no room is explicitly selected yet, lock in the resolved
+      // session's ID so the URL-sync effect won't try to "switch" to it via
+      // localStorage.
+      if (!selectedRoomId) {
+        setSelectedRoomId(selectedRoom.id);
       }
-      if (firstRoom && data.firstRoomVisits.length > 0) {
-        const studentsFromVisits = mapVisitsToSupervisionStudents(
-          data.firstRoomVisits,
-          {
-            roomName: firstRoom.room_name,
-            roomColor: firstRoom.room_color,
-            groupNameToId: nameToIdMap,
-          },
-        );
+      const studentsFromVisits = mapVisitsToSupervisionStudents(
+        data.firstRoomVisits,
+        {
+          roomName: selectedRoom.room_name,
+          roomColor: selectedRoom.room_color,
+          groupNameToId: nameToIdMap,
+        },
+      );
+      setStudents(studentsFromVisits);
+      updateRoomStudentCount(selectedRoom.id, studentsFromVisits.length);
+    }
 
-        setStudents(studentsFromVisits);
-        updateRoomStudentCount(firstRoom.id, studentsFromVisits.length);
-      } else if (firstRoom) {
-        setStudents([]);
-        updateRoomStudentCount(firstRoom.id, 0);
-      }
+    // Schulhof tab: the aggregate resolves the Schulhof session when it was
+    // requested (user supervising the yard) — apply its visits under the
+    // Schulhof heading.
+    if (
+      isSchulhofTabSelected &&
+      data.selectedGroupId &&
+      data.schulhofStatus?.isUserSupervising &&
+      data.schulhofStatus.activeGroupId === data.selectedGroupId
+    ) {
+      setStudents(
+        mapVisitsToSupervisionStudents(data.firstRoomVisits, {
+          roomName: SCHULHOF_ROOM_NAME,
+          groupNameToId: nameToIdMap,
+        }),
+      );
     }
 
     setError(null);
@@ -1423,18 +1469,12 @@ function MeinRaumPageContent() {
       if (isSchulhofTabSelected) return;
       setIsSchulhofTabSelected(true);
       setSelectedRoomId(null);
-      // Load Schulhof visits if supervising
-      if (schulhofStatus?.isUserSupervising && schulhofStatus.activeGroupId) {
-        loadRoomVisits(
-          schulhofStatus.activeGroupId,
-          SCHULHOF_ROOM_NAME,
-          groupNameToIdMapRef.current,
-        )
-          .then(setStudents)
-          .catch(() => {
-            // Error already handled in loadRoomVisits
-          });
-      } else {
+      // When supervising, the selection-reconciliation effect re-runs the
+      // aggregate for the yard session and the sync effect applies its
+      // visits; otherwise there is nothing to show.
+      if (!(
+        schulhofStatus?.isUserSupervising && schulhofStatus.activeGroupId
+      )) {
         setStudents([]);
       }
     };
@@ -1484,40 +1524,9 @@ function MeinRaumPageContent() {
     schulhofStatus?.isUserSupervising,
   ]);
 
-  // SWR-based per-room visit subscription for real-time updates.
-  // When global SSE invalidates "visit*" or "supervision*" caches, this triggers a refetch.
-  // This ensures non-first rooms also receive real-time check-in/checkout updates.
-  const { data: swrVisitsData } = useSWRAuth<StudentWithVisit[]>(
-    hasAccess && currentRoomId ? `supervision-visits-${currentRoomId}` : null,
-    async () => {
-      if (!currentRoom) return [];
-
-      const visits = await activeService.getActiveGroupVisitsWithDisplay(
-        currentRoomId!,
-      );
-
-      return mapVisitsToSupervisionStudents(visits, {
-        roomName: currentRoom.room_name,
-        roomColor: currentRoom.room_color,
-        groupNameToId: groupNameToIdMapRef.current,
-      });
-    },
-    {
-      // Never expose one room's children under another room's heading while
-      // the new key loads. Same-key SSE revalidation still keeps its cache.
-      keepPreviousData: false,
-      revalidateOnFocus: false, // Handled by global SSE
-    },
-  );
-
-  // Sync SWR visit data with local state
-  // This runs when SSE triggers cache invalidation, ensuring real-time updates for ALL rooms
-  useEffect(() => {
-    if (swrVisitsData && currentRoomId) {
-      setStudents(swrVisitsData);
-      updateRoomStudentCount(currentRoomId, swrVisitsData.length);
-    }
-  }, [swrVisitsData, currentRoomId, updateRoomStudentCount]);
+  // Per-room visits ride in the aggregate (#2096): SSE invalidates the
+  // dashboard key, the fetcher re-requests the selected session, and the
+  // sync effect above applies its visits — no separate per-room fetch.
 
   const timetableRosterKey = activeSupervisionRosterKey({
     selectedTimetableInstanceId,
@@ -1626,42 +1635,48 @@ function MeinRaumPageContent() {
     };
   }, [activeTimetableInstanceId, addStudentSearch]);
 
-  // Tracking indicators: fetch when student list changes (SSE-driven via SWR revalidation)
-  const trackingStudentIds = useMemo(
-    () => students.map((s) => s.id),
-    [students],
-  );
-  const { data: trackingData } = useSWRAuth<TrackingIndicatorsResponse>(
-    trackingStudentIds.length > 0
-      ? `tracking-supervisions-${currentRoomId}-${trackingStudentIds.join(",")}`
-      : null,
-    async () => activeService.getTrackingIndicators(trackingStudentIds),
-    { keepPreviousData: true, revalidateOnFocus: false },
-  );
+  // Tracking indicators, pickup times, and arrival times ride in the
+  // aggregate for the selected session (#2096) — no separate fetches, no
+  // extra tenant transactions. SSE invalidation of the dashboard key keeps
+  // them fresh together with the visits they belong to.
+  const trackingData = dashboardData?.trackingIndicators;
 
   // Current time for pickup urgency calculation (updates every minute)
   const now = useMinuteClock();
 
-  // Pickup times: fetch when student list or date changes
-  const todayKey = toISODate(now);
-  const { data: pickupTimesData } = useSWRAuth<Map<string, BulkPickupTime>>(
-    trackingStudentIds.length > 0 && currentRoomId
-      ? `pickup-supervisions-${todayKey}-${trackingStudentIds.join(",")}`
-      : null,
-    async () => fetchBulkPickupTimes(trackingStudentIds),
-    { keepPreviousData: true, revalidateOnFocus: false },
-  );
+  const pickupTimesData = useMemo(() => {
+    if (!dashboardData?.pickupTimes) return undefined;
+    const map = new Map<string, BulkPickupTime>();
+    for (const pickup of dashboardData.pickupTimes) {
+      map.set(pickup.studentId, {
+        studentId: pickup.studentId,
+        date: pickup.date,
+        weekdayName: pickup.weekdayName,
+        pickupTime: pickup.pickupTime ?? undefined,
+        isException: pickup.isException,
+        notes: pickup.notes || undefined,
+        dayNotes: pickup.dayNotes,
+      });
+    }
+    return map;
+  }, [dashboardData?.pickupTimes]);
 
-  // Arrival times: fetch when student list or date changes
-  const { data: arrivalTimesRaw } = useSWRAuth<Map<string, BulkArrivalTime>>(
-    trackingStudentIds.length > 0 && currentRoomId
-      ? `arrival-supervisions-${todayKey}-${trackingStudentIds.join(",")}`
-      : null,
-    async () => fetchBulkArrivalTimes(trackingStudentIds),
-    { keepPreviousData: true, revalidateOnFocus: false },
-  );
-  const arrivalTimesData: Map<string, BulkArrivalTime> | undefined =
-    arrivalTimesRaw instanceof Map ? arrivalTimesRaw : undefined;
+  const arrivalTimesData = useMemo(() => {
+    if (!dashboardData?.arrivalTimes) return undefined;
+    const map = new Map<string, BulkArrivalTime>();
+    for (const arrival of dashboardData.arrivalTimes) {
+      map.set(arrival.studentId, {
+        studentId: arrival.studentId,
+        date: arrival.date,
+        weekdayName: arrival.weekdayName,
+        expectedArrival: arrival.expectedArrival ?? undefined,
+        isException: arrival.isException,
+        notes: arrival.notes || undefined,
+        dayNotes: arrival.dayNotes,
+      });
+    }
+    return map;
+  }, [dashboardData?.arrivalTimes]);
 
   // Handle dashboard error
   useEffect(() => {
@@ -1827,9 +1842,10 @@ function MeinRaumPageContent() {
     localStorage.setItem("supervision-last-session", SCHULHOF_TAB_ID);
     localStorage.setItem("sidebar-last-room", SCHULHOF_TAB_ID);
     localStorage.setItem("sidebar-last-room-name", SCHULHOF_ROOM_NAME);
-    // The keyed SWR subscription becomes active with the Schulhof tab and is
-    // the single owner of loading its visits. A second manual request can land
-    // later and overwrite a fresher SSE revalidation.
+    // The selection-reconciliation effect re-runs the aggregate for the
+    // Schulhof session and is the single owner of loading its visits. A
+    // second manual request can land later and overwrite a fresher SSE
+    // revalidation.
     setStudents([]);
   }, [router, schulhofStatusRef]);
 
@@ -2178,26 +2194,10 @@ function MeinRaumPageContent() {
     setStudents([]); // Clear current students
 
     try {
-      // Use bulk endpoint to fetch visits for selected room
-      const studentsFromVisits = await loadRoomVisits(
-        selectedRoom.id,
-        selectedRoom.room_name,
-        groupNameToIdMapRef.current,
-        selectedRoom.room_color,
-      );
-
-      // Set students state
-      setStudents([...studentsFromVisits]);
-
-      // Update room with actual student count
-      setAllRooms((prev) =>
-        prev.map((room) =>
-          room.id === roomId
-            ? { ...room, student_count: studentsFromVisits.length }
-            : room,
-        ),
-      );
-
+      // Re-run the aggregate for the newly selected session; the sync
+      // effect applies its visits and student count when the data arrives.
+      requestedGroupIdRef.current = roomId;
+      await mutateDashboard();
       setError(null);
     } catch (err) {
       // Handle 403 gracefully - show message but don't break the UI

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -50,6 +50,7 @@ import {
 } from "~/components/students/student-card";
 import type { BulkPickupTime } from "~/lib/pickup-schedule-api";
 import type { BulkArrivalTime } from "~/lib/student-arrival-api";
+import { berlinTodayISO } from "~/lib/date-helpers";
 import { useMinuteClock } from "~/lib/pickup-helpers";
 import { canCompleteInstance } from "~/lib/timetable-lifecycle";
 import { createLogger } from "~/lib/logger";
@@ -1107,6 +1108,9 @@ function MeinRaumPageContent() {
   // fetcher reads the selection from a ref; room switches re-run it via
   // mutateDashboard() instead of spawning per-room cache keys.
   const requestedGroupIdRef = useRef<string | null>(null);
+  const now = useMinuteClock();
+  const dashboardDay = berlinTodayISO(now);
+  const previousDashboardDayRef = useRef(dashboardDay);
 
   // SWR-based aggregate fetching with caching
   // Cache key "active-supervision-dashboard" will be invalidated by global SSE on relevant events
@@ -1164,6 +1168,16 @@ function MeinRaumPageContent() {
       revalidateOnFocus: false,
     },
   );
+
+  // Pickup and arrival rows are resolved for the backend's current Berlin
+  // calendar day. The SWR key deliberately stays stable for SSE invalidation,
+  // so roll the aggregate forward explicitly when the minute clock crosses
+  // Berlin midnight (or catches up after a backgrounded tab resumes).
+  useEffect(() => {
+    if (previousDashboardDayRef.current === dashboardDay) return;
+    previousDashboardDayRef.current = dashboardDay;
+    void mutateDashboard();
+  }, [dashboardDay, mutateDashboard]);
 
   // Reconcile selection and aggregate: whenever the visible session changes
   // through any path (tab click, Schulhof open, URL/localStorage restore)
@@ -1547,9 +1561,6 @@ function MeinRaumPageContent() {
   // extra tenant transactions. SSE invalidation of the dashboard key keeps
   // them fresh together with the visits they belong to.
   const trackingData = dashboardData?.trackingIndicators;
-
-  // Current time for pickup urgency calculation (updates every minute)
-  const now = useMinuteClock();
 
   const pickupTimesData = useMemo(() => {
     if (!dashboardData?.pickupTimes) return undefined;

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -251,7 +251,8 @@ interface BFFDashboardResponse {
   // Folded-in sections of the selected session (#2096): the aggregate
   // resolves group_id (or the first supervised session) and ships its
   // visits, tracking indicators, and pickup/arrival times in the same
-  // response. Optional so the admin fallback payload stays minimal.
+  // response. Optional so a cached payload from an older backend degrades
+  // gracefully instead of breaking the page.
   selectedGroupId?: string | null;
   trackingIndicators?: TrackingIndicatorsResponse;
   pickupTimes?: Array<{
@@ -1088,103 +1089,14 @@ function MeinRaumPageContent() {
   );
 
   // SSE is handled globally by TenantAuthWrapper - no page-level setup needed.
-  // When student_checkin/checkout events occur, global SSE invalidates "visit*" caches,
-  // which triggers SWR refetch for supervision-visits-* keys automatically.
+  // When relevant events occur, global SSE invalidates the aggregated
+  // "active-supervision-dashboard-" cache, which triggers the SWR refetch.
   // NOTE: Do NOT call useGlobalSSE() here - it's already called in TenantAuthWrapper.
   // Calling it again would create a duplicate SSE connection.
-
-  // Admin fallback: when BFF fails, load supervised groups directly
-  const fetchAdminDashboardFallback =
-    useCallback(async (): Promise<BFFDashboardResponse> => {
-      const [groupsRes, schulhofRes] = await Promise.all([
-        fetch("/api/active/supervisors/all", {
-          headers: { "Content-Type": "application/json" },
-          cache: "no-store",
-        }),
-        fetch("/api/active/schulhof/status", {
-          headers: { "Content-Type": "application/json" },
-          cache: "no-store",
-        }).catch(() => null),
-      ]);
-
-      let supervisedGroups: BFFDashboardResponse["supervisedGroups"] = [];
-      if (groupsRes.ok) {
-        const json = (await groupsRes.json()) as {
-          data?: Array<{
-            id: number;
-            name?: string;
-            room_id?: number;
-            room?: { id: number; name: string };
-          }>;
-        };
-        supervisedGroups = (json.data ?? []).map((g) => ({
-          id: g.id.toString(),
-          name: g.name ?? "",
-          room_id: g.room_id?.toString(),
-          room: g.room
-            ? { id: g.room.id.toString(), name: g.room.name }
-            : undefined,
-        }));
-      }
-
-      let schulhofStatus: BFFDashboardResponse["schulhofStatus"] = null;
-      if (schulhofRes?.ok) {
-        const json = (await schulhofRes.json()) as {
-          data?: {
-            data?: {
-              exists: boolean;
-              room_id?: number;
-              room_name: string;
-              active_group_id?: number;
-              is_user_supervising: boolean;
-              supervision_id?: number;
-              supervisor_count: number;
-              student_count: number;
-              supervisors?: Array<{
-                id: number;
-                staff_id: number;
-                name: string;
-                is_current_user: boolean;
-              }>;
-            };
-          };
-        };
-        const s = json.data?.data;
-        if (s?.exists) {
-          schulhofStatus = {
-            exists: true,
-            roomId: s.room_id?.toString() ?? null,
-            roomName: s.room_name,
-            activityGroupId: null,
-            activeGroupId: s.active_group_id?.toString() ?? null,
-            isUserSupervising: s.is_user_supervising,
-            supervisionId: s.supervision_id?.toString() ?? null,
-            supervisorCount: s.supervisor_count,
-            studentCount: s.student_count,
-            supervisors: (s.supervisors ?? []).map((sup) => ({
-              id: sup.id.toString(),
-              staffId: sup.staff_id.toString(),
-              name: sup.name,
-              isCurrentUser: sup.is_current_user,
-            })),
-          };
-        }
-      }
-
-      return {
-        supervisedGroups,
-        unclaimedGroups: [],
-        currentStaff: null,
-        educationalGroups: [],
-        firstRoomVisits: [],
-        firstRoomId:
-          supervisedGroups.length > 0
-            ? (supervisedGroups[0]?.room_id ?? null)
-            : null,
-        schulhofStatus,
-        plannedNow: [],
-      };
-    }, []);
+  //
+  // There is deliberately NO client-side fallback fan-out when the aggregate
+  // fails: silently-empty partial payloads are the failure mode #2096
+  // removed. Errors surface via dashboardError instead.
 
   // Get current room ID (the selected session's active group id)
   const currentRoomId = currentRoom?.id;
@@ -1233,13 +1145,8 @@ function MeinRaumPageContent() {
       }
 
       if (!response.ok) {
-        // Admin fallback: load data directly from individual endpoints
-        if (isAdmin(session)) {
-          logger.info("bff_failed_admin_fallback", {
-            status: response.status,
-          });
-          return await fetchAdminDashboardFallback();
-        }
+        // No silent fallback fan-out (#2096): a failed aggregate is an
+        // error, never a partial-empty payload — admins included.
         throw new Error(`BFF request failed: ${response.status}`);
       }
 
@@ -1261,7 +1168,7 @@ function MeinRaumPageContent() {
   // Reconcile selection and aggregate: whenever the visible session changes
   // through any path (tab click, Schulhof open, URL/localStorage restore)
   // and the cached aggregate belongs to another session, re-run the fetch.
-  // Payloads without selectedGroupId (admin fallback) never trigger this.
+  // Payloads without selectedGroupId (older backend) never trigger this.
   useEffect(() => {
     requestedGroupIdRef.current = currentRoomId ?? null;
     if (!currentRoomId || !dashboardData) return;
@@ -1380,7 +1287,7 @@ function MeinRaumPageContent() {
     // revalidation while the user views another room must NOT overwrite
     // their current view.
     const firstRoom = activeRooms[0];
-    // A payload without selectedGroupId (admin fallback) keeps the former
+    // A payload without selectedGroupId (older backend) keeps the former
     // semantics: its visits belong to the first room.
     const selectedRoom = data.selectedGroupId
       ? activeRooms.find((r) => r.id === data.selectedGroupId)

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -1111,6 +1111,7 @@ function MeinRaumPageContent() {
   const now = useMinuteClock();
   const dashboardDay = berlinTodayISO(now);
   const previousDashboardDayRef = useRef(dashboardDay);
+  const lastDashboardReconciliationRef = useRef<string | null>(null);
 
   // SWR-based aggregate fetching with caching
   // Cache key "active-supervision-dashboard" will be invalidated by global SSE on relevant events
@@ -1182,12 +1183,17 @@ function MeinRaumPageContent() {
   // Reconcile selection and aggregate: whenever the visible session changes
   // through any path (tab click, Schulhof open, URL/localStorage restore)
   // and the cached aggregate belongs to another session, re-run the fetch.
-  // Payloads without selectedGroupId (older backend) never trigger this.
   useEffect(() => {
     requestedGroupIdRef.current = currentRoomId ?? null;
     if (!currentRoomId || !dashboardData) return;
     const resolved = dashboardData.selectedGroupId;
-    if (resolved == null || resolved === currentRoomId) return;
+    if (resolved === currentRoomId) {
+      lastDashboardReconciliationRef.current = null;
+      return;
+    }
+    const reconciliation = `${resolved ?? "none"}:${currentRoomId}`;
+    if (lastDashboardReconciliationRef.current === reconciliation) return;
+    lastDashboardReconciliationRef.current = reconciliation;
     void Promise.resolve(mutateDashboard()).catch(() => {
       // Errors surface via dashboardError handling
     });

--- a/frontend/src/app/api/active-supervision-dashboard/route.test.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.test.ts
@@ -1,6 +1,11 @@
 /**
- * Tests for Active Supervision Dashboard BFF Route
- * Tests the endpoint that consolidates 8+ API calls into 1 for performance
+ * Tests for the Active Supervision Dashboard proxy route (#2096).
+ *
+ * The former BFF fan-out (~11 backend calls, silent-empty fallbacks) moved
+ * into the aggregated Go endpoint /api/active/supervision-dashboard; its
+ * semantics are pinned by backend tests. This suite covers the thin proxy:
+ * one backend call, group_id forwarding, wire→camelCase mapping, and error
+ * propagation (no swallowed sub-loads).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Session } from "next-auth";
@@ -52,8 +57,6 @@ function createMockContext(
 }
 
 const defaultSession = mockSessionData() as ExtendedSession;
-const emptyPlannedNowResponse = { data: { instances: [] } };
-const emptyActiveSessionsResponse = { data: { sessions: [] } };
 
 interface ApiResponse<T> {
   success: boolean;
@@ -65,11 +68,22 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
   return (await response.json()) as T;
 }
 
+const emptyWire = {
+  groups: [],
+  unclaimed_groups: [],
+  educational_groups: [],
+  schulhof_status: null,
+  capabilities: { web_spontaneous_activities_enabled: false },
+  active_sessions: [],
+  planned_now: [],
+  visits: [],
+  tracking_indicators: { labels: [], results: {} },
+  pickup_times: [],
+  arrival_times: [],
+};
+
 describe("GET /api/active-supervision-dashboard", () => {
   beforeEach(() => {
-    // mockReset also clears any pending `mockResolvedValueOnce` queue so
-    // unmatched mocks from a previous test cannot leak into the next one
-    // (vi.clearAllMocks only clears call history, not the once-queue).
     mockApiGet.mockReset();
     mockAuth.mockReset();
     mockAuth.mockResolvedValue(defaultSession);
@@ -78,685 +92,249 @@ describe("GET /api/active-supervision-dashboard", () => {
   it("returns 401 when not authenticated", async () => {
     mockAuth.mockResolvedValueOnce(null);
 
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
+    const response = await GET(
+      createMockRequest("/api/active-supervision-dashboard"),
+      createMockContext(),
+    );
 
     expect(response.status).toBe(401);
   });
 
-  it("returns early with unclaimed groups when no supervised groups", async () => {
-    const unclaimedGroups = [
-      { id: 1, name: "Schulhof", room: { id: 10, name: "Schulhof" } },
-    ];
-    const educationalGroups = [
-      { id: 2, name: "OGS Gruppe A", room: { id: 20, name: "Raum 101" } },
-    ];
-    const staff = { id: 5, person_id: 50 };
-
-    // Mock parallel API calls - supervised returns empty
-    mockApiGet
-      .mockResolvedValueOnce({ data: [] }) // supervised groups
-      .mockResolvedValueOnce({ data: unclaimedGroups }) // unclaimed groups
-      .mockResolvedValueOnce({ data: staff }) // staff
-      .mockResolvedValueOnce({ data: educationalGroups }) // educational groups
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse); // active sessions
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: unknown[];
-        unclaimedGroups: Array<{ id: string; name: string }>;
-        currentStaff: { id: string } | null;
-        educationalGroups: Array<{ id: string; name: string }>;
-        firstRoomVisits: unknown[];
-        firstRoomId: string | null;
-      }>
-    >(response);
-
-    expect(json.data.supervisedGroups).toEqual([]);
-    expect(json.data.unclaimedGroups).toHaveLength(1);
-    expect(json.data.unclaimedGroups[0]?.id).toBe("1");
-    expect(json.data.currentStaff?.id).toBe("5");
-    expect(json.data.educationalGroups).toHaveLength(1);
-    expect(json.data.firstRoomVisits).toEqual([]);
-    expect(json.data.firstRoomId).toBeNull();
-  });
-
-  it("fetches upcoming planned timetable slots with roster preview", async () => {
-    mockApiGet
-      .mockResolvedValueOnce({ data: [] }) // supervised groups
-      .mockResolvedValueOnce({ data: [] }) // unclaimed groups
-      .mockResolvedValueOnce({ data: { id: 5, person_id: 50 } }) // staff
-      .mockResolvedValueOnce({ data: [] }) // educational groups
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce({
-        data: {
-          instances: [
-            {
-              id: 10,
-              title: "Hausaufgaben",
-              date: "2026-06-04",
-              start_time: "14:00",
-              end_time: "15:00",
-              room_id: 20,
-              room_name: "Lernraum",
-              status: "planned",
-              is_overdue: false,
-              minutes_until_start: 30,
-              expected_students_count: 1,
-              present_students_count: 0,
-              assigned_staff_ids: [5],
-              is_assigned: true,
-              is_primary: true,
-              is_substitute: false,
-              is_absent: false,
-              can_start: false,
-              start_available_at: "2026-06-04T13:45:00+02:00",
-              roster_preview: [
-                {
-                  student_id: 99,
-                  student_name: "Mia Bauer",
-                  school_class: "2a",
-                  group_name: "Sternengruppe",
-                  planned: true,
-                  is_unplanned: false,
-                  currently_present: false,
-                  status: "expected",
-                  warnings: [
-                    {
-                      kind: "arrival_after_slot_start",
-                      message:
-                        "Erwartete Ankunft liegt nach dem Start dieser Betreuung.",
-                      expected_arrival: "14:30",
-                      slot_start: "14:00",
-                      expected_group_id: 12,
-                      expected_group_name: "Klasse 2a",
-                      current_education_group_id: 13,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      }) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse); // active sessions
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-    expect(mockApiGet).toHaveBeenCalledWith(
-      "/api/timetable/operations/planned-now?horizon_minutes=480&limit=5&include_roster=true",
-      defaultSession.user.token,
-    );
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        plannedNow: Array<{
-          id: string;
-          roomName: string | null;
-          isPrimary: boolean;
-          canStart: boolean;
-          startAvailableAt: string;
-          rosterPreview: Array<{
-            studentId: string;
-            studentName: string;
-            warnings: Array<{
-              kind: string;
-              message: string;
-              expectedArrival: string | null;
-              slotStart: string | null;
-              expectedGroupId: string | null;
-              expectedGroupName: string | null;
-              currentEducationGroupId: string | null;
-            }>;
-          }>;
-        }>;
-      }>
-    >(response);
-
-    expect(json.data.plannedNow[0]).toMatchObject({
-      id: "10",
-      roomName: "Lernraum",
-      isPrimary: true,
-      canStart: false,
-      startAvailableAt: "2026-06-04T13:45:00+02:00",
-    });
-    expect(json.data.plannedNow[0]?.rosterPreview[0]).toMatchObject({
-      studentId: "99",
-      studentName: "Mia Bauer",
-      warnings: [
-        {
-          kind: "arrival_after_slot_start",
-          message: "Erwartete Ankunft liegt nach dem Start dieser Betreuung.",
-          expectedArrival: "14:30",
-          slotStart: "14:00",
-          expectedGroupId: "12",
-          expectedGroupName: "Klasse 2a",
-          currentEducationGroupId: "13",
-        },
-      ],
-    });
-  });
-
-  it("fetches supervised groups with room data and visits", async () => {
-    const supervisedGroups = [
-      {
-        id: 1,
-        name: "Schulhof",
-        room_id: 10,
-        room: { id: 10, name: "Schulhof" },
-      },
-    ];
-    const unclaimedGroups = [] as Array<{
-      id: number;
-      name: string;
-      room?: { id: number; name: string };
-    }>;
-    const staff = { id: 5, person_id: 50 };
-    const educationalGroups = [
-      { id: 2, name: "OGS A", room: { id: 20, name: "Raum 101" } },
-    ];
-    const visits = [
-      {
-        id: 100,
-        student_id: 200,
-        active_group_id: 1,
-        check_in_time: "2024-01-15T10:00:00Z",
-        student_name: "Max Mustermann",
-        school_class: "1a",
-        group_name: "OGS Gruppe A",
-        is_active: true,
-      },
-      {
-        id: 101,
-        student_id: 201,
-        active_group_id: 1,
-        check_in_time: "2024-01-15T09:00:00Z",
-        check_out_time: "2024-01-15T10:30:00Z",
-        student_name: "Lisa Schmidt",
-        school_class: "2b",
-        group_name: "OGS Gruppe B",
-        is_active: false, // Should be filtered out
-      },
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: unclaimedGroups })
-      .mockResolvedValueOnce({ data: staff })
-      .mockResolvedValueOnce({ data: educationalGroups })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: visits }); // visits for first group
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{ id: string; name: string }>;
-        firstRoomVisits: Array<{
-          studentId: string;
-          studentName: string;
-          isActive: boolean;
-        }>;
-        firstRoomId: string | null;
-      }>
-    >(response);
-
-    expect(json.data.supervisedGroups).toHaveLength(1);
-    expect(json.data.supervisedGroups[0]?.id).toBe("1");
-    expect(json.data.firstRoomId).toBe("1");
-
-    // Only active visits should be returned
-    expect(json.data.firstRoomVisits).toHaveLength(1);
-    expect(json.data.firstRoomVisits[0]?.studentName).toBe("Max Mustermann");
-    expect(json.data.firstRoomVisits[0]?.isActive).toBe(true);
-  });
-
-  it("fetches room data when not included in supervised group response", async () => {
-    const supervisedGroups = [
-      { id: 1, name: "Schulhof", room_id: 10 }, // No room object, needs fetch
-    ];
-    const roomData = { id: 10, name: "Schulhof" };
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] }) // unclaimed
-      .mockResolvedValueOnce({ data: null }) // staff (not found)
-      .mockResolvedValueOnce({ data: [] }) // educational groups
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: roomData }) // room fetch
-      .mockResolvedValueOnce({ data: [] }); // visits
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{
-          id: string;
-          name: string;
-          room?: { id: string; name: string };
-        }>;
-      }>
-    >(response);
-
-    expect(json.data.supervisedGroups[0]?.room?.name).toBe("Schulhof");
-  });
-
-  it("propagates supervised fetch errors so real outages surface", async () => {
-    // The supervised fetch is authoritative — if the backend is down or
-    // returning 5xx, the BFF must NOT silently return an empty dashboard.
-    // Other parallel fetches (unclaimed, staff, edu, schulhof) still fall
-    // back to safe defaults individually.
-    mockApiGet
-      .mockRejectedValueOnce(new Error("API error (500): backend unavailable")) // supervised
-      .mockRejectedValueOnce(new Error("Unclaimed groups error"))
-      .mockRejectedValueOnce(new Error("Staff error"))
-      .mockRejectedValueOnce(new Error("Educational groups error"))
-      .mockRejectedValueOnce(new Error("Schulhof status error"))
-      .mockResolvedValueOnce(emptyPlannedNowResponse)
-      .mockResolvedValueOnce(emptyActiveSessionsResponse);
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(500);
-  });
-
-  it("keeps normal supervision available while disabling a failed Schulhof status", async () => {
-    mockApiGet
-      .mockResolvedValueOnce({ data: [] }) // supervised
-      .mockResolvedValueOnce({ data: [] }) // unclaimed
-      .mockResolvedValueOnce({ data: { id: 5, person_id: 50 } }) // staff
-      .mockResolvedValueOnce({ data: [] }) // educational groups
-      .mockRejectedValueOnce(
-        new Error("API error (500): Schulhof status unavailable"),
-      )
-      .mockResolvedValueOnce(emptyPlannedNowResponse)
-      .mockResolvedValueOnce(emptyActiveSessionsResponse);
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-    const json =
-      await parseJsonResponse<ApiResponse<{ schulhofStatus: unknown }>>(
-        response,
-      );
-    expect(json.data.schulhofStatus).toBeNull();
-  });
-
-  it("falls back to own supervisions when admin endpoint returns 403", async () => {
-    // Dual-role / setting-disabled admin: /supervisors/all returns 403 and
-    // the BFF should silently use the caregiver endpoint. Tested with an
-    // explicit admin session so the admin endpoint is actually attempted.
-    const adminSession = {
-      ...mockSessionData(),
-      user: { ...mockSessionData().user, roles: ["admin"] },
-    } as ExtendedSession;
-    // Both route-wrapper and the handler itself call auth(), so mock the
-    // resolved value (not Once) so both calls see the admin session.
-    mockAuth.mockResolvedValue(adminSession);
-    const ownGroups = [{ id: 42, name: "Raum A", room: { id: 9, name: "A" } }];
-    // Promise.all fires the 6 parallel calls synchronously in array order
-    // (supervised, unclaimed, staff, edu, schulhof, plannedNow). The 7th mock
-    // is consumed asynchronously by the fallback apiGet inside the supervised
-    // catch.
-    mockApiGet
-      .mockRejectedValueOnce(new Error("API error (403): forbidden")) // supervised
-      .mockResolvedValueOnce({ data: [] }) // unclaimed
-      .mockResolvedValueOnce({ data: null }) // staff
-      .mockResolvedValueOnce({ data: [] }) // educational
-      .mockResolvedValueOnce({ data: { exists: false } }) // schulhof
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: ownGroups }); // caregiver fallback
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-    const json =
-      await parseJsonResponse<
-        ApiResponse<{ supervisedGroups: Array<{ id: string }> }>
-      >(response);
-    expect(json.data.supervisedGroups).toHaveLength(1);
-    expect(json.data.supervisedGroups[0]?.id).toBe("42");
-  });
-
-  it("handles null response data safely", async () => {
-    mockApiGet
-      .mockResolvedValueOnce({ data: null }) // supervised (null instead of array)
-      .mockResolvedValueOnce({ data: null }) // unclaimed
-      .mockResolvedValueOnce({ data: null }) // staff
-      .mockResolvedValueOnce({ data: null }) // educational groups
-      .mockResolvedValueOnce({ data: null }) // Schulhof status
-      .mockResolvedValueOnce({ data: null }) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse); // active sessions
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: unknown[];
-        unclaimedGroups: unknown[];
-        firstRoomId: string | null;
-      }>
-    >(response);
-
-    expect(json.data.supervisedGroups).toEqual([]);
-    expect(json.data.unclaimedGroups).toEqual([]);
-    expect(json.data.firstRoomId).toBeNull();
-  });
-
-  it("handles 403 error for visits without crashing", async () => {
-    const supervisedGroups = [
-      { id: 1, name: "Schulhof", room: { id: 10, name: "Schulhof" } },
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { id: 5 } })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockRejectedValueOnce(new Error("403 Forbidden")); // visits fetch fails with 403
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: unknown[];
-        firstRoomVisits: unknown[];
-        firstRoomId: string | null;
-      }>
-    >(response);
-
-    // Should still return supervised groups, just with empty visits
-    expect(json.data.supervisedGroups).toHaveLength(1);
-    expect(json.data.firstRoomVisits).toEqual([]);
-    expect(json.data.firstRoomId).toBe("1");
-  });
-
-  it("handles room fetch failure without crashing", async () => {
-    const supervisedGroups = [
-      { id: 1, name: "Schulhof", room_id: 10 }, // No room object
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: null })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockRejectedValueOnce(new Error("Room not found")) // room fetch fails
-      .mockResolvedValueOnce({ data: [] }); // visits
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{
-          id: string;
-          name: string;
-          room?: { id: string; name: string };
-        }>;
-      }>
-    >(response);
-
-    // Should still have the group, just without room data
-    expect(json.data.supervisedGroups).toHaveLength(1);
-    expect(json.data.supervisedGroups[0]?.id).toBe("1");
-    expect(json.data.supervisedGroups[0]?.room).toBeUndefined();
-  });
-
-  it("converts backend int64 IDs to frontend strings", async () => {
-    const supervisedGroups = [
-      { id: 123456789, name: "Test", room: { id: 987654321, name: "Room" } },
-    ];
-    const staff = { id: 555666777 };
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: staff })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: [] }); // visits
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{
-          id: string;
-          room?: { id: string };
-        }>;
-        currentStaff: { id: string };
-      }>
-    >(response);
-
-    // All IDs should be strings
-    expect(typeof json.data.supervisedGroups[0]?.id).toBe("string");
-    expect(json.data.supervisedGroups[0]?.id).toBe("123456789");
-    expect(json.data.supervisedGroups[0]?.room?.id).toBe("987654321");
-    expect(json.data.currentStaff.id).toBe("555666777");
-  });
-
-  it("handles supervised group without room_id", async () => {
-    const supervisedGroups = [
-      { id: 1, name: "Draussen" }, // No room_id, no room object
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] }) // unclaimed
-      .mockResolvedValueOnce({ data: null }) // staff
-      .mockResolvedValueOnce({ data: [] }) // educational groups
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: [] }); // visits
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    expect(response.status).toBe(200);
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{
-          id: string;
-          name: string;
-          room_id?: string;
-          room?: { id: string; name: string };
-        }>;
-      }>
-    >(response);
-
-    expect(json.data.supervisedGroups).toHaveLength(1);
-    expect(json.data.supervisedGroups[0]?.id).toBe("1");
-    expect(json.data.supervisedGroups[0]?.room_id).toBeUndefined();
-    expect(json.data.supervisedGroups[0]?.room).toBeUndefined();
-  });
-
-  it("handles visits with missing optional fields", async () => {
-    const supervisedGroups = [
-      { id: 1, name: "Test", room: { id: 10, name: "Room A" } },
-    ];
-    const visits = [
-      {
-        id: 100,
-        student_id: 200,
-        active_group_id: 1,
-        check_in_time: "2024-01-15T10:00:00Z",
-        // Missing: student_name, school_class, group_name
-        is_active: true,
-      },
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: null })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: visits });
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        firstRoomVisits: Array<{
-          studentName: string;
-          schoolClass: string;
-          groupName: string;
-        }>;
-      }>
-    >(response);
-
-    // Should use empty string defaults for missing optional fields
-    expect(json.data.firstRoomVisits).toHaveLength(1);
-    expect(json.data.firstRoomVisits[0]?.studentName).toBe("");
-    expect(json.data.firstRoomVisits[0]?.schoolClass).toBe("");
-    expect(json.data.firstRoomVisits[0]?.groupName).toBe("");
-  });
-
-  it("sorts supervised groups by room name", async () => {
-    const supervisedGroups = [
-      { id: 2, name: "Group B", room: { id: 20, name: "Zimmer" } },
-      { id: 1, name: "Group A", room: { id: 10, name: "Aula" } },
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: null })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse) // active sessions
-      .mockResolvedValueOnce({ data: [] }); // visits for first (Aula)
-
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
-
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{ id: string; name: string }>;
-        firstRoomId: string | null;
-      }>
-    >(response);
-
-    // Sorted by room name: "Aula" before "Zimmer"
-    expect(json.data.supervisedGroups[0]?.id).toBe("1");
-    expect(json.data.firstRoomId).toBe("1");
-  });
-
-  it("sorts parallel sessions by session name before preloading visits", async () => {
-    const supervisedGroups = [
-      { id: 2, name: "GT 2", room: { id: 54, name: "Mehrzweckraum" } },
-      { id: 1, name: "GT 1", room: { id: 54, name: "Mehrzweckraum" } },
-    ];
-
-    mockApiGet
-      .mockResolvedValueOnce({ data: supervisedGroups })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: null })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } })
-      .mockResolvedValueOnce(emptyPlannedNowResponse)
-      .mockResolvedValueOnce(emptyActiveSessionsResponse)
-      .mockResolvedValueOnce({ data: [] });
+  it("issues exactly one backend request without group_id", async () => {
+    mockApiGet.mockResolvedValueOnce({ data: emptyWire });
 
     const response = await GET(
       createMockRequest("/api/active-supervision-dashboard"),
       createMockContext(),
     );
-    const json = await parseJsonResponse<
-      ApiResponse<{
-        supervisedGroups: Array<{ id: string }>;
-        firstRoomId: string | null;
-      }>
-    >(response);
 
-    expect(json.data.supervisedGroups.map((group) => group.id)).toEqual([
-      "1",
-      "2",
-    ]);
-    expect(json.data.firstRoomId).toBe("1");
+    expect(response.status).toBe(200);
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
     expect(mockApiGet).toHaveBeenCalledWith(
-      "/api/active/groups/1/visits/display",
-      "test-token",
+      "/api/active/supervision-dashboard",
+      expect.any(String),
     );
   });
 
-  it("maps unclaimed groups with room names correctly", async () => {
-    const unclaimedGroups = [
-      { id: 5, name: "Unclaimed", room: { id: 50, name: "Hof" } },
-      { id: 6, name: "No Room" }, // No room object
-    ];
+  it("forwards a valid group_id and drops an invalid one", async () => {
+    mockApiGet.mockResolvedValue({ data: emptyWire });
 
-    mockApiGet
-      .mockResolvedValueOnce({ data: [] }) // no supervised groups
-      .mockResolvedValueOnce({ data: unclaimedGroups })
-      .mockResolvedValueOnce({ data: null })
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({ data: { exists: false } }) // Schulhof status
-      .mockResolvedValueOnce(emptyPlannedNowResponse) // planned now
-      .mockResolvedValueOnce(emptyActiveSessionsResponse); // active sessions
+    await GET(
+      createMockRequest("/api/active-supervision-dashboard?group_id=42"),
+      createMockContext(),
+    );
+    expect(mockApiGet).toHaveBeenLastCalledWith(
+      "/api/active/supervision-dashboard?group_id=42",
+      expect.any(String),
+    );
 
-    const request = createMockRequest("/api/active-supervision-dashboard");
-    const response = await GET(request, createMockContext());
+    await GET(
+      createMockRequest("/api/active-supervision-dashboard?group_id=abc"),
+      createMockContext(),
+    );
+    expect(mockApiGet).toHaveBeenLastCalledWith(
+      "/api/active/supervision-dashboard",
+      expect.any(String),
+    );
+  });
+
+  it("maps the wire projection to the camelCase dashboard shape", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: {
+        ...emptyWire,
+        groups: [
+          {
+            id: "7",
+            room_id: "10",
+            room_name: "Raum 101",
+            room_color: "#83CD2D",
+          },
+        ],
+        selected_group_id: "7",
+        unclaimed_groups: [{ id: "9", room_name: "Schulhof" }],
+        current_staff_id: "5",
+        educational_groups: [{ id: "2", name: "OGS A", room_name: "Raum 101" }],
+        schulhof_status: {
+          exists: true,
+          room_id: 30,
+          room_name: "Schulhof",
+          activity_group_id: 31,
+          active_group_id: 32,
+          is_user_supervising: true,
+          supervision_id: 33,
+          supervisor_count: 1,
+          student_count: 4,
+          supervisors: [
+            { id: 33, staff_id: 5, name: "Max Muster", is_current_user: true },
+          ],
+        },
+        capabilities: { web_spontaneous_activities_enabled: true },
+        active_sessions: [
+          {
+            active_group_id: 7,
+            instance_id: 70,
+            title: "Fußball",
+            start_time: "14:00",
+            end_time: "15:00",
+          },
+        ],
+        visits: [
+          {
+            student_id: "100",
+            student_name: "Kind Eins",
+            school_class: "1a",
+            group_name: "OGS A",
+            active_group_id: "7",
+            check_in_time: "2026-08-19T10:00:00Z",
+            actual_arrival_time: "12:00",
+            sick: false,
+            excused: false,
+          },
+        ],
+        tracking_indicators: {
+          labels: ["Hausaufgaben"],
+          results: { "100": [true] },
+        },
+        pickup_times: [
+          {
+            student_id: "100",
+            date: "2026-08-19",
+            weekday_name: "Mittwoch",
+            pickup_time: "15:30",
+            is_exception: true,
+            day_notes: [{ id: "1", content: "Oma holt ab" }],
+          },
+        ],
+        arrival_times: [
+          {
+            student_id: "100",
+            date: "2026-08-19",
+            weekday_name: "Mittwoch",
+            expected_arrival: "11:45",
+            is_exception: false,
+          },
+        ],
+      },
+    });
+
+    const response = await GET(
+      createMockRequest("/api/active-supervision-dashboard"),
+      createMockContext(),
+    );
+    expect(response.status).toBe(200);
 
     const json = await parseJsonResponse<
       ApiResponse<{
-        unclaimedGroups: Array<{
+        supervisedGroups: Array<{
           id: string;
-          name: string;
-          room?: { name: string };
+          room_id?: string;
+          room?: { id: string; name: string; color?: string | null };
+        }>;
+        unclaimedGroups: Array<{ id: string; room?: { name: string } }>;
+        currentStaff: { id: string } | null;
+        educationalGroups: Array<{ id: string; name: string }>;
+        firstRoomVisits: Array<{
+          studentId: string;
+          studentName: string;
+          activeGroupId: string;
+          isActive: boolean;
+          actualArrivalTime?: string;
+        }>;
+        firstRoomId: string | null;
+        selectedGroupId: string | null;
+        schulhofStatus: {
+          exists: boolean;
+          activeGroupId: string | null;
+          supervisors: Array<{ staffId: string; isCurrentUser: boolean }>;
+        } | null;
+        capabilities?: { webSpontaneousActivitiesEnabled: boolean };
+        activeSessions: Array<{ activeGroupId: string; title: string }>;
+        trackingIndicators: {
+          labels: string[];
+          results: Record<string, boolean[]>;
+        };
+        pickupTimes: Array<{
+          studentId: string;
+          pickupTime: string | null;
+          dayNotes: Array<{ content: string }>;
+        }>;
+        arrivalTimes: Array<{
+          studentId: string;
+          expectedArrival: string | null;
         }>;
       }>
     >(response);
 
-    expect(json.data.unclaimedGroups).toHaveLength(2);
-    expect(json.data.unclaimedGroups[0]?.room?.name).toBe("Hof");
-    expect(json.data.unclaimedGroups[1]?.room).toBeUndefined();
+    const data = json.data;
+    expect(data.supervisedGroups).toEqual([
+      {
+        id: "7",
+        name: "",
+        room_id: "10",
+        room: { id: "10", name: "Raum 101", color: "#83CD2D" },
+      },
+    ]);
+    expect(data.unclaimedGroups[0]).toMatchObject({
+      id: "9",
+      room: { name: "Schulhof" },
+    });
+    expect(data.currentStaff).toEqual({ id: "5" });
+    expect(data.educationalGroups[0]).toMatchObject({ id: "2", name: "OGS A" });
+    expect(data.firstRoomVisits[0]).toMatchObject({
+      studentId: "100",
+      studentName: "Kind Eins",
+      activeGroupId: "7",
+      isActive: true,
+      actualArrivalTime: "12:00",
+    });
+    expect(data.firstRoomId).toBe("7");
+    expect(data.selectedGroupId).toBe("7");
+    expect(data.schulhofStatus).toMatchObject({
+      exists: true,
+      activeGroupId: "32",
+      supervisors: [{ staffId: "5", isCurrentUser: true }],
+    });
+    expect(data.capabilities?.webSpontaneousActivitiesEnabled).toBe(true);
+    expect(data.activeSessions[0]).toMatchObject({
+      activeGroupId: "7",
+      title: "Fußball",
+    });
+    expect(data.trackingIndicators).toEqual({
+      labels: ["Hausaufgaben"],
+      results: { "100": [true] },
+    });
+    expect(data.pickupTimes[0]).toMatchObject({
+      studentId: "100",
+      pickupTime: "15:30",
+      dayNotes: [{ id: "1", content: "Oma holt ab" }],
+    });
+    expect(data.arrivalTimes[0]).toMatchObject({
+      studentId: "100",
+      expectedArrival: "11:45",
+    });
+  });
+
+  it("propagates backend errors instead of degrading to empty sections", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("API error (403): forbidden"));
+
+    const response = await GET(
+      createMockRequest("/api/active-supervision-dashboard?group_id=42"),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("propagates backend 500s", async () => {
+    mockApiGet.mockRejectedValueOnce(
+      new Error("API error (500): schulhof load failed"),
+    );
+
+    const response = await GET(
+      createMockRequest("/api/active-supervision-dashboard"),
+      createMockContext(),
+    );
+
+    expect(response.status).toBe(500);
   });
 });

--- a/frontend/src/app/api/active-supervision-dashboard/route.test.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.test.ts
@@ -145,6 +145,7 @@ describe("GET /api/active-supervision-dashboard", () => {
         groups: [
           {
             id: "7",
+            name: "Malen",
             room_id: "10",
             room_name: "Raum 101",
             room_color: "#83CD2D",
@@ -269,7 +270,7 @@ describe("GET /api/active-supervision-dashboard", () => {
     expect(data.supervisedGroups).toEqual([
       {
         id: "7",
-        name: "",
+        name: "Malen",
         room_id: "10",
         room: { id: "10", name: "Raum 101", color: "#83CD2D" },
       },

--- a/frontend/src/app/api/active-supervision-dashboard/route.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.ts
@@ -16,6 +16,7 @@ import type { CareDayStatus } from "~/lib/timetable-types";
 
 interface WireGroup {
   id: string;
+  name: string;
   room_id?: string;
   room_name?: string;
   room_color?: string | null;
@@ -300,7 +301,7 @@ function mapDashboard(wire: WireDashboard): ActiveSupervisionDashboardResponse {
   return {
     supervisedGroups: (wire.groups ?? []).map((g) => ({
       id: g.id,
-      name: "",
+      name: g.name,
       room_id: g.room_id,
       room: g.room_id
         ? {

--- a/frontend/src/app/api/active-supervision-dashboard/route.ts
+++ b/frontend/src/app/api/active-supervision-dashboard/route.ts
@@ -1,97 +1,38 @@
 // app/api/active-supervision-dashboard/route.ts
-// BFF (Backend-for-Frontend) endpoint for Active Supervisions Dashboard
-// Consolidates 8+ API calls into 1 to eliminate redundant auth() overhead
+// Proxy for the aggregated supervision dashboard projection (#2096).
+// One backend request returns supervised sessions (rooms bulk-loaded),
+// unclaimed groups, staff id, educational groups, Schulhof status,
+// capabilities, active sessions, planned instances, and the selected
+// session's visits, tracking indicators, and pickup/arrival times —
+// replacing the former BFF fan-out of ~11 backend calls. Errors are
+// forwarded as-is: the backend fails the whole request instead of
+// degrading sections to empty arrays.
 import type { NextRequest } from "next/server";
 import { apiGet } from "~/lib/api-helpers.server";
 import { createGetHandler } from "~/lib/route-wrapper.server";
 import type { CareDayStatus } from "~/lib/timetable-types";
 
-// Backend response types for supervised/active groups
-interface BackendActiveGroup {
-  id: number;
+// ===== Wire types (Go: backend/services/supervisiondashboard/service.go) =====
+
+interface WireGroup {
+  id: string;
+  room_id?: string;
+  room_name?: string;
+  room_color?: string | null;
+}
+
+interface WireUnclaimedGroup {
+  id: string;
+  room_name?: string;
+}
+
+interface WireEducationalGroup {
+  id: string;
   name: string;
-  room_id?: number;
-  room?: {
-    id: number;
-    name: string;
-    color?: string | null;
-  };
-  end_time?: string;
+  room_name?: string;
 }
 
-// Backend response for unclaimed groups
-interface BackendUnclaimedGroup {
-  id: number;
-  name: string;
-  room_id?: number;
-  room?: {
-    id: number;
-    name: string;
-  };
-}
-
-// Backend response for staff
-interface BackendStaff {
-  id: number;
-  person_id: number;
-  role?: string;
-  person?: {
-    first_name: string;
-    last_name: string;
-  };
-}
-
-// Backend response for educational groups
-interface BackendEducationalGroup {
-  id: number;
-  name: string;
-  room_id?: number;
-  room?: {
-    id: number;
-    name: string;
-  };
-}
-
-// Backend response for room
-interface BackendRoom {
-  id: number;
-  name: string;
-  building?: string;
-  floor?: number;
-  color?: string | null;
-}
-
-// Backend response for visits with display data
-interface BackendVisitDisplay {
-  id: number;
-  student_id: number;
-  active_group_id: number;
-  check_in_time: string;
-  check_out_time?: string;
-  actual_arrival_time?: string;
-  actual_pickup_time?: string;
-  student_name?: string;
-  school_class?: string;
-  group_name?: string;
-  sick?: boolean;
-  sick_since?: string;
-  excused?: boolean;
-  excused_since?: string;
-  is_active: boolean;
-  // Authenticated /api/students/{id}/photo/{filename} URL — backend
-  // rewrites the raw /uploads path before returning.
-  photo_url?: string;
-}
-
-// Backend response for Schulhof status
-interface BackendSchulhofSupervisor {
-  id: number;
-  staff_id: number;
-  name: string;
-  is_current_user: boolean;
-}
-
-interface BackendSchulhofStatus {
+interface WireSchulhofStatus {
   exists: boolean;
   room_id?: number;
   room_name: string;
@@ -101,10 +42,23 @@ interface BackendSchulhofStatus {
   supervision_id?: number;
   supervisor_count: number;
   student_count: number;
-  supervisors: BackendSchulhofSupervisor[];
+  supervisors: Array<{
+    id: number;
+    staff_id: number;
+    name: string;
+    is_current_user: boolean;
+  }>;
 }
 
-interface BackendPlannedTimetableInstance {
+interface WireActiveSession {
+  active_group_id: number;
+  instance_id: number;
+  title: string;
+  start_time: string;
+  end_time: string;
+}
+
+interface WirePlannedInstance {
   id: number;
   title: string;
   date: string;
@@ -126,10 +80,10 @@ interface BackendPlannedTimetableInstance {
   can_start?: boolean;
   start_available_at?: string;
   start_expires_at?: string;
-  roster_preview?: BackendTimetableRosterRow[];
+  roster_preview?: WireRosterRow[];
 }
 
-interface BackendTimetableRosterRow {
+interface WireRosterRow {
   student_id: number;
   student_name: string;
   school_class: string;
@@ -143,11 +97,11 @@ interface BackendTimetableRosterRow {
   note?: string | null;
   checked_in_at?: string | null;
   visit_entry_time?: string | null;
-  warnings?: BackendTimetableRosterWarning[];
+  warnings?: WireRosterWarning[];
   care_day_status?: CareDayStatus;
 }
 
-interface BackendTimetableRosterWarning {
+interface WireRosterWarning {
   kind: string;
   message: string;
   expected_arrival?: string | null;
@@ -157,49 +111,85 @@ interface BackendTimetableRosterWarning {
   current_education_group_id?: number | null;
 }
 
-interface BackendTimetableOperationCapabilities {
-  web_spontaneous_activities_enabled?: boolean;
+interface WireVisit {
+  student_id: string;
+  student_name: string;
+  school_class: string;
+  group_name: string;
+  active_group_id: string;
+  check_in_time: string;
+  actual_arrival_time?: string;
+  actual_pickup_time?: string;
+  sick: boolean;
+  sick_since?: string;
+  excused: boolean;
+  excused_since?: string;
+  photo_url?: string;
 }
 
-// Backend response for today's running timetable sessions (#2265)
-interface BackendActiveTimetableSession {
-  active_group_id: number;
-  instance_id: number;
-  title: string;
-  start_time: string;
-  end_time: string;
+interface WireDayNote {
+  id: string;
+  content: string;
 }
 
-// Combined dashboard response type
+interface WirePickupTime {
+  student_id: string;
+  date: string;
+  weekday_name: string;
+  pickup_time?: string;
+  is_exception: boolean;
+  notes?: string;
+  day_notes?: WireDayNote[];
+}
+
+interface WireArrivalTime {
+  student_id: string;
+  date: string;
+  weekday_name: string;
+  expected_arrival?: string;
+  is_exception: boolean;
+  notes?: string;
+  day_notes?: WireDayNote[];
+}
+
+interface WireDashboard {
+  groups: WireGroup[];
+  selected_group_id?: string;
+  unclaimed_groups: WireUnclaimedGroup[];
+  current_staff_id?: string;
+  educational_groups: WireEducationalGroup[];
+  schulhof_status: WireSchulhofStatus | null;
+  capabilities: { web_spontaneous_activities_enabled: boolean };
+  active_sessions: WireActiveSession[];
+  planned_now: WirePlannedInstance[];
+  visits: WireVisit[];
+  tracking_indicators: { labels: string[]; results: Record<string, boolean[]> };
+  pickup_times: WirePickupTime[];
+  arrival_times: WireArrivalTime[];
+}
+
+// ===== Frontend response type (camelCase view the page consumes) =====
+
 interface ActiveSupervisionDashboardResponse {
-  // User's supervised active groups (with room info pre-loaded)
   supervisedGroups: Array<{
     id: string;
     name: string;
     room_id?: string;
     room?: { id: string; name: string; color?: string | null };
   }>;
-
-  // Unclaimed groups available to claim
   unclaimedGroups: Array<{
     id: string;
     name: string;
     room?: { name: string };
   }>;
-
-  // Current staff info
-  currentStaff: {
-    id: string;
-  } | null;
-
-  // Educational groups for permission checking
+  currentStaff: { id: string } | null;
   educationalGroups: Array<{
     id: string;
     name: string;
     room?: { name: string };
   }>;
-
-  // Visits for first supervised room (pre-loaded)
+  // Visits of the selected session (the backend resolves group_id, or the
+  // first supervised session when the parameter is absent).
   firstRoomVisits: Array<{
     studentId: string;
     studentName: string;
@@ -216,11 +206,7 @@ interface ActiveSupervisionDashboardResponse {
     excusedSince?: string;
     photoUrl?: string;
   }>;
-
-  // ID of first room (for state initialization)
   firstRoomId: string | null;
-
-  // Schulhof (Schoolyard) status - always included for permanent tab
   schulhofStatus: {
     exists: boolean;
     roomId: string | null;
@@ -241,8 +227,6 @@ interface ActiveSupervisionDashboardResponse {
   capabilities?: {
     webSpontaneousActivitiesEnabled: boolean;
   };
-  // Plan windows of today's running sessions, keyed by active group, so tab
-  // labels can show "Aktivitätsname · Planzeit" (#2265)
   activeSessions: Array<{
     activeGroupId: string;
     instanceId: string;
@@ -288,114 +272,106 @@ interface ActiveSupervisionDashboardResponse {
       visitEntryTime: string | null;
     }>;
   }>;
+  // Folded-in sections of the selected session (#2096) — replace the former
+  // separate supervision-visits / tracking / pickup / arrival fetches.
+  selectedGroupId: string | null;
+  trackingIndicators: { labels: string[]; results: Record<string, boolean[]> };
+  pickupTimes: Array<{
+    studentId: string;
+    date: string;
+    weekdayName: string;
+    pickupTime: string | null;
+    isException: boolean;
+    notes: string;
+    dayNotes: Array<{ id: string; content: string }>;
+  }>;
+  arrivalTimes: Array<{
+    studentId: string;
+    date: string;
+    weekdayName: string;
+    expectedArrival: string | null;
+    isException: boolean;
+    notes: string;
+    dayNotes: Array<{ id: string; content: string }>;
+  }>;
 }
 
-/**
- * GET /api/active-supervision-dashboard
- *
- * BFF endpoint that fetches all data needed for the Active Supervisions page in a single request.
- * This eliminates 8+ separate auth() calls (each ~300ms) by making one auth() call
- * and then fetching data in parallel from the Go backend.
- *
- * Performance improvement: ~2500-4000ms → ~400-500ms (80% faster)
- */
-export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
-  async (_request: NextRequest, token: string) => {
-    // Step 1: Fetch all initial data in parallel (including Schulhof status)
-    const [
-      supervisedResult,
-      unclaimedResult,
-      staffResult,
-      groupsResult,
-      schulhofResult,
-      plannedNowResult,
-      activeSessionsResult,
-    ] = await Promise.all([
-      // Try the all-groups operational endpoint first. It is available to
-      // configured admins and to permission-bearing staff in open-care mode.
-      // Fixed-group staff receive 403 and fall back to their own rooms.
-      // Other errors (5xx, network) are not swallowed — they propagate so
-      // the frontend can surface them instead of silently rendering empty.
-      apiGet<{ data: BackendActiveGroup[] | null }>(
-        "/api/active/supervisors/all",
-        token,
-      ).catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("(403)") || msg.includes(" 403 ")) {
-          return apiGet<{ data: BackendActiveGroup[] | null }>(
-            "/api/me/groups/supervised",
-            token,
-          );
+function mapDashboard(wire: WireDashboard): ActiveSupervisionDashboardResponse {
+  return {
+    supervisedGroups: (wire.groups ?? []).map((g) => ({
+      id: g.id,
+      name: "",
+      room_id: g.room_id,
+      room: g.room_id
+        ? {
+            id: g.room_id,
+            name: g.room_name ?? "",
+            color: g.room_color ?? null,
+          }
+        : undefined,
+    })),
+    unclaimedGroups: (wire.unclaimed_groups ?? []).map((g) => ({
+      id: g.id,
+      name: "",
+      room: g.room_name ? { name: g.room_name } : undefined,
+    })),
+    currentStaff: wire.current_staff_id ? { id: wire.current_staff_id } : null,
+    educationalGroups: (wire.educational_groups ?? []).map((g) => ({
+      id: g.id,
+      name: g.name,
+      room: g.room_name ? { name: g.room_name } : undefined,
+    })),
+    firstRoomVisits: (wire.visits ?? []).map((v) => ({
+      studentId: v.student_id,
+      studentName: v.student_name,
+      schoolClass: v.school_class,
+      groupName: v.group_name,
+      activeGroupId: v.active_group_id,
+      checkInTime: v.check_in_time,
+      actualArrivalTime: v.actual_arrival_time,
+      actualPickupTime: v.actual_pickup_time,
+      isActive: true,
+      sick: v.sick,
+      sickSince: v.sick_since,
+      excused: v.excused,
+      excusedSince: v.excused_since,
+      photoUrl: v.photo_url,
+    })),
+    firstRoomId: wire.selected_group_id ?? null,
+    schulhofStatus: wire.schulhof_status
+      ? {
+          exists: wire.schulhof_status.exists,
+          roomId: wire.schulhof_status.room_id?.toString() ?? null,
+          roomName: wire.schulhof_status.room_name,
+          activityGroupId:
+            wire.schulhof_status.activity_group_id?.toString() ?? null,
+          activeGroupId:
+            wire.schulhof_status.active_group_id?.toString() ?? null,
+          isUserSupervising: wire.schulhof_status.is_user_supervising,
+          supervisionId:
+            wire.schulhof_status.supervision_id?.toString() ?? null,
+          supervisorCount: wire.schulhof_status.supervisor_count,
+          studentCount: wire.schulhof_status.student_count,
+          supervisors: (wire.schulhof_status.supervisors ?? []).map((s) => ({
+            id: s.id.toString(),
+            staffId: s.staff_id.toString(),
+            name: s.name,
+            isCurrentUser: s.is_current_user,
+          })),
         }
-        throw err;
-      }),
-
-      // Unclaimed groups available to claim
-      apiGet<{ data: BackendUnclaimedGroup[] | null }>(
-        "/api/active/groups/unclaimed",
-        token,
-      ).catch(() => ({ data: [] as BackendUnclaimedGroup[] })),
-
-      // Current staff info
-      apiGet<{ data: BackendStaff }>("/api/me/staff", token).catch(() => ({
-        data: null as BackendStaff | null,
-      })),
-
-      // Educational groups for permission checking
-      apiGet<{ data: BackendEducationalGroup[] | null }>(
-        "/api/me/groups",
-        token,
-      ).catch(() => ({ data: [] as BackendEducationalGroup[] })),
-
-      // Schulhof status for permanent tab
-      apiGet<{ data: BackendSchulhofStatus }>(
-        "/api/active/schulhof/status",
-        token,
-      ).catch(() => ({ data: null as BackendSchulhofStatus | null })),
-      apiGet<{ data: { instances: BackendPlannedTimetableInstance[] } }>(
-        "/api/timetable/operations/planned-now?horizon_minutes=480&limit=5&include_roster=true",
-        token,
-      ).catch(() => ({
-        data: { instances: [] as BackendPlannedTimetableInstance[] },
-      })),
-
-      // Plan windows of today's running sessions for tab labels (#2265).
-      // Older backends without the endpoint degrade to name-only labels.
-      apiGet<{ data: { sessions: BackendActiveTimetableSession[] } }>(
-        "/api/timetable/operations/active-sessions",
-        token,
-      ).catch(() => ({
-        data: { sessions: [] as BackendActiveTimetableSession[] },
-      })),
-    ]);
-    const activeSessions = (activeSessionsResult.data?.sessions ?? []).map(
-      (s) => ({
-        activeGroupId: s.active_group_id.toString(),
-        instanceId: s.instance_id.toString(),
-        title: s.title,
-        startTime: s.start_time,
-        endTime: s.end_time,
-      }),
-    );
-
-    // Extract data with null safety, sorted by room name for deterministic order
-    const supervisedGroups = (
-      Array.isArray(supervisedResult.data) ? supervisedResult.data : []
-    ).sort((a, b) =>
-      (a.room?.name ?? a.name ?? "").localeCompare(
-        b.room?.name ?? b.name ?? "",
-        "de",
-      ),
-    );
-    const unclaimedGroups = Array.isArray(unclaimedResult.data)
-      ? unclaimedResult.data
-      : [];
-    const currentStaff = staffResult.data;
-    const educationalGroups = Array.isArray(groupsResult.data)
-      ? groupsResult.data
-      : [];
-    const schulhofData = schulhofResult.data;
-    const plannedNow = (plannedNowResult.data?.instances ?? []).map((i) => ({
+      : null,
+    capabilities: {
+      webSpontaneousActivitiesEnabled:
+        wire.capabilities?.web_spontaneous_activities_enabled === true,
+    },
+    activeSessions: (wire.active_sessions ?? []).map((s) => ({
+      activeGroupId: s.active_group_id.toString(),
+      instanceId: s.instance_id.toString(),
+      title: s.title,
+      startTime: s.start_time,
+      endTime: s.end_time,
+    })),
+    plannedNow: (wire.planned_now ?? []).map((i) => ({
       id: i.id.toString(),
       title: i.title,
       date: i.date,
@@ -409,7 +385,7 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
       expectedStudentsCount: i.expected_students_count,
       presentStudentsCount: i.present_students_count,
       notScheduledStudentsCount: i.not_scheduled_students_count ?? 0,
-      assignedStaffIds: i.assigned_staff_ids.map(String),
+      assignedStaffIds: (i.assigned_staff_ids ?? []).map(String),
       isAssigned: i.is_assigned ?? false,
       isPrimary: i.is_primary ?? false,
       isSubstitute: i.is_substitute ?? false,
@@ -443,190 +419,58 @@ export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
             warning.current_education_group_id?.toString() ?? null,
         })),
       })),
-    }));
-
-    // Transform Schulhof status to frontend format
-    const schulhofStatus = schulhofData
-      ? {
-          exists: schulhofData.exists,
-          roomId: schulhofData.room_id?.toString() ?? null,
-          roomName: schulhofData.room_name,
-          activityGroupId: schulhofData.activity_group_id?.toString() ?? null,
-          activeGroupId: schulhofData.active_group_id?.toString() ?? null,
-          isUserSupervising: schulhofData.is_user_supervising,
-          supervisionId: schulhofData.supervision_id?.toString() ?? null,
-          supervisorCount: schulhofData.supervisor_count,
-          studentCount: schulhofData.student_count,
-          supervisors: (schulhofData.supervisors ?? []).map((s) => ({
-            id: s.id.toString(),
-            staffId: s.staff_id.toString(),
-            name: s.name,
-            isCurrentUser: s.is_current_user,
-          })),
-        }
-      : null;
-
-    const fetchCapabilities = async () => {
-      const result = await Promise.resolve(
-        apiGet<{ data: BackendTimetableOperationCapabilities }>(
-          "/api/timetable/operations/capabilities",
-          token,
-        ),
-      ).catch(() => ({
-        data: {
-          web_spontaneous_activities_enabled: false,
-        } satisfies BackendTimetableOperationCapabilities,
-      }));
-      return {
-        webSpontaneousActivitiesEnabled:
-          result?.data?.web_spontaneous_activities_enabled === true,
-      };
-    };
-
-    // If no supervised groups, return early with just unclaimed groups data
-    if (supervisedGroups.length === 0) {
-      const capabilities = await fetchCapabilities();
-      return {
-        supervisedGroups: [],
-        unclaimedGroups: unclaimedGroups.map((g) => ({
-          id: g.id.toString(),
-          name: g.name,
-          room: g.room ? { name: g.room.name } : undefined,
-        })),
-        currentStaff: currentStaff ? { id: currentStaff.id.toString() } : null,
-        educationalGroups: educationalGroups.map((g) => ({
-          id: g.id.toString(),
-          name: g.name,
-          room: g.room ? { name: g.room.name } : undefined,
-        })),
-        firstRoomVisits: [],
-        firstRoomId: null,
-        schulhofStatus,
-        capabilities,
-        activeSessions,
-        plannedNow,
-      };
-    }
-
-    // Step 2: Enrich supervised groups with room info.
-    const enrichedGroups = await Promise.all(
-      supervisedGroups.map(async (group) => {
-        // If room info already present, use it
-        if (group.room?.name) {
-          return {
-            id: group.id.toString(),
-            name: group.name,
-            room_id: group.room_id?.toString(),
-            room: {
-              id: group.room.id.toString(),
-              name: group.room.name,
-              color: group.room.color ?? null,
-            },
-          };
-        }
-
-        // Otherwise fetch room info if room_id exists
-        if (group.room_id) {
-          try {
-            const roomResponse = await apiGet<{ data: BackendRoom }>(
-              `/api/rooms/${group.room_id}`,
-              token,
-            );
-            return {
-              id: group.id.toString(),
-              name: group.name,
-              room_id: group.room_id.toString(),
-              room: roomResponse.data
-                ? {
-                    id: roomResponse.data.id.toString(),
-                    name: roomResponse.data.name,
-                    color: roomResponse.data.color ?? null,
-                  }
-                : undefined,
-            };
-          } catch {
-            return {
-              id: group.id.toString(),
-              name: group.name,
-              room_id: group.room_id.toString(),
-              room: undefined,
-            };
-          }
-        }
-
-        return {
-          id: group.id.toString(),
-          name: group.name,
-          room_id: undefined,
-          room: undefined,
-        };
-      }),
-    );
-
-    enrichedGroups.sort(
-      (a, b) =>
-        (a.room?.name ?? a.name ?? "").localeCompare(
-          b.room?.name ?? b.name ?? "",
-          "de",
-        ) || (a.name ?? "").localeCompare(b.name ?? "", "de"),
-    );
-    const firstGroupId = enrichedGroups[0]?.id ?? null;
-
-    // Step 3: Fetch visits for first room (pre-load for immediate display)
-    let firstRoomVisits: ActiveSupervisionDashboardResponse["firstRoomVisits"] =
-      [];
-
-    if (firstGroupId) {
-      try {
-        const visitsResponse = await apiGet<{ data: BackendVisitDisplay[] }>(
-          `/api/active/groups/${firstGroupId}/visits/display`,
-          token,
-        );
-
-        firstRoomVisits = (visitsResponse.data ?? [])
-          .filter((v) => v.is_active)
-          .map((v) => ({
-            studentId: v.student_id.toString(),
-            studentName: v.student_name ?? "",
-            schoolClass: v.school_class ?? "",
-            groupName: v.group_name ?? "",
-            activeGroupId: v.active_group_id.toString(),
-            checkInTime: v.check_in_time,
-            actualArrivalTime: v.actual_arrival_time,
-            actualPickupTime: v.actual_pickup_time,
-            isActive: v.is_active,
-            sick: v.sick,
-            sickSince: v.sick_since,
-            excused: v.excused,
-            excusedSince: v.excused_since,
-            photoUrl: v.photo_url,
-          }));
-      } catch {
-        firstRoomVisits = [];
-      }
-    }
-
-    const capabilities = await fetchCapabilities();
-
-    return {
-      supervisedGroups: enrichedGroups,
-      unclaimedGroups: unclaimedGroups.map((g) => ({
-        id: g.id.toString(),
-        name: g.name,
-        room: g.room ? { name: g.room.name } : undefined,
+    })),
+    selectedGroupId: wire.selected_group_id ?? null,
+    trackingIndicators: {
+      labels: wire.tracking_indicators?.labels ?? [],
+      results: wire.tracking_indicators?.results ?? {},
+    },
+    pickupTimes: (wire.pickup_times ?? []).map((p) => ({
+      studentId: p.student_id,
+      date: p.date,
+      weekdayName: p.weekday_name,
+      pickupTime: p.pickup_time ?? null,
+      isException: p.is_exception,
+      notes: p.notes ?? "",
+      dayNotes: (p.day_notes ?? []).map((n) => ({
+        id: n.id,
+        content: n.content,
       })),
-      currentStaff: currentStaff ? { id: currentStaff.id.toString() } : null,
-      educationalGroups: educationalGroups.map((g) => ({
-        id: g.id.toString(),
-        name: g.name,
-        room: g.room ? { name: g.room.name } : undefined,
+    })),
+    arrivalTimes: (wire.arrival_times ?? []).map((a) => ({
+      studentId: a.student_id,
+      date: a.date,
+      weekdayName: a.weekday_name,
+      expectedArrival: a.expected_arrival ?? null,
+      isException: a.is_exception,
+      notes: a.notes ?? "",
+      dayNotes: (a.day_notes ?? []).map((n) => ({
+        id: n.id,
+        content: n.content,
       })),
-      firstRoomVisits,
-      firstRoomId: firstGroupId,
-      schulhofStatus,
-      capabilities,
-      activeSessions,
-      plannedNow,
-    };
+    })),
+  };
+}
+
+/**
+ * GET /api/active-supervision-dashboard?group_id={activeGroupId}
+ *
+ * Thin proxy over the aggregated Go projection. The backend owns scope
+ * authorization, the room bulk load, and the strict error contract; an
+ * unknown group_id is a backend 403 (retry without the parameter to let the
+ * backend resolve the caller's first supervised session).
+ */
+export const GET = createGetHandler<ActiveSupervisionDashboardResponse>(
+  async (request: NextRequest, token: string) => {
+    const groupId = request.nextUrl.searchParams.get("group_id");
+    const query =
+      groupId && /^[1-9]\d{0,18}$/.test(groupId)
+        ? `?group_id=${encodeURIComponent(groupId)}`
+        : "";
+    const response = await apiGet<{ data: WireDashboard }>(
+      `/api/active/supervision-dashboard${query}`,
+      token,
+    );
+    return mapDashboard(response.data);
   },
 );

--- a/frontend/src/components/rooms/transit-students-section.test.tsx
+++ b/frontend/src/components/rooms/transit-students-section.test.tsx
@@ -380,13 +380,13 @@ describe("TransitStudentsSection", () => {
     expect(mutateKey).toHaveBeenCalledWith("rooms-list");
     expect(mutateMatching).toHaveBeenCalledTimes(1);
     // The needle list must cover the /active-supervisions caches too:
-    // when this section is embedded there, the room grid
-    // (supervision-visits-*) and roster (timetable-roster-*) would
-    // otherwise only refresh via SSE.
+    // when this section is embedded there, the aggregated dashboard key
+    // (matched via "dashboard", carrying the room's visits since #2096)
+    // and roster (timetable-roster-*) would otherwise only refresh via SSE.
     expect(vi.mocked(useTenantMutateMatching)).toHaveBeenCalledWith(
       expect.arrayContaining([
         "room-students-",
-        "supervision-visits-",
+        "dashboard",
         "timetable-roster-",
       ]),
     );

--- a/frontend/src/components/rooms/transit-students-section.tsx
+++ b/frontend/src/components/rooms/transit-students-section.tsx
@@ -73,16 +73,16 @@ export function TransitStudentsSection({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const { success: toastSuccess } = useToast();
   const mutateKey = useTenantMutate();
-  // "supervision-visits-" and "timetable-roster-" keep the
-  // /active-supervisions room grid and roster in sync when this section
-  // is embedded there — without them the assigned children only appear
-  // once an SSE event happens to arrive.
+  // "dashboard" (matching the aggregated active-supervision-dashboard key,
+  // which carries the room's visits since #2096) and "timetable-roster-"
+  // keep the /active-supervisions room grid and roster in sync when this
+  // section is embedded there — without them the assigned children only
+  // appear once an SSE event happens to arrive.
   const mutateMatching = useTenantMutateMatching([
     "room-students-",
     "room-detail-",
     "rooms-list",
     "dashboard",
-    "supervision-visits-",
     "timetable-roster-",
   ]);
 

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -382,7 +382,9 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("tenant:supervision-visits-123")
+          (matcher as (key: string) => boolean)(
+            "tenant:active-supervision-dashboard-0",
+          )
         );
       });
       expect(supervisionCall).toBeDefined();
@@ -431,7 +433,9 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("tenant:supervision-visits-123")
+          (matcher as (key: string) => boolean)(
+            "tenant:active-supervision-dashboard-0",
+          )
         );
       });
       expect(supervisionCall).toBeDefined();
@@ -468,15 +472,14 @@ describe("useGlobalSSE", () => {
 
       const mutateCalls = vi.mocked(mutate).mock.calls;
 
-      const touchedSupervisionOrStudent = mutateCalls.some((call) => {
+      const touchedStudentDetail = mutateCalls.some((call) => {
         const matcher = call[0];
         if (typeof matcher !== "function") return false;
-        const fn = matcher as (key: string) => boolean;
-        return (
-          fn("tenant:supervision-visits-123") || fn("tenant:student-detail-42")
+        return (matcher as (key: string) => boolean)(
+          "tenant:student-detail-42",
         );
       });
-      expect(touchedSupervisionOrStudent).toBe(false);
+      expect(touchedStudentDetail).toBe(false);
     });
 
     it("invalidates activity caches on activity_start event", () => {
@@ -553,9 +556,6 @@ describe("useGlobalSSE", () => {
             "tenant:active-supervision-dashboard-0",
           ) &&
           (matcher as (key: string) => boolean)(
-            "tenant:supervision-visits-456",
-          ) &&
-          (matcher as (key: string) => boolean)(
             "tenant:timetable-roster-active-group-456",
           )
         );
@@ -563,11 +563,13 @@ describe("useGlobalSSE", () => {
       expect(activeSupervisionCall).toBeDefined();
 
       const matcher = activeSupervisionCall![0] as (key: string) => boolean;
-      expect(matcher("tenant:supervision-visits-456")).toBe(true);
+      // Per-room visits and tracking ride in the aggregate since #2096 —
+      // the dashboard key stands in for the removed supervision-visits- and
+      // tracking-supervisions- keys.
+      expect(matcher("tenant:active-supervision-dashboard-0")).toBe(true);
       expect(matcher("tenant:timetable-roster-123")).toBe(true);
       expect(matcher("tenant:timetable-roster-active-group-456")).toBe(true);
       expect(matcher("tenant:room-detail-12")).toBe(true);
-      expect(matcher("tenant:tracking-supervisions-1")).toBe(true);
       expect(matcher("tenant:tracking-indicators-search")).toBe(true);
       // #2057: no bare "dashboard" substring any more — dashboard-analytics
       // is covered by the count-dashboard block, and the substring dragged
@@ -789,7 +791,6 @@ describe("useGlobalSSE", () => {
       });
       expect(listCall).toBeDefined();
       const listMatcher = listCall![0] as (key: string) => boolean;
-      expect(listMatcher("my-tenant:tracking-supervisions-1-42,43")).toBe(true);
       expect(listMatcher("my-tenant:tracking-indicators-search-group1")).toBe(
         true,
       );
@@ -1129,13 +1130,15 @@ describe("useGlobalSSE", () => {
         const matcher = call[0];
         return (
           typeof matcher === "function" &&
-          (matcher as (key: string) => boolean)("arrival-supervisions-X")
+          (matcher as (key: string) => boolean)("tenant:arrival-data-42")
         );
       });
       expect(arrivalCall).toBeDefined();
 
       const matcher = arrivalCall![0] as (key: string) => boolean;
-      expect(matcher("tenant:arrival-supervisions-1")).toBe(true);
+      // The Aufsicht arrival rows ride in the aggregate since #2096; the
+      // dashboard key is refreshed by the count-dashboard block on the same
+      // event, so this list only carries the remaining arrival caches.
       expect(matcher("tenant:arrival-data-42")).toBe(true);
       expect(matcher("tenant:unrelated-key")).toBe(false);
 
@@ -1234,32 +1237,9 @@ describe("useGlobalSSE", () => {
       consoleSpy.mockRestore();
     });
 
-    it("handles mutate rejection in supervision_visits scope gracefully", async () => {
-      vi.mocked(mutate).mockRejectedValue(new Error("SWR error"));
-      const consoleSpy = vi
-        .spyOn(console, "debug")
-        .mockImplementation(() => undefined);
-
-      renderHook(() => useGlobalSSE());
-
-      const onMessage = vi.mocked(useSSE).mock.calls[0]?.[1]?.onMessage;
-      onMessage?.({
-        type: "student_checkin",
-        active_group_id: "42",
-        data: { student_id: "1" },
-        timestamp: new Date().toISOString(),
-      });
-
-      vi.advanceTimersByTime(500);
-      await vi.runAllTimersAsync();
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "swr_revalidation_failed",
-        expect.objectContaining({ scope: "supervision_visits" }),
-      );
-
-      consoleSpy.mockRestore();
-    });
+    // The former supervision_visits mutate scope was removed with #2096:
+    // per-room visits ride in the aggregated dashboard key, whose rejection
+    // path is covered by the dashboard-scope test.
 
     it("invalidates timetable caches on instance lifecycle events", () => {
       renderHook(() => useGlobalSSE());

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -687,15 +687,12 @@ describe("useGlobalSSE — companion announcements", () => {
     }
   });
 
-  // The two tests below pin the Aktuelle-Aufsicht bulk time caches. Unlike the
-  // OGS group view — whose aggregated ogs-students-{gid} response carries the
-  // pickup times, so any trigger refreshes them together (#2056) — this page
-  // still fetches pickup and arrival under their own keys. Those keys embed
-  // the room's student-id list and disable focus revalidation, so an SSE
-  // invalidation is their ONLY live update path: nothing but a roster change
-  // or Berlin midnight rotates the key on its own.
-  const AUFSICHT_PICKUP_KEY = "t1:pickup-supervisions-2026-07-22-7,8,9";
-  const AUFSICHT_ARRIVAL_KEY = "t1:arrival-supervisions-2026-07-22-7,8,9";
+  // The two tests below pin the Aktuelle-Aufsicht live times. Since #2096
+  // the aggregated active-supervision-dashboard response carries the pickup
+  // and arrival times (like the OGS view's ogs-students-{gid}, #2056), and
+  // the key disables focus revalidation, so an SSE invalidation is its ONLY
+  // pickup-driven live update path.
+  const AUFSICHT_DASHBOARD_KEY = "t1:active-supervision-dashboard-0";
 
   // Fires one event, flushes the burst debounce, and asserts that some matcher
   // handed to mutate() claims each key.
@@ -723,25 +720,23 @@ describe("useGlobalSSE — companion announcements", () => {
     }
   }
 
-  it("refreshes the Aufsicht pickup cache on pickup_schedule_changed", () => {
+  it("refreshes the Aufsicht aggregate on pickup_schedule_changed", () => {
     // A staff Gehzeit write (weekly plan or date exception) emits only this
     // event — see api/students/pickup_schedule_handlers.go. The supervising
     // staff member watching the room is exactly who must see the new time.
     expectEventInvalidates(makeEvent("pickup_schedule_changed", {}), [
-      AUFSICHT_PICKUP_KEY,
+      AUFSICHT_DASHBOARD_KEY,
     ]);
   });
 
-  it("refreshes both Aufsicht time caches on student_updated", () => {
+  it("refreshes the Aufsicht aggregate on student_updated", () => {
     // A parent care exception (submit AND delete) rewrites that day's pickup
     // and arrival override under student_updated alone, and an approved care
     // request rewrites the weekly pickup plan while announcing only
     // student_updated + arrival_schedule_changed. Both writes can target a
-    // child already standing in the room, so neither rotates the roster-keyed
-    // cache key.
+    // child already standing in the room; the aggregate carries the times.
     expectEventInvalidates(makeEvent("student_updated", { student_id: "7" }), [
-      AUFSICHT_PICKUP_KEY,
-      AUFSICHT_ARRIVAL_KEY,
+      AUFSICHT_DASHBOARD_KEY,
     ]);
   });
 

--- a/frontend/src/lib/hooks/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/use-global-sse.test.ts
@@ -740,6 +740,12 @@ describe("useGlobalSSE — companion announcements", () => {
     ]);
   });
 
+  it("refreshes the Aufsicht aggregate on arrival_schedule_changed", () => {
+    expectEventInvalidates(makeEvent("arrival_schedule_changed", {}), [
+      AUFSICHT_DASHBOARD_KEY,
+    ]);
+  });
+
   it("does not revalidate another child whose id merely starts with the event's", () => {
     renderHook(() => useGlobalSSE());
 

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -107,16 +107,16 @@ const STUDENT_SCOPED_KEY_PREFIXES = [
 const OGS_STUDENTS_KEY_PREFIX = "ogs-students-";
 
 // Every cache family that renders a child's resolved PICKUP (Gehzeit) time.
-// "pickup-supervisions-" is the Aktuelle-Aufsicht card row, whose key embeds
-// the room's student-id list — nothing but a roster change or Berlin midnight
-// rotates it, and it disables focus revalidation, so this list is its only
-// live update path.
+// "active-supervision-dashboard-" carries the Aktuelle-Aufsicht pickup rows
+// since #2096 folded them into the aggregate; the key disables focus
+// revalidation, so this list is its only pickup-driven live update path.
+// ("pickup-supervisions-" was the former per-room bulk fetch's key.)
 const PICKUP_TIME_CACHE_KEY_PARTS = [
   "care-plan-day-",
   "care-plan-week-",
   "pickup-data-",
   "student-partial-absences-",
-  "pickup-supervisions-",
+  "active-supervision-dashboard-",
   "student-detail-",
   // A pulled-forward day pickup time auto-excuses the child from later
   // blocks (#2360): the planner list renders the changed attendance plus the
@@ -134,7 +134,6 @@ const PICKUP_TIME_CACHE_KEY_PARTS = [
 // their own, they read it inline from their list responses, which the
 // student-list and ogs-students blocks invalidate on the same event.
 const ARRIVAL_TIME_CACHE_KEY_PARTS = [
-  "arrival-supervisions-",
   "arrival-data-",
   "care-plan-day-",
   "care-plan-week-",
@@ -157,8 +156,6 @@ const STUDENT_UPDATE_CACHE_KEY_PARTS = [
   "care-plan-week-",
   "pickup-data-",
   "arrival-data-",
-  "pickup-supervisions-",
-  "arrival-supervisions-",
   // Parent care-exception submits/deletes announce ONLY student_updated, and
   // a pulled-forward pickup time now rewrites timetable attendance and the
   // early_pickup_time marker (#2360) — same narrow key set as the pickup
@@ -350,21 +347,10 @@ export function useGlobalSSE(): SSEHookState {
       });
     }
 
-    // Invalidate ALL supervision-visits caches for student/dashboard events.
-    // A student checked out of Room A may appear on the Schulhof (catch-all),
-    // so we can't limit to just the source group's cache key.
-    // Zero-topic clients only receive dashboard_counts_changed, so include
-    // that flag to keep their detail views in sync.
-    if (pendingGroupIds.current.size > 0 || hasPendingDashboardEvent.current) {
-      mutate(
-        (key) => typeof key === "string" && key.includes("supervision-visits-"),
-      ).catch((err) => {
-        logger.debug("swr_revalidation_failed", {
-          error: err instanceof Error ? err.message : String(err),
-          scope: "supervision_visits",
-        });
-      });
-    }
+    // Per-room supervision visits ride in the aggregated
+    // active-supervision-dashboard key since #2096 — the count-dashboard
+    // block below covers the same pendingGroupIds/dashboard triggers, so no
+    // separate supervision-visits invalidation exists anymore.
 
     // Invalidate the per-group OGS student lists ("Meine Gruppe"). Scoped
     // (#2057): when every pending count event carried its educational group
@@ -490,7 +476,6 @@ export function useGlobalSSE(): SSEHookState {
         (key) =>
           typeof key === "string" &&
           (key.includes("database-students-list") ||
-            key.includes("tracking-supervisions-") ||
             key.includes("tracking-indicators-") ||
             // Live "Kinder im Raum" view on /rooms/{id}. Cache key shape is
             // "room-students-{roomId}" — see
@@ -698,10 +683,8 @@ export function useGlobalSSE(): SSEHookState {
         (key) =>
           typeof key === "string" &&
           (key.includes("active-supervision-dashboard-") ||
-            key.includes("supervision-visits-") ||
             key.includes("timetable-roster-") ||
             key.includes("room-detail-") ||
-            key.includes("tracking-supervisions-") ||
             key.includes("tracking-indicators-")),
       ).catch((err) => {
         logger.debug("swr_revalidation_failed", {

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -137,6 +137,7 @@ const ARRIVAL_TIME_CACHE_KEY_PARTS = [
   "arrival-data-",
   "care-plan-day-",
   "care-plan-week-",
+  "active-supervision-dashboard-",
 ] as const;
 
 // What a student_updated write can invalidate. It covers both time families on
@@ -156,6 +157,7 @@ const STUDENT_UPDATE_CACHE_KEY_PARTS = [
   "care-plan-week-",
   "pickup-data-",
   "arrival-data-",
+  "active-supervision-dashboard-",
   // Parent care-exception submits/deletes announce ONLY student_updated, and
   // a pulled-forward pickup time now rewrites timetable attendance and the
   // early_pickup_time marker (#2360) — same narrow key set as the pickup

--- a/frontend/src/lib/swr/room-derived-caches.ts
+++ b/frontend/src/lib/swr/room-derived-caches.ts
@@ -39,9 +39,8 @@
  * collisions are harder.
  *
  * Keep this list in sync with the actual SWR keys used in pages. Currently:
- *   - `active-supervision-dashboard-${refreshKey}` — active-supervisions BFF
- *   - `supervision-visits-${roomId}` — active-supervisions per-room visit
- *     refresh
+ *   - `active-supervision-dashboard-${refreshKey}` — active-supervisions
+ *     aggregate (carries the selected session's visits since #2096)
  *   - `ogs-students-${groupId}` — OGS-Groups aggregated live view (#2056;
  *     `ogs-students-auto` on a cold start before a group is selected)
  *   - `search-students-g${groupFilter}-${term}-…` — Students Search list
@@ -50,7 +49,6 @@
  */
 export const ROOM_DERIVED_CACHE_KEY_FRAGMENTS: readonly string[] = [
   "active-supervision-dashboard-",
-  "supervision-visits-",
   "ogs-students-",
   "search-students-",
 ] as const;


### PR DESCRIPTION
Closes #2096.

## Was

Ein aggregierter Go-Endpunkt `GET /api/active/supervision-dashboard?group_id={activeGroupId}` ersetzt den Next-BFF-Fan-out der Seite „Aktuelle Aufsicht“ sowie die separaten Fetches für Besuche, Tracking-Indikatoren, Abholzeiten und Ankunftszeiten.

Die Projektion lädt in einer Tenant-Transaktion:

- beaufsichtigte Sessions inklusive Raumdaten per Bulk-Load
- unbeanspruchte Gruppen
- aktuelle Staff-ID und Bildungsgruppen
- Schulhof-Status und Capabilities
- laufende Sessions und `planned_now`
- Besuche, Tracking-Indikatoren sowie Abhol- und Ankunftszeiten der ausgewählten Session

Der frühere Room-N+1-Load entfällt. Der separate `timetable-roster-{id}`-Request bleibt bestehen, weil er einen eigenen Lebenszyklus hat.

## Fehlervertrag

- Pflicht-Teilloads schlagen den gesamten Request fehl; es gibt keine Silent-Empty-Fallbacks mehr.
- Fehlende `schedules:read`- bzw. `users:read`-Berechtigungen redigieren die jeweiligen Sektionen deterministisch.
- Unbekannte oder fremde `group_id`-Werte liefern `403`.
- Bei einer veralteten Auswahl versucht der Frontend-Fetcher einmalig den Request ohne `group_id`; das Backend löst dann die erste zulässige Session auf.
- Tenant-Isolation und die Minimalprojektion ohne nicht benötigte personenbezogene Felder sind abgesichert.

## Frontend

- Der BFF-Route-Handler ist ein dünner Proxy mit genau einem Backend-Request.
- Der SWR-Key bleibt `active-supervision-dashboard-${refreshKey}`; der bestehende SSE-Invalidierungsvertrag bleibt erhalten.
- `pickup_schedule_changed` und `arrival_schedule_changed` invalidieren nun den Aggregat-Key.
- Die früheren Keys für `supervision-visits-*`, `tracking-supervisions-*`, `pickup-supervisions-*` und `arrival-supervisions-*` sind entfernt.
- Ein Selektions-Reconciler lädt die Projektion bei Sessionwechseln neu, einschließlich Tab-Klick, Schulhof, URL- und localStorage-Restore.
- Bei Ladefehlern zeigt die Seite eine Fehlermeldung statt einer stillschweigend leeren Teilansicht.

## Vorher / Nachher

| | Vorher | Nachher |
|---|---|---|
| Backend-Requests pro Laden | BFF-Fan-out plus Room-N+1 und vier Seiten-Fetches: ca. 15+N | **1 aggregierter Request** |
| Queries pro Request | Über mehrere Tenant-Transaktionen verteilt | **29 Queries im Referenzfall, unabhängig von der Kinderzahl**; Test-Cap 40 |
| Payload | Summe vieler Einzelantworten | **12,9 KB bei 30 Kindern**; Test-Cap 4 KB plus 700 B/Kind |
| Fehlerverhalten | Silent-Empty-Fallbacks und Admin-Fallback | All-or-nothing, mit deterministischer Permission-Redaktion |

Abgesichert durch Aggregations-, Minimalprojektion-, Query-Budget-, Payload-Budget-, Fehlervertrags- und Tenant-Isolationstests sowie die Frontend-Tests für Auswahl, Sessionwechsel, Schulhof und Fehlerbehandlung.

## Nutzer-sichtbare Änderungen

Kein visueller Umbau. Das Verhalten ändert sich an drei Stellen:

1. Fehler beim Laden werden auch Admins als Fehler angezeigt.
2. Eine nicht berechtigte Session führt zu einem Berechtigungshinweis statt zu einer leer wirkenden Ansicht.
3. Änderungen an Abhol- und Ankunftszeiten aktualisieren die Ansicht live; Laden und Sessionwechsel benötigen deutlich weniger Requests.

## Route-Golden

`route_table.golden` enthält die neue Route `GET /api/active/supervision-dashboard`. Bestehende Routen bleiben unverändert.

## Manuelle Prüfung vor dem Merge

- Seite „Aktuelle Aufsicht“ öffnen und Session wechseln.
- Schulhof-Tab öffnen bzw. eine Schulhof-Aufsicht übernehmen.
- Auswahl über URL und localStorage wiederherstellen.
- Abholzeit ändern und prüfen, dass die offene Aufsichtsansicht per SSE aktualisiert wird.
