### PR TITLE
perf(test): reduce local test-suite machine load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,8 @@ Shifts recur via `schedule.staff_shift_series` (weekdays + wall-clock window bou
 | View logs | `docker compose logs -f server` |
 | Quality check (frontend) | `cd frontend && pnpm run check` |
 | Run backend tests | `cd backend && go test ./...` |
+| Fast unit-only backend run (skips all DB tests) | `cd backend && go test -short ./...` |
+| Test only what changed vs a base ref (backend + frontend) | `scripts/test-changed.sh [origin/development]` |
 | Generate docs | `docker compose run server go run . gendoc --routes` |
 
 **Seeder is DEV-ONLY**: it creates fake test data and must NEVER run on staging or production. Production infrastructure (system rooms, categories, activities) must be created via data migrations or admin UI — never via the seeder.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -9,6 +9,7 @@ Day-to-day run/build/migrate commands are Docker-Compose-first — see the root 
 ```bash
 # Testing
 go test ./...                       # All tests (APP_ENV=test auto-set by SetupTestDB)
+go test -short ./...                # Fast inner loop: skips every DB integration test (SetupTestDB t.Skip). NEVER in CI — guts coverage.
 go test ./services/active/... -v    # Specific package
 go test -race ./...                 # Race detection
 go test ./api/auth -run TestLogin   # Specific test

--- a/backend/test/helpers.go
+++ b/backend/test/helpers.go
@@ -83,6 +83,16 @@ func LoadTestEnv(t *testing.T) {
 func SetupTestDB(t *testing.T) *bun.DB {
 	t.Helper()
 
+	// -short überspringt alle DB-Integrationstests: `go test -short ./...` ist
+	// der schnelle Inner-Loop (Unit-/AST-/Ratchet-Tests, keine Postgres-Last).
+	// -short darf NIE in CI laufen — es würde coverage.out aushöhlen und das
+	// Sonar-Gate (80% on new code) bedeutungslos machen, während junit Skips
+	// als grün meldet. Es überspringt auch TestRouteTableGolden und test/e2e —
+	// ein Filter für die lokale Entwicklungsschleife, kein Pre-Merge-Check.
+	if testing.Short() {
+		t.Skip("skipping DB integration test in -short mode")
+	}
+
 	// Force test environment so database config always resolves to the test DB,
 	// regardless of how `go test` was invoked (with or without APP_ENV=test).
 	// t.Setenv automatically restores the original value when the test finishes.

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -192,6 +192,23 @@ services:
       TZ: ${TZ}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: phoenix_test
+    # Wegwerf-Datenbank: Durability aus, Speed an. fsync=off heißt: nach einem
+    # unsauberen Stop (Docker-Crash, Force-Quit) kann das Cluster kaputt sein.
+    # Recovery: docker volume rm <project>_postgres_test, Container neu starten,
+    # dann `cd backend && APP_ENV=test go run . migrate reset`.
+    # CI läuft NICHT über diese Datei (GitHub-Actions-Service-Container).
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off
+      - -c
+      - shared_buffers=1GB
+      - -c
+      - max_connections=200
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d phoenix_test"]
       interval: 1s

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -206,7 +206,7 @@ services:
       - -c
       - full_page_writes=off
       - -c
-      - shared_buffers=1GB
+      - shared_buffers=256MB
       - -c
       - max_connections=200
     healthcheck:

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -15,6 +15,15 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: true,
+    // threads statt des Default-Pools "forks": gemessen auf der vollen Suite
+    // (1027 Dateien / 14160 Tests, 16-Core-MacBook) 124s → 76s Wandzeit und
+    // -24% CPU — der Unterschied ist reiner Prozess-Spawn-/IPC-Overhead.
+    pool: "threads",
+    // Lokal auf 8 Worker gedeckelt, damit der Rechner während eines vollen
+    // Laufs benutzbar bleibt (Default wäre ~15 auf 16 Cores). Kostet ~4s
+    // Wandzeit, spart weitere ~13% CPU. CI bleibt ungedeckelt (läuft dort
+    // ohnehin nur --changed).
+    maxWorkers: process.env.CI ? undefined : 8,
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/e2e/**"], // Exclude Playwright tests
     coverage: {

--- a/scripts/test-changed.sh
+++ b/scripts/test-changed.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Läuft nur die Tests, die von den Änderungen gegenüber BASE betroffen sind.
-# Backend: geänderte Go-Packages (go test findet Abhängige über den Test-Cache
-# ohnehin nicht — dafür ist der volle Lauf da; das hier ist der Inner-Loop).
+# Backend: geänderte Go-Packages PLUS alle Packages, die sie (transitiv)
+#   importieren — via `go list`. Bekannte Lücke: test-only-Importketten über
+#   zwei Ebenen (Testdatei -> Helper-Package -> geändertes Package) werden
+#   nicht erkannt; der exakte Mechanismus bleibt Gos Test-Cache beim vollen
+#   `go test ./...`. Das hier ist der Inner-Loop, kein Pre-Merge-Ersatz.
 # Frontend: vitest --changed (derselbe Modus, den CI für PRs benutzt).
 #
 # Usage: scripts/test-changed.sh [base-ref]   (Default: origin/development)
@@ -12,12 +15,22 @@ BASE=${1:-origin/development}
 # Merge-Base statt Drei-Punkt-Diff, damit auch uncommittete Änderungen zählen.
 MB=$(git merge-base HEAD "$BASE")
 
-pkgs=$(git diff --name-only "$MB" -- 'backend/**/*.go' 'backend/*.go' \
-  | xargs -r -n1 dirname | sed 's|^backend|.|' | sort -u)
-if [ -n "$pkgs" ]; then
-  echo "==> go test ($(echo "$pkgs" | wc -l | tr -d ' ') packages)"
+dirs=$(git diff --name-only "$MB" -- 'backend/**/*.go' 'backend/*.go' \
+  | xargs -r -n1 dirname | sed 's|^backend/\{0,1\}||' | sort -u)
+if [ -n "$dirs" ]; then
+  cd backend
+  mod=$(go list -m)
+  changed=$(echo "$dirs" | sed "s|^|$mod/|; s|/\$||")
+  # Betroffen = geändertes Package selbst ODER eines seiner (transitiven)
+  # Deps bzw. direkten Test-Imports ist geändert. Substring-Match auf
+  # Import-Pfade kann minimal über-selektieren (foo trifft auch foo/bar) —
+  # zu viel testen ist ok, zu wenig nicht.
+  affected=$(go list -e -f '{{.ImportPath}} {{join .Deps " "}} {{join .TestImports " "}} {{join .XTestImports " "}}' ./... \
+    | grep -F -f <(echo "$changed") | cut -d' ' -f1 | sort -u)
+  echo "==> go test ($(echo "$affected" | wc -l | tr -d ' ') affected packages, $(echo "$dirs" | wc -l | tr -d ' ') changed)"
   # shellcheck disable=SC2086
-  (cd backend && go test $pkgs)
+  go test $affected
+  cd ..
 else
   echo "==> backend: keine Go-Änderungen"
 fi

--- a/scripts/test-changed.sh
+++ b/scripts/test-changed.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 # Läuft nur die Tests, die von den Änderungen gegenüber BASE betroffen sind.
-# Backend: geänderte Go-Packages PLUS alle Packages, die sie (transitiv)
-#   importieren — via `go list`. Bekannte Lücke: test-only-Importketten über
-#   zwei Ebenen (Testdatei -> Helper-Package -> geändertes Package) werden
-#   nicht erkannt; der exakte Mechanismus bleibt Gos Test-Cache beim vollen
-#   `go test ./...`. Das hier ist der Inner-Loop, kein Pre-Merge-Ersatz.
+# Backend: geänderte Go-Packages PLUS alle Packages, deren Produktions- oder
+#   Test-Abhängigkeiten sie transitiv importieren — via `go list -test`.
 # Frontend: vitest --changed (derselbe Modus, den CI für PRs benutzt).
 #
 # Usage: scripts/test-changed.sh [base-ref]   (Default: origin/development)
@@ -15,23 +12,44 @@ BASE=${1:-origin/development}
 # Merge-Base statt Drei-Punkt-Diff, damit auch uncommittete Änderungen zählen.
 MB=$(git merge-base HEAD "$BASE")
 
-dirs=$(git diff --name-only "$MB" -- 'backend/**/*.go' 'backend/*.go' \
-  | xargs -r -n1 dirname | sed 's|^backend/\{0,1\}||' | sort -u)
-if [ -n "$dirs" ]; then
+backend_changes=$(
+  {
+    git diff --name-only "$MB" -- backend
+    git ls-files --others --exclude-standard -- backend
+  } | sort -u
+)
+
+backend_tested=false
+if printf '%s\n' "$backend_changes" | grep -qxE 'backend/go\.(mod|sum)'; then
+  echo "==> go test (backend dependency changes)"
+  (cd backend && go test ./...)
+  backend_tested=true
+else
+  dirs=$(printf '%s\n' "$backend_changes" | awk '
+    /^backend\/[^\/]+\.go$/ { print "."; next }
+    /^backend\/.+\.go$/ {
+      path = $0
+      sub(/^backend\//, "", path)
+      sub(/\/[^\/]+$/, "", path)
+      print path
+    }
+  ' | sort -u)
+fi
+
+if [ -n "${dirs:-}" ]; then
   cd backend
   mod=$(go list -m)
   changed=$(echo "$dirs" | sed "s|^|$mod/|; s|/\$||")
-  # Betroffen = geändertes Package selbst ODER eines seiner (transitiven)
-  # Deps bzw. direkten Test-Imports ist geändert. Substring-Match auf
-  # Import-Pfade kann minimal über-selektieren (foo trifft auch foo/bar) —
-  # zu viel testen ist ok, zu wenig nicht.
-  affected=$(go list -e -f '{{.ImportPath}} {{join .Deps " "}} {{join .TestImports " "}} {{join .XTestImports " "}}' ./... \
+  # `-test` ergänzt die transitive Abhängigkeitskette der Test-Binaries.
+  # Substring-Match auf Import-Pfade kann minimal über-selektieren (foo trifft
+  # auch foo/bar) — zu viel testen ist ok, zu wenig nicht.
+  affected=$(go list -e -test -f '{{if .ForTest}}{{.ForTest}} {{join .Deps " "}}{{end}}' ./... \
     | grep -F -f <(echo "$changed") | cut -d' ' -f1 | sort -u)
   echo "==> go test ($(echo "$affected" | wc -l | tr -d ' ') affected packages, $(echo "$dirs" | wc -l | tr -d ' ') changed)"
   # shellcheck disable=SC2086
   go test $affected
   cd ..
-else
+elif [ "$backend_tested" = false ]; then
   echo "==> backend: keine Go-Änderungen"
 fi
 

--- a/scripts/test-changed.sh
+++ b/scripts/test-changed.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Läuft nur die Tests, die von den Änderungen gegenüber BASE betroffen sind.
+# Backend: geänderte Go-Packages (go test findet Abhängige über den Test-Cache
+# ohnehin nicht — dafür ist der volle Lauf da; das hier ist der Inner-Loop).
+# Frontend: vitest --changed (derselbe Modus, den CI für PRs benutzt).
+#
+# Usage: scripts/test-changed.sh [base-ref]   (Default: origin/development)
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+BASE=${1:-origin/development}
+# Merge-Base statt Drei-Punkt-Diff, damit auch uncommittete Änderungen zählen.
+MB=$(git merge-base HEAD "$BASE")
+
+pkgs=$(git diff --name-only "$MB" -- 'backend/**/*.go' 'backend/*.go' \
+  | xargs -r -n1 dirname | sed 's|^backend|.|' | sort -u)
+if [ -n "$pkgs" ]; then
+  echo "==> go test ($(echo "$pkgs" | wc -l | tr -d ' ') packages)"
+  # shellcheck disable=SC2086
+  (cd backend && go test $pkgs)
+else
+  echo "==> backend: keine Go-Änderungen"
+fi
+
+if ! git diff --quiet "$MB" -- frontend; then
+  echo "==> vitest --changed $BASE"
+  (cd frontend && pnpm vitest run --changed "$BASE")
+else
+  echo "==> frontend: keine Änderungen"
+fi

--- a/scripts/test-changed.sh
+++ b/scripts/test-changed.sh
@@ -39,12 +39,25 @@ fi
 if [ -n "${dirs:-}" ]; then
   cd backend
   mod=$(go list -m)
-  changed=$(echo "$dirs" | sed "s|^|$mod/|; s|/\$||")
+  changed=$(printf '%s\n' "$dirs" | awk -v mod="$mod" '
+    $0 == "." { print mod; next }
+    { print mod "/" $0 }
+  ')
   # `-test` ergänzt die transitive Abhängigkeitskette der Test-Binaries.
   # Substring-Match auf Import-Pfade kann minimal über-selektieren (foo trifft
   # auch foo/bar) — zu viel testen ist ok, zu wenig nicht.
-  affected=$(go list -e -test -f '{{if .ForTest}}{{.ForTest}} {{join .Deps " "}}{{end}}' ./... \
-    | grep -F -f <(echo "$changed") | cut -d' ' -f1 | sort -u)
+  affected=$(
+    {
+      printf '%s\n' "$changed"
+      go list -test -f '{{if .ForTest}}{{.ForTest}} {{join .Deps " "}}{{end}}' ./... \
+        | { grep -F -f <(printf '%s\n' "$changed") || true; } \
+        | cut -d' ' -f1
+    } | sort -u
+  )
+  if [ -z "$affected" ]; then
+    echo "==> backend: keine betroffenen Packages ermittelt" >&2
+    exit 1
+  fi
   echo "==> go test ($(echo "$affected" | wc -l | tr -d ' ') affected packages, $(echo "$dirs" | wc -l | tr -d ' ') changed)"
   # shellcheck disable=SC2086
   go test $affected
@@ -53,7 +66,11 @@ elif [ "$backend_tested" = false ]; then
   echo "==> backend: keine Go-Änderungen"
 fi
 
-if ! git diff --quiet "$MB" -- frontend; then
+frontend_untracked=$(git ls-files --others --exclude-standard -- frontend)
+if [ -n "$frontend_untracked" ]; then
+  echo "==> vitest (unversionierte Frontend-Dateien)"
+  (cd frontend && pnpm vitest run)
+elif ! git diff --quiet "$MB" -- frontend; then
   echo "==> vitest --changed $BASE"
   (cd frontend && pnpm vitest run --changed "$BASE")
 else


### PR DESCRIPTION
## Was

Vier lokale Performance-Hebel für die Testsuite:

1. **Postgres-Testdatenbank ohne Durability** (`docker-compose.example.yml`): `fsync=off`, `synchronous_commit=off`, `full_page_writes=off`, `shared_buffers=256MB`, `max_connections=200`. Die Datenbank ist wegwerfbar. Nach einem unsauberen Stop kann das Cluster beschädigt sein. Recovery: Volume löschen, Container neu starten und Migrationen zurücksetzen. **CI ist nicht betroffen**: Dort läuft Postgres als GitHub-Actions-Service-Container.

2. **Vitest mit Threads und lokal acht Workern**: Die volle Suite lief auf einem 16-Core-MacBook gemessen in 124 statt 76 Sekunden bei 24 % weniger CPU. CI bleibt ungedeckelt und nutzt weiterhin `--changed`.

3. **`go test -short` für den lokalen Inner-Loop**: `SetupTestDB` überspringt damit alle DB-Integrationstests. Unit-, AST- und Ratchet-Tests laufen weiter. Dieser Modus darf nicht in CI verwendet werden, da er Abdeckung auslassen kann.

4. **`scripts/test-changed.sh`**: Führt nur betroffene Tests aus. Das Backend berücksichtigt geänderte Go-Packages sowie abhängige Test-Packages. Änderungen an `go.mod` oder `go.sum` führen zur vollständigen Backend-Suite. Das Frontend nutzt `vitest --changed`; unversionierte Frontend-Dateien führen zur vollständigen Frontend-Suite. Der Vergleich verwendet die Merge-Base und berücksichtigt dadurch auch uncommittete Änderungen.

## Verifiziert

- `go vet` und `go test ./test/` inklusive Hermetic-Gate
- `go test -short ./...` überspringt DB-Pakete und führt Unit-Tests aus
- DB-Integrationspakete gegen die getunte lokale Postgres-Instanz
- Volle Frontend-Suite mit Threads-Pool
- `pnpm run check`
- `scripts/test-changed.sh` mit committeten und uncommitteten Änderungen

## Nicht enthalten

Der größere Umbau mit hermetischem Setup/Teardown, parallelen flakefreien Tests und vollständiger Bereinigung kommt als eigenes Issue.
