### PR TITLE
ci: Coverage-Kosten-Experiment – NICHT MERGEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,7 @@ jobs:
           PARENTS_URL: http://parents.localhost:3000
           NEXT_PUBLIC_OPERATOR_HOSTNAME: operator.localhost:3000
           TENANT_DOMAIN: localhost
+        # CI-Kosten-Experiment (#2419): Lauf A = unveränderte Flags (Baseline).
         # Single pass produces junit.xml AND coverage.out. No --rerun-fails:
         # gotestsum reruns overwrite the coverage profile (upstream issue;
         # fix PR unmerged), and flaky tests should fail loudly, not retry.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,8 @@ jobs:
           PARENTS_URL: http://parents.localhost:3000
           NEXT_PUBLIC_OPERATOR_HOSTNAME: operator.localhost:3000
           TENANT_DOMAIN: localhost
-        # CI-Kosten-Experiment (#2419): Lauf A = unveränderte Flags (Baseline).
+        # CI-Kosten-Experiment (#2419): Lauf B = ohne -coverpkg=./...
+        # (Standard-Coverage: jedes Package misst nur sich selbst).
         # Single pass produces junit.xml AND coverage.out. No --rerun-fails:
         # gotestsum reruns overwrite the coverage profile (upstream issue;
         # fix PR unmerged), and flaky tests should fail loudly, not retry.
@@ -138,7 +139,7 @@ jobs:
           go tool gotestsum \
             --format pkgname-and-test-fails \
             --junitfile junit.xml \
-            -- -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+            -- -covermode=atomic -coverprofile=coverage.out ./...
 
       - name: Fix Go coverage paths for SonarCloud
         if: ${{ always() && hashFiles('backend/coverage.out') != '' }}

--- a/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.test.tsx
@@ -1,165 +1,30 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import AdminChangeRequestsPage from "./page";
-import { canReviewChangeRequests } from "~/lib/change-request-access";
-import { useRequirePermission } from "~/lib/hooks/use-require-permission";
-
-const { mockUseSession } = vi.hoisted(() => ({ mockUseSession: vi.fn() }));
-
-// Die Seite liest die Sitzung, seit die Stammdaten-Warteschlangen an
-// users:update hängen und users:absence allein nur die Entschuldigungen
-// freischaltet (#2232). Ohne Provider wirft useSession, also wird es gemockt.
-vi.mock("next-auth/react", () => ({
-  useSession: (): ReturnType<typeof mockUseSession> => mockUseSession(),
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
 }));
 
-vi.mock("~/lib/hooks/use-require-permission", () => ({
-  useRequirePermission: vi.fn(),
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
 }));
 
-vi.mock("~/components/students/master-data-review-list", () => ({
-  MasterDataReviewList: () => <div>master-data-review-list</div>,
+vi.mock("~/lib/tenant-path", () => ({
+  useTenantAwarePath: () => (href: string) => `/test-tenant${href}`,
 }));
 
-vi.mock("~/components/students/care-request-review-list", () => ({
-  CareRequestReviewList: () => <div>care-request-review-list</div>,
-}));
+import AdminChangeRequestsRedirect from "./page";
 
-vi.mock("~/components/students/offering-request-review-list", () => ({
-  OfferingRequestReviewList: () => <div>offering-request-review-list</div>,
-}));
-
-vi.mock("~/components/students/excused-request-review-list", () => ({
-  ExcusedRequestReviewList: () => <div>excused-request-review-list</div>,
-}));
-
-vi.mock("~/components/students/request-history-list", () => ({
-  MasterDataHistoryList: () => <div>master-data-history-list</div>,
-  CareRequestHistoryList: () => <div>care-request-history-list</div>,
-  OfferingRequestHistoryList: () => <div>offering-request-history-list</div>,
-  ExcusedRequestHistoryList: () => <div>excused-request-history-list</div>,
-}));
-
-const mockUseRequirePermission = vi.mocked(useRequirePermission);
-
-/** Sitzung mit den angegebenen Rechten, ohne Admin-Rolle. */
-function sessionWith(permissions: readonly string[]) {
-  return {
-    data: { user: { id: "7", roles: ["user"], permissions } },
-    status: "authenticated" as const,
-  };
-}
-
-describe("AdminChangeRequestsPage", () => {
+// Die Freigabeansicht ist in das Anfragen-Modul umgezogen (#2429); die
+// Alt-Route muss gespeicherte Links tenant-korrekt dorthin weiterleiten.
+describe("AdminChangeRequestsRedirect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseSession.mockReturnValue(sessionWith(["users:update"]));
   });
 
-  it("shows a loading state until the permission check is ready", () => {
-    mockUseRequirePermission.mockReturnValue({
-      isReady: false,
-      isLoading: true,
-    });
+  it("redirects the legacy route to /anfragen with the tenant prefix", () => {
+    render(<AdminChangeRequestsRedirect />);
 
-    render(<AdminChangeRequestsPage />);
-
-    expect(
-      screen.getByLabelText("Änderungsanfragen werden geladen…"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders both review queues once access is ready", () => {
-    mockUseRequirePermission.mockReturnValue({
-      isReady: true,
-      isLoading: false,
-    });
-
-    render(<AdminChangeRequestsPage />);
-
-    expect(
-      screen.getByRole("heading", { name: "Änderungsanfragen" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("master-data-review-list")).toBeInTheDocument();
-    expect(screen.getByText("care-request-review-list")).toBeInTheDocument();
-  });
-
-  it("zeigt einer Person mit users:absence nur die Entschuldigungen", () => {
-    mockUseRequirePermission.mockReturnValue({
-      isReady: true,
-      isLoading: false,
-    });
-    mockUseSession.mockReturnValue(
-      sessionWith(["users:read", "users:absence"]),
-    );
-
-    render(<AdminChangeRequestsPage />);
-
-    expect(screen.getByText("excused-request-review-list")).toBeInTheDocument();
-    expect(screen.queryByText("master-data-review-list")).toBeNull();
-    expect(screen.queryByText("care-request-review-list")).toBeNull();
-    expect(screen.queryByText("offering-request-review-list")).toBeNull();
-  });
-
-  it("tauscht per Historie-Schalter alle vier Sektionen gegen die Historie", () => {
-    mockUseRequirePermission.mockReturnValue({
-      isReady: true,
-      isLoading: false,
-    });
-
-    render(<AdminChangeRequestsPage />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Historie" }));
-
-    expect(screen.getByText("master-data-history-list")).toBeInTheDocument();
-    expect(screen.getByText("care-request-history-list")).toBeInTheDocument();
-    expect(
-      screen.getByText("offering-request-history-list"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("excused-request-history-list"),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("master-data-review-list")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Offen" }));
-    expect(screen.getByText("master-data-review-list")).toBeInTheDocument();
-    expect(screen.queryByText("master-data-history-list")).toBeNull();
-  });
-
-  it("zeigt einer Person mit users:absence in der Historie nur die Entschuldigungen", () => {
-    mockUseRequirePermission.mockReturnValue({
-      isReady: true,
-      isLoading: false,
-    });
-    mockUseSession.mockReturnValue(
-      sessionWith(["users:read", "users:absence"]),
-    );
-
-    render(<AdminChangeRequestsPage />);
-    fireEvent.click(screen.getByRole("button", { name: "Historie" }));
-
-    expect(
-      screen.getByText("excused-request-history-list"),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("master-data-history-list")).toBeNull();
-    expect(screen.queryByText("care-request-history-list")).toBeNull();
-    expect(screen.queryByText("offering-request-history-list")).toBeNull();
-  });
-
-  // Der Zugriff hängt an der geteilten Regel, nicht an einer zweiten
-  // Aufzählung in der Seite: users:update ODER das Paar users:absence +
-  // users:read, genau wie Sidebar, Eltern-Übersicht und Zähler-Badge.
-  it("öffnet die Seite über canReviewChangeRequests", () => {
-    mockUseRequirePermission.mockReturnValue({
-      isReady: true,
-      isLoading: false,
-    });
-
-    render(<AdminChangeRequestsPage />);
-
-    expect(mockUseRequirePermission).toHaveBeenCalledWith(
-      canReviewChangeRequests,
-    );
+    expect(mocks.redirect).toHaveBeenCalledWith("/test-tenant/anfragen");
   });
 });

--- a/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/admin/change-requests/page.tsx
@@ -1,152 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { redirect } from "next/navigation";
 
-import { useSession } from "next-auth/react";
+import { useTenantAwarePath } from "~/lib/tenant-path";
 
-import { CareRequestReviewList } from "~/components/students/care-request-review-list";
-import { ExcusedRequestReviewList } from "~/components/students/excused-request-review-list";
-import { MasterDataReviewList } from "~/components/students/master-data-review-list";
-import { OfferingRequestReviewList } from "~/components/students/offering-request-review-list";
-import {
-  CareRequestHistoryList,
-  ExcusedRequestHistoryList,
-  MasterDataHistoryList,
-  OfferingRequestHistoryList,
-} from "~/components/students/request-history-list";
-import { SegmentedControl } from "~/components/ui/segmented-control";
-import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
-import { SkeletonRegion, ListSkeleton } from "~/components/ui/page-skeletons";
-import {
-  canReviewChangeRequests,
-  canReviewStudentDataRequests,
-} from "~/lib/change-request-access";
-import { useRequirePermission } from "~/lib/hooks/use-require-permission";
-
-export default function AdminChangeRequestsPage() {
-  // Gated on users:update OR das Paar users:absence + users:read (nicht
-  // admin-only), passend zu den Backend-Routen und zur Abwesenheits-Prüfung
-  // dahinter. Der Zugriff steht in canReviewChangeRequests — dieselbe Regel
-  // trägt Sidebar-Eintrag, Eltern-Übersicht und Zähler-Badge. Das Backend
-  // begrenzt jede Warteschlange zusätzlich pro Kind, eine betreuende Person
-  // sieht also nur die Anfragen ihrer Gruppe.
-  const { isReady } = useRequirePermission(canReviewChangeRequests);
-  const { data: session } = useSession();
-  // Only the excused-absence queue accepts users:absence. Whoever holds just
-  // that permission gets a 403 on the three Stammdaten-side queues, so they are
-  // not rendered at all instead of showing three error cards (#2232).
-  const showStudentDataQueues = canReviewStudentDataRequests(session);
-  // "open" shows the four pending queues, "history" the decided requests of
-  // the same four sections. Decided requests used to vanish without a trace,
-  // which read as "no requests arrive anymore" whenever a colleague had
-  // already worked the queue.
-  const [view, setView] = useState<"open" | "history">("open");
-  if (!isReady) {
-    return (
-      <div className="-mt-1.5 w-full">
-        <PageHeaderWithSearch title="Änderungsanfragen" />
-        <SkeletonRegion label="Änderungsanfragen werden geladen…">
-          <ListSkeleton rows={4} avatar={false} />
-        </SkeletonRegion>
-      </div>
-    );
-  }
-
-  // Stacked sections instead of tabs: both queues are short, and tabs
-  // would hide the pending count of the inactive one. Unlike the enrollment
-  // queues, these guardian change requests are not tied to Anmeldung and are
-  // fully reviewable on mobile — so no DesktopOnlyNotice gate here. Each
-  // request renders as a calm card (flex-wrap, mobile-safe), not a bare table.
-  return (
-    <div className="-mt-1.5 w-full">
-      {/* Der Seitentitel steht auf dem Desktop in der Breadcrumb der Kopfzeile.
-          PageHeaderWithSearch blendet seine Überschrift deshalb ab md ein
-          (md:hidden), genau wie auf der Schwesterseite Konto-Anfragen. Ein
-          eigenes h1 hätte den Titel zweimal untereinander gezeigt. */}
-      <PageHeaderWithSearch title="Änderungsanfragen" />
-      <p className="mb-4 max-w-3xl text-sm text-gray-600">
-        {view === "open"
-          ? "Von Eltern eingereichte Änderungen, die eine Freigabe benötigen."
-          : "Bereits entschiedene Anfragen mit Datum, Person und Begründung."}
-      </p>
-      <div className="mb-6">
-        <SegmentedControl
-          items={[
-            { value: "open", label: "Offen" },
-            { value: "history", label: "Historie" },
-          ]}
-          value={view}
-          onChange={setView}
-          ariaLabel="Ansicht wählen"
-        />
-      </div>
-
-      {showStudentDataQueues && (
-        <>
-          <section className="mb-8">
-            <h2 className="text-base font-semibold text-gray-900">
-              Stammdaten
-            </h2>
-            <p className="mt-1 mb-3 text-sm text-gray-600">
-              Anfragen zu Name, Geburtsdatum und erlaubten Abholarten des
-              Kindes. Freigeben übernimmt die Änderung direkt in die Stammdaten.
-            </p>
-            {view === "open" ? (
-              <MasterDataReviewList />
-            ) : (
-              <MasterDataHistoryList />
-            )}
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-base font-semibold text-gray-900">
-              Betreuungszeiten
-            </h2>
-            <p className="mt-1 mb-3 text-sm text-gray-600">
-              Anfragen zu dauerhaften Bring- und Abholzeiten sowie zur Abholart.
-              Freigeben übernimmt die Änderungen direkt in den Wochenplan des
-              Kindes.
-            </p>
-            {view === "open" ? (
-              <CareRequestReviewList />
-            ) : (
-              <CareRequestHistoryList />
-            )}
-          </section>
-
-          <section className="mb-8">
-            <h2 className="text-base font-semibold text-gray-900">
-              Betreuungsangebote und AGs
-            </h2>
-            <p className="mt-1 mb-3 text-sm text-gray-600">
-              Anfragen zu den gebuchten Betreuungsangeboten. Freigeben stellt
-              das Kind zum gewünschten Datum um: Bisheriges endet an diesem Tag,
-              Neues beginnt dann. Vergangene Zeiträume bleiben unverändert.
-            </p>
-            {view === "open" ? (
-              <OfferingRequestReviewList />
-            ) : (
-              <OfferingRequestHistoryList />
-            )}
-          </section>
-        </>
-      )}
-
-      <section>
-        <h2 className="text-base font-semibold text-gray-900">
-          Entschuldigte Abmeldungen
-        </h2>
-        <p className="mt-1 mb-3 text-sm text-gray-600">
-          Von Eltern gemeldete entschuldigte Abwesenheiten, die eine Bestätigung
-          benötigen. Das Kind bleibt bis zur Freigabe eingeplant. Freigeben
-          meldet das Kind für die gemeldeten Tage ab.
-        </p>
-        {view === "open" ? (
-          <ExcusedRequestReviewList />
-        ) : (
-          <ExcusedRequestHistoryList />
-        )}
-      </section>
-    </div>
-  );
+/**
+ * Alt-Route der Freigabeansicht für Elternanfragen. Der Inhalt lebt seit
+ * #2429 im Anfragen-Modul (/anfragen, Reiter "Eltern"); gespeicherte Links
+ * und Gewohnheiten landen hier und werden weitergeleitet. Der History-Eintrag
+ * wird ersetzt, damit "Zurück" nicht in einer Redirect-Schleife endet.
+ */
+export default function AdminChangeRequestsRedirect() {
+  const tenantPath = useTenantAwarePath();
+  return redirect(tenantPath("/anfragen"));
 }

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AnfragenPage from "./page";
+import { canOpenRequestsPage } from "~/lib/change-request-access";
+import { useRequirePermission } from "~/lib/hooks/use-require-permission";
+
+const { mockUseSession } = vi.hoisted(() => ({ mockUseSession: vi.fn() }));
+
+vi.mock("next-auth/react", () => ({
+  useSession: (): ReturnType<typeof mockUseSession> => mockUseSession(),
+}));
+
+vi.mock("~/lib/hooks/use-require-permission", () => ({
+  useRequirePermission: vi.fn(),
+}));
+
+vi.mock("~/components/students/master-data-review-list", () => ({
+  MasterDataReviewList: () => <div>master-data-review-list</div>,
+}));
+
+vi.mock("~/components/students/care-request-review-list", () => ({
+  CareRequestReviewList: () => <div>care-request-review-list</div>,
+}));
+
+vi.mock("~/components/students/offering-request-review-list", () => ({
+  OfferingRequestReviewList: () => <div>offering-request-review-list</div>,
+}));
+
+vi.mock("~/components/students/excused-request-review-list", () => ({
+  ExcusedRequestReviewList: () => <div>excused-request-review-list</div>,
+}));
+
+vi.mock("~/components/students/request-history-list", () => ({
+  MasterDataHistoryList: () => <div>master-data-history-list</div>,
+  CareRequestHistoryList: () => <div>care-request-history-list</div>,
+  OfferingRequestHistoryList: () => <div>offering-request-history-list</div>,
+  ExcusedRequestHistoryList: () => <div>excused-request-history-list</div>,
+}));
+
+// NavigationTabs beobachtet seine Scroll-Breite; jsdom kennt ResizeObserver
+// nicht (gleiches Muster wie die Master-Detail-Tests).
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+const mockUseRequirePermission = vi.mocked(useRequirePermission);
+
+/** Sitzung mit den angegebenen Rechten, ohne Admin-Rolle. */
+function sessionWith(permissions: readonly string[]) {
+  return {
+    data: { user: { id: "7", roles: ["user"], permissions } },
+    status: "authenticated" as const,
+  };
+}
+
+const PLACEHOLDER_TITLE = "Anträge von Mitarbeitenden ziehen bald hierhin um";
+
+describe("AnfragenPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRequirePermission.mockReturnValue({
+      isReady: true,
+      isLoading: false,
+    });
+    mockUseSession.mockReturnValue(sessionWith(["users:update"]));
+  });
+
+  it("shows a loading state until the permission check is ready", () => {
+    mockUseRequirePermission.mockReturnValue({
+      isReady: false,
+      isLoading: true,
+    });
+
+    render(<AnfragenPage />);
+
+    expect(
+      screen.getByLabelText("Anfragen werden geladen…"),
+    ).toBeInTheDocument();
+  });
+
+  // Der Zugriff hängt an der geteilten Regel, nicht an einer zweiten
+  // Aufzählung in der Seite — dieselbe Regel tragen Sidebar-Eintrag, mobile
+  // Navigation und Zähler-Badge.
+  it("öffnet die Seite über canOpenRequestsPage", () => {
+    render(<AnfragenPage />);
+
+    expect(mockUseRequirePermission).toHaveBeenCalledWith(canOpenRequestsPage);
+  });
+
+  it("renders both review queues once access is ready", () => {
+    render(<AnfragenPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Anfragen" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("master-data-review-list")).toBeInTheDocument();
+    expect(screen.getByText("care-request-review-list")).toBeInTheDocument();
+  });
+
+  it("zeigt einer Person mit users:absence nur die Entschuldigungen", () => {
+    mockUseSession.mockReturnValue(
+      sessionWith(["users:read", "users:absence"]),
+    );
+
+    render(<AnfragenPage />);
+
+    expect(screen.getByText("excused-request-review-list")).toBeInTheDocument();
+    expect(screen.queryByText("master-data-review-list")).toBeNull();
+    expect(screen.queryByText("care-request-review-list")).toBeNull();
+    expect(screen.queryByText("offering-request-review-list")).toBeNull();
+  });
+
+  it("tauscht per Historie-Schalter alle vier Sektionen gegen die Historie", () => {
+    render(<AnfragenPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Historie" }));
+
+    expect(screen.getByText("master-data-history-list")).toBeInTheDocument();
+    expect(screen.getByText("care-request-history-list")).toBeInTheDocument();
+    expect(
+      screen.getByText("offering-request-history-list"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("excused-request-history-list"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("master-data-review-list")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Offen" }));
+    expect(screen.getByText("master-data-review-list")).toBeInTheDocument();
+    expect(screen.queryByText("master-data-history-list")).toBeNull();
+  });
+
+  // Reiter-Sichtbarkeit nach Berechtigung (#2429): der Mitarbeitende-Reiter
+  // hängt an vacation:approve, der Eltern-Reiter an canReviewChangeRequests.
+  it("versteckt den Mitarbeitende-Reiter ohne vacation:approve", () => {
+    render(<AnfragenPage />);
+
+    expect(screen.queryByRole("button", { name: "Mitarbeitende" })).toBeNull();
+    expect(screen.queryByText(PLACEHOLDER_TITLE)).toBeNull();
+  });
+
+  it("zeigt mit vacation:approve beide Reiter und wechselt zum Platzhalter", () => {
+    mockUseSession.mockReturnValue(
+      sessionWith(["users:update", "vacation:approve"]),
+    );
+
+    render(<AnfragenPage />);
+
+    // Eltern-Reiter ist voreingestellt aktiv.
+    expect(screen.getByText("master-data-review-list")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mitarbeitende" }));
+
+    expect(screen.getByText(PLACEHOLDER_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText("master-data-review-list")).toBeNull();
+  });
+
+  it("zeigt mit nur vacation:approve den Platzhalter ohne Reiterleiste", () => {
+    mockUseSession.mockReturnValue(sessionWith(["vacation:approve"]));
+
+    render(<AnfragenPage />);
+
+    expect(screen.getByText(PLACEHOLDER_TITLE)).toBeInTheDocument();
+    // Nur ein sichtbarer Reiter → keine Reiterleiste, kein Eltern-Inhalt.
+    expect(screen.queryByRole("button", { name: "Eltern" })).toBeNull();
+    expect(screen.queryByText("excused-request-review-list")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Historie" })).toBeNull();
+  });
+
+  it("zeigt Admins beide Reiter", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "1", roles: ["admin"], permissions: ["admin:*"] } },
+      status: "authenticated" as const,
+    });
+
+    render(<AnfragenPage />);
+
+    expect(
+      screen.getByRole("button", { name: "Mitarbeitende" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("master-data-review-list")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { useSession } from "next-auth/react";
+import { TrayIcon } from "@phosphor-icons/react/ssr";
+
+import { CareRequestReviewList } from "~/components/students/care-request-review-list";
+import { ExcusedRequestReviewList } from "~/components/students/excused-request-review-list";
+import { MasterDataReviewList } from "~/components/students/master-data-review-list";
+import { OfferingRequestReviewList } from "~/components/students/offering-request-review-list";
+import {
+  CareRequestHistoryList,
+  ExcusedRequestHistoryList,
+  MasterDataHistoryList,
+  OfferingRequestHistoryList,
+} from "~/components/students/request-history-list";
+import { EmptyState } from "~/components/ui/empty-state";
+import { SegmentedControl } from "~/components/ui/segmented-control";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
+import { SkeletonRegion, ListSkeleton } from "~/components/ui/page-skeletons";
+import {
+  canOpenRequestsPage,
+  canReviewChangeRequests,
+  canReviewStaffAbsenceRequests,
+  canReviewStudentDataRequests,
+} from "~/lib/change-request-access";
+import { useRequirePermission } from "~/lib/hooks/use-require-permission";
+
+type AnfragenTabId = "eltern" | "mitarbeitende";
+
+/**
+ * Anfragen-Modul (#2429): ein Ort für alle eingereichten Wünsche, mit Reitern
+ * nach Herkunft. Der Eltern-Reiter ist die unverändert umgezogene
+ * Freigabeansicht (vorher /admin/change-requests); der Mitarbeitende-Reiter
+ * ist bis zum Aggregator-Umbau ein Platzhalter und erscheint nur mit
+ * Freigaberecht für Abwesenheiten (vacation:approve).
+ */
+export default function AnfragenPage() {
+  // Die Seite öffnet, wer mindestens einen Reiter sehen darf. Die Regeln
+  // stehen in change-request-access — dieselben tragen Sidebar-Eintrag,
+  // mobile Navigation und Zähler-Badge.
+  const { isReady } = useRequirePermission(canOpenRequestsPage);
+  const { data: session } = useSession();
+
+  const showElternTab = canReviewChangeRequests(session);
+  const showMitarbeitendeTab = canReviewStaffAbsenceRequests(session);
+
+  // Reiter erscheinen nur mit passender Berechtigung; wer nur einen sehen
+  // darf, bekommt keine Reiterleiste mit einem einzelnen Eintrag.
+  const visibleTabs = useMemo(() => {
+    const tabs: { id: AnfragenTabId; label: string }[] = [];
+    if (showElternTab) tabs.push({ id: "eltern", label: "Eltern" });
+    if (showMitarbeitendeTab)
+      tabs.push({ id: "mitarbeitende", label: "Mitarbeitende" });
+    return tabs;
+  }, [showElternTab, showMitarbeitendeTab]);
+
+  const [selectedTab, setSelectedTab] = useState<AnfragenTabId>("eltern");
+  // Fällt die Auswahl aus den sichtbaren Reitern (z. B. Session noch am
+  // Laden), gilt der erste sichtbare — so flackert nie ein leerer Inhalt.
+  const activeTab = visibleTabs.some((tab) => tab.id === selectedTab)
+    ? selectedTab
+    : (visibleTabs[0]?.id ?? "eltern");
+
+  if (!isReady) {
+    return (
+      <div className="-mt-1.5 w-full">
+        <PageHeaderWithSearch title="Anfragen" />
+        <SkeletonRegion label="Anfragen werden geladen…">
+          <ListSkeleton rows={4} avatar={false} />
+        </SkeletonRegion>
+      </div>
+    );
+  }
+
+  return (
+    <div className="-mt-1.5 w-full">
+      {/* Der Seitentitel steht auf dem Desktop in der Breadcrumb der
+          Kopfzeile; PageHeaderWithSearch blendet seine Überschrift ab md aus
+          (md:hidden), wie auf der vorherigen Freigabeansicht. */}
+      <PageHeaderWithSearch
+        title="Anfragen"
+        tabs={
+          visibleTabs.length > 1
+            ? {
+                items: visibleTabs,
+                activeTab,
+                onTabChange: (tabId) => setSelectedTab(tabId as AnfragenTabId),
+              }
+            : undefined
+        }
+      />
+      {activeTab === "mitarbeitende" ? (
+        <MitarbeitendeTab />
+      ) : (
+        <ElternTab session={session} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Die bisherige Freigabeansicht der Elternanfragen — vier Abschnitte plus
+ * Umschalter Offen | Historie, funktional unverändert übernommen (#2429).
+ */
+function ElternTab({
+  session,
+}: {
+  readonly session: ReturnType<typeof useSession>["data"];
+}) {
+  // Only the excused-absence queue accepts users:absence. Whoever holds just
+  // that permission gets a 403 on the three Stammdaten-side queues, so they are
+  // not rendered at all instead of showing three error cards (#2232).
+  const showStudentDataQueues = canReviewStudentDataRequests(session);
+  // "open" shows the four pending queues, "history" the decided requests of
+  // the same four sections. Decided requests used to vanish without a trace,
+  // which read as "no requests arrive anymore" whenever a colleague had
+  // already worked the queue.
+  const [view, setView] = useState<"open" | "history">("open");
+
+  // Stacked sections instead of tabs: both queues are short, and tabs
+  // would hide the pending count of the inactive one. Unlike the enrollment
+  // queues, these guardian change requests are not tied to Anmeldung and are
+  // fully reviewable on mobile — so no DesktopOnlyNotice gate here. Each
+  // request renders as a calm card (flex-wrap, mobile-safe), not a bare table.
+  return (
+    <div className="w-full">
+      <p className="mb-4 max-w-3xl text-sm text-gray-600">
+        {view === "open"
+          ? "Von Eltern eingereichte Änderungen, die eine Freigabe benötigen."
+          : "Bereits entschiedene Anfragen mit Datum, Person und Begründung."}
+      </p>
+      <div className="mb-6">
+        <SegmentedControl
+          items={[
+            { value: "open", label: "Offen" },
+            { value: "history", label: "Historie" },
+          ]}
+          value={view}
+          onChange={setView}
+          ariaLabel="Ansicht wählen"
+        />
+      </div>
+
+      {showStudentDataQueues && (
+        <>
+          <section className="mb-8">
+            <h2 className="text-base font-semibold text-gray-900">
+              Stammdaten
+            </h2>
+            <p className="mt-1 mb-3 text-sm text-gray-600">
+              Anfragen zu Name, Geburtsdatum und erlaubten Abholarten des
+              Kindes. Freigeben übernimmt die Änderung direkt in die Stammdaten.
+            </p>
+            {view === "open" ? (
+              <MasterDataReviewList />
+            ) : (
+              <MasterDataHistoryList />
+            )}
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-base font-semibold text-gray-900">
+              Betreuungszeiten
+            </h2>
+            <p className="mt-1 mb-3 text-sm text-gray-600">
+              Anfragen zu dauerhaften Bring- und Abholzeiten sowie zur Abholart.
+              Freigeben übernimmt die Änderungen direkt in den Wochenplan des
+              Kindes.
+            </p>
+            {view === "open" ? (
+              <CareRequestReviewList />
+            ) : (
+              <CareRequestHistoryList />
+            )}
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-base font-semibold text-gray-900">
+              Betreuungsangebote und AGs
+            </h2>
+            <p className="mt-1 mb-3 text-sm text-gray-600">
+              Anfragen zu den gebuchten Betreuungsangeboten. Freigeben stellt
+              das Kind zum gewünschten Datum um: Bisheriges endet an diesem Tag,
+              Neues beginnt dann. Vergangene Zeiträume bleiben unverändert.
+            </p>
+            {view === "open" ? (
+              <OfferingRequestReviewList />
+            ) : (
+              <OfferingRequestHistoryList />
+            )}
+          </section>
+        </>
+      )}
+
+      <section>
+        <h2 className="text-base font-semibold text-gray-900">
+          Entschuldigte Abmeldungen
+        </h2>
+        <p className="mt-1 mb-3 text-sm text-gray-600">
+          Von Eltern gemeldete entschuldigte Abwesenheiten, die eine Bestätigung
+          benötigen. Das Kind bleibt bis zur Freigabe eingeplant. Freigeben
+          meldet das Kind für die gemeldeten Tage ab.
+        </p>
+        {view === "open" ? (
+          <ExcusedRequestReviewList />
+        ) : (
+          <ExcusedRequestHistoryList />
+        )}
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Platzhalter, bis die Abwesenheitsanträge der Mitarbeitenden hierher
+ * umziehen (Folge-Ticket zum Anfragen-Umbau). Sichtbar nur mit
+ * vacation:approve.
+ */
+function MitarbeitendeTab() {
+  return (
+    <EmptyState
+      icon={<TrayIcon size={48} aria-hidden="true" />}
+      title="Anträge von Mitarbeitenden ziehen bald hierhin um"
+      description="Urlaubs-, Krank- und Fortbildungsanträge entscheiden Sie bis dahin wie gewohnt auf der Seite Mitarbeiter."
+    />
+  );
+}

--- a/frontend/src/app/[tenant]/(protected)/eltern/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/eltern/page.tsx
@@ -11,7 +11,6 @@ import {
 } from "~/components/ui/page-skeletons";
 import { useIsMobile } from "~/components/ui/hooks/useIsMobile";
 import { hasPermission, hasRole } from "~/lib/auth-utils";
-import { canReviewChangeRequests } from "~/lib/change-request-access";
 import { useSettingsSchema } from "~/lib/hooks/use-settings-schema";
 import { getSettingValue } from "~/lib/settings-api";
 import { useTenantAwarePath } from "~/lib/tenant-path";
@@ -74,14 +73,8 @@ function ElternContent() {
       points: ["Neue Anfragen prüfen", "Konten bestätigen"],
       show: userIsAdmin,
     },
-    {
-      href: "/admin/change-requests",
-      title: "Änderungsanfragen",
-      body: "Wünsche der Eltern zu Betreuungszeiten und Stammdaten bearbeiten.",
-      concept: "changeHistory",
-      points: ["Betreuungszeiten anpassen", "Stammdaten aktualisieren"],
-      show: canReviewChangeRequests(session),
-    },
+    // Die Elternanfragen-Kachel ist entfallen: die Freigabeansicht lebt seit
+    // #2429 im Top-Level-Modul "Anfragen" (eigener Sidebar-Eintrag).
     {
       href: "/parent-announcements",
       title: "Elternmitteilungen",
@@ -117,7 +110,7 @@ function ElternContent() {
           </p>
           <p className="mt-3 text-base leading-7 text-gray-600">
             Alles rund um die Kommunikation mit den Eltern an einem Ort.
-            Nachrichten, Anfragen, Mitteilungen und der Essensplan.
+            Nachrichten, Konto-Anfragen, Mitteilungen und der Essensplan.
           </p>
         </div>
 

--- a/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/messages/[threadId]/page.tsx
@@ -330,8 +330,7 @@ function MessageThreadContent() {
                         canReviewRequests && requestStillOpen(message)
                           ? {
                               label: "Anfrage bearbeiten",
-                              onClick: () =>
-                                router.push("/admin/change-requests"),
+                              onClick: () => router.push("/anfragen"),
                             }
                           : undefined
                       }

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.test.ts
@@ -176,9 +176,10 @@ describe("breadcrumb-utils", () => {
         expect(getPageTitle("/admin/guardian-approvals")).toBe(
           "Konto-Anfragen",
         );
-        expect(getPageTitle("/admin/change-requests")).toBe(
-          "Änderungsanfragen",
-        );
+        // Alt-Route der Freigabeansicht: nur noch ein Redirect-Frame auf
+        // /anfragen (#2429); der Titel verhindert den "Home"-Blitzer.
+        expect(getPageTitle("/admin/change-requests")).toBe("Anfragen");
+        expect(getPageTitle("/anfragen")).toBe("Anfragen");
       });
 
       it("should return titles for recent staff navigation entries", () => {
@@ -449,9 +450,9 @@ describe("breadcrumb-utils", () => {
           sectionHref: "/eltern",
           pageLabel: "Konto-Anfragen",
         });
-        expect(getSectionBreadcrumb("/admin/change-requests")?.pageLabel).toBe(
-          "Änderungsanfragen",
-        );
+        // /admin/change-requests ist kein Eltern-Katalogeintrag mehr — nur
+        // noch ein Redirect auf das Top-Level-Modul /anfragen (#2429).
+        expect(getSectionBreadcrumb("/admin/change-requests")).toBeNull();
         expect(getSectionBreadcrumb("/parent-announcements")?.pageLabel).toBe(
           "Mitteilungen und Umfragen",
         );

--- a/frontend/src/components/dashboard/header/breadcrumb-utils.ts
+++ b/frontend/src/components/dashboard/header/breadcrumb-utils.ts
@@ -67,6 +67,10 @@ const mainRoutes: Record<string, string> = {
   // einen Eintrag, damit während des Client-Redirects kein falscher Titel
   // aufblitzt.
   "/planung": PLANNING_SECTION.label,
+  // Alt-Route der Freigabeansicht; nur noch ein Redirect-Frame auf /anfragen
+  // (#2429). Der Eintrag verhindert, dass während des Client-Redirects kurz
+  // "Home" aufblitzt.
+  "/admin/change-requests": STAFF_FLAT_PAGES.anfragen.label,
   // Die Sektions-Hubs; ihre Unterseiten kommen aus den Katalogen.
   [DATABASE_SECTION.href]: DATABASE_SECTION.label,
   [PARENT_SECTION.href]: PARENT_SECTION.label,

--- a/frontend/src/components/dashboard/mobile-bottom-nav.tsx
+++ b/frontend/src/components/dashboard/mobile-bottom-nav.tsx
@@ -20,6 +20,7 @@ import {
   isCaregiver,
   isLehrkraftOnly,
 } from "~/lib/auth-utils";
+import { canOpenRequestsPage } from "~/lib/change-request-access";
 import { navigationIcons } from "~/lib/navigation-icons";
 import { MOTO_CONCEPTS, type MotoConceptKey } from "~/lib/moto-concepts";
 import { MotoDuotoneIcon } from "~/components/ui/moto-duotone-icon";
@@ -367,6 +368,15 @@ const additionalNavItems: AdditionalNavItem[] = [
     alwaysShow: true,
   },
   {
+    // Anfragen-Modul (#2429). Gating unten in filteredAdditionalItems über
+    // canOpenRequestsPage: requiresPermission kann das
+    // users:absence+users:read-Paar nicht ausdrücken.
+    href: "/anfragen",
+    label: "Anfragen",
+    iconKey: "tray",
+    concept: "requests",
+  },
+  {
     href: "/calendar",
     label: "Mein Kalender",
     iconKey: "calendar",
@@ -675,6 +685,9 @@ export function MobileBottomNav({ className = "" }: MobileBottomNavProps) {
     // Dual-Role-Lehrkraft (#1772): Klassenansicht über das Overflow-Menü,
     // die Haupt-Nav bleibt die Staff-/Admin-Leiste.
     if (item.href === "/klassen") return hasRole(session, "lehrkraft");
+    // Anfragen (#2429): geteilte Regel für beide Reiter, siehe
+    // change-request-access.
+    if (item.href === "/anfragen") return canOpenRequestsPage(session);
     // Hide items marked as hideForAdmin for admin users
     if (item.hideForAdmin && userIsAdmin && !userIsCaregiver) {
       return false;

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -25,7 +25,7 @@ import {
   isCaregiver,
   isLehrkraftOnly,
 } from "~/lib/auth-utils";
-import { canReviewChangeRequests } from "~/lib/change-request-access";
+import { canOpenRequestsPage } from "~/lib/change-request-access";
 import { operatorPath } from "~/lib/operator-url";
 import { useSidebarAccordion } from "~/lib/hooks/use-sidebar-accordion";
 import { useLocalStorageValue } from "~/lib/hooks/use-local-storage-value";
@@ -171,6 +171,17 @@ const NAV_ITEMS: NavItem[] = [
     icon: "M9 12h6m-6 4h6M9 8h6M5 21h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2zM9 3v2m6-2v2",
     activeColor: "text-moto-green",
     requiresPermission: "users:read",
+  },
+  {
+    // Anfragen-Modul (#2429): eingereichte Wünsche von Eltern und
+    // Mitarbeitenden an einem Ort. Sichtbarkeit hängt an zwei getrennten
+    // Rechte-Regeln (Eltern-Reiter bzw. Mitarbeitende-Reiter) — Gating unten
+    // in filteredNavItems über canOpenRequestsPage, weil requiresPermission
+    // das users:absence+users:read-Paar nicht ausdrücken kann.
+    ...STAFF_FLAT_PAGES.anfragen,
+    icon: navigationIcons.tray,
+    concept: "requests",
+    activeColor: "text-moto-blue",
   },
   {
     href: "#",
@@ -533,10 +544,6 @@ function SidebarContent({ className = "" }: SidebarProps) {
             return true;
           case "approvals":
             return userIsAdmin;
-          case "changeRequests":
-            // users:absence alone opens the page too — it carries the excused
-            // absence queue, which that permission decides (#2232).
-            return canReviewChangeRequests(session);
           case "announcements":
             return canAnnounce && parentNewsEnabled;
           case "mealPlan":
@@ -549,14 +556,9 @@ function SidebarContent({ className = "" }: SidebarProps) {
     [userIsAdmin, session, canAnnounce, parentNewsEnabled, mealPlanEnabled],
   );
 
-  // Aggregate Eltern badge: unread messages plus pending change requests when
-  // the corresponding sub-page is visible.
-  const parentShowsChangeRequests = parentSubPages.some(
-    (page) => page.feature === "changeRequests",
-  );
-  const parentSectionBadgeCount =
-    messagesUnreadCount +
-    (parentShowsChangeRequests ? changeRequestsPendingCount : 0);
+  // Eltern badge: unread messages. Die Elternanfragen zählen seit #2429 am
+  // Top-Level-Eintrag "Anfragen", nicht mehr hier.
+  const parentSectionBadgeCount = messagesUnreadCount;
 
   // Filter flat navigation items based on permissions
   const filteredNavItems = NAV_ITEMS.filter((item) => {
@@ -564,6 +566,10 @@ function SidebarContent({ className = "" }: SidebarProps) {
     // matches class_day:read, but admins have no class assignments and the
     // page would render empty for them.
     if (item.href === "/klassen") return userIsLehrkraft;
+    // Anfragen (#2429): zwei Reiter mit getrennten Rechten. Die geteilte Regel
+    // deckt users:update, das Paar users:absence+users:read und
+    // vacation:approve ab — als requiresPermission nicht ausdrückbar.
+    if (item.href === "/anfragen") return canOpenRequestsPage(session);
     if (item.hideForAdmin && userIsAdmin && !userIsCaregiver) return false;
     if (!nfcEnabled && NFC_ONLY_HREFS.has(item.href)) return false;
     if (isBinaryMode && BINARY_HIDDEN_HREFS.has(item.href)) return false;
@@ -784,6 +790,14 @@ function SidebarContent({ className = "" }: SidebarProps) {
               <UnreadBadge
                 count={suggestionsUnreadCount}
                 tone="feedback"
+                className="ml-2"
+              />
+            )}
+            {item.href === "/anfragen" && (
+              <NotificationBadge
+                count={changeRequestsPendingCount}
+                tone="staff"
+                ariaLabel={`${changeRequestsPendingCount} ${changeRequestsPendingCount === 1 ? "offene Anfrage" : "offene Anfragen"}`}
                 className="ml-2"
               />
             )}
@@ -1229,8 +1243,10 @@ function SidebarContent({ className = "" }: SidebarProps) {
             renderNavItem(substitutionsItem)}
 
           {/* Eltern accordion — bundles the parent-communication surfaces
-              (Nachrichten, Anfragen, Mitteilungen, Essensplan) behind an
-              overview hub. Shown to all staff; sub-items are gated per item. */}
+              (Nachrichten, Konto-Anfragen, Mitteilungen, Essensplan) behind an
+              overview hub. Shown to all staff; sub-items are gated per item.
+              Die Elternanfragen leben seit #2429 im Top-Level-Modul
+              "Anfragen". */}
           <SidebarAccordionSection
             icon={navigationIcons.parents}
             concept="parents"
@@ -1258,11 +1274,7 @@ function SidebarContent({ className = "" }: SidebarProps) {
                 label={page.label}
                 isActive={activeParentSubPageHref === page.href}
                 badgeCount={
-                  page.feature === "messages"
-                    ? messagesUnreadCount
-                    : page.feature === "changeRequests"
-                      ? changeRequestsPendingCount
-                      : 0
+                  page.feature === "messages" ? messagesUnreadCount : 0
                 }
               />
             ))}

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -619,7 +619,7 @@ export const appChapters: readonly GuideChapter[] = [
         ],
         callout: {
           title: "Abmeldungen von Eltern",
-          body: "Wenn das Elternportal aktiv ist, können Eltern ihr Kind selbst abmelden – wahlweise als `Krank` oder als `Entschuldigt` (z. B. wegen eines Termins), auch für Tage in der Zukunft. Bei einer entschuldigten Abmeldung ist eine kurze Begründung Pflicht. Eine Krankmeldung erscheint sofort wie eine des Teams (das Kind wird als krank angezeigt). Eine entschuldigte Abmeldung wird standardmäßig ebenfalls sofort eingetragen; Sie können in den `Einstellungen` im Bereich `Elternportal` aber festlegen, dass entschuldigte Abmeldungen erst vom Team bestätigt werden müssen. Bis zur Bestätigung gilt das Kind als erwartet, und die Anfrage erscheint unter `Eltern` > `Änderungsanfragen`.",
+          body: "Wenn das Elternportal aktiv ist, können Eltern ihr Kind selbst abmelden – wahlweise als `Krank` oder als `Entschuldigt` (z. B. wegen eines Termins), auch für Tage in der Zukunft. Bei einer entschuldigten Abmeldung ist eine kurze Begründung Pflicht. Eine Krankmeldung erscheint sofort wie eine des Teams (das Kind wird als krank angezeigt). Eine entschuldigte Abmeldung wird standardmäßig ebenfalls sofort eingetragen; Sie können in den `Einstellungen` im Bereich `Elternportal` aber festlegen, dass entschuldigte Abmeldungen erst vom Team bestätigt werden müssen. Bis zur Bestätigung gilt das Kind als erwartet, und die Anfrage erscheint in der Seitenleiste unter `Anfragen` im Reiter `Eltern`.",
           tone: "blue",
         },
         screenshot:
@@ -671,7 +671,7 @@ export const appChapters: readonly GuideChapter[] = [
       },
       {
         id: "stammdaten-aenderungen-pruefen",
-        title: "Änderungsanfragen der Eltern prüfen",
+        title: "Anfragen der Eltern prüfen",
         icon: ClipboardCheck,
         summary:
           "Eltern pflegen viele Stammdaten ihres Kindes im Elternportal selbst. Sensible Angaben (Name, Geburtsdatum, Gehzeiten), die dauerhaften Betreuungszeiten und die gebuchten Betreuungsangebote ändern sie nur auf Anfrage – diese geben Sie hier zentral frei.",
@@ -679,7 +679,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Die meisten Felder (z. B. Gesundheitshinweise, eigene Kontaktdaten der Eltern) ändern Eltern direkt; die Änderung wird sofort übernommen und protokolliert.",
           "Für Name, Geburtsdatum und Gehzeiten reichen Eltern über `Änderung anfragen` einen Vorschlag ein, statt direkt zu ändern.",
           "Die dauerhaften Bring- und Abholzeiten ändern Eltern seit dem Umbau der Eltern-App nicht mehr selbst: Die Rubrik `Betreuungszeiten` gibt es dort nicht mehr, der Wochenplan steht nur noch als Anzeige. Der Hinweis dort nennt die OGS als Stelle, die die Zeiten pflegt; Änderungswünsche kommen jetzt als Nachricht. Ältere, noch offene Anfragen bleiben in der Warteschlange und lassen sich normal entscheiden.",
-          "Offene Anfragen finden Sie als Admin in der Seitenleiste unter `Eltern` > `Änderungsanfragen`, getrennt nach `Stammdaten`, `Betreuungszeiten`, `Betreuungsangebote und AGs` und – falls aktiviert – `Entschuldigte Abmeldungen`.",
+          "Offene Anfragen finden Sie als Admin in der Seitenleiste unter `Anfragen` im Reiter `Eltern`, getrennt nach `Stammdaten`, `Betreuungszeiten`, `Betreuungsangebote und AGs` und – falls aktiviert – `Entschuldigte Abmeldungen`.",
           "Pro Anfrage sehen Sie das Kind und die Änderung (alter → neuer Wert); bei Betreuungszeiten den Wochenplan-Vergleich je Wochentag (Bringzeit, Abholzeit, Abholart); bei Betreuungsangeboten das gewünschte Startdatum und welche Angebote dazukommen oder wegfallen; bei entschuldigten Abmeldungen die betroffenen Tage und die Begründung der Eltern.",
           "Angebote, die eine Mitbuchungs-Regel ergänzt, tragen die Markierung `Automatisch mitgebucht` und nennen das Angebot, das die Mitbuchung auslöst. So erkennen Sie, was die Eltern selbst gewählt haben. Über den Haken `Automatisch mitbuchen` können Sie ein solches Angebot für genau diese Anfrage abwählen; die Regel bleibt für alle anderen Anfragen eingeschaltet.",
           "Mit `Freigeben` wird der neue Wert übernommen – bei Betreuungszeiten direkt in den Wochenplan des Kindes, bei einer entschuldigten Abmeldung wird das Kind für die Tage als entschuldigt eingetragen. Mit `Ablehnen` bleibt der bisherige Stand erhalten; bei Betreuungszeiten, Betreuungsangeboten und entschuldigten Abmeldungen ist dafür eine Begründung erforderlich, bei Stammdaten optional.",
@@ -694,7 +694,7 @@ export const appChapters: readonly GuideChapter[] = [
           tone: "blue",
         },
         screenshot:
-          "Admin-Seite „Änderungsanfragen“ mit den Bereichen Stammdaten, Betreuungszeiten und Betreuungsangebote, je mit Kind, Änderung (alt → neu) sowie Freigeben- und Ablehnen-Schaltflächen.",
+          "Seite „Anfragen“, Reiter „Eltern“, mit den Bereichen Stammdaten, Betreuungszeiten und Betreuungsangebote, je mit Kind, Änderung (alt → neu) sowie Freigeben- und Ablehnen-Schaltflächen.",
       },
       {
         id: "meine-gruppen",
@@ -1622,13 +1622,13 @@ export const appChapters: readonly GuideChapter[] = [
         summary:
           "Der zentrale Posteingang für die Kommunikation mit den Eltern, wie ein Chat. Mit jeder Bezugsperson läuft pro Kind genau eine fortlaufende Unterhaltung (ohne Betreff); so wird die E-Mail-Kommunikation überflüssig.",
         steps: [
-          "In der Seitenleiste den Bereich `Eltern` aufklappen und `Nachrichten` öffnen. Ein rotes Abzeichen am Bereich `Eltern` zeigt die Zahl der ungelesenen Eltern-Nachrichten (und offenen Anfragen); aufgeklappt steht es direkt am Punkt `Nachrichten`.",
+          "In der Seitenleiste den Bereich `Eltern` aufklappen und `Nachrichten` öffnen. Ein rotes Abzeichen am Bereich `Eltern` zeigt die Zahl der ungelesenen Eltern-Nachrichten; aufgeklappt steht es direkt am Punkt `Nachrichten`.",
           "Der Posteingang listet alle Unterhaltungen, die du sehen darfst (als Admin alle, sonst die Kinder deiner Gruppen), neueste zuerst. Jede Zeile zeigt die Bezugsperson mit Beziehung zum Kind und die letzte Nachricht. Über `Nur ungelesen` lässt sich die Liste eingrenzen.",
           "Eine Zeile öffnet das Chat-Fenster mit dem kompletten Verlauf. Über `Zum Kinderprofil` gelangst du von dort zur Kinderdetailansicht.",
           "Im Chat direkt antworten: Text eingeben und auf `Senden` tippen.",
           "Über `Neue Nachricht` selbst eine Unterhaltung starten: Kind suchen und Bezugsperson wählen. Damit öffnet sich das Chat-Fenster; den eigentlichen Text schreibst du dort und tippst auf `Senden`. Gibt es mit der Person schon eine Unterhaltung, wird sie fortgesetzt.",
           "Antworten erscheinen sofort in der Eltern-App der jeweiligen Bezugsperson; dort als `OGS` der Schule, ohne einzelnen Mitarbeitenden-Namen.",
-          "Neben Nachrichten erscheinen im Verlauf auch automatische Hinweise, etwa wenn Eltern eine Krankmeldung abgeben, eine Abholzeit für einen Tag ändern oder eine Änderungsanfrage stellen. Diese Einträge sind reine Information ohne Schaltflächen; Anfragen bearbeitest du als Admin unter `Änderungsanfragen` (siehe nächster Abschnitt).",
+          "Neben Nachrichten erscheinen im Verlauf auch automatische Hinweise, etwa wenn Eltern eine Krankmeldung abgeben, eine Abholzeit für einen Tag ändern oder eine Änderungsanfrage stellen. Diese Einträge sind reine Information ohne Schaltflächen; Anfragen bearbeitest du als Admin in der Seitenleiste unter `Anfragen` (siehe nächster Abschnitt).",
         ],
         callout: {
           title: "Voraussetzung",
@@ -1644,22 +1644,22 @@ export const appChapters: readonly GuideChapter[] = [
         title: "Anfragen der Eltern bearbeiten",
         icon: ClipboardCheck,
         summary:
-          "Bezugspersonen können über die Eltern-App strukturierte Anfragen stellen: Änderungen an den Stammdaten (Name, Geburtsdatum, Gehzeiten) und an der gebuchten Betreuung. Anfragen entstehen im Kinderbereich der Eltern-App und werden zentral auf der Seite `Änderungsanfragen` entschieden.",
+          "Bezugspersonen können über die Eltern-App strukturierte Anfragen stellen: Änderungen an den Stammdaten (Name, Geburtsdatum, Gehzeiten) und an der gebuchten Betreuung. Anfragen entstehen im Kinderbereich der Eltern-App und werden zentral in der Seitenleiste unter `Anfragen` entschieden.",
         steps: [
           "Eltern sehen im Kinderbereich unter `Gebuchte Betreuung`, was für ihr Kind gebucht ist, und daneben ihren Wochenplan (Bringzeit, Abholzeit, Abholart je Wochentag). Der Wochenplan ist reine Anzeige: Die Zeiten pflegt die OGS, deshalb ändern Eltern sie nicht mehr selbst. Eine Änderung des gebuchten Angebots reichen sie über `Änderung anfragen` ein.",
           "Neue Anfragen erscheinen im Nachrichten-Verlauf des Kindes als Hinweis, sind dort aber nicht bedienbar.",
-          "In der Seitenleiste den Bereich `Eltern` aufklappen und `Änderungsanfragen` öffnen. Dort stehen alle offenen Anfragen, getrennt nach `Stammdaten`, `Betreuungszeiten` und `Betreuungsangebote`, jeweils mit dem Vergleich `aktuell -> gewünscht`. Der Bereich `Betreuungszeiten` bekommt keine neuen Anfragen mehr; noch offene Altfälle lassen sich dort weiterhin entscheiden.",
+          "In der Seitenleiste `Anfragen` öffnen; der Reiter `Eltern` ist voreingestellt. Dort stehen alle offenen Anfragen, getrennt nach `Stammdaten`, `Betreuungszeiten` und `Betreuungsangebote`, jeweils mit dem Vergleich `aktuell -> gewünscht`. Der Bereich `Betreuungszeiten` bekommt keine neuen Anfragen mehr; noch offene Altfälle lassen sich dort weiterhin entscheiden.",
           "Mit `Freigeben` wird die Änderung übernommen: Bei Betreuungszeiten wird der Wochenplan des Kindes direkt aktualisiert.",
           "Passt die Anfrage nicht, eine kurze `Begründung` eintragen und auf `Ablehnen` tippen. Der Grund wird der Bezugsperson angezeigt.",
           "Nach der Entscheidung wird die Bezugsperson in ihrer App über das Ergebnis informiert (Hinweis im Nachrichten-Verlauf und Status im Kinderbereich).",
         ],
         callout: {
           title: "Wer darf entscheiden",
-          body: "Die Seite `Änderungsanfragen` steht Admins sowie Mitarbeitenden mit Bearbeitungsrecht für die Kinderdaten zur Verfügung. Die für die Gruppe eines Kindes zuständige Aufsicht sieht dabei nur Anfragen zu Kindern aus ihren eigenen Gruppen. Solange eine Anfrage offen ist, können Eltern sie im Kinderbereich zurückziehen.",
+          body: "Der Bereich `Anfragen` steht Admins sowie Mitarbeitenden mit Bearbeitungsrecht für die Kinderdaten zur Verfügung. Die für die Gruppe eines Kindes zuständige Aufsicht sieht dabei nur Anfragen zu Kindern aus ihren eigenen Gruppen. Solange eine Anfrage offen ist, können Eltern sie im Kinderbereich zurückziehen.",
           tone: "orange",
         },
         screenshot:
-          "Admin-Seite Änderungsanfragen, Bereich Betreuungszeiten: Wochenplan-Vergleich aktuell zu gewünscht mit den Schaltflächen Freigeben und Ablehnen.",
+          "Seite Anfragen, Reiter Eltern, Bereich Betreuungszeiten: Wochenplan-Vergleich aktuell zu gewünscht mit den Schaltflächen Freigeben und Ablehnen.",
         image: "/help/screens/offene-anfragen.webp",
       },
       {

--- a/frontend/src/lib/analytics-routes.ts
+++ b/frontend/src/lib/analytics-routes.ts
@@ -7,6 +7,8 @@ export const TRACKED_TENANT_ROUTE_TEMPLATES = [
   "/absences",
   "/active-supervisions",
   "/activities",
+  // Nur noch ein Redirect-Frame auf /anfragen (#2429); bleibt gelistet, weil
+  // die Allowlist jede page.tsx unter (protected) abdecken muss.
   "/admin/change-requests",
   "/admin/enrollments",
   "/admin/enrollments/:id",
@@ -14,6 +16,7 @@ export const TRACKED_TENANT_ROUTE_TEMPLATES = [
   "/admin/enrollments/change-requests/:id",
   "/admin/enrollments/phases/:phaseId",
   "/admin/guardian-approvals",
+  "/anfragen",
   "/betreuungsplan",
   "/calendar",
   "/calendar-periods",

--- a/frontend/src/lib/change-request-access.ts
+++ b/frontend/src/lib/change-request-access.ts
@@ -3,9 +3,9 @@ import type { Session } from "next-auth";
 import { hasPermission, isAdmin } from "~/lib/auth-utils";
 
 /**
- * Zugriffsregeln der Seite "Änderungsanfragen" an einer Stelle, weil sie an
- * vier Orten gleich lauten müssen: Seite, Sidebar-Eintrag, Eltern-Übersicht und
- * das Zähler-Badge. Auseinanderlaufen heißt entweder ein Badge ohne erreichbare
+ * Zugriffsregeln des Anfragen-Moduls an einer Stelle, weil sie an vier Orten
+ * gleich lauten müssen: Seite, Sidebar-Eintrag, mobile Navigation und das
+ * Zähler-Badge. Auseinanderlaufen heißt entweder ein Badge ohne erreichbare
  * Seite oder eine Warteschlange, die niemand findet.
  */
 
@@ -36,5 +36,27 @@ export function canReviewChangeRequests(session: Session | null): boolean {
     canReviewStudentDataRequests(session) ||
     (hasPermission(session, "users:absence") &&
       hasPermission(session, "users:read"))
+  );
+}
+
+/**
+ * Darf die Person Abwesenheitsanträge von Mitarbeitenden entscheiden? Dasselbe
+ * vacation:approve, das die Abwesenheits-Inbox und ihr Badge (#1419) tragen —
+ * es schaltet im Anfragen-Modul den Reiter "Mitarbeitende" frei.
+ */
+export function canReviewStaffAbsenceRequests(
+  session: Session | null,
+): boolean {
+  return isAdmin(session) || hasPermission(session, "vacation:approve");
+}
+
+/**
+ * Darf die Person die Anfragen-Seite überhaupt öffnen? Sie besteht aus zwei
+ * Reitern mit getrennten Rechten (Eltern bzw. Mitarbeitende); wer eines von
+ * beiden hält, sieht die Seite mit den entsprechenden Reitern.
+ */
+export function canOpenRequestsPage(session: Session | null): boolean {
+  return (
+    canReviewChangeRequests(session) || canReviewStaffAbsenceRequests(session)
   );
 }

--- a/frontend/src/lib/hooks/__tests__/use-sidebar-accordion.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-sidebar-accordion.test.ts
@@ -89,10 +89,11 @@ describe("useSidebarAccordion", () => {
   });
 
   it("expands 'eltern' section for parent sub-pages", () => {
+    // /admin/change-requests gehört seit #2429 nicht mehr zum Eltern-Bereich —
+    // die Route ist nur noch ein Redirect auf das Top-Level-Modul /anfragen.
     for (const path of [
       "/messages",
       "/admin/guardian-approvals",
-      "/admin/change-requests",
       "/parent-announcements",
       "/meal-plan",
     ]) {

--- a/frontend/src/lib/moto-concepts.ts
+++ b/frontend/src/lib/moto-concepts.ts
@@ -51,6 +51,7 @@ import {
   SignOutIcon,
   SunIcon,
   TranslateIcon,
+  TrayIcon,
   TrendUpIcon,
   UserCheckIcon,
   UserCircleGearIcon,
@@ -404,6 +405,9 @@ export const MOTO_CONCEPTS = {
     "function",
     "administration",
   ),
+  // Anfragen-Modul (#2429): eingereichte Wünsche von Eltern und
+  // Mitarbeitenden, über die die OGS entscheidet.
+  requests: concept("Anfragen", TrayIcon, "blue", "function", "communication"),
   rfid: concept(
     "RFID",
     ContactlessPaymentIcon,

--- a/frontend/src/lib/navigation-icons.ts
+++ b/frontend/src/lib/navigation-icons.ts
@@ -75,4 +75,6 @@ export const navigationIcons = {
   dienstplan:
     "M9 2h6a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2 M12 11h4 M12 16h4 M8 11h.01 M8 16h.01",
   vertretung: "M8 3 4 7l4 4 M4 7h16 M16 21l4-4-4-4 M20 17H4",
+  // Inbox tray, used for the Anfragen module (#2429)
+  tray: "M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4",
 } as const;

--- a/frontend/src/lib/section-navigation.ts
+++ b/frontend/src/lib/section-navigation.ts
@@ -81,12 +81,7 @@ export const DATABASE_SUB_PAGES: readonly SectionSubPage[] = [
  * sidebar.tsx; hier steht nur, welche Regel gilt.
  */
 type ParentSubPageFeature =
-  | "overview"
-  | "messages"
-  | "approvals"
-  | "changeRequests"
-  | "announcements"
-  | "mealPlan";
+  "overview" | "messages" | "approvals" | "announcements" | "mealPlan";
 
 export interface ParentSubPage extends SectionSubPage {
   readonly feature: ParentSubPageFeature;
@@ -103,11 +98,8 @@ export const PARENT_SUB_PAGES: readonly ParentSubPage[] = [
     label: "Konto-Anfragen",
     feature: "approvals",
   },
-  {
-    href: "/admin/change-requests",
-    label: "Änderungsanfragen",
-    feature: "changeRequests",
-  },
+  // Die Elternanfragen sind in das Top-Level-Modul "Anfragen" umgezogen
+  // (#2429); /admin/change-requests leitet dorthin um.
   {
     // One entry, two jobs: the page itself splits Mitteilungen from Umfragen
     // (#1371). Both are the same broadcast workflow, so a second nav item would
@@ -143,6 +135,9 @@ export const STAFF_FLAT_PAGES = {
   activities: { href: "/activities", label: "Aktivitäten" },
   rooms: { href: "/rooms", label: "Räume" },
   staff: { href: "/staff", label: "Mitarbeiter" },
+  // Anfragen-Modul (#2429): eingereichte Wünsche von Eltern und Mitarbeitenden
+  // an einem Ort, mit Reitern nach Herkunft.
+  anfragen: { href: "/anfragen", label: "Anfragen" },
   calendar: { href: "/calendar", label: "Mein Kalender" },
   substitutions: { href: "/substitutions", label: "Gruppenzugriff" },
   infoDisplays: { href: "/info-displays", label: "Info-Displays" },


### PR DESCRIPTION
Messreihe zu #2419 / Blacksmith-Kosten: zwei identische CI-Läufe, einmal mit und einmal ohne \`-coverpkg=./...\` im Backend-Testjob.

- Lauf A (dieser Stand): Flags unverändert, nur Kommentar geändert (Baseline).
- Lauf B (Folge-Commit): \`-coverpkg=./...\` entfernt, sonst identisch.

Verglichen werden test-backend-Dauer und Gesamt-Coverage aus den Artefakten. Der PR wird danach geschlossen, nicht gemerged.