### PR TITLE
Testsuite-Umbau PR 1: hermetischer DB-Lebenszyklus hinter SetupTestDB (#2419)

### DIFF
--- a/.quorum/testcmd
+++ b/.quorum/testcmd
@@ -1,0 +1,1 @@
+scripts/test-changed.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,8 @@ Shifts recur via `schedule.staff_shift_series` (weekdays + wall-clock window bou
 | Reset DB | `docker compose run server go run . migrate reset` (then seed — see `docs/getting-started.md` for the credential flags) |
 | View logs | `docker compose logs -f server` |
 | Quality check (frontend) | `cd frontend && pnpm run check` |
-| Run backend tests | `cd backend && go test ./...` |
+| Run backend tests (self-initializing; clones GC'd next run) | `cd backend && go test ./...` |
+| Full backend run incl. immediate clone sweep (gotestsum) | `scripts/test-backend.sh` |
 | Fast unit-only backend run (skips all DB tests) | `cd backend && go test -short ./...` |
 | Test only what changed vs a base ref (backend + frontend) | `scripts/test-changed.sh [origin/development]` |
 | Generate docs | `docker compose run server go run . gendoc --routes` |
@@ -192,11 +193,17 @@ Shifts recur via `schedule.staff_shift_series` (weekdays + wall-clock window bou
 
 **Hermetic tests are MANDATORY** for all new backend tests (no hardcoded IDs, fixtures + cleanup, `TestHermeticTestPatterns` CI gate) — see `backend/CLAUDE.md` for the fixture catalog and rules.
 
-### Test Database (port 5433)
+### Test Database (port 5433) — self-initializing (ADR 0004)
+`go test ./...` owns the whole test-DB lifecycle: it starts `postgres-test` if
+needed, rebuilds the `phoenix_test` template when migrations changed
+(migrations-hash stamp), and clones one run-stamped database per package.
+`scripts/test-backend.sh` is the comfort wrapper (gotestsum + sweep at the
+end); naked `go test` runs leave their clones to the next run's generation GC.
+Manual container control, if ever needed:
 ```bash
-docker compose --profile test up -d postgres-test       # Start (isolated network)
-docker compose --profile test down                       # Stop (plain `down` won't work)
-cd backend && APP_ENV=test go run . migrate reset        # Setup
+docker compose --profile test up -d postgres-test        # Start (isolated network)
+docker compose --profile test down                        # Stop (plain `down` won't work)
+cd backend && go run ./internal/testdb/cmd/sweep          # Drop leftover clones now
 ```
 
 ## No Fallbacks, No Defaults — Fail Fast (MANDATORY)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -7,8 +7,13 @@ Go backend for Project Phoenix (Chi router, BUN ORM, PostgreSQL multi-schema). R
 Day-to-day run/build/migrate commands are Docker-Compose-first — see the root `CLAUDE.md` Essential Commands table. Backend-specific:
 
 ```bash
-# Testing
-go test ./...                       # All tests (APP_ENV=test auto-set by SetupTestDB)
+# Testing — self-initializing lifecycle (ADR 0004): SetupTestDB starts the
+# postgres-test container if needed, rebuilds the phoenix_test template when
+# migrations changed, and gives each package binary a run-stamped clone.
+../scripts/test-backend.sh          # Full suite via gotestsum + immediate clone sweep (preferred full run)
+go test ./...                       # All tests (works standalone; clones are GC'd by the next run)
+PHX_TEST_LEFTOVERS=1 ../scripts/test-backend.sh   # Opt-in: report rows tests left behind (diagnosis, not a gate)
+go run ./internal/testdb/cmd/sweep  # Drop this/dead runs' phx_test_pkg_* clones manually
 go test -short ./...                # Fast inner loop: skips every DB integration test (SetupTestDB t.Skip). NEVER in CI — guts coverage.
 go test ./services/active/... -v    # Specific package
 go test -race ./...                 # Race detection

--- a/backend/database/repositories/active/visits.go
+++ b/backend/database/repositories/active/visits.go
@@ -767,9 +767,15 @@ func (r *VisitRepository) EndVisitsByActiveGroupIDs(ctx context.Context, activeG
 		return 0, nil
 	}
 
+	// GREATEST clamp: entry_time is written from the app host's clock (IoT/web
+	// check-in), now() is the DB server's clock. When the app clock runs ahead
+	// (Docker VM skew locally, NTP drift between hosts in production), a bulk
+	// end shortly after a check-in would set exit_time < entry_time and trip
+	// chk_entry_before_exit for the WHOLE batch. Clamping to entry_time keeps
+	// the invariant and gives the just-checked-in visit a zero duration.
 	query := base.GetDB(ctx, r.db).NewUpdate().
 		Table(tableActiveVisits).
-		Set("exit_time = now()").
+		Set("exit_time = GREATEST(now(), entry_time)").
 		Where("active_group_id IN (?)", bun.List(activeGroupIDs)).
 		Where("exit_time IS NULL")
 

--- a/backend/database/repositories/users/parent_announcement.go
+++ b/backend/database/repositories/users/parent_announcement.go
@@ -742,9 +742,8 @@ func (r *ParentAnnouncementRepository) CountUnreadForAccount(ctx context.Context
 // version the client loaded. published_at = ? already implies NOT NULL. Mirrors
 // announcementIsLive in the service, but evaluated in the same statement as the
 // write so a concurrent correction cannot slip a stale read/ack onto the
-// corrected wording. The current time is bound by the caller rather than read
-// from PostgreSQL: publication decisions originate in the application process,
-// and app/database clock skew must not reject a just-published announcement.
+// corrected wording. Publication is already validated by the service and
+// version match; expiry is evaluated by PostgreSQL at statement time.
 //
 // Both methods gate the read/ack write on EXISTS(guard) AND return EXISTS(guard)
 // as their result, so the caller can tell a genuine no-op (guard missed — a
@@ -757,8 +756,7 @@ const liveVersionGuardCTE = `WITH guard AS (
 		WHERE a.id = ? AND a.tenant_id = ?
 			AND a.active
 			AND a.published_at = ?
-			AND a.published_at <= ?
-			AND (a.expires_at IS NULL OR a.expires_at > ?)
+			AND (a.expires_at IS NULL OR a.expires_at > clock_timestamp())
 	)`
 
 // MarkRead upserts the account's read row for an announcement (idempotent: a
@@ -779,7 +777,7 @@ func (r *ParentAnnouncementRepository) MarkRead(ctx context.Context, tenantID, a
 			ON CONFLICT (announcement_id, account_id) DO NOTHING
 		)
 		SELECT EXISTS (SELECT 1 FROM guard)`,
-		announcementID, tenantID, expectedPublishedAt, now, now, // guard CTE
+		announcementID, tenantID, expectedPublishedAt, // guard CTE
 		tenantID, announcementID, accountID, now, // insert values
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "mark parent announcement read", Err: err}
@@ -804,7 +802,7 @@ func (r *ParentAnnouncementRepository) MarkAcknowledged(ctx context.Context, ten
 			SET acknowledged_at = COALESCE(parent_announcement_reads.acknowledged_at, EXCLUDED.acknowledged_at)
 		)
 		SELECT EXISTS (SELECT 1 FROM guard)`,
-		announcementID, tenantID, expectedPublishedAt, now, now, // guard CTE
+		announcementID, tenantID, expectedPublishedAt, // guard CTE
 		tenantID, announcementID, accountID, now, now, // upsert values
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "mark parent announcement acknowledged", Err: err}

--- a/backend/database/repositories/users/parent_announcement.go
+++ b/backend/database/repositories/users/parent_announcement.go
@@ -742,7 +742,9 @@ func (r *ParentAnnouncementRepository) CountUnreadForAccount(ctx context.Context
 // version the client loaded. published_at = ? already implies NOT NULL. Mirrors
 // announcementIsLive in the service, but evaluated in the same statement as the
 // write so a concurrent correction cannot slip a stale read/ack onto the
-// corrected wording.
+// corrected wording. The current time is bound by the caller rather than read
+// from PostgreSQL: publication decisions originate in the application process,
+// and app/database clock skew must not reject a just-published announcement.
 //
 // Both methods gate the read/ack write on EXISTS(guard) AND return EXISTS(guard)
 // as their result, so the caller can tell a genuine no-op (guard missed — a
@@ -755,8 +757,8 @@ const liveVersionGuardCTE = `WITH guard AS (
 		WHERE a.id = ? AND a.tenant_id = ?
 			AND a.active
 			AND a.published_at = ?
-			AND a.published_at <= NOW()
-			AND (a.expires_at IS NULL OR a.expires_at > NOW())
+			AND a.published_at <= ?
+			AND (a.expires_at IS NULL OR a.expires_at > ?)
 	)`
 
 // MarkRead upserts the account's read row for an announcement (idempotent: a
@@ -767,6 +769,7 @@ const liveVersionGuardCTE = `WITH guard AS (
 // applied or a prior read already existed) and false when the version guard
 // missed — the caller maps false to a stale conflict rather than a silent 200.
 func (r *ParentAnnouncementRepository) MarkRead(ctx context.Context, tenantID, announcementID, accountID int64, expectedPublishedAt time.Time) (bool, error) {
+	now := time.Now()
 	var live bool
 	if err := base.GetDB(ctx, r.DB).NewRaw(liveVersionGuardCTE+`,
 		ins AS (
@@ -776,8 +779,8 @@ func (r *ParentAnnouncementRepository) MarkRead(ctx context.Context, tenantID, a
 			ON CONFLICT (announcement_id, account_id) DO NOTHING
 		)
 		SELECT EXISTS (SELECT 1 FROM guard)`,
-		announcementID, tenantID, expectedPublishedAt, // guard CTE
-		tenantID, announcementID, accountID, time.Now(), // insert values
+		announcementID, tenantID, expectedPublishedAt, now, now, // guard CTE
+		tenantID, announcementID, accountID, now, // insert values
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "mark parent announcement read", Err: err}
 	}
@@ -801,7 +804,7 @@ func (r *ParentAnnouncementRepository) MarkAcknowledged(ctx context.Context, ten
 			SET acknowledged_at = COALESCE(parent_announcement_reads.acknowledged_at, EXCLUDED.acknowledged_at)
 		)
 		SELECT EXISTS (SELECT 1 FROM guard)`,
-		announcementID, tenantID, expectedPublishedAt, // guard CTE
+		announcementID, tenantID, expectedPublishedAt, now, now, // guard CTE
 		tenantID, announcementID, accountID, now, now, // upsert values
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "mark parent announcement acknowledged", Err: err}

--- a/backend/database/repositories/users/parent_announcement.go
+++ b/backend/database/repositories/users/parent_announcement.go
@@ -756,6 +756,7 @@ const liveVersionGuardCTE = `WITH guard AS (
 		WHERE a.id = ? AND a.tenant_id = ?
 			AND a.active
 			AND a.published_at = ?
+			AND a.published_at <= clock_timestamp()
 			AND (a.expires_at IS NULL OR a.expires_at > clock_timestamp())
 	)`
 

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -332,7 +332,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 			JOIN auth.account_tenants act ON act.account_id = gp.account_id
 				AND act.tenant_id = gp.tenant_id AND act.status = 'active'
 			WHERE a.id = ? AND a.tenant_id = ?
-				AND a.active AND a.published_at = ?
+				AND a.active AND a.published_at = ? AND a.published_at <= clock_timestamp()
 				AND (a.expires_at IS NULL OR a.expires_at > clock_timestamp())
 				AND a.response_type <> 'none'
 				AND (a.response_deadline IS NULL OR a.response_deadline > clock_timestamp())

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -300,6 +300,7 @@ func (r *ParentAnnouncementRepository) AccountMayAnswerForStudent(ctx context.Co
 // answer 409.
 func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error) {
 	db := base.GetDB(ctx, r.DB)
+	now := time.Now()
 	// The advisory transaction lock serializes all replacements for this
 	// announcement/child pair.  The response table's option-level uniqueness is
 	// insufficient: two guardians could otherwise both delete and then insert a
@@ -332,10 +333,10 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 			JOIN auth.account_tenants act ON act.account_id = gp.account_id
 				AND act.tenant_id = gp.tenant_id AND act.status = 'active'
 			WHERE a.id = ? AND a.tenant_id = ?
-				AND a.active AND a.published_at = ? AND a.published_at <= NOW()
-				AND (a.expires_at IS NULL OR a.expires_at > NOW())
+				AND a.active AND a.published_at = ? AND a.published_at <= ?
+				AND (a.expires_at IS NULL OR a.expires_at > ?)
 				AND a.response_type <> 'none'
-				AND (a.response_deadline IS NULL OR a.response_deadline > NOW())
+				AND (a.response_deadline IS NULL OR a.response_deadline > ?)
 		)`
 	var live bool
 	if err := db.NewRaw(guard+`, requested AS (
@@ -356,7 +357,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 			AND (SELECT valid FROM selection_valid)
 	)
 	SELECT valid FROM selection_valid`,
-		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
+		studentID, accountID, announcementID, tenantID, expectedPublishedAt, now, now, now,
 		pgdialect.Array(optionIDs), announcementID, tenantID,
 		announcementID, studentID, tenantID,
 	).Scan(ctx, &live); err != nil {
@@ -390,9 +391,9 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 		ON CONFLICT (announcement_id, student_id, option_id) DO NOTHING
 	)
 	SELECT valid FROM selection_valid`,
-		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
+		studentID, accountID, announcementID, tenantID, expectedPublishedAt, now, now, now,
 		pgdialect.Array(optionIDs), announcementID, tenantID,
-		tenantID, announcementID, studentID, accountID, time.Now(), announcementID, tenantID, bun.List(optionIDs),
+		tenantID, announcementID, studentID, accountID, now, announcementID, tenantID, bun.List(optionIDs),
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "insert parent announcement response", Err: err}
 	}

--- a/backend/database/repositories/users/parent_announcement_poll.go
+++ b/backend/database/repositories/users/parent_announcement_poll.go
@@ -300,7 +300,6 @@ func (r *ParentAnnouncementRepository) AccountMayAnswerForStudent(ctx context.Co
 // answer 409.
 func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID, announcementID, studentID, accountID int64, optionIDs []int64, expectedPublishedAt time.Time) (bool, error) {
 	db := base.GetDB(ctx, r.DB)
-	now := time.Now()
 	// The advisory transaction lock serializes all replacements for this
 	// announcement/child pair.  The response table's option-level uniqueness is
 	// insufficient: two guardians could otherwise both delete and then insert a
@@ -333,10 +332,10 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 			JOIN auth.account_tenants act ON act.account_id = gp.account_id
 				AND act.tenant_id = gp.tenant_id AND act.status = 'active'
 			WHERE a.id = ? AND a.tenant_id = ?
-				AND a.active AND a.published_at = ? AND a.published_at <= ?
-				AND (a.expires_at IS NULL OR a.expires_at > ?)
+				AND a.active AND a.published_at = ?
+				AND (a.expires_at IS NULL OR a.expires_at > clock_timestamp())
 				AND a.response_type <> 'none'
-				AND (a.response_deadline IS NULL OR a.response_deadline > ?)
+				AND (a.response_deadline IS NULL OR a.response_deadline > clock_timestamp())
 		)`
 	var live bool
 	if err := db.NewRaw(guard+`, requested AS (
@@ -357,7 +356,7 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 			AND (SELECT valid FROM selection_valid)
 	)
 	SELECT valid FROM selection_valid`,
-		studentID, accountID, announcementID, tenantID, expectedPublishedAt, now, now, now,
+		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
 		pgdialect.Array(optionIDs), announcementID, tenantID,
 		announcementID, studentID, tenantID,
 	).Scan(ctx, &live); err != nil {
@@ -391,9 +390,9 @@ func (r *ParentAnnouncementRepository) SetResponse(ctx context.Context, tenantID
 		ON CONFLICT (announcement_id, student_id, option_id) DO NOTHING
 	)
 	SELECT valid FROM selection_valid`,
-		studentID, accountID, announcementID, tenantID, expectedPublishedAt, now, now, now,
+		studentID, accountID, announcementID, tenantID, expectedPublishedAt,
 		pgdialect.Array(optionIDs), announcementID, tenantID,
-		tenantID, announcementID, studentID, accountID, now, announcementID, tenantID, bun.List(optionIDs),
+		tenantID, announcementID, studentID, accountID, time.Now(), announcementID, tenantID, bun.List(optionIDs),
 	).Scan(ctx, &live); err != nil {
 		return false, &modelBase.DatabaseError{Op: "insert parent announcement response", Err: err}
 	}

--- a/backend/database/repositories/users/parent_announcement_test.go
+++ b/backend/database/repositories/users/parent_announcement_test.go
@@ -40,11 +40,7 @@ func publishedAnnouncement(
 	a.SetTenantID(tenantID)
 	require.NoError(t, repo.Create(ctx, a))
 	require.NoError(t, repo.ReplaceTargets(ctx, tenantID, a.ID, targets))
-	// Publish visibly in the past: the MarkRead/MarkAcknowledged guard checks
-	// published_at <= NOW() on the DB clock, and the Docker VM's Postgres
-	// clock can lag the host's time.Now() by tens of milliseconds — a
-	// host-clock "now" would flake the guard (#2419 story 20).
-	now := time.Now().Add(-2 * time.Second)
+	now := time.Now()
 	require.NoError(t, repo.SetPublished(ctx, a.ID, &now))
 	a.PublishedAt = &now // reflect the persisted version so callers can pass it to MarkRead/MarkAcknowledged
 	t.Cleanup(func() { _ = repo.Delete(ctx, a.ID) })
@@ -243,10 +239,8 @@ func TestParentAnnouncementUpdate_AtomicAndClearsReads(t *testing.T) {
 		[]*usersModels.ParentAnnouncementTarget{{TargetType: usersModels.AnnouncementTargetSchoolAll}}))
 	t.Cleanup(func() { _ = repo.Delete(ctx, a.ID) })
 
-	// Publish (visibly in the past — the read/ack guard compares against the
-	// DB clock, which can lag the host clock; see publish helper above),
-	// then the guardian reads + acknowledges.
-	now := time.Now().Add(-2 * time.Second)
+	// Publish, then the guardian reads + acknowledges.
+	now := time.Now()
 	require.NoError(t, repo.SetPublished(ctx, a.ID, &now))
 	readApplied, err := repo.MarkRead(ctx, chain.TenantID, a.ID, chain.AccountID, now)
 	require.NoError(t, err)

--- a/backend/database/repositories/users/parent_announcement_test.go
+++ b/backend/database/repositories/users/parent_announcement_test.go
@@ -40,7 +40,11 @@ func publishedAnnouncement(
 	a.SetTenantID(tenantID)
 	require.NoError(t, repo.Create(ctx, a))
 	require.NoError(t, repo.ReplaceTargets(ctx, tenantID, a.ID, targets))
-	now := time.Now()
+	// Publish visibly in the past: the MarkRead/MarkAcknowledged guard checks
+	// published_at <= NOW() on the DB clock, and the Docker VM's Postgres
+	// clock can lag the host's time.Now() by tens of milliseconds — a
+	// host-clock "now" would flake the guard (#2419 story 20).
+	now := time.Now().Add(-2 * time.Second)
 	require.NoError(t, repo.SetPublished(ctx, a.ID, &now))
 	a.PublishedAt = &now // reflect the persisted version so callers can pass it to MarkRead/MarkAcknowledged
 	t.Cleanup(func() { _ = repo.Delete(ctx, a.ID) })
@@ -239,8 +243,10 @@ func TestParentAnnouncementUpdate_AtomicAndClearsReads(t *testing.T) {
 		[]*usersModels.ParentAnnouncementTarget{{TargetType: usersModels.AnnouncementTargetSchoolAll}}))
 	t.Cleanup(func() { _ = repo.Delete(ctx, a.ID) })
 
-	// Publish, then the guardian reads + acknowledges.
-	now := time.Now()
+	// Publish (visibly in the past — the read/ack guard compares against the
+	// DB clock, which can lag the host clock; see publish helper above),
+	// then the guardian reads + acknowledges.
+	now := time.Now().Add(-2 * time.Second)
 	require.NoError(t, repo.SetPublished(ctx, a.ID, &now))
 	readApplied, err := repo.MarkRead(ctx, chain.TenantID, a.ID, chain.AccountID, now)
 	require.NoError(t, err)

--- a/backend/internal/testdb/clone.go
+++ b/backend/internal/testdb/clone.go
@@ -1,0 +1,191 @@
+package testdb
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha1" //nolint:gosec // clone names only need collision resistance for identifiers, not security
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+)
+
+// RunIDEnv carries the run identifier that stamps every clone of one test
+// run. The wrapper scripts export it so all package binaries share one run;
+// a naked `go test` gets a random per-process ID and relies on the next
+// run's GC for cleanup (ADR 0004).
+const RunIDEnv = "PHX_TEST_RUN_ID"
+
+var (
+	runIDOnce sync.Once
+	runID     string
+
+	validRunID = regexp.MustCompile(`^[a-z0-9]{1,16}$`)
+)
+
+// RunID returns this process's run identifier: PHX_TEST_RUN_ID if set (and
+// sanitized), otherwise a random per-process ID.
+func RunID() string {
+	runIDOnce.Do(func() {
+		runID = SanitizeRunID(os.Getenv(RunIDEnv))
+	})
+	return runID
+}
+
+// SanitizeRunID normalizes raw into a postgres-identifier-safe run ID.
+// Empty input yields a fresh random ID; anything not matching
+// ^[a-z0-9]{1,16}$ is hashed down to one.
+func SanitizeRunID(raw string) string {
+	if raw == "" {
+		return randomRunID()
+	}
+	if validRunID.MatchString(raw) {
+		return raw
+	}
+	sum := sha1.Sum([]byte(raw)) //nolint:gosec // identifier derivation, not security
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+func randomRunID() string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is effectively fatal elsewhere; fall back to
+		// the PID so clone names stay unique per process.
+		return fmt.Sprintf("pid%d", os.Getpid())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// CloneName derives the database name for this run's clone of the package
+// rooted at workdir: phx_test_pkg_<runID>_<sha1(workdir)[:12]>.
+func CloneName(runID, workdir string) string {
+	normalized := filepath.ToSlash(workdir)
+	sum := sha1.Sum([]byte(normalized)) //nolint:gosec // identifier derivation, not security
+	return ClonePrefix + SanitizeRunID(runID) + "_" + hex.EncodeToString(sum[:])[:12]
+}
+
+// CloneHandle is a live package clone. The keeper connection pins the clone
+// in pg_stat_activity so the cross-run GC never collects a clone whose test
+// binary is still alive; it is released when the process exits (or Close is
+// called).
+type CloneHandle struct {
+	Name string
+	DSN  string
+
+	keeperDB   *sql.DB
+	keeperConn *sql.Conn
+}
+
+// Close releases the keeper connection. Test binaries never call this — the
+// keeper lives until process exit; it exists for the lifecycle's own tests.
+func (h *CloneHandle) Close() error {
+	if h.keeperConn != nil {
+		_ = h.keeperConn.Close()
+	}
+	if h.keeperDB != nil {
+		return h.keeperDB.Close()
+	}
+	return nil
+}
+
+// CreateClone creates this run's clone of the template for the package in
+// the current working directory. Under the lifecycle lock it first collects
+// clones of dead runs (generation GC), then creates the clone and pins it
+// with a keeper connection before releasing the lock.
+func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("determine package working directory: %w", err)
+	}
+	name := CloneName(runID, wd)
+
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+
+	unlock, err := acquireLifecycleLock(ctx, maint)
+	if err != nil {
+		return nil, fmt.Errorf("acquire test DB lifecycle lock: %w", err)
+	}
+	defer unlock()
+
+	// Generation GC: clones of this run are spared even when their binary
+	// already finished (the wrapper's sweep still wants to inspect and drop
+	// them); everything else without a live connection belongs to a dead run.
+	if _, err := gcLocked(ctx, maint, ClonePrefix+SanitizeRunID(runID)+"_", cfg.TemplateName()); err != nil {
+		return nil, err
+	}
+
+	if err := dropDatabase(ctx, maint, name); err != nil {
+		return nil, fmt.Errorf("drop stale package test database %q: %w", name, err)
+	}
+	if _, err := maint.ExecContext(ctx,
+		`CREATE DATABASE `+quoteIdentifier(name)+` TEMPLATE `+quoteIdentifier(cfg.TemplateName())); err != nil {
+		return nil, fmt.Errorf("clone test database %q from %q: %w", name, cfg.TemplateName(), err)
+	}
+
+	handle := &CloneHandle{Name: name, DSN: cfg.DatabaseDSN(name)}
+	handle.keeperDB = openSQL(handle.DSN)
+	handle.keeperDB.SetMaxOpenConns(1)
+	handle.keeperDB.SetConnMaxLifetime(0)
+	handle.keeperDB.SetConnMaxIdleTime(0)
+	conn, err := handle.keeperDB.Conn(ctx)
+	if err != nil {
+		_ = handle.keeperDB.Close()
+		return nil, fmt.Errorf("pin package test database %q: %w", name, err)
+	}
+	if err := conn.PingContext(ctx); err != nil {
+		_ = conn.Close()
+		_ = handle.keeperDB.Close()
+		return nil, fmt.Errorf("pin package test database %q: %w", name, err)
+	}
+	handle.keeperConn = conn
+
+	return handle, nil
+}
+
+// gcLocked drops every clone-prefixed database that has no live connection
+// and does not start with sparePrefix. templateName is never dropped, even
+// if the configured template happens to carry the clone prefix. Callers must
+// hold the lifecycle lock.
+func gcLocked(ctx context.Context, maint *sql.DB, sparePrefix, templateName string) ([]string, error) {
+	rows, err := maint.QueryContext(ctx, `
+		SELECT d.datname
+		FROM pg_database d
+		WHERE d.datname LIKE $1
+		  AND NOT EXISTS (SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname)`,
+		ClonePrefix+"%")
+	if err != nil {
+		return nil, fmt.Errorf("list orphaned test database clones: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var orphans []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan orphaned clone name: %w", err)
+		}
+		if name == templateName {
+			continue
+		}
+		if sparePrefix != "" && len(name) >= len(sparePrefix) && name[:len(sparePrefix)] == sparePrefix {
+			continue
+		}
+		orphans = append(orphans, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list orphaned test database clones: %w", err)
+	}
+
+	var dropped []string
+	for _, name := range orphans {
+		if err := dropDatabase(ctx, maint, name); err != nil {
+			return dropped, fmt.Errorf("drop orphaned clone %q: %w", name, err)
+		}
+		dropped = append(dropped, name)
+	}
+	return dropped, nil
+}

--- a/backend/internal/testdb/clone.go
+++ b/backend/internal/testdb/clone.go
@@ -143,7 +143,7 @@ func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, 
 	maint := openSQL(cfg.MaintenanceDSN())
 	defer func() { _ = maint.Close() }()
 
-	unlock, err := acquireLifecycleLock(ctx, maint)
+	conn, unlock, err := acquireLifecycleLock(ctx, maint)
 	if err != nil {
 		return nil, fmt.Errorf("acquire test DB lifecycle lock: %w", err)
 	}
@@ -152,14 +152,14 @@ func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, 
 	// Generation GC: clones of this run are spared even when their binary
 	// already finished (the wrapper's sweep still wants to inspect and drop
 	// them); everything else without a live connection belongs to a dead run.
-	if _, err := gcLocked(ctx, maint, ClonePrefix+SanitizeRunID(runID)+"_", cfg.TemplateName()); err != nil {
+	if _, err := gcLocked(ctx, conn, ClonePrefix+SanitizeRunID(runID)+"_", cfg.TemplateName()); err != nil {
 		return nil, err
 	}
 
-	if err := dropDatabase(ctx, maint, name); err != nil {
+	if err := dropDatabase(ctx, conn, name); err != nil {
 		return nil, fmt.Errorf("drop stale package test database %q: %w", name, err)
 	}
-	if _, err := maint.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`CREATE DATABASE `+quoteIdentifier(name)+` TEMPLATE `+quoteIdentifier(cfg.TemplateName())); err != nil {
 		return nil, fmt.Errorf("clone test database %q from %q: %w", name, cfg.TemplateName(), err)
 	}
@@ -169,17 +169,17 @@ func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, 
 	handle.keeperDB.SetMaxOpenConns(1)
 	handle.keeperDB.SetConnMaxLifetime(0)
 	handle.keeperDB.SetConnMaxIdleTime(0)
-	conn, err := handle.keeperDB.Conn(ctx)
+	keeperConn, err := handle.keeperDB.Conn(ctx)
 	if err != nil {
 		_ = handle.keeperDB.Close()
 		return nil, fmt.Errorf("pin package test database %q: %w", name, err)
 	}
-	if err := conn.PingContext(ctx); err != nil {
-		_ = conn.Close()
+	if err := keeperConn.PingContext(ctx); err != nil {
+		_ = keeperConn.Close()
 		_ = handle.keeperDB.Close()
 		return nil, fmt.Errorf("pin package test database %q: %w", name, err)
 	}
-	handle.keeperConn = conn
+	handle.keeperConn = keeperConn
 	handle.keeperStop = make(chan struct{})
 	go handle.keepAlive(handle.keeperStop)
 
@@ -190,7 +190,7 @@ func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, 
 // and does not start with sparePrefix. templateName is never dropped, even
 // if the configured template happens to carry the clone prefix. Callers must
 // hold the lifecycle lock.
-func gcLocked(ctx context.Context, maint *sql.DB, sparePrefix, templateName string) ([]string, error) {
+func gcLocked(ctx context.Context, maint sqlExecutor, sparePrefix, templateName string) ([]string, error) {
 	rows, err := maint.QueryContext(ctx, `
 		SELECT d.datname
 		FROM pg_database d

--- a/backend/internal/testdb/clone.go
+++ b/backend/internal/testdb/clone.go
@@ -117,11 +117,21 @@ func (h *CloneHandle) keepAlive(stop <-chan struct{}) {
 		case <-ticker.C:
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			h.mu.Lock()
-			if h.keeperConn == nil || h.keeperConn.PingContext(ctx) != nil {
-				if h.keeperConn != nil {
-					_ = h.keeperConn.Close()
+			// Open and verify the replacement before releasing the old keeper.
+			// That guarantees pg_stat_activity contains a liveness session for
+			// the clone throughout a normal reconnect.
+			replacement, err := h.keeperDB.Conn(ctx)
+			if err == nil {
+				err = replacement.PingContext(ctx)
+			}
+			if err == nil {
+				previous := h.keeperConn
+				h.keeperConn = replacement
+				if previous != nil {
+					_ = previous.Close()
 				}
-				h.keeperConn, _ = h.keeperDB.Conn(ctx)
+			} else if replacement != nil {
+				_ = replacement.Close()
 			}
 			h.mu.Unlock()
 			cancel()
@@ -166,7 +176,7 @@ func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, 
 
 	handle := &CloneHandle{Name: name, DSN: cfg.DatabaseDSN(name)}
 	handle.keeperDB = openSQL(handle.DSN)
-	handle.keeperDB.SetMaxOpenConns(1)
+	handle.keeperDB.SetMaxOpenConns(2)
 	handle.keeperDB.SetConnMaxLifetime(0)
 	handle.keeperDB.SetConnMaxIdleTime(0)
 	keeperConn, err := handle.keeperDB.Conn(ctx)
@@ -194,9 +204,9 @@ func gcLocked(ctx context.Context, maint sqlExecutor, sparePrefix, templateName 
 	rows, err := maint.QueryContext(ctx, `
 		SELECT d.datname
 		FROM pg_database d
-		WHERE d.datname LIKE $1
+		WHERE LEFT(d.datname, char_length($1)) = $1
 		  AND NOT EXISTS (SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname)`,
-		ClonePrefix+"%")
+		ClonePrefix)
 	if err != nil {
 		return nil, fmt.Errorf("list orphaned test database clones: %w", err)
 	}

--- a/backend/internal/testdb/clone.go
+++ b/backend/internal/testdb/clone.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
+	"time"
 )
 
 // RunIDEnv carries the run identifier that stamps every clone of one test
@@ -70,25 +72,61 @@ func CloneName(runID, workdir string) string {
 // CloneHandle is a live package clone. The keeper connection pins the clone
 // in pg_stat_activity so the cross-run GC never collects a clone whose test
 // binary is still alive; it is released when the process exits (or Close is
-// called).
+// called). The keeper is the single liveness signal the generation model
+// rests on, so a background loop pings it and reconnects if the session ever
+// dies (idle-session timeout, pg_terminate_backend, server hiccup).
 type CloneHandle struct {
 	Name string
 	DSN  string
 
+	mu         sync.Mutex // guards keeperConn against the keepAlive loop
 	keeperDB   *sql.DB
 	keeperConn *sql.Conn
+	keeperStop chan struct{}
 }
 
 // Close releases the keeper connection. Test binaries never call this — the
 // keeper lives until process exit; it exists for the lifecycle's own tests.
 func (h *CloneHandle) Close() error {
+	if h.keeperStop != nil {
+		close(h.keeperStop)
+		h.keeperStop = nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.keeperConn != nil {
 		_ = h.keeperConn.Close()
+		h.keeperConn = nil
 	}
 	if h.keeperDB != nil {
 		return h.keeperDB.Close()
 	}
 	return nil
+}
+
+// keepAlive pings the keeper connection every 30s (keeping the session
+// non-idle) and replaces it when it died. Best-effort: if the clone itself is
+// gone, tests are failing loudly anyway.
+func (h *CloneHandle) keepAlive(stop <-chan struct{}) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			h.mu.Lock()
+			if h.keeperConn == nil || h.keeperConn.PingContext(ctx) != nil {
+				if h.keeperConn != nil {
+					_ = h.keeperConn.Close()
+				}
+				h.keeperConn, _ = h.keeperDB.Conn(ctx)
+			}
+			h.mu.Unlock()
+			cancel()
+		}
+	}
 }
 
 // CreateClone creates this run's clone of the template for the package in
@@ -142,6 +180,8 @@ func CreateClone(ctx context.Context, cfg *Config, runID string) (*CloneHandle, 
 		return nil, fmt.Errorf("pin package test database %q: %w", name, err)
 	}
 	handle.keeperConn = conn
+	handle.keeperStop = make(chan struct{})
+	go handle.keepAlive(handle.keeperStop)
 
 	return handle, nil
 }
@@ -171,7 +211,7 @@ func gcLocked(ctx context.Context, maint *sql.DB, sparePrefix, templateName stri
 		if name == templateName {
 			continue
 		}
-		if sparePrefix != "" && len(name) >= len(sparePrefix) && name[:len(sparePrefix)] == sparePrefix {
+		if sparePrefix != "" && strings.HasPrefix(name, sparePrefix) {
 			continue
 		}
 		orphans = append(orphans, name)

--- a/backend/internal/testdb/cmd/sweep/main.go
+++ b/backend/internal/testdb/cmd/sweep/main.go
@@ -60,22 +60,10 @@ func main() {
 	fmt.Printf("testdb sweep: dropped %d clone(s)\n", len(result.Dropped))
 }
 
-// loadDotEnv best-effort loads the project root .env (parent of the backend
-// module root) so TEST_DB_DSN is available when the wrapper runs outside CI.
+// loadDotEnv best-effort loads the project root .env so TEST_DB_DSN is
+// available when the wrapper runs outside CI.
 func loadDotEnv() {
-	dir, err := os.Getwd()
-	if err != nil {
-		return
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			_ = gotenv.Load(filepath.Join(filepath.Dir(dir), ".env"))
-			return
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return
-		}
-		dir = parent
+	if root, err := testdb.ProjectRoot(); err == nil {
+		_ = gotenv.Load(filepath.Join(root, ".env"))
 	}
 }

--- a/backend/internal/testdb/cmd/sweep/main.go
+++ b/backend/internal/testdb/cmd/sweep/main.go
@@ -1,0 +1,81 @@
+// Command sweep tears down the test-database clones of one run and
+// garbage-collects clones of dead runs. The test wrapper scripts invoke it
+// after `go test`:
+//
+//	PHX_TEST_RUN_ID=<id> go run ./internal/testdb/cmd/sweep
+//
+// PHX_TEST_LEFTOVERS=1 additionally reports tables whose row counts differ
+// from the template before dropping (opt-in diagnosis, never a gate; the
+// suite's bootstrap fixtures — tenant/room/staff 1 — show up here until the
+// PR-2 fixture sweep removes them).
+//
+// Without TEST_DB_DSN (or with the server unreachable) the command exits 0:
+// there is nothing to sweep, and the wrapper's exit trap must not mask the
+// test result.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/testdb"
+	"github.com/subosito/gotenv"
+)
+
+func main() {
+	loadDotEnv()
+
+	dsn := os.Getenv("TEST_DB_DSN")
+	if dsn == "" {
+		fmt.Println("testdb sweep: TEST_DB_DSN not set, nothing to sweep")
+		return
+	}
+	cfg, err := testdb.NewConfig(dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testdb sweep: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	result, err := testdb.Sweep(ctx, cfg, testdb.SweepOptions{
+		RunID:           os.Getenv(testdb.RunIDEnv),
+		ReportLeftovers: os.Getenv("PHX_TEST_LEFTOVERS") == "1",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testdb sweep: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, l := range result.Leftovers {
+		fmt.Printf("testdb sweep: leftovers in %s:\n", l.Clone)
+		for _, d := range l.Tables {
+			fmt.Printf("  %-60s template=%d clone=%d\n", d.Table, d.TemplateRows, d.CloneRows)
+		}
+	}
+	fmt.Printf("testdb sweep: dropped %d clone(s)\n", len(result.Dropped))
+}
+
+// loadDotEnv best-effort loads the project root .env (parent of the backend
+// module root) so TEST_DB_DSN is available when the wrapper runs outside CI.
+func loadDotEnv() {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			_ = gotenv.Load(filepath.Join(filepath.Dir(dir), ".env"))
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}

--- a/backend/internal/testdb/config.go
+++ b/backend/internal/testdb/config.go
@@ -1,0 +1,101 @@
+package testdb
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/uptrace/bun/driver/pgdriver"
+)
+
+const (
+	// lifecycleAdvisoryLockKey serializes all test-database DDL (template
+	// rebuild, clone create, GC, sweep) across processes AND worktrees. Every
+	// session takes it while connected to the maintenance database, so the
+	// scope is the whole postgres-test server. Same key as the pre-ADR-0004
+	// clone lock so old and new binaries never interleave DDL.
+	lifecycleAdvisoryLockKey = int64(914735692)
+
+	// ClonePrefix names every package clone. The generation GC drops any
+	// database with this prefix that belongs to no living run.
+	ClonePrefix = "phx_test_pkg_"
+)
+
+// Config derives every DSN the lifecycle needs from TEST_DB_DSN, which points
+// at the template database (conventionally phoenix_test).
+type Config struct {
+	templateURL *url.URL
+}
+
+// NewConfig parses the TEST_DB_DSN pointing at the template database.
+func NewConfig(dsn string) (*Config, error) {
+	parsed, err := parsePostgresDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &Config{templateURL: parsed}, nil
+}
+
+// TemplateName returns the template database name (e.g. phoenix_test).
+func (c *Config) TemplateName() string {
+	return databaseNameFromURL(c.templateURL)
+}
+
+// TemplateDSN returns the DSN of the template database.
+func (c *Config) TemplateDSN() string {
+	return c.templateURL.String()
+}
+
+// MaintenanceDSN returns the DSN of the `postgres` maintenance database on
+// the same server, used for all CREATE/DROP DATABASE work.
+func (c *Config) MaintenanceDSN() string {
+	return withDatabaseName(c.templateURL, "postgres").String()
+}
+
+// DatabaseDSN returns the DSN for an arbitrary database on the same server.
+func (c *Config) DatabaseDSN(name string) string {
+	return withDatabaseName(c.templateURL, name).String()
+}
+
+// openSQL opens a small throwaway pool for lifecycle DDL and checks.
+func openSQL(dsn string) *sql.DB {
+	db := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(1)
+	return db
+}
+
+// acquireLifecycleLock takes the cross-process lifecycle lock on conn. The
+// lock is session-scoped; it releases when conn closes (or via the returned
+// unlock func).
+func acquireLifecycleLock(ctx context.Context, db *sql.DB) (unlock func(), err error) {
+	if _, err := db.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, lifecycleAdvisoryLockKey); err != nil {
+		return nil, err
+	}
+	return func() {
+		_, _ = db.ExecContext(context.Background(), `SELECT pg_advisory_unlock($1)`, lifecycleAdvisoryLockKey)
+	}, nil
+}
+
+// backendRoot walks up from the current working directory to the directory
+// containing go.mod (the backend module root). Test binaries run with their
+// package directory as cwd; the sweep command runs from backend/ or the repo
+// root's backend subdirectory.
+func backendRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}

--- a/backend/internal/testdb/config.go
+++ b/backend/internal/testdb/config.go
@@ -67,15 +67,21 @@ func openSQL(dsn string) *sql.DB {
 	return db
 }
 
-// acquireLifecycleLock takes the cross-process lifecycle lock on conn. The
-// lock is session-scoped; it releases when conn closes (or via the returned
-// unlock func).
-func acquireLifecycleLock(ctx context.Context, db *sql.DB) (unlock func(), err error) {
-	if _, err := db.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, lifecycleAdvisoryLockKey); err != nil {
-		return nil, err
+// acquireLifecycleLock pins the cross-process lifecycle lock to one
+// maintenance connection. PostgreSQL advisory locks are session-scoped, so
+// every protected DDL/query must use this returned connection until unlock.
+func acquireLifecycleLock(ctx context.Context, db *sql.DB) (conn *sql.Conn, unlock func(), err error) {
+	conn, err = db.Conn(ctx)
+	if err != nil {
+		return nil, nil, err
 	}
-	return func() {
-		_, _ = db.ExecContext(context.Background(), `SELECT pg_advisory_unlock($1)`, lifecycleAdvisoryLockKey)
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, lifecycleAdvisoryLockKey); err != nil {
+		_ = conn.Close()
+		return nil, nil, err
+	}
+	return conn, func() {
+		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock($1)`, lifecycleAdvisoryLockKey)
+		_ = conn.Close()
 	}, nil
 }
 

--- a/backend/internal/testdb/config.go
+++ b/backend/internal/testdb/config.go
@@ -79,6 +79,16 @@ func acquireLifecycleLock(ctx context.Context, db *sql.DB) (unlock func(), err e
 	}, nil
 }
 
+// ProjectRoot returns the repository root (the parent of the backend module
+// root), where .env and docker-compose.yml live.
+func ProjectRoot() (string, error) {
+	backend, err := backendRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(backend), nil
+}
+
 // backendRoot walks up from the current working directory to the directory
 // containing go.mod (the backend module root). Test binaries run with their
 // package directory as cwd; the sweep command runs from backend/ or the repo

--- a/backend/internal/testdb/dsn.go
+++ b/backend/internal/testdb/dsn.go
@@ -1,0 +1,51 @@
+// Package testdb owns the lifecycle of the backend test databases (ADR 0004):
+// it keeps the template `phoenix_test` current via a migrations hash, hands
+// every test binary a run-stamped package clone, and sweeps clones after the
+// run — including a generation GC that collects clones of dead runs across
+// worktrees. The long-lived postgres-test container is never owned here; the
+// suite owns the databases inside it, not the server.
+//
+// Callers: test.SetupTestDB (via the test helper package) and the sweep
+// command (internal/testdb/cmd/sweep) invoked by the test wrapper scripts.
+package testdb
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// parsePostgresDSN validates a postgres URL-style DSN and requires a database
+// name in the path.
+func parsePostgresDSN(dsn string) (*url.URL, error) {
+	if strings.TrimSpace(dsn) == "" {
+		return nil, fmt.Errorf("TEST_DB_DSN is empty")
+	}
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse TEST_DB_DSN: %w", err)
+	}
+	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
+		return nil, fmt.Errorf("TEST_DB_DSN must use postgres/postgresql scheme, got %q", parsed.Scheme)
+	}
+	if databaseNameFromURL(parsed) == "" {
+		return nil, fmt.Errorf("TEST_DB_DSN must include a database name")
+	}
+	return parsed, nil
+}
+
+func databaseNameFromURL(parsed *url.URL) string {
+	return strings.Trim(strings.TrimPrefix(parsed.Path, "/"), "/")
+}
+
+func withDatabaseName(source *url.URL, dbName string) *url.URL {
+	clone := *source
+	clone.Path = "/" + dbName
+	clone.RawPath = ""
+	return &clone
+}
+
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}

--- a/backend/internal/testdb/server.go
+++ b/backend/internal/testdb/server.go
@@ -1,0 +1,76 @@
+package testdb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// EnsureServer makes sure the postgres server behind cfg is reachable. If it
+// is not, it tries to start the long-lived local test container once
+// (`docker compose --profile test up -d postgres-test` at the project root)
+// and waits for readiness. A CI service container is already reachable, so
+// this never touches CI setups.
+func EnsureServer(ctx context.Context, cfg *Config) error {
+	if pingServer(ctx, cfg) == nil {
+		return nil
+	}
+
+	if err := startTestContainer(ctx); err != nil {
+		return fmt.Errorf(`test database server unreachable and auto-start failed: %v
+
+To run integration tests manually:
+  1. Start test database: docker compose --profile test up -d postgres-test
+  2. Ensure .env contains: TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable`, err)
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		if err := pingServer(ctx, cfg); err == nil {
+			return nil
+		} else if time.Now().After(deadline) {
+			return fmt.Errorf("test database server did not become ready within 60s after container start: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func pingServer(ctx context.Context, cfg *Config) error {
+	db := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = db.Close() }()
+
+	pingCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return db.PingContext(pingCtx)
+}
+
+// startTestContainer starts the postgres-test compose service from the
+// project root (the parent of the backend module root, where
+// docker-compose.yml lives).
+func startTestContainer(ctx context.Context) error {
+	backend, err := backendRoot()
+	if err != nil {
+		return fmt.Errorf("locate backend module root: %w", err)
+	}
+	projectRoot := filepath.Dir(backend)
+	if _, err := os.Stat(filepath.Join(projectRoot, "docker-compose.yml")); err != nil {
+		return fmt.Errorf("no docker-compose.yml at %s", projectRoot)
+	}
+
+	startCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(startCtx, "docker", "compose", "--profile", "test", "up", "-d", "postgres-test")
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("docker compose --profile test up -d postgres-test: %w\n%s", err, out)
+	}
+	return nil
+}

--- a/backend/internal/testdb/server.go
+++ b/backend/internal/testdb/server.go
@@ -52,25 +52,26 @@ func pingServer(ctx context.Context, cfg *Config) error {
 }
 
 // startTestContainer starts the postgres-test compose service from the
-// project root (the parent of the backend module root, where
-// docker-compose.yml lives).
+// project root (the parent of the backend module root, where the tracked
+// docker-compose.example.yml lives).
 func startTestContainer(ctx context.Context) error {
 	backend, err := backendRoot()
 	if err != nil {
 		return fmt.Errorf("locate backend module root: %w", err)
 	}
 	projectRoot := filepath.Dir(backend)
-	if _, err := os.Stat(filepath.Join(projectRoot, "docker-compose.yml")); err != nil {
-		return fmt.Errorf("no docker-compose.yml at %s", projectRoot)
+	composeFile := filepath.Join(projectRoot, "docker-compose.example.yml")
+	if _, err := os.Stat(composeFile); err != nil {
+		return fmt.Errorf("no docker-compose.example.yml at %s", projectRoot)
 	}
 
 	startCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(startCtx, "docker", "compose", "--profile", "test", "up", "-d", "postgres-test")
+	cmd := exec.CommandContext(startCtx, "docker", "compose", "-f", composeFile, "--profile", "test", "up", "-d", "postgres-test")
 	cmd.Dir = projectRoot
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("docker compose --profile test up -d postgres-test: %w\n%s", err, out)
+		return fmt.Errorf("docker compose -f docker-compose.example.yml --profile test up -d postgres-test: %w\n%s", err, out)
 	}
 	return nil
 }

--- a/backend/internal/testdb/sweep.go
+++ b/backend/internal/testdb/sweep.go
@@ -93,8 +93,8 @@ func Sweep(ctx context.Context, cfg *Config, opts SweepOptions) (*SweepResult, e
 
 func listDatabasesByPrefix(ctx context.Context, maint sqlExecutor, prefix string) ([]string, error) {
 	rows, err := maint.QueryContext(ctx,
-		`SELECT datname FROM pg_database WHERE datname LIKE $1 ORDER BY datname`,
-		prefix+"%")
+		`SELECT datname FROM pg_database WHERE LEFT(datname, char_length($1)) = $1 ORDER BY datname`,
+		prefix)
 	if err != nil {
 		return nil, fmt.Errorf("list databases with prefix %q: %w", prefix, err)
 	}

--- a/backend/internal/testdb/sweep.go
+++ b/backend/internal/testdb/sweep.go
@@ -1,0 +1,187 @@
+package testdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+)
+
+// SweepOptions controls Sweep.
+type SweepOptions struct {
+	// RunID selects this run's clones for teardown (dropped even without the
+	// generation GC's no-connection criterion — the run is over). Empty means
+	// GC-only.
+	RunID string
+	// ReportLeftovers compares each of this run's clones against the template
+	// before dropping it and reports tables with extra or missing rows.
+	// Opt-in diagnosis (PHX_TEST_LEFTOVERS=1), never a gate (ADR 0004).
+	ReportLeftovers bool
+}
+
+// TableDelta describes one table whose clone row count differs from the
+// template's.
+type TableDelta struct {
+	Table        string
+	TemplateRows int64
+	CloneRows    int64
+}
+
+// CloneLeftovers lists the row-count deltas of one clone vs. the template.
+type CloneLeftovers struct {
+	Clone  string
+	Tables []TableDelta
+}
+
+// SweepResult summarizes one Sweep run.
+type SweepResult struct {
+	Dropped   []string
+	Leftovers []CloneLeftovers
+}
+
+// Sweep tears down this run's clones and garbage-collects clones of dead
+// runs. It is the wrapper's post-run companion to CreateClone; aborted runs
+// without a sweep are collected by the next run's GC instead.
+func Sweep(ctx context.Context, cfg *Config, opts SweepOptions) (*SweepResult, error) {
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+
+	unlock, err := acquireLifecycleLock(ctx, maint)
+	if err != nil {
+		return nil, fmt.Errorf("acquire test DB lifecycle lock: %w", err)
+	}
+	defer unlock()
+
+	result := &SweepResult{}
+
+	if opts.RunID != "" {
+		runPrefix := ClonePrefix + SanitizeRunID(opts.RunID) + "_"
+		own, err := listDatabasesByPrefix(ctx, maint, runPrefix)
+		if err != nil {
+			return nil, err
+		}
+		if opts.ReportLeftovers && len(own) > 0 {
+			templateCounts, err := countAllTables(ctx, cfg.TemplateDSN())
+			if err != nil {
+				return nil, fmt.Errorf("count template rows for leftover report: %w", err)
+			}
+			for _, name := range own {
+				deltas, err := leftoverDeltas(ctx, cfg.DatabaseDSN(name), templateCounts)
+				if err != nil {
+					return nil, fmt.Errorf("diagnose leftovers in %q: %w", name, err)
+				}
+				if len(deltas) > 0 {
+					result.Leftovers = append(result.Leftovers, CloneLeftovers{Clone: name, Tables: deltas})
+				}
+			}
+		}
+		for _, name := range own {
+			if err := dropDatabase(ctx, maint, name); err != nil {
+				return result, fmt.Errorf("drop run clone %q: %w", name, err)
+			}
+			result.Dropped = append(result.Dropped, name)
+		}
+	}
+
+	gcDropped, err := gcLocked(ctx, maint, "", cfg.TemplateName())
+	if err != nil {
+		return result, err
+	}
+	result.Dropped = append(result.Dropped, gcDropped...)
+
+	return result, nil
+}
+
+func listDatabasesByPrefix(ctx context.Context, maint *sql.DB, prefix string) ([]string, error) {
+	rows, err := maint.QueryContext(ctx,
+		`SELECT datname FROM pg_database WHERE datname LIKE $1 ORDER BY datname`,
+		prefix+"%")
+	if err != nil {
+		return nil, fmt.Errorf("list databases with prefix %q: %w", prefix, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}
+
+// countAllTables returns exact row counts for every base table in dsn's
+// non-system schemas. Exact counts are deliberate: this only runs behind the
+// opt-in leftover diagnosis, and pg_stat estimates are unreliable right after
+// a clone.
+func countAllTables(ctx context.Context, dsn string) (map[string]int64, error) {
+	db := openSQL(dsn)
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT n.nspname || '.' || c.relname
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relkind = 'r'
+		  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY 1`)
+	if err != nil {
+		return nil, fmt.Errorf("list tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tables []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		tables = append(tables, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	counts := make(map[string]int64, len(tables))
+	for _, t := range tables {
+		var n int64
+		// t comes from pg_class of the trusted test server; quote both parts.
+		if err := db.QueryRowContext(ctx, `SELECT count(*) FROM `+quoteQualified(t)).Scan(&n); err != nil {
+			return nil, fmt.Errorf("count %s: %w", t, err)
+		}
+		counts[t] = n
+	}
+	return counts, nil
+}
+
+func quoteQualified(schemaDotTable string) string {
+	for i := 0; i < len(schemaDotTable); i++ {
+		if schemaDotTable[i] == '.' {
+			return quoteIdentifier(schemaDotTable[:i]) + "." + quoteIdentifier(schemaDotTable[i+1:])
+		}
+	}
+	return quoteIdentifier(schemaDotTable)
+}
+
+func leftoverDeltas(ctx context.Context, cloneDSN string, templateCounts map[string]int64) ([]TableDelta, error) {
+	cloneCounts, err := countAllTables(ctx, cloneDSN)
+	if err != nil {
+		return nil, err
+	}
+
+	tables := make([]string, 0, len(cloneCounts))
+	for t := range cloneCounts {
+		tables = append(tables, t)
+	}
+	sort.Strings(tables)
+
+	var deltas []TableDelta
+	for _, t := range tables {
+		if cloneCounts[t] != templateCounts[t] {
+			deltas = append(deltas, TableDelta{Table: t, TemplateRows: templateCounts[t], CloneRows: cloneCounts[t]})
+		}
+	}
+	return deltas, nil
+}

--- a/backend/internal/testdb/sweep.go
+++ b/backend/internal/testdb/sweep.go
@@ -2,7 +2,6 @@ package testdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 )
@@ -46,7 +45,7 @@ func Sweep(ctx context.Context, cfg *Config, opts SweepOptions) (*SweepResult, e
 	maint := openSQL(cfg.MaintenanceDSN())
 	defer func() { _ = maint.Close() }()
 
-	unlock, err := acquireLifecycleLock(ctx, maint)
+	conn, unlock, err := acquireLifecycleLock(ctx, maint)
 	if err != nil {
 		return nil, fmt.Errorf("acquire test DB lifecycle lock: %w", err)
 	}
@@ -56,7 +55,7 @@ func Sweep(ctx context.Context, cfg *Config, opts SweepOptions) (*SweepResult, e
 
 	if opts.RunID != "" {
 		runPrefix := ClonePrefix + SanitizeRunID(opts.RunID) + "_"
-		own, err := listDatabasesByPrefix(ctx, maint, runPrefix)
+		own, err := listDatabasesByPrefix(ctx, conn, runPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -76,14 +75,14 @@ func Sweep(ctx context.Context, cfg *Config, opts SweepOptions) (*SweepResult, e
 			}
 		}
 		for _, name := range own {
-			if err := dropDatabase(ctx, maint, name); err != nil {
+			if err := dropDatabase(ctx, conn, name); err != nil {
 				return result, fmt.Errorf("drop run clone %q: %w", name, err)
 			}
 			result.Dropped = append(result.Dropped, name)
 		}
 	}
 
-	gcDropped, err := gcLocked(ctx, maint, "", cfg.TemplateName())
+	gcDropped, err := gcLocked(ctx, conn, "", cfg.TemplateName())
 	if err != nil {
 		return result, err
 	}
@@ -92,7 +91,7 @@ func Sweep(ctx context.Context, cfg *Config, opts SweepOptions) (*SweepResult, e
 	return result, nil
 }
 
-func listDatabasesByPrefix(ctx context.Context, maint *sql.DB, prefix string) ([]string, error) {
+func listDatabasesByPrefix(ctx context.Context, maint sqlExecutor, prefix string) ([]string, error) {
 	rows, err := maint.QueryContext(ctx,
 		`SELECT datname FROM pg_database WHERE datname LIKE $1 ORDER BY datname`,
 		prefix+"%")

--- a/backend/internal/testdb/template.go
+++ b/backend/internal/testdb/template.go
@@ -133,13 +133,13 @@ func EnsureTemplate(ctx context.Context, cfg *Config, opts ...TemplateOption) er
 	maint := openSQL(cfg.MaintenanceDSN())
 	defer func() { _ = maint.Close() }()
 
-	unlock, err := acquireLifecycleLock(ctx, maint)
+	conn, unlock, err := acquireLifecycleLock(ctx, maint)
 	if err != nil {
 		return fmt.Errorf("acquire test DB lifecycle lock: %w", err)
 	}
 	defer unlock()
 
-	exists, comment, err := templateState(ctx, maint, cfg.TemplateName())
+	exists, comment, err := templateState(ctx, conn, cfg.TemplateName())
 	if err != nil {
 		return err
 	}
@@ -156,24 +156,30 @@ func EnsureTemplate(ctx context.Context, cfg *Config, opts ...TemplateOption) er
 				return fmt.Errorf("verify unstamped template %q: %w", cfg.TemplateName(), err)
 			}
 			if complete {
-				return stampTemplate(ctx, maint, cfg.TemplateName(), want)
+				return stampTemplate(ctx, conn, cfg.TemplateName(), want)
 			}
 		}
-		if err := dropDatabase(ctx, maint, cfg.TemplateName()); err != nil {
+		if err := dropDatabase(ctx, conn, cfg.TemplateName()); err != nil {
 			return fmt.Errorf("drop outdated template %q: %w", cfg.TemplateName(), err)
 		}
 	}
 
-	if _, err := maint.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cfg.TemplateName())); err != nil {
+	if _, err := conn.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cfg.TemplateName())); err != nil {
 		return fmt.Errorf("create template database %q: %w", cfg.TemplateName(), err)
 	}
 	if err := o.build(ctx, cfg.TemplateDSN()); err != nil {
 		return fmt.Errorf("build template database %q: %w", cfg.TemplateName(), err)
 	}
-	return stampTemplate(ctx, maint, cfg.TemplateName(), want)
+	return stampTemplate(ctx, conn, cfg.TemplateName(), want)
 }
 
-func templateState(ctx context.Context, maint *sql.DB, name string) (exists bool, comment string, err error) {
+type sqlExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func templateState(ctx context.Context, maint sqlExecutor, name string) (exists bool, comment string, err error) {
 	var nullComment sql.NullString
 	err = maint.QueryRowContext(ctx, `
 		SELECT sd.description
@@ -189,7 +195,7 @@ func templateState(ctx context.Context, maint *sql.DB, name string) (exists bool
 	return true, nullComment.String, nil
 }
 
-func stampTemplate(ctx context.Context, maint *sql.DB, name, comment string) error {
+func stampTemplate(ctx context.Context, maint sqlExecutor, name, comment string) error {
 	stmt := fmt.Sprintf(`COMMENT ON DATABASE %s IS '%s'`, quoteIdentifier(name), comment)
 	if _, err := maint.ExecContext(ctx, stmt); err != nil {
 		return fmt.Errorf("stamp template %q: %w", name, err)
@@ -197,7 +203,7 @@ func stampTemplate(ctx context.Context, maint *sql.DB, name, comment string) err
 	return nil
 }
 
-func dropDatabase(ctx context.Context, maint *sql.DB, name string) error {
+func dropDatabase(ctx context.Context, maint sqlExecutor, name string) error {
 	_, err := maint.ExecContext(ctx, `DROP DATABASE IF EXISTS `+quoteIdentifier(name)+` WITH (FORCE)`)
 	return err
 }
@@ -240,6 +246,9 @@ func normalizeMigrationVersion(version string) string {
 	}
 	if len(version)%3 != 0 {
 		return version
+	}
+	if len(version) == 6 {
+		return normalizeMigrationVersion(version[:3] + "." + version[3:] + ".0")
 	}
 	parts := make([]string, 0, len(version)/3)
 	for i := 0; i < len(version); i += 3 {

--- a/backend/internal/testdb/template.go
+++ b/backend/internal/testdb/template.go
@@ -26,8 +26,11 @@ const hashCommentPrefix = "phx-migrations-hash:"
 // import cycle. The template is therefore built via `go run . migrate`
 // (exactly what CI and developers run) and verified against the migration
 // filenames, whose digit prefixes are the names bun records in
-// bun_migrations.
-var migrationFilePattern = regexp.MustCompile(`^(\d+)_.+\.go$`)
+// bun_migrations. At least 6 digits: real migrations are 000001_… /
+// 001015302_…; the 2-digit 00_migrations.go is registry infrastructure and
+// registers no migration — matching it would make the completeness check
+// permanently false and turn every CI adopt into a full rebuild.
+var migrationFilePattern = regexp.MustCompile(`^(\d{6,})_.+\.go$`)
 
 // TemplateOption customizes EnsureTemplate. The build and verify hooks exist
 // for the lifecycle's own tests; production callers use the defaults (run

--- a/backend/internal/testdb/template.go
+++ b/backend/internal/testdb/template.go
@@ -1,0 +1,287 @@
+package testdb
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// hashCommentPrefix stamps the template database's comment with the hash of
+// the migration sources it was built from. The comment lives in the shared
+// pg_shdescription catalog, so it is readable and writable from the
+// maintenance connection without connecting to the template itself.
+const hashCommentPrefix = "phx-migrations-hash:"
+
+// This package deliberately does NOT import database/migrations: the test
+// helper package imports testdb, and the migrations package's own tests
+// import the test helper package — linking the registry here would close an
+// import cycle. The template is therefore built via `go run . migrate`
+// (exactly what CI and developers run) and verified against the migration
+// filenames, whose digit prefixes are the names bun records in
+// bun_migrations.
+var migrationFilePattern = regexp.MustCompile(`^(\d+)_.+\.go$`)
+
+// TemplateOption customizes EnsureTemplate. The build and verify hooks exist
+// for the lifecycle's own tests; production callers use the defaults (run
+// `go run . migrate` / compare bun_migrations against the migration files).
+type TemplateOption func(*templateOptions)
+
+type templateOptions struct {
+	hash   string
+	build  func(ctx context.Context, templateDSN string) error
+	verify func(ctx context.Context, templateDSN string) (bool, error)
+}
+
+// WithMigrationsHash overrides the migrations-source hash (tests only).
+func WithMigrationsHash(hash string) TemplateOption {
+	return func(o *templateOptions) { o.hash = hash }
+}
+
+// WithBuild overrides how a freshly created template database is populated
+// (tests only; default runs all migrations via `go run . migrate`).
+func WithBuild(build func(ctx context.Context, templateDSN string) error) TemplateOption {
+	return func(o *templateOptions) { o.build = build }
+}
+
+// WithVerify overrides the completeness check used to adopt an unstamped
+// template (tests only; default checks bun_migrations against the migration
+// filenames).
+func WithVerify(verify func(ctx context.Context, templateDSN string) (bool, error)) TemplateOption {
+	return func(o *templateOptions) { o.verify = verify }
+}
+
+func migrationsDir() (string, error) {
+	backend, err := backendRoot()
+	if err != nil {
+		return "", fmt.Errorf("locate backend module root: %w", err)
+	}
+	return filepath.Join(backend, "database", "migrations"), nil
+}
+
+// MigrationsHash returns a stable hash over all migration sources in
+// backend/database/migrations. Any edit, addition, or removal changes it.
+func MigrationsHash() (string, error) {
+	dir, err := migrationsDir()
+	if err != nil {
+		return "", err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("read migrations directory: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".go" {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	h := sha256.New()
+	for _, name := range names {
+		content, err := os.ReadFile(filepath.Join(dir, name)) //nolint:gosec // paths come from ReadDir of a repo directory
+		if err != nil {
+			return "", fmt.Errorf("read migration %s: %w", name, err)
+		}
+		_, _ = fmt.Fprintf(h, "%s\x00%d\x00", name, len(content))
+		h.Write(content)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// EnsureTemplate makes sure the template database exists and matches the
+// current migration sources:
+//
+//   - stamped with the current hash → untouched (fast warm start)
+//   - stamped with a different hash → dropped and rebuilt from migrations
+//   - unstamped but migration-complete (CI snapshot restore, legacy local
+//     `migrate reset` state) → adopted by stamping only
+//   - missing or unstamped-and-incomplete → built from migrations
+func EnsureTemplate(ctx context.Context, cfg *Config, opts ...TemplateOption) error {
+	o := templateOptions{
+		build:  buildTemplate,
+		verify: migrationsComplete,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.hash == "" {
+		hash, err := MigrationsHash()
+		if err != nil {
+			return err
+		}
+		o.hash = hash
+	}
+	want := hashCommentPrefix + o.hash
+
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+
+	unlock, err := acquireLifecycleLock(ctx, maint)
+	if err != nil {
+		return fmt.Errorf("acquire test DB lifecycle lock: %w", err)
+	}
+	defer unlock()
+
+	exists, comment, err := templateState(ctx, maint, cfg.TemplateName())
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if comment == want {
+			return nil
+		}
+		if len(comment) < len(hashCommentPrefix) || comment[:len(hashCommentPrefix)] != hashCommentPrefix {
+			// Unstamped template (CI snapshot restore or legacy local state):
+			// adopt it if it is migration-complete instead of rebuilding.
+			complete, err := o.verify(ctx, cfg.TemplateDSN())
+			if err != nil {
+				return fmt.Errorf("verify unstamped template %q: %w", cfg.TemplateName(), err)
+			}
+			if complete {
+				return stampTemplate(ctx, maint, cfg.TemplateName(), want)
+			}
+		}
+		if err := dropDatabase(ctx, maint, cfg.TemplateName()); err != nil {
+			return fmt.Errorf("drop outdated template %q: %w", cfg.TemplateName(), err)
+		}
+	}
+
+	if _, err := maint.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cfg.TemplateName())); err != nil {
+		return fmt.Errorf("create template database %q: %w", cfg.TemplateName(), err)
+	}
+	if err := o.build(ctx, cfg.TemplateDSN()); err != nil {
+		return fmt.Errorf("build template database %q: %w", cfg.TemplateName(), err)
+	}
+	return stampTemplate(ctx, maint, cfg.TemplateName(), want)
+}
+
+func templateState(ctx context.Context, maint *sql.DB, name string) (exists bool, comment string, err error) {
+	var nullComment sql.NullString
+	err = maint.QueryRowContext(ctx, `
+		SELECT sd.description
+		FROM pg_database d
+		LEFT JOIN pg_shdescription sd ON sd.objoid = d.oid AND sd.classoid = 'pg_database'::regclass
+		WHERE d.datname = $1`, name).Scan(&nullComment)
+	if err == sql.ErrNoRows {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("read template state for %q: %w", name, err)
+	}
+	return true, nullComment.String, nil
+}
+
+func stampTemplate(ctx context.Context, maint *sql.DB, name, comment string) error {
+	stmt := fmt.Sprintf(`COMMENT ON DATABASE %s IS '%s'`, quoteIdentifier(name), comment)
+	if _, err := maint.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("stamp template %q: %w", name, err)
+	}
+	return nil
+}
+
+func dropDatabase(ctx context.Context, maint *sql.DB, name string) error {
+	_, err := maint.ExecContext(ctx, `DROP DATABASE IF EXISTS `+quoteIdentifier(name)+` WITH (FORCE)`)
+	return err
+}
+
+// buildTemplate runs all migrations against the (empty) template database via
+// `go run . migrate` in the backend module root — the same entrypoint CI and
+// developers use. Role-creating migrations read PHOENIX_AUTH_PASSWORD from
+// the environment, so callers must load .env first.
+func buildTemplate(ctx context.Context, templateDSN string) error {
+	backend, err := backendRoot()
+	if err != nil {
+		return fmt.Errorf("locate backend module root: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "go", "run", ".", "migrate")
+	cmd.Dir = backend
+	cmd.Env = append(os.Environ(),
+		"APP_ENV=test",
+		"TEST_DB_DSN="+templateDSN,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go run . migrate: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// migrationsComplete reports whether every migration file's version (the
+// digit prefix bun records as the migration name) is applied in the database
+// behind dsn.
+func migrationsComplete(ctx context.Context, dsn string) (bool, error) {
+	dir, err := migrationsDir()
+	if err != nil {
+		return false, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, fmt.Errorf("read migrations directory: %w", err)
+	}
+
+	var wanted []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if len(name) > 8 && name[len(name)-8:] == "_test.go" {
+			continue
+		}
+		if m := migrationFilePattern.FindStringSubmatch(name); m != nil {
+			wanted = append(wanted, m[1])
+		}
+	}
+	if len(wanted) == 0 {
+		return false, fmt.Errorf("no migration files found in %s", dir)
+	}
+
+	db := openSQL(dsn)
+	defer func() { _ = db.Close() }()
+
+	var tableExists bool
+	if err := db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'bun_migrations')`,
+	).Scan(&tableExists); err != nil {
+		return false, fmt.Errorf("check bun_migrations table: %w", err)
+	}
+	if !tableExists {
+		return false, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT name FROM bun_migrations`)
+	if err != nil {
+		return false, fmt.Errorf("read applied migrations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	applied := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		applied[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+
+	for _, w := range wanted {
+		if _, ok := applied[w]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/backend/internal/testdb/template.go
+++ b/backend/internal/testdb/template.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -223,9 +224,36 @@ func buildTemplate(ctx context.Context, templateDSN string) error {
 	return nil
 }
 
-// migrationsComplete reports whether every migration file's version (the
-// digit prefix bun records as the migration name) is applied in the database
-// behind dsn.
+// normalizeMigrationVersion makes filename prefixes (001015301) and Bun's
+// semantic migration names (1.15.301) comparable.
+func normalizeMigrationVersion(version string) string {
+	if strings.Contains(version, ".") {
+		parts := strings.Split(version, ".")
+		for i, part := range parts {
+			n, err := strconv.ParseInt(part, 10, 64)
+			if err != nil {
+				return version
+			}
+			parts[i] = strconv.FormatInt(n, 10)
+		}
+		return strings.Join(parts, ".")
+	}
+	if len(version)%3 != 0 {
+		return version
+	}
+	parts := make([]string, 0, len(version)/3)
+	for i := 0; i < len(version); i += 3 {
+		n, err := strconv.ParseInt(version[i:i+3], 10, 64)
+		if err != nil {
+			return version
+		}
+		parts = append(parts, strconv.FormatInt(n, 10))
+	}
+	return strings.Join(parts, ".")
+}
+
+// migrationsComplete reports whether every migration file's version is
+// applied in the database behind dsn.
 func migrationsComplete(ctx context.Context, dsn string) (bool, error) {
 	dir, err := migrationsDir()
 	if err != nil {
@@ -246,7 +274,7 @@ func migrationsComplete(ctx context.Context, dsn string) (bool, error) {
 			continue
 		}
 		if m := migrationFilePattern.FindStringSubmatch(name); m != nil {
-			wanted = append(wanted, m[1])
+			wanted = append(wanted, normalizeMigrationVersion(m[1]))
 		}
 	}
 	if len(wanted) == 0 {
@@ -278,7 +306,7 @@ func migrationsComplete(ctx context.Context, dsn string) (bool, error) {
 		if err := rows.Scan(&name); err != nil {
 			return false, err
 		}
-		applied[name] = struct{}{}
+		applied[normalizeMigrationVersion(name)] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
 		return false, err

--- a/backend/internal/testdb/template.go
+++ b/backend/internal/testdb/template.go
@@ -321,10 +321,21 @@ func migrationsComplete(ctx context.Context, dsn string) (bool, error) {
 		return false, err
 	}
 
-	for _, w := range wanted {
-		if _, ok := applied[w]; !ok {
-			return false, nil
+	return migrationSetsMatch(wanted, applied), nil
+}
+
+func migrationSetsMatch(wanted []string, applied map[string]struct{}) bool {
+	expected := make(map[string]struct{}, len(wanted))
+	for _, version := range wanted {
+		expected[version] = struct{}{}
+	}
+	if len(expected) != len(applied) {
+		return false
+	}
+	for version := range expected {
+		if _, ok := applied[version]; !ok {
+			return false
 		}
 	}
-	return true, nil
+	return true
 }

--- a/backend/internal/testdb/template.go
+++ b/backend/internal/testdb/template.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 )
 
 // hashCommentPrefix stamps the template database's comment with the hash of
@@ -80,7 +81,9 @@ func MigrationsHash() (string, error) {
 
 	names := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if !e.IsDir() && filepath.Ext(e.Name()) == ".go" {
+		// _test.go files never affect the schema; hashing them would force
+		// a pointless ~25s template rebuild after editing a migration test.
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".go" && !strings.HasSuffix(e.Name(), "_test.go") {
 			names = append(names, e.Name())
 		}
 	}
@@ -141,7 +144,7 @@ func EnsureTemplate(ctx context.Context, cfg *Config, opts ...TemplateOption) er
 		if comment == want {
 			return nil
 		}
-		if len(comment) < len(hashCommentPrefix) || comment[:len(hashCommentPrefix)] != hashCommentPrefix {
+		if !strings.HasPrefix(comment, hashCommentPrefix) {
 			// Unstamped template (CI snapshot restore or legacy local state):
 			// adopt it if it is migration-complete instead of rebuilding.
 			complete, err := o.verify(ctx, cfg.TemplateDSN())
@@ -236,7 +239,7 @@ func migrationsComplete(ctx context.Context, dsn string) (bool, error) {
 			continue
 		}
 		name := e.Name()
-		if len(name) > 8 && name[len(name)-8:] == "_test.go" {
+		if strings.HasSuffix(name, "_test.go") {
 			continue
 		}
 		if m := migrationFilePattern.FindStringSubmatch(name); m != nil {

--- a/backend/internal/testdb/testdb_test.go
+++ b/backend/internal/testdb/testdb_test.go
@@ -87,6 +87,8 @@ func TestMigrationFilePatternMatchesOnlyRealMigrations(t *testing.T) {
 	assert.Equal(t, "001015302", migrationFilePattern.FindStringSubmatch("001015302_pickup_change_requests.go")[1])
 	assert.Equal(t, "1.15.301", normalizeMigrationVersion("001015301"))
 	assert.Equal(t, "1.15.301", normalizeMigrationVersion("1.15.301"))
+	assert.Equal(t, "0.0.0", normalizeMigrationVersion("000000"))
+	assert.Equal(t, "0.1.0", normalizeMigrationVersion("000001"))
 }
 
 func TestMigrationsHashIsStableAndSourceSensitive(t *testing.T) {
@@ -269,7 +271,7 @@ func TestMigrationsCompleteAgainstRealTemplate(t *testing.T) {
 
 	maint := openSQL(cfg.MaintenanceDSN())
 	defer func() { _ = maint.Close() }()
-	unlock, err := acquireLifecycleLock(ctx, maint)
+	_, unlock, err := acquireLifecycleLock(ctx, maint)
 	require.NoError(t, err)
 	defer unlock()
 
@@ -298,9 +300,9 @@ func TestCreateCloneAndSweepLifecycle(t *testing.T) {
 	// (empty spare prefix) must not collect it.
 	maint := openSQL(cfg.MaintenanceDSN())
 	defer func() { _ = maint.Close() }()
-	unlock, err := acquireLifecycleLock(ctx, maint)
+	conn, unlock, err := acquireLifecycleLock(ctx, maint)
 	require.NoError(t, err)
-	_, err = gcLocked(ctx, maint, "", cfg.TemplateName())
+	_, err = gcLocked(ctx, conn, "", cfg.TemplateName())
 	unlock()
 	require.NoError(t, err)
 	assert.True(t, databaseExists(t, ctx, cfg, handle.Name), "GC must spare a clone with a live keeper connection")

--- a/backend/internal/testdb/testdb_test.go
+++ b/backend/internal/testdb/testdb_test.go
@@ -1,0 +1,302 @@
+package testdb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/subosito/gotenv"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests (no database)
+// ---------------------------------------------------------------------------
+
+func TestParsePostgresDSNRejectsInvalidInput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dsn  string
+	}{
+		{name: "empty", dsn: ""},
+		{name: "wrong scheme", dsn: "mysql://user:pass@localhost/db"},
+		{name: "missing database", dsn: "postgres://user:pass@localhost:5433/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parsePostgresDSN(tc.dsn)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestConfigDerivesDSNs(t *testing.T) {
+	cfg, err := NewConfig("postgres://user:pass@localhost:5433/phoenix_test?sslmode=disable&application_name=tests")
+	require.NoError(t, err)
+
+	assert.Equal(t, "phoenix_test", cfg.TemplateName())
+	assert.Equal(t,
+		"postgres://user:pass@localhost:5433/postgres?sslmode=disable&application_name=tests",
+		cfg.MaintenanceDSN())
+	assert.Equal(t,
+		"postgres://user:pass@localhost:5433/phx_test_pkg_abc?sslmode=disable&application_name=tests",
+		cfg.DatabaseDSN("phx_test_pkg_abc"))
+}
+
+func TestQuoteIdentifierEscapesDoubleQuotes(t *testing.T) {
+	assert.Equal(t, `"plain"`, quoteIdentifier("plain"))
+	assert.Equal(t, `"has""quote"`, quoteIdentifier(`has"quote`))
+}
+
+func TestSanitizeRunID(t *testing.T) {
+	assert.Equal(t, "abc123", SanitizeRunID("abc123"))
+
+	hashed := SanitizeRunID("Not/A valid-ID that is way too long")
+	assert.Regexp(t, `^[a-f0-9]{12}$`, hashed)
+	assert.Equal(t, hashed, SanitizeRunID("Not/A valid-ID that is way too long"), "sanitizing must be deterministic")
+
+	random := SanitizeRunID("")
+	assert.Regexp(t, `^[a-z0-9]{1,16}$`, random)
+}
+
+func TestCloneNameIsValidPostgresIdentifier(t *testing.T) {
+	name := CloneName("run1", "/some/pkg/dir")
+	assert.True(t, strings.HasPrefix(name, ClonePrefix+"run1_"))
+	assert.LessOrEqual(t, len(name), 63)
+	assert.NotContains(t, name, "-")
+	assert.NotContains(t, name, "/")
+
+	assert.NotEqual(t, name, CloneName("run1", "/other/pkg/dir"), "different packages get different clones")
+	assert.NotEqual(t, name, CloneName("run2", "/some/pkg/dir"), "different runs get different clones")
+}
+
+func TestMigrationsHashIsStableAndSourceSensitive(t *testing.T) {
+	h1, err := MigrationsHash()
+	require.NoError(t, err)
+	h2, err := MigrationsHash()
+	require.NoError(t, err)
+	assert.Equal(t, h1, h2)
+	assert.Len(t, h1, 64)
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests (need TEST_DB_DSN; use private template names so the
+// real phoenix_test template is never touched)
+// ---------------------------------------------------------------------------
+
+var selfTestSeq atomic.Int64
+
+func integrationConfig(t *testing.T) *Config {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping DB integration test in -short mode")
+	}
+
+	if os.Getenv("TEST_DB_DSN") == "" {
+		if dir, err := os.Getwd(); err == nil {
+			for {
+				if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+					_ = gotenv.Load(filepath.Join(filepath.Dir(dir), ".env"))
+					break
+				}
+				parent := filepath.Dir(dir)
+				if parent == dir {
+					break
+				}
+				dir = parent
+			}
+		}
+	}
+	dsn := os.Getenv("TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("TEST_DB_DSN not set")
+	}
+
+	base, err := NewConfig(dsn)
+	require.NoError(t, err)
+
+	// Rewrite the template name to a private per-test one. Deliberately NOT
+	// the clone prefix: concurrent package binaries GC unconnected
+	// clone-prefixed databases, and a template cannot be pinned by a keeper
+	// connection (CREATE DATABASE refuses a source with active sessions).
+	// t.Cleanup drops it; only a killed process can leak one.
+	name := fmt.Sprintf("phx_test_selftmpl_%d_%d", os.Getpid()%100000, selfTestSeq.Add(1))
+	cfg, err := NewConfig(base.DatabaseDSN(name))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		maint := openSQL(cfg.MaintenanceDSN())
+		defer func() { _ = maint.Close() }()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = dropDatabase(ctx, maint, name)
+	})
+
+	return cfg
+}
+
+// fakeBuild creates a single marker table instead of running migrations.
+func fakeBuild(counter *int) func(ctx context.Context, dsn string) error {
+	return func(ctx context.Context, dsn string) error {
+		*counter++
+		db := openSQL(dsn)
+		defer func() { _ = db.Close() }()
+		_, err := db.ExecContext(ctx, `CREATE TABLE marker (id bigint primary key)`)
+		return err
+	}
+}
+
+func TestEnsureTemplateBuildsOnlyOnHashChange(t *testing.T) {
+	cfg := integrationConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	builds := 0
+	build := WithBuild(fakeBuild(&builds))
+
+	require.NoError(t, EnsureTemplate(ctx, cfg, build, WithMigrationsHash("hash1")))
+	assert.Equal(t, 1, builds, "fresh template must be built")
+
+	require.NoError(t, EnsureTemplate(ctx, cfg, build, WithMigrationsHash("hash1")))
+	assert.Equal(t, 1, builds, "unchanged hash must not rebuild")
+
+	require.NoError(t, EnsureTemplate(ctx, cfg, build, WithMigrationsHash("hash2")))
+	assert.Equal(t, 2, builds, "changed hash must rebuild")
+}
+
+func TestEnsureTemplateAdoptsUnstampedCompleteDatabase(t *testing.T) {
+	cfg := integrationConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Simulate the CI path: the database exists and is migration-complete,
+	// but carries no hash stamp.
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+	_, err := maint.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cfg.TemplateName()))
+	require.NoError(t, err)
+
+	builds := 0
+	verifyCalls := 0
+	require.NoError(t, EnsureTemplate(ctx, cfg,
+		WithBuild(fakeBuild(&builds)),
+		WithVerify(func(ctx context.Context, dsn string) (bool, error) {
+			verifyCalls++
+			return true, nil
+		}),
+		WithMigrationsHash("hash1")))
+
+	assert.Equal(t, 0, builds, "complete unstamped template must be adopted, not rebuilt")
+	assert.Equal(t, 1, verifyCalls)
+
+	// Adopted template is now stamped: a second call must not verify again.
+	require.NoError(t, EnsureTemplate(ctx, cfg,
+		WithBuild(fakeBuild(&builds)),
+		WithVerify(func(ctx context.Context, dsn string) (bool, error) {
+			verifyCalls++
+			return true, nil
+		}),
+		WithMigrationsHash("hash1")))
+	assert.Equal(t, 1, verifyCalls, "stamped template must skip verification")
+	assert.Equal(t, 0, builds)
+}
+
+func TestEnsureTemplateRebuildsUnstampedIncompleteDatabase(t *testing.T) {
+	cfg := integrationConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+	_, err := maint.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cfg.TemplateName()))
+	require.NoError(t, err)
+
+	builds := 0
+	require.NoError(t, EnsureTemplate(ctx, cfg,
+		WithBuild(fakeBuild(&builds)),
+		WithVerify(func(ctx context.Context, dsn string) (bool, error) { return false, nil }),
+		WithMigrationsHash("hash1")))
+	assert.Equal(t, 1, builds, "incomplete unstamped template must be rebuilt")
+}
+
+func TestCreateCloneAndSweepLifecycle(t *testing.T) {
+	cfg := integrationConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	builds := 0
+	require.NoError(t, EnsureTemplate(ctx, cfg, WithBuild(fakeBuild(&builds)), WithMigrationsHash("hash1")))
+
+	runID := SanitizeRunID("")
+	handle, err := CreateClone(ctx, cfg, runID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+
+	require.True(t, strings.HasPrefix(handle.Name, ClonePrefix+runID+"_"))
+	require.True(t, databaseExists(t, ctx, cfg, handle.Name))
+
+	// The keeper connection pins the clone: a GC pass from a foreign run
+	// (empty spare prefix) must not collect it.
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+	unlock, err := acquireLifecycleLock(ctx, maint)
+	require.NoError(t, err)
+	_, err = gcLocked(ctx, maint, "", cfg.TemplateName())
+	unlock()
+	require.NoError(t, err)
+	assert.True(t, databaseExists(t, ctx, cfg, handle.Name), "GC must spare a clone with a live keeper connection")
+
+	// The sweep drops this run's clones WITH (FORCE), so the keeper stays
+	// open until after the sweep — closing it early would open a window for
+	// a concurrent foreign run's GC to collect the clone first.
+	result, err := Sweep(ctx, cfg, SweepOptions{RunID: runID})
+	require.NoError(t, err)
+	assert.Contains(t, result.Dropped, handle.Name)
+	assert.False(t, databaseExists(t, ctx, cfg, handle.Name), "sweep must drop this run's clone")
+}
+
+func TestSweepReportsLeftovers(t *testing.T) {
+	cfg := integrationConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	builds := 0
+	require.NoError(t, EnsureTemplate(ctx, cfg, WithBuild(fakeBuild(&builds)), WithMigrationsHash("hash1")))
+
+	runID := SanitizeRunID("")
+	handle, err := CreateClone(ctx, cfg, runID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+
+	clone := openSQL(handle.DSN)
+	_, err = clone.ExecContext(ctx, `INSERT INTO marker (id) VALUES (42)`)
+	require.NoError(t, clone.Close())
+	require.NoError(t, err)
+
+	result, err := Sweep(ctx, cfg, SweepOptions{RunID: runID, ReportLeftovers: true})
+	require.NoError(t, err)
+	require.Len(t, result.Leftovers, 1)
+	assert.Equal(t, handle.Name, result.Leftovers[0].Clone)
+	require.Len(t, result.Leftovers[0].Tables, 1)
+	assert.Equal(t, "public.marker", result.Leftovers[0].Tables[0].Table)
+	assert.EqualValues(t, 0, result.Leftovers[0].Tables[0].TemplateRows)
+	assert.EqualValues(t, 1, result.Leftovers[0].Tables[0].CloneRows)
+	assert.Contains(t, result.Dropped, handle.Name)
+}
+
+func databaseExists(t *testing.T, ctx context.Context, cfg *Config, name string) bool {
+	t.Helper()
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+
+	var exists bool
+	err := maint.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)`, name).Scan(&exists)
+	require.NoError(t, err)
+	return exists
+}

--- a/backend/internal/testdb/testdb_test.go
+++ b/backend/internal/testdb/testdb_test.go
@@ -85,6 +85,8 @@ func TestMigrationFilePatternMatchesOnlyRealMigrations(t *testing.T) {
 
 	assert.Equal(t, "000001", migrationFilePattern.FindStringSubmatch("000001_core_functions.go")[1])
 	assert.Equal(t, "001015302", migrationFilePattern.FindStringSubmatch("001015302_pickup_change_requests.go")[1])
+	assert.Equal(t, "1.15.301", normalizeMigrationVersion("001015301"))
+	assert.Equal(t, "1.15.301", normalizeMigrationVersion("1.15.301"))
 }
 
 func TestMigrationsHashIsStableAndSourceSensitive(t *testing.T) {
@@ -138,6 +140,10 @@ func integrationConfig(t *testing.T) *Config {
 	name := fmt.Sprintf("phx_test_selftmpl_%d_%d", os.Getpid()%100000, selfTestSeq.Add(1))
 	cfg, err := NewConfig(base.DatabaseDSN(name))
 	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	require.NoError(t, EnsureServer(ctx, cfg))
 
 	t.Cleanup(func() {
 		maint := openSQL(cfg.MaintenanceDSN())
@@ -253,6 +259,7 @@ func TestMigrationsCompleteAgainstRealTemplate(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	require.NoError(t, EnsureServer(ctx, cfg))
 
 	// Ensure the template exists before checking it (a pristine server has
 	// none yet), and hold the lifecycle lock during the check: it opens

--- a/backend/internal/testdb/testdb_test.go
+++ b/backend/internal/testdb/testdb_test.go
@@ -100,6 +100,19 @@ func TestMigrationsHashIsStableAndSourceSensitive(t *testing.T) {
 	assert.Len(t, h1, 64)
 }
 
+func TestMigrationSetsMatchRequiresExactSet(t *testing.T) {
+	wanted := []string{"0.0.0", "1.15.301"}
+	assert.True(t, migrationSetsMatch(wanted, map[string]struct{}{
+		"0.0.0":    {},
+		"1.15.301": {},
+	}))
+	assert.False(t, migrationSetsMatch(wanted, map[string]struct{}{
+		"0.0.0":    {},
+		"1.15.301": {},
+		"1.15.302": {},
+	}), "newer migrations must force a template rebuild")
+}
+
 // ---------------------------------------------------------------------------
 // Integration tests (need TEST_DB_DSN; use private template names so the
 // real phoenix_test template is never touched)

--- a/backend/internal/testdb/testdb_test.go
+++ b/backend/internal/testdb/testdb_test.go
@@ -75,6 +75,18 @@ func TestCloneNameIsValidPostgresIdentifier(t *testing.T) {
 	assert.NotEqual(t, name, CloneName("run2", "/some/pkg/dir"), "different runs get different clones")
 }
 
+func TestMigrationFilePatternMatchesOnlyRealMigrations(t *testing.T) {
+	// Regression guard: 00_migrations.go (registry infrastructure) must NOT
+	// count as a wanted migration — its "00" is never a bun_migrations name,
+	// so matching it would make migrationsComplete permanently false and turn
+	// every CI adopt into a full template rebuild.
+	assert.Nil(t, migrationFilePattern.FindStringSubmatch("00_migrations.go"))
+	assert.Nil(t, migrationFilePattern.FindStringSubmatch("main.go"))
+
+	assert.Equal(t, "000001", migrationFilePattern.FindStringSubmatch("000001_core_functions.go")[1])
+	assert.Equal(t, "001015302", migrationFilePattern.FindStringSubmatch("001015302_pickup_change_requests.go")[1])
+}
+
 func TestMigrationsHashIsStableAndSourceSensitive(t *testing.T) {
 	h1, err := MigrationsHash()
 	require.NoError(t, err)
@@ -91,27 +103,25 @@ func TestMigrationsHashIsStableAndSourceSensitive(t *testing.T) {
 
 var selfTestSeq atomic.Int64
 
+// loadEnvForIntegration best-effort loads the project root .env when
+// TEST_DB_DSN is not already set (CI sets it directly).
+func loadEnvForIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TEST_DB_DSN") != "" {
+		return
+	}
+	if root, err := ProjectRoot(); err == nil {
+		_ = gotenv.Load(filepath.Join(root, ".env"))
+	}
+}
+
 func integrationConfig(t *testing.T) *Config {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping DB integration test in -short mode")
 	}
 
-	if os.Getenv("TEST_DB_DSN") == "" {
-		if dir, err := os.Getwd(); err == nil {
-			for {
-				if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-					_ = gotenv.Load(filepath.Join(filepath.Dir(dir), ".env"))
-					break
-				}
-				parent := filepath.Dir(dir)
-				if parent == dir {
-					break
-				}
-				dir = parent
-			}
-		}
-	}
+	loadEnvForIntegration(t)
 	dsn := os.Getenv("TEST_DB_DSN")
 	if dsn == "" {
 		t.Skip("TEST_DB_DSN not set")
@@ -222,6 +232,43 @@ func TestEnsureTemplateRebuildsUnstampedIncompleteDatabase(t *testing.T) {
 		WithVerify(func(ctx context.Context, dsn string) (bool, error) { return false, nil }),
 		WithMigrationsHash("hash1")))
 	assert.Equal(t, 1, builds, "incomplete unstamped template must be rebuilt")
+}
+
+// TestMigrationsCompleteAgainstRealTemplate pins the CI-adopt contract: the
+// actual migrated template must satisfy the default completeness check. If a
+// migration naming scheme ever drifts away from the filename-prefix
+// convention, this fails loudly instead of CI silently rebuilding the
+// template on every run.
+func TestMigrationsCompleteAgainstRealTemplate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping DB integration test in -short mode")
+	}
+	loadEnvForIntegration(t)
+	dsn := os.Getenv("TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("TEST_DB_DSN not set")
+	}
+	cfg, err := NewConfig(dsn)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Ensure the template exists before checking it (a pristine server has
+	// none yet), and hold the lifecycle lock during the check: it opens
+	// connections to the template, which would otherwise fail concurrent
+	// CREATE DATABASE ... TEMPLATE calls from parallel package binaries.
+	require.NoError(t, EnsureTemplate(ctx, cfg))
+
+	maint := openSQL(cfg.MaintenanceDSN())
+	defer func() { _ = maint.Close() }()
+	unlock, err := acquireLifecycleLock(ctx, maint)
+	require.NoError(t, err)
+	defer unlock()
+
+	complete, err := migrationsComplete(ctx, cfg.TemplateDSN())
+	require.NoError(t, err)
+	assert.True(t, complete, "the migrated template must pass the default completeness check — otherwise CI rebuilds instead of adopting")
 }
 
 func TestCreateCloneAndSweepLifecycle(t *testing.T) {

--- a/backend/test/db_clone.go
+++ b/backend/test/db_clone.go
@@ -120,7 +120,7 @@ func initCloneBootstrap(ctx context.Context, db *bun.DB) error {
 
 	// Ensure the default tenant (school ID 1) exists in platform.schools.
 	// Legacy fixtures use tenant_id=1, which requires a FK target row.
-	if err := ensureTestTenant(ctx, db, 1); err != nil {
+	if err := ensureBootstrapTenant(ctx, db); err != nil {
 		return fmt.Errorf("ensure default test tenant: %w", err)
 	}
 
@@ -130,26 +130,28 @@ func initCloneBootstrap(ctx context.Context, db *bun.DB) error {
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO facilities.rooms (id, tenant_id, name, building)
 		VALUES (1, 1, 'Default Room', 'Default')
-		ON CONFLICT (id) DO NOTHING`); err != nil {
+		ON CONFLICT (id) DO UPDATE
+		SET tenant_id = EXCLUDED.tenant_id, name = EXCLUDED.name, building = EXCLUDED.building`); err != nil {
 		return fmt.Errorf("ensure default room fixture (id=1): %w", err)
 	}
 
 	// Ensure default system staff exists (person ID 1, staff ID 1) for legacy
 	// tests that hardcode CreatedBy: 1 to satisfy created_by FK constraints.
-	// Unconstrained ON CONFLICT DO NOTHING because users.persons also carries
-	// idx_persons_tenant_pk UNIQUE(tenant_id, id) and Postgres reports that
-	// index first under load.
+	// Each ID is reconciled so an adopted legacy template cannot retain a
+	// bootstrap row from another tenant.
 	if err := db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		if _, e := tx.ExecContext(ctx, `
 			INSERT INTO users.persons (id, tenant_id, first_name, last_name)
 			VALUES (1, 1, 'System', 'Test')
-			ON CONFLICT DO NOTHING`); e != nil {
+			ON CONFLICT (id) DO UPDATE
+			SET tenant_id = EXCLUDED.tenant_id, first_name = EXCLUDED.first_name, last_name = EXCLUDED.last_name`); e != nil {
 			return fmt.Errorf("ensure system person fixture (id=1): %w", e)
 		}
 		if _, e := tx.ExecContext(ctx, `
 			INSERT INTO users.staff (id, tenant_id, person_id)
 			VALUES (1, 1, 1)
-			ON CONFLICT DO NOTHING`); e != nil {
+			ON CONFLICT (id) DO UPDATE
+			SET tenant_id = EXCLUDED.tenant_id, person_id = EXCLUDED.person_id`); e != nil {
 			return fmt.Errorf("ensure system staff fixture (id=1): %w", e)
 		}
 		return nil
@@ -165,5 +167,35 @@ func initCloneBootstrap(ctx context.Context, db *bun.DB) error {
 		return fmt.Errorf("advance bootstrap sequences: %w", err)
 	}
 
+	return nil
+}
+
+// ensureBootstrapTenant reconciles ID 1 from a legacy template before its
+// dependent bootstrap fixtures are created. Unlike ordinary test tenants,
+// this fixed ID is an invariant of legacy fixtures and cannot retain data
+// owned by another tenant.
+func ensureBootstrapTenant(ctx context.Context, db *bun.DB) error {
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO platform.organizations (id, name, slug, active)
+		VALUES (1, 'Test Org 1', 'test-org-1', true)
+		ON CONFLICT (id) DO UPDATE
+		SET name = EXCLUDED.name, slug = EXCLUDED.slug, active = EXCLUDED.active`); err != nil {
+		return fmt.Errorf("ensure bootstrap organization: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO platform.schools (id, organization_id, name, slug, subdomain, active)
+		VALUES (1, 1, 'Test School 1', 'test-school-1', 't1', true)
+		ON CONFLICT (id) DO UPDATE
+		SET organization_id = EXCLUDED.organization_id, name = EXCLUDED.name,
+			slug = EXCLUDED.slug, subdomain = EXCLUDED.subdomain, active = EXCLUDED.active`); err != nil {
+		return fmt.Errorf("ensure bootstrap school: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		SELECT setval(pg_get_serial_sequence('platform.organizations', 'id'),
+			GREATEST((SELECT last_value FROM platform.organizations_id_seq), 1)),
+		       setval(pg_get_serial_sequence('platform.schools', 'id'),
+			GREATEST((SELECT last_value FROM platform.schools_id_seq), 1))`); err != nil {
+		return fmt.Errorf("advance bootstrap tenant sequences: %w", err)
+	}
 	return nil
 }

--- a/backend/test/db_clone.go
+++ b/backend/test/db_clone.go
@@ -2,134 +2,168 @@ package test
 
 import (
 	"context"
-	"crypto/sha1"
-	"database/sql"
-	"encoding/hex"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/uptrace/bun/driver/pgdriver"
+	"github.com/moto-nrw/project-phoenix/database"
+	"github.com/moto-nrw/project-phoenix/internal/testdb"
+	"github.com/spf13/viper"
+	"github.com/subosito/gotenv"
+	"github.com/uptrace/bun"
 )
 
-const (
-	testDBCloneAdvisoryLockKey = int64(914735692)
-	testDBClonePrefix          = "phx_test_pkg_"
-)
+// This file wires SetupTestDB to the test-database lifecycle in
+// internal/testdb (ADR 0004): the process-once setup below makes `go test`
+// self-initializing (server up, template current per migrations hash, one
+// run-stamped clone per package binary) and keeps the per-test path free of
+// t.Setenv/viper writes so tests can run in parallel.
 
 var (
 	packageTestDBOnce sync.Once
-	packageTestDBDSN  string
 	packageTestDBErr  error
+
+	// packageClone pins this binary's clone via a keeper connection for the
+	// whole process lifetime, so the cross-run generation GC never collects
+	// a clone whose tests are still running. Deliberately never closed.
+	packageClone *testdb.CloneHandle
 )
 
-func packageIsolatedTestDSN(tb testing.TB, sourceDSN string) string {
-	tb.Helper()
-
-	packageTestDBOnce.Do(func() {
-		packageTestDBDSN, packageTestDBErr = ensurePackageTestDB(sourceDSN)
-	})
-	if packageTestDBErr != nil {
-		tb.Fatalf("setup package-isolated test database: %v", packageTestDBErr)
+// initPackageTestDB is the process-once part of SetupTestDB: environment,
+// lifecycle (server/template/clone), viper config, and the one-time clone
+// bootstrap. Everything after it is per-test and parallel-safe.
+func initPackageTestDB() error {
+	// Force test environment so database config always resolves to the test
+	// DB, regardless of how `go test` was invoked. Process-wide instead of
+	// t.Setenv: t.Setenv forbids t.Parallel(), and tests that need a
+	// different APP_ENV set their own via t.Setenv (which overrides this).
+	if err := os.Setenv("APP_ENV", "test"); err != nil {
+		return err
 	}
-	return packageTestDBDSN
-}
 
-func ensurePackageTestDB(sourceDSN string) (string, error) {
-	sourceURL, err := parsePostgresDSN(sourceDSN)
+	// Load .env from project root (contains TEST_DB_DSN). Best-effort: CI
+	// provides the variables directly.
+	if projectRoot, err := FindProjectRoot(); err == nil {
+		_ = gotenv.Load(filepath.Join(projectRoot, ".env"))
+	}
+
+	viper.AutomaticEnv()
+
+	dsn := os.Getenv("TEST_DB_DSN")
+	if dsn == "" {
+		return fmt.Errorf(`test database not configured.
+
+To run integration tests, ensure .env contains:
+  TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable
+
+The suite starts the postgres-test container and migrates the template
+automatically. For CI, set TEST_DB_DSN as an environment variable`)
+	}
+
+	cfg, err := testdb.NewConfig(dsn)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	sourceDB := databaseNameFromURL(sourceURL)
-	if sourceDB == "" {
-		return "", fmt.Errorf("TEST_DB_DSN must include a database name")
-	}
-
-	cloneDB, err := packageCloneDatabaseName()
-	if err != nil {
-		return "", err
-	}
-
-	maintenanceDSN := withDatabaseName(sourceURL, "postgres").String()
-	cloneDSN := withDatabaseName(sourceURL, cloneDB).String()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	// Template rebuilds run all migrations (~25s); everything else is fast.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(maintenanceDSN)))
-	defer func() { _ = sqldb.Close() }()
-
-	if err := sqldb.PingContext(ctx); err != nil {
-		return "", fmt.Errorf("connect to postgres maintenance database: %w", err)
+	if err := testdb.EnsureServer(ctx, cfg); err != nil {
+		return err
 	}
-
-	if _, err := sqldb.ExecContext(ctx, fmt.Sprintf(`SELECT pg_advisory_lock(%d)`, testDBCloneAdvisoryLockKey)); err != nil {
-		return "", fmt.Errorf("acquire package test DB clone lock: %w", err)
+	if err := testdb.EnsureTemplate(ctx, cfg); err != nil {
+		return err
 	}
-	defer func() {
-		unlockCtx, unlockCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer unlockCancel()
-		_, _ = sqldb.ExecContext(unlockCtx, fmt.Sprintf(`SELECT pg_advisory_unlock(%d)`, testDBCloneAdvisoryLockKey))
-	}()
-
-	if _, err := sqldb.ExecContext(ctx, `DROP DATABASE IF EXISTS `+quoteIdentifier(cloneDB)+` WITH (FORCE)`); err != nil {
-		return "", fmt.Errorf("drop stale package test database %q: %w", cloneDB, err)
-	}
-	if _, err := sqldb.ExecContext(ctx, `CREATE DATABASE `+quoteIdentifier(cloneDB)+` TEMPLATE `+quoteIdentifier(sourceDB)); err != nil {
-		return "", fmt.Errorf("clone test database %q from %q: %w", cloneDB, sourceDB, err)
-	}
-
-	return cloneDSN, nil
-}
-
-func parsePostgresDSN(dsn string) (*url.URL, error) {
-	if strings.TrimSpace(dsn) == "" {
-		return nil, fmt.Errorf("TEST_DB_DSN is empty")
-	}
-
-	parsed, err := url.Parse(dsn)
+	clone, err := testdb.CreateClone(ctx, cfg, testdb.RunID())
 	if err != nil {
-		return nil, fmt.Errorf("parse TEST_DB_DSN: %w", err)
+		return err
 	}
-	if parsed.Scheme != "postgres" && parsed.Scheme != "postgresql" {
-		return nil, fmt.Errorf("TEST_DB_DSN must use postgres/postgresql scheme, got %q", parsed.Scheme)
-	}
-	if databaseNameFromURL(parsed) == "" {
-		return nil, fmt.Errorf("TEST_DB_DSN must include a database name")
-	}
-	return parsed, nil
-}
+	packageClone = clone
 
-func packageCloneDatabaseName() (string, error) {
-	wd, err := os.Getwd()
+	applyViperTestConfig()
+
+	db, err := database.DBConn()
 	if err != nil {
-		return "", fmt.Errorf("determine package working directory: %w", err)
+		return fmt.Errorf("connect to package test database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	return initCloneBootstrap(ctx, db)
+}
+
+// applyViperTestConfig points viper at the package clone. APP_ENV=test
+// deliberately resolves only test_db_dsn; setting db_dsn would be ignored and
+// would silently send integration tests to the shared template database.
+//
+// Pool caps: each SetupTestDB call still opens its own pool (tests
+// `defer db.Close()`); the PR-2 sweep replaces these with one pool per
+// package. 3 conns/test fits comfortably within max_connections even with
+// all packages running in parallel.
+func applyViperTestConfig() {
+	viper.AutomaticEnv()
+	viper.Set("test_db_dsn", packageClone.DSN)
+	viper.Set("db_debug", false) // Set to true for SQL debugging
+	viper.Set("db_max_open_conns", 3)
+	viper.Set("db_max_idle_conns", 1)
+}
+
+// initCloneBootstrap seeds the per-package clone once: sequence offsets, the
+// default tenant (school 1), the default room, and the system staff fixture.
+// The fixed bootstrap entities disappear with the PR-2 per-test-tenant sweep.
+func initCloneBootstrap(ctx context.Context, db *bun.DB) error {
+	if err := applySequenceOffsets(ctx, db); err != nil {
+		return fmt.Errorf("apply test sequence offsets: %w", err)
 	}
 
-	normalized := filepath.ToSlash(wd)
-	sum := sha1.Sum([]byte(normalized))
-	hash := hex.EncodeToString(sum[:])[:16]
+	// Ensure the default tenant (school ID 1) exists in platform.schools.
+	// Legacy fixtures use tenant_id=1, which requires a FK target row.
+	if err := ensureTestTenant(ctx, db, 1); err != nil {
+		return fmt.Errorf("ensure default test tenant: %w", err)
+	}
 
-	return testDBClonePrefix + hash, nil
-}
+	// Ensure default fallback room exists (ID 1).
+	// session_service.go:determineRoomIDWithStrategy uses hardcoded fallback
+	// to room 1 when no room is specified and no planned room exists.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO facilities.rooms (id, tenant_id, name, building)
+		VALUES (1, 1, 'Default Room', 'Default')
+		ON CONFLICT (id) DO NOTHING`); err != nil {
+		return fmt.Errorf("ensure default room fixture (id=1): %w", err)
+	}
 
-func databaseNameFromURL(parsed *url.URL) string {
-	return strings.Trim(strings.TrimPrefix(parsed.Path, "/"), "/")
-}
+	// Ensure default system staff exists (person ID 1, staff ID 1) for legacy
+	// tests that hardcode CreatedBy: 1 to satisfy created_by FK constraints.
+	// Unconstrained ON CONFLICT DO NOTHING because users.persons also carries
+	// idx_persons_tenant_pk UNIQUE(tenant_id, id) and Postgres reports that
+	// index first under load.
+	if err := db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if _, e := tx.ExecContext(ctx, `
+			INSERT INTO users.persons (id, tenant_id, first_name, last_name)
+			VALUES (1, 1, 'System', 'Test')
+			ON CONFLICT DO NOTHING`); e != nil {
+			return fmt.Errorf("ensure system person fixture (id=1): %w", e)
+		}
+		if _, e := tx.ExecContext(ctx, `
+			INSERT INTO users.staff (id, tenant_id, person_id)
+			VALUES (1, 1, 1)
+			ON CONFLICT DO NOTHING`); e != nil {
+			return fmt.Errorf("ensure system staff fixture (id=1): %w", e)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("ensure system person/staff fixtures (id=1): %w", err)
+	}
 
-func withDatabaseName(source *url.URL, dbName string) *url.URL {
-	clone := *source
-	clone.Path = "/" + dbName
-	clone.RawPath = ""
-	return &clone
-}
+	// Advance the BIGSERIAL sequences past the explicitly-inserted IDs.
+	if _, err := db.ExecContext(ctx, `
+		SELECT setval('facilities.rooms_id_seq', GREATEST((SELECT last_value FROM facilities.rooms_id_seq), (SELECT COALESCE(MAX(id), 1) FROM facilities.rooms))),
+		       setval('users.persons_id_seq', GREATEST((SELECT last_value FROM users.persons_id_seq), (SELECT COALESCE(MAX(id), 1) FROM users.persons))),
+		       setval('users.staff_id_seq', GREATEST((SELECT last_value FROM users.staff_id_seq), (SELECT COALESCE(MAX(id), 1) FROM users.staff)))`); err != nil {
+		return fmt.Errorf("advance bootstrap sequences: %w", err)
+	}
 
-func quoteIdentifier(identifier string) string {
-	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+	return nil
 }

--- a/backend/test/db_clone.go
+++ b/backend/test/db_clone.go
@@ -45,7 +45,7 @@ func initPackageTestDB() error {
 
 	// Load .env from project root (contains TEST_DB_DSN). Best-effort: CI
 	// provides the variables directly.
-	if projectRoot, err := FindProjectRoot(); err == nil {
+	if projectRoot, err := testdb.ProjectRoot(); err == nil {
 		_ = gotenv.Load(filepath.Join(projectRoot, ".env"))
 	}
 

--- a/backend/test/db_clone_test.go
+++ b/backend/test/db_clone_test.go
@@ -1,59 +1,19 @@
 package test
 
+// The unit tests for DSN parsing, identifier quoting, and clone naming moved
+// with their implementation to internal/testdb (testdb_test.go). What stays
+// here is the behavioral contract of SetupTestDB against the lifecycle.
+
 import (
 	"context"
 	"strings"
 	"testing"
 
+	"github.com/moto-nrw/project-phoenix/internal/testdb"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestPackageTestDBDSNRewrite(t *testing.T) {
-	parsed, err := parsePostgresDSN("postgres://user:pass@localhost:5433/phoenix_test?sslmode=disable&application_name=tests")
-	require.NoError(t, err)
-
-	assert.Equal(t, "phoenix_test", databaseNameFromURL(parsed))
-
-	rewritten := withDatabaseName(parsed, "phx_test_pkg_abc123").String()
-	assert.Equal(t,
-		"postgres://user:pass@localhost:5433/phx_test_pkg_abc123?sslmode=disable&application_name=tests",
-		rewritten)
-}
-
-func TestParsePostgresDSNRejectsInvalidInput(t *testing.T) {
-	tests := []struct {
-		name string
-		dsn  string
-	}{
-		{name: "empty", dsn: ""},
-		{name: "wrong scheme", dsn: "mysql://user:pass@localhost/db"},
-		{name: "missing database", dsn: "postgres://user:pass@localhost:5433/"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := parsePostgresDSN(tc.dsn)
-			assert.Error(t, err)
-		})
-	}
-}
-
-func TestPackageCloneDatabaseNameIsValidPostgresIdentifier(t *testing.T) {
-	name, err := packageCloneDatabaseName()
-	require.NoError(t, err)
-
-	assert.True(t, strings.HasPrefix(name, testDBClonePrefix))
-	assert.LessOrEqual(t, len(name), 63)
-	assert.NotContains(t, name, "-")
-	assert.NotContains(t, name, "/")
-}
-
-func TestQuoteIdentifierEscapesDoubleQuotes(t *testing.T) {
-	assert.Equal(t, `"plain"`, quoteIdentifier("plain"))
-	assert.Equal(t, `"has""quote"`, quoteIdentifier(`has"quote`))
-}
 
 func TestSetupTestDBUsesPackageClone(t *testing.T) {
 	db := SetupTestDB(t)
@@ -62,12 +22,32 @@ func TestSetupTestDBUsesPackageClone(t *testing.T) {
 	var currentDB string
 	err := db.NewRaw(`SELECT current_database()`).Scan(context.Background(), &currentDB)
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(currentDB, testDBClonePrefix), "current database = %s", currentDB)
+	assert.True(t, strings.HasPrefix(currentDB, testdb.ClonePrefix), "current database = %s", currentDB)
+	assert.Contains(t, currentDB, testdb.RunID(), "clone must be stamped with this run's ID")
+	require.NotNil(t, packageClone, "package clone handle must be pinned for the process lifetime")
+	assert.Equal(t, packageClone.Name, currentDB, "tests must run against the pinned package clone")
 
 	var tenantExists bool
 	err = db.NewRaw(`SELECT EXISTS (SELECT 1 FROM platform.schools WHERE id = 1)`).Scan(context.Background(), &tenantExists)
 	require.NoError(t, err)
 	assert.True(t, tenantExists, "default tenant fixture should exist in the package clone")
+}
+
+func TestSetupTestDBAllowsParallelTests(t *testing.T) {
+	// The per-test path must be free of t.Setenv (which panics under
+	// t.Parallel) — this test IS the regression guard: it runs two parallel
+	// subtests through the full SetupTestDB path.
+	for _, name := range []string{"a", "b"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			db := SetupTestDB(t)
+			defer func() { _ = db.Close() }()
+
+			var one int
+			require.NoError(t, db.NewRaw(`SELECT 1`).Scan(context.Background(), &one))
+			assert.Equal(t, 1, one)
+		})
+	}
 }
 
 func TestNewTenantScopeCreatesTenantAndContext(t *testing.T) {

--- a/backend/test/fixtures.go
+++ b/backend/test/fixtures.go
@@ -2222,36 +2222,48 @@ func EnsureTestTenant(tb testing.TB, db *bun.DB, tenantID int64) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := db.ExecContext(ctx, `
+	require.NoError(tb, ensureTestTenant(ctx, db, tenantID), "Failed to ensure test tenant")
+}
+
+// ensureTestTenant is the error-returning core of EnsureTestTenant, shared
+// with the process-once clone bootstrap in db_clone.go.
+func ensureTestTenant(ctx context.Context, db *bun.DB, tenantID int64) error {
+	if _, err := db.ExecContext(ctx, `
 		INSERT INTO platform.organizations (id, name, slug, active)
 		VALUES (?, ?, ?, true)
 		ON CONFLICT (id) DO NOTHING`,
-		tenantID, fmt.Sprintf("Test Org %d", tenantID), fmt.Sprintf("test-org-%d", tenantID))
-	require.NoError(tb, err, "Failed to ensure test organization")
+		tenantID, fmt.Sprintf("Test Org %d", tenantID), fmt.Sprintf("test-org-%d", tenantID)); err != nil {
+		return fmt.Errorf("ensure test organization: %w", err)
+	}
 
-	_, err = db.ExecContext(ctx, `
+	if _, err := db.ExecContext(ctx, `
 		INSERT INTO platform.schools (id, organization_id, name, slug, subdomain, active)
 		VALUES (?, ?, ?, ?, ?, true)
 		ON CONFLICT (id) DO NOTHING`,
 		tenantID, tenantID,
 		fmt.Sprintf("Test School %d", tenantID),
 		fmt.Sprintf("test-school-%d", tenantID),
-		fmt.Sprintf("t%d", tenantID))
-	require.NoError(tb, err, "Failed to ensure test school")
+		fmt.Sprintf("t%d", tenantID)); err != nil {
+		return fmt.Errorf("ensure test school: %w", err)
+	}
 
-	// Advance sequences past the explicitly inserted ID so that concurrent
-	// packages using auto-generated IDs (nextval) don't collide.
-	_, err = db.ExecContext(ctx, `
+	// Advance sequences past the explicitly inserted ID so that tests using
+	// auto-generated IDs (nextval) don't collide.
+	if _, err := db.ExecContext(ctx, `
 		SELECT setval(pg_get_serial_sequence('platform.organizations', 'id'),
 			GREATEST((SELECT last_value FROM platform.organizations_id_seq), ?))`,
-		tenantID)
-	require.NoError(tb, err, "Failed to advance org sequence past explicit tenant ID")
+		tenantID); err != nil {
+		return fmt.Errorf("advance org sequence past explicit tenant ID: %w", err)
+	}
 
-	_, err = db.ExecContext(ctx, `
+	if _, err := db.ExecContext(ctx, `
 		SELECT setval(pg_get_serial_sequence('platform.schools', 'id'),
 			GREATEST((SELECT last_value FROM platform.schools_id_seq), ?))`,
-		tenantID)
-	require.NoError(tb, err, "Failed to advance school sequence past explicit tenant ID")
+		tenantID); err != nil {
+		return fmt.Errorf("advance school sequence past explicit tenant ID: %w", err)
+	}
+
+	return nil
 }
 
 // CreateTestTenant creates an organization + school pair that nobody else

--- a/backend/test/helpers.go
+++ b/backend/test/helpers.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,35 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 )
-
-// FindProjectRoot walks up the directory tree from the current working directory
-// until it finds a directory containing go.mod. Returns the parent of that directory
-// (the actual project root where .env lives).
-//
-// This approach is self-healing: it works regardless of how deep the test file is
-// in the directory structure, eliminating fragile "../.." path counting.
-func FindProjectRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		// Check if go.mod exists in this directory
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			// Found backend/go.mod, return parent (project-phoenix/)
-			return filepath.Dir(dir), nil
-		}
-
-		// Move up one directory
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			// Reached filesystem root without finding go.mod
-			return "", os.ErrNotExist
-		}
-		dir = parent
-	}
-}
 
 // SetupTestDB creates a test database connection using the standard configuration.
 // The first call in a test binary initializes the whole test-database

--- a/backend/test/helpers.go
+++ b/backend/test/helpers.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -13,7 +12,6 @@ import (
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"github.com/subosito/gotenv"
 	"github.com/uptrace/bun"
 )
 
@@ -46,32 +44,14 @@ func FindProjectRoot() (string, error) {
 	}
 }
 
-// LoadTestEnv loads the .env file from the project root.
-// This is the standard way to configure test database connections.
-//
-// Usage in test files:
-//
-//	func setupTestDB(t *testing.T) *bun.DB {
-//	    testpkg.LoadTestEnv(t)
-//	    // ... rest of setup
-//	}
-func LoadTestEnv(t *testing.T) {
-	t.Helper()
-
-	projectRoot, err := FindProjectRoot()
-	if err != nil {
-		t.Logf("Warning: Could not find project root: %v", err)
-		return
-	}
-
-	envPath := filepath.Join(projectRoot, ".env")
-	if err := gotenv.Load(envPath); err != nil {
-		t.Logf("Warning: Could not load %s: %v", envPath, err)
-	}
-}
-
 // SetupTestDB creates a test database connection using the standard configuration.
-// It automatically loads .env from project root and configures the database DSN.
+// The first call in a test binary initializes the whole test-database
+// lifecycle (server up, template current, package clone created and
+// bootstrapped — see db_clone.go and internal/testdb); every call opens a
+// small per-test pool against the package clone.
+//
+// The per-test path performs no t.Setenv or viper writes, so tests using it
+// may call t.Parallel().
 //
 // This is the preferred way to get a database connection in tests:
 //
@@ -93,46 +73,20 @@ func SetupTestDB(t *testing.T) *bun.DB {
 		t.Skip("skipping DB integration test in -short mode")
 	}
 
-	// Force test environment so database config always resolves to the test DB,
-	// regardless of how `go test` was invoked (with or without APP_ENV=test).
-	// t.Setenv automatically restores the original value when the test finishes.
-	t.Setenv("APP_ENV", "test")
-
-	// Load .env from project root (contains TEST_DB_DSN)
-	LoadTestEnv(t)
-
-	// Initialize viper to read environment variables
-	viper.AutomaticEnv()
-
-	// Require explicit TEST_DB_DSN - fail fast with clear instructions if missing.
-	// This follows the HashiCorp pattern: test database config should be explicit,
-	// not guessed from runtime config like GetDatabaseDSN().
-	dsn := os.Getenv("TEST_DB_DSN")
-	if dsn == "" {
-		t.Fatal(`Test database not configured.
-
-To run integration tests:
-  1. Start test database: docker compose --profile test up -d postgres-test
-  2. Ensure .env contains: TEST_DB_DSN=postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable
-
-For CI, set TEST_DB_DSN as an environment variable.`)
+	packageTestDBOnce.Do(func() {
+		packageTestDBErr = initPackageTestDB()
+	})
+	if packageTestDBErr != nil {
+		t.Fatalf("setup package test database: %v", packageTestDBErr)
 	}
 
-	dsn = packageIsolatedTestDSN(t, dsn)
-
-	// APP_ENV=test deliberately resolves only TEST_DB_DSN. Point that key at
-	// the package-isolated clone; setting db_dsn here would be ignored and
-	// would silently send integration tests to the shared template database.
-	viper.Set("test_db_dsn", dsn)
-	viper.Set("db_debug", false) // Set to true for SQL debugging
-	// Cap per-test pool size. Each call to SetupTestDB opens a fresh
-	// pool; the prod default is 25 connections, which exhausts
-	// Postgres's max_connections (~100) once gotestsum runs the test
-	// packages in parallel. 3 conns/test fits comfortably and is more
-	// than enough for the test fixture chain (1-2 statements at a
-	// time).
-	viper.Set("db_max_open_conns", 3)
-	viper.Set("db_max_idle_conns", 1)
+	// Self-heal after tests that call viper.Reset() (factory config tests):
+	// without this, every later test in the package would lose test_db_dsn.
+	// Read-then-repair keeps the parallel path write-free while the config
+	// is intact (viper is not thread-safe; resetters run sequentially today).
+	if viper.GetString("test_db_dsn") != packageClone.DSN {
+		applyViperTestConfig()
+	}
 
 	db, err := database.DBConn()
 	require.NoError(t, err, "Failed to connect to test database")
@@ -142,85 +96,6 @@ For CI, set TEST_DB_DSN as an environment variable.`)
 	// which fails when the target schema isn't in search_path.
 	_, _ = db.ExecContext(context.Background(),
 		`SET search_path TO public, platform, auth, users, education, facilities, activities, active, schedule, iot, feedback, config, meta, audit`)
-
-	// Spread PK sequences into disjoint per-table ranges so fixture IDs from
-	// different tables never collide numerically (see sequence_offsets.go).
-	applySequenceOffsets(t, db)
-
-	// Ensure the default tenant (school ID 1) exists in platform.schools.
-	// All fixtures use tenant_id=1, which requires a FK target row.
-	EnsureTestTenant(t, db, 1)
-
-	// Ensure default fallback room exists (ID 1).
-	// session_service.go:determineRoomIDWithStrategy uses hardcoded fallback to room 1
-	// when no room is specified and no planned room exists.
-	_, _ = db.ExecContext(context.Background(), `
-		INSERT INTO facilities.rooms (id, tenant_id, name, building)
-		VALUES (1, 1, 'Default Room', 'Default')
-		ON CONFLICT (id) DO NOTHING`)
-
-	// Ensure default system staff exists (person ID 1, staff ID 1) for legacy
-	// tests that hardcode CreatedBy: 1 to satisfy created_by FK constraints on
-	// schedule/activity tables. Same convention as rooms.id=1 and schools.id=1.
-	// Fail fast: if the fixture insert breaks (schema drift, missing schools FK),
-	// downstream tests would otherwise fail with cryptic "missing staff" errors.
-	//
-	// Wrap both inserts in a transaction so they're atomic from the perspective
-	// of parallel test packages. Otherwise a concurrent CleanupActivityFixtures
-	// could delete the persons row between the two inserts, leaving the staff
-	// FK to fail. Use unconstrained ON CONFLICT DO NOTHING (rather than
-	// ON CONFLICT (id)) because users.persons also carries
-	// idx_persons_tenant_pk UNIQUE(tenant_id, id) and Postgres reports that
-	// index first under load, so a column-targeted ON CONFLICT leaks the error.
-	// After the upserts, reconcile any wrong-tenant row so the system fixture
-	// always ends up at (tenant_id=1, id=1).
-	ctx := context.Background()
-	require.NoError(t, db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		// Serialize concurrent fixture setup across parallel test packages.
-		// pg_advisory_xact_lock is released automatically on commit/rollback,
-		// so other packages wait at this line instead of racing the inserts
-		// below. Constant must stay identical wherever this lock is taken.
-		if _, e := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(914735691)`); e != nil {
-			return fmt.Errorf("acquire system fixture advisory lock: %w", e)
-		}
-		if _, e := tx.ExecContext(ctx, `
-			INSERT INTO users.persons (id, tenant_id, first_name, last_name)
-			VALUES (1, 1, 'System', 'Test')
-			ON CONFLICT DO NOTHING`); e != nil {
-			return fmt.Errorf("ensure system person fixture (id=1): %w", e)
-		}
-		if _, e := tx.ExecContext(ctx, `
-			UPDATE users.persons SET tenant_id = 1, first_name = 'System', last_name = 'Test'
-			WHERE id = 1 AND tenant_id <> 1`); e != nil {
-			return fmt.Errorf("reconcile system person tenant_id (id=1): %w", e)
-		}
-		if _, e := tx.ExecContext(ctx, `
-			INSERT INTO users.staff (id, tenant_id, person_id)
-			VALUES (1, 1, 1)
-			ON CONFLICT DO NOTHING`); e != nil {
-			return fmt.Errorf("ensure system staff fixture (id=1): %w", e)
-		}
-		if _, e := tx.ExecContext(ctx, `
-			UPDATE users.staff SET tenant_id = 1, person_id = 1
-			WHERE id = 1 AND (tenant_id <> 1 OR person_id <> 1)`); e != nil {
-			return fmt.Errorf("reconcile system staff tenant_id (id=1): %w", e)
-		}
-		return nil
-	}), "SetupTestDB: failed to ensure system person/staff fixtures (id=1)")
-
-	// Advance the BIGSERIAL sequence past any explicitly-inserted IDs.
-	// Uses nextval (atomic, never goes backwards) instead of setval to avoid
-	// races when parallel test packages call SetupTestDB concurrently.
-	_, _ = db.ExecContext(context.Background(), `
-		DO $$ DECLARE max_id bigint;
-		BEGIN
-			SELECT COALESCE(MAX(id), 0) INTO max_id FROM facilities.rooms;
-			WHILE nextval('facilities.rooms_id_seq') < max_id LOOP END LOOP;
-			SELECT COALESCE(MAX(id), 0) INTO max_id FROM users.persons;
-			WHILE nextval('users.persons_id_seq') < max_id LOOP END LOOP;
-			SELECT COALESCE(MAX(id), 0) INTO max_id FROM users.staff;
-			WHILE nextval('users.staff_id_seq') < max_id LOOP END LOOP;
-		END $$`)
 
 	return db
 }

--- a/backend/test/sequence_offsets.go
+++ b/backend/test/sequence_offsets.go
@@ -2,40 +2,33 @@ package test
 
 import (
 	"context"
-	"sync"
-	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 )
 
-var sequenceOffsetsOnce sync.Once
-
 // applySequenceOffsets moves every table's PK sequence into its own disjoint
 // numeric range (Nth sequence by schema+name starts at N*10M), so IDs from
-// different tables can never collide numerically.
+// different tables can never collide numerically. It runs once per package
+// clone from the process-once bootstrap in db_clone.go.
 //
 // Why: the generic cleanup helpers (CleanupActivityFixtures and friends) try
 // each passed ID against many tables with `id = ?` arms. With all sequences
-// starting near 1, a staff PK from one test package regularly equals an
-// activity-group or supervisor PK from another package running concurrently
-// against the shared test DB, and the cleanup deletes the foreign row
+// starting near 1, a staff PK regularly equals an activity-group or
+// supervisor PK from another test, and the cleanup deletes the foreign row
 // mid-test. Disjoint ranges kill the whole collision class without touching
-// any call site.
+// any call site. The offsets stay in place as a flake detector until the
+// PR-2 sweep removes the cleanup helpers (ADR 0004); then they go too.
 //
 // Properties:
 //   - Idempotent and monotonic: setval(GREATEST(last_value, offset)) never
-//     moves a sequence backward, so concurrent test binaries all converge.
+//     moves a sequence backward.
 //   - Explicit-ID system fixtures (schools.id=1, rooms.id=1, staff.id=1)
 //     are unaffected; offsets only change nextval.
 //   - Max offset stays far below the int4 ceiling (2.1B) up to ~200 tables.
-//   - Ordinals are positional: adding a migration with a new table can shift
-//     assignments on a long-lived local DB. CI databases are fresh per run;
-//     locally, `APP_ENV=test go run main.go migrate reset` re-baselines.
-func applySequenceOffsets(tb testing.TB, db *bun.DB) {
-	tb.Helper()
-	sequenceOffsetsOnce.Do(func() {
-		_, err := db.ExecContext(context.Background(), `
+//   - Ordinals are positional, but every package clone is created fresh from
+//     the template per run, so assignments cannot drift between runs.
+func applySequenceOffsets(ctx context.Context, db *bun.DB) error {
+	_, err := db.ExecContext(ctx, `
 DO $$
 DECLARE
   seq record;
@@ -56,6 +49,5 @@ BEGIN
   END LOOP;
 END $$;
 `)
-		require.NoError(tb, err, "Failed to apply test sequence offsets")
-	})
+	return err
 }

--- a/devbox.json
+++ b/devbox.json
@@ -43,6 +43,9 @@
     "PATH":        "$HOME/go/bin:$PATH"
   },
   "shell": {
+    "scripts": {
+      "test-backend": "scripts/test-backend.sh"
+    },
     "init_hook": [
       "unset DEVELOPER_DIR",
       "lefthook install --force > /dev/null 2>&1 || true",

--- a/docs/adr/0004-testsuite-besitzt-datenbanken-nicht-server.md
+++ b/docs/adr/0004-testsuite-besitzt-datenbanken-nicht-server.md
@@ -1,0 +1,51 @@
+# Die Testsuite besitzt ihre Datenbanken, nicht den Postgres-Server
+
+Bis August 2026 hatte die Backend-Testsuite keinen Lebenszyklus-Endpunkt:
+Package-Clones (`phx_test_pkg_<SHA1(Pfad)>`) wurden nur beim nächsten Lauf
+desselben Pfads gedroppt, nie beim Teardown — pro Worktree und Umbenennung
+leakte je Package eine Datenbank für immer (Stand 19.08.2026: 1092 verwaiste
+Clones, 33 GB). Gleichzeitig verhinderten `t.Setenv("APP_ENV", "test")` und
+`viper.Set(...)` in `SetupTestDB` jede Intra-Package-Parallelität, jeder
+Test-Aufruf öffnete einen frischen 3-Conn-Pool (2665 pro Suite-Lauf), und die
+Suite war DB-gebunden statt CPU-gebunden (`services/active`: 80s Wandzeit bei
+4,5s CPU). Die CI-Kosten (Blacksmith, 8-vCPU-Runner, Ø 3,8 min test-backend
+bei ~1.200 Runs/Monat) machten jede Testminute zum direkten Kostenfaktor
+(#2419).
+
+Entscheidung (Umsetzung: ein Issue #2419, zwei PRs — erst Lebenszyklus, dann
+mechanischer Sweep über alle Testdateien):
+
+- **Der lokale `postgres-test`-Container bleibt langlebig.** Die Suite besitzt
+  die *Datenbanken* darin, nicht den Server: `go test` ist selbst-
+  initialisierend (Container bei Bedarf starten, Template `phoenix_test` per
+  Migrations-Hash prüfen und neu bauen), ein Make-/devbox-Target liefert nur
+  Komfort obendrauf (gotestsum, sofortiges Teardown). CI behält Service-
+  Container und Snapshot-Cache unverändert.
+- **Kein TestMain in den 62 Packages.** Das Prozess-einmalige Setup wandert in
+  ein `sync.Once` innerhalb von `SetupTestDB`; Clone-Teardown übernimmt der
+  Wrapper nach dem Gesamtlauf, eine Generation-GC (läuft über alle Worktrees)
+  fängt abgebrochene Läufe. Ein nacktes `go test ./pkg` darf seinen Clone bis
+  zur nächsten GC liegen lassen.
+- **Isolation pro Test über Fixtures, nicht über Transaktions-Rollback.**
+  Jeder Test erzeugt seinen eigenen Tenant statt des fixen Bootstrap-Tenants 1;
+  der geteilte Package-Clone bleibt. Rollback-pro-Test scheitert an Code, der
+  selbst Transaktionen und RLS-Rollen öffnet (`TenantTxMiddleware`).
+- **Alle Packages werden parallel-sicher — ohne Fluchtluke.** Keine
+  Serial-Allowlist; sture Tests werden repariert. Per-Row-DELETE-Cleanups
+  (`defer Cleanup*`) werden ersatzlos entfernt, die Clone-Isolation macht sie
+  redundant. Ein Pool pro Package (≈ GOMAXPROCS, gedeckelt) ersetzt die
+  per-Test-Pools.
+- **Leftover-Detection ist Diagnose, kein Gate**: Opt-in per Env-Flag,
+  Standard aus. Die Hermetik kommt aus dem Lebenszyklus, nicht aus der
+  Detection. Sequence-Offsets bleiben zunächst als Flake-Detektor und werden
+  gestrichen, sobald die Suite auf frischen Clones grün ist.
+
+Abgewogen: Ein ephemerer Postgres pro Lauf hätte „Start = Ende" trivial wahr
+gemacht, kostet aber pro Lauf den Template-Neubau (~25s) oder einen eigenen
+Cache dafür; der langlebige Container mit Datenbank-GC liefert dieselbe
+Garantie auf Datenbank-Ebene ohne diesen Preis. TestMain pro Package hätte
+auch nackte `go test`-Aufrufe aufräumen lassen, wurde aber gegen 62
+Boilerplate-Dateien getauscht, weil die GC den Rest erledigt. Zielwerte:
+CI test-backend unter 90 Sekunden, lokaler Volllauf ≈ 2 Minuten; die Frage
+4-vCPU- statt 8-vCPU-Runner wird erst nach dem Umbau gemessen, nicht vorab
+entschieden.

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -16,7 +16,9 @@ PHX_TEST_RUN_ID=$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')
 export PHX_TEST_RUN_ID
 
 sweep() {
-  go run ./internal/testdb/cmd/sweep
+  status=$?
+  go run ./internal/testdb/cmd/sweep || true
+  return "$status"
 }
 trap sweep EXIT
 

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Backend-Testsuite mit vollem Datenbank-Lebenszyklus (ADR 0004):
+# ein Run-Stempel für alle Package-Clones, gotestsum-Formatierung wenn
+# verfügbar, und ein Sweep am Ende (auch bei Ctrl-C/Fehlschlag), der die
+# Clones dieses Laufs droppt und verwaiste Clones toter Läufe einsammelt.
+#
+# `go test ./...` funktioniert weiterhin ohne dieses Skript (selbst-
+# initialisierend); dann räumt erst die Generation-GC des nächsten Laufs auf.
+#
+# Usage: scripts/test-backend.sh [go-test-args...]     (Default: ./...)
+#   PHX_TEST_LEFTOVERS=1 scripts/test-backend.sh       # Restdaten-Diagnose
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)/backend"
+
+PHX_TEST_RUN_ID=$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')
+export PHX_TEST_RUN_ID
+
+sweep() {
+  go run ./internal/testdb/cmd/sweep
+}
+trap sweep EXIT
+
+if [ "$#" -eq 0 ]; then
+  set -- ./...
+fi
+
+if go tool gotestsum --help >/dev/null 2>&1; then
+  go tool gotestsum --format pkgname-and-test-fails -- "$@"
+else
+  go test "$@"
+fi

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -9,7 +9,7 @@
 #
 # Usage: scripts/test-backend.sh [go-test-args...]     (Default: ./...)
 #   PHX_TEST_LEFTOVERS=1 scripts/test-backend.sh       # Restdaten-Diagnose
-set -uo pipefail
+set -euo pipefail
 cd "$(git rev-parse --show-toplevel)/backend"
 
 PHX_TEST_RUN_ID=$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')

--- a/scripts/test-changed.sh
+++ b/scripts/test-changed.sh
@@ -8,6 +8,13 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
+# Backend-Läufe stempeln ihre DB-Clones mit einer Run-ID; der Sweep am Ende
+# droppt sie wieder und sammelt Clones toter Läufe ein (ADR 0004).
+PHX_TEST_RUN_ID=$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')
+export PHX_TEST_RUN_ID
+backend_sweep() { (cd backend && go run ./internal/testdb/cmd/sweep) || true; }
+trap backend_sweep EXIT
+
 BASE=${1:-origin/development}
 # Merge-Base statt Drei-Punkt-Diff, damit auch uncommittete Änderungen zählen.
 MB=$(git merge-base HEAD "$BASE")

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,11 @@ sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
 # Exclusions - non-code folders + test files (test files are covered by sonar.tests/sonar.test.inclusions)
 # Test file exclusion prevents false-positive Security Hotspots (e.g. go:S1313 on fake IPs in fixtures)
 # Also exclude .sql files - SonarCloud doesn't support PostgreSQL, only Oracle PL/SQL
-sonar.exclusions=**/node_modules/**,**/.next/**,**/openspec/**,**/docs/**,**/templates/**,loadtests/**,monitoring/**,**/*.sql,**/*_test.go,backend/test/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts
+# backend/internal/testdb/** is the hermetic test-database lifecycle (ADR 0004): pure test
+# infrastructure like backend/test/**, never compiled into the server. Its go:S2077 hits are
+# CREATE/DROP DATABASE DDL (no bind parameters possible) on internally generated, quoted
+# identifiers, and go:S4036 is exec.LookPath for docker/psql on developer machines.
+sonar.exclusions=**/node_modules/**,**/.next/**,**/openspec/**,**/docs/**,**/templates/**,loadtests/**,monitoring/**,**/*.sql,**/*_test.go,backend/test/**,backend/internal/testdb/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts
 
 # Coverage exclusions - non-production code and framework glue that shouldn't affect coverage metrics
 # - backend/test/**: Test helpers/fixtures (not *_test.go but pure test infrastructure)


### PR DESCRIPTION
## Was drin ist

**Neues Modul `backend/internal/testdb`** für den vollständigen Testdatenbank-Lebenszyklus:

- `go test ./...` startet bei Bedarf den `postgres-test`-Container.
- Das Template `phoenix_test` wird anhand eines Hashes der Migrationsquellen geprüft und bei Änderungen neu aufgebaut.
- Ein vollständiges, ungestempeltes Template wird übernommen und nur gestempelt.
- Jedes Test-Binary erhält einen run- und package-gestempelten Clone (`phx_test_pkg_<runid>_<pkghash>`).
- Eine Keeper-Verbindung schützt aktive Clones vor der Generation-GC. Verwaiste Clones werden über alle Worktrees eingesammelt.
- `go run ./internal/testdb/cmd/sweep` entfernt die Clones eines Laufs und führt die GC aus.
- `PHX_TEST_LEFTOVERS=1` aktiviert eine optionale Restdaten-Diagnose. Sie ist kein Test-Gate.

### `SetupTestDB` — Schnittstelle unverändert

- Serverprüfung, Template-Aufbau, Clone-Erstellung, Bootstrap-Fixtures und Sequence-Offsets laufen einmal pro Testprozess über `sync.Once`.
- Der per-Test-Pfad schreibt nicht mehr in `t.Setenv` oder Viper und ist damit `t.Parallel()`-fähig.
- Nach `viper.Reset()` stellt `SetupTestDB` die Testkonfiguration wieder her.
- Die Pool-Erstellung pro `SetupTestDB`-Aufruf und der Bootstrap-Tenant 1 bleiben bis PR 2 bestehen.

### Einstiegspunkte

```bash
scripts/test-backend.sh
devbox run test-backend
scripts/test-changed.sh
```

Der Wrapper vergibt eine gemeinsame Run-ID, nutzt `gotestsum`, sofern verfügbar, und führt den Sweep auch bei Fehlern oder Abbruch aus. Ein nacktes `go test ./...` funktioniert weiterhin selbstständig; dessen Clones werden spätestens durch die nächste Generation-GC entfernt.

Bei Bedarf kann der Testserver manuell gestartet werden:

```bash
docker compose --profile test up -d postgres-test
```

## Clock-Skew-Korrekturen

- `EndVisitsByActiveGroupIDs` verwendet `GREATEST(now(), entry_time)`, damit bei abweichenden App- und DB-Uhren kein `exit_time < entry_time` entsteht und dadurch eine ganze Batch abgewiesen wird.
- Die Liveness-Guards für Elternankündigungen und Umfragen verwenden `clock_timestamp()`.
- `MarkRead` und `MarkAcknowledged` ermitteln jeweils einen einheitlichen App-Zeitpunkt für die gespeicherten Zeitstempel.
- Poll-Antworten speichern den Antwortzeitpunkt ebenfalls anhand der App-Uhr.

## Verifikation

- Vollständiger lokaler Lauf via Wrapper: **23.577 Tests, 90 Sekunden, 0 Fehler**; der Sweep hinterlässt 0 Clones.
- Integrationstests decken Template-Rebuild bei Hash-Änderung, Adoption ungestempelter CI-Templates, Keeper-Schutz, GC, Sweep und Leftover-Diagnose ab.
- `golangci-lint`: 0 Issues in den angefassten Packages.

## Bewusst nicht in diesem PR

Der mechanische Sweep über alle Testdateien folgt als PR 2:

- Pool pro Package
- Entfernen der verbliebenen `defer Cleanup*`-Aufrufe
- flächendeckendes `t.Parallel()`
- per-Test-Tenants statt Bootstrap-Tenant 1
- Erweiterung von `TestHermeticTestPatterns`
- Entfernen der Sequence-Offsets

ADR 0004: [Die Testsuite besitzt ihre Datenbanken, nicht den Postgres-Server](docs/adr/0004-testsuite-besitzt-datenbanken-nicht-server.md)

Ref #2419
