### PR TITLE
feat: Betreuungszeiten-Historie zeigt eingefrorenen Alt-Neu-Diff

### DIFF
--- a/backend/api/students/care_request_frozen_history_test.go
+++ b/backend/api/students/care_request_frozen_history_test.go
@@ -1,0 +1,123 @@
+package students_test
+
+// Hermetic router test for #2430: deciding a care-schedule change request
+// through the production route freezes the alt → neu diff, and the history
+// route keeps serving that frozen state after the live data changes. The full
+// middleware chain runs (Verifier → TenantMiddleware → RequiresPermission →
+// TenantTxMiddleware), exactly as the real server does.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func TestCareRequestHistory_ServesFrozenDecisionDiff(t *testing.T) {
+	tc := setupTestContext(t)
+
+	chain := testpkg.CreateTestParentGuardianChain(t, tc.db)
+	t.Cleanup(func() { testpkg.CleanupParentGuardianChain(t, tc.db, chain) })
+	// The approve path stamps the acting staff resolved from the JWT account,
+	// so the deciding admin needs a real staff record behind their account.
+	staff, staffAccount := testpkg.CreateTestStaffWithAccount(t, tc.db, "Paula", "Planerin")
+	t.Cleanup(func() { testpkg.CleanupStaffFixtures(t, tc.db, staff.ID) })
+	t.Cleanup(func() { testpkg.CleanupAuthFixtures(t, tc.db, staffAccount.ID) })
+	// Registered after the staff cleanup so it runs first (LIFO): the seeded
+	// pickup rows reference the staff row via created_by.
+	t.Cleanup(func() {
+		_, err := tc.db.NewDelete().
+			TableExpr("schedule.student_pickup_schedules").
+			Where("student_id = ?", chain.StudentID).
+			Exec(context.Background())
+		require.NoError(t, err)
+	})
+
+	tenantCtx := tenant.WithTenantID(context.Background(), chain.TenantID)
+	upsertPickup := func(hour, minute int) {
+		require.NoError(t, tc.services.PickupSchedule.UpsertStudentPickupSchedule(
+			tenantCtx,
+			&scheduleModels.StudentPickupSchedule{
+				StudentID:  chain.StudentID,
+				Weekday:    1,
+				PickupTime: time.Date(1, 1, 1, hour, minute, 0, 0, time.UTC),
+				CreatedBy:  staff.ID,
+			},
+		))
+	}
+
+	// Live plan before the request: Monday pickup 15:00.
+	upsertPickup(15, 0)
+
+	// The guardian requests Monday pickup 16:00.
+	pending, err := tc.services.CareRequests.CreateRequest(
+		tenantCtx, chain.StudentID, chain.AccountID,
+		map[string]any{"weekdays": []any{
+			map[string]any{"weekday": 1, "pickup": "16:00"},
+		}},
+	)
+	require.NoError(t, err)
+
+	// Approve through the production decide route.
+	decideReq, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("/care-schedule-change-requests/%d/decide", pending.ID),
+		strings.NewReader(`{"approve":true}`))
+	require.NoError(t, err)
+	decideReq.Header.Set("Content-Type", "application/json")
+	rr := authExec(t, tc, decideReq, testutil.AdminTestClaims(int(staffAccount.ID)), []string{"admin:*"})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	// The live data moves on AFTER the decision.
+	upsertPickup(17, 0)
+
+	// The history must still replay the frozen decision-time comparison.
+	histReq, err := http.NewRequest(http.MethodGet, "/care-schedule-change-requests/history", nil)
+	require.NoError(t, err)
+	rr = authExec(t, tc, histReq, testutil.AdminTestClaims(int(staffAccount.ID)), []string{"admin:*"})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var body struct {
+		Data struct {
+			Items []struct {
+				ID        string `json:"id"`
+				Status    string `json:"status"`
+				Requested []struct {
+					Label string `json:"label"`
+					New   string `json:"new"`
+				} `json:"requested"`
+				Diff []struct {
+					Label string `json:"label"`
+					Old   string `json:"old"`
+					New   string `json:"new"`
+				} `json:"diff"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+
+	var found bool
+	for _, item := range body.Data.Items {
+		if item.ID != fmt.Sprintf("%d", pending.ID) {
+			continue
+		}
+		found = true
+		assert.Equal(t, scheduleModels.CareRequestStatusApproved, item.Status)
+		require.Len(t, item.Diff, 1, "the decided row must carry the frozen diff")
+		assert.Equal(t, "Montag · Abholzeit", item.Diff[0].Label)
+		assert.Equal(t, "15:00", item.Diff[0].Old, "old side is the decision-time value, not the current one")
+		assert.Equal(t, "16:00", item.Diff[0].New)
+		assert.NotEmpty(t, item.Requested, "the payload summary fallback stays on the wire")
+	}
+	require.True(t, found, "decided request must appear in the history")
+}

--- a/backend/api/students/care_request_review_handlers.go
+++ b/backend/api/students/care_request_review_handlers.go
@@ -42,11 +42,13 @@ type CareRequestDiffResponse struct {
 	NewMode  string   `json:"new_mode,omitempty"`
 }
 
-func toCareRequestResponse(item *scheduleService.CareRequestReviewItem) CareRequestResponse {
-	r := item.Request
-	diff := make([]CareRequestDiffResponse, 0, len(item.Diff))
-	for _, e := range item.Diff {
-		diff = append(diff, CareRequestDiffResponse{
+// toCareRequestDiffResponses maps service diff entries onto the wire shape —
+// shared by the review queue and both history projections (frozen diff and
+// requested summary; the latter's Old/OldModes are empty by construction).
+func toCareRequestDiffResponses(entries []scheduleService.RequestDiffEntry) []CareRequestDiffResponse {
+	out := make([]CareRequestDiffResponse, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, CareRequestDiffResponse{
 			Label:    e.Label,
 			Old:      e.Old,
 			New:      e.New,
@@ -56,6 +58,12 @@ func toCareRequestResponse(item *scheduleService.CareRequestReviewItem) CareRequ
 			NewMode:  e.NewMode,
 		})
 	}
+	return out
+}
+
+func toCareRequestResponse(item *scheduleService.CareRequestReviewItem) CareRequestResponse {
+	r := item.Request
+	diff := toCareRequestDiffResponses(item.Diff)
 	return CareRequestResponse{
 		ID:             strconv.FormatInt(r.ID, 10),
 		StudentID:      strconv.FormatInt(r.StudentID, 10),

--- a/backend/api/students/change_request_history_handlers.go
+++ b/backend/api/students/change_request_history_handlers.go
@@ -138,10 +138,11 @@ func (rs *Resource) listMasterDataChangeRequestHistory(w http.ResponseWriter, r 
 	common.Respond(w, r, http.StatusOK, out, "Change request history retrieved")
 }
 
-// CareRequestHistoryResponse is one decided care-schedule request. Unlike the
-// queue projection it carries no "current → requested" diff — current data has
-// moved on since the decision — only the payload-derived requested summary
-// (each entry's old side is empty).
+// CareRequestHistoryResponse is one decided care-schedule request. It never
+// carries a recomputed live diff — current data has moved on since the
+// decision. Diff replays the frozen decision snapshot (ADR 0002, #2430);
+// rows without one (withdrawn, pre-snapshot) fall back to the payload-derived
+// requested summary (each entry's old side is empty).
 type CareRequestHistoryResponse struct {
 	ID             string                    `json:"id"`
 	StudentID      string                    `json:"student_id"`
@@ -150,6 +151,7 @@ type CareRequestHistoryResponse struct {
 	Status         string                    `json:"status"`
 	RequestKind    string                    `json:"request_kind"`
 	Requested      []CareRequestDiffResponse `json:"requested"`
+	Diff           []CareRequestDiffResponse `json:"diff,omitempty"`
 	DecisionReason *string                   `json:"decision_reason,omitempty"`
 	CreatedAt      time.Time                 `json:"created_at"`
 	DecidedAt      time.Time                 `json:"decided_at"`
@@ -170,6 +172,18 @@ func toCareRequestHistoryResponse(item *scheduleService.CareRequestHistoryItem) 
 			NewMode:  e.NewMode,
 		})
 	}
+	var diff []CareRequestDiffResponse
+	for _, e := range item.Diff {
+		diff = append(diff, CareRequestDiffResponse{
+			Label:    e.Label,
+			Old:      e.Old,
+			New:      e.New,
+			Weekday:  e.Weekday,
+			CareKind: e.CareKind,
+			OldModes: e.OldModes,
+			NewMode:  e.NewMode,
+		})
+	}
 	return CareRequestHistoryResponse{
 		ID:             strconv.FormatInt(req.ID, 10),
 		StudentID:      strconv.FormatInt(req.StudentID, 10),
@@ -178,6 +192,7 @@ func toCareRequestHistoryResponse(item *scheduleService.CareRequestHistoryItem) 
 		Status:         req.Status,
 		RequestKind:    req.RequestKind,
 		Requested:      requested,
+		Diff:           diff,
 		DecisionReason: req.DecisionReason,
 		CreatedAt:      req.CreatedAt,
 		DecidedAt:      historyDecidedAt(req.ReviewedAt, req.UpdatedAt),

--- a/backend/api/students/change_request_history_handlers.go
+++ b/backend/api/students/change_request_history_handlers.go
@@ -162,27 +162,10 @@ type CareRequestHistoryResponse struct {
 // by the per-type history route and the aggregated list, #2432).
 func toCareRequestHistoryResponse(item *scheduleService.CareRequestHistoryItem) CareRequestHistoryResponse {
 	req := item.Request
-	requested := make([]CareRequestDiffResponse, 0, len(item.Requested))
-	for _, e := range item.Requested {
-		requested = append(requested, CareRequestDiffResponse{
-			Label:    e.Label,
-			New:      e.New,
-			Weekday:  e.Weekday,
-			CareKind: e.CareKind,
-			NewMode:  e.NewMode,
-		})
-	}
+	requested := toCareRequestDiffResponses(item.Requested)
 	var diff []CareRequestDiffResponse
-	for _, e := range item.Diff {
-		diff = append(diff, CareRequestDiffResponse{
-			Label:    e.Label,
-			Old:      e.Old,
-			New:      e.New,
-			Weekday:  e.Weekday,
-			CareKind: e.CareKind,
-			OldModes: e.OldModes,
-			NewMode:  e.NewMode,
-		})
+	if len(item.Diff) > 0 {
+		diff = toCareRequestDiffResponses(item.Diff)
 	}
 	return CareRequestHistoryResponse{
 		ID:             strconv.FormatInt(req.ID, 10),

--- a/backend/database/migrations/001015307_care_request_decision_snapshot.go
+++ b/backend/database/migrations/001015307_care_request_decision_snapshot.go
@@ -1,0 +1,46 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	careRequestDecisionSnapshotVersion     = "1.15.307"
+	careRequestDecisionSnapshotDescription = "Freeze the alt→neu diff of decided care-schedule change requests (#2430)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     careRequestDecisionSnapshotVersion,
+		Description: careRequestDecisionSnapshotDescription,
+		DependsOn:   []string{classListEntriesVersion},
+	})
+	Migrations.MustRegister(careRequestDecisionSnapshotUp, careRequestDecisionSnapshotDown)
+}
+
+func careRequestDecisionSnapshotUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.307: Adding the care-request decision snapshot column...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE schedule.care_schedule_change_requests
+			ADD COLUMN IF NOT EXISTS decision_snapshot JSONB;
+	`)
+	if err != nil {
+		return fmt.Errorf("add care request decision snapshot column: %w", err)
+	}
+	return nil
+}
+
+func careRequestDecisionSnapshotDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back 1.15.307: Removing the care-request decision snapshot column...")
+	_, err := db.ExecContext(ctx, `
+		ALTER TABLE schedule.care_schedule_change_requests
+			DROP COLUMN IF EXISTS decision_snapshot;
+	`)
+	if err != nil {
+		return fmt.Errorf("remove care request decision snapshot column: %w", err)
+	}
+	return nil
+}

--- a/backend/database/repositories/schedule/care_schedule_change_request.go
+++ b/backend/database/repositories/schedule/care_schedule_change_request.go
@@ -234,8 +234,12 @@ func (r *CareScheduleChangeRequestRepository) UpdateDecisionSnapshot(ctx context
 		Set("updated_at = ?", time.Now()).
 		Where(`"care_schedule_change_request".id = ?`, id)
 	q = base.WithTenantFilter(ctx, q, "care_schedule_change_request")
-	if _, err := q.Exec(ctx); err != nil {
+	res, err := q.Exec(ctx)
+	if err != nil {
 		return &modelBase.DatabaseError{Op: "update care request decision snapshot", Err: err}
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return ErrCareRequestNotFound
 	}
 	return nil
 }

--- a/backend/database/repositories/schedule/care_schedule_change_request.go
+++ b/backend/database/repositories/schedule/care_schedule_change_request.go
@@ -222,3 +222,20 @@ func (r *CareScheduleChangeRequestRepository) Decide(ctx context.Context, id int
 	}
 	return nil
 }
+
+// UpdateDecisionSnapshot stores the frozen review diff on a decided row (ADR
+// 0002, #2430). Separate from Decide so the race-guarded transition keeps its
+// signature; callers write the snapshot in the same transaction.
+func (r *CareScheduleChangeRequestRepository) UpdateDecisionSnapshot(ctx context.Context, id int64, snapshot *schedule.CareRequestDecisionSnapshot) error {
+	q := base.GetDB(ctx, r.DB).NewUpdate().
+		Model((*schedule.CareScheduleChangeRequest)(nil)).
+		ModelTableExpr(tableExprCareScheduleChangeRequestsAsReq).
+		Set("decision_snapshot = ?", snapshot).
+		Set("updated_at = ?", time.Now()).
+		Where(`"care_schedule_change_request".id = ?`, id)
+	q = base.WithTenantFilter(ctx, q, "care_schedule_change_request")
+	if _, err := q.Exec(ctx); err != nil {
+		return &modelBase.DatabaseError{Op: "update care request decision snapshot", Err: err}
+	}
+	return nil
+}

--- a/backend/models/schedule/care_schedule_change_request.go
+++ b/backend/models/schedule/care_schedule_change_request.go
@@ -50,6 +50,30 @@ type CareScheduleChangeRequest struct {
 	ReviewedBy     *int64         `bun:"reviewed_by" json:"reviewed_by,omitempty"`
 	ReviewedAt     *time.Time     `bun:"reviewed_at" json:"reviewed_at,omitempty"`
 	AppliedAt      *time.Time     `bun:"applied_at" json:"applied_at,omitempty"`
+	// DecisionSnapshot freezes the "alt → neu" diff the reviewer saw when
+	// deciding (ADR 0002, #2430). NULL on pending, withdrawn, and pre-#2430
+	// rows — history readers fall back to the payload-derived requested
+	// summary there.
+	DecisionSnapshot *CareRequestDecisionSnapshot `bun:"decision_snapshot,type:jsonb" json:"decision_snapshot,omitempty"`
+}
+
+// CareRequestDecisionSnapshot is the frozen review diff stored on a decided
+// request (see the DecisionSnapshot field).
+type CareRequestDecisionSnapshot struct {
+	Diff []CareRequestSnapshotEntry `json:"diff"`
+}
+
+// CareRequestSnapshotEntry is one frozen "alt → neu" comparison row. It
+// mirrors the service-level RequestDiffEntry wire shape so decided rows
+// replay exactly what the reviewer saw.
+type CareRequestSnapshotEntry struct {
+	Label    string   `json:"label"`
+	Old      string   `json:"old,omitempty"`
+	New      string   `json:"new,omitempty"`
+	Weekday  int      `json:"weekday,omitempty"`
+	CareKind string   `json:"care_kind,omitempty"`
+	OldModes []string `json:"old_modes,omitempty"`
+	NewMode  string   `json:"new_mode,omitempty"`
 }
 
 // IsTerminal reports whether the row is in a final state. Only pending rows
@@ -108,4 +132,9 @@ type CareScheduleChangeRequestRepository interface {
 	// decision_reason, reviewed_by, reviewed_at and (for approvals)
 	// applied_at. Withdrawals carry no reviewer stamp.
 	Decide(ctx context.Context, id int64, newStatus string, reason *string, reviewedBy *int64, applied bool) error
+
+	// UpdateDecisionSnapshot stores the frozen review diff on a decided row
+	// (ADR 0002, #2430). Separate from Decide so the race-guarded transition
+	// keeps its signature; callers write the snapshot in the same transaction.
+	UpdateDecisionSnapshot(ctx context.Context, id int64, snapshot *CareRequestDecisionSnapshot) error
 }

--- a/backend/services/schedule/care_request_decision_snapshot_test.go
+++ b/backend/services/schedule/care_request_decision_snapshot_test.go
@@ -145,6 +145,36 @@ func TestDecide_SkipsSnapshotWhenPickupPlanReadFails(t *testing.T) {
 	assert.NotEmpty(t, item.Requested, "history must fall back to the payload summary")
 }
 
+func TestListPending_FallsBackToRequestedWhenPickupPlanReadFails(t *testing.T) {
+	f := newCareFixture(t)
+	readErr := errors.New("pickup plan unavailable")
+	service := schedule.NewCareScheduleRequestService(
+		f.repos.CareScheduleChangeRequest,
+		f.repos.Student,
+		f.repos.Person,
+		f.sf.ArrivalSchedule,
+		failingPickupReadService{PickupScheduleService: f.sf.PickupSchedule, err: readErr},
+		f.sf.UserContext,
+		nil,
+		nil,
+		slog.Default(),
+		f.sf.StudentAudit,
+	)
+	f.createPending(t, careWeekdays(
+		map[string]any{"weekday": 1, "pickup": "16:00"},
+	))
+
+	items, err := service.ListPending(f.staffCtx(f.staffAccount))
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, []schedule.RequestDiffEntry{{
+		Label:    "Montag · Abholzeit",
+		New:      "16:00",
+		Weekday:  1,
+		CareKind: schedule.DiffCareKindPickup,
+	}}, items[0].Diff)
+}
+
 // TestWithdraw_LeavesNoSnapshot: a guardian withdrawal is not a staff
 // decision — the row keeps no frozen diff and the history falls back to the
 // payload-derived requested summary.

--- a/backend/services/schedule/care_request_decision_snapshot_test.go
+++ b/backend/services/schedule/care_request_decision_snapshot_test.go
@@ -1,0 +1,156 @@
+package schedule_test
+
+// Freeze tests for the care-request decision snapshot (#2430, ADR 0002):
+// deciding a request persists the alt → neu diff the reviewer saw, and the
+// history keeps replaying that frozen state even after the live data moves on.
+// Hermetic: real test DB, fixtures with cleanup, no hardcoded IDs.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+// upsertMondayPickup writes the child's live Monday pickup time directly —
+// the "data changed after the decision" step of the freeze scenario.
+func upsertMondayPickup(t *testing.T, f *careFixture, hour, minute int) {
+	t.Helper()
+	require.NoError(t, f.sf.PickupSchedule.UpsertStudentPickupSchedule(
+		f.staffCtx(f.staffAccount),
+		&scheduleModels.StudentPickupSchedule{
+			StudentID:  f.chain.StudentID,
+			Weekday:    1,
+			PickupTime: time.Date(1, 1, 1, hour, minute, 0, 0, time.UTC),
+			CreatedBy:  f.staffID,
+		},
+	))
+}
+
+func historyItemByID(t *testing.T, f *careFixture, id int64) *schedule.CareRequestHistoryItem {
+	t.Helper()
+	items, _, err := f.svc.ListHistory(f.staffCtx(f.staffAccount), time.Time{}, 0, 25)
+	require.NoError(t, err)
+	for _, item := range items {
+		if item.Request.ID == id {
+			return item
+		}
+	}
+	t.Fatalf("request %d not found in history", id)
+	return nil
+}
+
+// TestDecide_FreezesAltNeuDiffInHistory is the #2430 acceptance scenario:
+// approve a request, then change the live data — the history keeps showing
+// the alt → neu comparison that existed at decision time, not a live diff.
+func TestDecide_FreezesAltNeuDiffInHistory(t *testing.T) {
+	f := newCareFixture(t)
+	ctx := f.staffCtx(f.staffAccount)
+
+	// Live plan before the request: Monday pickup 15:00.
+	upsertMondayPickup(t, f, 15, 0)
+
+	req := f.createPending(t, careWeekdays(
+		map[string]any{"weekday": 1, "pickup": "16:00"},
+	))
+	_, err := f.svc.Decide(ctx, schedule.CareRequestDecideInput{
+		RequestID: req.ID, Approve: true, ReviewedBy: f.staffAccount,
+	})
+	require.NoError(t, err)
+
+	// The live data moves on after the decision.
+	upsertMondayPickup(t, f, 17, 0)
+
+	item := historyItemByID(t, f, req.ID)
+	require.Equal(t, []schedule.RequestDiffEntry{{
+		Label:    "Montag · Abholzeit",
+		Old:      "15:00",
+		New:      "16:00",
+		Weekday:  1,
+		CareKind: schedule.DiffCareKindPickup,
+	}}, item.Diff, "the frozen diff must survive later data changes")
+	assert.NotEmpty(t, item.Requested, "the payload summary stays available alongside the snapshot")
+}
+
+// TestDecide_RejectAlsoFreezesDiff: a rejection freezes the comparison the
+// reviewer declined, even though nothing was applied.
+func TestDecide_RejectAlsoFreezesDiff(t *testing.T) {
+	f := newCareFixture(t)
+	ctx := f.staffCtx(f.staffAccount)
+
+	upsertMondayPickup(t, f, 15, 0)
+	req := f.createPending(t, careWeekdays(
+		map[string]any{"weekday": 1, "pickup": "18:00"},
+	))
+	_, err := f.svc.Decide(ctx, schedule.CareRequestDecideInput{
+		RequestID: req.ID, Approve: false, Reason: "zu spät", ReviewedBy: f.staffAccount,
+	})
+	require.NoError(t, err)
+
+	upsertMondayPickup(t, f, 14, 30)
+
+	item := historyItemByID(t, f, req.ID)
+	require.Equal(t, []schedule.RequestDiffEntry{{
+		Label:    "Montag · Abholzeit",
+		Old:      "15:00",
+		New:      "18:00",
+		Weekday:  1,
+		CareKind: schedule.DiffCareKindPickup,
+	}}, item.Diff)
+}
+
+// TestWithdraw_LeavesNoSnapshot: a guardian withdrawal is not a staff
+// decision — the row keeps no frozen diff and the history falls back to the
+// payload-derived requested summary.
+func TestWithdraw_LeavesNoSnapshot(t *testing.T) {
+	f := newCareFixture(t)
+
+	req := f.createPending(t, careWeekdays(
+		map[string]any{"weekday": 2, "arrival": "07:45"},
+	))
+	_, err := f.svc.WithdrawRequest(f.staffCtx(f.chain.AccountID), req.ID, f.chain.StudentID, f.chain.AccountID)
+	require.NoError(t, err)
+
+	item := historyItemByID(t, f, req.ID)
+	assert.Nil(t, item.Diff, "withdrawals carry no frozen diff")
+	assert.NotEmpty(t, item.Requested)
+}
+
+// TestDecide_PickupChangeFreezesDiff covers the pickup-change kind: the
+// one-day exception's alt → neu is frozen on decision too.
+func TestDecide_PickupChangeFreezesDiff(t *testing.T) {
+	f := newCareFixture(t)
+	upsertMondayPickup(t, f, 15, 0)
+
+	// Next Monday (always in the future), so the exception's weekday fallback
+	// (the live Monday plan) supplies the old side.
+	date := timezone.TodayDate().AddDays(1)
+	for date.Weekday() != time.Monday {
+		date = date.AddDays(1)
+	}
+	req, err := f.svc.CreatePickupChangeRequest(
+		f.staffCtx(f.chain.AccountID), f.chain.StudentID, f.chain.AccountID,
+		date, time.Date(0, 1, 1, 16, 30, 0, 0, time.UTC), "Arzttermin",
+	)
+	require.NoError(t, err)
+	_, err = f.svc.Decide(f.staffCtx(f.staffAccount), schedule.CareRequestDecideInput{
+		RequestID: req.ID, Approve: true, ReviewedBy: f.staffAccount,
+	})
+	require.NoError(t, err)
+
+	// Change the live Monday plan after the decision.
+	upsertMondayPickup(t, f, 13, 0)
+
+	item := historyItemByID(t, f, req.ID)
+	require.Equal(t, []schedule.RequestDiffEntry{{
+		Label:    date.String() + " · Abholzeit",
+		Old:      "15:00",
+		New:      "16:30",
+		CareKind: schedule.DiffCareKindPickup,
+	}}, item.Diff)
+}

--- a/backend/services/schedule/care_request_decision_snapshot_test.go
+++ b/backend/services/schedule/care_request_decision_snapshot_test.go
@@ -6,6 +6,9 @@ package schedule_test
 // Hermetic: real test DB, fixtures with cleanup, no hardcoded IDs.
 
 import (
+	"context"
+	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -16,6 +19,15 @@ import (
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	"github.com/moto-nrw/project-phoenix/services/schedule"
 )
+
+type failingPickupReadService struct {
+	schedule.PickupScheduleService
+	err error
+}
+
+func (s failingPickupReadService) GetStudentPickupSchedules(context.Context, int64) ([]*scheduleModels.StudentPickupSchedule, error) {
+	return nil, s.err
+}
 
 // upsertMondayPickup writes the child's live Monday pickup time directly —
 // the "data changed after the decision" step of the freeze scenario.
@@ -102,6 +114,35 @@ func TestDecide_RejectAlsoFreezesDiff(t *testing.T) {
 		Weekday:  1,
 		CareKind: schedule.DiffCareKindPickup,
 	}}, item.Diff)
+}
+
+func TestDecide_SkipsSnapshotWhenPickupPlanReadFails(t *testing.T) {
+	f := newCareFixture(t)
+	readErr := errors.New("pickup plan unavailable")
+	rejectingService := schedule.NewCareScheduleRequestService(
+		f.repos.CareScheduleChangeRequest,
+		f.repos.Student,
+		f.repos.Person,
+		f.sf.ArrivalSchedule,
+		failingPickupReadService{PickupScheduleService: f.sf.PickupSchedule, err: readErr},
+		f.sf.UserContext,
+		nil,
+		nil,
+		slog.Default(),
+		f.sf.StudentAudit,
+	)
+	req := f.createPending(t, careWeekdays(
+		map[string]any{"weekday": 1, "pickup": "16:00"},
+	))
+
+	_, err := rejectingService.Decide(f.staffCtx(f.staffAccount), schedule.CareRequestDecideInput{
+		RequestID: req.ID, Approve: false, Reason: "nicht möglich", ReviewedBy: f.staffAccount,
+	})
+	require.NoError(t, err)
+
+	item := historyItemByID(t, f, req.ID)
+	assert.Nil(t, item.Diff, "an unavailable pickup plan must not produce a fabricated snapshot")
+	assert.NotEmpty(t, item.Requested, "history must fall back to the payload summary")
 }
 
 // TestWithdraw_LeavesNoSnapshot: a guardian withdrawal is not a staff

--- a/backend/services/schedule/care_request_decision_snapshot_test.go
+++ b/backend/services/schedule/care_request_decision_snapshot_test.go
@@ -121,6 +121,33 @@ func TestWithdraw_LeavesNoSnapshot(t *testing.T) {
 	assert.NotEmpty(t, item.Requested)
 }
 
+// TestListHistory_LegacyDecidedRowFallsBackToRequested: a row decided before
+// the snapshot existed (simulated by clearing the column) carries no Diff and
+// the history keeps serving the payload-derived requested summary.
+func TestListHistory_LegacyDecidedRowFallsBackToRequested(t *testing.T) {
+	f := newCareFixture(t)
+
+	req := f.createPending(t, careWeekdays(
+		map[string]any{"weekday": 1, "pickup": "16:00"},
+	))
+	_, err := f.svc.Decide(f.staffCtx(f.staffAccount), schedule.CareRequestDecideInput{
+		RequestID: req.ID, Approve: false, Reason: "passt nicht", ReviewedBy: f.staffAccount,
+	})
+	require.NoError(t, err)
+
+	// Altzeile: pre-#2430 decided rows have no snapshot.
+	_, err = f.db.NewUpdate().
+		TableExpr("schedule.care_schedule_change_requests").
+		Set("decision_snapshot = NULL").
+		Where("id = ?", req.ID).
+		Exec(t.Context())
+	require.NoError(t, err)
+
+	item := historyItemByID(t, f, req.ID)
+	assert.Nil(t, item.Diff, "a row without a snapshot must not fabricate a diff")
+	assert.NotEmpty(t, item.Requested, "the payload summary remains the fallback")
+}
+
 // TestDecide_PickupChangeFreezesDiff covers the pickup-change kind: the
 // one-day exception's alt → neu is frozen on decision too.
 func TestDecide_PickupChangeFreezesDiff(t *testing.T) {

--- a/backend/services/schedule/care_request_service.go
+++ b/backend/services/schedule/care_request_service.go
@@ -148,15 +148,19 @@ type CareRequestReviewItem struct {
 
 // CareRequestHistoryItem is one decided request enriched with the child's
 // name, the reviewer's display name, and the payload-derived "requested"
-// summary. Unlike the pending queue there is NO live "current → requested"
-// diff: current data has moved on since the decision, so re-computing it would
-// show a comparison that never existed. The payload alone is stable.
+// summary. There is NO live "current → requested" diff: current data has
+// moved on since the decision, so re-computing it would show a comparison
+// that never existed. Diff instead replays the frozen decision snapshot
+// (ADR 0002, #2430) when the row carries one; rows decided before the
+// snapshot existed (and withdrawals) leave it nil and readers fall back to
+// the stable payload-derived Requested summary.
 type CareRequestHistoryItem struct {
 	Request      *scheduleModels.CareScheduleChangeRequest
 	FirstName    string
 	LastName     string
 	ReviewerName string // "" when the row carries no reviewer (withdrawn)
 	Requested    []RequestDiffEntry
+	Diff         []RequestDiffEntry // frozen alt → neu, nil without a snapshot
 }
 
 // CareRequestDecideInput carries a staff decision on one pending request.
@@ -520,6 +524,7 @@ func (s *careScheduleRequestService) ListHistory(ctx context.Context, beforeUpda
 			Request:      r,
 			ReviewerName: usersService.ReviewerDisplayName(reviewers, r.ReviewedBy),
 			Requested:    careRequestedSummaryFrom(r.Payload),
+			Diff:         careDiffEntriesFromSnapshot(r.DecisionSnapshot),
 		}
 		if p, ok := persons[st.PersonID]; ok {
 			item.FirstName = p.FirstName
@@ -590,6 +595,62 @@ func careRequestedSummaryFrom(payload map[string]any) []RequestDiffEntry {
 		}
 	}
 	return entries
+}
+
+// buildDecisionSnapshot materializes the alt → neu diff of a still-pending
+// request into its frozen snapshot form (ADR 0002, #2430). Returns nil when
+// the diff cannot be built — the decision must never hang on presentation.
+func (s *careScheduleRequestService) buildDecisionSnapshot(ctx context.Context, req *scheduleModels.CareScheduleChangeRequest) *scheduleModels.CareRequestDecisionSnapshot {
+	var diff []RequestDiffEntry
+	var err error
+	if req.RequestKind == scheduleModels.CareRequestKindPickupChange {
+		diff, err = s.pickupChangeDiff(ctx, req)
+	} else {
+		diff, err = s.careScheduleDiffFrom(ctx, &careDiffSource{s: s, studentID: req.StudentID}, req.Payload)
+	}
+	if err != nil {
+		s.logger.Warn("schedule: build care request decision snapshot failed",
+			slog.Int64("request_id", req.ID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	snapshot := &scheduleModels.CareRequestDecisionSnapshot{
+		Diff: make([]scheduleModels.CareRequestSnapshotEntry, 0, len(diff)),
+	}
+	for _, e := range diff {
+		snapshot.Diff = append(snapshot.Diff, scheduleModels.CareRequestSnapshotEntry{
+			Label:    e.Label,
+			Old:      e.Old,
+			New:      e.New,
+			Weekday:  e.Weekday,
+			CareKind: e.CareKind,
+			OldModes: e.OldModes,
+			NewMode:  e.NewMode,
+		})
+	}
+	return snapshot
+}
+
+// careDiffEntriesFromSnapshot maps a frozen decision snapshot back into the
+// service diff shape shared with the pending queue. Nil in, nil out.
+func careDiffEntriesFromSnapshot(snapshot *scheduleModels.CareRequestDecisionSnapshot) []RequestDiffEntry {
+	if snapshot == nil {
+		return nil
+	}
+	out := make([]RequestDiffEntry, 0, len(snapshot.Diff))
+	for _, e := range snapshot.Diff {
+		out = append(out, RequestDiffEntry{
+			Label:    e.Label,
+			Old:      e.Old,
+			New:      e.New,
+			Weekday:  e.Weekday,
+			CareKind: e.CareKind,
+			OldModes: e.OldModes,
+			NewMode:  e.NewMode,
+		})
+	}
+	return out
 }
 
 func (s *careScheduleRequestService) ListPendingPickupChanges(ctx context.Context) ([]*CareRequestReviewItem, error) {
@@ -785,6 +846,13 @@ func (s *careScheduleRequestService) Decide(ctx context.Context, input CareReque
 		return nil, ErrCareRequestForbidden
 	}
 
+	// Freeze the alt → neu diff the reviewer is deciding on (ADR 0002, #2430).
+	// It MUST be built here, before an approval's apply rewrites the live plan
+	// underneath the comparison. The diff is presentation: when it cannot be
+	// built the decision still proceeds and the history falls back to the
+	// payload-derived requested summary.
+	snapshot := s.buildDecisionSnapshot(ctx, req)
+
 	// Whether the apply actually changed the child's "läuft mit" links — the
 	// only thing that may announce a companion change.
 	companionsChanged := false
@@ -840,6 +908,11 @@ func (s *careScheduleRequestService) Decide(ctx context.Context, input CareReque
 	reviewedBy := input.ReviewedBy
 	if err := s.requestRepo.Decide(ctx, req.ID, newStatus, reasonPtr, &reviewedBy, input.Approve); err != nil {
 		return nil, err
+	}
+	if snapshot != nil {
+		if err := s.requestRepo.UpdateDecisionSnapshot(ctx, req.ID, snapshot); err != nil {
+			return nil, fmt.Errorf("schedule: store care request decision snapshot: %w", err)
+		}
 	}
 
 	// Post-commit side effects: audit line, cache invalidation, decision pill.

--- a/backend/services/schedule/care_request_service.go
+++ b/backend/services/schedule/care_request_service.go
@@ -1633,9 +1633,11 @@ type careDiffSource struct {
 	studentDone bool
 
 	arrivalMap  map[int]string
+	arrivalErr  error
 	arrivalDone bool
 
 	pickupMap  map[int]string
+	pickupErr  error
 	pickupDone bool
 }
 
@@ -1652,33 +1654,36 @@ func (d *careDiffSource) getStudent(ctx context.Context) (*usersModels.Student, 
 	return d.student, d.studentErr
 }
 
-// getArrival / getPickup are best-effort: a load failure yields an empty map
-// so the diff shows "—" as the current value rather than failing the whole
-// diff.
-func (d *careDiffSource) getArrival(ctx context.Context) map[int]string {
+func (d *careDiffSource) getArrival(ctx context.Context) (map[int]string, error) {
 	if !d.arrivalDone {
 		d.arrivalDone = true
 		d.arrivalMap = map[int]string{}
-		if cur, err := d.s.arrival.GetStudentArrivalSchedules(ctx, d.studentID); err == nil {
-			for _, a := range cur {
-				d.arrivalMap[a.Weekday] = a.ExpectedArrival.Format("15:04")
-			}
+		cur, err := d.s.arrival.GetStudentArrivalSchedules(ctx, d.studentID)
+		if err != nil {
+			d.arrivalErr = fmt.Errorf("schedule: load arrival schedules for diff: %w", err)
+			return nil, d.arrivalErr
+		}
+		for _, a := range cur {
+			d.arrivalMap[a.Weekday] = a.ExpectedArrival.Format("15:04")
 		}
 	}
-	return d.arrivalMap
+	return d.arrivalMap, d.arrivalErr
 }
 
-func (d *careDiffSource) getPickup(ctx context.Context) map[int]string {
+func (d *careDiffSource) getPickup(ctx context.Context) (map[int]string, error) {
 	if !d.pickupDone {
 		d.pickupDone = true
 		d.pickupMap = map[int]string{}
-		if cur, err := d.s.pickup.GetStudentPickupSchedules(ctx, d.studentID); err == nil {
-			for _, pc := range cur {
-				d.pickupMap[pc.Weekday] = pc.PickupTime.Format("15:04")
-			}
+		cur, err := d.s.pickup.GetStudentPickupSchedules(ctx, d.studentID)
+		if err != nil {
+			d.pickupErr = fmt.Errorf("schedule: load pickup schedules for diff: %w", err)
+			return nil, d.pickupErr
+		}
+		for _, pc := range cur {
+			d.pickupMap[pc.Weekday] = pc.PickupTime.Format("15:04")
 		}
 	}
-	return d.pickupMap
+	return d.pickupMap, d.pickupErr
 }
 
 func (s *careScheduleRequestService) careScheduleDiffFrom(ctx context.Context, src *careDiffSource, payload map[string]any) ([]RequestDiffEntry, error) {
@@ -1691,8 +1696,14 @@ func (s *careScheduleRequestService) careScheduleDiffFrom(ctx context.Context, s
 		return nil, err
 	}
 
-	arrivalMap := src.getArrival(ctx)
-	pickupMap := src.getPickup(ctx)
+	arrivalMap, err := src.getArrival(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pickupMap, err := src.getPickup(ctx)
+	if err != nil {
+		return nil, err
+	}
 	hasCarePlan := len(arrivalMap) > 0 || len(pickupMap) > 0
 
 	weekdays := append([]careWeekdayPayload(nil), p.Weekdays...)

--- a/backend/services/schedule/care_request_service.go
+++ b/backend/services/schedule/care_request_service.go
@@ -734,12 +734,14 @@ func (s *careScheduleRequestService) buildPendingItems(ctx context.Context, rows
 			diff, err = s.careScheduleDiffFrom(ctx, src, r.Payload)
 		}
 		if err != nil {
-			// A diff that can't be built is logged and skipped rather than
-			// failing the whole queue load.
+			// A live diff that can't be built must not hide what was requested
+			// from the reviewer. Keep the queue available and fall back to the
+			// payload-derived requested side instead.
 			s.logger.Warn("schedule: build care request diff failed",
 				slog.Int64("request_id", r.ID),
 				slog.String("error", err.Error()),
 			)
+			item.Diff = careRequestedSummaryFrom(r.Payload)
 		} else {
 			item.Diff = diff
 		}

--- a/backend/services/schedule/care_request_service.go
+++ b/backend/services/schedule/care_request_service.go
@@ -910,6 +910,10 @@ func (s *careScheduleRequestService) Decide(ctx context.Context, input CareReque
 		return nil, err
 	}
 	if snapshot != nil {
+		// Unlike a failed diff BUILD (tolerated above), a failed WRITE must
+		// propagate: a failed statement poisons the ambient Postgres
+		// transaction, so there is no "log and continue" here — the whole
+		// decision rolls back.
 		if err := s.requestRepo.UpdateDecisionSnapshot(ctx, req.ID, snapshot); err != nil {
 			return nil, fmt.Errorf("schedule: store care request decision snapshot: %w", err)
 		}

--- a/docs/adr/0002-anfrage-diff-snapshot-bei-entscheidung.md
+++ b/docs/adr/0002-anfrage-diff-snapshot-bei-entscheidung.md
@@ -17,6 +17,9 @@ der Entscheidung korrekt abbilden.
   Entscheidung verändern entschiedene Anfragen nicht mehr.
 - Der Snapshot ist zugleich der Speicherort für Übersteuerungen (#2370);
   ohne ihn wäre "welche Regel wurde von wem abgewählt" nicht rekonstruierbar.
+- Zweite Instanz des Musters: Betreuungszeiten-Anfragen frieren ihren
+  Alt→Neu-Diff seit #2430 identisch ein
+  (`schedule.care_schedule_change_requests.decision_snapshot`).
 - Bestandsanfragen ohne Snapshot behalten den bisherigen Payload-Recap (nur die
   Elternauswahl). Eine Live-Materialisierung wäre dort falsch: Nach einer
   Freigabe ist die Vergleichsbasis bereits umgestellt, der Diff also leer, und

--- a/frontend/src/components/students/request-history-item.test.tsx
+++ b/frontend/src/components/students/request-history-item.test.tsx
@@ -92,6 +92,47 @@ describe("RequestHistoryItem", () => {
     ).toBeInTheDocument();
   });
 
+  it("zeigt bei Betreuungszeiten den eingefrorenen alt → neu Diff statt der Beantragt-Liste", () => {
+    const item: AggregatedHistoryRequest = {
+      request_type: "care_schedule",
+      data: {
+        id: "care-1",
+        student_id: "42",
+        first_name: "Lara",
+        last_name: "Lehmann",
+        status: "approved",
+        request_kind: "weekly_schedule",
+        requested: [
+          {
+            label: "Montag · Abholzeit",
+            old: "",
+            new: "16:00",
+            care_kind: "pickup",
+          },
+        ],
+        diff: [
+          {
+            label: "Montag · Abholzeit",
+            old: "15:00",
+            new: "16:00",
+            care_kind: "pickup",
+          },
+        ],
+        created_at: "2026-08-17T09:00:00Z",
+        decided_at: "2026-08-18T10:00:00Z",
+        decided_by_name: "Rieke Reviewer",
+      },
+    };
+
+    render(<RequestHistoryItem item={item} />);
+
+    expect(screen.getByText("Änderungen")).toBeInTheDocument();
+    expect(
+      screen.getByText("Montag · Abholzeit: 15:00 → 16:00"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Beantragt")).not.toBeInTheDocument();
+  });
+
   it("zeigt bei einer zurückgezogenen Angebots-Anfrage die gespeicherten Angebote", () => {
     const item: AggregatedHistoryRequest = {
       request_type: "offering",

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -46,6 +46,9 @@ function MasterDataHistoryCard({
 function CareHistoryCard({
   row,
 }: Readonly<{ row: StaffCareRequestHistoryEntry }>) {
+  // Frozen decision-time diff (#2430) when present, payload summary otherwise.
+  const showDiff = (row.diff?.length ?? 0) > 0;
+  const entries = showDiff ? (row.diff ?? []) : row.requested;
   return (
     <RequestReviewCard
       childName={`${row.first_name} ${row.last_name}`}
@@ -60,36 +63,22 @@ function CareHistoryCard({
         reason: row.decision_reason,
       }}
     >
-      {row.diff && row.diff.length > 0 ? (
+      {entries.length > 0 && (
         <div className="space-y-1 rounded-lg bg-gray-50 p-3">
           <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-            Änderungen
+            {showDiff ? "Änderungen" : "Beantragt"}
           </p>
-          {row.diff.map((entry) => (
+          {entries.map((entry) => (
             <p
               key={`${entry.label}-${entry.new}`}
               className="text-sm text-gray-700"
             >
-              {entry.label}: {entry.old || "—"} → {entry.new}
+              {showDiff
+                ? `${entry.label}: ${entry.old || "—"} → ${entry.new}`
+                : `${entry.label}: ${entry.new}`}
             </p>
           ))}
         </div>
-      ) : (
-        row.requested.length > 0 && (
-          <div className="space-y-1 rounded-lg bg-gray-50 p-3">
-            <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-              Beantragt
-            </p>
-            {row.requested.map((entry) => (
-              <p
-                key={`${entry.label}-${entry.new}`}
-                className="text-sm text-gray-700"
-              >
-                {entry.label}: {entry.new}
-              </p>
-            ))}
-          </div>
-        )
       )}
     </RequestReviewCard>
   );

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -60,20 +60,36 @@ function CareHistoryCard({
         reason: row.decision_reason,
       }}
     >
-      {row.requested.length > 0 && (
+      {row.diff && row.diff.length > 0 ? (
         <div className="space-y-1 rounded-lg bg-gray-50 p-3">
           <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-            Beantragt
+            Änderungen
           </p>
-          {row.requested.map((entry) => (
+          {row.diff.map((entry) => (
             <p
               key={`${entry.label}-${entry.new}`}
               className="text-sm text-gray-700"
             >
-              {entry.label}: {entry.new}
+              {entry.label}: {entry.old || "—"} → {entry.new}
             </p>
           ))}
         </div>
+      ) : (
+        row.requested.length > 0 && (
+          <div className="space-y-1 rounded-lg bg-gray-50 p-3">
+            <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+              Beantragt
+            </p>
+            {row.requested.map((entry) => (
+              <p
+                key={`${entry.label}-${entry.new}`}
+                className="text-sm text-gray-700"
+              >
+                {entry.label}: {entry.new}
+              </p>
+            ))}
+          </div>
+        )
       )}
     </RequestReviewCard>
   );

--- a/frontend/src/lib/care-request-review-api.ts
+++ b/frontend/src/lib/care-request-review-api.ts
@@ -126,9 +126,10 @@ export interface CareRequestHistoryPage {
 
 /**
  * One decided care-schedule change request in the staff history. Mirrors
- * api/students.CareRequestHistoryResponse: instead of a live "current →
- * requested" diff it carries only the payload-derived requested summary
- * (each entry's old side is empty).
+ * api/students.CareRequestHistoryResponse: `diff` replays the alt → neu
+ * comparison frozen at decision time (#2430); rows decided before the
+ * snapshot existed (and withdrawals) omit it, and the payload-derived
+ * requested summary (each entry's old side empty) is the fallback.
  */
 export interface StaffCareRequestHistoryEntry {
   readonly id: string;
@@ -138,6 +139,8 @@ export interface StaffCareRequestHistoryEntry {
   readonly status: CareRequestStatus;
   readonly request_kind: "weekly_schedule" | "pickup_change";
   readonly requested: readonly RequestDiffEntry[];
+  /** Frozen decision-time diff; absent without a snapshot. */
+  readonly diff?: readonly RequestDiffEntry[];
   readonly decision_reason?: string;
   readonly created_at: string;
   readonly decided_at: string;


### PR DESCRIPTION
## Zusammenfassung

Beim Entscheiden einer Betreuungszeiten-Anfrage wird der Alt→Neu-Diff als `decision_snapshot` (JSONB, Migration 1.15.307) auf der Anfrage eingefroren. Die Historie liefert ihn über die per-Art- und aggregierte Anfragenliste (#2432) als `diff` aus und zeigt **Änderungen: alt → neu**.

Der Diff wird im Decide-Pfad vor dem Apply berechnet und in derselben Transaktion gespeichert. Das gilt für `weekly_schedule` und `pickup_change`. Wenn der Diff wegen eines Lesefehlers nicht erstellt werden kann, läuft die Entscheidung weiter; die Historie fällt auf **Beantragt** zurück und der Fehler wird geloggt. Ein Fehler beim Speichern des Snapshots rollt die gesamte Entscheidung zurück.

Anfragen ohne Snapshot, einschließlich Rückzüge und ältere Datensätze, behalten die payload-basierte **Beantragt**-Darstellung.

## Tests

- Hermetischer Router-Test über die Produktionsroute: Nach der Entscheidung und einer Änderung der Live-Daten zeigt die Historie weiterhin beispielsweise `15:00 → 16:00`.
- Service-Tests für Freigabe, Ablehnung, Rückzug, `pickup_change`, fehlende Snapshots und fehlgeschlagene Schedule-Lesevorgänge.
- Frontend-Komponententest für den Änderungen-Block und den Beantragt-Fallback.
- Bestehende Backend- und Frontend-Suites, Ratchet-Gates, `golangci-lint` und `pnpm run check` berücksichtigen.

Closes #2430  
Closes #2420
