### PR TITLE
Load machine-local env overrides in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,7 @@
 # Devbox + direnv integration
 # Run `direnv allow` once to trust this file
 eval "$(devbox generate direnv --print-envrc)"
+
+# Machine-local overrides (e.g. TEST_DB_DSN for checkouts without a .env,
+# such as review worktrees). Absent on machines that don't need them.
+dotenv_if_exists ~/.config/project-phoenix/local.env


### PR DESCRIPTION
Review worktrees check out the repo without the untracked `.env`, so integration tests fail with "Test database not configured" (missing `TEST_DB_DSN`).

This adds one line to `.envrc`: direnv loads an optional `~/.config/project-phoenix/local.env` after the devbox environment. Machine-local values like `TEST_DB_DSN` then reach every checkout of the repo, including throwaway worktrees. On machines without that file the line is a no-op.

Note: direnv treats a changed `.envrc` as untrusted, so everyone needs one `direnv allow` after pulling this.