### PR TITLE
ci: pin golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -117,7 +117,7 @@ jobs:
       - name: golang ci lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v6
         with:
-          version: latest
+          version: v2.12.2 # pinned: v2.13.0 crashes (staticcheck nilness panics on sentry-go)
           args: --timeout 10m
           working-directory: backend
 


### PR DESCRIPTION
## Problem

`backend-lint` schlägt auf `development` fehl, ohne dass sich Code geändert hat.

golangci-lint war im Workflow als `version: latest` konfiguriert. Der letzte grüne Run (19:16 Uhr) lief mit **v2.12.2**, der rote Run von 00:57 Uhr zog **v2.13.0** — veröffentlicht am 19.08. um 23:29 UTC, also rund 90 Minuten vorher.

v2.13.0 bringt staticcheck `honnef.co/go/tools@v0.8.0-rc.1` mit. Dessen `nilness`-Analyzer paniced beim Analysieren der Dependency `getsentry/sentry-go`:

```
level=error msg="[runner] Panic: nilness: package \"sentry\": internal error: unhandled builtin recover"
Running error: can't run linter goanalysis_metalinter
##[error]golangci-lint exit with code 3
```

`ci-gate` failt als Folgefehler, weil `lint` rot ist.

Der Fehler stammt aus einem Vendor-Paket, nicht aus `backend/`. Kein Commit hat ihn ausgelöst; der Merge von #2450 war zufällig der erste Run nach dem Release.

## Fix

Version auf v2.12.2 pinnen, die Version, die zuletzt grün war.

## Verworfene Alternativen

- **`nilness` abschalten**: kostet einen echten Check wegen eines temporären Upstream-Bugs, und `latest` reisst beim nächsten Release wieder etwas ein.
- **sentry-go hochziehen**: löst es nicht. Der Analyzer paniced auf einem `recover()`-Builtin, und sentry-go ist ein Panic-Capturing-SDK. Jede Version benutzt `recover()`.
- **Auf einen Fix-Release warten**: es gibt weder einen Fix noch ein offenes Issue upstream.

## Follow-up

Pin wieder hochziehen, sobald golangci-lint einen Fix veröffentlicht (Kommentar steht im Workflow).

Randnotiz, nicht Teil dieses PRs: `devbox.json` pinnt lokal `golangci-lint@2.8.0`. Lokale Runs waren also nie betroffen, aber CI und lokal driften auseinander.