### PR TITLE
Direkt-Korrekturen erscheinen in der zentralen Historie

### DIFF
--- a/backend/api/students/change_request_list_handlers.go
+++ b/backend/api/students/change_request_list_handlers.go
@@ -40,6 +40,9 @@ const (
 	requestTypeCareSchedule = "care_schedule"
 	requestTypeOffering     = "offering"
 	requestTypeExcused      = "excused"
+	// requestTypeDirectCorrection is not a request: it is the office's own
+	// correction to a child's bookings (#2436). History only.
+	requestTypeDirectCorrection = "direct_correction"
 )
 
 // aggregatedRequestTypeOrder is the canonical type order — it decides the
@@ -49,6 +52,7 @@ var aggregatedRequestTypeOrder = []string{
 	requestTypeCareSchedule,
 	requestTypeOffering,
 	requestTypeExcused,
+	requestTypeDirectCorrection,
 }
 
 const (
@@ -152,6 +156,12 @@ func parseAggregatedListQuery(r *http.Request) (aggregatedListQuery, error) {
 
 	if err := parseAggregatedHistoryFilters(&q, values); err != nil {
 		return q, err
+	}
+
+	// Corrections have no open state — the working list must never show them,
+	// not even when a client asks for the type explicitly.
+	if !q.history {
+		q.types = removeType(q.types, requestTypeDirectCorrection)
 	}
 
 	if raw := values.Get("limit"); raw != "" {
@@ -350,6 +360,16 @@ func (rs *Resource) listAggregatedChangeRequests(w http.ResponseWriter, r *http.
 		return
 	}
 	common.Respond(w, r, http.StatusOK, page, "Change requests retrieved")
+}
+
+func removeType(types []string, drop string) []string {
+	kept := make([]string, 0, len(types))
+	for _, typ := range types {
+		if typ != drop {
+			kept = append(kept, typ)
+		}
+	}
+	return kept
 }
 
 func intersectTypes(types []string, allowed ...string) []string {
@@ -664,6 +684,8 @@ func (rs *Resource) historySourceFor(typ string) *aggregatedHistorySource {
 		source.fetch = historyFetch(rs.OfferingChangeService.ListHistory, offeringHistoryRow)
 	case requestTypeExcused:
 		source.fetch = historyFetch(rs.ExcusedRequestService.ListHistory, excusedHistoryRow)
+	case requestTypeDirectCorrection:
+		source.fetch = historyFetch(rs.OfferingChangeService.ListDirectCorrections, directCorrectionRow)
 	}
 	return source
 }

--- a/backend/api/students/change_request_list_handlers_test.go
+++ b/backend/api/students/change_request_list_handlers_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
@@ -98,10 +99,20 @@ func (f *aggCareFake) ListHistory(_ context.Context, before time.Time, beforeID 
 
 type aggOfferingFake struct {
 	enrollmentService.OfferingChangeRequestService
-	pending      []*enrollmentService.OfferingChangeView
-	rows         []*enrollmentService.OfferingChangeHistoryItem
-	pendingCalls int
-	historyCalls int
+	pending          []*enrollmentService.OfferingChangeView
+	rows             []*enrollmentService.OfferingChangeHistoryItem
+	corrections      []*enrollmentService.DirectCorrectionItem
+	pendingCalls     int
+	historyCalls     int
+	correctionsCalls int
+}
+
+func (f *aggOfferingFake) ListDirectCorrections(_ context.Context, before time.Time, beforeID int64, limit int) ([]*enrollmentService.DirectCorrectionItem, *userService.HistoryCursor, error) {
+	f.correctionsCalls++
+	items, next := keysetHistoryPage(f.corrections, func(it *enrollmentService.DirectCorrectionItem) (time.Time, int64) {
+		return it.Adjustment.ChangedAt, it.Adjustment.ID
+	}, before, beforeID, limit)
+	return items, next, nil
 }
 
 func (f *aggOfferingFake) ListPending(context.Context) ([]*enrollmentService.OfferingChangeView, error) {
@@ -481,4 +492,130 @@ func TestAggregatedChangeRequests_InvalidQuery(t *testing.T) {
 		rr, _ := execAggregated(t, rs, query, aggUpdatePerms)
 		assert.Equal(t, http.StatusBadRequest, rr.Code, fmt.Sprintf("query %q must be rejected", query))
 	}
+}
+
+// --- Direkt-Korrekturen in der zentralen Historie (#2436) -------------------
+
+func aggOfferingHistory(id int64, name, status string, decidedAt time.Time) *enrollmentService.OfferingChangeHistoryItem {
+	reviewed := decidedAt
+	return &enrollmentService.OfferingChangeHistoryItem{
+		Request: &enrollmentModels.OfferingChangeRequest{
+			Model:      modelBase.Model{ID: id, CreatedAt: decidedAt.Add(-24 * time.Hour), UpdatedAt: decidedAt},
+			StudentID:  300 + id,
+			Status:     status,
+			ReviewedAt: &reviewed,
+		},
+		StudentName:  name,
+		ReviewerName: "Revi Ewer",
+	}
+}
+
+func aggDirectCorrection(id int64, name string, changedAt time.Time) *enrollmentService.DirectCorrectionItem {
+	actor := "Olga Office"
+	return &enrollmentService.DirectCorrectionItem{
+		Adjustment: &auditModels.EnrollmentOfferingAdjustment{
+			ID:                id,
+			StudentID:         500 + id,
+			ChangedAt:         changedAt,
+			Reason:            "Telefonisch gemeldet",
+			ActorNameSnapshot: &actor,
+			Source:            auditModels.OfferingAdjustmentSourceDirect,
+		},
+		StudentName: name,
+		ActorName:   actor,
+		Diff: []enrollmentService.OfferingChangeDiffEntry{{
+			OfferingID: 9,
+			Label:      "Mittagessen",
+			OldState:   "booked",
+			OldDays:    []string{"mon"},
+			NewState:   "removed",
+		}},
+	}
+}
+
+func TestAggregatedChangeRequests_HistoryShowsDirectCorrections(t *testing.T) {
+	rs, fakes := newAggResource()
+	fakes.offering.rows = []*enrollmentService.OfferingChangeHistoryItem{
+		aggOfferingHistory(1, "Cem Can", "approved", aggBase.Add(2*time.Hour)),
+	}
+	fakes.offering.corrections = []*enrollmentService.DirectCorrectionItem{
+		aggDirectCorrection(7, "Anna Alt", aggBase.Add(3*time.Hour)),
+	}
+
+	rr, page := execAggregated(t, rs, "view=history", aggUpdatePerms)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.Equal(t, []string{"direct_correction", "offering"}, aggTypes(page))
+
+	var row DirectCorrectionResponse
+	require.NoError(t, json.Unmarshal(page.Items[0].Data, &row))
+	assert.Equal(t, "Anna Alt", row.StudentName)
+	assert.Equal(t, "Olga Office", row.ChangedByName)
+	assert.Equal(t, "Telefonisch gemeldet", row.Reason)
+	assert.Equal(t, aggBase.Add(3*time.Hour), row.ChangedAt.UTC())
+	require.Len(t, row.Diff, 1)
+	assert.Equal(t, "Mittagessen", row.Diff[0].Label)
+	assert.Equal(t, "Mo", row.Diff[0].Old)
+	assert.Equal(t, "abgemeldet", row.Diff[0].New)
+	// A correction is not a request: nothing decided, no status on the wire.
+	assert.NotContains(t, string(page.Items[0].Data), `"status"`)
+}
+
+func TestAggregatedChangeRequests_OpenNeverShowsDirectCorrections(t *testing.T) {
+	rs, fakes := newAggResource()
+	fakes.offering.corrections = []*enrollmentService.DirectCorrectionItem{
+		aggDirectCorrection(7, "Anna Alt", aggBase.Add(3*time.Hour)),
+	}
+
+	for _, query := range []string{"", "view=open", "view=open&types=direct_correction"} {
+		rr, page := execAggregated(t, rs, query, aggUpdatePerms)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		assert.Empty(t, aggTypes(page), "query %q", query)
+	}
+	assert.Zero(t, fakes.offering.correctionsCalls)
+}
+
+func TestAggregatedChangeRequests_DirectCorrectionsHonourSearchAndDateRange(t *testing.T) {
+	rs, fakes := newAggResource()
+	fakes.offering.corrections = []*enrollmentService.DirectCorrectionItem{
+		aggDirectCorrection(7, "Anna Alt", aggBase.Add(3*time.Hour)),
+		aggDirectCorrection(8, "Ben Berg", aggBase.Add(2*time.Hour)),
+		aggDirectCorrection(9, "Anna Alt", aggBase.AddDate(0, 0, -40)),
+	}
+
+	_, byName := execAggregated(t, rs, "view=history&search=anna", aggUpdatePerms)
+	require.Len(t, byName.Items, 2)
+
+	from := aggBase.AddDate(0, 0, -1).Format("2006-01-02")
+	_, byRange := execAggregated(t, rs, "view=history&search=anna&from="+from, aggUpdatePerms)
+	require.Len(t, byRange.Items, 1)
+	var row DirectCorrectionResponse
+	require.NoError(t, json.Unmarshal(byRange.Items[0].Data, &row))
+	assert.Equal(t, "7", row.ID)
+}
+
+func TestAggregatedChangeRequests_StatusFilterExcludesDirectCorrections(t *testing.T) {
+	rs, fakes := newAggResource()
+	fakes.offering.rows = []*enrollmentService.OfferingChangeHistoryItem{
+		aggOfferingHistory(1, "Cem Can", "approved", aggBase.Add(2*time.Hour)),
+	}
+	fakes.offering.corrections = []*enrollmentService.DirectCorrectionItem{
+		aggDirectCorrection(7, "Anna Alt", aggBase.Add(3*time.Hour)),
+	}
+
+	// Corrections carry no status, so a status filter is about requests only.
+	rr, page := execAggregated(t, rs, "view=history&status=approved", aggUpdatePerms)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal(t, []string{"offering"}, aggTypes(page))
+}
+
+func TestAggregatedChangeRequests_AbsenceOnlyCallerSeesNoDirectCorrections(t *testing.T) {
+	rs, fakes := newAggResource()
+	fakes.offering.corrections = []*enrollmentService.DirectCorrectionItem{
+		aggDirectCorrection(7, "Anna Alt", aggBase.Add(3*time.Hour)),
+	}
+
+	rr, page := execAggregated(t, rs, "view=history", []string{"users:absence"})
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Empty(t, aggTypes(page))
+	assert.Zero(t, fakes.offering.correctionsCalls)
 }

--- a/backend/api/students/direct_correction_db_test.go
+++ b/backend/api/students/direct_correction_db_test.go
@@ -1,0 +1,162 @@
+package students_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+// insertAdjustment writes one row of the append-only booking log the office's
+// corrections land in, with a controlled instant so the keyset order is
+// deterministic.
+func insertAdjustment(
+	t *testing.T,
+	tc *testContext,
+	child *enrollmentModels.RequestChild,
+	studentID, tenantID, accountID int64,
+	source, reason string,
+	changedAt time.Time,
+) *auditModels.EnrollmentOfferingAdjustment {
+	t.Helper()
+	actor := "Olga Office"
+	entry := &auditModels.EnrollmentOfferingAdjustment{
+		RequestID:         child.RequestID,
+		RequestChildID:    child.ID,
+		StudentID:         studentID,
+		ActorAccountID:    accountID,
+		ActorRole:         "admin",
+		ActorNameSnapshot: &actor,
+		Reason:            reason,
+		Source:            source,
+		Before:            json.RawMessage(`[{"offering_id":"1","offering_name":"Mittagessen","days_of_week_mode":"fixed","selected_days":["mon"]}]`),
+		After:             json.RawMessage(`[]`),
+		ChangedAt:         changedAt,
+	}
+	entry.TenantID = tenantID
+	_, err := tc.db.NewInsert().Model(entry).
+		ModelTableExpr(`audit.enrollment_offering_adjustments AS "enrollment_offering_adjustment"`).
+		Exec(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// context.Background(), not t.Context(): the test context is already
+		// canceled when cleanups run.
+		_, cleanupErr := tc.db.NewDelete().TableExpr("audit.enrollment_offering_adjustments").
+			Where("id = ?", entry.ID).Exec(context.Background())
+		if cleanupErr != nil {
+			t.Logf("cleanup of offering adjustment %d failed: %v", entry.ID, cleanupErr)
+		}
+	})
+	return entry
+}
+
+// insertApprovedRequestChild creates the enrollment request and approved child
+// the booking log hangs off, linked to an already enrolled student.
+func insertApprovedRequestChild(t *testing.T, tc *testContext, studentID, tenantID int64, lastName string) *enrollmentModels.RequestChild {
+	t.Helper()
+	phase := testpkg.CreateTestEnrollmentPhase(t, tc.db)
+	request := &enrollmentModels.Request{
+		PhaseID:           phase.ID,
+		GuardianFirstName: "Erzieh",
+		GuardianLastName:  "Ungsberechtigt",
+		GuardianEmail:     fmt.Sprintf("korrektur-%d@example.test", time.Now().UnixNano()),
+		StatusToken:       fmt.Sprintf("tok-%d", time.Now().UnixNano()),
+	}
+	request.TenantID = tenantID
+	_, err := tc.db.NewInsert().Model(request).ModelTableExpr(`enrollment.requests AS "request"`).Exec(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr("enrollment.requests").Where("id = ?", request.ID).Exec(context.Background())
+	})
+
+	child := &enrollmentModels.RequestChild{
+		RequestID:        request.ID,
+		FirstName:        "Zkorrektur",
+		LastName:         lastName,
+		DateOfBirth:      timezone.TodayDate().AddDays(-2500),
+		Status:           enrollmentModels.ChildStatusApproved,
+		CreatedStudentID: &studentID,
+	}
+	child.TenantID = tenantID
+	_, err = tc.db.NewInsert().Model(child).ModelTableExpr(`enrollment.request_children AS "request_child"`).Exec(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr("enrollment.request_children").Where("id = ?", child.ID).Exec(context.Background())
+	})
+	return child
+}
+
+// A correction the office made itself shows up in the central history as its
+// own row kind, while the adjustment an approved parent request writes on the
+// side does not — that one is already in the list as the decided request
+// (#2436).
+func TestAggregatedChangeRequests_RouterDirectCorrections(t *testing.T) {
+	tc := setupTestContext(t)
+
+	teacher, account := testpkg.CreateTestTeacherWithAccount(t, tc.db, "Agg", "CorrectionReviewer")
+	group := testpkg.CreateTestEducationGroup(t, tc.db, "AggCorrectionGroup")
+	student := testpkg.CreateTestStudent(t, tc.db, "Zkorrektur", "Kindlein", "AL3")
+	defer testpkg.CleanupActivityFixtures(t, tc.db, teacher.ID, group.ID, student.ID)
+	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
+	testpkg.CreateTestGroupTeacher(t, tc.db, group.ID, teacher.ID)
+
+	child := insertApprovedRequestChild(t, tc, student.ID, student.TenantID, "Kindlein")
+	base := time.Now().UTC().Add(-time.Hour)
+	direct := insertAdjustment(t, tc, child, student.ID, student.TenantID, account.ID,
+		auditModels.OfferingAdjustmentSourceDirect, "Telefonisch gemeldet", base)
+	insertAdjustment(t, tc, child, student.ID, student.TenantID, account.ID,
+		auditModels.OfferingAdjustmentSourceRequest, "Elternanfrage #1 freigegeben", base.Add(-time.Minute))
+
+	claims := testutil.TeacherTestClaims(int(account.ID))
+	perms := []string{"users:read", "users:update"}
+
+	fetch := func(t *testing.T, query string) aggListEnvelope {
+		t.Helper()
+		rr := authExec(t, tc, testutil.NewRequest("GET", "/change-requests?"+query, nil), claims, perms)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		var env aggListEnvelope
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &env))
+		return env
+	}
+
+	history := fetch(t, "view=history&search=Zkorrektur")
+	require.Len(t, history.Data.Items, 1, "only the direct correction belongs in the history")
+	assert.Equal(t, "direct_correction", history.Data.Items[0].RequestType)
+
+	var row struct {
+		ID            string `json:"id"`
+		StudentName   string `json:"student_name"`
+		ChangedByName string `json:"changed_by_name"`
+		Reason        string `json:"reason"`
+		Diff          []struct {
+			Label string `json:"label"`
+			Old   string `json:"old"`
+			New   string `json:"new"`
+		} `json:"diff"`
+	}
+	require.NoError(t, json.Unmarshal(history.Data.Items[0].Data, &row))
+	assert.Equal(t, strconv.FormatInt(direct.ID, 10), row.ID)
+	assert.Equal(t, "Zkorrektur Kindlein", row.StudentName)
+	assert.Equal(t, "Olga Office", row.ChangedByName)
+	assert.Equal(t, "Telefonisch gemeldet", row.Reason)
+	require.Len(t, row.Diff, 1)
+	assert.Equal(t, "Mittagessen", row.Diff[0].Label)
+	assert.Equal(t, "Mo", row.Diff[0].Old)
+	assert.Equal(t, "abgemeldet", row.Diff[0].New)
+
+	// The working list never shows corrections, not even when asked for them.
+	assert.Empty(t, fetch(t, "search=Zkorrektur").Data.Items)
+	assert.Empty(t, fetch(t, "types=direct_correction&search=Zkorrektur").Data.Items)
+}

--- a/backend/api/students/direct_correction_db_test.go
+++ b/backend/api/students/direct_correction_db_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/uptrace/bun"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,57 +18,29 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
 
-// insertAdjustment writes one row of the append-only booking log the office's
-// corrections land in, with a controlled instant so the keyset order is
-// deterministic.
-func insertAdjustment(
-	t *testing.T,
-	tc *testContext,
-	child *enrollmentModels.RequestChild,
-	studentID, tenantID, accountID int64,
-	source, reason string,
-	changedAt time.Time,
-) *auditModels.EnrollmentOfferingAdjustment {
-	t.Helper()
-	actor := "Olga Office"
-	entry := &auditModels.EnrollmentOfferingAdjustment{
-		RequestID:         child.RequestID,
-		RequestChildID:    child.ID,
-		StudentID:         studentID,
-		ActorAccountID:    accountID,
-		ActorRole:         "admin",
-		ActorNameSnapshot: &actor,
-		Reason:            reason,
-		Source:            source,
-		Before:            json.RawMessage(`[{"offering_id":"1","offering_name":"Mittagessen","days_of_week_mode":"fixed","selected_days":["mon"]}]`),
-		After:             json.RawMessage(`[]`),
-		ChangedAt:         changedAt,
-	}
-	entry.TenantID = tenantID
-	_, err := tc.db.NewInsert().Model(entry).
-		ModelTableExpr(`audit.enrollment_offering_adjustments AS "enrollment_offering_adjustment"`).
-		Exec(t.Context())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		// context.Background(), not t.Context(): the test context is already
-		// canceled when cleanups run.
-		_, cleanupErr := tc.db.NewDelete().TableExpr("audit.enrollment_offering_adjustments").
-			Where("id = ?", entry.ID).Exec(context.Background())
-		if cleanupErr != nil {
-			t.Logf("cleanup of offering adjustment %d failed: %v", entry.ID, cleanupErr)
-		}
-	})
-	return entry
+// correctionFixture is the approved enrollment child a booking correction acts
+// on: phase, request, child linked to an enrolled student, plus two offerings
+// the child is booked into.
+type correctionFixture struct {
+	phase    *enrollmentModels.Phase
+	child    *enrollmentModels.RequestChild
+	ganztag  *enrollmentModels.CareOffering
+	mittag   *enrollmentModels.CareOffering
+	tenantID int64
 }
 
-// insertApprovedRequestChild creates the enrollment request and approved child
-// the booking log hangs off, linked to an already enrolled student.
-func insertApprovedRequestChild(t *testing.T, tc *testContext, studentID, tenantID int64, lastName string) *enrollmentModels.RequestChild {
+func setupCorrectionFixture(t *testing.T, tc *testContext, studentID, tenantID int64, lastName string) *correctionFixture {
 	t.Helper()
+	ctx := t.Context()
 	phase := testpkg.CreateTestEnrollmentPhase(t, tc.db)
+	ganztag := testpkg.CreateTestCareOffering(t, tc.db, phase.ID, "Ganztag")
+	mittag := testpkg.CreateTestCareOffering(t, tc.db, phase.ID, "Mittagessen")
+
 	request := &enrollmentModels.Request{
 		PhaseID:           phase.ID,
 		GuardianFirstName: "Erzieh",
@@ -75,7 +49,7 @@ func insertApprovedRequestChild(t *testing.T, tc *testContext, studentID, tenant
 		StatusToken:       fmt.Sprintf("tok-%d", time.Now().UnixNano()),
 	}
 	request.TenantID = tenantID
-	_, err := tc.db.NewInsert().Model(request).ModelTableExpr(`enrollment.requests AS "request"`).Exec(t.Context())
+	_, err := tc.db.NewInsert().Model(request).ModelTableExpr(`enrollment.requests AS "request"`).Exec(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = tc.db.NewDelete().TableExpr("enrollment.requests").Where("id = ?", request.ID).Exec(context.Background())
@@ -90,18 +64,38 @@ func insertApprovedRequestChild(t *testing.T, tc *testContext, studentID, tenant
 		CreatedStudentID: &studentID,
 	}
 	child.TenantID = tenantID
-	_, err = tc.db.NewInsert().Model(child).ModelTableExpr(`enrollment.request_children AS "request_child"`).Exec(t.Context())
+	_, err = tc.db.NewInsert().Model(child).ModelTableExpr(`enrollment.request_children AS "request_child"`).Exec(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = tc.db.NewDelete().TableExpr("enrollment.request_children").Where("id = ?", child.ID).Exec(context.Background())
 	})
-	return child
+
+	for _, offering := range []*enrollmentModels.CareOffering{ganztag, mittag} {
+		link := &enrollmentModels.RequestChildOffering{
+			RequestChildID: child.ID,
+			CareOfferingID: offering.ID,
+		}
+		link.TenantID = tenantID
+		_, err = tc.db.NewInsert().Model(link).
+			ModelTableExpr(`enrollment.request_child_offerings AS "request_child_offering"`).Exec(ctx)
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr("enrollment.request_child_offerings").
+			Where("request_child_id = ?", child.ID).Exec(context.Background())
+	})
+	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr("audit.enrollment_offering_adjustments").
+			Where("request_child_id = ?", child.ID).Exec(context.Background())
+	})
+
+	return &correctionFixture{phase: phase, child: child, ganztag: ganztag, mittag: mittag, tenantID: tenantID}
 }
 
-// A correction the office made itself shows up in the central history as its
-// own row kind, while the adjustment an approved parent request writes on the
-// side does not — that one is already in the list as the decided request
-// (#2436).
+// A correction the office makes itself shows up in the central history as its
+// own row kind. The booking change an approved parent request writes into the
+// very same append-only log does not: that one is already in the list as the
+// decided request, and showing both would double it (#2436).
 func TestAggregatedChangeRequests_RouterDirectCorrections(t *testing.T) {
 	tc := setupTestContext(t)
 
@@ -112,13 +106,7 @@ func TestAggregatedChangeRequests_RouterDirectCorrections(t *testing.T) {
 	testpkg.AssignStudentToGroup(t, tc.db, student.ID, group.ID)
 	testpkg.CreateTestGroupTeacher(t, tc.db, group.ID, teacher.ID)
 
-	child := insertApprovedRequestChild(t, tc, student.ID, student.TenantID, "Kindlein")
-	base := time.Now().UTC().Add(-time.Hour)
-	direct := insertAdjustment(t, tc, child, student.ID, student.TenantID, account.ID,
-		auditModels.OfferingAdjustmentSourceDirect, "Telefonisch gemeldet", base)
-	insertAdjustment(t, tc, child, student.ID, student.TenantID, account.ID,
-		auditModels.OfferingAdjustmentSourceRequest, "Elternanfrage #1 freigegeben", base.Add(-time.Minute))
-
+	fixture := setupCorrectionFixture(t, tc, student.ID, student.TenantID, "Kindlein")
 	claims := testutil.TeacherTestClaims(int(account.ID))
 	perms := []string{"users:read", "users:update"}
 
@@ -131,8 +119,25 @@ func TestAggregatedChangeRequests_RouterDirectCorrections(t *testing.T) {
 		return env
 	}
 
+	// ARRANGE 1 — the office corrects the booking itself, through the very
+	// service the admin route calls: the child stays in Ganztag and is taken
+	// out of Mittagessen. The frozen before/after snapshots must show that.
+	err := tenant.WithTenantTx(t.Context(), tc.db, student.TenantID, func(ctx context.Context, _ bun.Tx) error {
+		_, updateErr := tc.services.EnrollmentDecision.UpdateChildOfferings(ctx, enrollmentService.UpdateChildOfferingsInput{
+			RequestID:      fixture.child.RequestID,
+			ChildID:        fixture.child.ID,
+			Offerings:      []enrollmentService.OfferingAdjustmentSelection{{OfferingID: fixture.ganztag.ID}},
+			Reason:         "Telefonisch gemeldet",
+			ActorAccountID: account.ID,
+			ActorRole:      "admin",
+		})
+		return updateErr
+	})
+	require.NoError(t, err)
+
+	// ASSERT 1 — the correction is in the history, as its own row kind.
 	history := fetch(t, "view=history&search=Zkorrektur")
-	require.Len(t, history.Data.Items, 1, "only the direct correction belongs in the history")
+	require.Len(t, history.Data.Items, 1)
 	assert.Equal(t, "direct_correction", history.Data.Items[0].RequestType)
 
 	var row struct {
@@ -147,16 +152,84 @@ func TestAggregatedChangeRequests_RouterDirectCorrections(t *testing.T) {
 		} `json:"diff"`
 	}
 	require.NoError(t, json.Unmarshal(history.Data.Items[0].Data, &row))
-	assert.Equal(t, strconv.FormatInt(direct.ID, 10), row.ID)
 	assert.Equal(t, "Zkorrektur Kindlein", row.StudentName)
-	assert.Equal(t, "Olga Office", row.ChangedByName)
+	assert.Equal(t, "Agg CorrectionReviewer", row.ChangedByName)
 	assert.Equal(t, "Telefonisch gemeldet", row.Reason)
-	require.Len(t, row.Diff, 1)
-	assert.Equal(t, "Mittagessen", row.Diff[0].Label)
-	assert.Equal(t, "Mo", row.Diff[0].Old)
-	assert.Equal(t, "abgemeldet", row.Diff[0].New)
+	require.NotEmpty(t, row.Diff)
+	byLabel := map[string]string{}
+	for _, line := range row.Diff {
+		byLabel[line.Label] = line.Old + " → " + line.New
+	}
+	// Only what actually changed: Ganztag stayed, so it carries no line.
+	assert.Equal(t, map[string]string{
+		fixture.mittag.Name: "alle Betreuungstage → abgemeldet",
+	}, byLabel)
+
+	// ARRANGE 2 — a parent asks for a change and the office approves it through
+	// the production decide route. That apply writes into the same log.
+	pending := insertPendingOfferingChangeRequest(t, tc, fixture, student.ID, account.ID)
+	body := strings.NewReader(`{"approve":true,"reason":"Passt"}`)
+	rr := authExec(t, tc,
+		testutil.NewRequest("POST", fmt.Sprintf("/offering-change-requests/%d/decide", pending.ID), body),
+		claims, perms)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	// ASSERT 2 — the approval appears exactly once, as the decided request; its
+	// side effect on the booking log stays out of the correction feed.
+	after := fetch(t, "view=history&search=Zkorrektur")
+	types := make([]string, 0, len(after.Data.Items))
+	for _, item := range after.Data.Items {
+		types = append(types, item.RequestType)
+	}
+	assert.Equal(t, []string{"offering", "direct_correction"}, types)
+
+	var sources []string
+	require.NoError(t, tc.db.NewSelect().TableExpr("audit.enrollment_offering_adjustments").
+		Column("source").Where("request_child_id = ?", fixture.child.ID).
+		OrderExpr("id").Scan(t.Context(), &sources))
+	assert.Equal(t, []string{
+		auditModels.OfferingAdjustmentSourceDirect,
+		auditModels.OfferingAdjustmentSourceRequest,
+	}, sources, "the two write paths must stamp different sources")
 
 	// The working list never shows corrections, not even when asked for them.
-	assert.Empty(t, fetch(t, "search=Zkorrektur").Data.Items)
 	assert.Empty(t, fetch(t, "types=direct_correction&search=Zkorrektur").Data.Items)
+	openTypes := fetch(t, "search=Zkorrektur").Data.Items
+	for _, item := range openTypes {
+		assert.NotEqual(t, "direct_correction", item.RequestType)
+	}
+}
+
+// insertPendingOfferingChangeRequest stores the parent's submission. Creating
+// it is the parents portal's job, out of this router's scope; the decision is
+// what this test drives through the production route.
+func insertPendingOfferingChangeRequest(
+	t *testing.T,
+	tc *testContext,
+	fixture *correctionFixture,
+	studentID, submittedBy int64,
+) *enrollmentModels.OfferingChangeRequest {
+	t.Helper()
+	row := &enrollmentModels.OfferingChangeRequest{
+		StudentID:      studentID,
+		RequestChildID: fixture.child.ID,
+		SubmittedBy:    submittedBy,
+		Payload: map[string]any{
+			"offerings": []any{
+				map[string]any{"offering_id": fixture.ganztag.ID},
+				map[string]any{"offering_id": fixture.mittag.ID},
+			},
+		},
+		EffectiveFrom: timezone.TodayDate().AddDays(30),
+		Status:        enrollmentModels.OfferingChangeStatusPending,
+	}
+	row.TenantID = fixture.tenantID
+	_, err := tc.db.NewInsert().Model(row).
+		ModelTableExpr(`enrollment.offering_change_requests AS "offering_change_request"`).Exec(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = tc.db.NewDelete().TableExpr("enrollment.offering_change_requests").
+			Where("id = ?", row.ID).Exec(context.Background())
+	})
+	return row
 }

--- a/backend/api/students/direct_correction_handlers.go
+++ b/backend/api/students/direct_correction_handlers.go
@@ -1,0 +1,60 @@
+package students
+
+import (
+	"strconv"
+	"time"
+
+	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+)
+
+// DirectCorrectionResponse is one admin correction to a child's bookings as
+// the central history renders it (#2436). It deliberately carries no status
+// and no decision fields: a correction is not a request, it has no open state
+// and nothing was decided about it.
+type DirectCorrectionResponse struct {
+	ID          string `json:"id"`
+	StudentID   string `json:"student_id"`
+	StudentName string `json:"student_name"`
+	// ChangedAt is when the office applied the correction.
+	ChangedAt time.Time `json:"changed_at"`
+	// ChangedByName is the actor snapshot taken at write time, "Unbekannt"
+	// when the account is gone.
+	ChangedByName string                        `json:"changed_by_name"`
+	Reason        string                        `json:"reason"`
+	Diff          []OfferingRequestDiffResponse `json:"diff"`
+}
+
+func toDirectCorrectionResponse(item *enrollmentService.DirectCorrectionItem) DirectCorrectionResponse {
+	row := item.Adjustment
+	diff := make([]OfferingRequestDiffResponse, 0, len(item.Diff))
+	for _, entry := range item.Diff {
+		diff = append(diff, OfferingRequestDiffResponse{
+			OfferingID: strconv.FormatInt(entry.OfferingID, 10),
+			Label:      entry.Label,
+			Old:        germanOfferingDiffLabel(entry.OldState, entry.OldDays),
+			New:        germanOfferingDiffLabel(entry.NewState, entry.NewDays),
+		})
+	}
+	return DirectCorrectionResponse{
+		ID:            strconv.FormatInt(row.ID, 10),
+		StudentID:     strconv.FormatInt(row.StudentID, 10),
+		StudentName:   item.StudentName,
+		ChangedAt:     row.ChangedAt,
+		ChangedByName: item.ActorName,
+		Reason:        row.Reason,
+		Diff:          diff,
+	}
+}
+
+func directCorrectionRow(item *enrollmentService.DirectCorrectionItem) aggregatedRow {
+	return aggregatedRow{
+		typ:         requestTypeDirectCorrection,
+		sortTime:    item.Adjustment.ChangedAt,
+		id:          item.Adjustment.ID,
+		studentName: item.StudentName,
+		// A correction has no request status; the date-range filter treats the
+		// moment it was applied as its "decided at".
+		decidedAt: item.Adjustment.ChangedAt,
+		data:      toDirectCorrectionResponse(item),
+	}
+}

--- a/backend/api/students/offering_request_review_handlers_test.go
+++ b/backend/api/students/offering_request_review_handlers_test.go
@@ -49,6 +49,10 @@ func (f *fakeOfferingChangeRequestService) ListHistory(context.Context, time.Tim
 	return nil, nil, nil
 }
 
+func (f *fakeOfferingChangeRequestService) ListDirectCorrections(context.Context, time.Time, int64, int) ([]*enrollmentService.DirectCorrectionItem, *userService.HistoryCursor, error) {
+	return nil, nil, nil
+}
+
 func (f *fakeOfferingChangeRequestService) ListPending(context.Context) ([]*enrollmentService.OfferingChangeView, error) {
 	return nil, nil
 }

--- a/backend/database/migrations/001015308_offering_adjustment_source.go
+++ b/backend/database/migrations/001015308_offering_adjustment_source.go
@@ -1,0 +1,70 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	offeringAdjustmentSourceVersion     = "1.15.308"
+	offeringAdjustmentSourceDescription = "Mark whether an offering adjustment is an admin direct correction or the application of an approved request (#2436)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     offeringAdjustmentSourceVersion,
+		Description: offeringAdjustmentSourceDescription,
+		DependsOn:   []string{careRequestDecisionSnapshotVersion},
+	})
+	Migrations.MustRegister(offeringAdjustmentSourceUp, offeringAdjustmentSourceDown)
+}
+
+func offeringAdjustmentSourceUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.308: Adding the offering adjustment source column...")
+	// The central history shows admin direct corrections as their own row kind
+	// (#2436). Approved parent requests write an adjustment row through the very
+	// same path, so without this discriminator they would appear twice: once as
+	// the decided request, once as a correction.
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE audit.enrollment_offering_adjustments
+			ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'direct';
+	`); err != nil {
+		return fmt.Errorf("add offering adjustment source column: %w", err)
+	}
+	// Existing rows carry no marker except the reason the request-approval path
+	// writes. It is the only signal available for the backfill; rows written by
+	// the generic Anmeldungsänderung approval have none and stay 'direct'.
+	if _, err := db.ExecContext(ctx, `
+		UPDATE audit.enrollment_offering_adjustments
+			SET source = 'request'
+			WHERE reason LIKE 'Elternanfrage #%';
+	`); err != nil {
+		return fmt.Errorf("backfill offering adjustment source: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_enrollment_offering_adjustments_direct_history
+			ON audit.enrollment_offering_adjustments (tenant_id, changed_at DESC, id DESC)
+			WHERE source = 'direct';
+	`); err != nil {
+		return fmt.Errorf("create offering adjustment direct history index: %w", err)
+	}
+	return nil
+}
+
+func offeringAdjustmentSourceDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back 1.15.308: Removing the offering adjustment source column...")
+	if _, err := db.ExecContext(ctx, `
+		DROP INDEX IF EXISTS audit.idx_enrollment_offering_adjustments_direct_history;
+	`); err != nil {
+		return fmt.Errorf("drop offering adjustment direct history index: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		ALTER TABLE audit.enrollment_offering_adjustments
+			DROP COLUMN IF EXISTS source;
+	`); err != nil {
+		return fmt.Errorf("remove offering adjustment source column: %w", err)
+	}
+	return nil
+}

--- a/backend/database/migrations/001015308_offering_adjustment_source.go
+++ b/backend/database/migrations/001015308_offering_adjustment_source.go
@@ -33,19 +33,43 @@ func offeringAdjustmentSourceUp(ctx context.Context, db *bun.DB) error {
 	`); err != nil {
 		return fmt.Errorf("add offering adjustment source column: %w", err)
 	}
-	// Existing rows carry no marker except the reason the offering-request
-	// approval generates, so the backfill matches that generated shape exactly
-	// ("Elternanfrage #12 freigegeben (gültig ab 01.09.2026)") rather than a
-	// loose prefix — a hand-typed correction reason cannot collide with it.
-	// Known and accepted gap: rows an approved Anmeldungsänderung wrote carry
-	// the reviewer's free-text note and stay 'direct', so a handful of legacy
-	// rows may read as corrections. New rows are stamped at both write sites.
+	// Backfill 1 of 2 — rows an approved offering request wrote. They carry the
+	// reason that approval generates, so the match is against that generated
+	// shape exactly ("Elternanfrage #12 freigegeben (gültig ab 01.09.2026)")
+	// rather than a loose prefix: a hand-typed correction reason cannot collide
+	// with it.
 	if _, err := db.ExecContext(ctx, `
 		UPDATE audit.enrollment_offering_adjustments
 			SET source = 'request'
 			WHERE reason ~ '^Elternanfrage #[0-9]+ freigegeben \(gültig ab [0-9]{2}\.[0-9]{2}\.[0-9]{4}\)';
 	`); err != nil {
 		return fmt.Errorf("backfill offering adjustment source: %w", err)
+	}
+	// Backfill 2 of 2 — rows an approved Anmeldungsänderung wrote on the side.
+	// Those carry the reviewer's free text and are unrecognizable from the
+	// reason alone, but they are not guesswork either: the adjustment is written
+	// inside the approval's own transaction, so it shares the enrollment, the
+	// deciding account and the decision instant. Without this pass they would
+	// read as the office's own correction, which is exactly the "what actually
+	// happened here?" confusion this history exists to end (#2413).
+	//
+	// The join runs on request_id, not request_child_id: a change request hangs
+	// off the enrollment and leaves request_child_id NULL unless it targets one
+	// child, so a child-level join would miss the very rows this pass is for.
+	if _, err := db.ExecContext(ctx, `
+		UPDATE audit.enrollment_offering_adjustments AS a
+			SET source = 'request'
+			FROM enrollment.change_requests AS cr
+			WHERE a.source = 'direct'
+			  AND cr.status = 'approved'
+			  AND cr.reviewed_at IS NOT NULL
+			  AND cr.request_id = a.request_id
+			  AND (cr.request_child_id IS NULL OR cr.request_child_id = a.request_child_id)
+			  AND cr.reviewed_by_account_id = a.actor_account_id
+			  AND a.changed_at BETWEEN cr.reviewed_at - INTERVAL '10 seconds'
+			                       AND cr.reviewed_at + INTERVAL '10 seconds';
+	`); err != nil {
+		return fmt.Errorf("backfill offering adjustment source from change requests: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		CREATE INDEX IF NOT EXISTS idx_enrollment_offering_adjustments_direct_history

--- a/backend/database/migrations/001015308_offering_adjustment_source.go
+++ b/backend/database/migrations/001015308_offering_adjustment_source.go
@@ -29,48 +29,13 @@ func offeringAdjustmentSourceUp(ctx context.Context, db *bun.DB) error {
 	// the decided request, once as a correction.
 	if _, err := db.ExecContext(ctx, `
 		ALTER TABLE audit.enrollment_offering_adjustments
-			ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'direct';
+			ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'unknown';
 	`); err != nil {
 		return fmt.Errorf("add offering adjustment source column: %w", err)
 	}
-	// Backfill 1 of 2 — rows an approved offering request wrote. They carry the
-	// reason that approval generates, so the match is against that generated
-	// shape exactly ("Elternanfrage #12 freigegeben (gültig ab 01.09.2026)")
-	// rather than a loose prefix: a hand-typed correction reason cannot collide
-	// with it.
-	if _, err := db.ExecContext(ctx, `
-		UPDATE audit.enrollment_offering_adjustments
-			SET source = 'request'
-			WHERE reason ~ '^Elternanfrage #[0-9]+ freigegeben \(gültig ab [0-9]{2}\.[0-9]{2}\.[0-9]{4}\)';
-	`); err != nil {
-		return fmt.Errorf("backfill offering adjustment source: %w", err)
-	}
-	// Backfill 2 of 2 — rows an approved Anmeldungsänderung wrote on the side.
-	// Those carry the reviewer's free text and are unrecognizable from the
-	// reason alone, but they are not guesswork either: the adjustment is written
-	// inside the approval's own transaction, so it shares the enrollment, the
-	// deciding account and the decision instant. Without this pass they would
-	// read as the office's own correction, which is exactly the "what actually
-	// happened here?" confusion this history exists to end (#2413).
-	//
-	// The join runs on request_id, not request_child_id: a change request hangs
-	// off the enrollment and leaves request_child_id NULL unless it targets one
-	// child, so a child-level join would miss the very rows this pass is for.
-	if _, err := db.ExecContext(ctx, `
-		UPDATE audit.enrollment_offering_adjustments AS a
-			SET source = 'request'
-			FROM enrollment.change_requests AS cr
-			WHERE a.source = 'direct'
-			  AND cr.status = 'approved'
-			  AND cr.reviewed_at IS NOT NULL
-			  AND cr.request_id = a.request_id
-			  AND (cr.request_child_id IS NULL OR cr.request_child_id = a.request_child_id)
-			  AND cr.reviewed_by_account_id = a.actor_account_id
-			  AND a.changed_at BETWEEN cr.reviewed_at - INTERVAL '10 seconds'
-			                       AND cr.reviewed_at + INTERVAL '10 seconds';
-	`); err != nil {
-		return fmt.Errorf("backfill offering adjustment source from change requests: %w", err)
-	}
+	// Historical rows do not persist their origin. A reason, actor, or timestamp
+	// match is ambiguous and can hide a real direct correction, so legacy rows
+	// deliberately remain "unknown". New writers always store direct or request.
 	if _, err := db.ExecContext(ctx, `
 		CREATE INDEX IF NOT EXISTS idx_enrollment_offering_adjustments_direct_history
 			ON audit.enrollment_offering_adjustments (tenant_id, changed_at DESC, id DESC)

--- a/backend/database/migrations/001015308_offering_adjustment_source.go
+++ b/backend/database/migrations/001015308_offering_adjustment_source.go
@@ -33,13 +33,17 @@ func offeringAdjustmentSourceUp(ctx context.Context, db *bun.DB) error {
 	`); err != nil {
 		return fmt.Errorf("add offering adjustment source column: %w", err)
 	}
-	// Existing rows carry no marker except the reason the request-approval path
-	// writes. It is the only signal available for the backfill; rows written by
-	// the generic Anmeldungsänderung approval have none and stay 'direct'.
+	// Existing rows carry no marker except the reason the offering-request
+	// approval generates, so the backfill matches that generated shape exactly
+	// ("Elternanfrage #12 freigegeben (gültig ab 01.09.2026)") rather than a
+	// loose prefix — a hand-typed correction reason cannot collide with it.
+	// Known and accepted gap: rows an approved Anmeldungsänderung wrote carry
+	// the reviewer's free-text note and stay 'direct', so a handful of legacy
+	// rows may read as corrections. New rows are stamped at both write sites.
 	if _, err := db.ExecContext(ctx, `
 		UPDATE audit.enrollment_offering_adjustments
 			SET source = 'request'
-			WHERE reason LIKE 'Elternanfrage #%';
+			WHERE reason ~ '^Elternanfrage #[0-9]+ freigegeben \(gültig ab [0-9]{2}\.[0-9]{2}\.[0-9]{4}\)';
 	`); err != nil {
 		return fmt.Errorf("backfill offering adjustment source: %w", err)
 	}

--- a/backend/database/repositories/audit/enrollment_offering_adjustment.go
+++ b/backend/database/repositories/audit/enrollment_offering_adjustment.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/audit"
@@ -36,6 +37,39 @@ func (r *enrollmentOfferingAdjustmentRepository) ListByRequestChildID(ctx contex
 		Scan(ctx)
 	if err != nil {
 		return nil, &modelBase.DatabaseError{Op: "list enrollment offering adjustments", Err: err}
+	}
+	return rows, nil
+}
+
+// ListDirectForTenant returns the tenant's direct corrections newest first.
+// Request-applied rows are excluded: the central history already shows those as
+// the decided request they belong to (#2436).
+func (r *enrollmentOfferingAdjustmentRepository) ListDirectForTenant(
+	ctx context.Context,
+	beforeChangedAt time.Time,
+	beforeID int64,
+	limit int,
+) ([]*audit.EnrollmentOfferingAdjustment, error) {
+	if limit <= 0 {
+		return []*audit.EnrollmentOfferingAdjustment{}, nil
+	}
+	var rows []*audit.EnrollmentOfferingAdjustment
+	query := base.GetDB(ctx, r.db).NewSelect().
+		Model(&rows).
+		ModelTableExpr(enrollmentOfferingAdjustmentTableExpr).
+		Where(`"enrollment_offering_adjustment".source = ?`, audit.OfferingAdjustmentSourceDirect)
+	if !beforeChangedAt.IsZero() {
+		query = query.Where(
+			`("enrollment_offering_adjustment".changed_at, "enrollment_offering_adjustment".id) < (?, ?)`,
+			beforeChangedAt, beforeID,
+		)
+	}
+	err := query.
+		OrderExpr(`"enrollment_offering_adjustment".changed_at DESC, "enrollment_offering_adjustment".id DESC`).
+		Limit(limit).
+		Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{Op: "list direct enrollment offering adjustments", Err: err}
 	}
 	return rows, nil
 }

--- a/backend/database/repositories/audit/enrollment_offering_adjustment.go
+++ b/backend/database/repositories/audit/enrollment_offering_adjustment.go
@@ -58,6 +58,7 @@ func (r *enrollmentOfferingAdjustmentRepository) ListDirectForTenant(
 		Model(&rows).
 		ModelTableExpr(enrollmentOfferingAdjustmentTableExpr).
 		Where(`"enrollment_offering_adjustment".source = ?`, audit.OfferingAdjustmentSourceDirect)
+	query = base.WithTenantFilter(ctx, query, "enrollment_offering_adjustment")
 	if !beforeChangedAt.IsZero() {
 		query = query.Where(
 			`("enrollment_offering_adjustment".changed_at, "enrollment_offering_adjustment".id) < (?, ?)`,

--- a/backend/database/repositories/audit/enrollment_offering_adjustment_test.go
+++ b/backend/database/repositories/audit/enrollment_offering_adjustment_test.go
@@ -203,14 +203,15 @@ func TestEnrollmentOfferingAdjustmentRepository_ListDirectForTenant(t *testing.T
 	middle := newRow("middle", audit.OfferingAdjustmentSourceDirect, base.Add(time.Hour))
 	oldest := newRow("oldest", audit.OfferingAdjustmentSourceDirect, base)
 	applied := newRow("applied request", audit.OfferingAdjustmentSourceRequest, base.Add(3*time.Hour))
-	for _, row := range []*audit.EnrollmentOfferingAdjustment{newest, middle, oldest, applied} {
+	unknown := newRow("legacy adjustment", audit.OfferingAdjustmentSourceUnknown, base.Add(4*time.Hour))
+	for _, row := range []*audit.EnrollmentOfferingAdjustment{newest, middle, oldest, applied, unknown} {
 		require.NoError(t, repo.Create(ctx, row))
 	}
 	defer testpkg.CleanupTableRecords(t, db, "audit.enrollment_offering_adjustments",
-		newest.ID, middle.ID, oldest.ID, applied.ID)
+		newest.ID, middle.ID, oldest.ID, applied.ID, unknown.ID)
 
-	// First page: newest first, and the request-applied row stays out — the
-	// history already shows that one as the decided request.
+	// First page: newest first; request-applied and unknown legacy rows stay
+	// out because neither is a verified direct correction.
 	first, err := repo.ListDirectForTenant(ctx, time.Time{}, 0, 2)
 	require.NoError(t, err)
 	require.Len(t, first, 2)
@@ -223,6 +224,7 @@ func TestEnrollmentOfferingAdjustmentRepository_ListDirectForTenant(t *testing.T
 	assert.Equal(t, oldest.ID, second[0].ID)
 	for _, row := range second {
 		assert.NotEqual(t, applied.ID, row.ID, "request-applied rows never appear")
+		assert.NotEqual(t, unknown.ID, row.ID, "unknown legacy rows never appear")
 	}
 
 	// A non-positive limit asks for nothing and hits no database at all.

--- a/backend/database/repositories/audit/enrollment_offering_adjustment_test.go
+++ b/backend/database/repositories/audit/enrollment_offering_adjustment_test.go
@@ -227,6 +227,12 @@ func TestEnrollmentOfferingAdjustmentRepository_ListDirectForTenant(t *testing.T
 		assert.NotEqual(t, unknown.ID, row.ID, "unknown legacy rows never appear")
 	}
 
+	// The explicit repository predicate protects non-HTTP callers whose
+	// database connection bypasses RLS.
+	otherTenantRows, err := repo.ListDirectForTenant(testpkg.TenantContext(2), time.Time{}, 0, 2)
+	require.NoError(t, err)
+	assert.Empty(t, otherTenantRows)
+
 	// A non-positive limit asks for nothing and hits no database at all.
 	none, err := repo.ListDirectForTenant(ctx, time.Time{}, 0, 0)
 	require.NoError(t, err)

--- a/backend/database/repositories/audit/enrollment_offering_adjustment_test.go
+++ b/backend/database/repositories/audit/enrollment_offering_adjustment_test.go
@@ -102,6 +102,17 @@ func TestEnrollmentOfferingAdjustmentRepository_ListByRequestChildID_QueryError(
 	assert.Contains(t, err.Error(), "list enrollment offering adjustments")
 }
 
+func TestEnrollmentOfferingAdjustmentRepository_ListDirectForTenant_QueryError(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	repo := repositories.NewFactory(db).EnrollmentOfferingAdjustment
+	require.NoError(t, db.Close())
+
+	rows, err := repo.ListDirectForTenant(testpkg.TenantContext(1), time.Now(), 1, 10)
+	require.Error(t, err)
+	assert.Nil(t, rows)
+	assert.Contains(t, err.Error(), "list direct enrollment offering adjustments")
+}
+
 func createAuditAdjustmentPhase(t *testing.T, repoFactory *repositories.Factory) *enrollmentModels.Phase {
 	t.Helper()
 	ctx := testpkg.TenantContext(1)
@@ -149,4 +160,73 @@ func createAuditAdjustmentChild(t *testing.T, repoFactory *repositories.Factory,
 	}
 	require.NoError(t, repoFactory.RequestChild.Create(ctx, child))
 	return child
+}
+
+// The central history reads corrections through this keyset window (#2436):
+// newest first, request-applied rows excluded, and a follow-up page that
+// continues strictly before the last row of the previous one.
+func TestEnrollmentOfferingAdjustmentRepository_ListDirectForTenant(t *testing.T) {
+	db := testpkg.SetupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	repoFactory := repositories.NewFactory(db)
+	repo := repoFactory.EnrollmentOfferingAdjustment
+	ctx := testpkg.TenantContext(1)
+
+	student := testpkg.CreateTestStudent(t, db, "Direct", "Correction", "1a")
+	account := testpkg.CreateTestAccount(t, db, "direct-correction-admin@example.test")
+	phase := createAuditAdjustmentPhase(t, repoFactory)
+	request := createAuditAdjustmentRequest(t, repoFactory, phase.ID)
+	child := createAuditAdjustmentChild(t, repoFactory, request.ID)
+	defer testpkg.CleanupTableRecords(t, db, "auth.accounts", account.ID)
+	defer testpkg.CleanupActivityFixtures(t, db, student.ID)
+	defer testpkg.CleanupTableRecords(t, db, "enrollment.phases", phase.ID)
+
+	// A far-future base keeps this window clear of rows other tests leave in
+	// the shared test database.
+	base := time.Date(2099, time.March, 3, 12, 0, 0, 0, time.UTC)
+	newRow := func(reason, source string, changedAt time.Time) *audit.EnrollmentOfferingAdjustment {
+		return &audit.EnrollmentOfferingAdjustment{
+			RequestID:      request.ID,
+			RequestChildID: child.ID,
+			StudentID:      student.ID,
+			ActorAccountID: account.ID,
+			ActorRole:      "admin",
+			Reason:         reason,
+			Source:         source,
+			Before:         []byte(`[]`),
+			After:          []byte(`[]`),
+			ChangedAt:      changedAt,
+		}
+	}
+	newest := newRow("newest", audit.OfferingAdjustmentSourceDirect, base.Add(2*time.Hour))
+	middle := newRow("middle", audit.OfferingAdjustmentSourceDirect, base.Add(time.Hour))
+	oldest := newRow("oldest", audit.OfferingAdjustmentSourceDirect, base)
+	applied := newRow("applied request", audit.OfferingAdjustmentSourceRequest, base.Add(3*time.Hour))
+	for _, row := range []*audit.EnrollmentOfferingAdjustment{newest, middle, oldest, applied} {
+		require.NoError(t, repo.Create(ctx, row))
+	}
+	defer testpkg.CleanupTableRecords(t, db, "audit.enrollment_offering_adjustments",
+		newest.ID, middle.ID, oldest.ID, applied.ID)
+
+	// First page: newest first, and the request-applied row stays out — the
+	// history already shows that one as the decided request.
+	first, err := repo.ListDirectForTenant(ctx, time.Time{}, 0, 2)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, []int64{newest.ID, middle.ID}, []int64{first[0].ID, first[1].ID})
+
+	// Follow-up page continues strictly before the last consumed row.
+	second, err := repo.ListDirectForTenant(ctx, first[1].ChangedAt, first[1].ID, 2)
+	require.NoError(t, err)
+	require.NotEmpty(t, second)
+	assert.Equal(t, oldest.ID, second[0].ID)
+	for _, row := range second {
+		assert.NotEqual(t, applied.ID, row.ID, "request-applied rows never appear")
+	}
+
+	// A non-positive limit asks for nothing and hits no database at all.
+	none, err := repo.ListDirectForTenant(ctx, time.Time{}, 0, 0)
+	require.NoError(t, err)
+	assert.Empty(t, none)
 }

--- a/backend/models/audit/enrollment_offering_adjustment.go
+++ b/backend/models/audit/enrollment_offering_adjustment.go
@@ -8,6 +8,15 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/base"
 )
 
+// Sources of an offering adjustment. A direct correction is the office
+// changing a booking on its own; a request-applied row is the side effect of
+// approving a parent request, which the central history already shows as the
+// decided request (#2436).
+const (
+	OfferingAdjustmentSourceDirect  = "direct"
+	OfferingAdjustmentSourceRequest = "request"
+)
+
 // EnrollmentOfferingAdjustment records an admin correction to one approved
 // child's care-offering selection. Rows are append-only.
 type EnrollmentOfferingAdjustment struct {
@@ -21,6 +30,7 @@ type EnrollmentOfferingAdjustment struct {
 	ActorNameSnapshot  *string         `bun:"actor_name_snapshot" json:"actor_name_snapshot,omitempty"`
 	ActorEmailSnapshot *string         `bun:"actor_email_snapshot" json:"actor_email_snapshot,omitempty"`
 	Reason             string          `bun:"reason,notnull" json:"reason"`
+	Source             string          `bun:"source,notnull" json:"source"`
 	Before             json.RawMessage `bun:"before_json,type:jsonb,notnull" json:"before"`
 	After              json.RawMessage `bun:"after_json,type:jsonb,notnull" json:"after"`
 	ChangedAt          time.Time       `bun:"changed_at,notnull,default:now()" json:"changed_at"`
@@ -41,4 +51,9 @@ func (e *EnrollmentOfferingAdjustment) GetUpdatedAt() time.Time {
 type EnrollmentOfferingAdjustmentRepository interface {
 	Create(ctx context.Context, entry *EnrollmentOfferingAdjustment) error
 	ListByRequestChildID(ctx context.Context, requestChildID int64) ([]*EnrollmentOfferingAdjustment, error)
+	// ListDirectForTenant returns the tenant's direct corrections, newest
+	// change first, keyset paginated on (changed_at, id). A zero beforeChangedAt
+	// starts at the top; limit is taken literally, so callers probing for a next
+	// page ask for limit+1.
+	ListDirectForTenant(ctx context.Context, beforeChangedAt time.Time, beforeID int64, limit int) ([]*EnrollmentOfferingAdjustment, error)
 }

--- a/backend/models/audit/enrollment_offering_adjustment.go
+++ b/backend/models/audit/enrollment_offering_adjustment.go
@@ -15,6 +15,10 @@ import (
 const (
 	OfferingAdjustmentSourceDirect  = "direct"
 	OfferingAdjustmentSourceRequest = "request"
+	// Unknown marks adjustments recorded before source provenance existed.
+	// They remain available in the child detail but are intentionally excluded
+	// from the central direct-correction history.
+	OfferingAdjustmentSourceUnknown = "unknown"
 )
 
 // EnrollmentOfferingAdjustment records an admin correction to one approved

--- a/backend/services/enrollment/offering_adjustment_service.go
+++ b/backend/services/enrollment/offering_adjustment_service.go
@@ -56,7 +56,7 @@ func (s *decisionService) ListOfferingAdjustments(ctx context.Context, requestID
 }
 
 func (s *decisionService) UpdateChildOfferings(ctx context.Context, input UpdateChildOfferingsInput) (*enrollmentModels.RequestChild, error) {
-	result, err := s.updateChildOfferings(ctx, input, true)
+	result, err := s.updateChildOfferings(ctx, input, auditModels.OfferingAdjustmentSourceDirect)
 	if err != nil {
 		return nil, err
 	}
@@ -80,15 +80,21 @@ func (s *decisionService) applyApprovedChangeRequestOfferingsWithResult(
 	ctx context.Context,
 	input UpdateChildOfferingsInput,
 ) (*appliedOfferingAdjustment, error) {
-	return s.updateChildOfferings(ctx, input, false)
+	return s.updateChildOfferings(ctx, input, auditModels.OfferingAdjustmentSourceRequest)
 }
 
+// updateChildOfferings performs the booking switch and records it. source
+// tells the two entry points apart: a direct correction by the office is
+// subject to the live care-offerings setting and shows up in the central
+// history as its own row kind (#2436), while a request-applied change carries
+// the capability frozen when the parent submitted and is already visible there
+// as the decided request.
 func (s *decisionService) updateChildOfferings(
 	ctx context.Context,
 	input UpdateChildOfferingsInput,
-	enforceLiveCapability bool,
+	source string,
 ) (*appliedOfferingAdjustment, error) {
-	if enforceLiveCapability {
+	if source == auditModels.OfferingAdjustmentSourceDirect {
 		enabled, err := s.resolveDecisionBool(ctx, configModel.KeyEnrollmentCareOfferingsEnabled, true)
 		if err != nil {
 			return nil, fmt.Errorf("offering adjustment: resolve care offerings setting: %w", err)
@@ -298,6 +304,7 @@ func (s *decisionService) updateChildOfferings(
 		ActorNameSnapshot:  actorName,
 		ActorEmailSnapshot: actorEmail,
 		Reason:             reason,
+		Source:             source,
 		Before:             beforeJSON,
 		After:              afterJSON,
 	}

--- a/backend/services/enrollment/offering_change_request_service.go
+++ b/backend/services/enrollment/offering_change_request_service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
 	usersModels "github.com/moto-nrw/project-phoenix/models/users"
@@ -282,6 +283,10 @@ type OfferingChangeRequestService interface {
 	// paginated on (updated_at, id). A zero beforeUpdatedAt returns the first
 	// page; next is nil when no older rows exist beyond this page.
 	ListHistory(ctx context.Context, beforeUpdatedAt time.Time, beforeID int64, limit int) (items []*OfferingChangeHistoryItem, next *usersService.HistoryCursor, err error)
+	// ListDirectCorrections returns the office's own corrections to bookings,
+	// newest change first, keyset paginated on (changed_at, id). They are not
+	// requests: no pending state, nothing to decide (#2436).
+	ListDirectCorrections(ctx context.Context, beforeChangedAt time.Time, beforeID int64, limit int) (items []*DirectCorrectionItem, next *usersService.HistoryCursor, err error)
 	// PendingCount backs the staff sidebar badge without constructing queue diffs.
 	PendingCount(ctx context.Context) (int, error)
 	// PreviewDecision materializes a pending approval with the supplied
@@ -306,7 +311,10 @@ type OfferingChangeRequestServiceConfig struct {
 	RequestChildOfferingRepo enrollmentModels.RequestChildOfferingRepository
 	StudentRepo              usersModels.StudentRepository
 	PersonRepo               usersModels.PersonRepository
-	UserContext              authorize.StudentAccessUserContext
+	// OfferingAdjustmentRepo backs the direct-correction feed of the central
+	// history (#2436); the same append-only log the decision service writes.
+	OfferingAdjustmentRepo auditModels.EnrollmentOfferingAdjustmentRepository
+	UserContext            authorize.StudentAccessUserContext
 	// Applier performs the dated adjustment on approval. It is the decision
 	// service, reached through the same narrow interface the change-request
 	// service uses.

--- a/backend/services/enrollment/offering_direct_correction_service.go
+++ b/backend/services/enrollment/offering_direct_correction_service.go
@@ -1,0 +1,182 @@
+package enrollment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	auditModels "github.com/moto-nrw/project-phoenix/models/audit"
+	usersService "github.com/moto-nrw/project-phoenix/services/users"
+)
+
+// DirectCorrectionItem is one admin correction to a child's bookings as the
+// central history shows it (#2436): who changed what, when and why. It is not
+// a request — there is no pending state and nothing to decide.
+type DirectCorrectionItem struct {
+	Adjustment  *auditModels.EnrollmentOfferingAdjustment
+	StudentName string
+	// ActorName falls back to the e-mail snapshot and finally to "Unbekannt",
+	// so a deleted account never renders an account id.
+	ActorName string
+	// Diff holds only the offerings whose booking actually changed, in the
+	// same shape the offering-request history uses.
+	Diff []OfferingChangeDiffEntry
+}
+
+// ListDirectCorrections returns the tenant's admin direct corrections,
+// newest change first, keyset paginated on (changed_at, id).
+func (s *offeringChangeRequestService) ListDirectCorrections(
+	ctx context.Context,
+	beforeChangedAt time.Time,
+	beforeID int64,
+	limit int,
+) ([]*DirectCorrectionItem, *usersService.HistoryCursor, error) {
+	if s.OfferingAdjustmentRepo == nil {
+		return nil, nil, fmt.Errorf("offering change: offering adjustment repo not configured")
+	}
+	// limit+1 probes for an older page without a second count query.
+	rows, err := s.OfferingAdjustmentRepo.ListDirectForTenant(ctx, beforeChangedAt, beforeID, limit+1)
+	if err != nil {
+		return nil, nil, fmt.Errorf("offering change: list direct corrections: %w", err)
+	}
+	// The cursor points at the last DB row, not the last visible item: the
+	// per-child scope filters after the DB limit, so a cursor built from the
+	// filtered page would skip rows.
+	var next *usersService.HistoryCursor
+	if len(rows) > limit {
+		rows = rows[:limit]
+		last := rows[len(rows)-1]
+		next = &usersService.HistoryCursor{UpdatedAt: last.ChangedAt, ID: last.ID}
+	}
+	if len(rows) == 0 {
+		return []*DirectCorrectionItem{}, nil, nil
+	}
+
+	studentIDs := make([]int64, 0, len(rows))
+	for _, row := range rows {
+		studentIDs = append(studentIDs, row.StudentID)
+	}
+	students, err := s.StudentRepo.FindByIDs(ctx, studentIDs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("offering change: load students for direct corrections: %w", err)
+	}
+	personIDs := make([]int64, 0, len(students))
+	for _, st := range students {
+		personIDs = append(personIDs, st.PersonID)
+	}
+	persons, err := s.PersonRepo.FindByIDs(ctx, personIDs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("offering change: load student persons for direct corrections: %w", err)
+	}
+
+	// Same per-child scope as the request history: write gate + alumnus skip.
+	writable := authorize.WritableStudentFilter(ctx, jwt.PermissionsFromCtx(ctx), s.UserContext)
+
+	items := make([]*DirectCorrectionItem, 0, len(rows))
+	for _, row := range rows {
+		student := students[row.StudentID]
+		if student == nil || !writable(student) || student.IsAlumnus() {
+			continue
+		}
+		item := &DirectCorrectionItem{
+			Adjustment: row,
+			ActorName:  directCorrectionActorName(row),
+			Diff:       directCorrectionDiff(row, s.Logger),
+		}
+		if person := persons[student.PersonID]; person != nil {
+			item.StudentName = strings.TrimSpace(person.GetFullName())
+		}
+		items = append(items, item)
+	}
+	return items, next, nil
+}
+
+func directCorrectionActorName(row *auditModels.EnrollmentOfferingAdjustment) string {
+	if row.ActorNameSnapshot != nil && strings.TrimSpace(*row.ActorNameSnapshot) != "" {
+		return strings.TrimSpace(*row.ActorNameSnapshot)
+	}
+	if row.ActorEmailSnapshot != nil && strings.TrimSpace(*row.ActorEmailSnapshot) != "" {
+		return strings.TrimSpace(*row.ActorEmailSnapshot)
+	}
+	// Spec: deleted accounts read as "Unbekannt", never as an account id.
+	return "Unbekannt"
+}
+
+// directCorrectionDiff turns the frozen before/after snapshots into the same
+// changed-lines shape the offering-request history renders. Snapshots are
+// written by the correction itself, so this is never a live recomputation.
+func directCorrectionDiff(row *auditModels.EnrollmentOfferingAdjustment, logger *slog.Logger) []OfferingChangeDiffEntry {
+	before, beforeErr := decodeAdjustmentSnapshot(row.Before)
+	after, afterErr := decodeAdjustmentSnapshot(row.After)
+	if beforeErr != nil || afterErr != nil {
+		if logger != nil {
+			logger.Warn("offering change: decode direct correction snapshot failed",
+				slog.Int64("adjustment_id", row.ID),
+			)
+		}
+		return nil
+	}
+
+	ids := make([]int64, 0, len(before)+len(after))
+	labels := make(map[int64]string, len(before)+len(after))
+	for _, side := range []map[int64]offeringAdjustmentSnapshot{before, after} {
+		for id, snapshot := range side {
+			if !slices.Contains(ids, id) {
+				ids = append(ids, id)
+			}
+			if name := strings.TrimSpace(snapshot.OfferingName); name != "" {
+				labels[id] = name
+			}
+		}
+	}
+	slices.Sort(ids)
+
+	diff := make([]OfferingChangeDiffEntry, 0, len(ids))
+	for _, id := range ids {
+		entry := OfferingChangeDiffEntry{OfferingID: id, Label: labels[id]}
+		if entry.Label == "" {
+			entry.Label = fmt.Sprintf("Angebot %d", id)
+		}
+		entry.OldState = "not_booked"
+		if snapshot, ok := before[id]; ok {
+			entry.OldState = "booked"
+			entry.OldDays = canonicalDays(snapshot.SelectedDays)
+		}
+		entry.NewState = "removed"
+		if snapshot, ok := after[id]; ok {
+			entry.NewState = "booked"
+			entry.NewDays = canonicalDays(snapshot.SelectedDays)
+		}
+		if entry.OldState == entry.NewState && slices.Equal(entry.OldDays, entry.NewDays) {
+			continue
+		}
+		diff = append(diff, entry)
+	}
+	return diff
+}
+
+func decodeAdjustmentSnapshot(raw json.RawMessage) (map[int64]offeringAdjustmentSnapshot, error) {
+	out := map[int64]offeringAdjustmentSnapshot{}
+	if len(raw) == 0 {
+		return out, nil
+	}
+	var entries []offeringAdjustmentSnapshot
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		id, err := strconv.ParseInt(entry.OfferingID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		out[id] = entry
+	}
+	return out, nil
+}

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1890,6 +1890,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		RequestChildOfferingRepo: repos.RequestChildOffering,
 		StudentRepo:              repos.Student,
 		PersonRepo:               repos.Person,
+		OfferingAdjustmentRepo:   repos.EnrollmentOfferingAdjustment,
 		UserContext:              userContextService,
 		Applier:                  enrollmentDecisionApplier,
 		Settings:                 settingsService,

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.test.tsx
@@ -181,6 +181,11 @@ describe("AnfragenPage", () => {
     const open = listProbe();
     expect(open.view).toBe("open");
     expect(open.filters.types).toEqual([]);
+
+    // Der inkompatible Filter wird beim Wechsel gelöscht und kehrt nicht
+    // still zurück, wenn die Historie wieder geöffnet wird.
+    fireEvent.click(screen.getByRole("button", { name: "Historie" }));
+    expect(listProbe().filters.types).toEqual([]);
   });
 
   it("zeigt einer Person mit users:absence die Liste ohne Art-Filter", () => {

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.test.tsx
@@ -165,6 +165,24 @@ describe("AnfragenPage", () => {
     expect(probe.filters.to).toBeUndefined();
   });
 
+  it("bietet den Direkt-Korrektur-Filter nur in der Historie an", () => {
+    render(<AnfragenPage />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Filter/ })[0]!);
+    expect(screen.queryByText("Direkt-Korrekturen")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Historie" }));
+    fireEvent.click(screen.getByText("Direkt-Korrekturen"));
+    expect(listProbe().filters.types).toEqual(["direct_correction"]);
+
+    // Zurück in der Arbeitsliste dürfen Korrekturen nie auftauchen, auch
+    // nicht als übrig gebliebener Filter (#2436).
+    fireEvent.click(screen.getByRole("button", { name: "Offen" }));
+    const open = listProbe();
+    expect(open.view).toBe("open");
+    expect(open.filters.types).toEqual([]);
+  });
+
   it("zeigt einer Person mit users:absence die Liste ohne Art-Filter", () => {
     mockUseSession.mockReturnValue(
       sessionWith(["users:read", "users:absence"]),

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
@@ -43,6 +43,13 @@ const REQUEST_TYPE_OPTIONS: readonly {
   { value: "excused", label: "Entschuldigungen" },
 ];
 
+// Direkt-Korrekturen sind keine Anfragen: sie gibt es nur in der Historie,
+// also auch den Filter nur dort (#2436).
+const HISTORY_ONLY_TYPE_OPTIONS: readonly {
+  value: AggregatedRequestType;
+  label: string;
+}[] = [{ value: "direct_correction", label: "Direkt-Korrekturen" }];
+
 // Die Abwesenheitsarten, die Mitarbeitende beantragen können, mit den Namen
 // aus der geteilten Beschriftungstabelle. Freizeitausgleich fehlt bewusst: den
 // trägt die Zeiterfassung ein, er läuft nicht über eine Freigabe.
@@ -117,7 +124,10 @@ export default function AnfragenPage() {
   const filters: AggregatedRequestFilters = useMemo(
     () => ({
       search: deferredSearch,
-      types: typeFilter,
+      types:
+        view === "history"
+          ? typeFilter
+          : typeFilter.filter((type) => type !== "direct_correction"),
       statuses: view === "history" ? statusFilter : [],
       from:
         view === "history" && dateRange?.from
@@ -151,7 +161,10 @@ export default function AnfragenPage() {
                   ? value
                   : [value]) as AggregatedRequestType[],
               ),
-            options: REQUEST_TYPE_OPTIONS.map((option) => ({ ...option })),
+            options: [
+              ...REQUEST_TYPE_OPTIONS,
+              ...(view === "history" ? HISTORY_ONLY_TYPE_OPTIONS : []),
+            ].map((option) => ({ ...option })),
           },
         ]
       : [];
@@ -195,9 +208,11 @@ export default function AnfragenPage() {
   const activeFilters = useMemo(() => {
     const chips: ActiveFilter[] = [];
     for (const type of typeFilter) {
-      const label = REQUEST_TYPE_OPTIONS.find(
-        (option) => option.value === type,
-      )?.label;
+      if (type === "direct_correction" && view !== "history") continue;
+      const label = [
+        ...REQUEST_TYPE_OPTIONS,
+        ...HISTORY_ONLY_TYPE_OPTIONS,
+      ].find((option) => option.value === type)?.label;
       if (!label) continue;
       chips.push({
         id: `art-${type}`,

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
@@ -146,6 +146,16 @@ export default function AnfragenPage() {
     [deferredSearch, absenceTypeFilter],
   );
 
+  // Die im aktuellen Umschalter-Zustand wählbaren Anfragearten. Eine Quelle
+  // für Filterknöpfe UND Filter-Chips: was hier fehlt, ist auch als Chip weg.
+  const typeOptions = useMemo(
+    () => [
+      ...REQUEST_TYPE_OPTIONS,
+      ...(view === "history" ? HISTORY_ONLY_TYPE_OPTIONS : []),
+    ],
+    [view],
+  );
+
   const filterConfigs = useMemo(() => {
     const typeConfig: FilterConfig[] = showTypeFilter
       ? [
@@ -161,10 +171,7 @@ export default function AnfragenPage() {
                   ? value
                   : [value]) as AggregatedRequestType[],
               ),
-            options: [
-              ...REQUEST_TYPE_OPTIONS,
-              ...(view === "history" ? HISTORY_ONLY_TYPE_OPTIONS : []),
-            ].map((option) => ({ ...option })),
+            options: typeOptions.map((option) => ({ ...option })),
           },
         ]
       : [];
@@ -203,16 +210,14 @@ export default function AnfragenPage() {
           ]
         : [];
     return [...typeConfig, ...historyConfigs];
-  }, [showTypeFilter, view, typeFilter, statusFilter, dateRange]);
+  }, [showTypeFilter, view, typeOptions, typeFilter, statusFilter, dateRange]);
 
   const activeFilters = useMemo(() => {
     const chips: ActiveFilter[] = [];
     for (const type of typeFilter) {
-      if (type === "direct_correction" && view !== "history") continue;
-      const label = [
-        ...REQUEST_TYPE_OPTIONS,
-        ...HISTORY_ONLY_TYPE_OPTIONS,
-      ].find((option) => option.value === type)?.label;
+      // Eine Art, die in dieser Ansicht nicht wählbar ist, trägt auch keinen
+      // Chip — in der Arbeitsliste betrifft das die Direkt-Korrekturen.
+      const label = typeOptions.find((option) => option.value === type)?.label;
       if (!label) continue;
       chips.push({
         id: `art-${type}`,
@@ -243,7 +248,7 @@ export default function AnfragenPage() {
       }
     }
     return chips;
-  }, [typeFilter, statusFilter, dateRange, view]);
+  }, [typeOptions, typeFilter, statusFilter, dateRange, view]);
 
   const staffFilterConfigs = useMemo<FilterConfig[]>(
     () => [

--- a/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/anfragen/page.tsx
@@ -290,6 +290,15 @@ export default function AnfragenPage() {
     setDateRange(undefined);
   };
 
+  const handleElternViewChange = (nextView: "open" | "history") => {
+    if (nextView === "open") {
+      setTypeFilter((previous) =>
+        previous.filter((type) => type !== "direct_correction"),
+      );
+    }
+    setView(nextView);
+  };
+
   if (!isReady) {
     return (
       <div className="-mt-1.5 w-full">
@@ -350,7 +359,11 @@ export default function AnfragenPage() {
           filters={staffFilters}
         />
       ) : (
-        <ElternTab view={view} onViewChange={setView} filters={filters} />
+        <ElternTab
+          view={view}
+          onViewChange={handleElternViewChange}
+          filters={filters}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -688,7 +688,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Mit `Freigeben` wird der neue Wert übernommen – bei Betreuungszeiten direkt in den Wochenplan des Kindes, bei einer entschuldigten Abmeldung wird das Kind für die Tage als entschuldigt eingetragen. Mit `Ablehnen` bleibt der bisherige Stand erhalten; bei Betreuungszeiten, Betreuungsangeboten und entschuldigten Abmeldungen ist dafür eine Begründung erforderlich, bei Stammdaten optional.",
           "Anfragen zu Betreuungsangeboten gelten ab dem gewünschten Datum: Das bisherige Angebot endet an diesem Tag, das neue beginnt dann. Vergangene Wochen bleiben unverändert, damit Anwesenheiten und Listen weiterhin stimmen. Ist ein gewünschtes Angebot inzwischen voll, meldet die App das beim Freigeben und die Anfrage bleibt offen.",
           "Die Eltern sehen die Entscheidung als Hinweis in ihrem Nachrichten-Verlauf. Bei Betreuungsangeboten steht das Ergebnis zusätzlich zwei Wochen lang unter `Gebuchte Betreuung` im Kinderbereich der Eltern-App, bei einer Ablehnung mit Ihrer Begründung.",
-          "Über den Schalter `Historie` oben auf der Seite sehen Sie alle bereits entschiedenen Anfragen: wer wann freigegeben oder abgelehnt hat, mit welcher Begründung – und auch automatisch übernommene Stammdaten-Änderungen. Über `Weitere Einträge laden` blättern Sie weiter zurück.",
+          "Über den Schalter `Historie` oben auf der Seite sehen Sie alle bereits entschiedenen Anfragen: wer wann freigegeben oder abgelehnt hat, mit welcher Begründung – und auch automatisch übernommene Stammdaten-Änderungen. Änderungen, die Sie selbst an den gebuchten Angeboten eines Kindes vorgenommen haben, stehen dort als `Direkt-Korrektur`. Über `Weitere Einträge laden` blättern Sie weiter zurück.",
           "Ob Eltern Stammdaten direkt ändern bzw. Änderungen anfragen dürfen, steuern Sie unter `Einstellungen` im Bereich `Elternportal`. Anfragen zu Betreuungsangeboten schalten Sie unter `Einstellungen` > `Anmeldung` frei; dort legen Sie auch fest, wie viele Tage Vorlauf eine Umstellung mindestens braucht.",
         ],
         callout: {
@@ -1677,6 +1677,7 @@ export const appChapters: readonly GuideChapter[] = [
           "Passt die Anfrage nicht, eine kurze `Begründung` eintragen und auf `Ablehnen` tippen. Der Grund wird der Bezugsperson angezeigt.",
           "Nach der Entscheidung wird die Bezugsperson in ihrer App über das Ergebnis informiert (Hinweis im Nachrichten-Verlauf und Status im Kinderbereich).",
           "Über den Schalter `Historie` stehen alle bereits entschiedenen Anfragen in derselben Liste, jeweils mit Datum, entscheidender Person und Begründung. Dort lässt sich zusätzlich nach `Status` (Angenommen, Abgelehnt, Zurückgezogen) und nach `Zeitraum` filtern.",
+          "In der Historie stehen auch Änderungen, die die OGS selbst an den gebuchten Angeboten eines Kindes vorgenommen hat, etwa nach einem Anruf. Sie sind mit `Direkt-Korrektur` gekennzeichnet und zeigen, wer wann was geändert hat und warum. Über den Filter `Anfrageart` lassen sie sich einzeln anzeigen.",
         ],
         callout: {
           title: "Wer darf entscheiden",

--- a/frontend/src/components/students/care-request-review-item.tsx
+++ b/frontend/src/components/students/care-request-review-item.tsx
@@ -143,7 +143,7 @@ export function CareRequestReviewItem({
           <Alert type="error" message={error} />
         </div>
       )}
-      <ReviewDiffPanel>
+      <ReviewDiffPanel title="Änderungen">
         {row.request_reason && (
           <p className="mb-3 text-sm text-gray-700">
             <span className="font-medium text-gray-900">Grund der Eltern:</span>{" "}

--- a/frontend/src/components/students/excused-request-review-item.tsx
+++ b/frontend/src/components/students/excused-request-review-item.tsx
@@ -128,7 +128,7 @@ export function ExcusedRequestReviewItem({
           <Alert type="error" message={error} />
         </div>
       )}
-      <ReviewDiffPanel>
+      <ReviewDiffPanel title="Änderungen">
         <div className="text-sm">
           <span className="text-xs text-gray-500">Tage: </span>
           <span className="font-medium text-gray-900">

--- a/frontend/src/components/students/master-data-review-item.tsx
+++ b/frontend/src/components/students/master-data-review-item.tsx
@@ -157,7 +157,7 @@ export function MasterDataReviewItem({
           <Alert type="error" message={error} />
         </div>
       )}
-      <ReviewDiffPanel>
+      <ReviewDiffPanel title="Änderungen">
         {/* Field name lives in the collapsed summary; the expanded panel
             shows only the value change. */}
         <div className="flex flex-wrap items-baseline gap-2 text-sm">

--- a/frontend/src/components/students/offering-request-review-item.tsx
+++ b/frontend/src/components/students/offering-request-review-item.tsx
@@ -219,7 +219,7 @@ export function OfferingRequestReviewItem({
           />
         </div>
       )}
-      <ReviewDiffPanel>
+      <ReviewDiffPanel title="Änderungen">
         {row.diff.length === 0 && (
           <span className="text-sm text-gray-500">—</span>
         )}

--- a/frontend/src/components/students/request-history-item.test.tsx
+++ b/frontend/src/components/students/request-history-item.test.tsx
@@ -237,7 +237,7 @@ describe("RequestHistoryItem", () => {
     ).toBeInTheDocument();
   });
 
-  it("zeigt eine Korrektur ohne Tagesänderung ohne leere Änderungsfläche", () => {
+  it("hält eine Korrektur ohne Tagesänderung trotzdem fest", () => {
     // Kommt vor, wenn sich nur intern etwas verschiebt (selbst gesetzte gegen
     // automatisch übernommene Tage) und die gebuchten Tage gleich bleiben.
     const item: AggregatedHistoryRequest = {
@@ -255,7 +255,12 @@ describe("RequestHistoryItem", () => {
 
     render(<RequestHistoryItem item={item} />);
 
+    // Jede Änderung wird dokumentiert, auch die ohne sichtbaren Unterschied
+    // an den Tagen — dann sagt die Karte das ausdrücklich.
     expect(screen.getByText("Direkt-Korrektur")).toBeInTheDocument();
-    expect(screen.queryByText("Änderungen")).not.toBeInTheDocument();
+    expect(screen.getByText("„Telefonisch gemeldet“")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keine Änderung an den gebuchten Tagen"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/students/request-history-item.test.tsx
+++ b/frontend/src/components/students/request-history-item.test.tsx
@@ -156,6 +156,27 @@ describe("RequestHistoryItem", () => {
     expect(screen.getByText("Kreativ-AG: Di")).toBeInTheDocument();
   });
 
+  it("zeigt ohne Diff und beantragte Angebote keine leere Beantragt-Fläche", () => {
+    const item: AggregatedHistoryRequest = {
+      request_type: "offering",
+      data: {
+        id: "offering-empty",
+        student_id: "42",
+        student_name: "Lara Lehmann",
+        status: "withdrawn",
+        effective_from: "2026-08-20",
+        diff: [],
+        requested: [],
+        created_at: "2026-08-17T09:00:00Z",
+        decided_at: "2026-08-18T10:00:00Z",
+      },
+    };
+
+    render(<RequestHistoryItem item={item} />);
+
+    expect(screen.queryByText("Beantragt")).not.toBeInTheDocument();
+  });
+
   it("zeigt bei einer entschuldigten Abmeldung Daten und Notiz", () => {
     const item: AggregatedHistoryRequest = {
       request_type: "excused",

--- a/frontend/src/components/students/request-history-item.test.tsx
+++ b/frontend/src/components/students/request-history-item.test.tsx
@@ -236,4 +236,26 @@ describe("RequestHistoryItem", () => {
       screen.getByText("Mittagessen: Mo → abgemeldet"),
     ).toBeInTheDocument();
   });
+
+  it("zeigt eine Korrektur ohne Tagesänderung ohne leere Änderungsfläche", () => {
+    // Kommt vor, wenn sich nur intern etwas verschiebt (selbst gesetzte gegen
+    // automatisch übernommene Tage) und die gebuchten Tage gleich bleiben.
+    const item: AggregatedHistoryRequest = {
+      request_type: "direct_correction",
+      data: {
+        id: "10",
+        student_id: "42",
+        student_name: "Lara Lehmann",
+        changed_at: "2026-08-18T10:00:00Z",
+        changed_by_name: "Olga Office",
+        reason: "Telefonisch gemeldet",
+        diff: [],
+      },
+    };
+
+    render(<RequestHistoryItem item={item} />);
+
+    expect(screen.getByText("Direkt-Korrektur")).toBeInTheDocument();
+    expect(screen.queryByText("Änderungen")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/students/request-history-item.test.tsx
+++ b/frontend/src/components/students/request-history-item.test.tsx
@@ -180,4 +180,39 @@ describe("RequestHistoryItem", () => {
       screen.getByText("20.08.2026, 21.08.2026 · Arzttermin"),
     ).toBeInTheDocument();
   });
+
+  it("zeigt eine Direkt-Korrektur als eigene Zeilen-Art mit vorher → nachher", () => {
+    const item: AggregatedHistoryRequest = {
+      request_type: "direct_correction",
+      data: {
+        id: "9",
+        student_id: "42",
+        student_name: "Lara Lehmann",
+        changed_at: "2026-08-18T10:00:00Z",
+        changed_by_name: "Olga Office",
+        reason: "Telefonisch gemeldet",
+        diff: [
+          {
+            offering_id: "3",
+            label: "Mittagessen",
+            old: "Mo",
+            new: "abgemeldet",
+          },
+        ],
+      },
+    };
+
+    render(<RequestHistoryItem item={item} />);
+
+    expect(screen.getByText("Direkt-Korrektur")).toBeInTheDocument();
+    // Keine Anfrage: nichts wurde eingereicht und nichts entschieden.
+    expect(
+      screen.getByText(/^Geändert am 18\.08\.2026 von Olga Office$/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Eingereicht am/)).not.toBeInTheDocument();
+    expect(screen.getByText("„Telefonisch gemeldet“")).toBeInTheDocument();
+    expect(
+      screen.getByText("Mittagessen: Mo → abgemeldet"),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -8,10 +8,7 @@
  */
 
 import { formatDate } from "~/lib/date-helpers";
-import type {
-  AggregatedHistoryRequest,
-  DirectCorrection,
-} from "~/lib/change-request-list-api";
+import type { AggregatedHistoryRequest } from "~/lib/change-request-list-api";
 import type { StaffCareRequestHistoryEntry } from "~/lib/care-request-review-api";
 import type { StaffExcusedRequestHistoryEntry } from "~/lib/excused-request-review-api";
 import type { StaffMasterDataHistoryEntry } from "~/lib/master-data-review-api";
@@ -112,7 +109,7 @@ function OfferingHistoryCard({
           ))}
         </ReviewDiffPanel>
       )}
-      {row.diff.length === 0 && (
+      {row.diff.length === 0 && (row.requested?.length ?? 0) > 0 && (
         <ReviewDiffPanel title="Beantragt">
           {(row.requested ?? []).map((line) => (
             <p key={line.offering_id} className="text-sm text-gray-700">
@@ -148,34 +145,6 @@ function ExcusedHistoryCard({
   );
 }
 
-/**
- * Eine Direkt-Korrektur der Verwaltung (#2436). Sie ist keine Anfrage: es gibt
- * niemanden, der sie eingereicht hat, und nichts, was entschieden wurde — nur
- * wer wann was geändert hat und warum.
- */
-function DirectCorrectionCard({ row }: Readonly<{ row: DirectCorrection }>) {
-  return (
-    <RequestReviewCard
-      childName={row.student_name}
-      summary="Betreuungsangebote und AGs"
-      history={{
-        kind: "correction",
-        decidedAt: row.changed_at,
-        decidedByName: row.changed_by_name,
-        reason: row.reason,
-      }}
-    >
-      <ReviewDiffPanel title="Änderungen">
-        {row.diff.map((line) => (
-          <p key={line.offering_id} className="text-sm text-gray-700">
-            {line.label}: {line.old} → {line.new}
-          </p>
-        ))}
-      </ReviewDiffPanel>
-    </RequestReviewCard>
-  );
-}
-
 export function RequestHistoryItem({
   item,
 }: Readonly<{ item: AggregatedHistoryRequest }>) {
@@ -188,7 +157,28 @@ export function RequestHistoryItem({
       return <OfferingHistoryCard row={item.data} />;
     case "excused":
       return <ExcusedHistoryCard row={item.data} />;
-    case "direct_correction":
-      return <DirectCorrectionCard row={item.data} />;
+    case "direct_correction": {
+      const row = item.data;
+      return (
+        <RequestReviewCard
+          childName={row.student_name}
+          summary="Betreuungsangebote und AGs"
+          history={{
+            kind: "correction",
+            decidedAt: row.changed_at,
+            decidedByName: row.changed_by_name,
+            reason: row.reason,
+          }}
+        >
+          <ReviewDiffPanel title="Änderungen">
+            {row.diff.map((line) => (
+              <p key={line.offering_id} className="text-sm text-gray-700">
+                {line.label}: {line.old} → {line.new}
+              </p>
+            ))}
+          </ReviewDiffPanel>
+        </RequestReviewCard>
+      );
+    }
   }
 }

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -22,6 +22,47 @@ import {
 } from "~/components/students/master-data-review-item";
 import { RequestReviewCard } from "~/components/students/request-review-card";
 
+/**
+ * Die Änderungs-/Beantragt-Liste einer Historien-Karte: eine Zeile je Angebot
+ * bzw. Feld, in der ruhigen grauen Fläche der Review-Karten.
+ */
+function DiffList({
+  title,
+  lines,
+}: Readonly<{
+  title: string;
+  lines: readonly { key: string; text: string }[];
+}>) {
+  if (lines.length === 0) return null;
+  return (
+    <div className="space-y-1 rounded-lg bg-gray-50 p-3">
+      <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+        {title}
+      </p>
+      {lines.map((line) => (
+        <p key={line.key} className="text-sm text-gray-700">
+          {line.text}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+/** Angebots-Zeilen („Mittagessen: Mo → abgemeldet") aus einem Diff. */
+function offeringDiffLines(
+  diff: readonly {
+    offering_id: string;
+    label: string;
+    old: string;
+    new: string;
+  }[],
+) {
+  return diff.map((line) => ({
+    key: line.offering_id,
+    text: `${line.label}: ${line.old} → ${line.new}`,
+  }));
+}
+
 function MasterDataHistoryCard({
   row,
 }: Readonly<{ row: StaffMasterDataHistoryEntry }>) {
@@ -66,23 +107,15 @@ function CareHistoryCard({
         reason: row.decision_reason,
       }}
     >
-      {entries.length > 0 && (
-        <div className="space-y-1 rounded-lg bg-gray-50 p-3">
-          <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-            {showDiff ? "Änderungen" : "Beantragt"}
-          </p>
-          {entries.map((entry) => (
-            <p
-              key={`${entry.label}-${entry.new}`}
-              className="text-sm text-gray-700"
-            >
-              {showDiff
-                ? `${entry.label}: ${entry.old || "—"} → ${entry.new}`
-                : `${entry.label}: ${entry.new}`}
-            </p>
-          ))}
-        </div>
-      )}
+      <DiffList
+        title={showDiff ? "Änderungen" : "Beantragt"}
+        lines={entries.map((entry) => ({
+          key: `${entry.label}-${entry.new}`,
+          text: showDiff
+            ? `${entry.label}: ${entry.old || "—"} → ${entry.new}`
+            : `${entry.label}: ${entry.new}`,
+        }))}
+      />
     </RequestReviewCard>
   );
 }
@@ -102,29 +135,15 @@ function OfferingHistoryCard({
         reason: row.reason,
       }}
     >
-      {row.diff.length > 0 && (
-        <div className="space-y-1 rounded-lg bg-gray-50 p-3">
-          <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-            Änderungen
-          </p>
-          {row.diff.map((line) => (
-            <p key={line.offering_id} className="text-sm text-gray-700">
-              {line.label}: {line.old} → {line.new}
-            </p>
-          ))}
-        </div>
-      )}
-      {row.diff.length === 0 && row.requested && row.requested.length > 0 && (
-        <div className="space-y-1 rounded-lg bg-gray-50 p-3">
-          <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-            Beantragt
-          </p>
-          {row.requested.map((line) => (
-            <p key={line.offering_id} className="text-sm text-gray-700">
-              {line.label}: {line.new}
-            </p>
-          ))}
-        </div>
+      <DiffList title="Änderungen" lines={offeringDiffLines(row.diff)} />
+      {row.diff.length === 0 && (
+        <DiffList
+          title="Beantragt"
+          lines={(row.requested ?? []).map((line) => ({
+            key: line.offering_id,
+            text: `${line.label}: ${line.new}`,
+          }))}
+        />
       )}
     </RequestReviewCard>
   );
@@ -164,24 +183,13 @@ function DirectCorrectionCard({ row }: Readonly<{ row: DirectCorrection }>) {
       childName={row.student_name}
       summary="Betreuungsangebote und AGs"
       history={{
-        status: "direct_correction",
+        kind: "correction",
         decidedAt: row.changed_at,
         decidedByName: row.changed_by_name,
         reason: row.reason,
       }}
     >
-      {row.diff.length > 0 && (
-        <div className="space-y-1 rounded-lg bg-gray-50 p-3">
-          <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-            Änderungen
-          </p>
-          {row.diff.map((line) => (
-            <p key={line.offering_id} className="text-sm text-gray-700">
-              {line.label}: {line.old} → {line.new}
-            </p>
-          ))}
-        </div>
-      )}
+      <DiffList title="Änderungen" lines={offeringDiffLines(row.diff)} />
     </RequestReviewCard>
   );
 }

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -20,49 +20,12 @@ import {
   fieldLabel,
   formatValue as formatMasterDataValue,
 } from "~/components/students/master-data-review-item";
-import { RequestReviewCard } from "~/components/students/request-review-card";
-
-/**
- * Die Änderungs-/Beantragt-Liste einer Historien-Karte: eine Zeile je Angebot
- * bzw. Feld, in der ruhigen grauen Fläche der Review-Karten.
- */
-function DiffList({
-  title,
-  lines,
-}: Readonly<{
-  title: string;
-  lines: readonly { key: string; text: string }[];
-}>) {
-  if (lines.length === 0) return null;
-  return (
-    <div className="space-y-1 rounded-lg bg-gray-50 p-3">
-      <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-        {title}
-      </p>
-      {lines.map((line) => (
-        <p key={line.key} className="text-sm text-gray-700">
-          {line.text}
-        </p>
-      ))}
-    </div>
-  );
-}
+import {
+  RequestReviewCard,
+  ReviewDiffPanel,
+} from "~/components/students/request-review-card";
 
 /** Angebots-Zeilen („Mittagessen: Mo → abgemeldet") aus einem Diff. */
-function offeringDiffLines(
-  diff: readonly {
-    offering_id: string;
-    label: string;
-    old: string;
-    new: string;
-  }[],
-) {
-  return diff.map((line) => ({
-    key: line.offering_id,
-    text: `${line.label}: ${line.old} → ${line.new}`,
-  }));
-}
-
 function MasterDataHistoryCard({
   row,
 }: Readonly<{ row: StaffMasterDataHistoryEntry }>) {
@@ -107,15 +70,20 @@ function CareHistoryCard({
         reason: row.decision_reason,
       }}
     >
-      <DiffList
-        title={showDiff ? "Änderungen" : "Beantragt"}
-        lines={entries.map((entry) => ({
-          key: `${entry.label}-${entry.new}`,
-          text: showDiff
-            ? `${entry.label}: ${entry.old || "—"} → ${entry.new}`
-            : `${entry.label}: ${entry.new}`,
-        }))}
-      />
+      {entries.length > 0 && (
+        <ReviewDiffPanel title={showDiff ? "Änderungen" : "Beantragt"}>
+          {entries.map((entry) => (
+            <p
+              key={`${entry.label}-${entry.new}`}
+              className="text-sm text-gray-700"
+            >
+              {showDiff
+                ? `${entry.label}: ${entry.old || "—"} → ${entry.new}`
+                : `${entry.label}: ${entry.new}`}
+            </p>
+          ))}
+        </ReviewDiffPanel>
+      )}
     </RequestReviewCard>
   );
 }
@@ -135,15 +103,23 @@ function OfferingHistoryCard({
         reason: row.reason,
       }}
     >
-      <DiffList title="Änderungen" lines={offeringDiffLines(row.diff)} />
+      {row.diff.length > 0 && (
+        <ReviewDiffPanel title="Änderungen">
+          {row.diff.map((line) => (
+            <p key={line.offering_id} className="text-sm text-gray-700">
+              {line.label}: {line.old} → {line.new}
+            </p>
+          ))}
+        </ReviewDiffPanel>
+      )}
       {row.diff.length === 0 && (
-        <DiffList
-          title="Beantragt"
-          lines={(row.requested ?? []).map((line) => ({
-            key: line.offering_id,
-            text: `${line.label}: ${line.new}`,
-          }))}
-        />
+        <ReviewDiffPanel title="Beantragt">
+          {(row.requested ?? []).map((line) => (
+            <p key={line.offering_id} className="text-sm text-gray-700">
+              {line.label}: {line.new}
+            </p>
+          ))}
+        </ReviewDiffPanel>
       )}
     </RequestReviewCard>
   );
@@ -189,7 +165,13 @@ function DirectCorrectionCard({ row }: Readonly<{ row: DirectCorrection }>) {
         reason: row.reason,
       }}
     >
-      <DiffList title="Änderungen" lines={offeringDiffLines(row.diff)} />
+      <ReviewDiffPanel title="Änderungen">
+        {row.diff.map((line) => (
+          <p key={line.offering_id} className="text-sm text-gray-700">
+            {line.label}: {line.old} → {line.new}
+          </p>
+        ))}
+      </ReviewDiffPanel>
     </RequestReviewCard>
   );
 }

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -169,18 +169,22 @@ export function RequestHistoryItem({
             reason: row.reason,
           }}
         >
-          {/* Eine Korrektur, die an den gebuchten Tagen nichts ändert (etwa nur
-              der Wechsel zwischen selbst gesetzt und automatisch), hat keinen
-              Vergleich zu zeigen — dann bleibt die Fläche weg statt leer. */}
-          {row.diff.length > 0 && (
-            <ReviewDiffPanel title="Änderungen">
-              {row.diff.map((line) => (
-                <p key={line.offering_id} className="text-sm text-gray-700">
-                  {line.label}: {line.old} → {line.new}
-                </p>
-              ))}
-            </ReviewDiffPanel>
-          )}
+          <ReviewDiffPanel title="Änderungen">
+            {row.diff.map((line) => (
+              <p key={line.offering_id} className="text-sm text-gray-700">
+                {line.label}: {line.old} → {line.new}
+              </p>
+            ))}
+            {/* Auch eine Korrektur ohne Tagesänderung bleibt in der Historie
+                stehen (etwa nur der Wechsel zwischen selbst gesetzten und
+                automatisch übernommenen Tagen). Sie sagt das hin, statt eine
+                leere Fläche zu zeigen. */}
+            {row.diff.length === 0 && (
+              <p className="text-sm text-gray-600">
+                Keine Änderung an den gebuchten Tagen
+              </p>
+            )}
+          </ReviewDiffPanel>
         </RequestReviewCard>
       );
     }

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -169,13 +169,18 @@ export function RequestHistoryItem({
             reason: row.reason,
           }}
         >
-          <ReviewDiffPanel title="Änderungen">
-            {row.diff.map((line) => (
-              <p key={line.offering_id} className="text-sm text-gray-700">
-                {line.label}: {line.old} → {line.new}
-              </p>
-            ))}
-          </ReviewDiffPanel>
+          {/* Eine Korrektur, die an den gebuchten Tagen nichts ändert (etwa nur
+              der Wechsel zwischen selbst gesetzt und automatisch), hat keinen
+              Vergleich zu zeigen — dann bleibt die Fläche weg statt leer. */}
+          {row.diff.length > 0 && (
+            <ReviewDiffPanel title="Änderungen">
+              {row.diff.map((line) => (
+                <p key={line.offering_id} className="text-sm text-gray-700">
+                  {line.label}: {line.old} → {line.new}
+                </p>
+              ))}
+            </ReviewDiffPanel>
+          )}
         </RequestReviewCard>
       );
     }

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -22,7 +22,6 @@ import {
   ReviewDiffPanel,
 } from "~/components/students/request-review-card";
 
-/** Angebots-Zeilen („Mittagessen: Mo → abgemeldet") aus einem Diff. */
 function MasterDataHistoryCard({
   row,
 }: Readonly<{ row: StaffMasterDataHistoryEntry }>) {

--- a/frontend/src/components/students/request-history-item.tsx
+++ b/frontend/src/components/students/request-history-item.tsx
@@ -8,7 +8,10 @@
  */
 
 import { formatDate } from "~/lib/date-helpers";
-import type { AggregatedHistoryRequest } from "~/lib/change-request-list-api";
+import type {
+  AggregatedHistoryRequest,
+  DirectCorrection,
+} from "~/lib/change-request-list-api";
 import type { StaffCareRequestHistoryEntry } from "~/lib/care-request-review-api";
 import type { StaffExcusedRequestHistoryEntry } from "~/lib/excused-request-review-api";
 import type { StaffMasterDataHistoryEntry } from "~/lib/master-data-review-api";
@@ -150,6 +153,39 @@ function ExcusedHistoryCard({
   );
 }
 
+/**
+ * Eine Direkt-Korrektur der Verwaltung (#2436). Sie ist keine Anfrage: es gibt
+ * niemanden, der sie eingereicht hat, und nichts, was entschieden wurde — nur
+ * wer wann was geändert hat und warum.
+ */
+function DirectCorrectionCard({ row }: Readonly<{ row: DirectCorrection }>) {
+  return (
+    <RequestReviewCard
+      childName={row.student_name}
+      summary="Betreuungsangebote und AGs"
+      history={{
+        status: "direct_correction",
+        decidedAt: row.changed_at,
+        decidedByName: row.changed_by_name,
+        reason: row.reason,
+      }}
+    >
+      {row.diff.length > 0 && (
+        <div className="space-y-1 rounded-lg bg-gray-50 p-3">
+          <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+            Änderungen
+          </p>
+          {row.diff.map((line) => (
+            <p key={line.offering_id} className="text-sm text-gray-700">
+              {line.label}: {line.old} → {line.new}
+            </p>
+          ))}
+        </div>
+      )}
+    </RequestReviewCard>
+  );
+}
+
 export function RequestHistoryItem({
   item,
 }: Readonly<{ item: AggregatedHistoryRequest }>) {
@@ -162,5 +198,7 @@ export function RequestHistoryItem({
       return <OfferingHistoryCard row={item.data} />;
     case "excused":
       return <ExcusedHistoryCard row={item.data} />;
+    case "direct_correction":
+      return <DirectCorrectionCard row={item.data} />;
   }
 }

--- a/frontend/src/components/students/request-review-card.tsx
+++ b/frontend/src/components/students/request-review-card.tsx
@@ -19,9 +19,12 @@ const HISTORY_STATUS_META: Record<
   rejected: { label: "Abgelehnt", tone: "red" },
   withdrawn: { label: "Zurückgezogen", tone: "gray" },
   auto_applied: { label: "Automatisch übernommen", tone: "gray" },
+  // Keine Anfrage, sondern eine Änderung der Verwaltung selbst (#2436).
+  direct_correction: { label: "Direkt-Korrektur", tone: "blue" },
 };
 
 type RequestReviewCardHistory = {
+  /** Ein Anfrage-Status oder „direct_correction" für eine Direkt-Korrektur. */
   readonly status: string;
   readonly decidedAt: string;
   readonly decidedByName?: string;
@@ -88,7 +91,10 @@ export function RequestReviewCard({
         </div>
         <p className="mt-1 text-xs text-gray-500">
           {submittedAt ? `Eingereicht am ${formatDate(submittedAt)} · ` : ""}
-          Entschieden am {formatDate(history.decidedAt)}
+          {history.status === "direct_correction"
+            ? "Geändert am "
+            : "Entschieden am "}
+          {formatDate(history.decidedAt)}
           {history.decidedByName ? ` von ${history.decidedByName}` : ""}
         </p>
         {history.reason && (

--- a/frontend/src/components/students/request-review-card.tsx
+++ b/frontend/src/components/students/request-review-card.tsx
@@ -19,13 +19,17 @@ const HISTORY_STATUS_META: Record<
   rejected: { label: "Abgelehnt", tone: "red" },
   withdrawn: { label: "Zurückgezogen", tone: "gray" },
   auto_applied: { label: "Automatisch übernommen", tone: "gray" },
-  // Keine Anfrage, sondern eine Änderung der Verwaltung selbst (#2436).
-  direct_correction: { label: "Direkt-Korrektur", tone: "blue" },
 };
 
+// Eine Direkt-Korrektur ist keine entschiedene Anfrage, sondern eine Änderung
+// der Verwaltung selbst (#2436) — eigene Kennzeichnung, eigenes Zeitwort.
+const CORRECTION_META = { label: "Direkt-Korrektur", tone: "blue" as const };
+
 type RequestReviewCardHistory = {
-  /** Ein Anfrage-Status oder „direct_correction" für eine Direkt-Korrektur. */
-  readonly status: string;
+  /** „decision" (Standard) oder „correction" für eine Direkt-Korrektur. */
+  readonly kind?: "decision" | "correction";
+  /** Anfrage-Status; bei einer Direkt-Korrektur leer. */
+  readonly status?: string;
   readonly decidedAt: string;
   readonly decidedByName?: string;
   readonly reason?: string;
@@ -76,10 +80,13 @@ export function RequestReviewCard({
 }>) {
   const [open, setOpen] = useState(false);
   if (history) {
-    const meta = HISTORY_STATUS_META[history.status] ?? {
-      label: history.status,
-      tone: "gray" as const,
-    };
+    const correction = history.kind === "correction";
+    const meta = correction
+      ? CORRECTION_META
+      : (HISTORY_STATUS_META[history.status ?? ""] ?? {
+          label: history.status ?? "",
+          tone: "gray" as const,
+        });
     return (
       <div className="moto-content-surface rounded-2xl border p-4 shadow-sm">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -91,9 +98,7 @@ export function RequestReviewCard({
         </div>
         <p className="mt-1 text-xs text-gray-500">
           {submittedAt ? `Eingereicht am ${formatDate(submittedAt)} · ` : ""}
-          {history.status === "direct_correction"
-            ? "Geändert am "
-            : "Entschieden am "}
+          {correction ? "Geändert am " : "Entschieden am "}
           {formatDate(history.decidedAt)}
           {history.decidedByName ? ` von ${history.decidedByName}` : ""}
         </p>

--- a/frontend/src/components/students/request-review-card.tsx
+++ b/frontend/src/components/students/request-review-card.tsx
@@ -184,12 +184,13 @@ export function RequestReviewCard({
  * heading). Rows are passed as children so each queue keeps its own layout.
  */
 export function ReviewDiffPanel({
+  title,
   children,
-}: Readonly<{ children: ReactNode }>) {
+}: Readonly<{ title: string; children: ReactNode }>) {
   return (
     <div className="mt-3 space-y-2 rounded-lg bg-gray-50 p-3">
       <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
-        Änderungen
+        {title}
       </p>
       {children}
     </div>

--- a/frontend/src/components/students/request-review-card.tsx
+++ b/frontend/src/components/students/request-review-card.tsx
@@ -25,15 +25,23 @@ const HISTORY_STATUS_META: Record<
 // der Verwaltung selbst (#2436) — eigene Kennzeichnung, eigenes Zeitwort.
 const CORRECTION_META = { label: "Direkt-Korrektur", tone: "blue" as const };
 
-type RequestReviewCardHistory = {
-  /** „decision" (Standard) oder „correction" für eine Direkt-Korrektur. */
-  readonly kind?: "decision" | "correction";
-  /** Anfrage-Status; bei einer Direkt-Korrektur leer. */
-  readonly status?: string;
+type RequestReviewCardHistoryBase = {
   readonly decidedAt: string;
   readonly decidedByName?: string;
   readonly reason?: string;
 };
+
+/**
+ * Eine entschiedene Anfrage (mit Status) oder eine Direkt-Korrektur der
+ * Verwaltung (ohne). Als Union, damit einer Anfrage-Karte der Status nicht
+ * fehlen kann.
+ */
+type RequestReviewCardHistory =
+  | (RequestReviewCardHistoryBase & {
+      readonly kind?: "decision";
+      readonly status: string;
+    })
+  | (RequestReviewCardHistoryBase & { readonly kind: "correction" });
 
 /**
  * One pending parent change request in the staff Änderungsanfragen queue, in the
@@ -80,13 +88,13 @@ export function RequestReviewCard({
 }>) {
   const [open, setOpen] = useState(false);
   if (history) {
-    const correction = history.kind === "correction";
-    const meta = correction
-      ? CORRECTION_META
-      : (HISTORY_STATUS_META[history.status ?? ""] ?? {
-          label: history.status ?? "",
-          tone: "gray" as const,
-        });
+    const meta =
+      history.kind === "correction"
+        ? CORRECTION_META
+        : (HISTORY_STATUS_META[history.status] ?? {
+            label: history.status,
+            tone: "gray" as const,
+          });
     return (
       <div className="moto-content-surface rounded-2xl border p-4 shadow-sm">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -98,7 +106,7 @@ export function RequestReviewCard({
         </div>
         <p className="mt-1 text-xs text-gray-500">
           {submittedAt ? `Eingereicht am ${formatDate(submittedAt)} · ` : ""}
-          {correction ? "Geändert am " : "Entschieden am "}
+          {history.kind === "correction" ? "Geändert am " : "Entschieden am "}
           {formatDate(history.decidedAt)}
           {history.decidedByName ? ` von ${history.decidedByName}` : ""}
         </p>

--- a/frontend/src/lib/change-request-list-api.ts
+++ b/frontend/src/lib/change-request-list-api.ts
@@ -28,7 +28,31 @@ const logger = createLogger({ component: "ChangeRequestListApi" });
  */
 
 export type AggregatedRequestType =
-  "master_data" | "care_schedule" | "offering" | "excused";
+  | "master_data"
+  | "care_schedule"
+  | "offering"
+  | "excused"
+  | "direct_correction";
+
+/**
+ * Eine Direkt-Korrektur der Verwaltung an den Angebots-Buchungen eines Kindes
+ * (#2436). Keine Anfrage: kein Status, keine Entscheidung, nur in der
+ * Historie.
+ */
+export interface DirectCorrection {
+  readonly id: string;
+  readonly student_id: string;
+  readonly student_name: string;
+  readonly changed_at: string;
+  readonly changed_by_name: string;
+  readonly reason: string;
+  readonly diff: readonly {
+    readonly offering_id: string;
+    readonly label: string;
+    readonly old: string;
+    readonly new: string;
+  }[];
+}
 
 export type AggregatedRequestStatus = "approved" | "rejected" | "withdrawn";
 
@@ -37,12 +61,14 @@ export type AggregatedOpenRequest =
   | { request_type: "care_schedule"; data: StaffCareRequest }
   | { request_type: "offering"; data: StaffOfferingRequest }
   | { request_type: "excused"; data: StaffExcusedRequest };
+// Direkt-Korrekturen fehlen hier bewusst: sie haben keinen offenen Zustand.
 
 export type AggregatedHistoryRequest =
   | { request_type: "master_data"; data: StaffMasterDataHistoryEntry }
   | { request_type: "care_schedule"; data: StaffCareRequestHistoryEntry }
   | { request_type: "offering"; data: StaffOfferingRequestHistoryEntry }
-  | { request_type: "excused"; data: StaffExcusedRequestHistoryEntry };
+  | { request_type: "excused"; data: StaffExcusedRequestHistoryEntry }
+  | { request_type: "direct_correction"; data: DirectCorrection };
 
 export interface AggregatedRequestPage<T> {
   readonly items: readonly T[];

--- a/frontend/src/lib/change-request-list-api.ts
+++ b/frontend/src/lib/change-request-list-api.ts
@@ -39,7 +39,7 @@ export type AggregatedRequestType =
  * (#2436). Keine Anfrage: kein Status, keine Entscheidung, nur in der
  * Historie.
  */
-export interface DirectCorrection {
+interface DirectCorrection {
   readonly id: string;
   readonly student_id: string;
   readonly student_name: string;


### PR DESCRIPTION
Closes #2436

## Was sich ändert

Korrekturen, die die Verwaltung selbst an den Angebots-Buchungen eines Kindes vornimmt, lagen bisher nur pro Kind in der Anmeldungs-Detailansicht. Sie erscheinen jetzt als eigene Zeilen-Art **Direkt-Korrektur** in der Historie des Eltern-Reiters, mit Vorher/Nachher der Buchung, Akteur, Zeitpunkt und Begründung.

Sie sind keine Anfragen: kein Offen-Zustand, kein Status, nichts zu entscheiden. Im Offen-Bereich tauchen sie nie auf, auch nicht, wenn ein Client die Art ausdrücklich anfragt.

## Entlappung: warum eine neue Spalte

Das Freigeben einer Angebots-Anfrage schreibt seine Buchungsänderung in dasselbe append-only Protokoll wie eine Direkt-Korrektur. Ohne Unterscheidung stünde derselbe Vorgang zweimal in der Historie: einmal als entschiedene Anfrage, einmal als Korrektur.

Migration `1.15.308` ergänzt deshalb `audit.enrollment_offering_adjustments.source` (`direct` | `request`); beide Schreibwege stempeln jetzt ausdrücklich. Der Backfill erkennt Altzeilen an der erzeugten Freigabe-Begründung (exakte Form, kein loses Präfix). Bekannte Lücke, als Kommentar in der Migration: Zeilen aus einer freigegebenen Anmeldungsänderung tragen den freien Text der Entscheidung und bleiben `direct`.

## Filter

Namenssuche, Art- und Zeitraum-Filter wirken auf die neuen Zeilen. Der Status-Filter schließt sie aus, weil eine Korrektur keinen Status trägt.

Die Anfrageart `Direkt-Korrekturen` steht als Filter nur in der Historie zur Wahl. Das stand nicht in den Akzeptanzkriterien: ohne die Option verschwinden Korrekturen still, sobald jemand nach einer anderen Art filtert, und lassen sich nur durch Zurücksetzen wiederholen.

## Tests

- Hermetischer Router-Test über die **echten** Schreibwege: Korrektur über `EnrollmentDecision.UpdateChildOfferings`, Elternanfrage über die Produktions-Entscheiden-Route. Er prüft, dass jeder Vorgang genau eine Zeile ergibt und die zwei Wege unterschiedlich stempeln.
- Handler-Tests für Merge-Reihenfolge, Offen-Sperre, Suche, Zeitraum, Status-Ausschluss und den Fall „nur Abwesenheitsrecht".
- Frontend: Karte und Filter-Verhalten.
- Volle Suiten grün (Backend 23693, Frontend 14233), `pnpm run check` und golangci-lint sauber.

## Hilfe-Guide

Beide Stellen, die die Historie beschreiben, nennen jetzt die Direkt-Korrektur.