### PR TITLE
Eliminate time- and order-dependent test flakes

### DIFF
--- a/backend/services/active/staff_overview_integration_test.go
+++ b/backend/services/active/staff_overview_integration_test.go
@@ -177,8 +177,8 @@ func (f *overviewFixture) addShift(t *testing.T, staffID int64, date timezone.Da
 	shift := &scheduleModels.StaffShift{
 		StaffID:   staffID,
 		Date:      date,
-		StartTime: time.Date(2000, time.January, 1, 0, 1, 0, 0, time.UTC),
-		EndTime:   time.Date(2000, time.January, 1, 23, 59, 0, 0, time.UTC),
+		StartTime: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2000, time.January, 1, 23, 59, 59, 999999000, time.UTC),
 		CreatedBy: staffID,
 	}
 	shift.SetTenantID(f.tenantID)

--- a/backend/services/iot/checkin/active_group_selection_internal_test.go
+++ b/backend/services/iot/checkin/active_group_selection_internal_test.go
@@ -157,11 +157,9 @@ func TestFindOrCreateSpecialRoomGroupEndsStaleConflictBeforeCreate(t *testing.T)
 		active:     activeStub,
 		activities: &rolloverActivityService{group: activity},
 		logger:     slog.New(slog.DiscardHandler),
+		now:        func() time.Time { return now },
 	}
 	room := &facilities.Room{Model: base.Model{ID: 42}, Name: constants.WCRoomName}
-	originalTimeNow := timeNow
-	timeNow = func() time.Time { return now }
-	t.Cleanup(func() { timeNow = originalTimeNow })
 
 	selection, err := service.findOrCreateActiveGroupForRoom(context.Background(), room, 91)
 
@@ -186,10 +184,8 @@ func TestFindOrCreateRegularRoomReusesPreviousDayGroup(t *testing.T) {
 	service := &CheckinService{
 		active: activeStub,
 		logger: slog.New(slog.DiscardHandler),
+		now:    func() time.Time { return now },
 	}
-	originalTimeNow := timeNow
-	timeNow = func() time.Time { return now }
-	t.Cleanup(func() { timeNow = originalTimeNow })
 
 	selection, err := service.findOrCreateActiveGroupForRoom(context.Background(), room, 91)
 
@@ -218,10 +214,8 @@ func TestFindOrCreateSpecialRoomGroupEndsStaleGroupBeforeSelectingCurrent(t *tes
 	service := &CheckinService{
 		active: activeStub,
 		logger: slog.New(slog.DiscardHandler),
+		now:    func() time.Time { return now },
 	}
-	originalTimeNow := timeNow
-	timeNow = func() time.Time { return now }
-	t.Cleanup(func() { timeNow = originalTimeNow })
 
 	selection, err := service.findOrCreateActiveGroupForRoom(context.Background(), room, 91)
 

--- a/backend/services/iot/checkin/checkin_service.go
+++ b/backend/services/iot/checkin/checkin_service.go
@@ -39,6 +39,7 @@ type CheckinService struct {
 	pickup     scheduleSvc.PickupScheduleService
 	education  educationSvc.Service
 	logger     *slog.Logger
+	now        func() time.Time
 }
 
 // CheckinServiceDeps groups the collaborators for NewCheckinService.
@@ -70,6 +71,13 @@ func NewCheckinService(deps CheckinServiceDeps) *CheckinService {
 // getLogger returns a nil-safe logger, falling back to slog.Default().
 func (s *CheckinService) getLogger() *slog.Logger {
 	return cmp.Or(s.logger, slog.Default())
+}
+
+func (s *CheckinService) currentTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 // SelectedActiveGroup is the active group chosen (or created) for a check-in,
@@ -505,7 +513,7 @@ func (s *CheckinService) findOrCreateActiveGroupForRoom(ctx context.Context, roo
 	// stay reusable, or scans would 404 until the next EndDailySessions run.
 	currentGroups := activeGroups
 	if room.Name == constants.SchulhofRoomName || constants.IsWCRoomName(room.Name) {
-		now := timeNow()
+		now := s.currentTime()
 		if err := s.endPreviousDayActiveGroups(ctx, activeGroups, now); err != nil {
 			s.getLogger().ErrorContext(ctx, "failed to end stale special-room session",
 				slog.Int64("room_id", room.ID),

--- a/backend/services/iot/checkin/checkout_gate.go
+++ b/backend/services/iot/checkin/checkout_gate.go
@@ -18,10 +18,6 @@ import (
 	facilitiesSvc "github.com/moto-nrw/project-phoenix/services/facilities"
 )
 
-// timeNow is a package-local clock hook that tests may override to pin the
-// "current time" for deterministic assertions. Production code uses time.Now.
-var timeNow = time.Now
-
 // ResolveRawDailyCheckoutTime resolves the raw daily checkout time string.
 // Fallback chain: tenant DB override → STUDENT_DAILY_CHECKOUT_TIME env var → empty string.
 // Returns empty string when no time is configured, meaning daily checkout is always available.
@@ -60,7 +56,7 @@ func (s *CheckinService) studentDailyCheckoutTime(ctx context.Context) (*time.Ti
 		return nil, fmt.Errorf("invalid minute in checkout time: %s", checkoutTimeStr)
 	}
 
-	now := timeNow()
+	now := s.currentTime()
 	checkoutTime := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
 	return &checkoutTime, nil
 }
@@ -116,7 +112,7 @@ func (s *CheckinService) perStudentCheckoutGate(ctx context.Context, student *us
 		return false, false
 	}
 
-	now := timeNow()
+	now := s.currentTime()
 	effectivePickup, err := s.pickup.GetEffectivePickupTimeForDate(ctx, student.ID, timezone.DateFromTime(now))
 	if err != nil || effectivePickup == nil || effectivePickup.PickupTime == nil {
 		return false, false
@@ -163,7 +159,7 @@ func (s *CheckinService) isAfterGlobalCheckoutTime(ctx context.Context) bool {
 	if checkoutTime == nil {
 		return true
 	}
-	return timeNow().After(*checkoutTime)
+	return s.currentTime().After(*checkoutTime)
 }
 
 // ShouldShowDailyCheckoutWithGroup reports whether the kiosk may OFFER "nach

--- a/backend/services/iot/checkin/checkout_gate_internal_test.go
+++ b/backend/services/iot/checkin/checkout_gate_internal_test.go
@@ -3,7 +3,7 @@
 // CheckinService with mock collaborators and exercise the extracted gate logic
 // (moved here from api/iot/checkin when the policy was extracted into the
 // service). They live in the internal package so they can set the service's
-// unexported collaborator fields and override the package-local timeNow clock.
+// unexported collaborator fields.
 package checkin
 
 import (
@@ -32,14 +32,6 @@ import (
 // =============================================================================
 // Test doubles
 // =============================================================================
-
-// overrideTimeNow pins the package-level timeNow clock to fixed and returns a
-// restore function that should be deferred by the caller.
-func overrideTimeNow(fixed time.Time) func() {
-	orig := timeNow
-	timeNow = func() time.Time { return fixed }
-	return func() { timeNow = orig }
-}
 
 // mockPickupScheduleService is a minimal mock for testing IsAfterCheckoutTimeGate.
 type mockPickupScheduleService struct {
@@ -751,13 +743,12 @@ func TestIsAfterCheckoutTimeGate_PerStudentEnabled_BeforeDelta(t *testing.T) {
 	// so a wrapped hour would otherwise land in the past and flip the
 	// assertion when CI runs late in the day.
 	fixedNow := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
-	restore := overrideTimeNow(fixedNow)
-	defer restore()
 
 	// Pickup time 2 hours from fixed now, delta 15 min → too early.
 	pickupTime := time.Date(2000, 1, 1, fixedNow.Hour()+2, 0, 0, 0, fixedNow.Location())
 
 	s := &CheckinService{
+		now: func() time.Time { return fixedNow },
 		settings: newMockSettingsService(
 			map[string]string{},
 			map[string]bool{"operations.per_student_checkout_enabled": true},

--- a/backend/services/notifications/staff_scope_test.go
+++ b/backend/services/notifications/staff_scope_test.go
@@ -3,7 +3,9 @@ package notifications_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/services/config/configtest"
 	"github.com/moto-nrw/project-phoenix/services/notifications"
@@ -30,6 +32,13 @@ func settingsWithWindow(start, end string) *configtest.Mock {
 			return "", nil
 		},
 	}
+}
+
+// inactiveWindow returns a valid one-minute window on the opposite side of
+// the clock. A fixed 00:00-00:01 fixture is active when CI runs at midnight.
+func inactiveWindow() (string, string) {
+	start := timezone.Now().Add(12 * time.Hour)
+	return start.Format("15:04"), start.Add(time.Minute).Format("15:04")
 }
 
 // testTenantID is the school every event in this file belongs to. These tests
@@ -147,8 +156,8 @@ func TestDeliveryWindow(t *testing.T) {
 
 	t.Run("outside the window nothing is dispatched", func(t *testing.T) {
 		bc := testpkg.NewRecordingBroadcaster()
-		// A window that has already closed for every possible current time.
-		svc := notifications.NewService(settingsWithWindow("00:00", "00:01"), nil,
+		start, end := inactiveWindow()
+		svc := notifications.NewService(settingsWithWindow(start, end), nil,
 			notifications.NewSSEChannel(bc))
 
 		err := dispatch(t, func(ctx context.Context) error {

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part10.test.tsx
@@ -23,6 +23,17 @@ const navigationMockState = vi.hoisted(() => ({
   roomParam: null as string | null,
 }));
 
+const defaultSupervisionState = vi.hoisted(() => ({
+  supervisedRooms: [],
+  isLoadingSupervision: false,
+  adminOverviewEnabled: false,
+  hasGroups: false,
+  isLoadingGroups: false,
+  groups: [],
+  isSupervising: false,
+  refresh: vi.fn(),
+}));
+
 // Mock auth-utils with hasRole that reads session roles
 vi.mock("~/lib/auth-utils", () => ({
   isAdmin: (session: { user?: { isAdmin?: boolean } } | null) =>
@@ -42,6 +53,10 @@ vi.mock("next-auth/react", () => ({
     data: { user: { token: "test-token" } },
     status: "authenticated",
   })),
+}));
+
+vi.mock("~/lib/supervision-context", () => ({
+  useOptionalSupervision: vi.fn(() => defaultSupervisionState),
 }));
 
 // Mock next/navigation
@@ -274,7 +289,38 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { useSession } from "next-auth/react";
+import { useOptionalSupervision } from "~/lib/supervision-context";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(useSession)
+    .mockReset()
+    .mockReturnValue({
+      data: { user: { token: "test-token" } },
+      status: "authenticated",
+    } as never);
+  vi.mocked(useOptionalSupervision)
+    .mockReset()
+    .mockReturnValue(defaultSupervisionState);
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("Action button click handlers", () => {
   const mockMutate = vi.fn();
@@ -863,6 +909,13 @@ describe("Schulhof tab onTabChange callback", () => {
 describe("RoleGuard integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useSWRAuth).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    });
   });
 
   it("shows ForbiddenPage for admin users", async () => {
@@ -900,8 +953,7 @@ describe("RoleGuard integration", () => {
     // Mock useOptionalSupervision to return adminOverviewEnabled = true,
     // which is the explicit signal that the admin_supervision_overview
     // setting is enabled on the backend.
-    const supervisionCtx = await import("~/lib/supervision-context");
-    vi.spyOn(supervisionCtx, "useOptionalSupervision").mockReturnValue({
+    vi.mocked(useOptionalSupervision).mockReturnValue({
       supervisedRooms: [{ id: "10", name: "Admin Room", groupId: "1" }],
       isLoadingSupervision: false,
       adminOverviewEnabled: true,
@@ -929,8 +981,7 @@ describe("RoleGuard integration", () => {
       status: "authenticated",
     } as never);
 
-    const supervisionCtx = await import("~/lib/supervision-context");
-    vi.spyOn(supervisionCtx, "useOptionalSupervision").mockReturnValue({
+    vi.mocked(useOptionalSupervision).mockReturnValue({
       supervisedRooms: [
         {
           id: "schulhof",
@@ -960,8 +1011,7 @@ describe("RoleGuard integration", () => {
       status: "authenticated",
     } as never);
 
-    const supervisionCtx = await import("~/lib/supervision-context");
-    vi.spyOn(supervisionCtx, "useOptionalSupervision").mockReturnValue({
+    vi.mocked(useOptionalSupervision).mockReturnValue({
       supervisedRooms: [],
       isLoadingSupervision: true,
       adminOverviewEnabled: false,
@@ -991,8 +1041,7 @@ describe("Aggregate fetcher error contract", () => {
       status: "authenticated",
     } as never);
 
-    const supervisionCtx = await import("~/lib/supervision-context");
-    vi.spyOn(supervisionCtx, "useOptionalSupervision").mockReturnValue({
+    vi.mocked(useOptionalSupervision).mockReturnValue({
       supervisedRooms: [{ id: "10", name: "Admin Room", groupId: "1" }],
       isLoadingSupervision: false,
       adminOverviewEnabled: true,

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part11.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part11.test.tsx
@@ -279,7 +279,27 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("Year filter (Klassenstufe) on active supervisions", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part12.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part12.test.tsx
@@ -271,11 +271,16 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import {
   useAttendanceWebEnabled,
   useShowTimetableCounts,
 } from "~/lib/tenant-context";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
 
 vi.mock("~/lib/student-api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/lib/student-api")>();
@@ -310,6 +315,21 @@ vi.mock("~/lib/timetable-operations-api", async (importOriginal) => {
 import { fireEvent } from "@testing-library/react";
 import { fetchStudents } from "~/lib/student-api";
 import { timetableOperationsApi } from "~/lib/timetable-operations-api";
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 const makeStudent = (id: string, first: string, last: string) => ({
   id,

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part2.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part2.test.tsx
@@ -264,7 +264,27 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("MeinRaumPage (Active Supervisions) (1/5)", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part3.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part3.test.tsx
@@ -273,7 +273,27 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("MeinRaumPage (Active Supervisions) (2/5)", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part4.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part4.test.tsx
@@ -283,7 +283,27 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("MeinRaumPage (Active Supervisions) (3/5)", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part5.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part5.test.tsx
@@ -268,11 +268,31 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import {
   useAttendanceWebEnabled,
   useShowTimetableCounts,
 } from "~/lib/tenant-context";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("MeinRaumPage (Active Supervisions) (4/5)", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part6.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part6.test.tsx
@@ -273,8 +273,28 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import { useNFCEnabled } from "~/lib/tenant-context";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("MeinRaumPage (Active Supervisions) (5/5)", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part7.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part7.test.tsx
@@ -279,7 +279,29 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  navigationMockState.roomParam = null;
+  localStorage.clear();
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("Active Supervisions helper functions", () => {
   it("filters students by search term", () => {

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part8.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part8.test.tsx
@@ -279,7 +279,27 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("Unauthenticated redirect coverage", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part9.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part9.test.tsx
@@ -283,7 +283,30 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { PageHeaderWithSearch } from "~/components/ui/page-header/PageHeaderWithSearch";
 import MeinRaumPage from "./page";
+
+const defaultPageHeader = vi
+  .mocked(PageHeaderWithSearch)
+  .getMockImplementation()!;
+
+beforeEach(() => {
+  navigationMockState.roomParam = null;
+  navigationMockState.sessionParam = null;
+  localStorage.clear();
+  vi.mocked(PageHeaderWithSearch)
+    .mockReset()
+    .mockImplementation(defaultPageHeader);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+});
 
 describe("ID-based selection coverage: first room visit enrichment", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -435,6 +435,7 @@ vi.mock("~/lib/swr", () => ({
 }));
 
 import { useSWRAuth } from "~/lib/swr";
+import { useSession } from "next-auth/react";
 import { isHomeLocation } from "~/lib/location-helper";
 import { groupTransferService } from "~/lib/group-transfer-api";
 import type {
@@ -485,6 +486,47 @@ function wireStudent(
     id: overrides.id.toString(),
   };
 }
+
+beforeEach(() => {
+  vi.mocked(useSession)
+    .mockReset()
+    .mockReturnValue({
+      data: { user: { token: "test-token" } },
+      status: "authenticated",
+    } as never);
+  vi.mocked(useSWRAuth)
+    .mockReset()
+    .mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+      mutate: vi.fn(),
+      isValidating: false,
+    } as never);
+  vi.mocked(isHomeLocation).mockReset().mockReturnValue(false);
+  mockSearchParamsGet.mockReset().mockReturnValue(null);
+  mockUserContext.mockReset().mockReturnValue({
+    userContext: { currentStaff: null },
+    isLoading: false,
+    error: undefined,
+    isReady: true,
+  });
+  vi.mocked(groupTransferService.getAllAvailableStaff)
+    .mockReset()
+    .mockResolvedValue([]);
+  vi.mocked(groupTransferService.getStaffByRole)
+    .mockReset()
+    .mockResolvedValue([]);
+  vi.mocked(groupTransferService.getActiveTransfersForGroup)
+    .mockReset()
+    .mockResolvedValue([]);
+  vi.mocked(groupTransferService.transferGroup)
+    .mockReset()
+    .mockResolvedValue(undefined);
+  vi.mocked(groupTransferService.cancelTransferBySubstitutionId)
+    .mockReset()
+    .mockResolvedValue(undefined);
+});
 
 describe("OGSGroupPage", () => {
   const mockMutate = vi.fn();

--- a/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/profile/page.test.tsx
@@ -85,6 +85,24 @@ vi.mock("~/components/settings/passkey-settings-section", () => ({
   PasskeySettingsSection: () => <div data-testid="passkey-settings" />,
 }));
 
+vi.mock("~/components/settings/trusted-devices-section", () => ({
+  TrustedDevicesSection: () => <div data-testid="trusted-devices" />,
+}));
+
+vi.mock("~/components/settings/notification-preferences-section", () => ({
+  NotificationPreferencesSection: () => (
+    <div data-testid="notification-preferences" />
+  ),
+}));
+
+vi.mock("~/components/settings/birthday-visibility-section", () => ({
+  BirthdayVisibilitySection: () => <div data-testid="birthday-visibility" />,
+}));
+
+vi.mock("~/components/settings/push-notification-section", () => ({
+  PushNotificationSection: () => <div data-testid="push-notifications" />,
+}));
+
 // Mock Button component
 vi.mock("~/components/ui/button", () => ({
   Button: ({

--- a/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/staff/[id]/page.permissions.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { staffService } from "~/lib/staff-api";
@@ -119,6 +120,31 @@ vi.mock("~/components/staff/arbeitszeitmodell-tab", () => ({
 
 vi.mock("~/components/staff/abwesenheiten-tab", () => ({
   AbwesenheitenTab: () => <div data-testid="abwesenheiten-tab" />,
+}));
+
+vi.mock("~/components/staff/dokumente-tab", () => ({
+  DokumenteTab: () => <div data-testid="dokumente-tab" />,
+}));
+
+vi.mock("~/components/staff/klassen-tab", () => ({
+  KlassenTab: () => <div data-testid="klassen-tab" />,
+}));
+
+vi.mock("~/components/staff/stammdaten-tab", () => ({
+  StammdatenTab: ({
+    canManagePayroll,
+    canManagePayrollSettings,
+  }: {
+    canManagePayroll: boolean;
+    canManagePayrollSettings: boolean;
+  }) => (
+    <div data-testid="stammdaten-tab">
+      {canManagePayroll ? <button>Bearbeiten</button> : null}
+      {canManagePayroll && canManagePayrollSettings ? (
+        <Link href="/payroll">Abrechnung</Link>
+      ) : null}
+    </div>
+  ),
 }));
 
 vi.mock("./page-skeleton", () => ({

--- a/frontend/src/app/api/active/groups/[id]/claim/route.test.ts
+++ b/frontend/src/app/api/active/groups/[id]/claim/route.test.ts
@@ -142,8 +142,6 @@ describe("POST /api/active/groups/[id]/claim", () => {
   });
 
   it("returns 500 when id parameter is invalid", async () => {
-    mockApiPost.mockRejectedValueOnce(new TypeError("Invalid group ID"));
-
     const request = createMockRequest("/api/active/groups/invalid/claim", {
       method: "POST",
     });

--- a/frontend/src/app/api/active/groups/[id]/end/route.test.ts
+++ b/frontend/src/app/api/active/groups/[id]/end/route.test.ts
@@ -141,8 +141,6 @@ describe("POST /api/active/groups/[id]/end", () => {
   });
 
   it("returns 500 when id parameter is invalid", async () => {
-    mockApiPost.mockRejectedValueOnce(new Error("Invalid id parameter"));
-
     const request = createMockRequest("/api/active/groups/invalid/end", {
       method: "POST",
     });

--- a/frontend/src/app/api/active/groups/[id]/supervisors/route.test.ts
+++ b/frontend/src/app/api/active/groups/[id]/supervisors/route.test.ts
@@ -150,8 +150,6 @@ describe("GET /api/active/groups/[id]/supervisors", () => {
   });
 
   it("returns 500 when id parameter is invalid", async () => {
-    mockApiGet.mockRejectedValueOnce(new Error("Invalid id parameter"));
-
     const request = createMockRequest("/api/active/groups/invalid/supervisors");
     const response = await GET(request, createMockContext({ id: undefined }));
 

--- a/frontend/src/app/api/active/groups/[id]/visits/route.test.ts
+++ b/frontend/src/app/api/active/groups/[id]/visits/route.test.ts
@@ -148,8 +148,6 @@ describe("GET /api/active/groups/[id]/visits", () => {
   });
 
   it("returns 500 when id parameter is invalid", async () => {
-    mockApiGet.mockRejectedValueOnce(new Error("Invalid id parameter"));
-
     const request = createMockRequest("/api/active/groups/invalid/visits");
     const response = await GET(request, createMockContext({ id: undefined }));
 

--- a/frontend/src/app/api/active/groups/group/[groupId]/route.test.ts
+++ b/frontend/src/app/api/active/groups/group/[groupId]/route.test.ts
@@ -148,8 +148,6 @@ describe("GET /api/active/groups/group/[groupId]", () => {
   });
 
   it("returns 500 when groupId parameter is invalid", async () => {
-    mockApiGet.mockRejectedValueOnce(new Error("Invalid groupId parameter"));
-
     const request = createMockRequest("/api/active/groups/group/invalid");
     const response = await GET(
       request,

--- a/frontend/src/app/api/active/groups/room/[roomId]/route.test.ts
+++ b/frontend/src/app/api/active/groups/room/[roomId]/route.test.ts
@@ -148,8 +148,6 @@ describe("GET /api/active/groups/room/[roomId]", () => {
   });
 
   it("returns 500 when roomId parameter is invalid", async () => {
-    mockApiGet.mockRejectedValueOnce(new Error("Invalid roomId parameter"));
-
     const request = createMockRequest("/api/active/groups/room/invalid");
     const response = await GET(
       request,

--- a/frontend/src/app/api/activities/[id]/supervisors/route.test.ts
+++ b/frontend/src/app/api/activities/[id]/supervisors/route.test.ts
@@ -70,7 +70,9 @@ async function parseJsonResponse<T>(response: Response): Promise<T> {
 describe("GET /api/activities/[id]/supervisors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAuth.mockResolvedValue(defaultSession);
+    mockAuth.mockReset().mockResolvedValue(defaultSession);
+    mockApiGet.mockReset();
+    mockApiPost.mockReset();
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -140,7 +142,9 @@ describe("GET /api/activities/[id]/supervisors", () => {
 describe("POST /api/activities/[id]/supervisors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAuth.mockResolvedValue(defaultSession);
+    mockAuth.mockReset().mockResolvedValue(defaultSession);
+    mockApiGet.mockReset();
+    mockApiPost.mockReset();
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -202,11 +206,8 @@ describe("POST /api/activities/[id]/supervisors", () => {
     expect(mockApiGet).not.toHaveBeenCalled();
   });
 
-  it("does not fail a successful assignment on refetch errors", async () => {
+  it("does not refetch after a successful assignment", async () => {
     mockApiPost.mockResolvedValueOnce(undefined);
-    mockApiGet.mockRejectedValueOnce(
-      new Error("Transient list refresh failure"),
-    );
 
     const request = createMockRequest("/api/activities/5/supervisors", {
       method: "POST",

--- a/frontend/src/app/operator/announcements/page.test.tsx
+++ b/frontend/src/app/operator/announcements/page.test.tsx
@@ -3,7 +3,27 @@
  * Tests the rendering, CRUD operations, and modal interactions for announcements
  */
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalScrollHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollHeight",
+);
+const originalClientHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "clientHeight",
+);
+
+function restoreHTMLElementDimension(
+  property: "scrollHeight" | "clientHeight",
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(HTMLElement.prototype, property, descriptor);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, property);
+  }
+}
 
 // Hoisted mocks
 const {
@@ -201,6 +221,12 @@ describe("OperatorAnnouncementsPage", () => {
       mutate: mockMutate,
     });
     mockMutate.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreHTMLElementDimension("scrollHeight", originalScrollHeight);
+    restoreHTMLElementDimension("clientHeight", originalClientHeight);
   });
 
   it("renders loading state", () => {

--- a/frontend/src/app/operator/suggestions/page.test.tsx
+++ b/frontend/src/app/operator/suggestions/page.test.tsx
@@ -3,7 +3,27 @@
  * Tests the rendering, filtering, search, and status updates for feedback/suggestions
  */
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalScrollHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollHeight",
+);
+const originalClientHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "clientHeight",
+);
+
+function restoreHTMLElementDimension(
+  property: "scrollHeight" | "clientHeight",
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(HTMLElement.prototype, property, descriptor);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, property);
+  }
+}
 
 // Hoisted mocks
 const {
@@ -172,6 +192,12 @@ describe("OperatorSuggestionsPage", () => {
 
     // Mock window.dispatchEvent
     vi.spyOn(window, "dispatchEvent").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreHTMLElementDimension("scrollHeight", originalScrollHeight);
+    restoreHTMLElementDimension("clientHeight", originalClientHeight);
   });
 
   it("renders loading state", () => {

--- a/frontend/src/components/activities/quick-create-modal.test.tsx
+++ b/frontend/src/components/activities/quick-create-modal.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { QuickCreateActivityModal } from "./quick-create-modal";
+import { useActivityForm } from "~/hooks/useActivityForm";
 
 // Mock all dependencies
 vi.mock("~/lib/use-notification", () => ({
@@ -110,6 +111,40 @@ describe("QuickCreateActivityModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useActivityForm).mockReturnValue({
+      form: {
+        name: "",
+        category_id: "",
+        max_participants: "15",
+      },
+      setForm: vi.fn(),
+      categories: [
+        {
+          id: "1",
+          name: "Gruppenraum",
+          created_at: new Date("2024-01-01"),
+          updated_at: new Date("2024-01-01"),
+        },
+        {
+          id: "2",
+          name: "Hausaufgaben",
+          created_at: new Date("2024-01-01"),
+          updated_at: new Date("2024-01-01"),
+        },
+        {
+          id: "3",
+          name: "Kreatives/Musik",
+          created_at: new Date("2024-01-01"),
+          updated_at: new Date("2024-01-01"),
+        },
+      ],
+      loading: false,
+      error: null,
+      setError: vi.fn(),
+      handleInputChange: vi.fn(),
+      validateForm: vi.fn(() => null),
+      loadCategories: vi.fn(),
+    });
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({ id: "1", name: "New Activity" }),

--- a/frontend/src/components/admin/invitation-form.test.tsx
+++ b/frontend/src/components/admin/invitation-form.test.tsx
@@ -497,11 +497,10 @@ describe("InvitationForm", () => {
         expect(
           screen.getByText(/Bitte gib eine gültige E-Mail-Adresse ein/),
         ).toBeInTheDocument();
-      });
-
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
 

--- a/frontend/src/components/auth/invitation-accept-form.test.tsx
+++ b/frontend/src/components/auth/invitation-accept-form.test.tsx
@@ -667,11 +667,10 @@ describe("InvitationAcceptForm", () => {
         expect(
           screen.getByText(/Bitte gib Vor- und Nachname an/i),
         ).toBeInTheDocument();
-      });
-
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
 

--- a/frontend/src/components/auth/mfa-admin-override-modal.test.tsx
+++ b/frontend/src/components/auth/mfa-admin-override-modal.test.tsx
@@ -46,6 +46,7 @@ const props = {
 describe("MFAAdminOverrideModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch = ok({ override: "none", enrolled: false });
   });
 
   afterEach(() => {

--- a/frontend/src/components/auth/smart-redirect.test.tsx
+++ b/frontend/src/components/auth/smart-redirect.test.tsx
@@ -53,6 +53,28 @@ import { usePresenceMode } from "~/lib/tenant-context";
 describe("SmartRedirect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: { id: "1", token: "valid-token" },
+        expires: "",
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+    vi.mocked(useSupervision).mockReturnValue({
+      hasGroups: false,
+      isLoadingGroups: false,
+      isSupervising: false,
+      isLoadingSupervision: false,
+      adminOverviewEnabled: false,
+      supervisedRooms: [],
+      groups: [],
+      refresh: vi.fn(),
+    });
+    vi.mocked(useSmartRedirectPath).mockReturnValue({
+      redirectPath: "/dashboard",
+      isReady: true,
+    });
     vi.mocked(usePresenceMode).mockReturnValue("detailed");
   });
 

--- a/frontend/src/components/dashboard/sidebar.test.tsx
+++ b/frontend/src/components/dashboard/sidebar.test.tsx
@@ -77,6 +77,22 @@ vi.mock("~/lib/hooks/use-change-requests-pending", () => ({
   })),
 }));
 
+vi.mock("~/lib/hooks/use-messages-unread", () => ({
+  useMessagesUnread: vi.fn(() => ({
+    unreadCount: 0,
+    isLoading: false,
+    refresh: vi.fn(),
+  })),
+}));
+
+vi.mock("~/lib/hooks/use-enrollment-requests-pending", () => ({
+  useEnrollmentRequestsPending: vi.fn(() => ({
+    unreadCount: 0,
+    isLoading: false,
+    refresh: vi.fn(),
+  })),
+}));
+
 // Import after mocks
 import { Sidebar } from "./sidebar";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -156,6 +172,7 @@ function createMockSession(isAdminUser: boolean) {
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
 
     // Default mock implementations
     mockUseShellAuth.mockReturnValue({
@@ -183,7 +200,18 @@ describe("Sidebar", () => {
       refresh: vi.fn(),
     });
     mockIsAdmin.mockReturnValue(false);
+    restoreDefaultHasPermission();
+    mockUsePresenceMode.mockReturnValue("detailed");
+    mockUseNFCEnabled.mockReturnValue(true);
+    mockUseOpenCareGroupMode.mockReturnValue(false);
     mockUseTenantRoutingModeSafe.mockReturnValue("path");
+    mockUseSWRDefault.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      isValidating: false,
+      mutate: vi.fn(),
+    } as unknown as ReturnType<typeof useSWR>);
     mockUseStaffAbsencesPending.mockReturnValue({
       unreadCount: 0,
       isLoading: false,
@@ -194,6 +222,10 @@ describe("Sidebar", () => {
       isLoading: false,
       refresh: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("rendering", () => {
@@ -800,8 +832,8 @@ describe("Sidebar", () => {
     beforeEach(() => {
       mockRouterPush.mockClear();
       // Mock localStorage
-      vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
-      vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      vi.spyOn(localStorage, "getItem").mockReturnValue(null);
+      vi.spyOn(localStorage, "setItem").mockImplementation(() => {
         // no-op
       });
     });
@@ -1037,12 +1069,10 @@ describe("Sidebar", () => {
 
   describe("child page highlight persistence", () => {
     it("highlights group sub-item on student detail from ogs-groups", () => {
-      vi.spyOn(Storage.prototype, "getItem").mockImplementation(
-        (key: string) => {
-          if (key === "sidebar-last-group") return "1";
-          return null;
-        },
-      );
+      vi.spyOn(localStorage, "getItem").mockImplementation((key: string) => {
+        if (key === "sidebar-last-group") return "1";
+        return null;
+      });
       mockUsePathname.mockReturnValue("/students/123");
       mockUseSearchParams.mockReturnValue(
         createMockSearchParams((key: string) =>
@@ -1099,14 +1129,9 @@ describe("Sidebar", () => {
     });
 
     it("highlights room sub-item on student detail from active-supervisions", () => {
-      const mockGetItem = vi.fn((key: string) => {
+      vi.spyOn(localStorage, "getItem").mockImplementation((key: string) => {
         if (key === "sidebar-last-room") return "10";
         return null;
-      });
-      Object.defineProperty(localStorage, "getItem", {
-        value: mockGetItem,
-        writable: true,
-        configurable: true,
       });
       mockUsePathname.mockReturnValue("/students/456");
       mockUseSearchParams.mockReturnValue(
@@ -1137,48 +1162,12 @@ describe("Sidebar", () => {
 
   describe("localStorage persistence", () => {
     const mockSetItem = vi.fn();
-    let originalSetItem: typeof localStorage.setItem;
-    let originalGetItem: typeof localStorage.getItem;
-    let originalRemoveItem: typeof localStorage.removeItem;
 
     beforeEach(() => {
       mockSetItem.mockClear();
-      originalSetItem = localStorage.setItem.bind(localStorage);
-      originalGetItem = localStorage.getItem.bind(localStorage);
-      originalRemoveItem = localStorage.removeItem.bind(localStorage);
-      Object.defineProperty(localStorage, "setItem", {
-        value: mockSetItem,
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "getItem", {
-        value: vi.fn().mockReturnValue(null),
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "removeItem", {
-        value: vi.fn(),
-        writable: true,
-        configurable: true,
-      });
-    });
-
-    afterEach(() => {
-      Object.defineProperty(localStorage, "setItem", {
-        value: originalSetItem,
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "getItem", {
-        value: originalGetItem,
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "removeItem", {
-        value: originalRemoveItem,
-        writable: true,
-        configurable: true,
-      });
+      vi.spyOn(localStorage, "setItem").mockImplementation(mockSetItem);
+      vi.spyOn(localStorage, "getItem").mockReturnValue(null);
+      vi.spyOn(localStorage, "removeItem").mockImplementation(() => undefined);
     });
 
     it("persists selected group and group name to localStorage", () => {
@@ -1306,43 +1295,10 @@ describe("Sidebar", () => {
   });
 
   describe("accordion toggle with saved localStorage", () => {
-    let originalSetItem: typeof localStorage.setItem;
-    let originalGetItem: typeof localStorage.getItem;
-    let originalRemoveItem: typeof localStorage.removeItem;
-
     beforeEach(() => {
       mockRouterPush.mockClear();
-      originalSetItem = localStorage.setItem.bind(localStorage);
-      originalGetItem = localStorage.getItem.bind(localStorage);
-      originalRemoveItem = localStorage.removeItem.bind(localStorage);
-      Object.defineProperty(localStorage, "setItem", {
-        value: vi.fn(),
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "removeItem", {
-        value: vi.fn(),
-        writable: true,
-        configurable: true,
-      });
-    });
-
-    afterEach(() => {
-      Object.defineProperty(localStorage, "setItem", {
-        value: originalSetItem,
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "getItem", {
-        value: originalGetItem,
-        writable: true,
-        configurable: true,
-      });
-      Object.defineProperty(localStorage, "removeItem", {
-        value: originalRemoveItem,
-        writable: true,
-        configurable: true,
-      });
+      vi.spyOn(localStorage, "setItem").mockImplementation(() => undefined);
+      vi.spyOn(localStorage, "removeItem").mockImplementation(() => undefined);
     });
 
     it("navigates to saved group from localStorage when toggling groups", () => {
@@ -1350,11 +1306,7 @@ describe("Sidebar", () => {
         if (key === "sidebar-last-group") return "2";
         return null;
       });
-      Object.defineProperty(localStorage, "getItem", {
-        value: mockGetItem,
-        writable: true,
-        configurable: true,
-      });
+      vi.spyOn(localStorage, "getItem").mockImplementation(mockGetItem);
       mockUsePathname.mockReturnValue("/activities");
       mockUseSupervision.mockReturnValue({
         hasGroups: true,
@@ -1385,11 +1337,7 @@ describe("Sidebar", () => {
         if (key === "sidebar-last-room") return "20";
         return null;
       });
-      Object.defineProperty(localStorage, "getItem", {
-        value: mockGetItem,
-        writable: true,
-        configurable: true,
-      });
+      vi.spyOn(localStorage, "getItem").mockImplementation(mockGetItem);
       mockUsePathname.mockReturnValue("/activities");
       mockUseSupervision.mockReturnValue({
         hasGroups: true,
@@ -1420,11 +1368,7 @@ describe("Sidebar", () => {
         if (key === "sidebar-last-group") return "999";
         return null;
       });
-      Object.defineProperty(localStorage, "getItem", {
-        value: mockGetItem,
-        writable: true,
-        configurable: true,
-      });
+      vi.spyOn(localStorage, "getItem").mockImplementation(mockGetItem);
       mockUsePathname.mockReturnValue("/activities");
       mockUseSupervision.mockReturnValue({
         hasGroups: true,
@@ -1455,11 +1399,7 @@ describe("Sidebar", () => {
         if (key === "sidebar-last-room") return "999";
         return null;
       });
-      Object.defineProperty(localStorage, "getItem", {
-        value: mockGetItem,
-        writable: true,
-        configurable: true,
-      });
+      vi.spyOn(localStorage, "getItem").mockImplementation(mockGetItem);
       mockUsePathname.mockReturnValue("/activities");
       mockUseSupervision.mockReturnValue({
         hasGroups: true,

--- a/frontend/src/components/parent/child/child-page.test.tsx
+++ b/frontend/src/components/parent/child/child-page.test.tsx
@@ -233,10 +233,24 @@ describe("ChildPage", () => {
   });
 
   it("zeigt Heute und standardmaessig die Betreuung", async () => {
+    let resolveToday!: (
+      value: Awaited<ReturnType<typeof getChildToday>>,
+    ) => void;
+    mockedToday.mockReturnValue(
+      new Promise((resolve) => {
+        resolveToday = resolve;
+      }),
+    );
     renderPage();
     await screen.findByRole("heading", { level: 1, name: "Felix Schneider" });
 
-    expect(screen.getByTestId("child-day-state-icon")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("child-day-state-icon"),
+    ).not.toBeInTheDocument();
+    resolveToday({ at_ogs: null, state: "unknown" });
+    expect(
+      await screen.findByTestId("child-day-state-icon"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Abholung")).toBeInTheDocument();
     expect(screen.getByText("Abholung heute um 15:00 Uhr")).toBeInTheDocument();
 

--- a/frontend/src/components/students/personal-info-form-modal.test.tsx
+++ b/frontend/src/components/students/personal-info-form-modal.test.tsx
@@ -14,12 +14,9 @@ vi.mock("~/components/ui/date-picker", async (importOriginal) => {
 });
 
 const { fetchStudentCompanionsMock } = vi.hoisted(() => ({
-  // Unreachable by default, exactly like the un-mocked network call these
-  // tests used to make: the stored links stay unknown, which is the state
-  // every suite below assumes.
   fetchStudentCompanionsMock: vi.fn<
     (studentId: string) => Promise<StudentCompanion[]>
-  >(() => Promise.reject(new Error("companions unavailable"))),
+  >(() => new Promise(() => undefined)),
 }));
 
 vi.mock("~/lib/student-companion-api", async (importOriginal) => ({
@@ -103,6 +100,9 @@ describe("PersonalInfoFormModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchStudentCompanionsMock.mockImplementation(
+      () => new Promise(() => undefined),
+    );
   });
 
   describe("Modal open/close behavior", () => {
@@ -684,6 +684,9 @@ describe("PersonalInfoFormModal — companion plan conflicts", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchStudentCompanionsMock.mockImplementation(
+      () => new Promise(() => undefined),
+    );
   });
 
   it("drops the conflicts when the question is dismissed", async () => {

--- a/frontend/src/components/students/pickup-day-edit-modal.test.tsx
+++ b/frontend/src/components/students/pickup-day-edit-modal.test.tsx
@@ -650,11 +650,10 @@ describe("PickupDayEditModal", () => {
 
       await waitFor(() => {
         expect(screen.getByText("Save failed")).toBeInTheDocument();
-      });
-
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
   });

--- a/frontend/src/components/students/pickup-schedule-form-modal.test.tsx
+++ b/frontend/src/components/students/pickup-schedule-form-modal.test.tsx
@@ -712,11 +712,10 @@ describe("PickupScheduleFormModal", () => {
         expect(
           screen.getByText("Bitte geben Sie mindestens eine Abholzeit an."),
         ).toBeInTheDocument();
-      });
-
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
   });

--- a/frontend/src/components/students/student-detail-components.test.tsx
+++ b/frontend/src/components/students/student-detail-components.test.tsx
@@ -19,6 +19,11 @@ vi.mock("~/lib/tenant-router", () => ({
   useTenantRouter: () => ({ push: vi.fn() }),
 }));
 
+vi.mock("~/lib/student-companion-api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/student-companion-api")>()),
+  fetchStudentCompanions: vi.fn(() => new Promise(() => undefined)),
+}));
+
 import {
   PersonIcon,
   ChevronDownIcon,

--- a/frontend/src/components/timetable/event-form/use-event-form.test.ts
+++ b/frontend/src/components/timetable/event-form/use-event-form.test.ts
@@ -1,10 +1,12 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ActivityCategory } from "~/lib/activity-helpers";
 import type { TimetableTemplate } from "~/lib/timetable-types";
 import * as plannerReferenceApi from "~/lib/planner-reference-api";
+import { planningTrackService } from "~/lib/planning-track-api";
 import { staffService } from "~/lib/staff-api";
+import { timetableService } from "~/lib/timetable-api";
 import * as formModel from "./form-model";
 import { reconcileCategoryId, useEventForm } from "./use-event-form";
 import type { UseEventFormParams } from "./use-event-form";
@@ -17,7 +19,17 @@ vi.mock("~/contexts/ToastContext", () => ({
   }),
 }));
 
+beforeEach(() => {
+  vi.spyOn(planningTrackService, "list").mockResolvedValue([]);
+  vi.spyOn(timetableService, "getOfferingSources").mockResolvedValue([]);
+  vi.spyOn(timetableService, "getCombinedOfferingCounts").mockResolvedValue({
+    totalCount: 0,
+    gradeCounts: {},
+  });
+});
+
 afterEach(() => {
+  cleanup();
   vi.restoreAllMocks();
 });
 

--- a/frontend/src/components/ui/database/database-form.test.tsx
+++ b/frontend/src/components/ui/database/database-form.test.tsx
@@ -1463,11 +1463,10 @@ describe("DatabaseForm", () => {
         expect(
           screen.getByText("Test Field ist erforderlich."),
         ).toBeInTheDocument();
-      });
-
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
 

--- a/frontend/src/components/ui/password-change-modal.test.tsx
+++ b/frontend/src/components/ui/password-change-modal.test.tsx
@@ -544,11 +544,10 @@ describe("PasswordChangeModal", () => {
         expect(
           screen.getByText(/Bitte füllen Sie alle Felder aus/i),
         ).toBeInTheDocument();
-      });
-
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({
-        behavior: "smooth",
-        block: "start",
+        expect(scrollIntoViewMock).toHaveBeenCalledWith({
+          behavior: "smooth",
+          block: "start",
+        });
       });
     });
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -2254,10 +2254,8 @@ describe("api.ts helper functions", () => {
   describe("error handling utilities", () => {
     it("handleApiError wraps errors with context", async () => {
       const error = new Error("Network failure");
-      await import("./api");
-
-      // Trigger an error through studentService
-      global.fetch = vi.fn().mockRejectedValue(error);
+      const { fetchWithRetry } = await import("./api-helpers");
+      vi.mocked(fetchWithRetry).mockRejectedValue(error);
 
       const { getSession } = await import("next-auth/react");
       vi.mocked(getSession).mockResolvedValue({

--- a/frontend/src/lib/hooks/use-navigation-guard.test.ts
+++ b/frontend/src/lib/hooks/use-navigation-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, cleanup } from "@testing-library/react";
 
 import { useNavigationGuard } from "./use-navigation-guard";
 import { attemptNavigation } from "./navigation-guard-store";
@@ -31,10 +31,15 @@ describe("useNavigationGuard", () => {
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
+    window.history.replaceState(null, "", "/");
+    vi.spyOn(window.history, "go").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
+    cleanup();
     document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    window.history.replaceState(null, "", "/");
   });
 
   it("intercepts an in-app link click and stores the destination", () => {
@@ -223,7 +228,6 @@ describe("useNavigationGuard", () => {
       expect(goSpy).toHaveBeenCalledWith(-2);
       expect(mockPush).not.toHaveBeenCalled();
       expect(result.current.pendingHref).toBeNull();
-      goSpy.mockRestore();
     });
 
     it("stays on the page on cancel without traversing history", () => {
@@ -239,7 +243,6 @@ describe("useNavigationGuard", () => {
 
       expect(goSpy).not.toHaveBeenCalled();
       expect(result.current.pendingHref).toBeNull();
-      goSpy.mockRestore();
     });
 
     it("collapses the sentinel when blocking is disarmed in place", () => {
@@ -257,7 +260,6 @@ describe("useNavigationGuard", () => {
       // The same-URL sentinel pushed on arm must be popped, otherwise the next
       // Back press lands on a leftover duplicate of the current URL.
       expect(goSpy).toHaveBeenCalledWith(-1);
-      goSpy.mockRestore();
     });
 
     it("does not accumulate sentinels across edit/save/edit cycles", () => {
@@ -280,7 +282,6 @@ describe("useNavigationGuard", () => {
       expect(pushSpy).toHaveBeenCalledTimes(2);
       expect(goSpy).toHaveBeenCalledWith(-1);
       pushSpy.mockRestore();
-      goSpy.mockRestore();
     });
 
     it("does not pop a sentinel after a link-click confirm navigates away", () => {
@@ -306,7 +307,6 @@ describe("useNavigationGuard", () => {
 
       expect(mockReplace).toHaveBeenCalledWith("/database");
       expect(goSpy).not.toHaveBeenCalled();
-      goSpy.mockRestore();
     });
 
     it("ignores the popstate it triggers itself on confirm", () => {
@@ -369,7 +369,6 @@ describe("useNavigationGuard", () => {
         window.dispatchEvent(new PopStateEvent("popstate"));
       });
       expect(proceed).toHaveBeenCalledTimes(1);
-      goSpy.mockRestore();
     });
 
     it("does not run the deferred navigation on cancel", () => {

--- a/frontend/src/lib/pickup-schedule-api.test.ts
+++ b/frontend/src/lib/pickup-schedule-api.test.ts
@@ -71,13 +71,17 @@ function createMockResponse(
   } as Response;
 }
 
+const originalFetch = global.fetch;
+
 describe("pickup-schedule-api", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch = vi.fn();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    global.fetch = originalFetch;
   });
 
   describe("bulkUpsertPickupSchedules", () => {

--- a/frontend/src/lib/student-api.test.ts
+++ b/frontend/src/lib/student-api.test.ts
@@ -93,6 +93,9 @@ describe("student-api", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedGetSession.mockResolvedValue(mockSessionData());
+    mockedHandleDomainApiError.mockImplementation(() => {
+      throw new Error("Mocked error");
+    });
   });
 
   describe("fetchStudents", () => {


### PR DESCRIPTION
## Summary
- eliminate Berlin-midnight failures in dashboard, notification-window, and all-day shift fixtures
- isolate mutable frontend mocks, auth/SWR state, browser globals, history, storage, DOM descriptors, and API queues between tests
- replace live or pending browser requests in unit tests with controlled collaborators
- replace the package-global IoT check-in clock with a per-service clock for parallel-test safety
- wait for asynchronous scroll and child-day effects before asserting

## Root causes fixed
- wall-clock fixtures becoming active or inactive at midnight
- one-shot mock implementations leaking into shuffled tests
- auth, routing, storage, DOM descriptor, and child-component state leaking across tests
- assertions racing React effects and asynchronous fetch resolution
- unmocked unit-test HTTP requests being aborted during happy-dom teardown
- parallel Go tests mutating a shared clock function

## Verification
- `scripts/test-backend.sh` — 23,733 tests passed in fresh per-package database clones
- `cd backend && go test -short -race ./...` — passed
- `cd frontend && pnpm exec vitest run` — 1,042 files / 14,281 tests passed
- frontend full-suite shuffle seeds 4103, 4104, and 4105 — 14,281 tests passed for each seed
- `cd frontend && pnpm run check` — passed
- pre-commit and pre-push hooks — passed, including Go vet, golangci-lint, dependency-cruiser, Knip, TypeScript, Oxlint, dead-code, and secret checks
