### PR TITLE
Remove Playwright test retries

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -55,12 +55,10 @@ export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
     baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
   projects: [

--- a/frontend/playwright.guides.config.ts
+++ b/frontend/playwright.guides.config.ts
@@ -8,8 +8,7 @@ import { defineConfig, devices } from "@playwright/test";
 // `next dev`: the PDFs ship inside the prod image, so they must be generated
 // from the same output users actually see , and a prod server renders
 // deterministically and fast (no first-request compile / HMR), which removes
-// the main flakiness source. The render step is on the deploy critical path,
-// so `retries` (in CI) absorbs transient hiccups instead of failing a deploy.
+// the main flakiness source.
 //
 // Env note: the /help pages are public and host-agnostic, but proxy.ts throws
 // when the operator/parents/tenant hostnames are unset. Locally those come from
@@ -21,7 +20,6 @@ export default defineConfig({
   // The 91-page features guide can exceed Playwright's 30-second default on CI.
   timeout: 120_000,
   workers: 1,
-  retries: process.env.CI ? 2 : 0,
   reporter: "list",
   use: {
     baseURL: "http://localhost:3000",

--- a/frontend/scripts/generate-guides.ts
+++ b/frontend/scripts/generate-guides.ts
@@ -25,9 +25,8 @@ const GUIDES = [
 const OUT_DIR = path.join(process.cwd(), "public", "help", "pdfs");
 
 // A correctly rendered guide PDF is always well above this; anything smaller
-// means the page rendered blank or the images never loaded. Failing here (and
-// retrying via the config) is preferable to silently shipping a broken
-// download into the production image.
+// means the page rendered blank or the images never loaded. Failing here is
+// preferable to silently shipping a broken download into the production image.
 const MIN_PDF_BYTES = 20_000;
 const PDF_MARGIN = { top: "18mm", right: "16mm", bottom: "18mm", left: "16mm" };
 const ONE_PAGER_MARGIN = { top: "0", right: "0", bottom: "0", left: "0" };


### PR DESCRIPTION
## Description

- Remove the CI-only retry count from both Playwright configurations.
- Remove the retry-only trace setting and stale retry comments.
- Playwright now uses its default of zero retries, so the first failed attempt fails the run.

Backend tests and Vitest were already single-pass and are unchanged.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test addition/modification
- [x] CI/CD improvement

## Related Issues

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Testing documentation updated

Commands run:
- `cd frontend && pnpm run check`
- `cd frontend && pnpm exec playwright test --list -c playwright.config.ts`
- `cd frontend && pnpm exec playwright test --list -c playwright.guides.config.ts`
- `cd frontend && pnpm exec playwright test --help` (confirmed the omitted retry setting defaults to no retries)

## Security Checklist
- [x] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Not applicable; no user-facing change.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

The regular PR workflow does not execute the Playwright E2E suite or the guide-PDF Playwright run. It will validate the static/frontend suite, but the changed retry behavior is exercised only when those Playwright commands run; guide generation currently runs during the post-merge image build.

