### PR TITLE
Seeder in CI fahren und Abdeckung ratchen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,3 +241,144 @@ jobs:
           path: frontend/coverage/lcov.info
           retention-days: 7
         if: always()
+
+  # The seeder is the widest end-to-end path in this repo: roughly a hundred
+  # real API calls across auth, enrollment, parent portal, time tracking and
+  # IoT. Until this job existed it ran nowhere automatically, so a tightened
+  # request contract could break it unnoticed — a mandatory `reason` field on
+  # the parent pickup-change endpoint did exactly that in July 2026 and only
+  # surfaced a month later, when a developer seeded by hand.
+  seed-smoke:
+    name: Seed & simulate smoke
+    if: ${{ inputs.run-backend }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: phoenix_seed
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          TZ: Europe/Berlin
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+      mailpit:
+        # Operator login enrolls MFA and reads the code back out of mailpit's
+        # REST API, so the seeder cannot authenticate without a mail sink.
+        image: axllent/mailpit:v1.30
+        ports:
+          - 1025:1025
+          - 8025:8025
+
+    env:
+      DB_DSN: postgres://postgres:postgres@localhost:5432/phoenix_seed?sslmode=disable
+      PHOENIX_AUTH_PASSWORD: phoenix_auth_test
+      # validateServeConfig() in cmd/serve.go requires every one of these:
+      # there are no fallback defaults anywhere in this codebase.
+      PORT: "8080"
+      APP_ENV: development
+      LOG_LEVEL: info
+      LOG_TEXTLOGGING: "true"
+      AUTH_JWT_SECRET: ci-test-secret-must-be-at-least-32-chars-long
+      AUTH_JWT_EXPIRY: 15m
+      AUTH_JWT_REFRESH_EXPIRY: 168h
+      # Read by os.Getenv in migration 001011003, which creates the operator
+      # account the seeder logs in with.
+      OPERATOR_EMAIL: operator@example.com
+      OPERATOR_PASSWORD: SeedSmoke1234%
+      OPERATOR_DISPLAY_NAME: CI Operator
+      ADMIN_EMAIL: admin@example.com
+      ADMIN_PASSWORD: SeedSmoke1234%
+      FRONTEND_URL: http://localhost:3000
+      PARENTS_URL: http://parents.localhost:3000
+      NEXT_PUBLIC_OPERATOR_HOSTNAME: operator.localhost:3000
+      NEXT_PUBLIC_PARENTS_HOSTNAME: parents.localhost:3000
+      TENANT_DOMAIN: localhost
+      # api/server.go refuses to build the server without it.
+      METRICS_BEARER_TOKEN: ci-metrics-token
+      # No tenant override exists on a fresh seed, so device auth falls back to
+      # this env var. It must match the seeder's --pin, or every RFID call in
+      # the simulation returns 401.
+      OGS_DEVICE_PIN: "1234"
+      EMAIL_SMTP_HOST: localhost
+      EMAIL_SMTP_PORT: 1025
+      EMAIL_FROM_ADDRESS: noreply@localhost
+      EMAIL_FROM_NAME: moto CI
+      MAILPIT_URL: http://localhost:8025
+      # The schedulers would mutate seeded rows behind the coverage check.
+      CLEANUP_SCHEDULER_ENABLED: "false"
+      SESSION_END_SCHEDULER_ENABLED: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Build backend binary
+        working-directory: backend
+        run: go build -o "${RUNNER_TEMP}/phoenix" .
+
+      - name: Run migrations
+        working-directory: backend
+        run: |
+          "${RUNNER_TEMP}/phoenix" migrate
+
+      - name: Start server
+        working-directory: backend
+        run: |
+          "${RUNNER_TEMP}/phoenix" serve > "${RUNNER_TEMP}/server.log" 2>&1 &
+          echo $! > "${RUNNER_TEMP}/server.pid"
+          for _ in $(seq 1 60); do
+            if curl -fsS http://localhost:8080/health > /dev/null; then
+              echo "server up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server did not become healthy in 60s"
+          exit 1
+
+      - name: Seed demo data
+        working-directory: backend
+        run: |
+          "${RUNNER_TEMP}/phoenix" seed \
+            --email "${OPERATOR_EMAIL}" \
+            --password "${OPERATOR_PASSWORD}" \
+            --pin 1234 \
+            --url http://localhost:8080 \
+            --tenant-slug demo-school \
+            --staff-password 'SeedSmoke1234%' \
+            --admin-email school-admin@example.com
+
+      - name: Simulate a full care day
+        working-directory: backend
+        run: |
+          "${RUNNER_TEMP}/phoenix" simulate full-day
+
+      - name: Check seed coverage ratchet
+        working-directory: backend
+        env:
+          SEED_COVERAGE_DSN: postgres://postgres:postgres@localhost:5432/phoenix_seed?sslmode=disable
+        run: go test ./seed/api/ -run TestSeedCoverageRatchet -v
+
+      - name: Server log
+        if: always()
+        run: tail -n 200 "${RUNNER_TEMP}/server.log" || true
+
+      - name: Stop server
+        if: always()
+        run: kill "$(cat "${RUNNER_TEMP}/server.pid")" 2>/dev/null || true

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -220,6 +220,30 @@ func TestExample(t *testing.T) {
 - Run the gate locally before pushing: `cd backend && go test ./test/ -run TestHermeticTestPatterns -v`
 - Never modify existing tests to make new code pass — see `.claude/rules/no-test-modifications.md`.
 
+## Seed Coverage (MANDATORY)
+
+The demo seeder (`seed/api`) plus `simulate full-day` are the widest end-to-end
+path in this repo, roughly a hundred real API calls across every module, and
+the only source of dev and demo data. Two rules follow from that:
+
+1. **A user-facing feature ships with seed data in the same PR.** A screen that
+   is empty on every dev machine is a screen nobody reviews.
+2. **The coverage ratchet is not optional.** `TestSeedCoverageRatchet`
+   (`seed/api/coverage_ratchet_test.go`) fails when a table ends up with no
+   seeded rows and is not allowlisted, and just as loudly when an allowlisted
+   table starts holding data (then delete the entry). The `seed-smoke` CI job
+   runs it, and by running the seeder at all it also proves every API contract
+   the seeder drives still holds.
+
+Allowlist entries reading `GAP: prod has N rows` are the measured backlog: 58
+tables that production tenants fill and the seeder does not. Shrink that list,
+never grow it.
+
+```bash
+# Against a seeded local stack
+docker compose exec server sh -c 'SEED_COVERAGE_DSN="$DB_DSN" go test ./seed/api/ -run TestSeedCoverageRatchet -v'
+```
+
 ## Logging: slog Only (MANDATORY)
 
 All backend code uses `log/slog` via injected loggers — never logrus or `log.Printf`. `sloglint` enforces key-value style (`no-mixed-args`, `key-naming-case: snake`, `args-on-sep-lines`). Use the `backend-structured-logging` skill for detailed patterns.

--- a/backend/seed/api/coverage_ratchet_test.go
+++ b/backend/seed/api/coverage_ratchet_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"database/sql"
@@ -214,10 +214,13 @@ func TestSeedCoverageRatchet(t *testing.T) {
 		discovered[table] = struct{}{}
 	}
 
-	var uncovered, stale, unknownAllowlist []string
-	for table := range seedCoverageAllowlist {
+	var uncovered, stale, unknownAllowlist, missingAllowlistReasons []string
+	for table, reason := range seedCoverageAllowlist {
 		if _, ok := discovered[table]; !ok {
 			unknownAllowlist = append(unknownAllowlist, table)
+		}
+		if strings.TrimSpace(reason) == "" {
+			missingAllowlistReasons = append(missingAllowlistReasons, table)
 		}
 	}
 	for _, table := range tables {
@@ -238,6 +241,7 @@ func TestSeedCoverageRatchet(t *testing.T) {
 	sort.Strings(uncovered)
 	sort.Strings(stale)
 	sort.Strings(unknownAllowlist)
+	sort.Strings(missingAllowlistReasons)
 
 	if len(uncovered) > 0 {
 		t.Errorf("%d table(s) hold no seeded data and are not allowlisted:\n  %s\n\n"+
@@ -253,6 +257,10 @@ func TestSeedCoverageRatchet(t *testing.T) {
 	if len(unknownAllowlist) > 0 {
 		t.Errorf("%d seedCoverageAllowlist entry or entries do not name an application table:\n  %s",
 			len(unknownAllowlist), strings.Join(unknownAllowlist, "\n  "))
+	}
+	if len(missingAllowlistReasons) > 0 {
+		t.Errorf("%d seedCoverageAllowlist entry or entries have no reason:\n  %s",
+			len(missingAllowlistReasons), strings.Join(missingAllowlistReasons, "\n  "))
 	}
 
 	t.Logf("seed coverage: %d/%d tables filled, %d allowlisted",

--- a/backend/seed/api/coverage_ratchet_test.go
+++ b/backend/seed/api/coverage_ratchet_test.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/uptrace/bun/driver/pgdriver"
+)
+
+// TestSeedCoverageRatchet keeps the demo seeder honest about which tables it
+// actually fills. It runs only against a stack that has been through
+// `migrate reset` + `seed` + `simulate full-day`, so it skips by default and
+// is driven by the seed-smoke CI job:
+//
+//	SEED_COVERAGE_DSN=postgres://... go test ./seed/api/ -run TestSeedCoverageRatchet
+//
+// The rules, mirroring the other ratchets in backend/test:
+//
+//   - A table that ends up EMPTY must be listed in seedCoverageAllowlist with a
+//     reason. A new table without seed coverage fails the build.
+//   - An allowlisted table that now HAS rows fails too: remove the entry. The
+//     ratchet only turns one way, the list may never grow silently.
+//
+// Entries marked "GAP: prod has N rows" are the real backlog: production
+// tenants fill those tables and the seeder does not, so every screen built on
+// them looks empty in dev. The counts come from a read-only aggregate scan of
+// the production database on 2026-08-20 (row counts only, no personal data).
+// Shrink this list by teaching the seeder the missing flow, never by deleting
+// the check.
+var seedCoverageAllowlist = map[string]string{
+	"active.combined_groups":               "empty in prod too",
+	"active.excused_absence_requests":      "empty in prod too",
+	"active.group_mappings":                "empty in prod too",
+	"active.scheduled_checkouts":           "empty in prod too",
+	"active.staff_balance_adjustments":     "GAP: prod has 9 rows",
+	"active.staff_month_balance_snapshots": "empty in prod too",
+	"active.staff_vacation_openings":       "empty in prod too",
+	"active.staff_vacation_quota":          "GAP: prod has 1 rows",
+	"active.work_session_breaks":           "GAP: prod has 7 rows",
+
+	"activities.group_targets": "GAP: prod has 29 rows",
+	"activities.schedules":     "GAP: prod has 330 rows",
+
+	"audit.class_list_entry_changes":        "not in prod yet (migration newer than the deployed image)",
+	"audit.data_access_log":                 "GAP: prod has 149 rows",
+	"audit.data_deletions":                  "GAP: prod has 796 rows",
+	"audit.data_imports":                    "GAP: prod has 11 rows",
+	"audit.deviation_events":                "GAP: prod has 4 rows",
+	"audit.enrollment_deletions":            "GAP: prod has 9 rows",
+	"audit.enrollment_offering_adjustments": "GAP: prod has 13 rows",
+	"audit.enrollment_restorations":         "empty in prod too",
+	"audit.guardian_changes":                "GAP: prod has 81 rows",
+	"audit.personnel_number_changes":        "empty in prod too",
+	"audit.room_color_migration_backup":     "GAP: prod has 38 rows",
+	"audit.staff_master_data_changes":       "GAP: prod has 18 rows",
+	"audit.student_deletions":               "GAP: prod has 110 rows",
+	"audit.student_field_edits":             "GAP: prod has 161 rows",
+	"audit.time_tracking_deletions":         "GAP: prod has 2 rows",
+	"audit.unregistered_tag_scans":          "GAP: prod has 307 rows",
+	"audit.wc_alias_migration_backup":       "empty in prod too",
+
+	"auth.accounts_parents":           "empty in prod too",
+	"auth.mfa_credentials":            "empty in prod too",
+	"auth.mfa_email_challenges":       "empty in prod too",
+	"auth.mfa_overrides":              "empty in prod too",
+	"auth.mfa_trusted_devices":        "empty in prod too",
+	"auth.passkey_credentials":        "empty in prod too",
+	"auth.passkey_sessions":           "GAP: prod has 72 rows",
+	"auth.password_reset_rate_limits": "GAP: prod has 1 rows",
+	"auth.password_reset_tokens":      "empty in prod too",
+
+	"calendar.appointment_occurrence_overrides":     "empty in prod too",
+	"calendar.appointment_recipient_students":       "empty in prod too",
+	"calendar.appointment_recipients":               "empty in prod too",
+	"calendar.appointment_reminder_push_deliveries": "empty in prod too",
+	"calendar.appointment_targets":                  "empty in prod too",
+	"calendar.appointments":                         "empty in prod too",
+	"calendar.recurrence_rules":                     "empty in prod too",
+
+	"config.work_time_model_entries": "empty in prod too",
+	"config.work_time_models":        "empty in prod too",
+
+	"display.displays": "empty in prod too",
+
+	"education.class_teachers":                      "empty in prod too",
+	"education.grade_transition_class_list_entries": "not in prod yet (migration newer than the deployed image)",
+	"education.grade_transition_class_teachers":     "empty in prod too",
+	"education.grade_transition_history":            "GAP: prod has 472 rows",
+	"education.grade_transition_mappings":           "GAP: prod has 33 rows",
+	"education.grade_transitions":                   "GAP: prod has 2 rows",
+	"education.group_substitution":                  "GAP: prod has 4 rows",
+
+	"enrollment.care_offering_auto_triggers": "empty in prod too",
+	"enrollment.change_request_messages":     "GAP: prod has 2 rows",
+	"enrollment.change_requests":             "GAP: prod has 23 rows",
+	"enrollment.form_schemas":                "GAP: prod has 53 rows",
+	"enrollment.late_invites":                "GAP: prod has 24 rows",
+	"enrollment.offering_change_requests":    "GAP: prod has 7 rows",
+
+	"feedback.entries": "empty in prod too",
+
+	"iot.push_subscriptions":   "GAP: prod has 37 rows",
+	"iot.pwa_standalone_usage": "not in prod yet (migration newer than the deployed image)",
+
+	"meta.migration_metadata": "empty in prod too",
+
+	"platform.announcement_views":           "GAP: prod has 135 rows",
+	"platform.operator_email_change_tokens": "empty in prod too",
+	"platform.operator_invitation_tokens":   "empty in prod too",
+	"platform.operator_mfa_trusted_devices": "GAP: prod has 1 rows",
+	"platform.operator_passkey_credentials": "GAP: prod has 1 rows",
+	"platform.operator_passkey_sessions":    "GAP: prod has 4 rows",
+
+	"public.bun_migration_locks": "empty in prod too",
+
+	"schedule.activity_exceptions":              "GAP: prod has 2 rows",
+	"schedule.calendar_periods":                 "GAP: prod has 10 rows",
+	"schedule.closing_days":                     "GAP: prod has 3 rows",
+	"schedule.dateframes":                       "empty in prod too",
+	"schedule.grade_transition_roster_removals": "empty in prod too",
+	"schedule.meal_plan_entries":                "GAP: prod has 12 rows",
+	"schedule.planning_tracks":                  "GAP: prod has 7 rows",
+	"schedule.recurrence_rules":                 "empty in prod too",
+	"schedule.shift_types":                      "GAP: prod has 5 rows",
+	"schedule.staff_shift_series":               "empty in prod too",
+	"schedule.staff_shift_series_exceptions":    "empty in prod too",
+	"schedule.staff_shifts":                     "GAP: prod has 3 rows",
+	"schedule.student_arrival_exceptions":       "GAP: prod has 327 rows",
+	"schedule.student_arrival_notes":            "GAP: prod has 20 rows",
+	"schedule.student_arrival_schedules":        "GAP: prod has 4002 rows",
+	"schedule.student_pickup_exceptions":        "GAP: prod has 205 rows",
+	"schedule.student_pickup_notes":             "GAP: prod has 53 rows",
+	"schedule.timeframes":                       "GAP: prod has 16 rows",
+	"schedule.timetable_conflict_acks":          "empty in prod too",
+
+	"suggestions.comment_reads": "GAP: prod has 117 rows",
+	"suggestions.post_reads":    "GAP: prod has 47 rows",
+
+	"users.class_list_entries":            "not in prod yet (migration newer than the deployed image)",
+	"users.guardian_phone_numbers":        "GAP: prod has 3071 rows",
+	"users.guests":                        "empty in prod too",
+	"users.notification_preferences":      "GAP: prod has 277 rows",
+	"users.parent_announcement_options":   "empty in prod too",
+	"users.parent_announcement_reads":     "GAP: prod has 31 rows",
+	"users.parent_announcement_responses": "empty in prod too",
+	"users.parent_announcement_targets":   "GAP: prod has 4 rows",
+	"users.parent_announcements":          "GAP: prod has 1 rows",
+	"users.parent_message_reads":          "GAP: prod has 352 rows",
+	"users.persons_guardians":             "empty in prod too",
+	"users.profiles":                      "GAP: prod has 1 rows",
+	"users.staff_document_file_cleanup":   "empty in prod too",
+	"users.staff_documents":               "empty in prod too",
+	"users.staff_financial_data":          "empty in prod too",
+	"users.staff_master_data":             "GAP: prod has 9 rows",
+	"users.staff_qualifications":          "empty in prod too",
+	"users.student_companions":            "empty in prod too",
+	"users.student_data_change_requests":  "GAP: prod has 97 rows",
+	"users.student_document_file_cleanup": "empty in prod too",
+	"users.student_documents":             "empty in prod too",
+}
+
+// tableCoverageQuery lists every application table. Views and system schemas
+// stay out: the ratchet is about data the seeder produces.
+const tableCoverageQuery = `
+	SELECT table_schema, table_name
+	FROM information_schema.tables
+	WHERE table_type = 'BASE TABLE'
+	  AND table_schema NOT IN ('pg_catalog', 'information_schema')
+	  AND table_schema NOT LIKE 'pg\_%'
+	ORDER BY table_schema, table_name`
+
+func TestSeedCoverageRatchet(t *testing.T) {
+	t.Parallel()
+
+	dsn := strings.TrimSpace(os.Getenv("SEED_COVERAGE_DSN"))
+	if dsn == "" {
+		t.Skip("SEED_COVERAGE_DSN not set: needs a seeded stack (migrate reset + seed + simulate full-day)")
+	}
+
+	db := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query(tableCoverageQuery)
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var schema, name string
+		if scanErr := rows.Scan(&schema, &name); scanErr != nil {
+			t.Fatalf("scan table row: %v", scanErr)
+		}
+		tables = append(tables, schema+"."+name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate tables: %v", err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close table cursor: %v", err)
+	}
+	if len(tables) == 0 {
+		t.Fatal("no application tables found: is SEED_COVERAGE_DSN pointing at a migrated database?")
+	}
+
+	var uncovered, stale []string
+	for _, table := range tables {
+		schema, name, _ := strings.Cut(table, ".")
+		var filled bool
+		query := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %q.%q)`, schema, name)
+		if err := db.QueryRow(query).Scan(&filled); err != nil {
+			t.Fatalf("probe %s: %v", table, err)
+		}
+		_, allowed := seedCoverageAllowlist[table]
+		switch {
+		case !filled && !allowed:
+			uncovered = append(uncovered, table)
+		case filled && allowed:
+			stale = append(stale, table)
+		}
+	}
+	sort.Strings(uncovered)
+	sort.Strings(stale)
+
+	if len(uncovered) > 0 {
+		t.Errorf("%d table(s) hold no seeded data and are not allowlisted:\n  %s\n\n"+
+			"Fix: teach the seeder (backend/seed/api) or the simulator (backend/simulate) to\n"+
+			"produce this data. Only if that is genuinely impossible, add the table to\n"+
+			"seedCoverageAllowlist with a reason.",
+			len(uncovered), strings.Join(uncovered, "\n  "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("%d allowlisted table(s) now hold data: remove them from seedCoverageAllowlist:\n  %s",
+			len(stale), strings.Join(stale, "\n  "))
+	}
+
+	t.Logf("seed coverage: %d/%d tables filled, %d allowlisted",
+		len(tables)-len(seedCoverageAllowlist), len(tables), len(seedCoverageAllowlist))
+}

--- a/backend/seed/api/coverage_ratchet_test.go
+++ b/backend/seed/api/coverage_ratchet_test.go
@@ -115,8 +115,6 @@ var seedCoverageAllowlist = map[string]string{
 	"platform.operator_passkey_credentials": "GAP: prod has 1 rows",
 	"platform.operator_passkey_sessions":    "GAP: prod has 4 rows",
 
-	"public.bun_migration_locks": "empty in prod too",
-
 	"schedule.activity_exceptions":              "GAP: prod has 2 rows",
 	"schedule.calendar_periods":                 "GAP: prod has 10 rows",
 	"schedule.closing_days":                     "GAP: prod has 3 rows",
@@ -163,14 +161,19 @@ var seedCoverageAllowlist = map[string]string{
 	"users.student_documents":             "empty in prod too",
 }
 
-// tableCoverageQuery lists every application table. Views and system schemas
-// stay out: the ratchet is about data the seeder produces.
+// tableCoverageQuery lists every application table. Views, system schemas, and
+// Bun's migration bookkeeping stay out: the ratchet is about data the seeder
+// produces.
 const tableCoverageQuery = `
 	SELECT table_schema, table_name
 	FROM information_schema.tables
 	WHERE table_type = 'BASE TABLE'
 	  AND table_schema NOT IN ('pg_catalog', 'information_schema')
 	  AND table_schema NOT LIKE 'pg\_%'
+	  AND (table_schema, table_name) NOT IN (
+		('public', 'bun_migrations'),
+		('public', 'bun_migration_locks')
+	)
 	ORDER BY table_schema, table_name`
 
 func TestSeedCoverageRatchet(t *testing.T) {
@@ -206,7 +209,17 @@ func TestSeedCoverageRatchet(t *testing.T) {
 		t.Fatal("no application tables found: is SEED_COVERAGE_DSN pointing at a migrated database?")
 	}
 
-	var uncovered, stale []string
+	discovered := make(map[string]struct{}, len(tables))
+	for _, table := range tables {
+		discovered[table] = struct{}{}
+	}
+
+	var uncovered, stale, unknownAllowlist []string
+	for table := range seedCoverageAllowlist {
+		if _, ok := discovered[table]; !ok {
+			unknownAllowlist = append(unknownAllowlist, table)
+		}
+	}
 	for _, table := range tables {
 		schema, name, _ := strings.Cut(table, ".")
 		var filled bool
@@ -224,6 +237,7 @@ func TestSeedCoverageRatchet(t *testing.T) {
 	}
 	sort.Strings(uncovered)
 	sort.Strings(stale)
+	sort.Strings(unknownAllowlist)
 
 	if len(uncovered) > 0 {
 		t.Errorf("%d table(s) hold no seeded data and are not allowlisted:\n  %s\n\n"+
@@ -235,6 +249,10 @@ func TestSeedCoverageRatchet(t *testing.T) {
 	if len(stale) > 0 {
 		t.Errorf("%d allowlisted table(s) now hold data: remove them from seedCoverageAllowlist:\n  %s",
 			len(stale), strings.Join(stale, "\n  "))
+	}
+	if len(unknownAllowlist) > 0 {
+		t.Errorf("%d seedCoverageAllowlist entry or entries do not name an application table:\n  %s",
+			len(unknownAllowlist), strings.Join(unknownAllowlist, "\n  "))
 	}
 
 	t.Logf("seed coverage: %d/%d tables filled, %d allowlisted",

--- a/backend/seed/api/parent_enrollment.go
+++ b/backend/seed/api/parent_enrollment.go
@@ -707,6 +707,7 @@ func (s parentEnrollmentSeedStep) seedParentPortalActions(rt *Runtime, parentAut
 			body: map[string]any{
 				"date":        time.Now().AddDate(0, 0, 3).Format("2006-01-02"),
 				"pickup_time": "14:30",
+				"reason":      "Demo-Abholänderung aus dem Elternportal",
 			},
 		},
 		{


### PR DESCRIPTION
## Warum

Der Seeder ist der breiteste End-to-End-Pfad im Repo: rund hundert echte API-Calls quer durch Auth, Anmeldung, Elternportal, Zeiterfassung und IoT. Er läuft jetzt automatisch in CI und erkennt dadurch API-Contract-Brüche frühzeitig.

## Was drin ist

1. **Seeder-Fix** (`fix(seed)`): Der Abholänderungsantrag im Elternportal sendet jetzt das seit `d6152e7ae` verpflichtende Feld `reason`.

2. **CI-Job `seed-smoke`** in `.github/workflows/test.yml`:  
   Bei `run-backend` startet CI PostgreSQL und Mailpit, führt `migrate` → `serve` → `seed` → `simulate full-day` aus und prüft anschließend die Tabellenabdeckung.

3. **`TestSeedCoverageRatchet`** (`backend/seed/api/coverage_ratchet_test.go`):  
   Der Test prüft jede Anwendungstabelle:
   - Eine leere Tabelle ohne Allowlist-Eintrag schlägt fehl.
   - Ein Allowlist-Eintrag, dessen Tabelle inzwischen Daten enthält, schlägt ebenfalls fehl.
   - Jeder Allowlist-Eintrag braucht eine Begründung.
   - Nicht mehr existierende Tabellen in der Allowlist werden erkannt.

   Ohne `SEED_COVERAGE_DSN` wird der Test übersprungen; im normalen `go test ./...` ist er daher nicht aktiv.

4. **Dokumentation** in `backend/CLAUDE.md` mit Regeln für Seed-Abdeckung und lokales Ausführen des Ratchets.

## Die Basislinie

Gemessen gegen die Produktionsdatenbank am 20.08.2026, read-only und nur als Aggregate:

| | |
|---|---:|
| Tabellen gesamt | 179 |
| durch `seed` befüllt | 58 |
| zusätzlich durch `simulate full-day` | 8 |
| auf der Allowlist | 112 |
| davon mit echten Prod-Daten (`GAP:`) | **58** |

Die 58 GAP-Einträge bilden den greppbaren Backlog. Besonders große Lücken bestehen bei `users.guardian_phone_numbers`, `schedule.student_arrival_schedules`, `schedule.calendar_periods` und `enrollment.form_schemas`.

## Verifikation

Die CI-Kette kann lokal gegen einen frisch migrierten Stack ausgeführt werden:

```bash
docker compose up -d
docker compose exec server sh -c 'SEED_COVERAGE_DSN="$DB_DSN" go test ./seed/api/ -run TestSeedCoverageRatchet -v'
```

Der CI-Job verwendet dieselbe Reihenfolge:

```text
migrate → serve → seed → simulate full-day → TestSeedCoverageRatchet
```

Wichtige CI-Konfiguration:

- Mailpit ist erforderlich, weil der Seeder MFA-E-Mails ausliest.
- `OGS_DEVICE_PIN` muss mit dem Seeder-PIN übereinstimmen.
- Der Server wird aus `backend` gestartet, damit die E-Mail-Templates gefunden werden.
- Scheduler bleiben deaktiviert, damit sie die Seed-Daten vor dem Ratchet nicht verändern.
- Server-Logs werden auch bei Fehlern ausgegeben; der Server wird in jedem Fall beendet.

## Kosten und Alternative

Der Job läuft zusammen mit den Backend-Checks und dauert je nach Cache-Lage voraussichtlich etwa drei bis fünf Minuten. Ein Nightly-Job wäre günstiger, würde Seeder- und Contract-Brüche aber erst nach dem Merge erkennen.
