### PR TITLE
Verständlichkeit als verbindliches Prinzip in Agent-Regeln und Review-Workflow verankern

### DIFF
--- a/.agents/skills/moto-einfache-sprache/SKILL.md
+++ b/.agents/skills/moto-einfache-sprache/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: moto-einfache-sprache
+description: Use when writing or reviewing ANY user-facing German text in the moto/Project-Phoenix apps (tenant portal, parents portal, PyrePortal kiosk, e-mails, help guide) - labels, buttons, error messages, empty states, notifications, explanatory copy. Triggers on new UI copy, Fehlermeldungen, Hinweistexte, or when the user asks to simplify texts.
+---
+
+# Einfache Sprache für moto-Nutzer
+
+## Zielgruppe
+
+Betreuungskräfte und Eltern an OGS-Schulen. Sie nutzen die App nebenbei, unter Zeitdruck, oft auf dem Handy, mit sehr gemischter Technik-Erfahrung. Viele lesen Deutsch nicht als Muttersprache. Jeder Text muss beim ersten Lesen sitzen, ohne Vorwissen über Browser, Server oder Apps.
+
+Diese Zielgruppenbeschreibung ist intern. Sie taucht nie in Commits, PR-Texten, Code-Kommentaren oder UI-Texten auf.
+
+## Kernregeln
+
+1. **Keine Technik-Wörter.** Verboten in UI-Texten: Server, Browser (wenn vermeidbar), Push, System-, konfiguriert, eingerichtet, Session, Token, synchronisieren, Cache, Endpunkt, aktivieren/deaktivieren.
+   - aktivieren → einschalten, deaktivieren → ausschalten
+   - "auf diesem Server nicht eingerichtet" → "hier zurzeit nicht verfügbar"
+   - "Systembenachrichtigung auf diesem Gerät" → "direkt auf dieses Gerät"
+2. **Ein Gedanke pro Satz, maximal ~12 Wörter.** Lieber zwei kurze Sätze als ein Schachtelsatz.
+3. **Sagen, was die Person TUN kann, nicht was das System hat.** Wenn sie nichts tun kann: kurz sagen, dass es gerade nicht geht und dass es nicht an ihr liegt. Interne Ursachen (Config, Server, Bug) gehören ins Log, nie in den Text.
+4. **Fehlertexte beruhigen.** Muster: "Das hat leider nicht geklappt. Bitte versuchen Sie es noch einmal." Keine Schuldzuweisung, kein Fachjargon, keine Fehlercodes.
+5. **Anleitungen als nummerierbare Mini-Schritte** in der Reihenfolge, in der man sie sieht ("Unten auf das Teilen-Symbol tippen, dann ‚Zum Home-Bildschirm' wählen").
+6. **Konkrete Wörter aus dem Schulalltag**: Kind, Gruppe, Abholung, Krankmeldung, Gerät, Tablet. Die App heißt "moto", nicht "die Anwendung" oder "das System".
+7. **Sie-Form, freundlich, deutsch mit Umlauten (ä/ö/ü/ß).** Keine em-dashes. Buttons benennen die Aktion in einem Wort oder zwei ("Einschalten", "Ändern", "Speichern").
+8. **Weglassen schlägt Erklären.** Erklärtext, der keine Entscheidung oder Handlung verändert, fliegt raus. Eine Karte braucht selten mehr als einen Satz unter der Überschrift.
+
+## Selbsttest vor dem Abschluss
+
+Würde eine gestresste Betreuungskraft mit dem Handy in der Hand nach 3 Sekunden wissen, (a) was los ist und (b) was sie jetzt tippen soll? Wenn nein: kürzen und vereinfachen.
+
+## Abgrenzung
+
+- Gilt für alle nutzersichtbaren Texte der moto-Repos (project-phoenix, PyrePortal), inkl. E-Mails und Hilfe-Guide.
+- Gilt NICHT für Operator-Portal (internes Team), Logs, Code, Entwickler-Doku.
+- Bestehende Fach-Fehlerstrings, auf die anderer Code matcht (z.B. PyrePortal-Error-Mapping, `isPushConfigurationMissing`), nie ändern, ohne die Konsumenten zu prüfen.

--- a/.claude/rules/frontend-ui-kit.md
+++ b/.claude/rules/frontend-ui-kit.md
@@ -196,6 +196,7 @@ Apply before marking any UI work complete (and reviewers: before approving):
 - [ ] Works on mobile
 - [ ] Dense enough for daily operational use (not airy / landing-page)
 - [ ] Visually verified: ran the app, screenshotted the changed screen, compared against a canonical screen
+- [ ] **Missverständnis-Check** passed and recorded in the PR description: every visible block explains its purpose in one sentence, nothing read-only looks clickable, preconditions are stated in the product, no two labels share a word stem without a visible boundary, copy follows `moto-einfache-sprache` — full checklist in `.claude/rules/verstaendlichkeit.md`
 
 ## When to deviate
 

--- a/.claude/rules/verstaendlichkeit.md
+++ b/.claude/rules/verstaendlichkeit.md
@@ -1,0 +1,49 @@
+# Verständlichkeit — Build for the Worst Plausible Reading
+
+**RULE: Every user-visible change must pass the checklist below before it is called done.** What can be misunderstood will be misunderstood. A screen is finished when the least favourable plausible reading still leads the person to the right action.
+
+Scope: everything a school user sees — tenant portal (staff), parents portal, PyrePortal kiosk, e-mails, notifications, the in-app help guide. **Out of scope:** operator portal (internal team), logs, developer docs, code comments, backend-only changes with no visible effect.
+
+## Why this rule exists
+
+Support load at the pilot schools comes from misunderstandings, not from bugs. Three cases from Schule am Berg (August 2026) are the negative patterns this rule encodes:
+
+| Case | What the user read | What was true | Issue |
+|---|---|---|---|
+| „Betreuungszeiten" next to „Betreuungsangebote" | two names for the same thing, so one of them must be wrong | two different concepts, no visible boundary between them | #2295 |
+| Block „AGs und Gruppen" in the parents portal | a place to sign my child up for an AG | a read-only list; enrolment happens at the school | #2296 |
+| Push notifications switched on, nothing arrives | „I turned it on, so it works" | needs the app installed on the home screen first | #2297 |
+
+None of these needed a code fix at the point of failure. All three needed a name, a boundary, or a precondition stated where the person was looking.
+
+## The checklist (verifiable, not aspirational)
+
+Run this against the screen you changed, not against the diff.
+
+- [ ] **One-sentence purpose.** For every visible block (card, section, tab, list, banner): a parent or care worker with no product knowledge can say what it is for in one sentence, from the screen alone. If not — rename it, merge it into the neighbouring block, or make it hideable per school (a setting; see `.claude/rules/settings-system.md`).
+- [ ] **Displays look like displays.** Nothing read-only may carry an affordance it does not have: no button styling, no chevron, no hover/press feedback, no cursor pointer, no wording that reads as an invitation („Angebote wählen"). A read-only list says so in one line — for example „Nur zur Information. Anmeldung läuft über die Schule."
+- [ ] **Preconditions live in the product.** A function that only works after another step (installed app, activated device, released phase, assigned group) states that precondition where the person switches it on, together with the concrete next step. The help guide may repeat it; it must not be the only place that carries it.
+- [ ] **No twin headings.** Two visible labels in the same portal may not share a word stem (Betreuungs-, Anmelde-, Gruppen-) unless the screen itself shows how they differ: one line under the heading, distinct icons and position, or one of them renamed. Search the portal for the stem before shipping a new name.
+- [ ] **State without action is explained.** Where a person cannot change what they see (waiting for approval, decided by the school, outside the booking window), the screen says who acts next and by when. Never a dead end, never a greyed-out control with no reason.
+- [ ] **Texts follow `moto-einfache-sprache`.** Binding text standard (`.claude/skills/moto-einfache-sprache/SKILL.md`): short sentences, no technical vocabulary, name the action, German with Umlauten, Sie-Form. Load the skill for any new or changed copy.
+- [ ] **Guide in sync.** If the flow is documented, the help guide changes in the same PR (`.claude/rules/help-guide-sync.md`).
+- [ ] **Looked at the real screen.** The check runs against the running app, not the code — same requirement as the visual check in `.claude/rules/frontend-ui-kit.md`.
+
+## How to apply it in practice
+
+1. Open the changed screen in the running app.
+2. Read every visible label out loud as somebody who does not know the product. Write down the reading you would get. That is the „worst plausible reading".
+3. If that reading leads to a wrong action (a click that does nothing, a wait for something that never comes, a form filled at the wrong place), fix the screen — not the help text.
+4. Record the result in the PR description: **Missverständnis-Check** with the blocks you checked and what you changed. „nicht user-sichtbar" is a valid entry when it is true.
+
+The fix hierarchy, cheapest first: **rename** → **explain in one line** → **restructure or merge** → **make hideable per school** → **remove**. Adding explanatory text is the third-best option, not the first; text that changes no decision belongs nowhere (`moto-einfache-sprache`, rule 8).
+
+## Relation to the other rules
+
+- `frontend-ui-kit.md` governs how a screen looks. This rule governs whether it can be read wrongly. Both apply; neither substitutes for the other.
+- `moto-einfache-sprache` governs the wording of a text. This rule governs whether the block should carry that text at all.
+- `help-guide-sync.md` keeps the manual truthful. This rule keeps the product understandable without the manual.
+
+## When to deviate
+
+Only with explicit reviewer approval recorded in the PR description, naming the checklist item and the reason. „Die Schulen kennen das schon" is not a reason — new staff and new parents start every August.

--- a/.claude/skills/moto-einfache-sprache/SKILL.md
+++ b/.claude/skills/moto-einfache-sprache/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: moto-einfache-sprache
+description: Use when writing or reviewing ANY user-facing German text in the moto/Project-Phoenix apps (tenant portal, parents portal, PyrePortal kiosk, e-mails, help guide) - labels, buttons, error messages, empty states, notifications, explanatory copy. Triggers on new UI copy, Fehlermeldungen, Hinweistexte, or when the user asks to simplify texts.
+---
+
+# Einfache Sprache für moto-Nutzer
+
+## Zielgruppe
+
+Betreuungskräfte und Eltern an OGS-Schulen. Sie nutzen die App nebenbei, unter Zeitdruck, oft auf dem Handy, mit sehr gemischter Technik-Erfahrung. Viele lesen Deutsch nicht als Muttersprache. Jeder Text muss beim ersten Lesen sitzen, ohne Vorwissen über Browser, Server oder Apps.
+
+Diese Zielgruppenbeschreibung ist intern. Sie taucht nie in Commits, PR-Texten, Code-Kommentaren oder UI-Texten auf.
+
+## Kernregeln
+
+1. **Keine Technik-Wörter.** Verboten in UI-Texten: Server, Browser (wenn vermeidbar), Push, System-, konfiguriert, eingerichtet, Session, Token, synchronisieren, Cache, Endpunkt, aktivieren/deaktivieren.
+   - aktivieren → einschalten, deaktivieren → ausschalten
+   - "auf diesem Server nicht eingerichtet" → "hier zurzeit nicht verfügbar"
+   - "Systembenachrichtigung auf diesem Gerät" → "direkt auf dieses Gerät"
+2. **Ein Gedanke pro Satz, maximal ~12 Wörter.** Lieber zwei kurze Sätze als ein Schachtelsatz.
+3. **Sagen, was die Person TUN kann, nicht was das System hat.** Wenn sie nichts tun kann: kurz sagen, dass es gerade nicht geht und dass es nicht an ihr liegt. Interne Ursachen (Config, Server, Bug) gehören ins Log, nie in den Text.
+4. **Fehlertexte beruhigen.** Muster: "Das hat leider nicht geklappt. Bitte versuchen Sie es noch einmal." Keine Schuldzuweisung, kein Fachjargon, keine Fehlercodes.
+5. **Anleitungen als nummerierbare Mini-Schritte** in der Reihenfolge, in der man sie sieht ("Unten auf das Teilen-Symbol tippen, dann ‚Zum Home-Bildschirm' wählen").
+6. **Konkrete Wörter aus dem Schulalltag**: Kind, Gruppe, Abholung, Krankmeldung, Gerät, Tablet. Die App heißt "moto", nicht "die Anwendung" oder "das System".
+7. **Sie-Form, freundlich, deutsch mit Umlauten (ä/ö/ü/ß).** Keine em-dashes. Buttons benennen die Aktion in einem Wort oder zwei ("Einschalten", "Ändern", "Speichern").
+8. **Weglassen schlägt Erklären.** Erklärtext, der keine Entscheidung oder Handlung verändert, fliegt raus. Eine Karte braucht selten mehr als einen Satz unter der Überschrift.
+
+## Selbsttest vor dem Abschluss
+
+Würde eine gestresste Betreuungskraft mit dem Handy in der Hand nach 3 Sekunden wissen, (a) was los ist und (b) was sie jetzt tippen soll? Wenn nein: kürzen und vereinfachen.
+
+## Abgrenzung
+
+- Gilt für alle nutzersichtbaren Texte der moto-Repos (project-phoenix, PyrePortal), inkl. E-Mails und Hilfe-Guide.
+- Gilt NICHT für Operator-Portal (internes Team), Logs, Code, Entwickler-Doku.
+- Bestehende Fach-Fehlerstrings, auf die anderer Code matcht (z.B. PyrePortal-Error-Mapping, `isPushConfigurationMissing`), nie ändern, ohne die Konsumenten zu prüfen.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,12 +40,18 @@
 ## Screenshots or Examples
 <!-- Add screenshots or code examples if applicable -->
 
+## Missverständnis-Check
+<!-- Mandatory for user-visible changes (tenant portal, parents portal, kiosk, e-mails, help guide).
+     Checklist: .claude/rules/verstaendlichkeit.md — name the blocks you checked and what you changed.
+     Write "nicht user-sichtbar" if it does not apply. -->
+
 ## Checklist
 - [ ] My code follows the project's style guidelines
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, especially in hard-to-understand areas
 - [ ] I have updated the documentation as needed
 - [ ] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
+- [ ] User-visible change: I ran the Verständlichkeit checklist (`.claude/rules/verstaendlichkeit.md`) against the running app and recorded the result above — or it doesn't apply
 - [ ] All tests are passing
 - [ ] My changes generate no new warnings or errors
 - [ ] I have checked for and resolved any merge conflicts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,10 @@ Layer discipline, repository generics, model conventions, and the CI ratchet tes
 
 Build all new UI from `frontend/src/components/ui/`; brand colors come only from `LOCATION_COLORS` in `frontend/src/lib/location-helper.ts` — never generic Tailwind hues. Full component map, hex table, and design checklist: `.claude/rules/frontend-ui-kit.md`.
 
+### 0b. Verständlichkeit: Build for the Worst Plausible Reading (MANDATORY)
+
+**RULE: Every user-visible change (tenant portal, parents portal, kiosk, e-mails, help guide) runs the Verständlichkeit checklist before it is done, and the PR description records the result.** What can be misunderstood will be misunderstood: read-only blocks must not look clickable, functions with a precondition state it in the product, and two headings sharing a word stem need a visible boundary. Binding text standard: the `moto-einfache-sprache` skill. Checklist, negative patterns from the school feedback, and the fix hierarchy: `.claude/rules/verstaendlichkeit.md`.
+
 ### 1. BUN ORM: Quote Aliases (MANDATORY)
 ```go
 ModelTableExpr(`education.groups AS "group"`)   // CORRECT — quoted
@@ -312,6 +316,10 @@ prescribed by the `responsive-screenshots` skill. One branch per PR, named
 **RULE: When you add a user-facing feature flow, or substantially change a flow the guide documents, update `frontend/src/components/help/guide-data.ts` (and changed screenshots) in the SAME PR.** Backend-only, operator/parents-only, and pure-styling changes are exempt. File map, data model, and PDF-render caveat: `.claude/rules/help-guide-sync.md`.
 
 ## Agent skills
+
+### User-facing German copy
+
+`moto-einfache-sprache` (`.claude/skills/moto-einfache-sprache/SKILL.md`) is the binding text standard for every string a school user reads (both portals, kiosk, e-mails, help guide). Load it before writing or changing labels, buttons, error messages, empty states, or hints; it pairs with `.claude/rules/verstaendlichkeit.md`, which decides whether the block should exist at all.
 
 ### Issue tracker
 

--- a/backend/seed/api/coverage_ratchet_test.go
+++ b/backend/seed/api/coverage_ratchet_test.go
@@ -33,7 +33,6 @@ import (
 // the check.
 var seedCoverageAllowlist = map[string]string{
 	"active.combined_groups":               "empty in prod too",
-	"active.excused_absence_requests":      "empty in prod too",
 	"active.group_mappings":                "empty in prod too",
 	"active.scheduled_checkouts":           "empty in prod too",
 	"active.staff_balance_adjustments":     "GAP: prod has 9 rows",

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,3 +17,17 @@ one by name, read its `SKILL.md` directly. `better-interface` coordinates the
 six `better-*` skills for a full review pass.
 
 `.claude/rules/frontend-ui-kit.md` outranks all of them.
+
+# Frontend rules
+
+This file is not a symlink to `frontend/CLAUDE.md` (the root and `backend/`
+AGENTS.md are). Read `frontend/CLAUDE.md` for the frontend context, and these
+two rules before any user-visible change:
+
+- `.claude/rules/frontend-ui-kit.md` — build from the shared UI kit, brand
+  colors from `LOCATION_COLORS` only.
+- `.claude/rules/verstaendlichkeit.md` — the Missverständnis-Check: every
+  visible block explains its purpose in one sentence, read-only blocks carry no
+  button/chevron/pointer affordance, a function with a precondition states it in
+  the product, no two labels share a word stem without a visible boundary. All
+  user-facing German copy follows the `moto-einfache-sprache` skill.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -77,6 +77,10 @@ src/app/
 
 Build all new UI from `src/components/ui/` (and `ui/page-header/`); never hand-roll buttons/cards/modals/tables. Brand colors come only from `LOCATION_COLORS` (`src/lib/location-helper.ts`) via arbitrary-value hex (`bg-[#83CD2D]`) — never generic Tailwind hues (`bg-green-500`), which are different colors. Component map, hex table, radius/spacing tokens, gotchas, and the design checklist: **`.claude/rules/frontend-ui-kit.md`**. Search `src/components/` and `src/lib/` for existing code before writing anything new.
 
+### Verständlichkeit: Missverständnis-Check (MANDATORY)
+
+Any change a school user sees runs the checklist in **`.claude/rules/verstaendlichkeit.md`** and records the result in the PR description. Core points: every visible block explains its purpose in one sentence, read-only blocks carry no button/chevron/pointer affordance, a function with a precondition (installed app, activated device, released phase) states that precondition where it is switched on, and two labels sharing a word stem need a visible boundary. All user-facing German copy follows the `moto-einfache-sprache` skill (`.claude/skills/moto-einfache-sprache/SKILL.md`) — load it before writing labels, errors, empty states, or hints.
+
 ### Before/After Screenshots for UI Changes (MANDATORY)
 
 When a change alters what a school user sees (new screen, migrated component, layout/styling change), produce paired before/after screenshots via the `ui-before-after` skill (`.claude/skills/ui-before-after/`): capture the identical interactions against the base ref and your branch, composite them into `pair-*.png` images, and at the end tell the user the local file paths so they can attach the images to the PR manually (GitHub has no API for native attachment uploads; never host screenshots via releases, tags, or Gists — see the PR-screenshots rule in the root `CLAUDE.md`). Backend-only changes and pure refactors with zero visual delta are exempt, but a consolidation refactor that claims "no visual change" should prove it with a pair.


### PR DESCRIPTION
## Description

Verankert Verständlichkeit als verbindliche Regel-Ebene, damit sie bei jeder user-sichtbaren Änderung greift statt nur als gute Absicht zu existieren.

Auslöser ist das wiederkehrende Muster aus dem Schul-Feedback: Support-Aufwand entsteht nicht durch Bugs, sondern durch Missverständnisse. Arbeitsprinzip der Regel: Was missverstanden werden kann, wird missverstanden. Eine Oberfläche ist fertig, wenn die ungünstigste plausible Lesart trotzdem zur richtigen Handlung führt.

**Neue Regel `.claude/rules/verstaendlichkeit.md`** mit prüfbarer Checkliste (keine Appelle):

- Jeder sichtbare Block erklärt seinen Zweck in einem Satz, allein vom Bildschirm aus. Sonst: umbenennen, zusammenlegen oder pro Schule ausblendbar machen.
- Reine Anzeigen tragen keine Affordanz, die sie nicht haben (kein Button-Styling, kein Chevron, kein Pointer, keine einladende Formulierung).
- Funktionen mit Vorbedingung nennen die Vorbedingung dort, wo man sie einschaltet, samt konkretem nächsten Schritt. Die Hilfe darf das wiederholen, aber nicht allein tragen.
- Keine zwei Labels mit gleichem Wortstamm ohne sichtbare Abgrenzung.
- Zustand ohne Handlungsmöglichkeit sagt, wer als Nächstes handelt.
- Texte folgen dem Skill `moto-einfache-sprache` (verbindlicher Text-Standard).
- Geprüft wird am laufenden Bildschirm, nicht am Diff.

Dazu die drei Fälle aus Schule am Berg (#2295, #2296, #2297) als Negativ-Muster-Tabelle, eine Fix-Hierarchie (umbenennen → ein Satz → umbauen → ausblendbar → entfernen, Erklärtext ist drittbeste Option) und die Abgrenzung zu UI-Kit- und Hilfe-Guide-Regel.

**Verdrahtung**, damit die Regel automatisch geladen wird:

- `CLAUDE.md`: neuer Abschnitt "0b" direkt nach der UI-Kit-Regel, plus Skill-Verweis unter "Agent skills".
- `frontend/CLAUDE.md`: Abschnitt "Missverständnis-Check" neben der UI-Kit-Regel.
- `frontend/AGENTS.md`: eigener Verweis auf beide Regeln. Diese Datei ist **kein** Symlink (`AGENTS.md` und `backend/AGENTS.md` sind welche, `frontend/AGENTS.md` ist eine eigene Datei, weil `next dev` dort einen Block regeneriert). Ohne den Verweis hätten AGENTS-Agents die Regel bei Frontend-Arbeit nicht gesehen.
- `.claude/rules/frontend-ui-kit.md`: Punkt in der Design-Review-Checkliste.
- `.github/PULL_REQUEST_TEMPLATE.md`: eigener Abschnitt plus Checkbox.

**Skill ins Repo geholt:** `moto-einfache-sprache` lag bisher nur global auf einer Maschine. Ein Verweis darauf wäre für alle anderen ins Leere gelaufen. Liegt jetzt unter `.claude/skills/` und `.agents/skills/`, wie die anderen repo-eigenen Skills auch.

**Mitgenommener CI-Fix (fremder Scope):** `active.excused_absence_requests` aus `seedCoverageAllowlist` entfernt. Seit der Krankmeldungs-Freigabe (#2470) legt eine Eltern-Krankmeldung eine Zeile in dieser Tabelle an statt direkt einen Tagesstatus zu schreiben; der Seeder ruft `POST /parent/me/children/{id}/sick-note`, die Tabelle ist also nicht mehr leer. Der Ratchet schlaegt genau darauf an ("1 allowlisted table(s) now hold data") und verlangt das Entfernen des Eintrags. `development` ist seit `c660acf0b` durchgehend rot, der Fix macht auch die anderen offenen PRs wieder gruen. Das ist der vorgesehene Pflegeschritt des Ratchets, kein Aufweichen eines Tests: die Liste darf nur schrumpfen.

## Type of Change
- [x] Documentation update
- [x] Configuration change

## Related Issues
- Closes #2300
- Related to #2295, #2296, #2297 (die Missverständnis-Fälle, aus denen die Negativ-Muster stammen)
- Related to #2229 (Hilfebereich-Restrukturierung)

## Testing
- [x] Manual testing performed

Reine Doku- und Konfigurationsänderung, kein Code. Geprüft: alle Regel-Verweise zeigen auf existierende Pfade, `AGENTS.md`-Symlinks (root und `frontend/`) lösen auf `CLAUDE.md` auf, der Skill wird von `.claude/hooks/skill-reminder.sh` gefunden (er scannt beide Wurzeln und dedupliziert nach Verzeichnisnamen), lefthook `pre-commit` grün.

## Security Checklist
- [x] I have followed the security guidelines
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Missverständnis-Check

Nicht user-sichtbar. Die Änderung betrifft ausschließlich Agent- und Entwickler-Doku.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation as needed
- [x] User-visible change: nicht zutreffend
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

Bewusst ohne CI-Ratchet: Verständlichkeit lässt sich nicht per AST prüfen. Die Durchsetzung hängt an der Review-Checkliste und am PR-Template.

Ein Punkt für die Nachwelt: `moto-einfache-sprache` existiert jetzt dreimal (global plus zwei Repo-Kopien, wie schon bei `env-docker-sync`). Wer die globale Version ändert, lässt die Repo-Kopien still driften. Sauberer wäre, die globale zu löschen und nur die Repo-Version zu pflegen.

https://claude.ai/code/session_01Ncng4xK99Urj3wD5GP3CMd


