### PR TITLE
fix: reconcile successful supervision roster actions

### DIFF
--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part13.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.part13.test.tsx
@@ -313,6 +313,8 @@ vi.mock("~/lib/student-api", () => ({
 vi.mock("~/lib/timetable-operations-api", () => ({
   timetableOperationsApi: {
     checkIn: vi.fn(),
+    checkOut: vi.fn(),
+    patchAttendance: vi.fn(),
     plannedNow: vi.fn(() => Promise.resolve([])),
   },
   isReopenUnavailableError: vi.fn(() => false),
@@ -326,8 +328,9 @@ import {
 import { timetableOperationsApi } from "~/lib/timetable-operations-api";
 import MeinRaumPage from "./page";
 
-describe("MeinRaumPage auto-move notice (#2386)", () => {
+describe("MeinRaumPage roster actions", () => {
   const mockMutate = vi.fn();
+  const mockRosterMutate = vi.fn();
 
   const dashboardData = {
     supervisedGroups: [
@@ -349,7 +352,7 @@ describe("MeinRaumPage auto-move notice (#2386)", () => {
     planned: true,
     isUnplanned: false,
     currentlyPresent: false,
-    visitId: null,
+    visitId: null as string | null,
     status: "expected",
     substatus: null,
     note: null,
@@ -381,6 +384,8 @@ describe("MeinRaumPage auto-move notice (#2386)", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMutate.mockResolvedValue(undefined);
+    mockRosterMutate.mockResolvedValue(undefined);
     vi.mocked(useAttendanceWebEnabled).mockReturnValue(true);
     vi.mocked(useShowTimetableCounts).mockReturnValue(true);
     navigationMockState.roomParam = null;
@@ -405,7 +410,7 @@ describe("MeinRaumPage auto-move notice (#2386)", () => {
             : { instance: rosterInstance, rows: primaryRosterRows },
           isLoading: false,
           error: null,
-          mutate: mockMutate,
+          mutate: mockRosterMutate,
           isValidating: false,
         };
       }
@@ -421,6 +426,7 @@ describe("MeinRaumPage auto-move notice (#2386)", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it("shows the origin of an auto-moved child after check-in", async () => {
@@ -473,6 +479,117 @@ describe("MeinRaumPage auto-move notice (#2386)", () => {
       expect(timetableOperationsApi.checkIn).toHaveBeenCalledWith("99", "100");
     });
     expect(screen.queryByTestId("alert-info")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["check-in", "Einchecken", expectedRow, "checkIn", null],
+    [
+      "check-out",
+      "Raum verlassen",
+      {
+        ...expectedRow,
+        currentlyPresent: true,
+        visitId: "visit-100",
+        status: "present",
+      },
+      "checkOut",
+      null,
+    ],
+    [
+      "excused",
+      "Entschuldigt",
+      expectedRow,
+      "patchAttendance",
+      { status: "absent", substatus: "excused" },
+    ],
+    [
+      "absent",
+      "Abwesend",
+      expectedRow,
+      "patchAttendance",
+      { status: "absent" },
+    ],
+    [
+      "expected",
+      "Zurück auf erwartet",
+      { ...expectedRow, status: "absent" },
+      "patchAttendance",
+      { status: "expected", substatus: null, note: null },
+    ],
+  ] as const)(
+    "reloads after a successful %s when the local roster update fails",
+    async (_action, buttonName, row, apiMethod, expectedPayload) => {
+      primaryRosterRows = [row];
+      const updatedRoster = {
+        instance: rosterInstance,
+        rows: [row],
+        movedFrom: null,
+      };
+      if (apiMethod === "checkIn") {
+        vi.mocked(timetableOperationsApi.checkIn).mockResolvedValue(
+          updatedRoster as never,
+        );
+      } else if (apiMethod === "checkOut") {
+        vi.mocked(timetableOperationsApi.checkOut).mockResolvedValue(
+          updatedRoster as never,
+        );
+      } else {
+        vi.mocked(timetableOperationsApi.patchAttendance).mockResolvedValue(
+          undefined,
+        );
+      }
+      mockRosterMutate.mockRejectedValueOnce(
+        new TypeError("undefined is not a function (near '...[t,r,n,a]...')"),
+      );
+      const reload = vi
+        .spyOn(window.location, "reload")
+        .mockImplementation(() => undefined);
+
+      render(<MeinRaumPage />);
+      fireEvent.click(await screen.findByRole("button", { name: buttonName }));
+
+      await waitFor(() => {
+        if (apiMethod === "checkIn") {
+          expect(timetableOperationsApi.checkIn).toHaveBeenCalledWith(
+            "99",
+            "100",
+          );
+        } else if (apiMethod === "checkOut") {
+          expect(timetableOperationsApi.checkOut).toHaveBeenCalledWith(
+            "99",
+            "100",
+          );
+        } else {
+          expect(timetableOperationsApi.patchAttendance).toHaveBeenCalledWith(
+            "99",
+            "100",
+            expectedPayload,
+          );
+        }
+        expect(reload).toHaveBeenCalledOnce();
+      });
+      expect(screen.queryByTestId("alert-error")).not.toBeInTheDocument();
+    },
+  );
+
+  it("reports a failed server action without reloading", async () => {
+    vi.mocked(timetableOperationsApi.checkIn).mockRejectedValue(
+      new Error("request failed"),
+    );
+    const reload = vi
+      .spyOn(window.location, "reload")
+      .mockImplementation(() => undefined);
+
+    render(<MeinRaumPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Einchecken" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("alert-error")).toHaveTextContent(
+        "Aktion im Betreuungsplan konnte nicht ausgeführt werden.",
+      );
+    });
+    expect(reload).not.toHaveBeenCalled();
+    expect(mockRosterMutate).not.toHaveBeenCalled();
   });
 
   it("shows the origin notice when an unplanned child is added", async () => {

--- a/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/active-supervisions/page.tsx
@@ -376,6 +376,39 @@ function RosterSummaryStat({
 type RosterAction =
   "check-in" | "check-out" | "excused" | "absent" | "expected";
 
+async function runRosterActionRequest(
+  action: RosterAction,
+  instanceId: string,
+  studentId: string,
+): Promise<TimetableRoster | null> {
+  if (action === "check-in") {
+    return runOwnAttendanceMutation("student_checkin", studentId, () =>
+      timetableOperationsApi.checkIn(instanceId, studentId),
+    );
+  }
+  if (action === "check-out") {
+    return runOwnAttendanceMutation("student_checkout", studentId, () =>
+      timetableOperationsApi.checkOut(instanceId, studentId),
+    );
+  }
+  if (action === "expected") {
+    await timetableOperationsApi.patchAttendance(instanceId, studentId, {
+      status: "expected",
+      substatus: null,
+      note: null,
+    });
+    return null;
+  }
+  await timetableOperationsApi.patchAttendance(
+    instanceId,
+    studentId,
+    action === "excused"
+      ? { status: "absent", substatus: "excused" }
+      : { status: "absent" },
+  );
+  return null;
+}
+
 interface RosterRowActionsProps {
   readonly row: TimetableRosterRow;
   readonly onAction: (
@@ -1792,50 +1825,17 @@ function MeinRaumPageContent() {
   }, [router, schulhofStatusRef]);
 
   const handleRosterAction = useCallback(
-    async (
-      action: "check-in" | "check-out" | "excused" | "absent" | "expected",
-      row: TimetableRosterRow,
-    ) => {
+    async (action: RosterAction, row: TimetableRosterRow) => {
       if (!activeTimetableInstanceId) return;
       const instanceId = activeTimetableInstanceId;
       setMoveNotice(null);
+      let roster: TimetableRoster | null;
       try {
-        if (action === "check-in") {
-          const roster = await runOwnAttendanceMutation(
-            "student_checkin",
-            row.studentId,
-            () => timetableOperationsApi.checkIn(instanceId, row.studentId),
-          );
-          if (activeTimetableInstanceIdRef.current !== instanceId) return;
-          setMoveNotice(moveNoticeFromRoster(roster, row.studentId));
-          await mutateRoster(roster, { revalidate: false });
-        } else if (action === "check-out") {
-          const roster = await runOwnAttendanceMutation(
-            "student_checkout",
-            row.studentId,
-            () => timetableOperationsApi.checkOut(instanceId, row.studentId),
-          );
-          if (activeTimetableInstanceIdRef.current !== instanceId) return;
-          await mutateRoster(roster, { revalidate: false });
-        } else if (action === "expected") {
-          await timetableOperationsApi.patchAttendance(
-            instanceId,
-            row.studentId,
-            { status: "expected", substatus: null, note: null },
-          );
-          if (activeTimetableInstanceIdRef.current !== instanceId) return;
-          await mutateRoster();
-        } else {
-          await timetableOperationsApi.patchAttendance(
-            instanceId,
-            row.studentId,
-            action === "excused"
-              ? { status: "absent", substatus: "excused" }
-              : { status: "absent" },
-          );
-          if (activeTimetableInstanceIdRef.current !== instanceId) return;
-          await mutateRoster();
-        }
+        roster = await runRosterActionRequest(
+          action,
+          instanceId,
+          row.studentId,
+        );
       } catch (err) {
         if (activeTimetableInstanceIdRef.current !== instanceId) return;
         logger.error("failed timetable roster action", {
@@ -1844,6 +1844,25 @@ function MeinRaumPageContent() {
           error: err instanceof Error ? err.message : String(err),
         });
         setError("Aktion im Betreuungsplan konnte nicht ausgeführt werden.");
+        return;
+      }
+      if (activeTimetableInstanceIdRef.current !== instanceId) return;
+      try {
+        if (action === "check-in" && roster) {
+          setMoveNotice(moveNoticeFromRoster(roster, row.studentId));
+        }
+        await (roster
+          ? mutateRoster(roster, { revalidate: false })
+          : mutateRoster());
+      } catch (err) {
+        if (activeTimetableInstanceIdRef.current !== instanceId) return;
+        logger.warn("timetable_roster_sync_failed_after_successful_action", {
+          action,
+          student_id: row.studentId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        void logger.flush();
+        window.location.reload();
       }
     },
     [activeTimetableInstanceId, activeTimetableInstanceIdRef, mutateRoster],

--- a/frontend/src/lib/logger.redaction.test.ts
+++ b/frontend/src/lib/logger.redaction.test.ts
@@ -141,4 +141,22 @@ describe("structured logger redaction", () => {
       expect.any(String),
     );
   });
+
+  it("omits keepalive for batches larger than the browser quota", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock;
+    const logger = createLogger({
+      component: "LargeClientProbe",
+      level: "debug",
+    });
+
+    logger.info("large_client_log", { detail: "x".repeat(60 * 1024) });
+    await logger.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ keepalive: false });
+  });
 });

--- a/frontend/src/lib/logger.redaction.test.ts
+++ b/frontend/src/lib/logger.redaction.test.ts
@@ -97,6 +97,7 @@ describe("structured logger redaction", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const request = fetchMock.mock.calls[0]?.[1];
+    expect(request).toMatchObject({ keepalive: true });
     const body = JSON.parse(String(request?.body)) as {
       entries: Array<Record<string, unknown>>;
     };

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -227,6 +227,8 @@ class ClientLogger implements Logger {
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly BATCH_SIZE = 10;
   private readonly BATCH_INTERVAL_MS = 5000; // 5 seconds
+  // Browsers limit all in-flight keepalive request bodies to about 64 KiB.
+  private readonly MAX_KEEPALIVE_PAYLOAD_BYTES = 60 * 1024;
 
   constructor(config: Required<LoggerConfig>) {
     this.config = config;
@@ -328,6 +330,7 @@ class ClientLogger implements Logger {
       entries: this.batch,
       timestamp: new Date().toISOString(),
     };
+    const body = JSON.stringify(payload);
 
     // Clear batch immediately (avoid duplicates)
     this.batch = [];
@@ -337,8 +340,10 @@ class ClientLogger implements Logger {
       const response = await fetch("/api/logs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        keepalive: true,
+        body,
+        keepalive:
+          new TextEncoder().encode(body).byteLength <=
+          this.MAX_KEEPALIVE_PAYLOAD_BYTES,
       });
 
       if (!response.ok) {

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -85,6 +85,9 @@ export interface Logger {
    */
   error(msg: string, context?: Record<string, unknown>): void;
 
+  /** Ship queued client logs without blocking navigation. */
+  flush(): Promise<void>;
+
   /**
    * Create child logger with merged context
    */
@@ -175,6 +178,10 @@ class ServerLogger implements Logger {
 
   error(msg: string, context?: Record<string, unknown>): void {
     this.log("error", msg, context);
+  }
+
+  flush(): Promise<void> {
+    return Promise.resolve();
   }
 
   child(context: Record<string, unknown>): Logger {
@@ -314,7 +321,7 @@ class ClientLogger implements Logger {
   /**
    * Flush batch to API endpoint
    */
-  private async flush(): Promise<void> {
+  async flush(): Promise<void> {
     if (this.batch.length === 0) return;
 
     const payload: LogBatch = {
@@ -331,6 +338,7 @@ class ClientLogger implements Logger {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
+        keepalive: true,
       });
 
       if (!response.ok) {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -74,6 +74,7 @@ vi.mock("~/lib/logger", () => {
       console.warn(msg, ctx),
     error: (msg: string, ctx?: Record<string, unknown>) =>
       console.error(msg, ctx),
+    flush: () => Promise.resolve(),
     child: () => createMockLogger(),
   });
   return {


### PR DESCRIPTION
## Summary
- separate server action failures from local roster reconciliation failures
- reload from server truth after a successful action when the local SWR update fails
- flush the structured recovery warning with a navigation-safe request
- avoid oversized `keepalive` log batches
- cover all five single-row roster actions and the true request-failure path

## Verification
- `cd frontend && pnpm run check`
- `cd frontend && pnpm test --run`
- `scripts/test-changed.sh origin/development`

Closes #2459
