### PR TITLE
fix: repair guardian enrollment account backfill

### DIFF
--- a/backend/database/migrations/001015311_guardian_enrollment_account_backfill.go
+++ b/backend/database/migrations/001015311_guardian_enrollment_account_backfill.go
@@ -36,7 +36,13 @@ func guardianEnrollmentAccountBackfillUp(ctx context.Context, db *bun.DB) error 
 		SET guardian_account_id = unique_account.account_id
 		FROM unique_accounts AS unique_account
 		WHERE request.guardian_account_id IS NULL
-		  AND LOWER(TRIM(request.guardian_email)) = unique_account.normalized_email;
+		  AND LOWER(TRIM(request.guardian_email)) = unique_account.normalized_email
+		  AND EXISTS (
+			  SELECT 1
+			  FROM users.guardian_profiles AS guardian_profile
+			  WHERE guardian_profile.account_id = unique_account.account_id
+			    AND guardian_profile.tenant_id = request.tenant_id
+		  );
 	`)
 	if err != nil {
 		return fmt.Errorf("backfill enrollment guardian account ids: %w", err)

--- a/backend/database/migrations/001015311_guardian_enrollment_account_backfill.go
+++ b/backend/database/migrations/001015311_guardian_enrollment_account_backfill.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	guardianEnrollmentAccountBackfillVersion     = "1.15.311"
+	guardianEnrollmentAccountBackfillDescription = "Link guardian-less enrollment requests to existing parent accounts (#2422)"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     guardianEnrollmentAccountBackfillVersion,
+		Description: guardianEnrollmentAccountBackfillDescription,
+		DependsOn:   []string{absenceRequestStatusVersion},
+	})
+	Migrations.MustRegister(guardianEnrollmentAccountBackfillUp, guardianEnrollmentAccountBackfillDown)
+}
+
+func guardianEnrollmentAccountBackfillUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.311: Linking guardian-less enrollment requests to parent accounts...")
+
+	result, err := db.ExecContext(ctx, `
+		WITH unique_accounts AS (
+			SELECT LOWER(TRIM(email)) AS normalized_email,
+			       MIN(id) AS account_id
+			FROM auth.accounts
+			GROUP BY LOWER(TRIM(email))
+			HAVING COUNT(*) = 1
+		)
+		UPDATE enrollment.requests AS request
+		SET guardian_account_id = unique_account.account_id
+		FROM unique_accounts AS unique_account
+		WHERE request.guardian_account_id IS NULL
+		  AND LOWER(TRIM(request.guardian_email)) = unique_account.normalized_email;
+	`)
+	if err != nil {
+		return fmt.Errorf("backfill enrollment guardian account ids: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count backfilled enrollment guardian account ids: %w", err)
+	}
+	fmt.Printf("Migration 1.15.311: Linked %d enrollment request(s) to parent accounts.\n", rows)
+	return nil
+}
+
+// The updated rows cannot be distinguished from links written by the live
+// invitation-accept flow, so clearing them on rollback would destroy valid
+// ownership data.
+func guardianEnrollmentAccountBackfillDown(_ context.Context, _ *bun.DB) error {
+	fmt.Println("Rolling back 1.15.311: no-op — enrollment ownership links are not safely reversible.")
+	return nil
+}

--- a/backend/database/migrations/001015311_guardian_enrollment_account_backfill_test.go
+++ b/backend/database/migrations/001015311_guardian_enrollment_account_backfill_test.go
@@ -1,0 +1,87 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func insertGuardianBackfillRequest(t *testing.T, db *bun.DB, phaseID int64, email string, accountID *int64) *enrollmentModels.Request {
+	t.Helper()
+	request := &enrollmentModels.Request{
+		PhaseID:           phaseID,
+		GuardianFirstName: "Guardian",
+		GuardianLastName:  "Backfill",
+		GuardianEmail:     email,
+		GuardianAccountID: accountID,
+		ConsentFlags:      map[string]any{},
+		CustomData:        map[string]any{},
+		SubmissionSource:  enrollmentModels.RequestSourcePublic,
+		SourceMetadata:    map[string]any{},
+		StatusToken:       fmt.Sprintf("guardian-account-backfill-%d", time.Now().UnixNano()),
+		SubmittedAt:       time.Now(),
+	}
+	request.SetTenantID(testpkg.Tenant(t))
+	_, err := db.NewInsert().Model(request).ModelTableExpr(`enrollment.requests AS "request"`).Exec(context.Background())
+	require.NoError(t, err)
+	return request
+}
+
+func guardianAccountIDForRequest(t *testing.T, db *bun.DB, requestID int64) *int64 {
+	t.Helper()
+	var accountID *int64
+	require.NoError(t, db.NewRaw(`
+		SELECT guardian_account_id
+		FROM enrollment.requests
+		WHERE id = ?
+	`, requestID).Scan(context.Background(), &accountID))
+	return accountID
+}
+
+func TestGuardianEnrollmentAccountBackfill(t *testing.T) {
+	t.Parallel()
+
+	db := testpkg.SetupTestDB(t)
+	phase := testpkg.CreateTestEnrollmentPhase(t, db)
+
+	uniqueAccount := testpkg.CreateTestAccount(t, db, "guardian-backfill-unique")
+	matching := insertGuardianBackfillRequest(t, db, phase.ID, "  "+strings.ToUpper(uniqueAccount.Email)+"  ", nil)
+
+	existingOwner := testpkg.CreateTestAccount(t, db, "guardian-backfill-owner")
+	alreadyLinked := insertGuardianBackfillRequest(t, db, phase.ID, uniqueAccount.Email, &existingOwner.ID)
+	unrelated := insertGuardianBackfillRequest(t, db, phase.ID, "no-account@example.invalid", nil)
+
+	ambiguousAccount := testpkg.CreateTestAccount(t, db, "guardian-backfill-ambiguous")
+	duplicate := &authModels.Account{Email: strings.ToUpper(ambiguousAccount.Email), Active: true}
+	_, err := db.NewInsert().Model(duplicate).ModelTableExpr(`auth.accounts AS "account"`).Exec(context.Background())
+	require.NoError(t, err)
+	testpkg.EnsureAccountTenant(t, db, duplicate.ID, testpkg.Tenant(t))
+	ambiguous := insertGuardianBackfillRequest(t, db, phase.ID, ambiguousAccount.Email, nil)
+
+	require.NoError(t, guardianEnrollmentAccountBackfillUp(context.Background(), db))
+
+	matchingAccountID := guardianAccountIDForRequest(t, db, matching.ID)
+	require.NotNil(t, matchingAccountID)
+	assert.Equal(t, uniqueAccount.ID, *matchingAccountID)
+	alreadyLinkedAccountID := guardianAccountIDForRequest(t, db, alreadyLinked.ID)
+	require.NotNil(t, alreadyLinkedAccountID)
+	assert.Equal(t, existingOwner.ID, *alreadyLinkedAccountID)
+	assert.Nil(t, guardianAccountIDForRequest(t, db, unrelated.ID))
+	assert.Nil(t, guardianAccountIDForRequest(t, db, ambiguous.ID))
+
+	require.NoError(t, guardianEnrollmentAccountBackfillUp(context.Background(), db), "backfill must be idempotent")
+	require.NoError(t, guardianEnrollmentAccountBackfillDown(context.Background(), db))
+	matchingAccountID = guardianAccountIDForRequest(t, db, matching.ID)
+	require.NotNil(t, matchingAccountID)
+	assert.Equal(t, uniqueAccount.ID, *matchingAccountID, "down migration must not erase valid ownership")
+}

--- a/backend/database/migrations/001015311_guardian_enrollment_account_backfill_test.go
+++ b/backend/database/migrations/001015311_guardian_enrollment_account_backfill_test.go
@@ -55,7 +55,16 @@ func TestGuardianEnrollmentAccountBackfill(t *testing.T) {
 	phase := testpkg.CreateTestEnrollmentPhase(t, db)
 
 	uniqueAccount := testpkg.CreateTestAccount(t, db, "guardian-backfill-unique")
+	guardianProfile := testpkg.CreateTestGuardianProfile(t, db, "guardian-backfill-profile")
+	_, err := db.NewRaw(`
+		UPDATE users.guardian_profiles
+		SET account_id = ?, has_account = TRUE
+		WHERE id = ?
+	`, uniqueAccount.ID, guardianProfile.ID).Exec(context.Background())
+	require.NoError(t, err)
 	matching := insertGuardianBackfillRequest(t, db, phase.ID, "  "+strings.ToUpper(uniqueAccount.Email)+"  ", nil)
+	staffOnlyAccount := testpkg.CreateTestAccount(t, db, "guardian-backfill-staff-only")
+	staffOnly := insertGuardianBackfillRequest(t, db, phase.ID, staffOnlyAccount.Email, nil)
 
 	existingOwner := testpkg.CreateTestAccount(t, db, "guardian-backfill-owner")
 	alreadyLinked := insertGuardianBackfillRequest(t, db, phase.ID, uniqueAccount.Email, &existingOwner.ID)
@@ -63,7 +72,7 @@ func TestGuardianEnrollmentAccountBackfill(t *testing.T) {
 
 	ambiguousAccount := testpkg.CreateTestAccount(t, db, "guardian-backfill-ambiguous")
 	duplicate := &authModels.Account{Email: strings.ToUpper(ambiguousAccount.Email), Active: true}
-	_, err := db.NewInsert().Model(duplicate).ModelTableExpr(`auth.accounts AS "account"`).Exec(context.Background())
+	_, err = db.NewInsert().Model(duplicate).ModelTableExpr(`auth.accounts AS "account"`).Exec(context.Background())
 	require.NoError(t, err)
 	testpkg.EnsureAccountTenant(t, db, duplicate.ID, testpkg.Tenant(t))
 	ambiguous := insertGuardianBackfillRequest(t, db, phase.ID, ambiguousAccount.Email, nil)
@@ -78,6 +87,7 @@ func TestGuardianEnrollmentAccountBackfill(t *testing.T) {
 	assert.Equal(t, existingOwner.ID, *alreadyLinkedAccountID)
 	assert.Nil(t, guardianAccountIDForRequest(t, db, unrelated.ID))
 	assert.Nil(t, guardianAccountIDForRequest(t, db, ambiguous.ID))
+	assert.Nil(t, guardianAccountIDForRequest(t, db, staffOnly.ID), "staff-only accounts must not receive enrollment ownership")
 
 	require.NoError(t, guardianEnrollmentAccountBackfillUp(context.Background(), db), "backfill must be idempotent")
 	require.NoError(t, guardianEnrollmentAccountBackfillDown(context.Background(), db))

--- a/backend/models/parent/child_summary.go
+++ b/backend/models/parent/child_summary.go
@@ -210,7 +210,7 @@ type EnrollmentRequestRepository interface {
 	// enrollment.requests row with guardian_account_id IS NULL and a
 	// case-insensitive match on guardian_email. Returns how many rows
 	// were updated. Cross-tenant — implementation MUST run under
-	// WithAdminTx. Called after a guardian invitation accept so
+	// WithAdminTx. Called inside a guardian invitation accept so
 	// pre-account submissions surface in /me/enrollments.
 	BackfillGuardianAccountID(ctx context.Context, accountID int64, email string) (int, error)
 }

--- a/backend/services/auth/guardian_invitation_service.go
+++ b/backend/services/auth/guardian_invitation_service.go
@@ -245,11 +245,8 @@ func schoolLogoURLFromSettings(settingsJSON string) string {
 // mapping, and guardian role assignment. Updates the GuardianProfile to
 // link to the new account. Public route, caller wraps in WithAdminTx.
 func (s *guardianInvitationService) Accept(ctx context.Context, token string, data GuardianInvitationAcceptData) (*authModels.Account, error) {
-	if data.Password != data.ConfirmPassword {
-		return nil, &AuthError{Op: opGuardianInviteAccept, Err: ErrPasswordMismatch}
-	}
-	if err := ValidatePasswordStrength(data.Password); err != nil {
-		return nil, &AuthError{Op: opGuardianInviteAccept, Err: err}
+	if err := validateGuardianAcceptPassword(data); err != nil {
+		return nil, err
 	}
 
 	invitation, err := s.fetchValidInvitation(ctx, token)
@@ -257,50 +254,19 @@ func (s *guardianInvitationService) Accept(ctx context.Context, token string, da
 		return nil, err
 	}
 
-	// Reject invitations for soft-deleted schools. Mirrors staff service.
-	if invitation.TenantID > 0 && s.SchoolRepo != nil {
-		school, schoolErr := s.SchoolRepo.FindByIDForShare(ctx, invitation.TenantID)
-		if schoolErr != nil {
-			return nil, &AuthError{Op: opGuardianInviteAccept, Err: schoolErr}
-		}
-		if school == nil || school.IsDeleted() {
-			return nil, &AuthError{Op: opGuardianInviteAccept, Err: ErrInvitationTenantDeleted}
-		}
-	}
-
-	profile, err := s.GuardianProfileRepo.FindByID(ctx, invitation.GuardianProfileID)
+	profile, emailAddress, err := s.guardianAcceptTarget(ctx, invitation)
 	if err != nil {
-		return nil, &AuthError{Op: opGuardianInviteAccept, Err: err}
+		return nil, err
 	}
-	if profile == nil || profile.Email == nil || strings.TrimSpace(*profile.Email) == "" {
-		return nil, &AuthError{Op: opGuardianInviteAccept, Err: fmt.Errorf("guardian profile missing email")}
-	}
-	emailAddress := strings.ToLower(strings.TrimSpace(*profile.Email))
 
 	passwordHash, err := HashPassword(data.Password)
 	if err != nil {
 		return nil, &AuthError{Op: opGuardianInviteAccept, Err: err}
 	}
 
-	tenantCtx := tenant.WithTenantID(ctx, invitation.TenantID)
-
-	var account *authModels.Account
-	txErr := s.txHandler.RunInTx(tenantCtx, func(txCtx context.Context, _ bun.Tx) error {
-		acc, innerErr := s.createOrFindAccount(txCtx, emailAddress, passwordHash)
-		if innerErr != nil {
-			return innerErr
-		}
-		if innerErr := s.linkProfileToAccount(txCtx, profile, acc.ID, invitation.TenantID, opGuardianInviteAccept); innerErr != nil {
-			return innerErr
-		}
-		if innerErr := s.InvitationRepo.MarkAsAccepted(txCtx, invitation.ID); innerErr != nil {
-			return &AuthError{Op: opGuardianInviteAccept, Err: innerErr}
-		}
-		account = acc
-		return nil
-	})
-	if txErr != nil {
-		return nil, txErr
+	account, err := s.acceptGuardianInvitation(ctx, invitation, profile, emailAddress, passwordHash)
+	if err != nil {
+		return nil, err
 	}
 
 	s.getLogger().Info("guardian invitation accepted",
@@ -309,35 +275,93 @@ func (s *guardianInvitationService) Accept(ctx context.Context, token string, da
 		slog.Int64("guardian_profile_id", profile.ID),
 	)
 
-	// Backfill guardian_account_id on every pre-account
-	// enrollment.requests row matching this email (case-insensitive,
-	// cross-tenant). Best-effort, the accept itself stays committed
-	// even if this fails. Runs in its own admin tx; the parent's
-	// /me/enrollments query reads via guardian_account_id, so without
-	// this step legacy submissions wouldn't surface in the dashboard.
-	if s.EnrollmentBackfiller != nil {
-		backfillErr := tenant.WithAdminTx(ctx, s.DB, func(adminCtx context.Context, _ bun.Tx) error {
-			n, err := s.EnrollmentBackfiller.BackfillGuardianAccountID(adminCtx, account.ID, emailAddress)
-			if err != nil {
-				return err
-			}
-			if n > 0 {
-				s.getLogger().Info("guardian invitation accept: claimed pre-account enrollments",
-					slog.Int64("account_id", account.ID),
-					slog.Int("rows_claimed", n),
-				)
-			}
-			return nil
-		})
-		if backfillErr != nil {
-			s.getLogger().Warn("guardian invitation accept: enrollment backfill failed",
-				slog.Int64("account_id", account.ID),
-				slog.String("error", backfillErr.Error()),
-			)
+	return account, nil
+}
+
+func validateGuardianAcceptPassword(data GuardianInvitationAcceptData) error {
+	if data.Password != data.ConfirmPassword {
+		return &AuthError{Op: opGuardianInviteAccept, Err: ErrPasswordMismatch}
+	}
+	if err := ValidatePasswordStrength(data.Password); err != nil {
+		return &AuthError{Op: opGuardianInviteAccept, Err: err}
+	}
+	return nil
+}
+
+func (s *guardianInvitationService) guardianAcceptTarget(ctx context.Context, invitation *authModels.GuardianInvitation) (*userModels.GuardianProfile, string, error) {
+	if invitation.TenantID > 0 && s.SchoolRepo != nil {
+		school, err := s.SchoolRepo.FindByIDForShare(ctx, invitation.TenantID)
+		if err != nil {
+			return nil, "", &AuthError{Op: opGuardianInviteAccept, Err: err}
+		}
+		if school == nil || school.IsDeleted() {
+			return nil, "", &AuthError{Op: opGuardianInviteAccept, Err: ErrInvitationTenantDeleted}
 		}
 	}
+	profile, err := s.GuardianProfileRepo.FindByID(ctx, invitation.GuardianProfileID)
+	if err != nil {
+		return nil, "", &AuthError{Op: opGuardianInviteAccept, Err: err}
+	}
+	if profile == nil || profile.Email == nil || strings.TrimSpace(*profile.Email) == "" {
+		return nil, "", &AuthError{Op: opGuardianInviteAccept, Err: fmt.Errorf("guardian profile missing email")}
+	}
+	return profile, strings.ToLower(strings.TrimSpace(*profile.Email)), nil
+}
 
-	return account, nil
+func (s *guardianInvitationService) acceptGuardianInvitation(ctx context.Context, invitation *authModels.GuardianInvitation, profile *userModels.GuardianProfile, emailAddress, passwordHash string) (*authModels.Account, error) {
+	var account *authModels.Account
+	err := s.txHandler.RunInTx(tenant.WithTenantID(ctx, invitation.TenantID), func(txCtx context.Context, _ bun.Tx) error {
+		acc, innerErr := s.createOrFindAccount(txCtx, emailAddress, passwordHash)
+		if innerErr != nil {
+			return innerErr
+		}
+		if innerErr = s.linkProfileToAccount(txCtx, profile, acc.ID, invitation.TenantID, opGuardianInviteAccept); innerErr != nil {
+			return innerErr
+		}
+		if innerErr = s.InvitationRepo.MarkAsAccepted(txCtx, invitation.ID); innerErr != nil {
+			return &AuthError{Op: opGuardianInviteAccept, Err: innerErr}
+		}
+		if innerErr = s.backfillEnrollmentRequests(txCtx, acc.ID, emailAddress); innerErr != nil {
+			return &AuthError{Op: opGuardianInviteAccept, Err: innerErr}
+		}
+		account = acc
+		return nil
+	})
+	return account, err
+}
+
+// backfillEnrollmentRequests claims pre-account enrollment requests inside
+// the accept transaction, where the newly inserted account is visible to the
+// guardian_account_id foreign key. A savepoint preserves the existing
+// best-effort contract without leaving the surrounding transaction aborted.
+func (s *guardianInvitationService) backfillEnrollmentRequests(ctx context.Context, accountID int64, emailAddress string) error {
+	if s.EnrollmentBackfiller == nil {
+		return nil
+	}
+
+	rowsClaimed := 0
+	backfillErr := tenant.WithSavepoint(ctx, func(savepointCtx context.Context) error {
+		var err error
+		rowsClaimed, err = s.EnrollmentBackfiller.BackfillGuardianAccountID(savepointCtx, accountID, emailAddress)
+		return err
+	})
+	if backfillErr != nil {
+		if errors.Is(backfillErr, tenant.ErrSavepointControl) {
+			return backfillErr
+		}
+		s.getLogger().Warn("guardian invitation accept: enrollment backfill failed",
+			slog.Int64("account_id", accountID),
+			slog.String("error", backfillErr.Error()),
+		)
+		return nil
+	}
+	if rowsClaimed > 0 {
+		s.getLogger().Info("guardian invitation accept: claimed pre-account enrollments",
+			slog.Int64("account_id", accountID),
+			slog.Int("rows_claimed", rowsClaimed),
+		)
+	}
+	return nil
 }
 
 // createOrFindAccount returns the existing auth.accounts row for this email

--- a/backend/services/auth/guardian_invitation_service_test.go
+++ b/backend/services/auth/guardian_invitation_service_test.go
@@ -827,6 +827,32 @@ func TestGuardianInvitationService_Accept_BackfillErrorDoesNotBreakAccept(t *tes
 	assert.Nil(t, unlinked.GuardianAccountID, "failed backfill write must be rolled back")
 }
 
+func TestGuardianInvitationService_Accept_OrdinaryBackfillErrorDoesNotBreakAccept(t *testing.T) {
+	t.Parallel()
+
+	bf := &stubEnrollmentBackfiller{returnError: errors.New("backfill failed")}
+	env := setupGuardianInviteWithBackfiller(t, bf)
+	defer env.cleanup()
+
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "backfill-ordinary-error")
+	creatorID := env.inviterAccountID(t)
+
+	invitation, err := env.service.Create(testpkg.Ctx(t), authService.GuardianInvitationCreateRequest{
+		GuardianProfileID: profile.ID,
+		CreatedBy:         creatorID,
+	})
+	require.NoError(t, err)
+	defer env.cleanupInvitation(t, invitation.ID, profile.ID)
+
+	account, err := env.service.Accept(context.Background(), invitation.Token, authService.GuardianInvitationAcceptData{
+		Password:        strongTestPassword,
+		ConfirmPassword: strongTestPassword,
+	})
+	require.NoError(t, err, "ordinary backfill errors must not fail acceptance")
+	t.Cleanup(func() { cleanupAcceptedAccount(t, env.db, account.ID) })
+	assert.Equal(t, 1, bf.calls, "backfiller must be invoked")
+}
+
 func TestGuardianInvitationService_Accept_SavepointControlFailureRollsBackAccept(t *testing.T) {
 	t.Parallel()
 

--- a/backend/services/auth/guardian_invitation_service_test.go
+++ b/backend/services/auth/guardian_invitation_service_test.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/moto-nrw/project-phoenix/database/repositories"
 	"github.com/moto-nrw/project-phoenix/email"
 	authModels "github.com/moto-nrw/project-phoenix/models/auth"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	parentModels "github.com/moto-nrw/project-phoenix/models/parent"
 	platformModels "github.com/moto-nrw/project-phoenix/models/platform"
 	"github.com/moto-nrw/project-phoenix/models/users"
 	authService "github.com/moto-nrw/project-phoenix/services/auth"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -581,14 +586,31 @@ func TestGuardianInvitationService_Resend_ResetsEmailColumns(t *testing.T) {
 // stubEnrollmentBackfiller records inputs to BackfillGuardianAccountID
 // and lets the test choose what to return. The accept flow swallows
 // backfill errors and only logs them, so we use this stub to confirm
-// the call happens with the right inputs without needing a real
-// enrollment.requests row.
+// ordinary backfill errors and only logs them; savepoint-control errors
+// remain fatal. This stub verifies calls without a real request row.
 type stubEnrollmentBackfiller struct {
 	calls       int
 	gotAccount  int64
 	gotEmail    string
 	returnRows  int
 	returnError error
+}
+
+type constraintFailingEnrollmentBackfiller struct {
+	requestID int64
+}
+
+func (s *constraintFailingEnrollmentBackfiller) BackfillGuardianAccountID(ctx context.Context, _ int64, _ string) (int, error) {
+	tx, ok := modelBase.TxFromContext(ctx)
+	if !ok || tx == nil {
+		return 0, errors.New("backfill transaction missing")
+	}
+	_, err := (*tx).NewRaw(`
+		UPDATE enrollment.requests
+		SET guardian_account_id = -1
+		WHERE id = ?
+	`, s.requestID).Exec(ctx)
+	return 0, err
 }
 
 func (s *stubEnrollmentBackfiller) BackfillGuardianAccountID(_ context.Context, accountID int64, email string) (int, error) {
@@ -647,6 +669,43 @@ func cleanupAcceptedAccount(t *testing.T, db *bun.DB, accountID int64) {
 	_, _ = db.NewDelete().TableExpr("auth.accounts").Where("id = ?", accountID).Exec(bg)
 }
 
+func createEnrollmentAwaitingGuardian(t *testing.T, env *guardianTestEnv, email string) *enrollmentModels.Request {
+	t.Helper()
+	phase := testpkg.CreateTestEnrollmentPhase(t, env.db)
+	request := &enrollmentModels.Request{
+		PhaseID:           phase.ID,
+		GuardianFirstName: "Guardian",
+		GuardianLastName:  "Test",
+		GuardianEmail:     email,
+		ConsentFlags:      map[string]any{},
+		CustomData:        map[string]any{},
+		SubmissionSource:  enrollmentModels.RequestSourcePublic,
+		SourceMetadata:    map[string]any{},
+		StatusToken:       "guardian-backfill-" + t.Name(),
+		SubmittedAt:       time.Now(),
+	}
+	request.SetTenantID(testpkg.Tenant(t))
+	require.NoError(t, env.repos.Request.Create(testpkg.Ctx(t), request))
+	return request
+}
+
+func requireGuardianEnrollmentClaimed(t *testing.T, env *guardianTestEnv, requestID, accountID int64) {
+	t.Helper()
+	linkedRequest, err := env.repos.Request.FindByID(testpkg.Ctx(t), requestID)
+	require.NoError(t, err)
+	require.NotNil(t, linkedRequest.GuardianAccountID)
+	assert.Equal(t, accountID, *linkedRequest.GuardianAccountID)
+
+	var enrollments []*parentModels.EnrollmentRequestSummary
+	require.NoError(t, tenant.WithAdminTx(context.Background(), env.db, func(ctx context.Context, _ bun.Tx) error {
+		var listErr error
+		enrollments, listErr = env.repos.ParentEnrollmentRequest.ListByAccount(ctx, accountID)
+		return listErr
+	}))
+	require.Len(t, enrollments, 1)
+	assert.Equal(t, requestID, enrollments[0].RequestID)
+}
+
 func TestGuardianInvitationService_Accept_InvokesBackfiller(t *testing.T) {
 	t.Parallel()
 
@@ -675,6 +734,37 @@ func TestGuardianInvitationService_Accept_InvokesBackfiller(t *testing.T) {
 	require.Equal(t, 1, bf.calls, "backfiller must be invoked exactly once on successful accept")
 	assert.Equal(t, account.ID, bf.gotAccount, "backfiller must receive the new account's id")
 	assert.Equal(t, *profile.Email, bf.gotEmail, "backfiller must receive the invitation email")
+}
+
+func TestGuardianInvitationService_Accept_ClaimsEnrollmentInsideOuterAdminTransaction(t *testing.T) {
+	t.Parallel()
+
+	db := testpkg.SetupTestDB(t)
+	realBackfiller := repositories.NewFactory(db).ParentEnrollmentRequest
+	env := setupGuardianInviteWithBackfiller(t, realBackfiller)
+
+	profile := testpkg.CreateTestGuardianProfile(t, db, "backfill-outer-admin")
+	request := createEnrollmentAwaitingGuardian(t, env, "  "+strings.ToUpper(*profile.Email)+"  ")
+
+	creatorID := env.inviterAccountID(t)
+	invitation, err := env.service.Create(testpkg.Ctx(t), authService.GuardianInvitationCreateRequest{
+		GuardianProfileID: profile.ID,
+		CreatedBy:         creatorID,
+	})
+	require.NoError(t, err)
+
+	var account *authModels.Account
+	err = tenant.WithAdminTx(context.Background(), db, func(adminCtx context.Context, _ bun.Tx) error {
+		var acceptErr error
+		account, acceptErr = env.service.Accept(adminCtx, invitation.Token, authService.GuardianInvitationAcceptData{
+			Password:        strongTestPassword,
+			ConfirmPassword: strongTestPassword,
+		})
+		return acceptErr
+	})
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	requireGuardianEnrollmentClaimed(t, env, request.ID, account.ID)
 }
 
 func TestGuardianInvitationService_Accept_NotInvokedOnPasswordMismatch(t *testing.T) {
@@ -706,11 +796,11 @@ func TestGuardianInvitationService_Accept_NotInvokedOnPasswordMismatch(t *testin
 func TestGuardianInvitationService_Accept_BackfillErrorDoesNotBreakAccept(t *testing.T) {
 	t.Parallel()
 
-	bf := &stubEnrollmentBackfiller{returnError: errors.New("synthetic backfill failure")}
+	bf := &constraintFailingEnrollmentBackfiller{}
 	env := setupGuardianInviteWithBackfiller(t, bf)
-	defer env.cleanup()
-
 	profile := testpkg.CreateTestGuardianProfile(t, env.db, "backfill-error")
+	request := createEnrollmentAwaitingGuardian(t, env, *profile.Email)
+	bf.requestID = request.ID
 	creatorID := env.inviterAccountID(t)
 
 	ctx := testpkg.Ctx(t)
@@ -721,9 +811,6 @@ func TestGuardianInvitationService_Accept_BackfillErrorDoesNotBreakAccept(t *tes
 	require.NoError(t, err)
 	defer env.cleanupInvitation(t, invitation.ID, profile.ID)
 
-	// Backfill returns an error, the accept must still succeed because
-	// backfill is best-effort and the new account has already been
-	// committed by the inner tx.
 	account, err := env.service.Accept(context.Background(), invitation.Token, authService.GuardianInvitationAcceptData{
 		Password:        strongTestPassword,
 		ConfirmPassword: strongTestPassword,
@@ -732,13 +819,37 @@ func TestGuardianInvitationService_Accept_BackfillErrorDoesNotBreakAccept(t *tes
 	require.NotNil(t, account)
 	t.Cleanup(func() { cleanupAcceptedAccount(t, env.db, account.ID) })
 
-	assert.Equal(t, 1, bf.calls, "backfiller must have been called even though it errored")
-
-	// The invitation is still marked accepted, proof the inner tx
-	// committed independent of the backfill outcome.
 	updated, err := env.repos.GuardianInvitation.FindByID(context.Background(), invitation.ID)
 	require.NoError(t, err)
 	assert.NotNil(t, updated.AcceptedAt, "invitation must remain accepted after backfill error")
+	unlinked, err := env.repos.Request.FindByID(testpkg.Ctx(t), request.ID)
+	require.NoError(t, err)
+	assert.Nil(t, unlinked.GuardianAccountID, "failed backfill write must be rolled back")
+}
+
+func TestGuardianInvitationService_Accept_SavepointControlFailureRollsBackAccept(t *testing.T) {
+	t.Parallel()
+
+	bf := &stubEnrollmentBackfiller{returnError: tenant.ErrSavepointControl}
+	env := setupGuardianInviteWithBackfiller(t, bf)
+	profile := testpkg.CreateTestGuardianProfile(t, env.db, "backfill-savepoint-control")
+	creatorID := env.inviterAccountID(t)
+
+	invitation, err := env.service.Create(testpkg.Ctx(t), authService.GuardianInvitationCreateRequest{
+		GuardianProfileID: profile.ID,
+		CreatedBy:         creatorID,
+	})
+	require.NoError(t, err)
+
+	_, err = env.service.Accept(context.Background(), invitation.Token, authService.GuardianInvitationAcceptData{
+		Password:        strongTestPassword,
+		ConfirmPassword: strongTestPassword,
+	})
+	require.ErrorIs(t, err, tenant.ErrSavepointControl)
+
+	updated, err := env.repos.GuardianInvitation.FindByID(context.Background(), invitation.ID)
+	require.NoError(t, err)
+	assert.Nil(t, updated.AcceptedAt, "untrusted transaction state must roll back invitation acceptance")
 }
 
 func TestGuardianInvitationService_Accept_NilBackfillerIsSafe(t *testing.T) {


### PR DESCRIPTION
# Pull Request

## Description

- Run enrollment ownership backfill inside the guardian invitation acceptance transaction so the new account satisfies the foreign key.
- Isolate ordinary backfill failures with a savepoint while treating savepoint-control failures as fatal.
- Add migration `1.15.311` to link guardian-less enrollment requests to a single matching normalized account email when that account has a guardian profile in the request’s tenant.
- Preserve existing ownership links and skip ambiguous, unmatched, and staff-only accounts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [x] Test addition/modification

## Related Issues

- Fixes #2422

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

Commands and checks:

- `scripts/test-backend.sh`
- Focused guardian invitation and migration database tests
- `golangci-lint`
- Migration validation and hermetic test-pattern checks
- Pre-push `go vet`, dead-code check, and `golangci-lint`

## Rollout Notes

Deploying this PR runs migration `1.15.311`, which repairs safe unique matches, including the reported orphaned enrollment. The down migration is intentionally a no-op because the links cannot be distinguished safely from links created by normal account acceptance.

## Security Checklist

- [x] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed
- [x] Environment variables are properly managed
- [x] No hardcoded secrets were added
- [x] No potential security vulnerabilities were introduced

## Screenshots or Examples

Not applicable: backend transaction and data-migration fix.

## Checklist

- [x] Follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated as needed
- [x] In-app help guide update does not apply because this is a backend-only fix
- [x] No new warnings or errors
- [x] Merge conflicts resolved
