### PR TITLE
Ungeplante Anwesenheit in Übersichten kennzeichnen

### DIFF
--- a/backend/api/students/day_planning.go
+++ b/backend/api/students/day_planning.go
@@ -468,7 +468,7 @@ func resetLiveLocationFields(responses []StudentResponse) {
 }
 
 func hasActualAttendanceToday(attendance *activeService.AttendanceStatus) bool {
-	return attendance != nil && attendance.CheckInTime != nil && attendance.Status != "not_checked_in"
+	return attendance.IsCurrentlyPresent()
 }
 
 func attendanceMapFromSnapshot(snapshot *common.StudentDataSnapshot) map[int64]*activeService.AttendanceStatus {

--- a/backend/api/students/day_planning_presence_test.go
+++ b/backend/api/students/day_planning_presence_test.go
@@ -1,0 +1,65 @@
+package students_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moto-nrw/project-phoenix/api/students"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func TestListStudents_UnplannedPresenceEndsAtCheckout(t *testing.T) {
+	t.Parallel()
+
+	tc := setupTestContext(t)
+	fixedNow := time.Date(2026, time.August, 21, 10, 0, 0, 0, time.UTC)
+	tc.resource.Now = func() time.Time { return fixedNow }
+
+	schoolClass := "Presence-2379"
+	absent := testpkg.CreateTestStudent(t, tc.db, "Absent", "Student", schoolClass)
+	present := testpkg.CreateTestStudent(t, tc.db, "Present", "Student", schoolClass)
+	checkedOut := testpkg.CreateTestStudent(t, tc.db, "CheckedOut", "Student", schoolClass)
+	plannedPresent := testpkg.CreateTestStudent(t, tc.db, "PlannedPresent", "Student", schoolClass)
+	sickPresent := testpkg.CreateTestStudent(t, tc.db, "SickPresent", "Student", schoolClass)
+	staff := testpkg.CreateTestStaff(t, tc.db, "Presence", "Supervisor")
+	device := testpkg.CreateTestDevice(t, tc.db, "presence-2379-device")
+	today := timezone.DateFromTime(fixedNow)
+
+	for _, student := range []int64{absent.ID, present.ID, checkedOut.ID} {
+		testpkg.CreateTestArrivalException(t, tc.db, student, today, staff.ID, "", "Kommt heute nicht")
+	}
+	testpkg.CreateTestStudentStatusDay(t, tc.db, sickPresent.ID, today, activeModel.StudentStatusDaySick)
+
+	checkIn := fixedNow.Add(-time.Hour)
+	testpkg.CreateTestAttendance(t, tc.db, present.ID, staff.ID, device.ID, checkIn, nil)
+	testpkg.CreateTestPickupSchedule(t, tc.db, plannedPresent.ID, scheduleModel.WeekdayFriday, staff.ID, "15:30")
+	testpkg.CreateTestAttendance(t, tc.db, plannedPresent.ID, staff.ID, device.ID, checkIn, nil)
+	testpkg.CreateTestAttendance(t, tc.db, sickPresent.ID, staff.ID, device.ID, checkIn, nil)
+	checkOut := fixedNow.Add(-30 * time.Minute)
+	testpkg.CreateTestAttendance(t, tc.db, checkedOut.ID, staff.ID, device.ID, checkIn, &checkOut)
+
+	req := testutil.NewRequest("GET", fmt.Sprintf("/?school_class=%s&page_size=50", schoolClass), nil)
+	rr := authExec(t, tc, req, testutil.AdminTestClaims(1), []string{"admin:*"})
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+
+	byID := decodeStudentsByID(t, rr.Body.Bytes())
+	assert.Equal(t, students.DayPlanningStatusNotComingToday, byID[absent.ID].DayPlanningStatus)
+	assert.Equal(t, "arrival_exception", byID[absent.ID].DayPlanningReason)
+	assert.Equal(t, students.DayPlanningStatusComesToday, byID[present.ID].DayPlanningStatus)
+	assert.Equal(t, "unplanned_attendance", byID[present.ID].DayPlanningReason)
+	assert.Equal(t, students.DayPlanningStatusNotComingToday, byID[checkedOut.ID].DayPlanningStatus)
+	assert.Equal(t, "arrival_exception", byID[checkedOut.ID].DayPlanningReason)
+	assert.Equal(t, students.DayPlanningStatusComesToday, byID[plannedPresent.ID].DayPlanningStatus)
+	assert.Equal(t, "pickup_schedule", byID[plannedPresent.ID].DayPlanningReason)
+	assert.Equal(t, students.DayPlanningStatusComesToday, byID[sickPresent.ID].DayPlanningStatus)
+	assert.Equal(t, "unplanned_attendance", byID[sickPresent.ID].DayPlanningReason)
+}

--- a/backend/api/students/list_projection.go
+++ b/backend/api/students/list_projection.go
@@ -61,9 +61,10 @@ type SlimStudentResponse struct {
 	ClassTrip      bool       `json:"class_trip"`
 	ClassTripSince *time.Time `json:"class_trip_since,omitempty"`
 
-	// Day planning. day_planning_reason is deliberately absent: the page
-	// renders day_planning_label and derives everything else from status.
+	// Day planning. The reason distinguishes actual unplanned attendance from
+	// ordinary planned presence; status and label alone cannot express that.
 	DayPlanningStatus  string  `json:"day_planning_status,omitempty"`
+	DayPlanningReason  string  `json:"day_planning_reason,omitempty"`
 	DayPlanningLabel   string  `json:"day_planning_label,omitempty"`
 	PendingExcusedNote *string `json:"pending_excused_note,omitempty"`
 
@@ -117,6 +118,7 @@ func slimStudentResponses(responses []StudentResponse, planningDate timezone.Dat
 			ClassTrip:           r.ClassTrip,
 			ClassTripSince:      r.ClassTripSince,
 			DayPlanningStatus:   r.DayPlanningStatus,
+			DayPlanningReason:   r.DayPlanningReason,
 			DayPlanningLabel:    r.DayPlanningLabel,
 			PendingExcusedNote:  r.PendingExcusedNote,
 			DepartureModes:      departure.Modes,

--- a/backend/api/students/list_projection_internal_test.go
+++ b/backend/api/students/list_projection_internal_test.go
@@ -119,6 +119,7 @@ func TestSlimStudentResponseWireContract(t *testing.T) {
 		"current_location",
 		"current_room_color",
 		"day_planning_label",
+		"day_planning_reason",
 		"day_planning_status",
 		"departure_modes",
 		"excused",
@@ -171,6 +172,7 @@ func TestSlimStudentResponseCopiesValues(t *testing.T) {
 	assert.Equal(t, full.ClassTrip, got.ClassTrip)
 	assert.Equal(t, full.ClassTripSince, got.ClassTripSince)
 	assert.Equal(t, full.DayPlanningStatus, got.DayPlanningStatus)
+	assert.Equal(t, full.DayPlanningReason, got.DayPlanningReason)
 	assert.Equal(t, full.DayPlanningLabel, got.DayPlanningLabel)
 	assert.Equal(t, full.PendingExcusedNote, got.PendingExcusedNote)
 	assert.Equal(t, []users.DepartureMode{users.DeparturePickup}, got.DepartureModes)

--- a/backend/api/students/list_projection_test.go
+++ b/backend/api/students/list_projection_test.go
@@ -105,7 +105,6 @@ func TestListStudents_SlimProjection(t *testing.T) {
 		"bus_days", "pickup_days", "departure_days", "allowed_departure_modes",
 		"pickup_status",
 		"departure_companion_note",
-		"day_planning_reason",
 		"photo_consent_given_at", "photo_consent_given_by",
 		"agb_accepted_at", "data_processing_accepted_at", "email_contact_accepted_at",
 		"created_at", "updated_at",
@@ -118,7 +117,7 @@ func TestListStudents_SlimProjection(t *testing.T) {
 	// Everything the Kindersuche cards, filters and badges do read.
 	for _, required := range []string{
 		"id", "first_name", "last_name", "school_class",
-		"current_location", "sick", "excused", "class_trip", "departure_modes", "has_full_access",
+		"current_location", "sick", "excused", "class_trip", "day_planning_reason", "departure_modes", "has_full_access",
 	} {
 		assert.Contains(t, body, required, "slim student list must include %q", required)
 	}

--- a/backend/services/active/interface.go
+++ b/backend/services/active/interface.go
@@ -390,6 +390,14 @@ type AttendanceStatus struct {
 	CheckedOutBy string     `json:"checked_out_by"` // Formatted as "FirstName LastName"
 }
 
+// IsCurrentlyPresent reports whether the attendance row represents a child
+// who is still on school premises. A completed attendance keeps its historical
+// check-in time but is no longer current presence.
+func (s *AttendanceStatus) IsCurrentlyPresent() bool {
+	return s != nil && s.CheckInTime != nil &&
+		(s.Status == "checked_in" || s.Status == "on_yard")
+}
+
 // DailyCheckoutResult represents the outcome of confirming a deferred daily
 // checkout from an IoT device.
 type DailyCheckoutResult struct {

--- a/backend/services/ogsgrouplive/service.go
+++ b/backend/services/ogsgrouplive/service.go
@@ -99,6 +99,7 @@ type Student struct {
 	ClassTrip          bool       `json:"class_trip"`
 	ClassTripSince     *time.Time `json:"class_trip_since,omitempty"`
 	DayPlanningStatus  string     `json:"day_planning_status,omitempty"`
+	DayPlanningReason  string     `json:"day_planning_reason,omitempty"`
 	DayPlanningLabel   string     `json:"day_planning_label,omitempty"`
 	PendingExcusedNote *string    `json:"pending_excused_note,omitempty"`
 	ArrivalTime        *string    `json:"arrival_time,omitempty"`
@@ -589,7 +590,7 @@ func applyPlanning(state *buildState, pending map[int64]*activeModels.ExcusedAbs
 		_, hasTimetable := state.timetable[student.ID]
 		attendance := state.data.locations.Attendances[student.ID]
 		decision := scheduleService.ResolveDayPlanning(scheduleService.DayPlanningInputs{
-			HasActualAttendance: attendance != nil && attendance.CheckInTime != nil && attendance.Status != "not_checked_in",
+			HasActualAttendance: attendance.IsCurrentlyPresent(),
 			Sick:                student.Sick,
 			ClassTrip:           student.ClassTrip,
 			Excused:             student.Excused,
@@ -601,6 +602,7 @@ func applyPlanning(state *buildState, pending map[int64]*activeModels.ExcusedAbs
 		if decision.ComesToday {
 			student.DayPlanningStatus = "comes_today"
 		}
+		student.DayPlanningReason = decision.Reason
 		student.DayPlanningLabel = planningLabel(decision)
 		applyTimes(student, state.arrivals[student.ID], attendance)
 	}

--- a/backend/services/ogsgrouplive/unplanned_presence_test.go
+++ b/backend/services/ogsgrouplive/unplanned_presence_test.go
@@ -1,0 +1,73 @@
+package ogsgrouplive
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	activeService "github.com/moto-nrw/project-phoenix/services/active"
+	scheduleService "github.com/moto-nrw/project-phoenix/services/schedule"
+)
+
+func TestApplyPlanningTracksUnplannedPresenceUntilCheckout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		absentID     int64 = 101
+		presentID    int64 = 102
+		checkedOutID int64 = 103
+		plannedID    int64 = 104
+		sickID       int64 = 105
+	)
+	checkIn := time.Date(2026, time.August, 21, 8, 0, 0, 0, time.UTC)
+	checkOut := checkIn.Add(time.Hour)
+	arrivalException := &scheduleService.EffectiveArrivalTime{IsException: true}
+	state := &buildState{
+		projected: []Student{
+			{ID: absentID, fullAccess: true},
+			{ID: presentID, fullAccess: true},
+			{ID: checkedOutID, fullAccess: true},
+			{ID: plannedID, fullAccess: true},
+			{ID: sickID, Sick: true, fullAccess: true},
+		},
+		data: &snapshot{locations: &activeService.StudentLocationSnapshot{
+			Attendances: map[int64]*activeService.AttendanceStatus{
+				presentID: {
+					Status:      "checked_in",
+					CheckInTime: &checkIn,
+				},
+				checkedOutID: {
+					Status:       "checked_out",
+					CheckInTime:  &checkIn,
+					CheckOutTime: &checkOut,
+				},
+				plannedID: {
+					Status:      "checked_in",
+					CheckInTime: &checkIn,
+				},
+				sickID: {
+					Status:      "checked_in",
+					CheckInTime: &checkIn,
+				},
+			},
+		}},
+		arrivals: map[int64]*scheduleService.EffectiveArrivalTime{
+			absentID:     arrivalException,
+			presentID:    arrivalException,
+			checkedOutID: arrivalException,
+		},
+		pickups: map[int64]*scheduleService.EffectivePickupTime{
+			plannedID: {PickupTime: &checkOut},
+		},
+		timetable: map[int64]struct{}{},
+	}
+
+	applyPlanning(state, nil)
+
+	assert.Equal(t, "arrival_exception", state.projected[0].DayPlanningReason)
+	assert.Equal(t, "unplanned_attendance", state.projected[1].DayPlanningReason)
+	assert.Equal(t, "arrival_exception", state.projected[2].DayPlanningReason)
+	assert.Equal(t, "pickup_schedule", state.projected[3].DayPlanningReason)
+	assert.Equal(t, "unplanned_attendance", state.projected[4].DayPlanningReason)
+}

--- a/backend/services/schedule/day_planning.go
+++ b/backend/services/schedule/day_planning.go
@@ -39,11 +39,9 @@ type DayPlanningDecision struct {
 	ExceptionNotes string
 }
 
-// ResolveDayPlanning applies the day-planning precedence: actual attendance
-// beats a reported absence (sick, class trip, excused), which beats a
-// same-day cancellation, which beats a planned arrival, which beats a planned
-// pickup, which beats a timetable booking. Everything else falls through to
-// "no plan".
+// ResolveDayPlanning resolves the plan first. Actual attendance changes an
+// absent/no-plan decision to unplanned attendance, but it does not erase a
+// valid arrival, pickup, or timetable plan.
 //
 // A timeless exception on either leg is the "Kommt heute nicht" marker and
 // cancels the whole care day — it must not fall through to the other leg's
@@ -59,9 +57,15 @@ type DayPlanningDecision struct {
 // precedence independently; both paths must keep resolving through this
 // function so they never disagree.
 func ResolveDayPlanning(in DayPlanningInputs) DayPlanningDecision {
-	switch {
-	case in.HasActualAttendance:
+	planned := resolvePlannedDay(in)
+	if in.HasActualAttendance && !planned.ComesToday {
 		return DayPlanningDecision{ComesToday: true, Reason: DayPlanningReasonUnplanned}
+	}
+	return planned
+}
+
+func resolvePlannedDay(in DayPlanningInputs) DayPlanningDecision {
+	switch {
 	case in.Sick:
 		return DayPlanningDecision{Reason: DayPlanningReasonSick}
 	case in.ClassTrip:

--- a/backend/services/schedule/day_planning_issue_2379_test.go
+++ b/backend/services/schedule/day_planning_issue_2379_test.go
@@ -1,0 +1,27 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveDayPlanningOnlyMarksAttendanceUnplannedWhenPlanSaysAbsent(t *testing.T) {
+	t.Parallel()
+
+	plannedTime := time.Date(2026, time.August, 21, 15, 0, 0, 0, time.UTC)
+	planned := ResolveDayPlanning(DayPlanningInputs{
+		HasActualAttendance: true,
+		Pickup:              &EffectivePickupTime{PickupTime: &plannedTime},
+	})
+	assert.True(t, planned.ComesToday)
+	assert.Equal(t, DayPlanningReasonPickupSchedule, planned.Reason)
+
+	absent := ResolveDayPlanning(DayPlanningInputs{
+		HasActualAttendance: true,
+		Arrival:             &EffectiveArrivalTime{IsException: true},
+	})
+	assert.True(t, absent.ComesToday)
+	assert.Equal(t, DayPlanningReasonUnplanned, absent.Reason)
+}

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.test.tsx
@@ -201,7 +201,7 @@ vi.mock("~/lib/location-helper", async (importOriginal) => {
     isHomeLocation: vi.fn(() => false),
     isSchoolyardLocation: vi.fn(() => false),
     isTransitLocation: vi.fn(() => false),
-    parseLocation: vi.fn(() => ({ room: "Room 1", status: "Anwesend" })),
+    parseLocation: actual.parseLocation,
   };
 });
 

--- a/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/ogs-groups/page.tsx
@@ -106,6 +106,7 @@ function mapStudentForOgsPage(student: OgsLiveWireStudent): Student {
     arrival_is_exception: student.arrival_is_exception,
     arrival_notes: student.arrival_notes,
     day_planning_status: student.day_planning_status,
+    day_planning_reason: student.day_planning_reason,
     day_planning_label: student.day_planning_label,
     pending_excused_note: student.pending_excused_note,
     actual_arrival_time: student.actual_arrival_time,

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -158,18 +158,20 @@ export function LocationBadge({
     supervisedRooms,
   );
 
-  // Check sick / class trip / excused / notArrival status display modes.
-  // Priority: sick > class trip > excused > notArrival. Only one replace-mode applies at a time.
-  const sickMode = getSickDisplayMode(student);
+  // An actual presence that contradicts the plan is the actionable state.
+  // At home, the specific absence status keeps its existing precedence.
+  const notArrivalMode = getNotArrivalDisplayMode(student);
+  const sickMode =
+    notArrivalMode === "additional" ? "none" : getSickDisplayMode(student);
   const classTripMode =
-    sickMode === "none" ? getClassTripDisplayMode(student) : "none";
-  const excusedMode =
-    sickMode === "none" && classTripMode === "none"
-      ? getExcusedDisplayMode(student)
+    notArrivalMode !== "additional" && sickMode === "none"
+      ? getClassTripDisplayMode(student)
       : "none";
-  const notArrivalMode =
-    sickMode === "none" && classTripMode === "none" && excusedMode === "none"
-      ? getNotArrivalDisplayMode(student)
+  const excusedMode =
+    notArrivalMode !== "additional" &&
+    sickMode === "none" &&
+    classTripMode === "none"
+      ? getExcusedDisplayMode(student)
       : "none";
 
   // Determine color based on display mode and permissions
@@ -321,7 +323,7 @@ export function LocationBadge({
         className={`${sizeConfig.dot} rounded-full`}
         style={{ backgroundColor: notArrivalTone.dotColor }}
       />
-      {LOCATION_STATUSES.NOT_ARRIVAL}
+      {LOCATION_STATUSES.UNPLANNED_PRESENT}
     </span>
   );
 

--- a/frontend/src/components/ui/location-badge.tsx
+++ b/frontend/src/components/ui/location-badge.tsx
@@ -329,7 +329,7 @@ export function LocationBadge({
 
   if (variant === "simple") {
     return (
-      <div className="flex flex-col items-center">
+      <div className="flex flex-col items-end">
         <span
           className={`${SIMPLE_BASE_CLASS} ${sizeConfig.simple}`}
           style={{
@@ -359,7 +359,7 @@ export function LocationBadge({
   }
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-end">
       <span
         className={`${MODERN_BASE_CLASS} ${sizeConfig.modern}`}
         style={{

--- a/frontend/src/components/ui/presence-badge-alignment.issue-2379.test.tsx
+++ b/frontend/src/components/ui/presence-badge-alignment.issue-2379.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LocationBadge } from "./location-badge";
+import { PresenceBadge } from "./presence-badge";
+
+const student = {
+  current_location: "Anwesend - Gruppenraum",
+  not_arrival_today: true,
+};
+
+describe.each([
+  [
+    "detailed presence badge",
+    <LocationBadge key="detailed" student={student} displayMode="roomName" />,
+  ],
+  [
+    "simple detailed presence badge",
+    <LocationBadge
+      key="simple-detailed"
+      student={student}
+      displayMode="roomName"
+      variant="simple"
+    />,
+  ],
+  ["binary presence badge", <PresenceBadge key="binary" student={student} />],
+  [
+    "simple binary presence badge",
+    <PresenceBadge key="simple-binary" student={student} variant="simple" />,
+  ],
+])("%s", (_name, badge) => {
+  it("right-aligns stacked status pills", () => {
+    const { container } = render(badge);
+
+    expect(container.firstElementChild).toHaveClass("items-end");
+  });
+});

--- a/frontend/src/components/ui/presence-badge.tsx
+++ b/frontend/src/components/ui/presence-badge.tsx
@@ -143,6 +143,12 @@ function resolveBadgeStyle(
   if (student.excused && atHome) {
     return { label: LOCATION_STATUSES.EXCUSED, color: LOCATION_COLORS.EXCUSED };
   }
+  if (student.not_arrival_today && atHome) {
+    return {
+      label: LOCATION_STATUSES.NOT_ARRIVAL,
+      color: LOCATION_COLORS.NOT_ARRIVAL,
+    };
+  }
 
   switch (state) {
     case "anwesend":
@@ -173,14 +179,21 @@ export function PresenceBadge({
   const sizeConfig = SIZE_MAP[sizeKey] ?? SIZE_MAP[DEFAULT_SIZE];
   const tone = getLocationBadgeTone(color);
 
-  // "Additional" sick/excused overlays — only when the student is present
-  // (not already shown as Krank/Entschuldigt via the replace path above).
-  const showSickOverlay = student.sick && state !== "abwesend";
+  // A contradiction between actual presence and the plan is more actionable
+  // than the underlying absence reason (krank, entschuldigt, etc.).
+  const showUnplannedOverlay =
+    student.not_arrival_today && state !== "abwesend";
+  const showSickOverlay =
+    student.sick && state !== "abwesend" && !showUnplannedOverlay;
   const showClassTripOverlay =
-    student.class_trip && state !== "abwesend" && !showSickOverlay;
+    student.class_trip &&
+    state !== "abwesend" &&
+    !showUnplannedOverlay &&
+    !showSickOverlay;
   const showExcusedOverlay =
     student.excused &&
     state !== "abwesend" &&
+    !showUnplannedOverlay &&
     !showSickOverlay &&
     !showClassTripOverlay;
 
@@ -240,6 +253,13 @@ export function PresenceBadge({
           seit {formattedTime} Uhr
         </span>
       )}
+      {showUnplannedOverlay &&
+        renderOverlayBadge({
+          overlayLabel: LOCATION_STATUSES.UNPLANNED_PRESENT,
+          overlayColor: LOCATION_COLORS.NOT_ARRIVAL,
+          dataAttr: "data-not-arrival-indicator",
+          sizeConfig,
+        })}
       {showSickOverlay &&
         renderOverlayBadge({
           overlayLabel: LOCATION_STATUSES.SICK,

--- a/frontend/src/components/ui/presence-badge.tsx
+++ b/frontend/src/components/ui/presence-badge.tsx
@@ -246,7 +246,7 @@ export function PresenceBadge({
     );
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-end">
       {pill}
       {showSinceTime && (
         <span className="mt-0.5 text-[10px] text-gray-500">

--- a/frontend/src/components/ui/unplanned-presence-badges.test.tsx
+++ b/frontend/src/components/ui/unplanned-presence-badges.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LocationBadge } from "./location-badge";
+import { PresenceBadge } from "./presence-badge";
+
+const student = {
+  current_location: "Anwesend - Gruppenraum",
+  not_arrival_today: true,
+  not_arrival_reason: "Kommt heute nicht",
+};
+
+describe.each([
+  [
+    "detailed presence badge",
+    <LocationBadge key="detailed" student={student} displayMode="roomName" />,
+    "Gruppenraum",
+  ],
+  [
+    "binary presence badge",
+    <PresenceBadge key="binary" student={student} />,
+    "Anwesend",
+  ],
+])("%s", (_name, badge, expectedLocation) => {
+  it("keeps the actual location primary and shows the contradiction", () => {
+    render(badge);
+
+    expect(screen.getByText(expectedLocation)).toBeInTheDocument();
+    expect(screen.getByText("Ungeplant anwesend")).toBeInTheDocument();
+    expect(screen.queryByText("Kommt heute nicht")).not.toBeInTheDocument();
+  });
+});
+
+it("shows the contradiction instead of the underlying absence reason", () => {
+  render(
+    <LocationBadge
+      student={{ ...student, sick: true }}
+      displayMode="roomName"
+    />,
+  );
+
+  expect(screen.getByText("Gruppenraum")).toBeInTheDocument();
+  expect(screen.getByText("Ungeplant anwesend")).toBeInTheDocument();
+  expect(screen.queryByText("Krank")).not.toBeInTheDocument();
+});

--- a/frontend/src/lib/day-planning-helper.issue-2379.test.ts
+++ b/frontend/src/lib/day-planning-helper.issue-2379.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { getStudentPresenceBadgePlanning } from "./day-planning-helper";
+
+describe("getStudentPresenceBadgePlanning unplanned presence", () => {
+  it("keeps a planned absence visible while the child is at home", () => {
+    expect(
+      getStudentPresenceBadgePlanning({
+        current_location: "Zuhause",
+        day_planning_status: "not_coming_today",
+        day_planning_label: "Kommt heute nicht",
+      }),
+    ).toEqual({
+      notArrivalToday: true,
+      notArrivalReason: "Kommt heute nicht",
+    });
+  });
+
+  it("marks actual attendance that contradicts the plan", () => {
+    expect(
+      getStudentPresenceBadgePlanning({
+        current_location: "Anwesend - Gruppenraum",
+        day_planning_status: "comes_today",
+        day_planning_reason: "unplanned_attendance",
+        day_planning_label: "ungeplant anwesend",
+        actual_arrival_time: "08:30",
+      }),
+    ).toEqual({
+      notArrivalToday: true,
+      notArrivalReason: "ungeplant anwesend",
+    });
+  });
+
+  it("restores the planned absence after checkout", () => {
+    expect(
+      getStudentPresenceBadgePlanning({
+        current_location: "Zuhause",
+        day_planning_status: "not_coming_today",
+        day_planning_reason: "arrival_exception",
+        day_planning_label: "Kommt heute nicht",
+        actual_arrival_time: "08:30",
+      }),
+    ).toEqual({
+      notArrivalToday: true,
+      notArrivalReason: "Kommt heute nicht",
+    });
+  });
+
+  it("does not mark a normally planned check-in as unplanned", () => {
+    expect(
+      getStudentPresenceBadgePlanning({
+        current_location: "Anwesend - Gruppenraum",
+        day_planning_status: "comes_today",
+        day_planning_reason: "pickup_schedule",
+        day_planning_label: "Abholplan heute",
+        actual_arrival_time: "08:30",
+      }),
+    ).toEqual({
+      notArrivalToday: false,
+      notArrivalReason: null,
+    });
+  });
+});

--- a/frontend/src/lib/day-planning-helper.issue-2379.test.ts
+++ b/frontend/src/lib/day-planning-helper.issue-2379.test.ts
@@ -46,6 +46,35 @@ describe("getStudentPresenceBadgePlanning unplanned presence", () => {
     });
   });
 
+  it("restores the planned absence for composite home locations after checkout", () => {
+    expect(
+      getStudentPresenceBadgePlanning({
+        current_location: "Zuhause - Abgeholt",
+        day_planning_status: "not_coming_today",
+        day_planning_reason: "arrival_exception",
+        day_planning_label: "Kommt heute nicht",
+        actual_arrival_time: "08:30",
+      }),
+    ).toEqual({
+      notArrivalToday: true,
+      notArrivalReason: "Kommt heute nicht",
+    });
+  });
+
+  it("keeps an active transit check-in marked as unplanned", () => {
+    expect(
+      getStudentPresenceBadgePlanning({
+        current_location: "Unterwegs",
+        day_planning_status: "comes_today",
+        day_planning_reason: "unplanned_attendance",
+        day_planning_label: "ungeplant anwesend",
+      }),
+    ).toEqual({
+      notArrivalToday: true,
+      notArrivalReason: "ungeplant anwesend",
+    });
+  });
+
   it("does not mark a normally planned check-in as unplanned", () => {
     expect(
       getStudentPresenceBadgePlanning({

--- a/frontend/src/lib/day-planning-helper.ts
+++ b/frontend/src/lib/day-planning-helper.ts
@@ -1,3 +1,5 @@
+import { LOCATION_STATUSES, parseLocation } from "./location-helper";
+
 type DayPlanningStatus = "comes_today" | "not_coming_today";
 
 export interface DayPlanningStudent {
@@ -62,7 +64,13 @@ export function getStudentPresenceBadgePlanning(student: DayPlanningStudent): {
 function hasActualAttendance(
   student: Pick<DayPlanningStudent, "actual_arrival_time" | "current_location">,
 ): boolean {
-  const location = student.current_location?.trim().toLowerCase();
-  if (location) return location !== "zuhause" && location !== "abwesend";
+  if (student.current_location?.trim()) {
+    const { status } = parseLocation(student.current_location);
+    return (
+      status === LOCATION_STATUSES.PRESENT ||
+      status === LOCATION_STATUSES.SCHOOLYARD ||
+      status === LOCATION_STATUSES.TRANSIT
+    );
+  }
   return !!student.actual_arrival_time;
 }

--- a/frontend/src/lib/day-planning-helper.ts
+++ b/frontend/src/lib/day-planning-helper.ts
@@ -2,6 +2,7 @@ type DayPlanningStatus = "comes_today" | "not_coming_today";
 
 export interface DayPlanningStudent {
   day_planning_status?: DayPlanningStatus;
+  day_planning_reason?: string;
   day_planning_label?: string;
   arrival_is_exception?: boolean;
   arrival_time?: string;
@@ -38,6 +39,16 @@ export function getStudentPresenceBadgePlanning(student: DayPlanningStudent): {
   notArrivalToday: boolean;
   notArrivalReason: string | null;
 } {
+  if (
+    student.day_planning_reason === "unplanned_attendance" &&
+    hasActualAttendance(student)
+  ) {
+    return {
+      notArrivalToday: true,
+      notArrivalReason: student.day_planning_label ?? "ungeplant anwesend",
+    };
+  }
+
   const dayPlanningLabel = getDayPlanningNotComingLabel(student);
   const arrivalExceptionAbsent =
     (student.arrival_is_exception ?? false) && !student.arrival_time;
@@ -51,7 +62,7 @@ export function getStudentPresenceBadgePlanning(student: DayPlanningStudent): {
 function hasActualAttendance(
   student: Pick<DayPlanningStudent, "actual_arrival_time" | "current_location">,
 ): boolean {
-  if (student.actual_arrival_time) return true;
   const location = student.current_location?.trim().toLowerCase();
-  return !!location && location !== "zuhause" && location !== "abwesend";
+  if (location) return location !== "zuhause" && location !== "abwesend";
+  return !!student.actual_arrival_time;
 }

--- a/frontend/src/lib/location-helper.ts
+++ b/frontend/src/lib/location-helper.ts
@@ -51,6 +51,7 @@ export const LOCATION_STATUSES = {
   EXCUSED: "Entschuldigt",
   CLASS_TRIP: "Klassenfahrt",
   NOT_ARRIVAL: "Kommt heute nicht",
+  UNPLANNED_PRESENT: "Ungeplant anwesend",
 } as const;
 
 /** Shared brand palette. Red follows Phoenix notifications and hours accounts. */

--- a/frontend/src/lib/ogs-group-live-api.ts
+++ b/frontend/src/lib/ogs-group-live-api.ts
@@ -31,6 +31,7 @@ export interface OgsLiveWireStudent {
   class_trip: boolean;
   class_trip_since?: string;
   day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
   day_planning_label?: string;
   pending_excused_note?: string;
   arrival_time?: string;

--- a/frontend/src/lib/student-helpers.test.ts
+++ b/frontend/src/lib/student-helpers.test.ts
@@ -48,6 +48,7 @@ describe("mapSlimStudentResponse", () => {
       sick: false,
       excused: false,
       class_trip: false,
+      day_planning_reason: "unplanned_attendance",
       departure_modes: ["bus", "pickup"],
       departure_label: "Taxi mit Begleitperson",
       has_full_access: true,
@@ -59,6 +60,9 @@ describe("mapSlimStudentResponse", () => {
     ]);
     expect(mapSlimStudentResponse(backendStudent).departure_label).toBe(
       "Taxi mit Begleitperson",
+    );
+    expect(mapSlimStudentResponse(backendStudent).day_planning_reason).toBe(
+      "unplanned_attendance",
     );
   });
 });

--- a/frontend/src/lib/student-helpers.ts
+++ b/frontend/src/lib/student-helpers.ts
@@ -547,6 +547,7 @@ export interface BackendSlimStudent {
   class_trip: boolean;
   class_trip_since?: string;
   day_planning_status?: "comes_today" | "not_coming_today";
+  day_planning_reason?: string;
   day_planning_label?: string;
   pending_excused_note?: string;
   departure_modes?: DepartureMode[];
@@ -871,6 +872,7 @@ export function mapSlimStudentResponse(
     class_trip: backendStudent.class_trip,
     class_trip_since: backendStudent.class_trip_since,
     day_planning_status: backendStudent.day_planning_status,
+    day_planning_reason: backendStudent.day_planning_reason,
     day_planning_label: backendStudent.day_planning_label,
     pending_excused_note: backendStudent.pending_excused_note,
     departure_modes: backendStudent.departure_modes,


### PR DESCRIPTION
## Beschreibung

Kennzeichnet Kinder als „Ungeplant anwesend“, wenn sie trotz geplanter Abwesenheit aktuell anwesend sind.

- Der tatsächliche Aufenthaltsort bleibt die primäre Anzeige.
- Kindersuche und OGS-Gruppenübersicht zeigen den zusätzlichen Hinweis einheitlich.
- Tagesplanung, Ankunftsausnahmen und bekannte Abwesenheitsgründe werden berücksichtigt.
- Regulär geplante und anwesende Kinder erhalten keinen Hinweis.
- Nach dem Checkout verschwindet der Hinweis über die bestehende Live-Aktualisierung.
- Zuhause bleibt der geplante Abwesenheitsgrund sichtbar.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [ ] Performance improvement
- [x] Test addition/modification
- [ ] CI/CD improvement

## Related Issues

- Fixes #2379

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] Testing documentation updated

Ausgeführt:

- `scripts/test-backend.sh`
- `pnpm run test`
- `scripts/test-changed.sh origin/development`
- `pnpm run check`
- `go vet`
- `golangci-lint`

## Security Checklist

- [x] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Vorher-/Nachher-Vergleiche für Desktop und Mobil folgen als PR-Kommentar.

## Missverständnis-Check

- Geprüfte Blöcke: Aufenthaltsstatus in Kindersuche und OGS-Gruppenübersicht.
- Der tatsächliche Ort bleibt oben und damit die primäre Aussage.
- „Ungeplant anwesend“ erscheint getrennt darunter und erklärt den Widerspruch zur Planung.
- Die Formulierung entspricht dem im Issue vorgegebenen Fachbegriff.
- Keine neue Bedienfolge; eine Änderung des Hilfe-Leitfadens ist nicht erforderlich.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [x] User-visible change: I ran the Verständlichkeit checklist (`.claude/rules/verstaendlichkeit.md`) against the running app and recorded the result above — or it doesn't apply
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

- Keine Änderung am Kiosk erforderlich.
- Der Slim-API-Vertrag enthält dafür zusätzlich `day_planning_reason`.
