### PR TITLE
Reduce local and CI test resource usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,11 +31,20 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     outputs:
-      # On PRs: only run what changed.
-      # On protected branch pushes: run both suites for full SonarCloud coverage,
-      # but still skip docs-only churn.
-      run-backend: ${{ steps.filter.outputs.backend == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && steps.filter.outputs.frontend == 'true') }}
-      run-frontend: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && steps.filter.outputs.backend == 'true') }}
+      # Test jobs cross-run after merge to produce complete Sonar coverage.
+      # Lint/build jobs stay scoped to the side that changed.
+      run-backend: ${{ steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && steps.filter.outputs.frontend == 'true') }}
+      run-frontend: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.frontend-test-infra == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && (steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true')) }}
+      run-backend-lint: ${{ steps.filter.outputs.backend-lint == 'true' || steps.filter.outputs.ci == 'true' }}
+      run-frontend-lint: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
+      # The seed smoke drives runtime API contracts. Test-only edits and
+      # frontend-only pushes cannot affect it and must not buy another runner.
+      run-seed-smoke: ${{ steps.filter.outputs.backend-production == 'true' || steps.filter.outputs.ci == 'true' }}
+      # Workflow/config changes validate the complete test commands. Ordinary
+      # PRs use changed-test selection; protected-branch pushes are always full
+      # because they produce the coverage consumed by SonarCloud.
+      full-backend-suite: ${{ steps.filter.outputs.backend-test-infra == 'true' || steps.filter.outputs.ci == 'true' || github.event_name == 'push' }}
+      full-frontend-suite: ${{ steps.filter.outputs.frontend-test-infra == 'true' || steps.filter.outputs.ci == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -43,11 +52,45 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          predicate-quantifier: "some-with-excludes"
           filters: |
-            backend:
-              - 'backend/**'
+            backend-tests:
+              - 'backend/**/*.go'
+              - 'backend/go.mod'
+              - 'backend/go.sum'
+              - 'backend/**/testdata/**'
+              - 'backend/localization/locales.json'
+              - 'backend/services/listexport/assets/**'
+              - 'backend/templates/email/**'
+            backend-lint:
+              - 'backend/**/*.go'
+              - 'backend/go.mod'
+              - 'backend/go.sum'
+              - 'backend/.golangci.yml'
+            backend-production:
+              - 'backend/**/*.go'
+              - '!backend/**/*_test.go'
+              - 'backend/go.mod'
+              - 'backend/go.sum'
+              - 'backend/localization/locales.json'
+              - 'backend/services/listexport/assets/**'
+              - 'backend/templates/email/**'
             frontend:
               - 'frontend/**'
+              - '!frontend/**/*.md'
+            backend-test-infra:
+              - 'scripts/backend-affected-packages.sh'
+              - 'scripts/backend-affected-packages_test.sh'
+              - 'scripts/test-backend.sh'
+              - 'scripts/test-changed.sh'
+            frontend-test-infra:
+              - 'frontend/package.json'
+              - 'frontend/pnpm-lock.yaml'
+              - 'frontend/pnpm-workspace.yaml'
+              - 'frontend/tsconfig.json'
+              - 'frontend/vitest.config.ts'
+              - 'frontend/src/test/setup.ts'
+              - 'scripts/test-changed.sh'
             ci:
               - '.github/**'
               - 'sonar-project.properties'
@@ -61,8 +104,8 @@ jobs:
     needs: detect-changes
     uses: ./.github/workflows/lint.yml
     with:
-      run-backend: ${{ needs.detect-changes.outputs.run-backend == 'true' }}
-      run-frontend: ${{ needs.detect-changes.outputs.run-frontend == 'true' }}
+      run-backend: ${{ needs.detect-changes.outputs.run-backend-lint == 'true' }}
+      run-frontend: ${{ needs.detect-changes.outputs.run-frontend-lint == 'true' }}
 
   test:
     permissions:
@@ -73,8 +116,11 @@ jobs:
     with:
       run-backend: ${{ needs.detect-changes.outputs.run-backend == 'true' }}
       run-frontend: ${{ needs.detect-changes.outputs.run-frontend == 'true' }}
+      run-seed-smoke: ${{ needs.detect-changes.outputs.run-seed-smoke == 'true' }}
       is-pr: ${{ github.event_name == 'pull_request' }}
       base_ref: ${{ github.base_ref }}
+      full-backend-suite: ${{ needs.detect-changes.outputs.full-backend-suite == 'true' }}
+      full-frontend-suite: ${{ needs.detect-changes.outputs.full-frontend-suite == 'true' }}
 
   # Deliberately NOT a ci-gate dependency. Sonar needs the coverage artifacts,
   # so it can only start once test finishes; keeping it in the gate added its

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,21 @@ on:
       run-frontend:
         type: boolean
         default: true
+      run-seed-smoke:
+        type: boolean
+        required: true
       is-pr:
         type: boolean
         default: false
       base_ref:
         type: string
         default: ""
+      full-backend-suite:
+        type: boolean
+        required: true
+      full-frontend-suite:
+        type: boolean
+        required: true
 
 defaults:
   run:
@@ -23,7 +32,10 @@ defaults:
 jobs:
   test-backend:
     if: ${{ inputs.run-backend }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # PRs run only affected packages without coverage; four vCPUs avoid paying
+    # the 8-vCPU rate for that smaller workload. Protected-branch pushes keep
+    # eight vCPUs for the full instrumented suite consumed by SonarCloud.
+    runs-on: ${{ inputs.is-pr && 'blacksmith-4vcpu-ubuntu-2404' || 'blacksmith-8vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       checks: write
@@ -47,6 +59,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # PR test selection needs origin/<base_ref>. Keeping one checkout
+          # shape for both event types avoids an untested expression branch.
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -54,6 +70,9 @@ jobs:
           go-version-file: backend/go.mod
           cache: true
           cache-dependency-path: backend/go.sum
+
+      - name: Test affected-package selection
+        run: scripts/backend-affected-packages_test.sh
 
       - name: Restore migrated DB snapshot
         id: db-snapshot
@@ -112,7 +131,7 @@ jobs:
           docker exec -i "$PG_CONTAINER" pg_dump -U postgres phoenix_test \
             > backend/.db-snapshot/dump.sql
 
-      - name: Run Go tests with coverage
+      - name: Run Go tests
         working-directory: backend
         env:
           TEST_DB_DSN: postgres://postgres:postgres@localhost:5432/phoenix_test?sslmode=disable
@@ -130,24 +149,38 @@ jobs:
           PARENTS_URL: http://parents.localhost:3000
           NEXT_PUBLIC_OPERATOR_HOSTNAME: operator.localhost:3000
           TENANT_DOMAIN: localhost
-        # Single pass produces junit.xml AND coverage.out. No --rerun-fails:
-        # gotestsum reruns overwrite the coverage profile (upstream issue;
-        # fix PR unmerged), and flaky tests should fail loudly, not retry.
-        # gotestsum is a go.mod tool directive, so its whole dependency
-        # graph is locked by go.sum (sonar githubactions:S8545).
+          BASE_REF: ${{ inputs.base_ref }}
+          FULL_SUITE: ${{ inputs.full-backend-suite }}
+          IS_PR: ${{ inputs.is-pr }}
         run: |
-          # -p/-parallel are pinned, not left at GOMAXPROCS: `go test` runs
-          # -p package binaries at once and each opens (-parallel + headroom)
-          # connections plus a keeper. 6 x 13 = 78 fits the 100 connections a
-          # stock postgres:17 service container allows and leaves 22 for
-          # lifecycle and maintenance sessions.
-          # scripts/test-backend.sh owns these numbers — change them there
-          # first, then mirror. CI cannot call the wrapper: it needs the
-          # coverage flags and does its own DB snapshot restore.
-          go tool gotestsum \
-            --format pkgname-and-test-fails \
-            --junitfile junit.xml \
-            -- -p 6 -parallel 8 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+          packages=(./...)
+          if [ "$IS_PR" = true ] && [ "$FULL_SUITE" = false ] && [ -n "$BASE_REF" ]; then
+            affected_output=$(../scripts/backend-affected-packages.sh "origin/$BASE_REF")
+            packages=()
+            while IFS= read -r package; do
+              [ -n "$package" ] && packages+=("$package")
+            done <<< "$affected_output"
+            if [ "${#packages[@]}" -eq 0 ]; then
+              echo "No changed Go packages"
+              exit 0
+            fi
+            echo "Running ${#packages[@]} changed/affected Go packages"
+          fi
+
+          test_args=(-parallel 8)
+          if [ "$IS_PR" = true ]; then
+            test_args+=(-p 4)
+          else
+            # Coverage is consumed only by the post-merge SonarCloud job.
+            # Keeping it off PRs avoids instrumenting every dependency and
+            # merging a large profile that no PR job reads.
+            test_args+=(-p 6 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out)
+          fi
+
+          # Single pass produces junit.xml and, on pushes, coverage.out. No
+          # retries: flaky tests should fail loudly, not be hidden.
+          go tool gotestsum --format pkgname-and-test-fails \
+            --junitfile junit.xml -- "${test_args[@]}" "${packages[@]}"
 
       - name: Fix Go coverage paths for SonarCloud
         if: ${{ always() && hashFiles('backend/coverage.out') != '' }}
@@ -185,11 +218,11 @@ jobs:
             backend/coverage.out
             backend/junit.xml
           retention-days: 7
-        if: always()
+        if: ${{ always() && ! inputs.is-pr && hashFiles('backend/coverage.out', 'backend/junit.xml') != '' }}
 
       - name: Publish backend test results
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
-        if: always()
+        if: ${{ always() && hashFiles('backend/junit.xml') != '' }}
         with:
           report_paths: backend/junit.xml
           check_name: Backend Test Results
@@ -222,15 +255,18 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
 
-      - name: Run changed frontend tests with coverage
-        if: ${{ inputs.is-pr && inputs.base_ref != '' }}
+      - name: Run changed frontend tests
+        if: ${{ inputs.is-pr && ! inputs.full-frontend-suite && inputs.base_ref != '' }}
         working-directory: frontend
-        env:
-          BASE_REF: ${{ inputs.base_ref }}
-        run: pnpm vitest run --changed "origin/${BASE_REF}" --coverage
+        run: pnpm vitest run --changed "origin/${{ inputs.base_ref }}"
+
+      - name: Run full frontend tests
+        if: ${{ inputs.is-pr && (inputs.full-frontend-suite || inputs.base_ref == '') }}
+        working-directory: frontend
+        run: pnpm run test:run
 
       - name: Run full frontend tests with coverage
-        if: ${{ !inputs.is-pr || inputs.base_ref == '' }}
+        if: ${{ ! inputs.is-pr }}
         working-directory: frontend
         run: pnpm run test:run --coverage
 
@@ -240,7 +276,7 @@ jobs:
           name: coverage-frontend
           path: frontend/coverage/lcov.info
           retention-days: 7
-        if: always()
+        if: ${{ always() && hashFiles('frontend/coverage/lcov.info') != '' }}
 
   # The seeder is the widest end-to-end path in this repo: roughly a hundred
   # real API calls across auth, enrollment, parent portal, time tracking and
@@ -250,7 +286,7 @@ jobs:
   # surfaced a month later, when a developer seeded by hand.
   seed-smoke:
     name: Seed & simulate smoke
-    if: ${{ inputs.run-backend }}
+    if: ${{ inputs.run-seed-smoke }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -198,8 +198,9 @@ func TestExample(t *testing.T) {
   tenants without a tenant transaction (RLS never narrows it), it measures a
   query budget on the shared pool, or it takes a row lock and expects a second
   transaction to block on it. Anything else gets fixed, not exempted.
-- **Concurrency is pinned, not inherited**: `scripts/test-backend.sh` and CI run
-  `-p 4 -parallel 8`. The pool per binary is derived from `-test.parallel` plus
+- **Concurrency is pinned, not inherited**: `scripts/test-backend.sh` and
+  post-merge CI run `-p 6 -parallel 8`; changed-only PRs run `-p 4 -parallel 8`.
+  The pool per binary is derived from `-test.parallel` plus
   headroom, because a test holding a tenant transaction that opens a second one
   needs two connections at once — without headroom those tests deadlock and
   every one of them fails on its own 5s deadline, which looks nothing like a

--- a/docs/adr/0004-testsuite-besitzt-datenbanken-nicht-server.md
+++ b/docs/adr/0004-testsuite-besitzt-datenbanken-nicht-server.md
@@ -58,8 +58,8 @@ mechanischer Sweep über alle Testdateien):
   Poolgröße kommt aus `-test.parallel` plus Reserve, nicht aus GOMAXPROCS:
   ein Test, der eine Tenant-Transaktion hält und darin eine zweite öffnet,
   braucht zwei Verbindungen gleichzeitig, und ohne Reserve blockieren sich
-  `-parallel` solcher Tests gegenseitig bis zum Timeout. Wrapper und CI
-  pinnen zusätzlich `-p 4 -parallel 8`, damit das serverseitige Budget
+  `-parallel` solcher Tests gegenseitig bis zum Timeout. Wrapper und
+  Post-Merge-CI pinnen zusätzlich `-p 6 -parallel 8`, damit das serverseitige Budget
   (p × (Pool + 1)) unter den 100 Verbindungen eines Standard-postgres:17
   bleibt.
 
@@ -129,12 +129,40 @@ mechanischer Sweep über alle Testdateien):
   datenbankweit, ein parallel laufender Nachbar wäre nicht vom eigenen Test
   zu trennen.
 
+CI-PRs verwenden dieselbe Reverse-Dependency-Auswahl wie
+`scripts/test-changed.sh` und erzeugen keine Coverage: Seit SonarCloud nur auf
+Pushes nach `development`/`main` läuft, hatte die PR-Coverage keinen Verbraucher.
+Änderungen an der Test-Infrastruktur erzwingen nur den Volllauf der betroffenen
+Suite; CI-Workflow-Änderungen erzwingen beide. Pushes fahren beide Vollläufe mit
+Coverage für SonarCloud. Reine Markdown- und nicht testrelevante
+Backend-Konfigurationsänderungen starten keine Tests.
+Lint- und Build-Jobs laufen dabei nur für den tatsächlich geänderten Stack;
+die Sonar-bedingte Gegen-Suite startet ausschließlich ihre Tests mit Coverage.
+Reine `_test.go`-Änderungen laufen nur im eigenen Package; nur geänderter
+Produktionscode zieht die transitiven Importierer nach sich. Eingebettete
+Produktions-Assets (Locales, Export-Schriften/-Logo) zählen wie Produktionscode;
+Goldens und E-Mail-Templates laufen in ihrem besitzenden Test-Package.
+
+Der lokale Changed-Loop nutzt höchstens die Hälfte der erkannten CPUs und
+maximal vier Package-Binaries. `GOMAXPROCS` pro Binary wird so berechnet, dass
+auch zusammen höchstens die halbe Maschine belegt wird; `-parallel` ist auf
+acht begrenzt. CI und der explizite Volllauf-Wrapper behalten für Post-Merge-Coverage
+`-p 6 -parallel 8`. Changed-only-PRs laufen auf dem 4-vCPU-Runner mit `-p 4`
+statt den doppelten Minutenpreis des 8-vCPU-Runners zu zahlen. Vitest nutzt
+lokal ebenfalls höchstens die Hälfte beziehungsweise vier Worker, in CI aber
+alle CPUs des isolierten Runners.
+
+Der eigenständige Seed-&-Simulate-Smoke läuft nur bei Backend-Produktionscode,
+seinen eingebetteten/runtime-geladenen Assets oder CI-Workflow-Änderungen.
+Frontend-only-Pushes und reine Backend-Teständerungen starten seinen
+4-vCPU-Runner nicht.
+
 Abgewogen: Ein ephemerer Postgres pro Lauf hätte „Start = Ende" trivial wahr
 gemacht, kostet aber pro Lauf den Template-Neubau (~25s) oder einen eigenen
 Cache dafür; der langlebige Container mit Datenbank-GC liefert dieselbe
 Garantie auf Datenbank-Ebene ohne diesen Preis. TestMain pro Package hätte
 auch nackte `go test`-Aufrufe aufräumen lassen, wurde aber gegen 62
 Boilerplate-Dateien getauscht, weil die GC den Rest erledigt. Zielwerte:
-CI test-backend unter 90 Sekunden, lokaler Volllauf ≈ 2 Minuten; die Frage
-4-vCPU- statt 8-vCPU-Runner wird erst nach dem Umbau gemessen, nicht vorab
-entschieden.
+CI test-backend unter 90 Sekunden, lokaler Volllauf ≈ 2 Minuten. Die
+Changed-only-PR-Last rechtfertigt den 4-vCPU-Runner; der instrumentierte
+Post-Merge-Volllauf bleibt auf 8 vCPUs.

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,22 +2,16 @@ import "@testing-library/jest-dom/vitest";
 import type React from "react";
 import { beforeEach, vi } from "vitest";
 
-// Reset the module-level session cache between tests. Resolve the lazy import
-// once per isolated test file instead of once per test (~1,000 vs ~14,000
-// imports per full run). A static import would bind next-auth/react before the
-// test file's vi.mock registers. Some tests mock session-cache without the
-// clear export, and Vitest throws while accessing that missing export.
-let clearSessionCache: (() => void) | undefined;
-let sessionCacheLoaded = false;
+// Reset the module-level session cache between tests. A static import would
+// bind next-auth/react before the test file's vi.mock registers. Importing here
+// also resolves the current module after a test calls vi.resetModules(). Some
+// tests mock session-cache without the clear export, and Vitest throws while
+// accessing that missing export.
 beforeEach(async () => {
-  if (!sessionCacheLoaded) {
-    sessionCacheLoaded = true;
-    const sessionCache = await import("~/lib/session-cache");
-    if ("clearSessionCache" in sessionCache) {
-      clearSessionCache = sessionCache.clearSessionCache;
-    }
+  const sessionCache = await import("~/lib/session-cache");
+  if ("clearSessionCache" in sessionCache) {
+    sessionCache.clearSessionCache();
   }
-  clearSessionCache?.();
 });
 
 function createStorageMock(): Storage {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,21 +2,22 @@ import "@testing-library/jest-dom/vitest";
 import type React from "react";
 import { beforeEach, vi } from "vitest";
 
-// Reset the module-level session cache between tests. Since #2123 the API
-// clients read the NextAuth session through ~/lib/session-cache (10s TTL), so
-// a session cached by one test would otherwise leak into the next. Lazy import
-// on purpose: a static import would load the real next-auth/react before a
-// test file's vi.mock of it registers, so mocked files would bind the real
-// getSession. try/catch instead of an export check: some tests mock
-// ./session-cache with only a sessionFetch export, and vitest's mock proxy
-// throws already on ACCESSING the missing clearSessionCache export.
+// Reset the module-level session cache between tests. Resolve the lazy import
+// once per isolated test file instead of once per test (~1,000 vs ~14,000
+// imports per full run). A static import would bind next-auth/react before the
+// test file's vi.mock registers. Some tests mock session-cache without the
+// clear export, and Vitest throws while accessing that missing export.
+let clearSessionCache: (() => void) | undefined;
+let sessionCacheLoaded = false;
 beforeEach(async () => {
-  try {
-    const { clearSessionCache } = await import("~/lib/session-cache");
-    clearSessionCache();
-  } catch {
-    // Module mocked without clearSessionCache — nothing to reset.
+  if (!sessionCacheLoaded) {
+    sessionCacheLoaded = true;
+    const sessionCache = await import("~/lib/session-cache");
+    if ("clearSessionCache" in sessionCache) {
+      clearSessionCache = sessionCache.clearSessionCache;
+    }
   }
+  clearSessionCache?.();
 });
 
 function createStorageMock(): Storage {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
+import { availableParallelism } from "node:os";
 
 // Pin the test process to Berlin time. The app reasons in Europe/Berlin
 // wall-clock (backend timestamps, reminder thresholds, calendar-date handling),
@@ -19,16 +20,22 @@ export default defineConfig({
     // (1027 Dateien / 14160 Tests, 16-Core-MacBook) 124s → 76s Wandzeit und
     // -24% CPU — der Unterschied ist reiner Prozess-Spawn-/IPC-Overhead.
     pool: "threads",
-    // Lokal auf 8 Worker gedeckelt, damit der Rechner während eines vollen
-    // Laufs benutzbar bleibt (Default wäre ~15 auf 16 Cores). Kostet ~4s
-    // Wandzeit, spart weitere ~13% CPU. CI bleibt ungedeckelt (läuft dort
-    // ohnehin nur --changed).
-    maxWorkers: process.env.CI ? undefined : 8,
+    // Lokal höchstens die Hälfte der CPUs und nie mehr als vier Worker.
+    // Gemessen auf 231 Dateien: 8 → 4 Worker senkt CPU um 19% und Peak-RSS
+    // von 3,8 auf 2,7 GB; die Wandzeit steigt von 53 auf 67 Sekunden. CI hat
+    // einen isolierten Runner und nutzt deshalb alle bezahlten CPUs.
+    maxWorkers: process.env.CI
+      ? availableParallelism()
+      : Math.max(1, Math.min(4, Math.floor(availableParallelism() / 2))),
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/e2e/**"], // Exclude Playwright tests
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html", "lcov"],
+      // CI uploads only lcov.info for SonarCloud. Building JSON/HTML trees and
+      // printing a 1,000-file table wastes CPU, disk, and log bandwidth.
+      reporter: process.env.CI
+        ? ["lcovonly"]
+        : ["text", "json", "html", "lcov"],
       reportOnFailure: true, // Generate coverage even when tests fail
       exclude: [
         "node_modules/",
@@ -42,8 +49,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "~": path.resolve(__dirname, "./src"),
-      "@": path.resolve(__dirname, "./src"),
+      "~": path.resolve(import.meta.dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 });

--- a/scripts/backend-affected-packages.sh
+++ b/scripts/backend-affected-packages.sh
@@ -74,7 +74,7 @@ done <<< "$changed_dirs"
 if [ "$deleted_production" = true ]; then
   # There is no package left to test, but surviving imports of the removed
   # package must fail instead of turning the changed-test run into a no-op.
-  (cd "$repo_root/backend" && go list -deps -export ./... >/dev/null)
+  (cd "$repo_root/backend" && go list -deps -test -export ./... >/dev/null)
 fi
 
 if [ "${#existing_dirs[@]}" -eq 0 ]; then

--- a/scripts/backend-affected-packages.sh
+++ b/scripts/backend-affected-packages.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Prints changed backend packages. Production changes also select every package
+# whose production or test graph depends on them. Output is one import per line.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+base=${1:-origin/development}
+merge_base=$(git merge-base HEAD "$base")
+
+backend_changes=$(
+  {
+    git diff --name-only "$merge_base" -- backend
+    git ls-files --others --exclude-standard -- backend
+  } | sort -u
+)
+
+if printf '%s\n' "$backend_changes" | grep -qxE 'backend/go\.(mod|sum)'; then
+  printf './...\n'
+  exit 0
+fi
+
+changed_dirs=$(printf '%s\n' "$backend_changes" | awk '
+  /\.go$/ {
+    path = $0
+    kind = path ~ /_test\.go$/ ? "test" : "production"
+    sub(/^backend\//, "", path)
+    if (path !~ /\//) {
+      path = "."
+    } else {
+      sub(/\/[^\/]+$/, "", path)
+    }
+    print kind, path
+    next
+  }
+  /^backend\/.*\/testdata\// {
+    path = $0
+    sub(/^backend\//, "", path)
+    sub(/\/testdata\/.*/, "", path)
+    print "test", path
+    next
+  }
+  /^backend\/templates\/email\/.*\.html$/ { print "test templates/email"; next }
+  /^backend\/localization\/locales\.json$/ { print "production localization"; next }
+  /^backend\/services\/listexport\/assets\// { print "production services/listexport" }
+' | sort -u)
+
+if [ -z "$changed_dirs" ]; then
+  exit 0
+fi
+
+existing_dirs=()
+deleted_production=false
+while read -r kind dir; do
+  package_dir="$repo_root/backend"
+  if [ "$dir" != "." ]; then
+    package_dir="$package_dir/$dir"
+  fi
+  # A deleted production package may leave only external test files behind.
+  package_exists=
+  for go_file in "$package_dir"/*.go; do
+    [ -e "$go_file" ] || continue
+    if [ "$kind" = test ] || [[ "$go_file" != *_test.go ]]; then
+      package_exists=$go_file
+      break
+    fi
+  done
+  if [ -n "$package_exists" ]; then
+    existing_dirs+=("$kind $dir")
+  elif [ "$kind" = production ]; then
+    deleted_production=true
+  fi
+done <<< "$changed_dirs"
+
+if [ "$deleted_production" = true ]; then
+  # There is no package left to test, but surviving imports of the removed
+  # package must fail instead of turning the changed-test run into a no-op.
+  (cd "$repo_root/backend" && go list -deps -export ./... >/dev/null)
+fi
+
+if [ "${#existing_dirs[@]}" -eq 0 ]; then
+  exit 0
+fi
+changed_dirs=$(printf '%s\n' "${existing_dirs[@]}")
+
+cd "$repo_root/backend"
+module=$(go list -m)
+changed=$(printf '%s\n' "$changed_dirs" | awk -v module="$module" '
+  { dirs[$2] = 1 }
+  END {
+    for (dir in dirs) {
+      if (dir == ".") print module
+      else print module "/" dir
+    }
+  }
+')
+production_changed=$(printf '%s\n' "$changed_dirs" | awk -v module="$module" '
+  $1 != "production" { next }
+  { dirs[$2] = 1 }
+  END {
+    for (dir in dirs) {
+      if (dir == ".") print module
+      else print module "/" dir
+    }
+  }
+')
+
+if [ -z "$production_changed" ]; then
+  printf '%s\n' "$changed" | sort -u
+  exit 0
+fi
+
+{
+  printf '%s\n' "$changed"
+  go list -test -f '{{if .ForTest}}{{.ForTest}}{{range .Deps}} {{.}}{{end}}{{end}}' ./... |
+    awk 'NR == FNR { changed[$0] = 1; next }
+      {
+        for (field = 2; field <= NF; field++) {
+          if ($field in changed) {
+            print $1
+            next
+          }
+        }
+      }' <(printf '%s\n' "$production_changed") -
+} | sort -u

--- a/scripts/backend-affected-packages_test.sh
+++ b/scripts/backend-affected-packages_test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+fixture=$(mktemp -d)
+cleanup() {
+  if [ -n "$fixture" ] && [ "$fixture" != / ] && [ -d "$fixture/.git" ]; then
+    rm -rf -- "$fixture"
+  else
+    echo "Refusing to delete unexpected fixture path: $fixture" >&2
+    return 1
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$fixture/backend"/{core,consumer,corex,localeconsumer,localization,exportconsumer,services/listexport/assets,templates/email}
+printf 'module example.test/project\n\ngo 1.25\n' >"$fixture/backend/go.mod"
+printf 'package core\n\nconst Value = 1\n' >"$fixture/backend/core/core.go"
+printf 'package core\n' >"$fixture/backend/core/core_test.go"
+cat >"$fixture/backend/consumer/consumer.go" <<'EOF'
+package consumer
+
+import "example.test/project/core"
+
+const Value = core.Value
+EOF
+printf 'package consumer\n' >"$fixture/backend/consumer/consumer_test.go"
+printf 'package corex\n' >"$fixture/backend/corex/corex.go"
+printf 'package corex\n' >"$fixture/backend/corex/corex_test.go"
+printf 'package localization\n\nconst Value = 1\n' >"$fixture/backend/localization/locales.go"
+printf 'package listexport\n\nconst Value = 1\n' >"$fixture/backend/services/listexport/export.go"
+printf 'package email\n' >"$fixture/backend/templates/email/template_test.go"
+cat >"$fixture/backend/localeconsumer/consumer.go" <<'EOF'
+package localeconsumer
+
+import "example.test/project/localization"
+
+const Value = localization.Value
+EOF
+printf 'package localeconsumer\n' >"$fixture/backend/localeconsumer/consumer_test.go"
+cat >"$fixture/backend/exportconsumer/consumer.go" <<'EOF'
+package exportconsumer
+
+import "example.test/project/services/listexport"
+
+const Value = listexport.Value
+EOF
+printf 'package exportconsumer\n' >"$fixture/backend/exportconsumer/consumer_test.go"
+
+git -C "$fixture" init -q
+git -C "$fixture" config user.email selector-test@example.invalid
+git -C "$fixture" config user.name selector-test
+git -C "$fixture" add .
+git -C "$fixture" commit -qm baseline
+
+select_packages() {
+  (cd "$fixture" && "$repo_root/scripts/backend-affected-packages.sh" HEAD)
+}
+
+assert_output() {
+  expected=$1
+  actual=$(select_packages)
+  if [ "$actual" != "$expected" ]; then
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_workflow_filter() {
+  filter=$1
+  pattern=$2
+  expected=$3
+  actual=$(awk -v filter="$filter:" -v pattern="- '$pattern'" '
+    $0 == "            " filter { active = 1; next }
+    active && $0 ~ /^            [a-z-]+:$/ { exit }
+    active && index($0, pattern) { found = 1 }
+    END { print found ? "present" : "absent" }
+  ' "$repo_root/.github/workflows/main.yml")
+  if [ "$actual" != "$expected" ]; then
+    echo "workflow filter $filter: expected $pattern to be $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+printf '\n// changed\n' >>"$fixture/backend/core/core_test.go"
+assert_output 'example.test/project/core'
+git -C "$fixture" restore backend/core/core_test.go
+
+printf '\n// changed\n' >>"$fixture/backend/core/core.go"
+assert_output $'example.test/project/consumer\nexample.test/project/core'
+git -C "$fixture" restore backend/core/core.go
+
+mkdir -p "$fixture/backend/consumer/testdata"
+printf 'fixture\n' >"$fixture/backend/consumer/testdata/input.golden"
+assert_output 'example.test/project/consumer'
+rm "$fixture/backend/consumer/testdata/input.golden"
+
+printf 'template\n' >"$fixture/backend/templates/email/probe.html"
+assert_output 'example.test/project/templates/email'
+rm "$fixture/backend/templates/email/probe.html"
+
+printf '{}\n' >"$fixture/backend/localization/locales.json"
+assert_output $'example.test/project/localeconsumer\nexample.test/project/localization'
+rm "$fixture/backend/localization/locales.json"
+
+printf 'asset\n' >"$fixture/backend/services/listexport/assets/probe.txt"
+assert_output $'example.test/project/exportconsumer\nexample.test/project/services/listexport'
+rm "$fixture/backend/services/listexport/assets/probe.txt"
+
+printf '\n// changed\n' >>"$fixture/backend/go.mod"
+assert_output './...'
+git -C "$fixture" restore backend/go.mod
+
+mv "$fixture/backend/core/core.go" "$fixture/core.go"
+if select_packages >/dev/null 2>&1; then
+  echo 'deleted imported package unexpectedly passed graph validation' >&2
+  exit 1
+fi
+
+assert_workflow_filter backend-tests 'backend/**/testdata/**' present
+assert_workflow_filter backend-production 'backend/**/testdata/**' absent
+for pattern in \
+  'backend/templates/email/**' \
+  'backend/localization/locales.json' \
+  'backend/services/listexport/assets/**'; do
+  assert_workflow_filter backend-tests "$pattern" present
+  assert_workflow_filter backend-production "$pattern" present
+done
+
+echo 'backend affected-package selector tests passed'

--- a/scripts/backend-affected-packages_test.sh
+++ b/scripts/backend-affected-packages_test.sh
@@ -16,7 +16,11 @@ trap cleanup EXIT
 mkdir -p "$fixture/backend"/{core,consumer,corex,localeconsumer,localization,exportconsumer,services/listexport/assets,templates/email}
 printf 'module example.test/project\n\ngo 1.25\n' >"$fixture/backend/go.mod"
 printf 'package core\n\nconst Value = 1\n' >"$fixture/backend/core/core.go"
-printf 'package core\n' >"$fixture/backend/core/core_test.go"
+cat >"$fixture/backend/core/core_test.go" <<'EOF'
+package core
+
+import _ "example.test/project/corex"
+EOF
 cat >"$fixture/backend/consumer/consumer.go" <<'EOF'
 package consumer
 
@@ -50,6 +54,7 @@ printf 'package exportconsumer\n' >"$fixture/backend/exportconsumer/consumer_tes
 git -C "$fixture" init -q
 git -C "$fixture" config user.email selector-test@example.invalid
 git -C "$fixture" config user.name selector-test
+git -C "$fixture" config commit.gpgSign false
 git -C "$fixture" add .
 git -C "$fixture" commit -qm baseline
 
@@ -110,6 +115,13 @@ rm "$fixture/backend/services/listexport/assets/probe.txt"
 printf '\n// changed\n' >>"$fixture/backend/go.mod"
 assert_output './...'
 git -C "$fixture" restore backend/go.mod
+
+mv "$fixture/backend/corex/corex.go" "$fixture/corex.go"
+if select_packages >/dev/null 2>&1; then
+  echo 'deleted package imported only by tests unexpectedly passed graph validation' >&2
+  exit 1
+fi
+mv "$fixture/corex.go" "$fixture/backend/corex/corex.go"
 
 mv "$fixture/backend/core/core.go" "$fixture/core.go"
 if select_packages >/dev/null 2>&1; then

--- a/scripts/test-changed.sh
+++ b/scripts/test-changed.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Läuft nur die Tests, die von den Änderungen gegenüber BASE betroffen sind.
 # Backend: geänderte Go-Packages PLUS alle Packages, deren Produktions- oder
-#   Test-Abhängigkeiten sie transitiv importieren — via `go list -test`.
+#   Test-Abhängigkeiten sie transitiv importieren.
 # Frontend: vitest --changed (derselbe Modus, den CI für PRs benutzt).
 #
 # Usage: scripts/test-changed.sh [base-ref]   (Default: origin/development)
@@ -9,76 +9,72 @@ set -euo pipefail
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
-# Backend-Läufe stempeln ihre DB-Clones mit einer Run-ID; der Sweep am Ende
-# droppt sie wieder und sammelt Clones toter Läufe ein (ADR 0004).
-PHX_TEST_RUN_ID=$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')
-export PHX_TEST_RUN_ID
-backend_sweep() { (cd "$repo_root/backend" && go run ./internal/testdb/cmd/sweep) || true; }
-trap backend_sweep EXIT
-
 BASE=${1:-origin/development}
 # Merge-Base statt Drei-Punkt-Diff, damit auch uncommittete Änderungen zählen.
 MB=$(git merge-base HEAD "$BASE")
 
-backend_changes=$(
-  {
-    git diff --name-only "$MB" -- backend
-    git ls-files --others --exclude-standard -- backend
-  } | sort -u
-)
+affected=()
+affected_output=$(scripts/backend-affected-packages.sh "$BASE")
+while IFS= read -r package; do
+  [ -n "$package" ] && affected+=("$package")
+done <<< "$affected_output"
 
-backend_tested=false
-if printf '%s\n' "$backend_changes" | grep -qxE 'backend/go\.(mod|sum)'; then
-  echo "==> go test (backend dependency changes)"
-  (cd backend && go test ./...)
-  backend_tested=true
-else
-  dirs=$(printf '%s\n' "$backend_changes" | awk '
-    /^backend\/[^\/]+\.go$/ { print "."; next }
-    /^backend\/.+\.go$/ {
-      path = $0
-      sub(/^backend\//, "", path)
-      sub(/\/[^\/]+$/, "", path)
-      print path
-    }
-  ' | sort -u)
-fi
-
-if [ -n "${dirs:-}" ]; then
-  cd backend
-  mod=$(go list -m)
-  changed=$(printf '%s\n' "$dirs" | awk -v mod="$mod" '
-    $0 == "." { print mod; next }
-    { print mod "/" $0 }
-  ')
-  # `-test` ergänzt die transitive Abhängigkeitskette der Test-Binaries.
-  # Substring-Match auf Import-Pfade kann minimal über-selektieren (foo trifft
-  # auch foo/bar) — zu viel testen ist ok, zu wenig nicht.
-  affected=$(
-    {
-      printf '%s\n' "$changed"
-      go list -test -f '{{if .ForTest}}{{.ForTest}} {{join .Deps " "}}{{end}}' ./... \
-        | { grep -F -f <(printf '%s\n' "$changed") || true; } \
-        | cut -d' ' -f1
-    } | sort -u
-  )
-  if [ -z "$affected" ]; then
-    echo "==> backend: keine betroffenen Packages ermittelt" >&2
+if [ "${#affected[@]}" -gt 0 ]; then
+  cpu_count=$(getconf _NPROCESSORS_ONLN)
+  if ! [[ "$cpu_count" =~ ^[1-9][0-9]*$ ]]; then
+    echo "getconf returned an invalid CPU count: $cpu_count" >&2
     exit 1
   fi
-  echo "==> go test ($(echo "$affected" | wc -l | tr -d ' ') affected packages, $(echo "$dirs" | wc -l | tr -d ' ') changed)"
-  # shellcheck disable=SC2086
-  go test $affected
-  cd ..
-elif [ "$backend_tested" = false ]; then
+  package_workers=$((cpu_count / 2))
+  if [ "$package_workers" -lt 1 ]; then
+    package_workers=1
+  elif [ "$package_workers" -gt 4 ]; then
+    package_workers=4
+  fi
+  binary_cpus=$((cpu_count / (2 * package_workers)))
+  if [ "$binary_cpus" -lt 1 ]; then
+    binary_cpus=1
+  fi
+  test_workers=$cpu_count
+  if [ "$test_workers" -gt 8 ]; then
+    test_workers=8
+  fi
+
+  # Half the machine (at most four package binaries) keeps the changed-test
+  # loop usable on weak hardware. Each DB-backed binary sizes its own pool from
+  # -parallel, so this also bounds local PostgreSQL connection pressure.
+  echo "==> go test (${#affected[@]} affected packages; -p $package_workers, GOMAXPROCS $binary_cpus, -parallel $test_workers)"
+  PHX_TEST_RUN_ID=$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')
+  export PHX_TEST_RUN_ID
+  backend_sweep() {
+    status=$?
+    if ! (cd "$repo_root/backend" && go run ./internal/testdb/cmd/sweep) &&
+      [ "$status" -eq 0 ]; then
+      status=1
+    fi
+    return "$status"
+  }
+  trap backend_sweep EXIT
+  (cd backend && GOMAXPROCS="$binary_cpus" go test \
+    -p "$package_workers" -parallel "$test_workers" "${affected[@]}")
+else
   echo "==> backend: keine Go-Änderungen"
 fi
 
-frontend_untracked=$(git ls-files --others --exclude-standard -- frontend)
-if [ -n "$frontend_untracked" ]; then
-  echo "==> vitest (unversionierte Frontend-Dateien)"
+frontend_changes=$(
+  {
+    git diff --name-only "$MB" -- frontend
+    git ls-files --others --exclude-standard -- frontend
+  } | awk '!/\.md$/' | sort -u
+)
+if printf '%s\n' "$frontend_changes" | grep -qxE \
+  'frontend/(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|tsconfig\.json|vitest\.config\.ts|src/test/setup\.ts)'; then
+  echo "==> vitest (frontend test infrastructure changed)"
   (cd frontend && pnpm vitest run)
-elif ! git diff --quiet "$MB" -- frontend; then
+elif [ -n "$frontend_changes" ]; then
+  # Vitest 4 includes committed, staged, unstaged, and untracked files in its
+  # dependency traversal. A separate full-suite fallback only duplicates work
+  # for new test files.
   echo "==> vitest --changed $BASE"
   (cd frontend && pnpm vitest run --changed "$BASE")
 else


### PR DESCRIPTION
# Pull Request

## Description

Reduce laptop heat and Blacksmith spend without weakening failure coverage:

- select changed backend packages plus exact transitive reverse dependencies
- keep test-only changes scoped to their owning package
- cap local Go and Vitest CPU use based on available hardware
- skip PR coverage; retain full post-merge coverage for SonarCloud
- keep cross-stack Sonar test runs while scoping lint and build jobs to changed stacks
- skip seed smoke for test-only and frontend-only changes
- add hermetic selector and workflow-routing regression tests
- make frontend session-cache resets fail clearly instead of swallowing import errors

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Configuration change
- [ ] Security improvement
- [x] Refactoring
- [x] Performance improvement
- [x] Test addition/modification
- [x] CI/CD improvement

## Related Issues

No issue linked.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] Testing documentation updated

Evidence:

- selector contract suite passes test-only, exact reverse dependency, testdata, template, locale, embedded-asset, go.mod, deletion, and YAML-filter cases
- backend representative broad set: 102 packages in 59.35s with aggregate CPU capped to half of the 16-core host (93.53s user, 37.49s sys, 832MB max RSS)
- frontend full suite: 1,046 files / 14,320 tests in 138.09s, 2.04GB max RSS
- frontend targeted session-cache/mock cases: 5 files / 66 tests passed
- `pnpm run check`, Actionlint, ShellCheck, Bash syntax, Prettier, `git diff --check`, pre-commit, and pre-push gates pass

## Security Checklist

- [x] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Not applicable; no UI change.

## Missverständnis-Check

nicht user-sichtbar

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [x] User-visible change: I ran the Verständlichkeit checklist (`.claude/rules/verstaendlichkeit.md`) against the running app and recorded the result above — or it doesn't apply
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

PRs run changed or affected tests without coverage. Workflow and test-infrastructure changes force the relevant full suite; CI workflow changes force both suites. Pushes to `development` and `main` run both full suites with coverage for SonarCloud. The seed-and-simulate smoke runs only for backend production changes, runtime-loaded assets, or CI workflow changes.
