### PR TITLE
test: run Schulhof room predicate test in parallel

### DIFF
--- a/backend/constants/activities_test.go
+++ b/backend/constants/activities_test.go
@@ -35,6 +35,8 @@ func TestIsSystemRoomName(t *testing.T) {
 // colour is admin-configurable, so callers that only care about the toilet
 // rooms need to tell the two apart.
 func TestIsSchulhofRoomName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string


### PR DESCRIPTION
## Description

Adds the missing `t.Parallel()` call to `TestIsSchulhofRoomName`. This restores the zero-serial-test ratchet for the `constants` package and fixes the failing protected-branch backend check.

## Type of Change

- [x] Bug fix
- [x] Test addition/modification
- [x] CI/CD improvement

## Related Issues

- Related to #2405

## Testing

- [x] `go test ./constants -run '^TestIsSchulhofRoomName$' -count=1`
- [ ] Full hermetic ratchet locally: blocked while linking because the workstation volume has only about 185 MiB free. GitHub CI runs the full suite from a clean environment.

## Security Checklist

- [x] No sensitive information is committed
- [x] No environment variables or security boundaries are changed
- [x] No hardcoded secrets are introduced

## Screenshots or Examples

Not applicable.

## Missverständnis-Check

nicht user-sichtbar

## Checklist

- [x] The change follows the project's style guidelines
- [x] Self-review completed
- [x] Documentation and help-guide updates do not apply
- [x] No merge conflicts
