### PR TITLE
Buchungsgebundene Planung als Zielarchitektur festhalten

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,10 +27,11 @@ tatsächliche Abholung kann davon abweichen.
 
 ## Angebots-Gehzeit
 
-Die **Angebots-Gehzeit** ist eine je Wochentag am Betreuungsangebot hinterlegte
-Gehzeit. Sie ist optional und dient als Vorgabe für die Gehzeiten der Kinder,
-die das Angebot an diesem Wochentag gebucht haben. Eine für ein einzelnes Kind
-gepflegte Gehzeit geht der Angebots-Gehzeit vor.
+Die **Angebots-Gehzeit** ist die je Wochentag am Betreuungsangebot hinterlegte
+Endzeit. In der buchungsgebundenen Planung braucht jedes betreuungswirksame
+Angebot an jedem wählbaren Tag eine solche Endzeit; die späteste gebuchte
+Endzeit bestimmt das Ende des Betreuungsfensters. Eine datierte
+Kind-Überschreibung kann davon abweichen.
 
 ## Abholart
 
@@ -52,7 +53,9 @@ Angaben bleiben unangetastet, bis sie erneut eingereicht werden.
 Das **Ausrollen** überträgt die Angebots-Gehzeit eines Betreuungsangebots auf
 die Gehzeiten aller Kinder, die das Angebot am jeweiligen Wochentag gebucht
 haben. Es geschieht nach ausdrücklicher Bestätigung; danach steht die Gehzeit
-am Kind selbst und trägt ihre Herkunft aus dem Angebot.
+am Kind selbst und trägt ihre Herkunft aus dem Angebot. Die buchungsgebundene
+Planung verwendet kein Ausrollen, sondern berechnet den Wert aus den am Datum
+wirksamen Angebotsbuchungen.
 
 ## Anfrage
 
@@ -210,6 +213,89 @@ Bestätigung durch die OGS wirksam.
 Ein **Betreuungstag** ist ein Wochentag, an dem das Kind laut regelmäßigem
 Wochenplan an der OGS-Betreuung teilnimmt.
 
+## Unterrichtsschluss
+
+Der **Unterrichtsschluss** ist die Uhrzeit, zu der der Unterricht einer
+Schulklasse an einem Wochentag endet. An Schultagen beginnt damit regelmäßig
+die anschließende OGS-Betreuung; eine datierte Kind-Überschreibung kann davon
+abweichen.
+
+## Betreuungsfenster
+
+Das **Betreuungsfenster** ist der Zeitraum, in dem ein Kind an einem Datum für
+die OGS-Betreuung eingeplant ist. An Schultagen beginnt es mit dem
+Unterrichtsschluss und endet mit der spätesten Endzeit seiner an diesem Tag
+gebuchten betreuungswirksamen Angebote.
+
+## Kind-Überschreibung
+
+Eine **Kind-Überschreibung** ersetzt für einen begrenzten Datumszeitraum den
+regelmäßigen Beginn oder das regelmäßige Ende des Betreuungsfensters eines
+Kindes. Sie trägt einen Grund und endet spätestens mit dem zugehörigen
+Halbjahr; eine einzelne Tagesabweichung ist keine Kind-Überschreibung.
+
+## Teilnehmerregel
+
+Eine **Teilnehmerregel** legt fest, nach welchen fachlichen Merkmalen ein
+wiederkehrender Termin seine Kinder erhält. Sie bleibt von einmaligen
+Änderungen an einem konkreten Termin getrennt.
+
+## Teilnehmer-Sollstand
+
+Der **Teilnehmer-Sollstand** ist die für ein Datum aus der Teilnehmerregel und
+den dann wirksamen Angebotsbuchungen berechnete Kinderliste eines noch nicht
+begonnenen Termins. Änderungen an den Quellen ändern diesen Sollstand, ohne
+gespeicherte Kinderlisten für zukünftige Termine abzugleichen.
+
+## Teilnehmer-Snapshot
+
+Der **Teilnehmer-Snapshot** ist die beim Start oder beim ersten tatsächlichen
+Ereignis festgehaltene Kinderliste eines konkreten Termins. Spätere Änderungen
+an Buchungen oder Teilnehmerregeln verändern diesen operativen und historischen
+Stand nicht rückwirkend.
+
+## Teilnehmerabweichung
+
+Eine **Teilnehmerabweichung** nimmt ein Kind für genau einen konkreten Termin
+zusätzlich in den Teilnehmer-Sollstand auf oder schließt es daraus aus. Sie
+trägt ihre Herkunft und einen Grund, verändert aber weder die Teilnehmerregel
+noch spätere Termine.
+
+## Buchungsgebundene Planung
+
+Bei der **buchungsgebundenen Planung** erhalten wiederkehrende Termine ihre
+Kinder ausschließlich durch Teilnehmerregeln aus wirksamen Angebotsbuchungen.
+Einmalige ungeplante Betreuung bleibt möglich, erzeugt aber weder eine
+Angebotsbuchung noch eine wiederkehrende Zuordnung.
+
+## Vergleichsbetrieb
+
+Der **Vergleichsbetrieb** berechnet den Teilnehmer-Sollstand der
+buchungsgebundenen Planung parallel zur weiterhin wirksamen manuellen Planung.
+Er zeigt Unterschiede, verändert aber noch keine operativen Kinderlisten oder
+Zeiten.
+
+## Konsistenzprüfung und Reparatur
+
+Die **Konsistenzprüfung** vergleicht wirksame Quellen mit daraus berechenbaren
+Daten und macht jede Abweichung für die OGS sichtbar. Eine **Reparatur** darf
+nur eindeutig ableitbare, noch nicht operative Daten verändern, die dem
+Ableitungsmechanismus gehören; fachliche Quellen, erklärte Abweichungen und
+Teilnehmer-Snapshots bleiben unangetastet.
+
+## Ungeplante Betreuung
+
+Eine **ungeplante Betreuung** nimmt ein Kind mit dokumentiertem Grund in einen
+konkreten Termin auf, obwohl keine passende Planung vorliegt. Sie gilt nur für
+diesen Termin und verändert keine Dauerregel.
+
+## Betreuungsplan und Dienstplan
+
+Der **Betreuungsplan** ordnet Aktivitäten, Räume, Aufsichten und Kinder zu
+konkreten Zeiten ein. Der **Dienstplan** legt davon getrennt fest, wann ein
+Teammitglied arbeitet; Abweichungen zwischen beiden Plänen sind Konflikte und
+ändern keinen der Pläne automatisch.
+
 ## Abholänderungsanfrage
 
 Eine **Abholänderungsanfrage** ist der Wunsch einer sorgeberechtigten Person,
@@ -222,6 +308,19 @@ die OGS wirksam.
 Ein **Betreuungsangebot** ist eine innerhalb der OGS-Betreuung auswählbare
 Leistung, etwa Mittagessen oder Ferienbetreuung. Eine Änderung der Auswahl ist
 eine Elternanfrage und wird erst nach Bestätigung durch die OGS wirksam.
+
+## Betreuungswirksames Angebot
+
+Ein **betreuungswirksames Angebot** begründet an seinen gebuchten Wochentagen
+einen Betreuungstag und trägt mit seiner Endzeit zum Betreuungsfenster bei.
+Zusatzangebote ohne diese Wirkung verändern das Betreuungsfenster nicht.
+
+## Angebotsbuchung
+
+Eine **Angebotsbuchung** ist die genehmigte, datierte Zuordnung eines Kindes zu
+einem Betreuungsangebot an ausgewählten Wochentagen. Sie ist von der
+Elternauswahl zu unterscheiden, die den noch nicht genehmigten Wunsch der
+Eltern festhält.
 
 ## Mitbuchungs-Regel
 

--- a/docs/adr/0001-angebots-gehzeit-materialisieren.md
+++ b/docs/adr/0001-angebots-gehzeit-materialisieren.md
@@ -1,5 +1,10 @@
 # Angebots-Gehzeiten werden auf Kind-Gehzeiten ausgerollt, nicht zur Lesezeit aufgelöst
 
+> **Vorgeschlagene Teilablösung:**
+> [ADR 0005](./0005-buchungsgebundene-planung-zur-lesezeit-projizieren.md)
+> schlägt vor, das Ausrollen für die buchungsgebundene Planung zu ersetzen.
+> Für die manuelle Planung bliebe diese Entscheidung gültig.
+
 Betreuungsangebote (`enrollment.care_offerings`) tragen optionale Gehzeiten pro
 Wochentag (#2290). Damit diese Zeiten "überall" erscheinen (Klassenliste,
 Kinderdetail, Kindersuche), haben wir uns entschieden, sie beim Speichern des

--- a/docs/adr/0005-buchungsgebundene-planung-zur-lesezeit-projizieren.md
+++ b/docs/adr/0005-buchungsgebundene-planung-zur-lesezeit-projizieren.md
@@ -1,0 +1,171 @@
+---
+status: proposed
+---
+
+# Buchungsgebundene Planung projiziert zukünftige Teilnehmer zur Lesezeit
+
+Der Produktionsvorfall bei der OGS am Berg im August 2026 zeigte, dass
+Angebotsbuchungen, Bring- und Gehzeiten sowie Termin-Teilnehmerlisten aus
+verschiedenen, teils undatierten Kopien gelesen werden. Ereignisgetriebene
+Abgleiche hielten diese Kopien nicht zuverlässig zusammen. Wir führen deshalb
+eine buchungsgebundene Teilnehmerplanung ein, die den zukünftigen Sollstand aus
+wirksamen fachlichen Quellen berechnet und erst beim operativen Beginn eines
+Termins als historischen Stand festhält.
+
+## Entscheidung
+
+### Betriebsprofile statt eines globalen autoritativen Modus
+
+Schulen kombinieren Anmeldung, Anwesenheit, Betreuungsplan sowie Dienst- und
+Zeiterfassung über einen geführten Einrichtungsprozess. Für die
+Teilnehmerplanung gibt es die Zustände `manual`, `shadow` und `bookings`:
+
+- `manual` verwendet weiterhin manuell gepflegte wiederkehrende Kinderlisten.
+- `shadow` berechnet die buchungsgebundene Planung parallel, zeigt Unterschiede
+  und verändert den operativen Plan noch nicht.
+- `bookings` verwendet den berechneten Sollstand für die operative Planung.
+
+Der Zustand ist eine mandantenbezogene Konfiguration im Settings-System, aber
+kein frei editierbares Standardfeld. Ein eigener Einrichtungs- und
+Umstellungsflow prüft Voraussetzungen und erlaubt nur gültige Übergänge. Neue
+Schulen können nach erfolgreicher Vorprüfung im Onboarding direkt mit
+buchungsgebundener Planung beginnen. Bestandskunden bleiben unverändert, bis
+sie ausdrücklich wechseln.
+
+### Fachliche Quellen des Betreuungsfensters
+
+An Schultagen beginnt das Betreuungsfenster eines Kindes mit dem datierten
+Unterrichtsschluss seiner Schulklasse. Es endet mit der spätesten Endzeit aller
+an diesem Datum wirksamen, betreuungswirksamen Angebotsbuchungen. Ohne eine
+solche Buchung gibt es in der buchungsgebundenen Planung an diesem Wochentag
+keinen Betreuungstag.
+
+Jedes betreuungswirksame Angebot braucht an jedem wählbaren Wochentag eine
+Endzeit. Unterrichtsschluss und Angebots-Endzeiten werden mit Gültigkeitsfenstern
+geändert; eine Änderung schreibt frühere Betreuungsfenster nicht um. Eine
+datierte Kind-Überschreibung kann Beginn oder Ende höchstens bis zum Ende des
+zugehörigen Halbjahres ersetzen. Eine Tagesausnahme gilt weiterhin nur für ihr
+Datum.
+
+Der Projektor liest ausschließlich wirksame Live-Daten. Offene Anfragen ändern
+weder Zeiten noch Teilnehmer. Die bestehenden Freigabeprozesse bleiben
+unverändert.
+
+### Eine sichtbare Teilnehmerregel pro wiederkehrendem Termin
+
+In der buchungsgebundenen Planung erhält jede wiederkehrende Vorlage ihre
+Kinder durch genau eine sichtbare Teilnehmerregel. Die zunächst unterstützte
+Regelsprache besteht aus:
+
+1. einem oder mehreren Betreuungsangeboten als deduplizierte Union,
+2. optional genau einem Jahrgangs- oder Klassenfilter und
+3. dem Wochentag des konkreten Termins, der die gebuchten Wochentage schneidet.
+
+Eine allgemeine Regel-Engine, freie Prädikate, Prioritäten und Fallbacks gehören
+nicht zu dieser Entscheidung. Dauerhafte manuelle Kinderlisten sind nur in der
+manuellen Planung erlaubt. Die buchungsgebundene Planung erlaubt stattdessen
+begründete einmalige Inklusionen und Exklusionen an einem konkreten Termin.
+Eine ungeplante Betreuung erzeugt keine Angebotsbuchung und keine Dauerregel.
+
+### Dynamischer Sollstand, eingefrorener operativer Stand
+
+Termininstanzen bleiben materialisiert, weil Raum, Zeit, Aufsicht, Status und
+Einzeltag-Abweichungen eine stabile Termin-ID benötigen. Der Teilnehmer-Sollstand
+eines zukünftigen, vorlagengebundenen und rein geplanten Termins wird dagegen
+zur Lesezeit in einer zentralen Batch-Projektion berechnet. Wochenplan,
+Tageslisten, Exporte, Kapazitätsprüfungen und Konfliktanzeigen müssen denselben
+Projektor verwenden.
+
+Eine geplante Einzeltag-Inklusion oder -Exklusion liegt als ausdrückliche
+Abweichung mit Herkunft und Grund über dem weiterhin dynamischen Sollstand. Der
+Teilnehmerstand wird beim frühesten operativen Ereignis atomar als Snapshot
+festgehalten: beim Start des Termins, beim ersten Check-in, bei der ersten
+manuellen Statusentscheidung, beim Abschluss oder Abbruch oder spätestens beim
+Tagesabschluss für einen vergangenen, noch geplanten Termin. Spätere
+Quelländerungen verändern operative und historische Snapshots nicht.
+
+### Sichtbare Konsistenzprüfung mit begrenzter Reparatur
+
+Ein wiederholbarer tenantweiter Lauf vergleicht wirksame Quellen und daraus
+ableitbare Daten. Im Vergleichsbetrieb liefert er die Umstellungsvorschau; nach
+der Umstellung erkennt er fehlende Quellen, ungültige Regeln und unerklärte
+Abweichungen.
+
+Der Lauf darf eine Abweichung automatisch und idempotent reparieren, wenn der
+Sollwert vollständig feststeht, die betroffenen Daten dem Ableitungsmechanismus
+gehören und der Termin noch rein geplant ist. Er verändert niemals
+Angebotsbuchungen, Unterrichtsschluss, Angebots-Endzeiten, Teilnehmerregeln,
+menschliche Abweichungen oder operative und historische Snapshots. Gefundene,
+reparierte und nicht reparierbare Abweichungen sowie Reparaturfehler sind für
+OGS-Admins sichtbar; betroffene operative Ansichten zeigen ungelöste Konflikte.
+Logs und Metriken ergänzen diese Anzeige, ersetzen sie aber nicht.
+
+### Getrennte Personalplanung
+
+Angebotsbuchungen bestimmen den erwarteten Betreuungsbedarf. Der
+Betreuungsplan ordnet Aktivitäten, Räume, Aufsichten und Kinder innerhalb der
+Betreuungsfenster ein. Der Dienstplan legt getrennt fest, wann Teammitglieder
+arbeiten. Das System zeigt Unterbesetzung und Aufsichten außerhalb ihrer
+Schichten als Konflikte, ändert aber keine Schicht aufgrund einer
+Buchungsänderung.
+
+## Einführung bei Bestandskunden
+
+Eine bestehende Schule wechselt nur über den Vergleichsbetrieb. Die Vorschau
+zeigt mindestens fehlende Quellen, ungültige Buchungen sowie Kinder, die durch
+den Wechsel in einen Termin aufgenommen oder daraus entfernt würden. Die OGS
+bestätigt die fachlichen Unterschiede und wählt einen Stichtag. Laufende und
+historische Snapshots bleiben unverändert.
+
+Die OGS am Berg ist der Pilot. Ihre sechs operativ genutzten manuellen
+Randstunden-Serien lassen sich als `Randstunde ∩ Schulklasse ∩ gebuchter
+Wochentag` ausdrücken. Der Wechsel erfolgt erst, nachdem die Schule diese Regeln
+und die Diff-Vorschau bestätigt sowie fehlende Angebots-Endzeiten und
+verdächtige Buchungen geklärt hat.
+
+Der Rückweg zu manueller Planung ist ebenfalls geführt. Zum gewählten Stichtag
+wird der dann berechnete Sollstand als datierte manuelle Planung übernommen;
+die Vorschau weist darauf hin, dass spätere Buchungsänderungen anschließend
+nicht mehr automatisch folgen. Ein direktes Umschalten ist nicht erlaubt.
+
+## Considered Options
+
+- **Globaler Schalter `enrollment.bookings_authoritative`:** verworfen, weil
+  Buchungen weder Unterrichtsschluss noch Dienstplan bestimmen und Schulen die
+  Module in verschiedenen Kombinationen verwenden.
+- **Ereignisgetriebene Synchronisation aller Kopien:** verworfen, weil jeder
+  neue Schreibweg sämtliche Ableitungen kennen müsste und zukünftige
+  Wirksamkeitsdaten ohne Ereignis erneut driften könnten.
+- **Vollständige Materialisierung mit Gültigkeitsfenstern:** bleibt dort
+  sinnvoll, wo ein stabiler operativer oder historischer Snapshot nötig ist,
+  erzeugt für rein zukünftige Teilnehmerlisten aber unnötige Kopien und
+  Abgleichspfade.
+- **Alles zur Lesezeit berechnen:** verworfen, weil begonnene und abgeschlossene
+  Termine sowie menschliche Entscheidungen einen unveränderlichen historischen
+  Stand brauchen.
+- **Allgemeine Teilnehmer-Regel-Engine:** verworfen, weil der Pilot nur
+  Angebots-Union, Wochentag sowie Klassen- oder Jahrgangsfilter benötigt.
+
+## Consequences
+
+- [ADR 0001](./0001-angebots-gehzeit-materialisieren.md) bleibt für die
+  manuelle Planung gültig. Für die buchungsgebundene Planung ersetzt diese ADR
+  das Ausrollen von Angebots-Gehzeiten durch die Projektion aus wirksamen
+  Angebotsbuchungen.
+- Der zentrale Projektor ist die einzige erlaubte Quelle für zukünftige
+  Teilnehmer-Sollstände. Ein nur in einzelnen Ansichten eingesetzter Projektor
+  würde die heutige Drift lediglich verschieben.
+- Die Projektion muss Zeiträume gebündelt laden und darf keine Abfrage pro
+  Vorlage, Termin oder Kind ausführen. Die erwarteten Schulgrößen sind klein;
+  Produktionsmessungen für Tages- und Mehrwochenansichten entscheiden über
+  zusätzliche Indizes.
+- Die sofortige Absicherung des heutigen manuellen Betriebs erfolgt über die
+  sichtbare Konsistenzprüfung und ihre begrenzte Reparatur, nicht über einen
+  weiteren unsichtbaren Sync-Pfad.
+
+## Scope
+
+Diese ADR entscheidet die Planung an regulären Schultagen. Der Beginn eines
+Betreuungsfensters in der Ferienbetreuung bleibt offen, bis der operative
+Ablauf mit einer Schule geklärt ist. Sie ändert weder bestehende
+Freigabeprozesse noch die fachliche Eigenständigkeit des Dienstplans.


### PR DESCRIPTION
## Zusammenfassung

- legt ADR 0005 als vorgeschlagene Zielarchitektur für buchungsgebundene Teilnehmerplanung an
- trennt zukünftigen dynamischen Teilnehmer-Sollstand von operativen und historischen Snapshots
- definiert Betreuungsfenster, Teilnehmerregeln, Vergleichsbetrieb und begrenzte Reparaturen im Domänenglossar
- lässt ADR 0001 für manuelle Planung bestehen und schlägt nur für buchungsgebundene Planung eine Teilablösung vor

## Zentrale Entscheidungen

- Betriebsprofile statt eines globalen `enrollment.bookings_authoritative`-Schalters
- geführter Übergang `manual → shadow → bookings`, keine automatische Migration von Bestandskunden
- Beginn des Betreuungsfensters aus dem datierten Unterrichtsschluss der Klasse
- Ende aus der spätesten Endzeit aller wirksamen betreuungswirksamen Angebotsbuchungen
- genau eine sichtbare Teilnehmerregel pro wiederkehrendem Termin
- minimale Regelsprache: Angebots-Union, optional Klasse oder Jahrgang, geschnitten mit dem Termin-Wochentag
- zentrale Batch-Projektion für zukünftige geplante Teilnehmer; Snapshot beim ersten operativen Ereignis
- sichtbare Konsistenzprüfung; automatische Reparatur nur für eindeutig ableitbare, projektoreigene und noch nicht operative Daten
- Approval-Flows und Dienstplan bleiben fachlich getrennt und unverändert

## Verifizierte Grundlage

Die lesende Production-Auswertung für die OGS am Berg ergab:

- sechs operativ aktive manuelle Randstunden-Serien
- alle sechs sind als `Randstunde ∩ Schulklasse ∩ gebuchter Wochentag` ausdrückbar
- die aktuellen manuellen Vollklassenkopien enthalten ungebuchte Kinder; die Regelprojektion findet zugleich fehlende gebuchte Kinder
- die übrigen aktiven Terminserien benötigen nur Angebots-Union sowie Klassen- oder Jahrgangsfilter

Der Pilot wechselt deshalb erst nach Vergleichsbetrieb, Diff-Vorschau und fachlicher Bestätigung durch die Schule.

## Scope

- reine Architektur- und Glossardokumentation, keine Laufzeitänderung
- keine Änderungen an den verknüpften Issues; deren Zuschnitt folgt erst nach Teamentscheidung
- Ferienbetreuung bleibt mangels geklärtem operativem Ablauf ausdrücklich offen
- ADR bleibt bis zur Teamentscheidung `proposed`

## Prüfung

- `git diff --check`
- lokale ADR-Links geprüft
- Lefthook `git-secrets` beim Commit und Push bestanden
- Verständlichkeit: keine Nutzeroberfläche oder Nutzertexte geändert; die ADR verwendet die im Glossar festgelegten Begriffe

Bezug: #2426
