### PR TITLE
Konsistenz-Audit für Buchungen und Betreuungsplanung

### DIFF
--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -181,6 +181,7 @@ func configureSchedulerRepos(sched *scheduler.Scheduler, api *API) {
 	// active.groups via repositories (issue #585 layering).
 	sched.SetTimetableBridgeRepos(repos.InstanceStudent, repos.ActivityInstance, api.Services.TimetableBridge)
 	sched.SetStudentStatusDayRepo(repos.StudentStatusDay)
+	sched.SetBookingConsistencyAudit(repos.BookingConsistency)
 	// Parent-enrollment PR 2: activate-students tick.
 	if repos.Student != nil {
 		sched.SetStudentLifecycleRepo(repos.Student)

--- a/backend/database/repositories/audit/booking_consistency.go
+++ b/backend/database/repositories/audit/booking_consistency.go
@@ -56,8 +56,16 @@ WITH params AS (
 ), approved_students AS (
 	SELECT
 		request_child.id AS request_child_id,
-		COALESCE(request_child.created_student_id, request_child.matched_student_id) AS student_id
+		COALESCE(request_child.created_student_id, request_child.matched_student_id) AS student_id,
+		phase.id AS phase_id,
+		request_child.tenant_id
 	FROM enrollment.request_children AS request_child
+	INNER JOIN enrollment.requests AS request
+		ON request.tenant_id = request_child.tenant_id
+		AND request.id = request_child.request_id
+	INNER JOIN enrollment.phases AS phase
+		ON phase.tenant_id = request.tenant_id
+		AND phase.id = request.phase_id
 	INNER JOIN users.students AS student
 		ON student.tenant_id = request_child.tenant_id
 		AND student.id = COALESCE(request_child.created_student_id, request_child.matched_student_id)
@@ -83,18 +91,11 @@ WITH params AS (
 	WHERE instance.status = 'planned'
 		AND instance.date >= params.audit_date
 		AND instance_student.is_unplanned = FALSE
-), relevant_dates AS (
-	SELECT date FROM audit_dates
-	UNION
-	SELECT date FROM planned_rows
 ), care_inputs AS (
 	SELECT
 		approved_students.student_id,
-		relevant_dates.date,
-		CASE
-			WHEN EXTRACT(ISODOW FROM relevant_dates.date)::int <= 5
-				THEN NULLIF(care_offering.pickup_times ->> day_code.value, '')
-		END AS pickup_time
+		audit_dates.date,
+		NULLIF(care_offering.pickup_times ->> day_code.value, '') AS pickup_time
 	FROM approved_students
 	INNER JOIN enrollment.request_child_offerings AS link
 		ON link.request_child_id = approved_students.request_child_id
@@ -102,9 +103,10 @@ WITH params AS (
 	INNER JOIN enrollment.care_offerings AS care_offering
 		ON care_offering.tenant_id = link.tenant_id
 		AND care_offering.id = link.care_offering_id
-	CROSS JOIN relevant_dates
+		AND care_offering.phase_id = approved_students.phase_id
+	CROSS JOIN audit_dates
 	CROSS JOIN LATERAL (
-		VALUES (CASE EXTRACT(ISODOW FROM relevant_dates.date)::int
+		VALUES (CASE EXTRACT(ISODOW FROM audit_dates.date)::int
 			WHEN 1 THEN 'mon'
 			WHEN 2 THEN 'tue'
 			WHEN 3 THEN 'wed'
@@ -116,8 +118,9 @@ WITH params AS (
 	) AS day_code(value)
 	WHERE care_offering.is_active = TRUE
 		AND care_offering.counts_as_care = TRUE
-		AND (link.valid_from IS NULL OR link.valid_from <= relevant_dates.date)
-		AND (link.valid_until IS NULL OR link.valid_until > relevant_dates.date)
+		AND EXTRACT(ISODOW FROM audit_dates.date)::int <= 5
+		AND (link.valid_from IS NULL OR link.valid_from <= audit_dates.date)
+		AND (link.valid_until IS NULL OR link.valid_until > audit_dates.date)
 		AND EXISTS (
 			SELECT 1
 			FROM jsonb_array_elements_text(CASE
@@ -143,7 +146,6 @@ WITH params AS (
 	GROUP BY student_id, date
 ), arrival_days AS (
 	SELECT DISTINCT
-		arrival.id AS row_id,
 		arrival.student_id,
 		audit_dates.date
 	FROM schedule.student_arrival_schedules AS arrival
@@ -151,8 +153,22 @@ WITH params AS (
 	INNER JOIN params ON params.tenant_id = arrival.tenant_id
 	INNER JOIN audit_dates
 		ON EXTRACT(ISODOW FROM audit_dates.date)::int = arrival.weekday
+	LEFT JOIN schedule.student_arrival_exceptions AS arrival_exception
+		ON arrival_exception.tenant_id = arrival.tenant_id
+		AND arrival_exception.student_id = arrival.student_id
+		AND arrival_exception.exception_date = audit_dates.date
+	WHERE arrival_exception.id IS NULL
+	UNION
+	SELECT DISTINCT
+		arrival_exception.student_id,
+		arrival_exception.exception_date
+	FROM schedule.student_arrival_exceptions AS arrival_exception
+	INNER JOIN approved_students ON approved_students.student_id = arrival_exception.student_id
+	INNER JOIN params ON params.tenant_id = arrival_exception.tenant_id
+	INNER JOIN audit_dates ON audit_dates.date = arrival_exception.exception_date
+	WHERE arrival_exception.expected_arrival IS NOT NULL
 ), arrival_without_booking AS (
-	SELECT arrival_days.row_id
+	SELECT arrival_days.student_id, arrival_days.date
 	FROM arrival_days
 	LEFT JOIN care_days
 		ON care_days.student_id = arrival_days.student_id
@@ -162,31 +178,74 @@ WITH params AS (
 	SELECT care_days.student_id, care_days.date
 	FROM care_days
 	INNER JOIN audit_dates ON audit_dates.date = care_days.date
+	CROSS JOIN params
 	LEFT JOIN arrival_days
 		ON arrival_days.student_id = care_days.student_id
 		AND arrival_days.date = care_days.date
+	LEFT JOIN schedule.student_arrival_exceptions AS arrival_exception
+		ON arrival_exception.tenant_id = params.tenant_id
+		AND arrival_exception.student_id = care_days.student_id
+		AND arrival_exception.exception_date = care_days.date
 	WHERE arrival_days.student_id IS NULL
+		AND arrival_exception.id IS NULL
 ), planned_without_booking AS (
 	SELECT planned_rows.row_id
 	FROM planned_rows
 	WHERE NOT EXISTS (
 		SELECT 1
-		FROM care_days
-		WHERE care_days.student_id = planned_rows.student_id
-			AND care_days.date = planned_rows.date
+		FROM approved_students AS booking_child
+		INNER JOIN enrollment.request_child_offerings AS link
+			ON link.tenant_id = booking_child.tenant_id
+			AND link.request_child_id = booking_child.request_child_id
+		INNER JOIN enrollment.care_offerings AS care_offering
+			ON care_offering.tenant_id = link.tenant_id
+			AND care_offering.id = link.care_offering_id
+			AND care_offering.phase_id = booking_child.phase_id
+		WHERE booking_child.student_id = planned_rows.student_id
+			AND care_offering.is_active = TRUE
+			AND care_offering.counts_as_care = TRUE
+			AND (link.valid_from IS NULL OR link.valid_from <= planned_rows.date)
+			AND (link.valid_until IS NULL OR link.valid_until > planned_rows.date)
+			AND EXISTS (
+				SELECT 1
+				FROM jsonb_array_elements_text(CASE
+					WHEN COALESCE(jsonb_array_length(link.selected_days), 0) > 0
+						OR care_offering.days_of_week_mode <> 'fixed'
+						THEN COALESCE(link.selected_days, '[]'::jsonb)
+					ELSE COALESCE(care_offering.available_days, '[]'::jsonb)
+				END) AS selected_day(value)
+				WHERE LOWER(BTRIM(selected_day.value)) = CASE EXTRACT(ISODOW FROM planned_rows.date)::int
+					WHEN 1 THEN 'mon'
+					WHEN 2 THEN 'tue'
+					WHEN 3 THEN 'wed'
+					WHEN 4 THEN 'thu'
+					WHEN 5 THEN 'fri'
+					WHEN 6 THEN 'sat'
+					ELSE 'sun'
+				END
+			)
 	)
 ), approved_without_offering AS (
-	SELECT phase.care_offering_selection_mode
-	FROM enrollment.request_children AS request_child
-	INNER JOIN enrollment.requests AS request
-		ON request.tenant_id = request_child.tenant_id
-		AND request.id = request_child.request_id
-	INNER JOIN enrollment.phases AS phase
-		ON phase.tenant_id = request.tenant_id
-		AND phase.id = request.phase_id
-	INNER JOIN params ON params.tenant_id = request_child.tenant_id
-	WHERE request_child.status = 'approved'
-		AND NOT EXISTS (
+	SELECT
+		phase.care_offering_selection_mode,
+		EXISTS (
+			SELECT 1
+			FROM enrollment.care_offerings AS required_offering
+			WHERE required_offering.tenant_id = phase.tenant_id
+				AND required_offering.phase_id = phase.id
+				AND required_offering.is_active = TRUE
+				AND required_offering.is_required = TRUE
+				AND NOT EXISTS (
+					SELECT 1
+					FROM enrollment.request_child_offerings AS required_link
+					WHERE required_link.tenant_id = request_child.tenant_id
+						AND required_link.request_child_id = request_child.id
+						AND required_link.care_offering_id = required_offering.id
+						AND (required_link.valid_from IS NULL OR required_link.valid_from <= phase.service_start_date)
+						AND (required_link.valid_until IS NULL OR required_link.valid_until > phase.service_start_date)
+				)
+		) AS missing_required_offering,
+		EXISTS (
 			SELECT 1
 			FROM enrollment.request_child_offerings AS link
 			INNER JOIN enrollment.care_offerings AS care_offering
@@ -196,9 +255,22 @@ WITH params AS (
 				AND care_offering.is_required = FALSE
 			WHERE link.tenant_id = request_child.tenant_id
 				AND link.request_child_id = request_child.id
-				AND (link.valid_from IS NULL OR link.valid_from <= phase.service_end_date)
+				AND (link.valid_from IS NULL OR link.valid_from <= phase.service_start_date)
 				AND (link.valid_until IS NULL OR link.valid_until > phase.service_start_date)
-		)
+		) AS has_choosable_offering
+	FROM enrollment.request_children AS request_child
+	INNER JOIN enrollment.requests AS request
+		ON request.tenant_id = request_child.tenant_id
+		AND request.id = request_child.request_id
+	INNER JOIN enrollment.phases AS phase
+		ON phase.tenant_id = request.tenant_id
+		AND phase.id = request.phase_id
+	INNER JOIN users.students AS student
+		ON student.tenant_id = request_child.tenant_id
+		AND student.id = COALESCE(request_child.created_student_id, request_child.matched_student_id)
+		AND student.status <> 'alumnus'
+	INNER JOIN params ON params.tenant_id = request_child.tenant_id
+	WHERE request_child.status = 'approved'
 )
 SELECT
 	params.tenant_id,
@@ -211,8 +283,11 @@ SELECT
 	(SELECT COUNT(*) FROM booking_without_arrival)::int AS booking_without_arrival_days,
 	(SELECT COUNT(*) FROM planned_without_booking)::int AS planned_without_booking_rows,
 	(SELECT COUNT(*) FROM approved_without_offering
-		WHERE care_offering_selection_mode <> 'optional')::int AS approved_without_required_offering,
+		WHERE missing_required_offering
+			OR (care_offering_selection_mode <> 'optional' AND NOT has_choosable_offering))::int AS approved_without_required_offering,
 	(SELECT COUNT(*) FROM approved_without_offering
-		WHERE care_offering_selection_mode = 'optional')::int AS approved_without_optional_offering
+		WHERE care_offering_selection_mode = 'optional'
+			AND NOT missing_required_offering
+			AND NOT has_choosable_offering)::int AS approved_without_optional_offering
 FROM params
 `

--- a/backend/database/repositories/audit/booking_consistency.go
+++ b/backend/database/repositories/audit/booking_consistency.go
@@ -248,30 +248,41 @@ WITH params AS (
 				AND required_offering.phase_id = phase.id
 				AND required_offering.is_active = TRUE
 				AND required_offering.is_required = TRUE
-				AND NOT EXISTS (
-					SELECT 1
+				AND NOT COALESCE((
+					SELECT range_agg(daterange(
+						GREATEST(COALESCE(required_link.valid_from, phase.service_start_date), phase.service_start_date),
+						LEAST(COALESCE(required_link.valid_until, phase.service_end_date + 1), phase.service_end_date + 1),
+						'[)'
+					)) @> daterange(phase.service_start_date, phase.service_end_date + 1, '[)')
 					FROM enrollment.request_child_offerings AS required_link
 					WHERE required_link.tenant_id = request_child.tenant_id
-					AND required_link.request_child_id = request_child.id
-					AND required_link.care_offering_id = required_offering.id
-					AND (required_link.valid_from IS NULL OR required_link.valid_from <= phase.service_start_date)
-					AND (required_link.valid_until IS NULL OR required_link.valid_until > phase.service_end_date)
-				)
+						AND required_link.request_child_id = request_child.id
+						AND required_link.care_offering_id = required_offering.id
+						AND (required_link.valid_from IS NULL OR required_link.valid_from <= phase.service_end_date)
+						AND (required_link.valid_until IS NULL OR required_link.valid_until > phase.service_start_date)
+				), FALSE)
 		) AS missing_required_offering,
 		EXISTS (
 			SELECT 1
-			FROM enrollment.request_child_offerings AS link
-			INNER JOIN enrollment.care_offerings AS care_offering
-				ON care_offering.tenant_id = link.tenant_id
-				AND care_offering.id = link.care_offering_id
+			FROM enrollment.care_offerings AS care_offering
+			WHERE care_offering.tenant_id = phase.tenant_id
 				AND care_offering.phase_id = phase.id
 				AND care_offering.is_active = TRUE
 				AND care_offering.is_required = FALSE
 				AND care_offering.counts_as_care = TRUE
-			WHERE link.tenant_id = request_child.tenant_id
-				AND link.request_child_id = request_child.id
-				AND (link.valid_from IS NULL OR link.valid_from <= phase.service_start_date)
-				AND (link.valid_until IS NULL OR link.valid_until > phase.service_end_date)
+				AND COALESCE((
+					SELECT range_agg(daterange(
+						GREATEST(COALESCE(link.valid_from, phase.service_start_date), phase.service_start_date),
+						LEAST(COALESCE(link.valid_until, phase.service_end_date + 1), phase.service_end_date + 1),
+						'[)'
+					)) @> daterange(phase.service_start_date, phase.service_end_date + 1, '[)')
+					FROM enrollment.request_child_offerings AS link
+					WHERE link.tenant_id = request_child.tenant_id
+						AND link.request_child_id = request_child.id
+						AND link.care_offering_id = care_offering.id
+						AND (link.valid_from IS NULL OR link.valid_from <= phase.service_end_date)
+						AND (link.valid_until IS NULL OR link.valid_until > phase.service_start_date)
+				), FALSE)
 		) AS has_choosable_offering
 	FROM enrollment.request_children AS request_child
 	INNER JOIN enrollment.requests AS request
@@ -286,6 +297,8 @@ WITH params AS (
 	INNER JOIN params ON params.tenant_id = request_child.tenant_id
 	WHERE request_child.status = 'approved'
 		AND (student.id IS NULL OR student.status <> 'alumnus')
+		AND phase.service_start_date <= params.audit_date + 6
+		AND phase.service_end_date >= params.audit_date
 )
 SELECT
 	params.tenant_id,

--- a/backend/database/repositories/audit/booking_consistency.go
+++ b/backend/database/repositories/audit/booking_consistency.go
@@ -1,0 +1,218 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModel "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	"github.com/uptrace/bun"
+)
+
+var errBookingConsistencyTenantRequired = errors.New("booking consistency audit requires a tenant context")
+
+type bookingConsistencyRepository struct {
+	db *bun.DB
+}
+
+func NewBookingConsistencyRepository(db *bun.DB) auditModel.BookingConsistencyRepository {
+	return &bookingConsistencyRepository{db: db}
+}
+
+// Audit compares the authoritative approved booking windows with the next
+// seven arrival/pickup days and every future planned instance. Legacy stored
+// pickup rows with source=care_offering are deliberately absent: the read-time
+// projection introduced by #2494 ignores them too.
+func (r *bookingConsistencyRepository) Audit(
+	ctx context.Context,
+	auditDate timezone.Date,
+) (*auditModel.BookingConsistencyReport, error) {
+	if auditDate.IsZero() {
+		return nil, errors.New("booking consistency audit date is required")
+	}
+	tenantID := tenant.FromContext(ctx)
+	if tenantID <= 0 {
+		return nil, errBookingConsistencyTenantRequired
+	}
+
+	report := &auditModel.BookingConsistencyReport{}
+	err := base.GetDB(ctx, r.db).NewRaw(bookingConsistencyQuery, tenantID, auditDate).Scan(ctx, report)
+	if err != nil {
+		return nil, fmt.Errorf("audit booking consistency for tenant %d: %w", tenantID, err)
+	}
+	return report, nil
+}
+
+const bookingConsistencyQuery = `
+WITH params AS (
+	SELECT ?::bigint AS tenant_id, ?::date AS audit_date
+), audit_dates AS (
+	SELECT (params.audit_date + day_offset.day)::date AS date
+	FROM params
+	CROSS JOIN generate_series(0, 6) AS day_offset(day)
+), approved_students AS (
+	SELECT
+		request_child.id AS request_child_id,
+		COALESCE(request_child.created_student_id, request_child.matched_student_id) AS student_id
+	FROM enrollment.request_children AS request_child
+	INNER JOIN users.students AS student
+		ON student.tenant_id = request_child.tenant_id
+		AND student.id = COALESCE(request_child.created_student_id, request_child.matched_student_id)
+		AND student.status <> 'alumnus'
+	INNER JOIN params ON params.tenant_id = request_child.tenant_id
+	WHERE request_child.status = 'approved'
+), planned_rows AS (
+	SELECT DISTINCT
+		instance_student.id AS row_id,
+		instance_student.student_id,
+		instance.date
+	FROM schedule.instance_students AS instance_student
+	INNER JOIN schedule.activity_instances AS instance
+		ON instance.tenant_id = instance_student.tenant_id
+		AND instance.id = instance_student.instance_id
+	INNER JOIN activities.groups AS activity_group
+		ON activity_group.tenant_id = instance.tenant_id
+		AND activity_group.id = instance.activity_group_id
+		AND activity_group.type = 'care'
+	INNER JOIN approved_students
+		ON approved_students.student_id = instance_student.student_id
+	INNER JOIN params ON params.tenant_id = instance_student.tenant_id
+	WHERE instance.status = 'planned'
+		AND instance.date >= params.audit_date
+		AND instance_student.is_unplanned = FALSE
+), relevant_dates AS (
+	SELECT date FROM audit_dates
+	UNION
+	SELECT date FROM planned_rows
+), care_inputs AS (
+	SELECT
+		approved_students.student_id,
+		relevant_dates.date,
+		CASE
+			WHEN EXTRACT(ISODOW FROM relevant_dates.date)::int <= 5
+				THEN NULLIF(care_offering.pickup_times ->> day_code.value, '')
+		END AS pickup_time
+	FROM approved_students
+	INNER JOIN enrollment.request_child_offerings AS link
+		ON link.request_child_id = approved_students.request_child_id
+	INNER JOIN params ON params.tenant_id = link.tenant_id
+	INNER JOIN enrollment.care_offerings AS care_offering
+		ON care_offering.tenant_id = link.tenant_id
+		AND care_offering.id = link.care_offering_id
+	CROSS JOIN relevant_dates
+	CROSS JOIN LATERAL (
+		VALUES (CASE EXTRACT(ISODOW FROM relevant_dates.date)::int
+			WHEN 1 THEN 'mon'
+			WHEN 2 THEN 'tue'
+			WHEN 3 THEN 'wed'
+			WHEN 4 THEN 'thu'
+			WHEN 5 THEN 'fri'
+			WHEN 6 THEN 'sat'
+			ELSE 'sun'
+		END)
+	) AS day_code(value)
+	WHERE care_offering.is_active = TRUE
+		AND care_offering.counts_as_care = TRUE
+		AND (link.valid_from IS NULL OR link.valid_from <= relevant_dates.date)
+		AND (link.valid_until IS NULL OR link.valid_until > relevant_dates.date)
+		AND EXISTS (
+			SELECT 1
+			FROM jsonb_array_elements_text(CASE
+				WHEN COALESCE(jsonb_array_length(link.selected_days), 0) > 0
+					OR care_offering.days_of_week_mode <> 'fixed'
+					THEN COALESCE(link.selected_days, '[]'::jsonb)
+				ELSE COALESCE(care_offering.available_days, '[]'::jsonb)
+			END) AS selected_day(value)
+			WHERE LOWER(BTRIM(selected_day.value)) = day_code.value
+		)
+), care_days AS (
+	SELECT
+		student_id,
+		date,
+		BOOL_OR(
+			pickup_time IS NOT NULL
+			AND pickup_time !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+		) AS has_invalid_pickup,
+		MAX(pickup_time) FILTER (
+			WHERE pickup_time ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+		) AS pickup_time
+	FROM care_inputs
+	GROUP BY student_id, date
+), arrival_days AS (
+	SELECT DISTINCT
+		arrival.id AS row_id,
+		arrival.student_id,
+		audit_dates.date
+	FROM schedule.student_arrival_schedules AS arrival
+	INNER JOIN approved_students ON approved_students.student_id = arrival.student_id
+	INNER JOIN params ON params.tenant_id = arrival.tenant_id
+	INNER JOIN audit_dates
+		ON EXTRACT(ISODOW FROM audit_dates.date)::int = arrival.weekday
+), arrival_without_booking AS (
+	SELECT arrival_days.row_id
+	FROM arrival_days
+	LEFT JOIN care_days
+		ON care_days.student_id = arrival_days.student_id
+		AND care_days.date = arrival_days.date
+	WHERE care_days.student_id IS NULL
+), booking_without_arrival AS (
+	SELECT care_days.student_id, care_days.date
+	FROM care_days
+	INNER JOIN audit_dates ON audit_dates.date = care_days.date
+	LEFT JOIN arrival_days
+		ON arrival_days.student_id = care_days.student_id
+		AND arrival_days.date = care_days.date
+	WHERE arrival_days.student_id IS NULL
+), planned_without_booking AS (
+	SELECT planned_rows.row_id
+	FROM planned_rows
+	WHERE NOT EXISTS (
+		SELECT 1
+		FROM care_days
+		WHERE care_days.student_id = planned_rows.student_id
+			AND care_days.date = planned_rows.date
+	)
+), approved_without_offering AS (
+	SELECT phase.care_offering_selection_mode
+	FROM enrollment.request_children AS request_child
+	INNER JOIN enrollment.requests AS request
+		ON request.tenant_id = request_child.tenant_id
+		AND request.id = request_child.request_id
+	INNER JOIN enrollment.phases AS phase
+		ON phase.tenant_id = request.tenant_id
+		AND phase.id = request.phase_id
+	INNER JOIN params ON params.tenant_id = request_child.tenant_id
+	WHERE request_child.status = 'approved'
+		AND NOT EXISTS (
+			SELECT 1
+			FROM enrollment.request_child_offerings AS link
+			INNER JOIN enrollment.care_offerings AS care_offering
+				ON care_offering.tenant_id = link.tenant_id
+				AND care_offering.id = link.care_offering_id
+				AND care_offering.phase_id = phase.id
+				AND care_offering.is_required = FALSE
+			WHERE link.tenant_id = request_child.tenant_id
+				AND link.request_child_id = request_child.id
+				AND (link.valid_from IS NULL OR link.valid_from <= phase.service_end_date)
+				AND (link.valid_until IS NULL OR link.valid_until > phase.service_start_date)
+		)
+)
+SELECT
+	params.tenant_id,
+	params.audit_date,
+	(SELECT COUNT(*)
+		FROM care_days
+		INNER JOIN audit_dates ON audit_dates.date = care_days.date
+		WHERE pickup_time IS NULL OR has_invalid_pickup)::int AS pickup_projection_missing_days,
+	(SELECT COUNT(*) FROM arrival_without_booking)::int AS arrival_without_booking_days,
+	(SELECT COUNT(*) FROM booking_without_arrival)::int AS booking_without_arrival_days,
+	(SELECT COUNT(*) FROM planned_without_booking)::int AS planned_without_booking_rows,
+	(SELECT COUNT(*) FROM approved_without_offering
+		WHERE care_offering_selection_mode <> 'optional')::int AS approved_without_required_offering,
+	(SELECT COUNT(*) FROM approved_without_offering
+		WHERE care_offering_selection_mode = 'optional')::int AS approved_without_optional_offering
+FROM params
+`

--- a/backend/database/repositories/audit/booking_consistency.go
+++ b/backend/database/repositories/audit/booking_consistency.go
@@ -58,6 +58,8 @@ WITH params AS (
 		request_child.id AS request_child_id,
 		COALESCE(request_child.created_student_id, request_child.matched_student_id) AS student_id,
 		phase.id AS phase_id,
+		phase.service_start_date,
+		phase.service_end_date,
 		request_child.tenant_id
 	FROM enrollment.request_children AS request_child
 	INNER JOIN enrollment.requests AS request
@@ -87,6 +89,8 @@ WITH params AS (
 		AND activity_group.type = 'care'
 	INNER JOIN approved_students
 		ON approved_students.student_id = instance_student.student_id
+		AND instance.date >= approved_students.service_start_date
+		AND instance.date <= approved_students.service_end_date
 	INNER JOIN params ON params.tenant_id = instance_student.tenant_id
 	WHERE instance.status = 'planned'
 		AND instance.date >= params.audit_date
@@ -118,6 +122,8 @@ WITH params AS (
 	) AS day_code(value)
 	WHERE care_offering.is_active = TRUE
 		AND care_offering.counts_as_care = TRUE
+		AND audit_dates.date >= approved_students.service_start_date
+		AND audit_dates.date <= approved_students.service_end_date
 		AND EXTRACT(ISODOW FROM audit_dates.date)::int <= 5
 		AND (link.valid_from IS NULL OR link.valid_from <= audit_dates.date)
 		AND (link.valid_until IS NULL OR link.valid_until > audit_dates.date)
@@ -153,6 +159,8 @@ WITH params AS (
 	INNER JOIN params ON params.tenant_id = arrival.tenant_id
 	INNER JOIN audit_dates
 		ON EXTRACT(ISODOW FROM audit_dates.date)::int = arrival.weekday
+		AND audit_dates.date >= approved_students.service_start_date
+		AND audit_dates.date <= approved_students.service_end_date
 	LEFT JOIN schedule.student_arrival_exceptions AS arrival_exception
 		ON arrival_exception.tenant_id = arrival.tenant_id
 		AND arrival_exception.student_id = arrival.student_id
@@ -165,7 +173,10 @@ WITH params AS (
 	FROM schedule.student_arrival_exceptions AS arrival_exception
 	INNER JOIN approved_students ON approved_students.student_id = arrival_exception.student_id
 	INNER JOIN params ON params.tenant_id = arrival_exception.tenant_id
-	INNER JOIN audit_dates ON audit_dates.date = arrival_exception.exception_date
+	INNER JOIN audit_dates
+		ON audit_dates.date = arrival_exception.exception_date
+		AND audit_dates.date >= approved_students.service_start_date
+		AND audit_dates.date <= approved_students.service_end_date
 	WHERE arrival_exception.expected_arrival IS NOT NULL
 ), arrival_without_booking AS (
 	SELECT arrival_days.student_id, arrival_days.date
@@ -202,6 +213,8 @@ WITH params AS (
 			AND care_offering.id = link.care_offering_id
 			AND care_offering.phase_id = booking_child.phase_id
 		WHERE booking_child.student_id = planned_rows.student_id
+			AND planned_rows.date >= booking_child.service_start_date
+			AND planned_rows.date <= booking_child.service_end_date
 			AND care_offering.is_active = TRUE
 			AND care_offering.counts_as_care = TRUE
 			AND (link.valid_from IS NULL OR link.valid_from <= planned_rows.date)
@@ -239,10 +252,10 @@ WITH params AS (
 					SELECT 1
 					FROM enrollment.request_child_offerings AS required_link
 					WHERE required_link.tenant_id = request_child.tenant_id
-						AND required_link.request_child_id = request_child.id
-						AND required_link.care_offering_id = required_offering.id
-						AND (required_link.valid_from IS NULL OR required_link.valid_from <= phase.service_start_date)
-						AND (required_link.valid_until IS NULL OR required_link.valid_until > phase.service_start_date)
+					AND required_link.request_child_id = request_child.id
+					AND required_link.care_offering_id = required_offering.id
+					AND (required_link.valid_from IS NULL OR required_link.valid_from <= phase.service_start_date)
+					AND (required_link.valid_until IS NULL OR required_link.valid_until > phase.service_end_date)
 				)
 		) AS missing_required_offering,
 		EXISTS (
@@ -252,11 +265,13 @@ WITH params AS (
 				ON care_offering.tenant_id = link.tenant_id
 				AND care_offering.id = link.care_offering_id
 				AND care_offering.phase_id = phase.id
+				AND care_offering.is_active = TRUE
 				AND care_offering.is_required = FALSE
+				AND care_offering.counts_as_care = TRUE
 			WHERE link.tenant_id = request_child.tenant_id
 				AND link.request_child_id = request_child.id
 				AND (link.valid_from IS NULL OR link.valid_from <= phase.service_start_date)
-				AND (link.valid_until IS NULL OR link.valid_until > phase.service_start_date)
+				AND (link.valid_until IS NULL OR link.valid_until > phase.service_end_date)
 		) AS has_choosable_offering
 	FROM enrollment.request_children AS request_child
 	INNER JOIN enrollment.requests AS request
@@ -265,12 +280,12 @@ WITH params AS (
 	INNER JOIN enrollment.phases AS phase
 		ON phase.tenant_id = request.tenant_id
 		AND phase.id = request.phase_id
-	INNER JOIN users.students AS student
+	LEFT JOIN users.students AS student
 		ON student.tenant_id = request_child.tenant_id
 		AND student.id = COALESCE(request_child.created_student_id, request_child.matched_student_id)
-		AND student.status <> 'alumnus'
 	INNER JOIN params ON params.tenant_id = request_child.tenant_id
 	WHERE request_child.status = 'approved'
+		AND (student.id IS NULL OR student.status <> 'alumnus')
 )
 SELECT
 	params.tenant_id,

--- a/backend/database/repositories/audit/booking_consistency_test.go
+++ b/backend/database/repositories/audit/booking_consistency_test.go
@@ -147,6 +147,42 @@ func TestBookingConsistencyAuditUsesEffectiveDatesAndExceptions(t *testing.T) {
 	assert.Equal(t, 1, report.ApprovedWithoutRequiredOffering)
 }
 
+func TestBookingConsistencyAuditAcceptsContinuousSplitOfferingLinks(t *testing.T) {
+	t.Parallel()
+
+	db := testpkg.SetupTestDB(t)
+	ctx := testpkg.Ctx(t)
+	repos := repositories.NewFactory(db)
+	auditDate := nextMonday(timezone.TodayDate())
+	staff := testpkg.CreateTestStaff(t, db, "Audit", "Split")
+	student := testpkg.CreateTestStudent(t, db, "Geteilt", "Audit", "1a")
+	child := createApprovedChildForStudent(t, ctx, repos, auditDate, student.ID,
+		enrollmentModel.PhaseCareOfferingSelectionAtLeastOne)
+	offering := testpkg.CreateTestCareOffering(t, db, child.phase.ID, "Geteilte Betreuung")
+	offering.DaysOfWeekMode = enrollmentModel.DaysOfWeekModeParentChoice
+	offering.PickupTimes = map[string]string{"mon": "14:30"}
+	require.NoError(t, repos.CareOffering.Update(ctx, offering))
+
+	splitDate := auditDate.AddDays(15)
+	phaseEndExclusive := child.phase.ServiceEndDate.AddDays(1)
+	require.NoError(t, repos.RequestChildOffering.Create(ctx, &enrollmentModel.RequestChildOffering{
+		RequestChildID: child.child.ID, CareOfferingID: offering.ID,
+		SelectedDays: []string{"mon"}, ValidFrom: &auditDate, ValidUntil: &splitDate,
+	}))
+	require.NoError(t, repos.RequestChildOffering.Create(ctx, &enrollmentModel.RequestChildOffering{
+		RequestChildID: child.child.ID, CareOfferingID: offering.ID,
+		SelectedDays: []string{"mon"}, ValidFrom: &splitDate, ValidUntil: &phaseEndExclusive,
+	}))
+	require.NoError(t, repos.StudentArrivalSchedule.Create(ctx, &scheduleModel.StudentArrivalSchedule{
+		StudentID: student.ID, Weekday: scheduleModel.WeekdayMonday, ExpectedArrival: wallClock(11, 45), CreatedBy: staff.ID,
+	}))
+
+	report, err := auditRepo.NewBookingConsistencyRepository(db).Audit(ctx, auditDate)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.ApprovedWithoutRequiredOffering)
+	assert.Equal(t, 0, report.BookingWithoutArrivalDays)
+}
+
 type approvedAuditChild struct {
 	phase *enrollmentModel.Phase
 	child *enrollmentModel.RequestChild

--- a/backend/database/repositories/audit/booking_consistency_test.go
+++ b/backend/database/repositories/audit/booking_consistency_test.go
@@ -104,6 +104,49 @@ func TestBookingConsistencyAuditRequiresDateAndTenant(t *testing.T) {
 	require.ErrorContains(t, err, "date is required")
 }
 
+func TestBookingConsistencyAuditUsesEffectiveDatesAndExceptions(t *testing.T) {
+	t.Parallel()
+
+	db := testpkg.SetupTestDB(t)
+	ctx := testpkg.Ctx(t)
+	repos := repositories.NewFactory(db)
+	auditDate := nextMonday(timezone.TodayDate())
+	staff := testpkg.CreateTestStaff(t, db, "Audit", "Ausnahme")
+
+	withArrivalException := testpkg.CreateTestStudent(t, db, "Ankunft", "Ausnahme", "1a")
+	child := createApprovedChildForStudent(t, ctx, repos, auditDate, withArrivalException.ID,
+		enrollmentModel.PhaseCareOfferingSelectionAtLeastOne)
+	offering := testpkg.CreateTestCareOffering(t, db, child.phase.ID, "Montagsbetreuung")
+	offering.DaysOfWeekMode = enrollmentModel.DaysOfWeekModeParentChoice
+	offering.PickupTimes = map[string]string{"mon": "14:30"}
+	require.NoError(t, repos.CareOffering.Update(ctx, offering))
+	require.NoError(t, repos.RequestChildOffering.Create(ctx, &enrollmentModel.RequestChildOffering{
+		RequestChildID: child.child.ID, CareOfferingID: offering.ID, SelectedDays: []string{"mon"}, ValidFrom: &auditDate,
+	}))
+	require.NoError(t, repos.StudentArrivalException.Create(ctx, &scheduleModel.StudentArrivalException{
+		StudentID: withArrivalException.ID, ExceptionDate: auditDate, CreatedBy: staff.ID,
+	}))
+
+	futureStudent := testpkg.CreateTestStudent(t, db, "Zukunft", "Ausnahme", "1c")
+	futureChild := createApprovedChildForStudent(t, ctx, repos, auditDate, futureStudent.ID,
+		enrollmentModel.PhaseCareOfferingSelectionAtLeastOne)
+	futureOffering := testpkg.CreateTestCareOffering(t, db, futureChild.phase.ID, "Spätere Betreuung")
+	futureOffering.DaysOfWeekMode = enrollmentModel.DaysOfWeekModeParentChoice
+	futureOffering.PickupTimes = map[string]string{"mon": "14:30"}
+	require.NoError(t, repos.CareOffering.Update(ctx, futureOffering))
+	futureDate := auditDate.AddDays(1)
+	require.NoError(t, repos.RequestChildOffering.Create(ctx, &enrollmentModel.RequestChildOffering{
+		RequestChildID: futureChild.child.ID, CareOfferingID: futureOffering.ID,
+		SelectedDays: []string{"mon"}, ValidFrom: &futureDate,
+	}))
+
+	report, err := auditRepo.NewBookingConsistencyRepository(db).Audit(ctx, auditDate)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.PickupProjectionMissingDays)
+	assert.Equal(t, 0, report.BookingWithoutArrivalDays)
+	assert.Equal(t, 1, report.ApprovedWithoutRequiredOffering)
+}
+
 type approvedAuditChild struct {
 	phase *enrollmentModel.Phase
 	child *enrollmentModel.RequestChild

--- a/backend/database/repositories/audit/booking_consistency_test.go
+++ b/backend/database/repositories/audit/booking_consistency_test.go
@@ -1,0 +1,161 @@
+package audit_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	auditRepo "github.com/moto-nrw/project-phoenix/database/repositories/audit"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModel "github.com/moto-nrw/project-phoenix/models/activities"
+	enrollmentModel "github.com/moto-nrw/project-phoenix/models/enrollment"
+	scheduleModel "github.com/moto-nrw/project-phoenix/models/schedule"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBookingConsistencyAuditFindsProjectionDrift(t *testing.T) {
+	t.Parallel()
+
+	db := testpkg.SetupTestDB(t)
+	ctx := testpkg.Ctx(t)
+	repos := repositories.NewFactory(db)
+	auditDate := nextMonday(timezone.TodayDate())
+
+	bookedStudent := testpkg.CreateTestStudent(t, db, "Gebucht", "Audit", "1a")
+	bookedChild := createApprovedChildForStudent(t, ctx, repos, auditDate, bookedStudent.ID,
+		enrollmentModel.PhaseCareOfferingSelectionAtLeastOne)
+	offering := testpkg.CreateTestCareOffering(t, db, bookedChild.phase.ID, "Betreuung")
+	offering.DaysOfWeekMode = enrollmentModel.DaysOfWeekModeParentChoice
+	offering.PickupTimes = map[string]string{"mon": "14:30"}
+	require.NoError(t, repos.CareOffering.Update(ctx, offering))
+	require.NoError(t, repos.RequestChildOffering.Create(ctx, &enrollmentModel.RequestChildOffering{
+		RequestChildID: bookedChild.child.ID,
+		CareOfferingID: offering.ID,
+		SelectedDays:   []string{"mon", "tue"},
+		ValidFrom:      &auditDate,
+	}))
+
+	staff := testpkg.CreateTestStaff(t, db, "Audit", "Planung")
+	require.NoError(t, repos.StudentArrivalSchedule.Create(ctx, &scheduleModel.StudentArrivalSchedule{
+		StudentID: bookedStudent.ID, Weekday: 1, ExpectedArrival: wallClock(11, 45), CreatedBy: staff.ID,
+	}))
+	require.NoError(t, repos.StudentArrivalSchedule.Create(ctx, &scheduleModel.StudentArrivalSchedule{
+		StudentID: bookedStudent.ID, Weekday: 3, ExpectedArrival: wallClock(11, 45), CreatedBy: staff.ID,
+	}))
+	offeringID := offering.ID
+	require.NoError(t, repos.StudentPickupSchedule.Create(ctx, &scheduleModel.StudentPickupSchedule{
+		StudentID: bookedStudent.ID, Weekday: 2, PickupTime: wallClock(16, 0),
+		Source: scheduleModel.PickupScheduleSourceCareOffering, CareOfferingID: &offeringID,
+	}))
+
+	room := testpkg.CreateTestRoom(t, db, "Audit")
+	nonCareGroup := testpkg.CreateTestActivityGroup(t, db, "Audit AG")
+	tuesday := testpkg.CreateTestActivityInstance(t, db, auditDate.AddDays(1), room.ID, testpkg.ActivityInstanceOpts{
+		ActivityGroupID: &nonCareGroup.ID,
+	})
+	testpkg.CreateTestInstanceStudent(t, db, tuesday.ID, bookedStudent.ID, scheduleModel.AttendanceStatusExpected)
+	thursday := testpkg.CreateTestActivityInstance(t, db, auditDate.AddDays(3), room.ID, testpkg.ActivityInstanceOpts{
+		ActivityGroupID: &nonCareGroup.ID,
+	})
+	testpkg.CreateTestInstanceStudent(t, db, thursday.ID, bookedStudent.ID, scheduleModel.AttendanceStatusExpected)
+	careGroup := testpkg.CreateTestActivityGroup(t, db, "Audit Betreuung")
+	careGroup.Type = activitiesModel.GroupTypeCare
+	require.NoError(t, repos.ActivityGroup.Update(ctx, careGroup))
+	wednesday := testpkg.CreateTestActivityInstance(t, db, auditDate.AddDays(2), room.ID, testpkg.ActivityInstanceOpts{
+		ActivityGroupID: &careGroup.ID,
+	})
+	testpkg.CreateTestInstanceStudent(t, db, wednesday.ID, bookedStudent.ID, scheduleModel.AttendanceStatusExpected)
+
+	missingRequiredStudent := testpkg.CreateTestStudent(t, db, "Pflicht", "Audit", "1b")
+	createApprovedChildForStudent(t, ctx, repos, auditDate, missingRequiredStudent.ID,
+		enrollmentModel.PhaseCareOfferingSelectionAtLeastOne)
+	optionalStudent := testpkg.CreateTestStudent(t, db, "Optional", "Audit", "1c")
+	createApprovedChildForStudent(t, ctx, repos, auditDate, optionalStudent.ID,
+		enrollmentModel.PhaseCareOfferingSelectionOptional)
+	otherTenant := testpkg.NewTenantScope(t, db)
+	otherStudent := testpkg.CreateTestStudentForTenant(t, db, otherTenant.TenantID, "Fremd", "Audit", "1d")
+	createApprovedChildForStudent(t, otherTenant.Context(), repos, auditDate, otherStudent.ID,
+		enrollmentModel.PhaseCareOfferingSelectionAtLeastOne)
+
+	report, err := auditRepo.NewBookingConsistencyRepository(db).Audit(ctx, auditDate)
+	require.NoError(t, err)
+	assert.Equal(t, testpkg.Tenant(t), report.TenantID)
+	assert.Equal(t, 1, report.PickupProjectionMissingDays)
+	assert.Equal(t, 1, report.ArrivalWithoutBookingDays)
+	assert.Equal(t, 1, report.BookingWithoutArrivalDays)
+	assert.Equal(t, 1, report.PlannedWithoutBookingRows)
+	assert.Equal(t, 1, report.ApprovedWithoutRequiredOffering)
+	assert.Equal(t, 1, report.ApprovedWithoutOptionalOffering)
+	assert.Equal(t, 5, report.TotalFindings())
+}
+
+func TestBookingConsistencyAuditRequiresDateAndTenant(t *testing.T) {
+	t.Parallel()
+
+	repo := auditRepo.NewBookingConsistencyRepository(nil)
+	_, err := repo.Audit(context.Background(), timezone.TodayDate())
+	require.ErrorContains(t, err, "requires a tenant context")
+
+	_, err = repo.Audit(testpkg.Ctx(t), timezone.Date{})
+	require.ErrorContains(t, err, "date is required")
+}
+
+type approvedAuditChild struct {
+	phase *enrollmentModel.Phase
+	child *enrollmentModel.RequestChild
+}
+
+func createApprovedChildForStudent(
+	t *testing.T,
+	ctx context.Context,
+	repos *repositories.Factory,
+	auditDate timezone.Date,
+	studentID int64,
+	selectionMode string,
+) approvedAuditChild {
+	t.Helper()
+	phase := &enrollmentModel.Phase{
+		Name:                      fmt.Sprintf("Audit-%d", studentID),
+		Kind:                      enrollmentModel.PhaseKindSchoolYear,
+		ServiceStartDate:          auditDate,
+		ServiceEndDate:            auditDate.AddDays(30),
+		CareOverflowMode:          enrollmentModel.PhaseCareOverflowWaitlist,
+		CareOfferingSelectionMode: selectionMode,
+		IsActive:                  true,
+	}
+	require.NoError(t, repos.Phase.Create(ctx, phase))
+	request := &enrollmentModel.Request{
+		PhaseID:           phase.ID,
+		GuardianFirstName: "Audit",
+		GuardianLastName:  "Test",
+		GuardianEmail:     fmt.Sprintf("booking-audit-request-%d@example.test", studentID),
+		ConsentFlags:      map[string]any{},
+		CustomData:        map[string]any{},
+		SubmissionSource:  enrollmentModel.RequestSourceAdminManual,
+		SourceMetadata:    map[string]any{},
+		StatusToken:       fmt.Sprintf("booking-audit-%d-%d", studentID, time.Now().UnixNano()),
+		SubmittedAt:       time.Now(),
+	}
+	require.NoError(t, repos.Request.Create(ctx, request))
+	child := &enrollmentModel.RequestChild{
+		RequestID: request.ID, FirstName: "Audit", LastName: "Kind",
+		DateOfBirth: timezone.NewDate(2018, time.January, 1), CustomData: map[string]any{},
+		Status: enrollmentModel.ChildStatusApproved, ActivationMode: enrollmentModel.ChildActivationImmediate,
+		CreatedStudentID: &studentID,
+	}
+	require.NoError(t, repos.RequestChild.Create(ctx, child))
+	return approvedAuditChild{phase: phase, child: child}
+}
+
+func nextMonday(date timezone.Date) timezone.Date {
+	delta := (int(time.Monday) - int(date.Weekday()) + 7) % 7
+	return date.AddDays(delta)
+}
+
+func wallClock(hour, minute int) time.Time {
+	return time.Date(2000, time.January, 1, hour, minute, 0, 0, time.UTC)
+}

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -195,6 +195,7 @@ type Factory struct {
 	StaffMasterDataChange        auditModels.StaffMasterDataChangeCreator
 	ClassListEntryChange         auditModels.ClassListEntryChangeRepository
 	TimeTrackingAuditLog         auditModels.TimeTrackingAuditLogRepository
+	BookingConsistency           auditModels.BookingConsistencyRepository
 
 	// Platform domain (operator dashboard)
 	Organization             platformModels.OrganizationRepository
@@ -415,6 +416,7 @@ func NewFactory(db *bun.DB) *Factory {
 		StaffMasterDataChange:        audit.NewStaffMasterDataChangeRepository(db),
 		ClassListEntryChange:         audit.NewClassListEntryChangeRepository(db),
 		TimeTrackingAuditLog:         audit.NewTimeTrackingAuditLogRepository(db),
+		BookingConsistency:           audit.NewBookingConsistencyRepository(db),
 
 		// Platform repositories
 		Organization:             platformRepo.NewOrganizationRepository(db),

--- a/backend/models/audit/booking_consistency.go
+++ b/backend/models/audit/booking_consistency.go
@@ -1,0 +1,37 @@
+package audit
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+)
+
+// BookingConsistencyReport counts booking-derived planning drift for one
+// tenant. Counts contain no person names or other direct identifiers.
+type BookingConsistencyReport struct {
+	TenantID                        int64         `bun:"tenant_id"`
+	AuditDate                       timezone.Date `bun:"audit_date"`
+	PickupProjectionMissingDays     int           `bun:"pickup_projection_missing_days"`
+	ArrivalWithoutBookingDays       int           `bun:"arrival_without_booking_days"`
+	BookingWithoutArrivalDays       int           `bun:"booking_without_arrival_days"`
+	PlannedWithoutBookingRows       int           `bun:"planned_without_booking_rows"`
+	ApprovedWithoutRequiredOffering int           `bun:"approved_without_required_offering"`
+	ApprovedWithoutOptionalOffering int           `bun:"approved_without_optional_offering"`
+}
+
+// TotalFindings returns the number of inconsistent rows or child-days. An
+// approved child in an optional-offering phase is reported for review but is
+// not itself inconsistent (#2491).
+func (r BookingConsistencyReport) TotalFindings() int {
+	return r.PickupProjectionMissingDays +
+		r.ArrivalWithoutBookingDays +
+		r.BookingWithoutArrivalDays +
+		r.PlannedWithoutBookingRows +
+		r.ApprovedWithoutRequiredOffering
+}
+
+// BookingConsistencyRepository evaluates booking-derived planning data for
+// the tenant in ctx on auditDate.
+type BookingConsistencyRepository interface {
+	Audit(ctx context.Context, auditDate timezone.Date) (*BookingConsistencyReport, error)
+}

--- a/backend/services/scheduler/booking_consistency.go
+++ b/backend/services/scheduler/booking_consistency.go
@@ -1,0 +1,91 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModel "github.com/moto-nrw/project-phoenix/models/audit"
+)
+
+const (
+	bookingConsistencyAuditStartupDelay = 30 * time.Second
+	bookingConsistencyAuditInterval     = 24 * time.Hour
+	bookingConsistencyAuditTimeout      = 15 * time.Minute
+)
+
+func (s *Scheduler) scheduleBookingConsistencyAuditTask() {
+	if s.bookingConsistency == nil {
+		s.getLogger().Info("booking consistency audit not configured")
+		return
+	}
+
+	s.registerTask("booking-consistency-audit", "24h-poll", s.runBookingConsistencyAuditTask)
+}
+
+func (s *Scheduler) runBookingConsistencyAuditTask(task *ScheduledTask) {
+	s.runIntervalPolling(task, "panic in booking consistency audit task",
+		"booking consistency audit using interval polling",
+		bookingConsistencyAuditStartupDelay,
+		func() time.Duration { return bookingConsistencyAuditInterval },
+		s.checkAndRunBookingConsistencyAudit,
+	)
+}
+
+func (s *Scheduler) checkAndRunBookingConsistencyAudit(task *ScheduledTask) {
+	task.mu.Lock()
+	if task.Running {
+		task.mu.Unlock()
+		return
+	}
+	task.Running = true
+	task.mu.Unlock()
+	defer func() {
+		task.mu.Lock()
+		task.Running = false
+		task.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), bookingConsistencyAuditTimeout)
+	defer cancel()
+
+	auditDate := timezone.TodayDate()
+	if err := s.forEachTenant(ctx, "booking-consistency-audit", func(tenantCtx context.Context) error {
+		report, err := s.bookingConsistency.Audit(tenantCtx, auditDate)
+		if err != nil {
+			return err
+		}
+		if report == nil {
+			return errors.New("booking consistency audit returned nil report")
+		}
+		s.logBookingConsistencyReport(report)
+		return nil
+	}); err != nil {
+		s.getLogger().Error("booking consistency audit failed",
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func (s *Scheduler) logBookingConsistencyReport(report *auditModel.BookingConsistencyReport) {
+	attrs := []slog.Attr{
+		slog.Int64("tenant_id", report.TenantID),
+		slog.String("audit_date", report.AuditDate.String()),
+		slog.Int("pickup_projection_missing_days", report.PickupProjectionMissingDays),
+		slog.Int("arrival_without_booking_days", report.ArrivalWithoutBookingDays),
+		slog.Int("booking_without_arrival_days", report.BookingWithoutArrivalDays),
+		slog.Int("planned_without_booking_rows", report.PlannedWithoutBookingRows),
+		slog.Int("approved_without_required_offering", report.ApprovedWithoutRequiredOffering),
+		slog.Int("approved_without_optional_offering", report.ApprovedWithoutOptionalOffering),
+		slog.Int("total_findings", report.TotalFindings()),
+	}
+	if report.TotalFindings() > 0 {
+		s.getLogger().LogAttrs(context.Background(), slog.LevelWarn,
+			"booking consistency audit found drift", attrs...)
+		return
+	}
+	s.getLogger().LogAttrs(context.Background(), slog.LevelInfo,
+		"booking consistency audit passed", attrs...)
+}

--- a/backend/services/scheduler/booking_consistency_test.go
+++ b/backend/services/scheduler/booking_consistency_test.go
@@ -1,0 +1,103 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	auditModel "github.com/moto-nrw/project-phoenix/models/audit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubBookingConsistencyAudit struct {
+	report *auditModel.BookingConsistencyReport
+	err    error
+	calls  int
+}
+
+func (s *stubBookingConsistencyAudit) Audit(
+	_ context.Context,
+	auditDate timezone.Date,
+) (*auditModel.BookingConsistencyReport, error) {
+	s.calls++
+	if s.report != nil {
+		s.report.AuditDate = auditDate
+	}
+	return s.report, s.err
+}
+
+func TestBookingConsistencyAuditLogsDriftCounts(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	auditor := &stubBookingConsistencyAudit{report: &auditModel.BookingConsistencyReport{
+		TenantID:                    42,
+		PickupProjectionMissingDays: 3,
+		PlannedWithoutBookingRows:   2,
+	}}
+	s := &Scheduler{
+		bookingConsistency: auditor,
+		tasks:              make(map[string]*ScheduledTask),
+		logger: slog.New(slog.NewJSONHandler(&output, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	}
+
+	s.checkAndRunBookingConsistencyAudit(&ScheduledTask{Name: "booking-consistency-audit"})
+
+	require.Equal(t, 1, auditor.calls)
+	logOutput := output.String()
+	assert.Contains(t, logOutput, `"msg":"booking consistency audit found drift"`)
+	assert.Contains(t, logOutput, `"tenant_id":42`)
+	assert.Contains(t, logOutput, `"pickup_projection_missing_days":3`)
+	assert.Contains(t, logOutput, `"planned_without_booking_rows":2`)
+	assert.Contains(t, logOutput, `"total_findings":5`)
+}
+
+func TestBookingConsistencyAuditLogsRepositoryError(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	want := errors.New("query failed")
+	auditor := &stubBookingConsistencyAudit{err: want}
+	s := &Scheduler{
+		bookingConsistency: auditor,
+		tasks:              make(map[string]*ScheduledTask),
+		logger: slog.New(slog.NewJSONHandler(&output, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	}
+
+	s.checkAndRunBookingConsistencyAudit(&ScheduledTask{Name: "booking-consistency-audit"})
+
+	require.Equal(t, 1, auditor.calls)
+	assert.Contains(t, output.String(), `"msg":"booking consistency audit failed"`)
+	assert.Contains(t, output.String(), `"error":"query failed"`)
+}
+
+func TestBookingConsistencyAuditTreatsOptionalNoOfferingAsReview(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	auditor := &stubBookingConsistencyAudit{report: &auditModel.BookingConsistencyReport{
+		TenantID:                        42,
+		ApprovedWithoutOptionalOffering: 2,
+	}}
+	s := &Scheduler{
+		bookingConsistency: auditor,
+		tasks:              make(map[string]*ScheduledTask),
+		logger: slog.New(slog.NewJSONHandler(&output, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	}
+
+	s.checkAndRunBookingConsistencyAudit(&ScheduledTask{Name: "booking-consistency-audit"})
+
+	assert.Contains(t, output.String(), `"msg":"booking consistency audit passed"`)
+	assert.Contains(t, output.String(), `"approved_without_optional_offering":2`)
+	assert.Contains(t, output.String(), `"total_findings":0`)
+}

--- a/backend/services/scheduler/scheduler.go
+++ b/backend/services/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModel "github.com/moto-nrw/project-phoenix/models/active"
+	auditModel "github.com/moto-nrw/project-phoenix/models/audit"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	facilitiesModel "github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/platform"
@@ -121,6 +122,7 @@ type Scheduler struct {
 	timeTrackingCleanup        active.TimeTrackingCleanupService
 	studentChangeLogCleanup    usersSvc.StudentChangeLogCleanupService
 	pwaUsageCleanup            pwaSvc.UsageService
+	bookingConsistency         auditModel.BookingConsistencyRepository
 	enrollmentRejectedCleanup  enrollmentSvc.RejectedEnrollmentCleaner
 	autoStart                  scheduleSvc.AutoStartService
 	settings                   SettingsResolver
@@ -326,6 +328,12 @@ func (s *Scheduler) SetPWAUsageCleanup(svc pwaSvc.UsageService) {
 	s.pwaUsageCleanup = svc
 }
 
+// SetBookingConsistencyAudit wires the tenant-scoped booking consistency
+// audit. Nil disables the daily check.
+func (s *Scheduler) SetBookingConsistencyAudit(repo auditModel.BookingConsistencyRepository) {
+	s.bookingConsistency = repo
+}
+
 func (s *Scheduler) SetEnrollmentRejectedCleanup(svc enrollmentSvc.RejectedEnrollmentCleaner) {
 	s.enrollmentRejectedCleanup = svc
 }
@@ -515,6 +523,9 @@ func (s *Scheduler) Start() {
 	// Schedule daily PWA standalone-usage GDPR cleanup (issue #2189).
 	// Same toggle + cleanup-time as the other retention jobs.
 	s.schedulePWAUsageCleanupTask()
+
+	// Compare authoritative booking windows with their planning projections.
+	s.scheduleBookingConsistencyAuditTask()
 
 	// Schedule daily session end at configurable time (default 6 PM)
 	s.scheduleSessionEndTask()


### PR DESCRIPTION
# Pull Request

## Beschreibung

Der Server startet 30 Sekunden nach dem Start und prüft danach alle 24 Stunden pro aktivem Mandanten die Konsistenz von Buchungen und Betreuungsplanung:

- fehlende oder ungültige Angebots-Lesezeiten für die nächsten sieben Tage
- Bringzeit-Tage ohne wirksame Buchung
- Buchungstage ohne Bringzeit
- zukünftige Kinderzeilen in geplanten Betreuungsterminen ohne wirksame Buchung
- freigegebene Kinder ohne vollständige Angebotsabdeckung für eine aktive Phase, getrennt nach Pflichtfehlern und optionalen Prüffällen

Der Audit verwendet `request_child_offerings` mit halb offenem Datumsfenster als Quelle für wirksame Buchungen. Alte gespeicherte Zeilen mit `source=care_offering` ignoriert er bewusst, weil auch die Laufzeitprojektion sie ignoriert. Manuelle `staff`-Zeilen bleiben Overrides, beheben aber keine fehlende Angebots-Lesezeit.

Der Job schreibt strukturierte Logs mit stabilen Zählern. Audits mit Befunden werden auf Warn-Level protokolliert, leere Audits auf Info-Level. Logs enthalten nur Mandanten-ID, Datum und Zähler, keine Namen oder Kind-IDs.

Optionale Phasen dürfen Kinder ohne Angebot freigeben (#2491). Diese Fälle erscheinen als `approved_without_optional_offering`, fließen aber nicht in `total_findings` ein.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Refactoring
- [x] Performance improvement
- [x] Test addition/modification
- [ ] CI/CD improvement

## Related Issues

- Closes #2425
- Related to #2494
- Related to #2416

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] Testing documentation updated

Ausgeführt:

- `scripts/test-changed.sh origin/development` — 116 betroffene Go-Pakete grün, inklusive DB-Tests
- `cd backend && go test -short ./...`
- `cd backend && go vet ./database/repositories/audit ./models/audit ./services/scheduler ./api`
- Pre-push: `go-vet`, `go-deadcode`, `golangci-lint` — 0 Findings

Die hermetischen Repository-Tests decken Datumsfenster, fehlende oder ungültige Lesezeiten, beide Bringzeit-Richtungen, geplante Betreuungstermine, Pflicht- und Optionalfälle, Fremdmandanten, wirksame Ausnahmen sowie das Ignorieren alter `care_offering`-Zeilen ab.

## Production-Check (read-only, 22.08.2026)

Die Query lief in `BEGIN TRANSACTION READ ONLY` gegen alle aktiven Production-Mandanten und gab nur aggregierte Zähler aus.

| Schule | Lesezeit fehlt | Bringzeit ohne Buchung | Buchung ohne Bringzeit | Planung ohne Buchung | Pflichtangebot fehlt | Optional prüfen |
|---|---:|---:|---:|---:|---:|---:|
| OGS Altenberge | 0 | 0 | 0 | 0 | 0 | 0 |
| OGS Burbach | 0 | 0 | 0 | 0 | 0 | 0 |
| Demo-OGS | 5 | 0 | 5 | 0 | 0 | 1 |
| OGS am Berg | 526 | 3 | 18 | 253 | 0 | 1 |
| OGS Wissingen | 299 | 12 | 2 | 0 | 0 | 0 |
| OGS Bissendorf | 0 | 0 | 0 | 0 | 0 | 0 |
| OGS Barnstorf | 0 | 0 | 0 | 0 | 0 | 0 |

`EXPLAIN ANALYZE` für OGS am Berg: rund 0,56 Sekunden. Hash-Anti-Joins statt wiederholter CTE-Scans senkten die Laufzeit gegenüber dem ersten Plan von 3,7 Sekunden.

Production läuft noch auf `c031fd7` und enthält #2494 nicht. Der Check nutzt daher bewusst das bereits nach `development` gemergte Lesezeit-Modell. Er benötigt keine neue Migration und läuft gegen das bestehende Production-Schema.

## Security Checklist

- [x] I have followed the [security guidelines](../SECURITY.md)
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

Jeder Mandant wird in einer eigenen `TenantTx` geprüft. Die Query bindet `tenant_id` in allen relevanten Datenpfaden. Warn-Logs enthalten keine personenbezogenen Daten.

## Screenshots or Examples

Nicht anwendbar: reine Backend-/Scheduler-Änderung.

## Missverständnis-Check

Nicht user-sichtbar. Keine Oberfläche, E-Mail oder Hilfetexte geändert.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [x] User-visible change: I ran the Verständlichkeit checklist (`.claude/rules/verstaendlichkeit.md`) against the running app and recorded the result above — or it doesn't apply
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

Der Audit meldet Drift nur. Er repariert keine Daten und ersetzt nicht die atomare Update-Kaskade aus #2416.
