### PR TITLE
fix: show manual planning conflicts before offering approval

### DIFF
--- a/backend/api/students/offering_request_review_handlers.go
+++ b/backend/api/students/offering_request_review_handlers.go
@@ -219,7 +219,17 @@ type OfferingRequestPreviewSelectionResponse struct {
 }
 
 type OfferingRequestPreviewResponse struct {
-	Selections []OfferingRequestPreviewSelectionResponse `json:"selections"`
+	Selections                        []OfferingRequestPreviewSelectionResponse `json:"selections"`
+	ManualPlanningConflicts           []ManualPlanningConflictResponse          `json:"manual_planning_conflicts"`
+	ArrivalExpectationsFollowBookings bool                                      `json:"arrival_expectations_follow_bookings"`
+}
+
+type ManualPlanningConflictResponse struct {
+	ActivityGroupID   string   `json:"activity_group_id"`
+	ActivityGroupName string   `json:"activity_group_name"`
+	Days              []string `json:"days"`
+	FirstDate         string   `json:"first_date"`
+	OccurrenceCount   int      `json:"occurrence_count"`
 }
 
 func parseExcludedOfferingIDs(rawIDs []string) ([]int64, error) {
@@ -265,15 +275,33 @@ func (rs *Resource) previewOfferingChangeRequest(w http.ResponseWriter, r *http.
 		renderOfferingDecisionError(w, r, err)
 		return
 	}
-	selections := make([]OfferingRequestPreviewSelectionResponse, 0, len(preview))
-	for _, selection := range preview {
+	if preview == nil {
+		renderError(w, r, common.ErrorInternalServer(errors.New("offering change preview is empty")))
+		return
+	}
+	selections := make([]OfferingRequestPreviewSelectionResponse, 0, len(preview.Selections))
+	for _, selection := range preview.Selections {
 		selections = append(selections, OfferingRequestPreviewSelectionResponse{
 			OfferingID: strconv.FormatInt(selection.OfferingID, 10),
 			New:        germanOfferingDiffLabel(selection.State, selection.Days),
 			Removed:    selection.State == "removed",
 		})
 	}
-	common.Respond(w, r, http.StatusOK, OfferingRequestPreviewResponse{Selections: selections}, "Preview materialized")
+	conflicts := make([]ManualPlanningConflictResponse, 0, len(preview.ManualPlanningConflicts))
+	for _, conflict := range preview.ManualPlanningConflicts {
+		conflicts = append(conflicts, ManualPlanningConflictResponse{
+			ActivityGroupID:   strconv.FormatInt(conflict.ActivityGroupID, 10),
+			ActivityGroupName: conflict.ActivityGroupName,
+			Days:              conflict.Days,
+			FirstDate:         conflict.FirstDate.String(),
+			OccurrenceCount:   conflict.OccurrenceCount,
+		})
+	}
+	common.Respond(w, r, http.StatusOK, OfferingRequestPreviewResponse{
+		Selections:                        selections,
+		ManualPlanningConflicts:           conflicts,
+		ArrivalExpectationsFollowBookings: preview.ArrivalExpectationsFollowBookings,
+	}, "Preview materialized")
 }
 
 // decideOfferingChangeRequest approves (and applies the dated switch) or

--- a/backend/api/students/offering_request_review_handlers_test.go
+++ b/backend/api/students/offering_request_review_handlers_test.go
@@ -23,7 +23,7 @@ type fakeOfferingChangeRequestService struct {
 	input                enrollmentService.DecideOfferingChangeInput
 	previewExcluded      []int64
 	previewEffectiveFrom *timezone.Date
-	preview              []enrollmentService.OfferingChangePreviewSelection
+	preview              *enrollmentService.OfferingChangePreview
 }
 
 func (f *fakeOfferingChangeRequestService) Catalog(context.Context, int64) (*enrollmentService.OfferingChangeCatalog, error) {
@@ -67,7 +67,7 @@ func (f *fakeOfferingChangeRequestService) PreviewDecision(
 	_ int64,
 	excluded []int64,
 	effectiveFrom *timezone.Date,
-) ([]enrollmentService.OfferingChangePreviewSelection, error) {
+) (*enrollmentService.OfferingChangePreview, error) {
 	f.previewExcluded = excluded
 	f.previewEffectiveFrom = effectiveFrom
 	return f.preview, nil
@@ -105,11 +105,21 @@ func TestDecideOfferingChangeRequest_UsesReviewerRolesForAudit(t *testing.T) {
 func TestPreviewOfferingChangeRequest_ReturnsMaterializedDays(t *testing.T) {
 	t.Parallel()
 
-	svc := &fakeOfferingChangeRequestService{preview: []enrollmentService.OfferingChangePreviewSelection{{
-		OfferingID: 11,
-		State:      "booked",
-		Days:       []string{"mon", "wed"},
-	}}}
+	svc := &fakeOfferingChangeRequestService{preview: &enrollmentService.OfferingChangePreview{
+		Selections: []enrollmentService.OfferingChangePreviewSelection{{
+			OfferingID: 11,
+			State:      "booked",
+			Days:       []string{"mon", "wed"},
+		}},
+		ManualPlanningConflicts: []enrollmentService.ManualPlanningConflict{{
+			ActivityGroupID:   17,
+			ActivityGroupName: "Freie Hausaufgaben-Gruppe",
+			Days:              []string{"tue"},
+			FirstDate:         timezone.NewDate(2027, 2, 2),
+			OccurrenceCount:   8,
+		}},
+		ArrivalExpectationsFollowBookings: true,
+	}}
 	rs := &Resource{ResourceConfig: ResourceConfig{OfferingChangeService: svc}}
 	req := httptest.NewRequest(http.MethodPost, "/offering-change-requests/100/preview",
 		strings.NewReader(`{"excluded_offering_ids":["9"]}`))
@@ -124,6 +134,11 @@ func TestPreviewOfferingChangeRequest_ReturnsMaterializedDays(t *testing.T) {
 	assert.Equal(t, []int64{9}, svc.previewExcluded)
 	assert.Contains(t, w.Body.String(), `"offering_id":"11"`)
 	assert.Contains(t, w.Body.String(), `"new":"Mo, Mi"`)
+	assert.Contains(t, w.Body.String(), `"activity_group_name":"Freie Hausaufgaben-Gruppe"`)
+	assert.Contains(t, w.Body.String(), `"days":["tue"]`)
+	assert.Contains(t, w.Body.String(), `"first_date":"2027-02-02"`)
+	assert.Contains(t, w.Body.String(), `"occurrence_count":8`)
+	assert.Contains(t, w.Body.String(), `"arrival_expectations_follow_bookings":true`)
 }
 
 func TestToOfferingRequestResponse_IncludesRemainingDaysForOverridePreview(t *testing.T) {
@@ -275,7 +290,7 @@ func TestDecideOfferingChangeRequest_RejectionNeedsNoDate(t *testing.T) {
 func TestPreviewOfferingChangeRequest_PassesTheChosenDate(t *testing.T) {
 	t.Parallel()
 
-	svc := &fakeOfferingChangeRequestService{}
+	svc := &fakeOfferingChangeRequestService{preview: &enrollmentService.OfferingChangePreview{}}
 	rs := &Resource{ResourceConfig: ResourceConfig{OfferingChangeService: svc}}
 	req := httptest.NewRequest(http.MethodPost, "/offering-change-requests/100/preview",
 		strings.NewReader(`{"excluded_offering_ids":[],"effective_from":"2026-09-01"}`))

--- a/backend/database/repositories/enrollment/offering_change_impact_repository.go
+++ b/backend/database/repositories/enrollment/offering_change_impact_repository.go
@@ -55,52 +55,6 @@ func (r *OfferingChangeImpactRepository) ListManualPlanningOccurrences(
 		Where(`"activity_group".is_template = TRUE`).
 		Where(`"activity_group".type = ?`, activitiesModels.GroupTypeCare).
 		Where(`COALESCE(jsonb_array_length("activity_group".source_care_offering_ids), 0) = 0`).
-		// A legacy ActivityGroupID link only owns the part of a student's
-		// roster covered by that child's approved offering: its phase, validity
-		// window, and selected weekdays. Rows outside that footprint remain
-		// manual planning and must be shown before approval.
-		Where(`NOT EXISTS (
-			SELECT 1
-			FROM enrollment.care_offerings AS "source_offering"
-			INNER JOIN enrollment.request_child_offerings AS "source_link"
-				ON "source_link".tenant_id = "source_offering".tenant_id
-				AND "source_link".care_offering_id = "source_offering".id
-			INNER JOIN enrollment.request_children AS "source_child"
-				ON "source_child".tenant_id = "source_link".tenant_id
-				AND "source_child".id = "source_link".request_child_id
-			INNER JOIN enrollment.phases AS "source_phase"
-				ON "source_phase".tenant_id = "source_offering".tenant_id
-				AND "source_phase".id = "source_offering".phase_id
-			WHERE "source_offering".tenant_id = "activity_group".tenant_id
-			  AND "source_offering".activity_group_id = "activity_group".id
-			  AND "source_offering".counts_as_care = TRUE
-			  AND "source_child".status = 'approved'
-			  AND COALESCE("source_child".created_student_id, "source_child".matched_student_id) = "instance_student".student_id
-			  AND ("source_link".valid_from IS NULL OR "source_link".valid_from <= "activity_instance".date)
-			  AND ("source_link".valid_until IS NULL OR "source_link".valid_until > "activity_instance".date)
-			  AND "source_phase".service_start_date <= "activity_instance".date
-			  AND "source_phase".service_end_date >= "activity_instance".date
-			  AND (
-				"source_link".selected_days @> jsonb_build_array(
-					CASE EXTRACT(ISODOW FROM "activity_instance".date)
-						WHEN 1 THEN 'mon' WHEN 2 THEN 'tue' WHEN 3 THEN 'wed'
-						WHEN 4 THEN 'thu' WHEN 5 THEN 'fri' WHEN 6 THEN 'sat'
-						WHEN 7 THEN 'sun'
-					END
-				)
-				OR (
-					COALESCE(jsonb_array_length("source_link".selected_days), 0) = 0
-					AND "source_offering".days_of_week_mode = 'fixed'
-					AND "source_offering".available_days @> jsonb_build_array(
-						CASE EXTRACT(ISODOW FROM "activity_instance".date)
-							WHEN 1 THEN 'mon' WHEN 2 THEN 'tue' WHEN 3 THEN 'wed'
-							WHEN 4 THEN 'thu' WHEN 5 THEN 'fri' WHEN 6 THEN 'sat'
-							WHEN 7 THEN 'sun'
-						END
-					)
-				)
-			  )
-		)`).
 		OrderExpr(`"activity_group".name, "activity_group".id, "activity_instance".date, "activity_instance".id`)
 	query = base.WithTenantFilter(ctx, query, "instance_student")
 

--- a/backend/database/repositories/enrollment/offering_change_impact_repository.go
+++ b/backend/database/repositories/enrollment/offering_change_impact_repository.go
@@ -1,0 +1,70 @@
+package enrollment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories/base"
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+	activitiesModels "github.com/moto-nrw/project-phoenix/models/activities"
+	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/uptrace/bun"
+)
+
+// OfferingChangeImpactRepository implements the read-only planning impact
+// projection for an offering-change preview. A generic repository cannot
+// express this tenant-safe join from student rosters through materialized
+// timetable instances to both current and legacy offering-source markers.
+type OfferingChangeImpactRepository struct {
+	db *bun.DB
+}
+
+func NewOfferingChangeImpactRepository(db *bun.DB) enrollmentModels.OfferingChangeImpactRepository {
+	return &OfferingChangeImpactRepository{db: db}
+}
+
+func (r *OfferingChangeImpactRepository) ListManualPlanningOccurrences(
+	ctx context.Context,
+	studentID int64,
+	from, to timezone.Date,
+) ([]enrollmentModels.ManualPlanningOccurrence, error) {
+	if studentID <= 0 {
+		return nil, fmt.Errorf("student id must be positive")
+	}
+	if from.IsZero() || to.IsZero() || to.Before(from) {
+		return nil, fmt.Errorf("valid planning date range is required")
+	}
+
+	rows := make([]enrollmentModels.ManualPlanningOccurrence, 0)
+	query := base.GetDB(ctx, r.db).NewSelect().
+		ModelTableExpr(`schedule.instance_students AS "instance_student"`).
+		ColumnExpr(`"activity_group".id AS activity_group_id`).
+		ColumnExpr(`"activity_group".name AS activity_group_name`).
+		ColumnExpr(`"activity_instance".id AS instance_id`).
+		ColumnExpr(`"activity_instance".date`).
+		Join(`INNER JOIN schedule.activity_instances AS "activity_instance" ON "activity_instance".id = "instance_student".instance_id AND "activity_instance".tenant_id = "instance_student".tenant_id`).
+		Join(`INNER JOIN activities.groups AS "activity_group" ON "activity_group".id = "activity_instance".activity_group_id AND "activity_group".tenant_id = "activity_instance".tenant_id`).
+		Where(`"instance_student".student_id = ?`, studentID).
+		Where(`"instance_student".is_unplanned = FALSE`).
+		Where(`"activity_instance".date BETWEEN ? AND ?`, from, to).
+		Where(`"activity_instance".status = ?`, scheduleModels.InstanceStatusPlanned).
+		Where(`"activity_instance".calendar_period_id IS NOT NULL`).
+		Where(`"activity_instance".is_spontaneous = FALSE`).
+		Where(`"activity_group".is_template = TRUE`).
+		Where(`"activity_group".type = ?`, activitiesModels.GroupTypeCare).
+		Where(`COALESCE(jsonb_array_length("activity_group".source_care_offering_ids), 0) = 0`).
+		Where(`NOT EXISTS (
+			SELECT 1
+			FROM enrollment.care_offerings AS "source_offering"
+			WHERE "source_offering".tenant_id = "activity_group".tenant_id
+			  AND "source_offering".activity_group_id = "activity_group".id
+		)`).
+		OrderExpr(`"activity_group".name, "activity_group".id, "activity_instance".date, "activity_instance".id`)
+	query = base.WithTenantFilter(ctx, query, "instance_student")
+
+	if err := query.Scan(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("list manual planning occurrences: %w", err)
+	}
+	return rows, nil
+}

--- a/backend/database/repositories/enrollment/offering_change_impact_repository.go
+++ b/backend/database/repositories/enrollment/offering_change_impact_repository.go
@@ -47,6 +47,7 @@ func (r *OfferingChangeImpactRepository) ListManualPlanningOccurrences(
 		Join(`INNER JOIN activities.groups AS "activity_group" ON "activity_group".id = "activity_instance".activity_group_id AND "activity_group".tenant_id = "activity_instance".tenant_id`).
 		Where(`"instance_student".student_id = ?`, studentID).
 		Where(`"instance_student".is_unplanned = FALSE`).
+		Where(`"instance_student".not_scheduled = FALSE`).
 		Where(`"activity_instance".date BETWEEN ? AND ?`, from, to).
 		Where(`"activity_instance".status = ?`, scheduleModels.InstanceStatusPlanned).
 		Where(`"activity_instance".calendar_period_id IS NOT NULL`).
@@ -72,6 +73,7 @@ func (r *OfferingChangeImpactRepository) ListManualPlanningOccurrences(
 				AND "source_phase".id = "source_offering".phase_id
 			WHERE "source_offering".tenant_id = "activity_group".tenant_id
 			  AND "source_offering".activity_group_id = "activity_group".id
+			  AND "source_offering".counts_as_care = TRUE
 			  AND "source_child".status = 'approved'
 			  AND COALESCE("source_child".created_student_id, "source_child".matched_student_id) = "instance_student".student_id
 			  AND ("source_link".valid_from IS NULL OR "source_link".valid_from <= "activity_instance".date)

--- a/backend/database/repositories/enrollment/offering_change_impact_repository.go
+++ b/backend/database/repositories/enrollment/offering_change_impact_repository.go
@@ -81,9 +81,7 @@ func (r *OfferingChangeImpactRepository) ListManualPlanningOccurrences(
 			  AND "source_phase".service_start_date <= "activity_instance".date
 			  AND "source_phase".service_end_date >= "activity_instance".date
 			  AND (
-				COALESCE(jsonb_array_length("source_link".selected_days), 0) = 0
-				AND "source_offering".days_of_week_mode <> 'fixed'
-				OR "source_link".selected_days @> jsonb_build_array(
+				"source_link".selected_days @> jsonb_build_array(
 					CASE EXTRACT(ISODOW FROM "activity_instance".date)
 						WHEN 1 THEN 'mon' WHEN 2 THEN 'tue' WHEN 3 THEN 'wed'
 						WHEN 4 THEN 'thu' WHEN 5 THEN 'fri' WHEN 6 THEN 'sat'

--- a/backend/database/repositories/enrollment/offering_change_impact_repository.go
+++ b/backend/database/repositories/enrollment/offering_change_impact_repository.go
@@ -54,11 +54,52 @@ func (r *OfferingChangeImpactRepository) ListManualPlanningOccurrences(
 		Where(`"activity_group".is_template = TRUE`).
 		Where(`"activity_group".type = ?`, activitiesModels.GroupTypeCare).
 		Where(`COALESCE(jsonb_array_length("activity_group".source_care_offering_ids), 0) = 0`).
+		// A legacy ActivityGroupID link only owns the part of a student's
+		// roster covered by that child's approved offering: its phase, validity
+		// window, and selected weekdays. Rows outside that footprint remain
+		// manual planning and must be shown before approval.
 		Where(`NOT EXISTS (
 			SELECT 1
 			FROM enrollment.care_offerings AS "source_offering"
+			INNER JOIN enrollment.request_child_offerings AS "source_link"
+				ON "source_link".tenant_id = "source_offering".tenant_id
+				AND "source_link".care_offering_id = "source_offering".id
+			INNER JOIN enrollment.request_children AS "source_child"
+				ON "source_child".tenant_id = "source_link".tenant_id
+				AND "source_child".id = "source_link".request_child_id
+			INNER JOIN enrollment.phases AS "source_phase"
+				ON "source_phase".tenant_id = "source_offering".tenant_id
+				AND "source_phase".id = "source_offering".phase_id
 			WHERE "source_offering".tenant_id = "activity_group".tenant_id
 			  AND "source_offering".activity_group_id = "activity_group".id
+			  AND "source_child".status = 'approved'
+			  AND COALESCE("source_child".created_student_id, "source_child".matched_student_id) = "instance_student".student_id
+			  AND ("source_link".valid_from IS NULL OR "source_link".valid_from <= "activity_instance".date)
+			  AND ("source_link".valid_until IS NULL OR "source_link".valid_until > "activity_instance".date)
+			  AND "source_phase".service_start_date <= "activity_instance".date
+			  AND "source_phase".service_end_date >= "activity_instance".date
+			  AND (
+				COALESCE(jsonb_array_length("source_link".selected_days), 0) = 0
+				AND "source_offering".days_of_week_mode <> 'fixed'
+				OR "source_link".selected_days @> jsonb_build_array(
+					CASE EXTRACT(ISODOW FROM "activity_instance".date)
+						WHEN 1 THEN 'mon' WHEN 2 THEN 'tue' WHEN 3 THEN 'wed'
+						WHEN 4 THEN 'thu' WHEN 5 THEN 'fri' WHEN 6 THEN 'sat'
+						WHEN 7 THEN 'sun'
+					END
+				)
+				OR (
+					COALESCE(jsonb_array_length("source_link".selected_days), 0) = 0
+					AND "source_offering".days_of_week_mode = 'fixed'
+					AND "source_offering".available_days @> jsonb_build_array(
+						CASE EXTRACT(ISODOW FROM "activity_instance".date)
+							WHEN 1 THEN 'mon' WHEN 2 THEN 'tue' WHEN 3 THEN 'wed'
+							WHEN 4 THEN 'thu' WHEN 5 THEN 'fri' WHEN 6 THEN 'sat'
+							WHEN 7 THEN 'sun'
+						END
+					)
+				)
+			  )
 		)`).
 		OrderExpr(`"activity_group".name, "activity_group".id, "activity_instance".date, "activity_instance".id`)
 	query = base.WithTenantFilter(ctx, query, "instance_student")

--- a/backend/database/repositories/factory.go
+++ b/backend/database/repositories/factory.go
@@ -217,6 +217,7 @@ type Factory struct {
 	RequestGuardian      enrollmentModels.RequestGuardianRepository
 	LateInvite           enrollmentModels.LateInviteRepository
 	CareOffering         enrollmentModels.CareOfferingRepository
+	OfferingChangeImpact enrollmentModels.OfferingChangeImpactRepository
 	RequestChildOffering enrollmentModels.RequestChildOfferingRepository
 	ChangeRequest        enrollmentModels.ChangeRequestRepository
 	ChangeRequestMessage enrollmentModels.ChangeRequestMessageRepository
@@ -431,6 +432,7 @@ func NewFactory(db *bun.DB) *Factory {
 		RequestGuardian:       enrollment.NewRequestGuardianRepository(db),
 		LateInvite:            enrollment.NewLateInviteRepository(db),
 		CareOffering:          enrollment.NewCareOfferingRepository(db),
+		OfferingChangeImpact:  enrollment.NewOfferingChangeImpactRepository(db),
 		RequestChildOffering:  enrollment.NewRequestChildOfferingRepository(db),
 		OfferingChangeRequest: enrollment.NewOfferingChangeRequestRepository(db),
 		ChangeRequest:         enrollment.NewChangeRequestRepository(db),

--- a/backend/models/enrollment/offering_change_impact.go
+++ b/backend/models/enrollment/offering_change_impact.go
@@ -1,0 +1,28 @@
+package enrollment
+
+import (
+	"context"
+
+	"github.com/moto-nrw/project-phoenix/internal/timezone"
+)
+
+// ManualPlanningOccurrence is one future timetable slot that an offering
+// change cannot reconcile because its recurring template is not sourced from
+// care offerings.
+type ManualPlanningOccurrence struct {
+	ActivityGroupID   int64         `bun:"activity_group_id"`
+	ActivityGroupName string        `bun:"activity_group_name"`
+	InstanceID        int64         `bun:"instance_id"`
+	Date              timezone.Date `bun:"date"`
+}
+
+// OfferingChangeImpactRepository reads the timetable rows outside the
+// offering-driven reconciliation path. It is deliberately read-only: the
+// office must decide how to resolve these rows after seeing the warning.
+type OfferingChangeImpactRepository interface {
+	ListManualPlanningOccurrences(
+		ctx context.Context,
+		studentID int64,
+		from, to timezone.Date,
+	) ([]ManualPlanningOccurrence, error)
+}

--- a/backend/services/enrollment/offering_change_request_automatic_test.go
+++ b/backend/services/enrollment/offering_change_request_automatic_test.go
@@ -414,8 +414,8 @@ func TestOfferingChangeRequestService_PreviewDecision_RecomputesPartialExclusion
 
 	preview, err := svc.PreviewDecision(ctx, row.ID, []int64{mixed.ID}, nil)
 	require.NoError(t, err)
-	byID := make(map[int64][]string, len(preview))
-	for _, selection := range preview {
+	byID := make(map[int64][]string, len(preview.Selections))
+	for _, selection := range preview.Selections {
 		byID[selection.OfferingID] = selection.Days
 	}
 	assert.Equal(t, []string{"mon", "wed"}, byID[mixed.ID])

--- a/backend/services/enrollment/offering_change_request_service.go
+++ b/backend/services/enrollment/offering_change_request_service.go
@@ -253,6 +253,23 @@ type OfferingChangePreviewSelection struct {
 	Days       []string
 }
 
+// ManualPlanningConflict groups future occurrences from one recurring roster
+// that the proposed care bookings no longer cover.
+type ManualPlanningConflict struct {
+	ActivityGroupID   int64
+	ActivityGroupName string
+	Days              []string
+	FirstDate         timezone.Date
+	OccurrenceCount   int
+}
+
+// OfferingChangePreview is the complete, non-writing approval projection.
+type OfferingChangePreview struct {
+	Selections                        []OfferingChangePreviewSelection
+	ManualPlanningConflicts           []ManualPlanningConflict
+	ArrivalExpectationsFollowBookings bool
+}
+
 // offeringDecisionRecencyDays bounds how long a decided request keeps being
 // reported. Same window the excused-absence requests use for the same purpose:
 // long enough that a guardian sees the outcome on their next visit, short
@@ -328,7 +345,7 @@ type OfferingChangeRequestService interface {
 		requestID int64,
 		excludedIDs []int64,
 		effectiveFrom *timezone.Date,
-	) ([]OfferingChangePreviewSelection, error)
+	) (*OfferingChangePreview, error)
 
 	// Decide approves (and applies) or rejects a pending request.
 	Decide(ctx context.Context, input DecideOfferingChangeInput) error
@@ -345,6 +362,7 @@ type OfferingChangeRequestServiceConfig struct {
 	RequestRepo              enrollmentModels.RequestRepository
 	PhaseRepo                enrollmentModels.PhaseRepository
 	CareOfferingRepo         enrollmentModels.CareOfferingRepository
+	ImpactRepo               enrollmentModels.OfferingChangeImpactRepository
 	RequestChildOfferingRepo enrollmentModels.RequestChildOfferingRepository
 	StudentRepo              usersModels.StudentRepository
 	PersonRepo               usersModels.PersonRepository
@@ -1493,7 +1511,7 @@ func (s *offeringChangeRequestService) PreviewDecision(
 	requestID int64,
 	excludedIDs []int64,
 	effectiveFrom *timezone.Date,
-) ([]OfferingChangePreviewSelection, error) {
+) (*OfferingChangePreview, error) {
 	if requestID <= 0 {
 		return nil, fmt.Errorf("%w: request is required", ErrOfferingChangeInvalid)
 	}
@@ -1543,7 +1561,102 @@ func (s *offeringChangeRequestService) PreviewDecision(
 			Days:       append([]string(nil), selection.SelectedDays...),
 		})
 	}
-	return preview, nil
+	conflicts, err := s.manualPlanningConflicts(ctx, row.StudentID, diff)
+	if err != nil {
+		return nil, err
+	}
+	if s.Settings == nil {
+		return nil, fmt.Errorf("offering change: settings are required for preview")
+	}
+	arrivalExpectationsFollowBookings, err := s.Settings.ResolveBool(
+		ctx, configModel.KeyEnrollmentBookingsAuthoritative,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("offering change: resolve booking authority for preview: %w", err)
+	}
+	return &OfferingChangePreview{
+		Selections:                        preview,
+		ManualPlanningConflicts:           conflicts,
+		ArrivalExpectationsFollowBookings: arrivalExpectationsFollowBookings,
+	}, nil
+}
+
+func (s *offeringChangeRequestService) manualPlanningConflicts(
+	ctx context.Context,
+	studentID int64,
+	diff *offeringDecisionDiff,
+) ([]ManualPlanningConflict, error) {
+	if s.ImpactRepo == nil {
+		return nil, fmt.Errorf("offering change: impact repository is required for preview")
+	}
+	occurrences, err := s.ImpactRepo.ListManualPlanningOccurrences(
+		ctx, studentID, diff.effectiveFrom, diff.phase.ServiceEndDate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("offering change: list manual planning conflicts: %w", err)
+	}
+	return aggregateManualPlanningConflicts(occurrences, coveredCareDays(diff)), nil
+}
+
+func coveredCareDays(diff *offeringDecisionDiff) map[string]bool {
+	covered := make(map[string]bool, 7)
+	for _, selection := range diff.selected {
+		offering := diff.offeringByID[selection.OfferingID]
+		if offering == nil || !offering.CountsAsCare {
+			continue
+		}
+		days := selection.SelectedDays
+		if offering.DaysOfWeekMode == enrollmentModels.DaysOfWeekModeFixed {
+			days = offering.AvailableDays
+		}
+		for _, day := range days {
+			covered[day] = true
+		}
+	}
+	return covered
+}
+
+func aggregateManualPlanningConflicts(
+	occurrences []enrollmentModels.ManualPlanningOccurrence,
+	coveredDays map[string]bool,
+) []ManualPlanningConflict {
+	conflicts := make([]ManualPlanningConflict, 0)
+	groupIndexes := make(map[int64]int)
+	seenDays := make(map[int64]map[string]bool)
+	for _, occurrence := range occurrences {
+		day := canonicalDayForWeekday(occurrence.Date.Weekday())
+		if coveredDays[day] {
+			continue
+		}
+		groupIndex, exists := groupIndexes[occurrence.ActivityGroupID]
+		if !exists {
+			conflicts = append(conflicts, ManualPlanningConflict{
+				ActivityGroupID:   occurrence.ActivityGroupID,
+				ActivityGroupName: occurrence.ActivityGroupName,
+				FirstDate:         occurrence.Date,
+			})
+			groupIndex = len(conflicts) - 1
+			groupIndexes[occurrence.ActivityGroupID] = groupIndex
+			seenDays[occurrence.ActivityGroupID] = make(map[string]bool)
+		}
+		conflict := &conflicts[groupIndex]
+		conflict.OccurrenceCount++
+		if occurrence.Date.Before(conflict.FirstDate) {
+			conflict.FirstDate = occurrence.Date
+		}
+		if !seenDays[occurrence.ActivityGroupID][day] {
+			seenDays[occurrence.ActivityGroupID][day] = true
+			conflict.Days = append(conflict.Days, day)
+		}
+	}
+	for i := range conflicts {
+		conflicts[i].Days = canonicalDays(conflicts[i].Days)
+	}
+	return conflicts
+}
+
+func canonicalDayForWeekday(weekday time.Weekday) string {
+	return [...]string{"sun", "mon", "tue", "wed", "thu", "fri", "sat"}[weekday]
 }
 
 func (s *offeringChangeRequestService) rejectionDecisionDiff(
@@ -2146,11 +2259,12 @@ func (s *offeringChangeRequestService) diffForRequest(
 // offeringDecisionDiff is a request's review diff plus the override bookkeeping
 // a staff approval with exclusions needs.
 type offeringDecisionDiff struct {
-	entries    []OfferingChangeDiffEntry
-	overridden []enrollmentModels.OfferingChangeSnapshotOffering
-	current    []*enrollmentModels.RequestChildOffering
-	base       []materializedOfferingSelection
-	selected   []materializedOfferingSelection
+	entries      []OfferingChangeDiffEntry
+	overridden   []enrollmentModels.OfferingChangeSnapshotOffering
+	current      []*enrollmentModels.RequestChildOffering
+	base         []materializedOfferingSelection
+	selected     []materializedOfferingSelection
+	offeringByID map[int64]*enrollmentModels.CareOffering
 	// phase, requested and effectiveFrom are the context the materialization
 	// ran against, so a caller can re-check applicability without resolving the
 	// same aggregate twice.
@@ -2329,7 +2443,7 @@ func materializedDecisionDiffFromSides(
 	sort.SliceStable(entries, func(i, j int) bool { return entries[i].Label < entries[j].Label })
 	return &offeringDecisionDiff{
 		entries: entries, overridden: overridden, current: current, base: base,
-		selected: materialized,
+		selected: materialized, offeringByID: offeringByID,
 	}
 }
 

--- a/backend/services/enrollment/offering_change_request_service.go
+++ b/backend/services/enrollment/offering_change_request_service.go
@@ -1595,37 +1595,63 @@ func (s *offeringChangeRequestService) manualPlanningConflicts(
 	if err != nil {
 		return nil, fmt.Errorf("offering change: list manual planning conflicts: %w", err)
 	}
-	return aggregateManualPlanningConflicts(occurrences, coveredCareDays(diff)), nil
+	return aggregateManualPlanningConflicts(occurrences, diff), nil
 }
 
-func coveredCareDays(diff *offeringDecisionDiff) map[string]bool {
-	covered := make(map[string]bool, 7)
+func proposedCareCoversOccurrence(diff *offeringDecisionDiff, occurrence enrollmentModels.ManualPlanningOccurrence) bool {
 	for _, selection := range diff.selected {
-		offering := diff.offeringByID[selection.OfferingID]
-		if offering == nil || !offering.CountsAsCare {
-			continue
-		}
-		days := selection.SelectedDays
-		if offering.DaysOfWeekMode == enrollmentModels.DaysOfWeekModeFixed {
-			days = offering.AvailableDays
-		}
-		for _, day := range days {
-			covered[day] = true
+		if proposedSelectionCoversOccurrence(diff, selection, occurrence) {
+			return true
 		}
 	}
-	return covered
+	return false
+}
+
+func proposedSelectionCoversOccurrence(
+	diff *offeringDecisionDiff,
+	selection materializedOfferingSelection,
+	occurrence enrollmentModels.ManualPlanningOccurrence,
+) bool {
+	if diff == nil || diff.phase == nil || occurrence.Date.Before(diff.effectiveFrom) || occurrence.Date.After(diff.phase.ServiceEndDate) {
+		return false
+	}
+	offering := diff.offeringByID[selection.OfferingID]
+	if offering == nil || !offering.CountsAsCare {
+		return false
+	}
+	days := selection.SelectedDays
+	if offering.DaysOfWeekMode == enrollmentModels.DaysOfWeekModeFixed {
+		days = offering.AvailableDays
+	}
+	return slices.Contains(days, canonicalDayForWeekday(occurrence.Date.Weekday()))
+}
+
+func proposedLegacyPlanningCoversOccurrence(diff *offeringDecisionDiff, occurrence enrollmentModels.ManualPlanningOccurrence) bool {
+	if diff == nil {
+		return false
+	}
+	for _, selection := range diff.selected {
+		offering := diff.offeringByID[selection.OfferingID]
+		if offering == nil || offering.ActivityGroupID == nil || *offering.ActivityGroupID != occurrence.ActivityGroupID {
+			continue
+		}
+		if proposedSelectionCoversOccurrence(diff, selection, occurrence) {
+			return true
+		}
+	}
+	return false
 }
 
 func aggregateManualPlanningConflicts(
 	occurrences []enrollmentModels.ManualPlanningOccurrence,
-	coveredDays map[string]bool,
+	diff *offeringDecisionDiff,
 ) []ManualPlanningConflict {
 	conflicts := make([]ManualPlanningConflict, 0)
 	groupIndexes := make(map[int64]int)
 	seenDays := make(map[int64]map[string]bool)
 	for _, occurrence := range occurrences {
 		day := canonicalDayForWeekday(occurrence.Date.Weekday())
-		if coveredDays[day] {
+		if proposedLegacyPlanningCoversOccurrence(diff, occurrence) || proposedCareCoversOccurrence(diff, occurrence) {
 			continue
 		}
 		groupIndex, exists := groupIndexes[occurrence.ActivityGroupID]

--- a/backend/services/enrollment/offering_change_request_service_test.go
+++ b/backend/services/enrollment/offering_change_request_service_test.go
@@ -1077,6 +1077,7 @@ type planningOccurrenceOpts struct {
 	spontaneous  bool
 	materialized bool
 	unplanned    bool
+	notScheduled bool
 }
 
 func createPlanningOccurrence(
@@ -1103,7 +1104,9 @@ func createPlanningOccurrence(
 		Status:           status,
 		IsSpontaneous:    opts.spontaneous,
 	})
-	attendance := testpkg.CreateTestInstanceStudent(t, env.db, instance.ID, studentID, "")
+	attendance := testpkg.CreateTestInstanceStudent(t, env.db, instance.ID, studentID, "", testpkg.InstanceStudentOpts{
+		NotScheduled: opts.notScheduled,
+	})
 	if opts.unplanned {
 		attendance.IsUnplanned = true
 		require.NoError(t, env.repos.InstanceStudent.Update(testpkg.Ctx(t), attendance))
@@ -1123,7 +1126,9 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	fx.newOffering.AvailableDays = []string{"mon"}
 	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.newOffering))
 	fx.oldOffering.DaysOfWeekMode = enrollmentModels.DaysOfWeekModeFixed
-	fx.oldOffering.AvailableDays = []string{"mon", "wed"}
+	fx.oldOffering.AvailableDays = []string{"mon", "wed", "thu"}
+	fx.oldOffering.CountsAsCare = false
+	fx.oldOffering.CountsAsCareSet = true
 	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.oldOffering))
 
 	row, err := svc.Create(ctx, enrollmentService.CreateOfferingChangeInput{
@@ -1171,7 +1176,7 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 		UPDATE enrollment.request_child_offerings
 		SET valid_until = ?
 		WHERE tenant_id = ? AND request_child_id = ? AND care_offering_id = ?
-	`, dateFor(time.Wednesday), testpkg.Tenant(t), fx.childID, fx.oldOffering.ID).Exec(ctx)
+	`, dateFor(time.Thursday), testpkg.Tenant(t), fx.childID, fx.oldOffering.ID).Exec(ctx)
 	require.NoError(t, err)
 	materialized := planningOccurrenceOpts{materialized: true}
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
@@ -1192,6 +1197,10 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 		dateFor(time.Tuesday), "Alte Angebots-Verknüpfung", materialized)
 	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Wednesday), "Abgelaufene Angebots-Verknüpfung", materialized)
+	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Thursday), "Nicht zählendes Angebot", materialized)
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Friday), "Nicht gebucht", planningOccurrenceOpts{materialized: true, notScheduled: true})
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Thursday), "Spontan", planningOccurrenceOpts{materialized: true, spontaneous: true})
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
@@ -1219,9 +1228,9 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	assert.Equal(t, 3, conflict.OccurrenceCount)
 	legacyConflict := conflictsByGroupID[legacySourcedGroup.ID]
 	assert.Equal(t, legacySourcedGroup.ID, legacyConflict.ActivityGroupID)
-	assert.Equal(t, []string{"tue", "wed"}, legacyConflict.Days)
+	assert.Equal(t, []string{"tue", "wed", "thu"}, legacyConflict.Days)
 	assert.Equal(t, dateFor(time.Tuesday), legacyConflict.FirstDate)
-	assert.Equal(t, 2, legacyConflict.OccurrenceCount)
+	assert.Equal(t, 3, legacyConflict.OccurrenceCount)
 	assert.True(t, preview.ArrivalExpectationsFollowBookings)
 	laterEffectiveFrom := dateFor(time.Thursday).AddDays(22)
 	laterPreview, err := svc.PreviewDecision(ctx, row.ID, nil, &laterEffectiveFrom)

--- a/backend/services/enrollment/offering_change_request_service_test.go
+++ b/backend/services/enrollment/offering_change_request_service_test.go
@@ -1160,6 +1160,19 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	legacySourcedGroup.IsTemplate = true
 	legacySourcedGroup.TargetGroupType = activitiesModels.TargetGroupTypeNone
 	require.NoError(t, env.repos.ActivityGroup.Update(ctx, legacySourcedGroup))
+	parentChoiceGroup := testpkg.CreateTestActivityGroup(t, env.db, "EmptyParentChoicePlanning")
+	parentChoiceGroup.Type = activitiesModels.GroupTypeCare
+	parentChoiceGroup.IsTemplate = true
+	require.NoError(t, env.repos.ActivityGroup.Update(ctx, parentChoiceGroup))
+	parentChoiceOffering := createAdjustmentCareOfferingWith(t, env, "Leere Tagesauswahl", func(o *enrollmentModels.CareOffering) {
+		o.ActivityGroupID = &parentChoiceGroup.ID
+		o.CountsAsCare, o.CountsAsCareSet = true, true
+	})
+	require.NoError(t, env.repos.RequestChildOffering.Create(ctx, &enrollmentModels.RequestChildOffering{
+		RequestChildID: fx.childID,
+		CareOfferingID: parentChoiceOffering.ID,
+		SelectedDays:   []string{},
+	}))
 
 	period := testpkg.CreateTestCalendarPeriod(
 		t, env.db, "Manual planning preview "+t.Name(), env.sourcePhase.ServiceStartDate, env.sourcePhase.ServiceEndDate,
@@ -1199,6 +1212,8 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 		dateFor(time.Wednesday), "Abgelaufene Angebots-Verknüpfung", materialized)
 	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Thursday), "Nicht zählendes Angebot", materialized)
+	createPlanningOccurrence(t, env, parentChoiceGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Tuesday), "Leere Tagesauswahl", materialized)
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Friday), "Nicht gebucht", planningOccurrenceOpts{materialized: true, notScheduled: true})
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
@@ -1215,7 +1230,7 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 
 	preview, err := svc.PreviewDecision(ctx, row.ID, nil, nil)
 	require.NoError(t, err)
-	require.Len(t, preview.ManualPlanningConflicts, 2)
+	require.Len(t, preview.ManualPlanningConflicts, 3)
 	conflictsByGroupID := make(map[int64]enrollmentService.ManualPlanningConflict, len(preview.ManualPlanningConflicts))
 	for _, item := range preview.ManualPlanningConflicts {
 		conflictsByGroupID[item.ActivityGroupID] = item
@@ -1231,6 +1246,11 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	assert.Equal(t, []string{"tue", "wed", "thu"}, legacyConflict.Days)
 	assert.Equal(t, dateFor(time.Tuesday), legacyConflict.FirstDate)
 	assert.Equal(t, 3, legacyConflict.OccurrenceCount)
+	parentChoiceConflict := conflictsByGroupID[parentChoiceGroup.ID]
+	assert.Equal(t, parentChoiceGroup.ID, parentChoiceConflict.ActivityGroupID)
+	assert.Equal(t, []string{"tue"}, parentChoiceConflict.Days)
+	assert.Equal(t, dateFor(time.Tuesday), parentChoiceConflict.FirstDate)
+	assert.Equal(t, 1, parentChoiceConflict.OccurrenceCount)
 	assert.True(t, preview.ArrivalExpectationsFollowBookings)
 	laterEffectiveFrom := dateFor(time.Thursday).AddDays(22)
 	laterPreview, err := svc.PreviewDecision(ctx, row.ID, nil, &laterEffectiveFrom)

--- a/backend/services/enrollment/offering_change_request_service_test.go
+++ b/backend/services/enrollment/offering_change_request_service_test.go
@@ -1127,7 +1127,7 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.newOffering))
 	fx.oldOffering.DaysOfWeekMode = enrollmentModels.DaysOfWeekModeFixed
 	fx.oldOffering.AvailableDays = []string{"mon", "wed", "thu"}
-	fx.oldOffering.CountsAsCare = false
+	fx.oldOffering.CountsAsCare = true
 	fx.oldOffering.CountsAsCareSet = true
 	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.oldOffering))
 

--- a/backend/services/enrollment/offering_change_request_service_test.go
+++ b/backend/services/enrollment/offering_change_request_service_test.go
@@ -1122,6 +1122,9 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	fx.newOffering.DaysOfWeekMode = enrollmentModels.DaysOfWeekModeFixed
 	fx.newOffering.AvailableDays = []string{"mon"}
 	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.newOffering))
+	fx.oldOffering.DaysOfWeekMode = enrollmentModels.DaysOfWeekModeFixed
+	fx.oldOffering.AvailableDays = []string{"mon", "wed"}
+	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.oldOffering))
 
 	row, err := svc.Create(ctx, enrollmentService.CreateOfferingChangeInput{
 		StudentID:     fx.studentID,
@@ -1164,6 +1167,12 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 		}
 		return date
 	}
+	_, err = env.db.NewRaw(`
+		UPDATE enrollment.request_child_offerings
+		SET valid_until = ?
+		WHERE tenant_id = ? AND request_child_id = ? AND care_offering_id = ?
+	`, dateFor(time.Wednesday), testpkg.Tenant(t), fx.childID, fx.oldOffering.ID).Exec(ctx)
+	require.NoError(t, err)
 	materialized := planningOccurrenceOpts{materialized: true}
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Monday), "Montags gedeckt", materialized)
@@ -1178,7 +1187,11 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 	createPlanningOccurrence(t, env, sourcedGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Tuesday), "Wird automatisch abgeglichen", materialized)
 	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Monday), "Von alter Buchung gedeckt", materialized)
+	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Tuesday), "Alte Angebots-Verknüpfung", materialized)
+	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Wednesday), "Abgelaufene Angebots-Verknüpfung", materialized)
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
 		dateFor(time.Thursday), "Spontan", planningOccurrenceOpts{materialized: true, spontaneous: true})
 	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
@@ -1193,13 +1206,22 @@ func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManual
 
 	preview, err := svc.PreviewDecision(ctx, row.ID, nil, nil)
 	require.NoError(t, err)
-	require.Len(t, preview.ManualPlanningConflicts, 1)
-	conflict := preview.ManualPlanningConflicts[0]
+	require.Len(t, preview.ManualPlanningConflicts, 2)
+	conflictsByGroupID := make(map[int64]enrollmentService.ManualPlanningConflict, len(preview.ManualPlanningConflicts))
+	for _, item := range preview.ManualPlanningConflicts {
+		conflictsByGroupID[item.ActivityGroupID] = item
+	}
+	conflict := conflictsByGroupID[manualGroup.ID]
 	assert.Equal(t, manualGroup.ID, conflict.ActivityGroupID)
 	assert.Equal(t, manualGroup.Name, conflict.ActivityGroupName)
 	assert.Equal(t, []string{"tue", "wed"}, conflict.Days)
 	assert.Equal(t, dateFor(time.Tuesday), conflict.FirstDate)
 	assert.Equal(t, 3, conflict.OccurrenceCount)
+	legacyConflict := conflictsByGroupID[legacySourcedGroup.ID]
+	assert.Equal(t, legacySourcedGroup.ID, legacyConflict.ActivityGroupID)
+	assert.Equal(t, []string{"tue", "wed"}, legacyConflict.Days)
+	assert.Equal(t, dateFor(time.Tuesday), legacyConflict.FirstDate)
+	assert.Equal(t, 2, legacyConflict.OccurrenceCount)
 	assert.True(t, preview.ArrivalExpectationsFollowBookings)
 	laterEffectiveFrom := dateFor(time.Thursday).AddDays(22)
 	laterPreview, err := svc.PreviewDecision(ctx, row.ID, nil, &laterEffectiveFrom)

--- a/backend/services/enrollment/offering_change_request_service_test.go
+++ b/backend/services/enrollment/offering_change_request_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,9 @@ import (
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	enrollmentModels "github.com/moto-nrw/project-phoenix/models/enrollment"
+	scheduleModels "github.com/moto-nrw/project-phoenix/models/schedule"
 	enrollmentService "github.com/moto-nrw/project-phoenix/services/enrollment"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
 
@@ -52,6 +55,7 @@ func newOfferingChangeServiceForTestWithCareRepo(
 		RequestChildOfferingRepo: env.repos.RequestChildOffering,
 		StudentRepo:              env.repos.Student,
 		PersonRepo:               env.repos.Person,
+		ImpactRepo:               env.repos.OfferingChangeImpact,
 		Applier:                  changeRequestApplierForTest(t, env),
 		Settings:                 env.settings,
 		Logger:                   slog.Default(),
@@ -1066,6 +1070,184 @@ func TestOfferingChangeRequestService_PreviewDecision_RefusesADateOutOfRange(t *
 	confirmed := timezone.TodayDate().AddDays(-1)
 	_, err = svc.PreviewDecision(ctx, row.ID, nil, &confirmed)
 	require.ErrorIs(t, err, enrollmentService.ErrOfferingChangeDateOutOfRange)
+}
+
+type planningOccurrenceOpts struct {
+	status       string
+	spontaneous  bool
+	materialized bool
+	unplanned    bool
+}
+
+func createPlanningOccurrence(
+	t *testing.T,
+	env *decisionTestEnv,
+	groupID, studentID, roomID, periodID int64,
+	date timezone.Date,
+	title string,
+	opts planningOccurrenceOpts,
+) {
+	t.Helper()
+	status := opts.status
+	if status == "" {
+		status = scheduleModels.InstanceStatusPlanned
+	}
+	var calendarPeriodID *int64
+	if opts.materialized {
+		calendarPeriodID = &periodID
+	}
+	instance := testpkg.CreateTestActivityInstance(t, env.db, date, roomID, testpkg.ActivityInstanceOpts{
+		ActivityGroupID:  &groupID,
+		CalendarPeriodID: calendarPeriodID,
+		Title:            title,
+		Status:           status,
+		IsSpontaneous:    opts.spontaneous,
+	})
+	attendance := testpkg.CreateTestInstanceStudent(t, env.db, instance.ID, studentID, "")
+	if opts.unplanned {
+		attendance.IsUnplanned = true
+		require.NoError(t, env.repos.InstanceStudent.Update(testpkg.Ctx(t), attendance))
+	}
+}
+
+func TestOfferingChangeRequestService_PreviewDecision_ReportsOnlyUncoveredManualPlanning(t *testing.T) {
+	t.Parallel()
+
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	env.settings.boolValues[configModel.KeyEnrollmentBookingsAuthoritative] = true
+	ctx := offeringChangeAdminContext(t)
+	svc := newOfferingChangeServiceForTest(t, env)
+	fx := setupOfferingChangeFixture(t, env, "PreviewManualPlanning")
+	fx.newOffering.DaysOfWeekMode = enrollmentModels.DaysOfWeekModeFixed
+	fx.newOffering.AvailableDays = []string{"mon"}
+	require.NoError(t, env.repos.CareOffering.Update(ctx, fx.newOffering))
+
+	row, err := svc.Create(ctx, enrollmentService.CreateOfferingChangeInput{
+		StudentID:     fx.studentID,
+		AccountID:     env.creatorID,
+		EffectiveFrom: fx.switchDate,
+		Selections: []enrollmentService.OfferingChangeSelection{
+			{OfferingID: fx.newOffering.ID},
+		},
+	})
+	require.NoError(t, err)
+
+	manualGroup := testpkg.CreateTestActivityGroup(t, env.db, "ManualPlanningPreview")
+	manualGroup.Type = activitiesModels.GroupTypeCare
+	manualGroup.IsTemplate = true
+	manualGroup.TargetGroupType = activitiesModels.TargetGroupTypeAngebot
+	require.NoError(t, env.repos.ActivityGroup.Update(ctx, manualGroup))
+
+	sourcedGroup := testpkg.CreateTestActivityGroup(t, env.db, "OfferingPlanningPreview")
+	sourcedGroup.Type = activitiesModels.GroupTypeCare
+	sourcedGroup.IsTemplate = true
+	sourcedGroup.TargetGroupType = activitiesModels.TargetGroupTypeAngebot
+	sourcedGroup.SourceCareOfferingIDs = []int64{fx.newOffering.ID}
+	require.NoError(t, env.repos.ActivityGroup.Update(ctx, sourcedGroup))
+
+	legacySourcedGroup, err := env.repos.ActivityGroup.FindByID(ctx, fx.oldGroupID)
+	require.NoError(t, err)
+	legacySourcedGroup.Type = activitiesModels.GroupTypeCare
+	legacySourcedGroup.IsTemplate = true
+	legacySourcedGroup.TargetGroupType = activitiesModels.TargetGroupTypeNone
+	require.NoError(t, env.repos.ActivityGroup.Update(ctx, legacySourcedGroup))
+
+	period := testpkg.CreateTestCalendarPeriod(
+		t, env.db, "Manual planning preview "+t.Name(), env.sourcePhase.ServiceStartDate, env.sourcePhase.ServiceEndDate,
+	)
+	room := testpkg.CreateTestRoom(t, env.db, "Manual planning preview")
+	dateFor := func(weekday time.Weekday) timezone.Date {
+		date := fx.switchDate
+		for date.Weekday() != weekday {
+			date = date.AddDays(1)
+		}
+		return date
+	}
+	materialized := planningOccurrenceOpts{materialized: true}
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Monday), "Montags gedeckt", materialized)
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Tuesday), "Dienstags ohne Buchung", materialized)
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Tuesday).AddDays(7), "Dienstags erneut", materialized)
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Wednesday), "Mittwochs ohne Buchung", materialized)
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		fx.switchDate.AddDays(-1), "Vor dem Wechsel", materialized)
+	createPlanningOccurrence(t, env, sourcedGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Tuesday), "Wird automatisch abgeglichen", materialized)
+	createPlanningOccurrence(t, env, legacySourcedGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Tuesday), "Alte Angebots-Verknüpfung", materialized)
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Thursday), "Spontan", planningOccurrenceOpts{materialized: true, spontaneous: true})
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Thursday).AddDays(7), "Nicht materialisiert", planningOccurrenceOpts{})
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Thursday).AddDays(14), "Abgesagt", planningOccurrenceOpts{
+			materialized: true,
+			status:       scheduleModels.InstanceStatusCancelled,
+		})
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		dateFor(time.Thursday).AddDays(21), "Ungeplant", planningOccurrenceOpts{materialized: true, unplanned: true})
+
+	preview, err := svc.PreviewDecision(ctx, row.ID, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, preview.ManualPlanningConflicts, 1)
+	conflict := preview.ManualPlanningConflicts[0]
+	assert.Equal(t, manualGroup.ID, conflict.ActivityGroupID)
+	assert.Equal(t, manualGroup.Name, conflict.ActivityGroupName)
+	assert.Equal(t, []string{"tue", "wed"}, conflict.Days)
+	assert.Equal(t, dateFor(time.Tuesday), conflict.FirstDate)
+	assert.Equal(t, 3, conflict.OccurrenceCount)
+	assert.True(t, preview.ArrivalExpectationsFollowBookings)
+	laterEffectiveFrom := dateFor(time.Thursday).AddDays(22)
+	laterPreview, err := svc.PreviewDecision(ctx, row.ID, nil, &laterEffectiveFrom)
+	require.NoError(t, err)
+	assert.Empty(t, laterPreview.ManualPlanningConflicts,
+		"the chosen effective date must bound the planning consequences")
+	env.settings.boolValues[configModel.KeyEnrollmentBookingsAuthoritative] = false
+	preview, err = svc.PreviewDecision(ctx, row.ID, nil, nil)
+	require.NoError(t, err)
+	assert.False(t, preview.ArrivalExpectationsFollowBookings)
+
+	otherTenantCtx := tenant.WithTenantID(context.Background(), testpkg.Tenant(t)+1)
+	foreignRows, err := env.repos.OfferingChangeImpact.ListManualPlanningOccurrences(
+		otherTenantCtx, fx.studentID, fx.switchDate, env.sourcePhase.ServiceEndDate,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, foreignRows, "the projection must not leak planning rows across tenants")
+}
+
+func TestOfferingChangeRequestService_PreviewDecision_ReportsManualPlanningForFullWithdrawal(t *testing.T) {
+	t.Parallel()
+
+	env, cleanup := setupDecisionTest(t)
+	defer cleanup()
+	env.settings.boolValues[configModel.KeyEnrollmentBookingsAuthoritative] = false
+	ctx := offeringChangeAdminContext(t)
+	svc := newOfferingChangeServiceForTest(t, env)
+	fx := setupOfferingChangeFixture(t, env, "PreviewFullWithdrawal")
+	row, err := svc.Create(ctx, enrollmentService.CreateOfferingChangeInput{
+		StudentID: fx.studentID, AccountID: env.creatorID, EffectiveFrom: fx.switchDate,
+	})
+	require.NoError(t, err)
+
+	manualGroup := testpkg.CreateTestActivityGroup(t, env.db, "ManualFullWithdrawal")
+	manualGroup.Type, manualGroup.IsTemplate = activitiesModels.GroupTypeCare, true
+	require.NoError(t, env.repos.ActivityGroup.Update(ctx, manualGroup))
+	period := testpkg.CreateTestCalendarPeriod(
+		t, env.db, "Manual full withdrawal "+t.Name(), env.sourcePhase.ServiceStartDate, env.sourcePhase.ServiceEndDate,
+	)
+	room := testpkg.CreateTestRoom(t, env.db, "Manual full withdrawal")
+	createPlanningOccurrence(t, env, manualGroup.ID, fx.studentID, room.ID, period.ID,
+		fx.switchDate, "Bleibt manuell geplant", planningOccurrenceOpts{materialized: true})
+
+	preview, err := svc.PreviewDecision(ctx, row.ID, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, preview.ManualPlanningConflicts, 1)
+	assert.Equal(t, manualGroup.ID, preview.ManualPlanningConflicts[0].ActivityGroupID)
+	assert.Equal(t, 1, preview.ManualPlanningConflicts[0].OccurrenceCount)
 }
 
 // The confirmed date is checked against the same capacity the parents' date

--- a/backend/services/factory.go
+++ b/backend/services/factory.go
@@ -1908,6 +1908,7 @@ func NewFactory(repos *repositories.Factory, db *bun.DB, logger *slog.Logger) (*
 		RequestRepo:              repos.Request,
 		PhaseRepo:                repos.Phase,
 		CareOfferingRepo:         repos.CareOffering,
+		ImpactRepo:               repos.OfferingChangeImpact,
 		RequestChildOfferingRepo: repos.RequestChildOffering,
 		StudentRepo:              repos.Student,
 		PersonRepo:               repos.Person,

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -727,8 +727,10 @@ export const appChapters: readonly GuideChapter[] = [
           "Angebote, die eine Mitbuchungs-Regel ergänzt, tragen die Markierung `Automatisch mitgebucht` und nennen das Angebot, das die Mitbuchung auslöst. So erkennen Sie, was die Eltern selbst gewählt haben. Über den Haken `Automatisch mitbuchen` können Sie ein solches Angebot für genau diese Anfrage abwählen; die Regel bleibt für alle anderen Anfragen eingeschaltet.",
           "Bei Betreuungsangeboten steht unter den Änderungen `Bleibt gebucht`: die Angebote, die diese Anfrage nicht anfasst. So sehen Sie vor der Entscheidung, was das Kind danach insgesamt gebucht hat.",
           "Meldet eine Anfrage das Kind von allen Angeboten ab, steht `Komplett-Abmeldung` schon in der zugeklappten Zeile, und in der Karte erscheint eine rote Warnung mit dem Namen des Kindes. Bitte vor dem Freigeben mit der Familie klären.",
-          "Nach dem Freigeben einer Angebots-Anfrage erinnert die Meldung oben an drei Punkte, die die App nicht automatisch mit anpasst: Gehzeiten des Kindes, Zuordnung im Stundenplan sowie Listen und Ausdrucke.",
-          "Mit `Freigeben` wird der neue Wert übernommen.",
+          "Bei einer Angebots-Anfrage öffnet `Freigeben` zuerst die Übersicht `Folgen der Freigabe`. Dort sehen Sie die Folgen ab dem gewählten Datum: neue Buchungen, Gruppen aus Angeboten und Gehzeiten. Bestimmen Buchungen die Betreuungstage, steht dort auch: Die Buchungen ändern die erwarteten Betreuungstage. Die Ankunftszeit kommt weiterhin aus der Klassenzeit oder einer eigenen Zeit.",
+          "Passt eine andere Gruppe im Betreuungsplan nicht mehr zu den neuen Betreuungstagen, steht sie in dieser Übersicht. moto ändert diese Gruppe nicht automatisch. Nach der Freigabe öffnen Sie den Betreuungsplan. Entfernen Sie das Kind an den genannten Tagen aus der Gruppe oder ändern Sie die Gruppentage.",
+          "Erst mit `Änderung freigeben` übernehmen Sie die Angebots-Anfrage und die angezeigten Folgeänderungen.",
+          "Bei den anderen Anfragearten wird der neue Wert direkt mit `Freigeben` übernommen.",
           "Freigegebene Betreuungszeiten ändern den Wochenplan des Kindes.",
           "Eine Abwesenheit gilt dann als `Krank` oder `Entschuldigt`.",
           "Mit `Ablehnen` bleibt der bisherige Stand erhalten.",
@@ -745,7 +747,7 @@ export const appChapters: readonly GuideChapter[] = [
           tone: "blue",
         },
         screenshot:
-          "Seite „Anfragen“, Reiter „Eltern“: alle offenen Anfragen in einer gemeinsamen Liste, je mit Kind und Änderung (alt → neu), darüber Suchfeld und Filter „Anfrageart“, pro Eintrag die Schaltflächen „Freigeben“ und „Ablehnen“.",
+          "Seite „Anfragen“, Reiter „Eltern“: offene Anfrage zu Betreuungsangeboten und die Übersicht „Folgen der Freigabe“ mit automatischen Änderungen, manuellen Konflikten sowie „Änderung freigeben“.",
       },
       {
         id: "meine-gruppen",

--- a/frontend/src/components/students/offering-request-review-item.test.tsx
+++ b/frontend/src/components/students/offering-request-review-item.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Fehler laufen als Toast; die Karte selbst zeigt keinen Fehlerkasten mehr.
@@ -20,6 +26,7 @@ async function expectErrorToast(pattern: RegExp) {
       expect.anything(),
     ),
   );
+  await act(async () => undefined);
 }
 
 import { OfferingRequestReviewItem } from "./offering-request-review-item";
@@ -27,6 +34,7 @@ import {
   OfferingRequestApiError,
   decideOfferingChangeRequest,
   previewOfferingChangeRequest,
+  type OfferingRequestPreview,
   type StaffOfferingRequest,
 } from "~/lib/offering-request-review-api";
 
@@ -51,6 +59,17 @@ vi.mock("~/lib/offering-request-review-api", async (importActual) => {
 
 const mockDecide = vi.mocked(decideOfferingChangeRequest);
 const mockPreview = vi.mocked(previewOfferingChangeRequest);
+
+function previewResult(
+  overrides: Partial<OfferingRequestPreview> = {},
+): OfferingRequestPreview {
+  return {
+    selections: [],
+    manual_planning_conflicts: [],
+    arrival_expectations_follow_bookings: false,
+    ...overrides,
+  };
+}
 
 function request(
   overrides: Partial<StaffOfferingRequest> = {},
@@ -84,10 +103,21 @@ function renderItem(
   return onDecided;
 }
 
+async function confirmApproval() {
+  fireEvent.click(screen.getByRole("button", { name: /^Freigeben$/ }));
+  const confirm = await screen.findByRole("button", {
+    name: "Änderung freigeben",
+  });
+  await act(async () => {
+    fireEvent.click(confirm);
+    await Promise.resolve();
+  });
+}
+
 describe("OfferingRequestReviewItem", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPreview.mockResolvedValue({ selections: [] });
+    mockPreview.mockResolvedValue(previewResult());
   });
 
   it("renders the request with its effective date and diff", () => {
@@ -104,7 +134,14 @@ describe("OfferingRequestReviewItem", () => {
     const onDecided = vi.fn();
     renderItem(request(), onDecided);
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Freigeben$/ }));
+
+    await waitFor(() =>
+      expect(mockPreview).toHaveBeenCalledWith("77", [], "2027-02-01"),
+    );
+    expect(mockDecide).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Änderung freigeben" }));
 
     await waitFor(() =>
       expect(mockDecide).toHaveBeenCalledWith(
@@ -116,7 +153,7 @@ describe("OfferingRequestReviewItem", () => {
       ),
     );
     expect(onDecided).toHaveBeenCalledWith(
-      "Änderung übernommen, gültig ab 01.02.2027. Bitte noch prüfen: Gehzeiten des Kindes, Zuordnung im Stundenplan, Listen und Ausdrucke.",
+      "Änderung übernommen, gültig ab 01.02.2027. Die angezeigten Folgeänderungen wurden übernommen.",
     );
   });
 
@@ -163,7 +200,7 @@ describe("OfferingRequestReviewItem", () => {
     const onDecided = vi.fn();
     renderItem(request(), onDecided);
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
 
     await expectErrorToast(/kein Platz mehr frei/);
     // The card survives a failed approval: the switch was not applied.
@@ -177,7 +214,7 @@ describe("OfferingRequestReviewItem", () => {
     );
     renderItem();
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
 
     await expectErrorToast(/bereits entschieden oder von den Eltern/);
   });
@@ -188,7 +225,7 @@ describe("OfferingRequestReviewItem", () => {
     );
     renderItem();
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
 
     await expectErrorToast(/keine gültige Anmeldung mehr vor/);
   });
@@ -197,7 +234,7 @@ describe("OfferingRequestReviewItem", () => {
     mockDecide.mockRejectedValue(new Error("boom"));
     renderItem();
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
 
     await expectErrorToast(
       /Die Entscheidung konnte nicht gespeichert werden\./,
@@ -282,9 +319,11 @@ describe("OfferingRequestReviewItem", () => {
   });
 
   it("hides the automatic-addition hint after opting out", async () => {
-    mockPreview.mockResolvedValue({
-      selections: [{ offering_id: "9", new: "Mo, Mi" }],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [{ offering_id: "9", new: "Mo, Mi" }],
+      }),
+    );
     renderItem(request({ diff: mixedRuleDiff }));
 
     fireEvent.click(
@@ -301,9 +340,11 @@ describe("OfferingRequestReviewItem", () => {
   });
 
   it("describes the disabled co-booking rule after opting out", async () => {
-    mockPreview.mockResolvedValue({
-      selections: [{ offering_id: "9", new: "Mo, Mi" }],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [{ offering_id: "9", new: "Mo, Mi" }],
+      }),
+    );
     renderItem(request({ diff: mixedRuleDiff }));
 
     fireEvent.click(
@@ -321,9 +362,11 @@ describe("OfferingRequestReviewItem", () => {
 
   it("sends unticked rule-added lines as excluded on approve", async () => {
     mockDecide.mockResolvedValue(undefined);
-    mockPreview.mockResolvedValue({
-      selections: [{ offering_id: "5", new: "Mo, Di, Mi, Do, Fr" }],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [{ offering_id: "5", new: "Mo, Di, Mi, Do, Fr" }],
+      }),
+    );
     renderItem(request({ diff: ruleDiff }));
 
     fireEvent.click(
@@ -334,7 +377,7 @@ describe("OfferingRequestReviewItem", () => {
     await waitFor(() =>
       expect(mockPreview).toHaveBeenCalledWith("77", ["9"], "2027-02-01"),
     );
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
 
     await waitFor(() =>
       expect(mockDecide).toHaveBeenCalledWith(
@@ -349,9 +392,11 @@ describe("OfferingRequestReviewItem", () => {
 
   it("does not send excluded lines on reject", async () => {
     mockDecide.mockResolvedValue(undefined);
-    mockPreview.mockResolvedValue({
-      selections: [{ offering_id: "5", new: "Mo, Di, Mi, Do, Fr" }],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [{ offering_id: "5", new: "Mo, Di, Mi, Do, Fr" }],
+      }),
+    );
     renderItem(request({ diff: ruleDiff }));
 
     fireEvent.click(
@@ -380,9 +425,11 @@ describe("OfferingRequestReviewItem", () => {
   });
 
   it("keeps manual and required days visible when rule days are unticked", async () => {
-    mockPreview.mockResolvedValue({
-      selections: [{ offering_id: "9", new: "Mo, Mi" }],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [{ offering_id: "9", new: "Mo, Mi" }],
+      }),
+    );
     renderItem(
       request({
         diff: [
@@ -413,13 +460,15 @@ describe("OfferingRequestReviewItem", () => {
   });
 
   it("recomputes downstream rule days after a partial override", async () => {
-    mockPreview.mockResolvedValue({
-      selections: [
-        { offering_id: "5", new: "Di" },
-        { offering_id: "9", new: "Mo, Mi" },
-        { offering_id: "11", new: "Mo, Mi" },
-      ],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [
+          { offering_id: "5", new: "Di" },
+          { offering_id: "9", new: "Mo, Mi" },
+          { offering_id: "11", new: "Mo, Mi" },
+        ],
+      }),
+    );
     renderItem(
       request({
         diff: [
@@ -473,13 +522,15 @@ describe("OfferingRequestReviewItem", () => {
   });
 
   it("greys a line whose trigger was unticked", async () => {
-    mockPreview.mockResolvedValue({
-      selections: [
-        { offering_id: "5", new: "Mo, Di, Mi, Do, Fr" },
-        { offering_id: "9", new: "abgemeldet", removed: true },
-        { offering_id: "11", new: "abgemeldet", removed: true },
-      ],
-    });
+    mockPreview.mockResolvedValue(
+      previewResult({
+        selections: [
+          { offering_id: "5", new: "Mo, Di, Mi, Do, Fr" },
+          { offering_id: "9", new: "abgemeldet", removed: true },
+          { offering_id: "11", new: "abgemeldet", removed: true },
+        ],
+      }),
+    );
     renderItem(request({ diff: ruleDiff }));
 
     fireEvent.click(
@@ -567,33 +618,96 @@ describe("OfferingRequestReviewItem", () => {
       expect(screen.getByText("Mittagessen:")).toBeInTheDocument();
     });
 
-    // Was die Freigabe nicht mit anpasst, gehört an die Erfolgsmeldung: vor der
-    // Entscheidung ist es nichts, was jemand tun kann.
-    it("keeps the after-approval checks out of the open request", () => {
+    it("keeps approval consequences out of the open request", () => {
       renderItem();
 
       expect(
-        screen.queryByText(/Nach dem Freigeben bitte prüfen/),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(/Gehzeiten des Kindes/),
+        screen.queryByText("Das ändert moto automatisch:"),
       ).not.toBeInTheDocument();
     });
 
-    it("names what to check in the notice after an approval", async () => {
-      mockDecide.mockResolvedValue(undefined);
-      const onDecided = vi.fn();
-      renderItem(request(), onDecided);
-
-      fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
-
-      await waitFor(() =>
-        expect(onDecided).toHaveBeenCalledWith(
-          expect.stringContaining(
-            "Bitte noch prüfen: Gehzeiten des Kindes, Zuordnung im Stundenplan, Listen und Ausdrucke.",
-          ),
-        ),
+    it("shows the automatic consequences before approval", async () => {
+      mockPreview.mockResolvedValue(
+        previewResult({ arrival_expectations_follow_bookings: true }),
       );
+      renderItem();
+
+      fireEvent.click(screen.getByRole("button", { name: /^Freigeben$/ }));
+
+      expect(
+        await screen.findByText("Das ändert moto automatisch:"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Angebotsgebundene Gruppen im Betreuungsplan und Gehzeiten werden angepasst.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Die neuen Buchungen bestimmen die erwarteten Betreuungstage. Die Ankunftszeit kommt weiterhin aus der Klassenzeit oder einer eigenen Zeit.",
+        ),
+      ).toBeInTheDocument();
+      expect(mockDecide).not.toHaveBeenCalled();
+    });
+
+    it("names manual planning conflicts and the next action", async () => {
+      mockPreview.mockResolvedValue(
+        previewResult({
+          manual_planning_conflicts: [
+            {
+              activity_group_id: "17",
+              activity_group_name: "Freie Hausaufgaben-Gruppe",
+              days: ["tue"],
+              first_date: "2027-02-02",
+              occurrence_count: 8,
+            },
+          ],
+        }),
+      );
+      renderItem();
+
+      fireEvent.click(screen.getByRole("button", { name: /^Freigeben$/ }));
+
+      expect(
+        await screen.findByText(/Freie Hausaufgaben-Gruppe/),
+      ).toHaveTextContent("Freie Hausaufgaben-Gruppe");
+      expect(
+        screen.getByText(/Freie Hausaufgaben-Gruppe/).parentElement,
+      ).toHaveTextContent("Di, ab 02.02.2027 · 8 Termine");
+      expect(
+        screen.getByText(
+          "Nach der Freigabe: Öffnen Sie den Betreuungsplan. Entfernen Sie Lara Beispiel an den genannten Tagen aus diesen Gruppen oder ändern Sie die Gruppentage.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("shows no manual warning when the preview has no conflict", async () => {
+      renderItem();
+
+      fireEvent.click(screen.getByRole("button", { name: /^Freigeben$/ }));
+
+      await screen.findByText("Das ändert moto automatisch:");
+      expect(
+        screen.getByText(
+          "Ankunftszeit und erwartete Betreuungstage bleiben wie bisher.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/moto ändert sie nicht automatisch/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not approve when the consequence preview fails", async () => {
+      mockPreview.mockRejectedValue(new Error("network"));
+      renderItem();
+
+      fireEvent.click(screen.getByRole("button", { name: /^Freigeben$/ }));
+
+      await expectErrorToast(/Folgen der Freigabe konnten nicht geprüft/);
+      expect(mockDecide).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole("button", { name: "Änderung freigeben" }),
+      ).not.toBeInTheDocument();
     });
   });
 });
@@ -603,7 +717,7 @@ describe("OfferingRequestReviewItem", () => {
 describe("OfferingRequestReviewItem — Gültig ab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPreview.mockResolvedValue({ selections: [] });
+    mockPreview.mockResolvedValue(previewResult());
   });
 
   // Das Häkchen „Anderes Datum wählen" schaltet das Feld frei. Ohne es steht
@@ -670,7 +784,7 @@ describe("OfferingRequestReviewItem — Gültig ab", () => {
     );
     expect(screen.queryByLabelText("Gültig ab")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
     await waitFor(() =>
       expect(mockDecide).toHaveBeenCalledWith(
         "77",
@@ -698,7 +812,7 @@ describe("OfferingRequestReviewItem — Gültig ab", () => {
     );
     expect(screen.getByText("KW 9")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Freigeben/ }));
+    await confirmApproval();
 
     await waitFor(() =>
       expect(mockDecide).toHaveBeenCalledWith(
@@ -710,7 +824,7 @@ describe("OfferingRequestReviewItem — Gültig ab", () => {
       ),
     );
     expect(onDecided).toHaveBeenCalledWith(
-      "Änderung übernommen, gültig ab 01.03.2027. Bitte noch prüfen: Gehzeiten des Kindes, Zuordnung im Stundenplan, Listen und Ausdrucke.",
+      "Änderung übernommen, gültig ab 01.03.2027. Die angezeigten Folgeänderungen wurden übernommen.",
     );
   });
 
@@ -730,9 +844,11 @@ describe("OfferingRequestReviewItem — Gültig ab", () => {
 
   it("clears an earlier preview when a later preview fails", async () => {
     mockPreview
-      .mockResolvedValueOnce({
-        selections: [{ offering_id: "1", new: "Mo" }],
-      })
+      .mockResolvedValueOnce(
+        previewResult({
+          selections: [{ offering_id: "1", new: "Mo" }],
+        }),
+      )
       .mockRejectedValueOnce(new Error("network"));
     renderItem(
       request({

--- a/frontend/src/components/students/offering-request-review-item.tsx
+++ b/frontend/src/components/students/offering-request-review-item.tsx
@@ -13,9 +13,11 @@ import { createLogger } from "~/lib/logger";
 import { useToast } from "~/contexts/ToastContext";
 import { Checkbox } from "~/components/ui/checkbox";
 import { StatusBadge } from "~/components/ui/status-badge";
+import { ConfirmationModal } from "~/components/ui/modal";
 import {
   OfferingRequestApiError,
   type OfferingRequestDiffLine,
+  type OfferingRequestPreview,
   type OfferingRequestPreviewSelection,
   type StaffOfferingRequest,
   decideOfferingChangeRequest,
@@ -76,12 +78,6 @@ function blockedReason(code: string | undefined): string {
   }
 }
 
-// Die Freigabe passt drei Dinge NICHT mit an. Der Hinweis gehört an die
-// Erfolgsmeldung, nicht als Dauer-Kasten in jede offene Anfrage: vor der
-// Entscheidung ist er nichts, was jemand tun kann (#2484).
-const AFTER_APPROVAL_HINT =
-  "Bitte noch prüfen: Gehzeiten des Kindes, Zuordnung im Stundenplan, Listen und Ausdrucke.";
-
 // joinNames renders trigger names as „A“ und „B“ for the explanation line.
 function joinNames(names: readonly string[]): string {
   return names.map((name) => `„${name}“`).join(" und ");
@@ -117,6 +113,20 @@ function cascadeSourceName(
   return "";
 }
 
+const WEEKDAY_LABELS: Readonly<Record<string, string>> = {
+  mon: "Mo",
+  tue: "Di",
+  wed: "Mi",
+  thu: "Do",
+  fri: "Fr",
+  sat: "Sa",
+  sun: "So",
+};
+
+function conflictDays(days: readonly string[]): string {
+  return days.map((day) => WEEKDAY_LABELS[day] ?? day).join(", ");
+}
+
 /**
  * Eine offene Angebots-Anfrage als entscheidbare Karte, inklusive der
  * Mitbuchungs-Abwahl mit Vorschau-Kaskade (#2370). Ablehnen verlangt eine
@@ -139,6 +149,8 @@ export function OfferingRequestReviewItem({
   const [preview, setPreview] = useState<
     readonly OfferingRequestPreviewSelection[] | undefined
   >(undefined);
+  const [approvalPreview, setApprovalPreview] =
+    useState<OfferingRequestPreview | null>(null);
   // Das Datum, ab dem die Umstellung gilt (#2484). Vorbelegt mit dem Wunsch der
   // Eltern; die OGS entscheidet, ob es dabei bleibt.
   const [effectiveFrom, setEffectiveFrom] = useState(row.effective_from);
@@ -168,7 +180,10 @@ export function OfferingRequestReviewItem({
       );
       onDecided(
         approve
-          ? `Änderung übernommen, gültig ab ${formatDate(effectiveFrom)}. ${AFTER_APPROVAL_HINT}`
+          ? approvalPreview &&
+            approvalPreview.manual_planning_conflicts.length > 0
+            ? `Änderung übernommen, gültig ab ${formatDate(effectiveFrom)}. Bitte jetzt im Betreuungsplan prüfen: ${joinNames(approvalPreview.manual_planning_conflicts.map((conflict) => conflict.activity_group_name))}.`
+            : `Änderung übernommen, gültig ab ${formatDate(effectiveFrom)}. Die angezeigten Folgeänderungen wurden übernommen.`
           : "Angebots-Anfrage abgelehnt",
       );
     } catch (err) {
@@ -180,7 +195,41 @@ export function OfferingRequestReviewItem({
         request_id: row.id,
         ...(code ? { code } : {}),
       });
+      setBusy(false);
       toast.error(decideErrorMessage(code), { duration: 8000 });
+    }
+  };
+
+  const prepareApproval = async () => {
+    setBusy(true);
+    setApprovalPreview(null);
+    try {
+      const nextPreview = await previewOfferingChangeRequest(
+        row.id,
+        excluded,
+        effectiveFrom,
+      );
+      setPreview(nextPreview.selections);
+      setBlocked(null);
+      setApprovalPreview(nextPreview);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code =
+        err instanceof OfferingRequestApiError ? err.code : undefined;
+      logger.warn("offering_request_review_approval_preview_failed", {
+        error: message,
+        request_id: row.id,
+        ...(code ? { code } : {}),
+      });
+      setBlocked(CONFLICT_CODES.has(code ?? "") ? blockedReason(code) : null);
+      toast.error(
+        decideErrorMessage(
+          code,
+          "Die Folgen der Freigabe konnten nicht geprüft werden. Bitte versuchen Sie es noch einmal.",
+        ),
+        { duration: 8000 },
+      );
+    } finally {
       setBusy(false);
     }
   };
@@ -319,7 +368,7 @@ export function OfferingRequestReviewItem({
       }
       busy={busy}
       approveDisabled={blocked !== null}
-      onApprove={() => void decide(true)}
+      onApprove={() => void prepareApproval()}
       onReject={() => void decide(false)}
     >
       {fullWithdrawal && (
@@ -488,6 +537,63 @@ export function OfferingRequestReviewItem({
           </label>
         </div>
       </div>
+      <ConfirmationModal
+        isOpen={approvalPreview !== null}
+        onClose={() => setApprovalPreview(null)}
+        onConfirm={() => void decide(true)}
+        title="Folgen der Freigabe"
+        confirmText="Änderung freigeben"
+        isConfirmLoading={busy}
+        loadingText="Wird freigegeben..."
+        mobileSheet
+      >
+        {approvalPreview && (
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm font-medium text-gray-900">
+                Das ändert moto automatisch:
+              </p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-700">
+                <li>
+                  Die neuen Buchungen gelten ab {formatDate(effectiveFrom)}.
+                </li>
+                <li>
+                  Angebotsgebundene Gruppen im Betreuungsplan und Gehzeiten
+                  werden angepasst.
+                </li>
+                <li>
+                  {approvalPreview.arrival_expectations_follow_bookings
+                    ? "Die neuen Buchungen bestimmen die erwarteten Betreuungstage. Die Ankunftszeit kommt weiterhin aus der Klassenzeit oder einer eigenen Zeit."
+                    : "Ankunftszeit und erwartete Betreuungstage bleiben wie bisher."}
+                </li>
+              </ul>
+            </div>
+            {approvalPreview.manual_planning_conflicts.length > 0 && (
+              <div className="space-y-2">
+                <Alert
+                  type="warning"
+                  message="Diese Gruppen passen nicht zu den neuen Betreuungstagen. moto ändert sie nicht automatisch."
+                />
+                <ul className="list-disc space-y-1 pl-5 text-sm text-gray-800">
+                  {approvalPreview.manual_planning_conflicts.map((conflict) => (
+                    <li key={conflict.activity_group_id}>
+                      <span className="font-medium">
+                        {conflict.activity_group_name}
+                      </span>
+                      {`: ${conflictDays(conflict.days)}, ab ${formatDate(conflict.first_date)} · ${conflict.occurrence_count} ${conflict.occurrence_count === 1 ? "Termin" : "Termine"}`}
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-sm text-gray-700">
+                  Nach der Freigabe: Öffnen Sie den Betreuungsplan. Entfernen
+                  Sie {row.student_name} an den genannten Tagen aus diesen
+                  Gruppen oder ändern Sie die Gruppentage.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </ConfirmationModal>
     </RequestReviewCard>
   );
 }

--- a/frontend/src/lib/offering-request-review-api.test.ts
+++ b/frontend/src/lib/offering-request-review-api.test.ts
@@ -78,6 +78,16 @@ describe("previewOfferingChangeRequest", () => {
   it("posts all current exclusions and returns materialized selections", async () => {
     const preview = {
       selections: [{ offering_id: "11", new: "Mo, Mi" }],
+      manual_planning_conflicts: [
+        {
+          activity_group_id: "17",
+          activity_group_name: "Freie Hausaufgaben-Gruppe",
+          days: ["tue"],
+          first_date: "2027-02-02",
+          occurrence_count: 8,
+        },
+      ],
+      arrival_expectations_follow_bookings: true,
     };
     const fetchMock = vi
       .fn()

--- a/frontend/src/lib/offering-request-review-api.ts
+++ b/frontend/src/lib/offering-request-review-api.ts
@@ -82,6 +82,16 @@ export interface OfferingRequestPreviewSelection {
 
 export interface OfferingRequestPreview {
   readonly selections: readonly OfferingRequestPreviewSelection[];
+  readonly manual_planning_conflicts: readonly ManualPlanningConflict[];
+  readonly arrival_expectations_follow_bookings: boolean;
+}
+
+interface ManualPlanningConflict {
+  readonly activity_group_id: string;
+  readonly activity_group_name: string;
+  readonly days: readonly string[];
+  readonly first_date: string;
+  readonly occurrence_count: number;
 }
 
 interface Envelope<T> {


### PR DESCRIPTION
## Worum geht es?

Die automatische Update-Kaskade ist durch #2489, #2494, #2497 und #2500 bereits weitgehend abgedeckt. Offen blieb die **manuelle Planung**:

Wenn Eltern Betreuungstage ändern, kann ein Kind weiterhin in zukünftigen Terminen einer manuell gepflegten Gruppe stehen. moto darf diese Zuordnungen nicht still löschen. Vor diesem PR war vor der Freigabe aber nicht sichtbar, welche Termine danach nicht mehr zu den gebuchten Betreuungstagen passen.

Dieser PR schließt diese Lücke.

## Was ändert sich?

`Freigeben` schreibt die Entscheidung bei Angebots-Anfragen nicht mehr sofort. Zuerst öffnet sich der Dialog **„Folgen der Freigabe“**.

| Bereich | Verhalten nach der Freigabe |
| --- | --- |
| Buchungen, angebotsgebundene Gruppen und Gehzeiten | moto passt sie automatisch an. |
| Erwartete Betreuungstage | Sie folgen den Buchungen, wenn der buchungsgebundene Modus für die Schule aktiv ist. |
| Manuell gepflegte Gruppen | moto lässt die Kinderliste unverändert und zeigt die betroffenen Termine als Hinweis. |

Für jeden manuellen Konflikt zeigt der Dialog:

- die Gruppe,
- die nicht mehr abgedeckten Wochentage,
- das erste betroffene Datum,
- die Anzahl der betroffenen Termine,
- den nächsten Schritt im Betreuungsplan.

Der Hinweis blockiert die Freigabe nicht. Erst **„Änderung freigeben“** übernimmt die Entscheidung. Danach erinnert auch die Erfolgsmeldung an die noch offene manuelle Prüfung.

Bei anderen Anfragearten bleibt die direkte Freigabe bestehen.

## Technische Umsetzung

- Die bestehende Freigabe-Vorschau liefert zusätzlich manuelle Planungskonflikte und den wirksamen Buchungsmodus.
- Die Vorschau prüft dieselben Datums- und Anwendbarkeitsregeln wie die Freigabe.
- Die Abfrage berücksichtigt nur zukünftige, geplante und materialisierte Termine im gewählten Betreuungszeitraum.
- Durch die vorgeschlagenen Buchungen weiterhin abgedeckte angebotsgebundene Zuordnungen erscheinen nicht als Konflikte.
- Spontane, abgesagte, ungeplante und nicht eingeplante Zuordnungen erscheinen nicht als manuelle Konflikte.
- Auch nicht mehr abgedeckte bestehende oder ältere Angebots-Verknüpfungen können als Konflikt erscheinen.
- Konflikte werden pro Gruppe zusammengefasst; Mandanten- und Datumsgrenzen bleiben erhalten.
- Der Hilfetext zur Prüfung von Angebots-Anfragen wurde aktualisiert.

## Bewusst nicht Teil dieses PRs

- keine zweite Reconcile- oder Reparatur-Engine,
- kein automatisches Löschen manueller Kinderlisten,
- kein geführter Abschluss nach einer Komplett-Abmeldung (#2424),
- keine weiteren Umbuchungs-Hinweise für Gehzeiten (#2427/#2428).

## E2E-Nachweis

Mit Agent Browser gegen einen isolierten Docker-Compose-Stack getestet:

1. Ein Elternteil ändert Linas Betreuung von Mo–Do auf Montag und sendet die Anfrage.
2. Die Mitarbeitenden-Vorschau zeigt die manuelle „Freie Hausaufgaben-Gruppe“ für Di/Mi ab 27.10.2026 mit drei Terminen.
3. Vorschau und Freigabe antworten jeweils mit HTTP 200.
4. Das Elternportal zeigt danach nur Montag als gebuchten Tag.
5. Die drei manuellen Raster-Zuordnungen bleiben bestehen.

📸 [Responsive Screenshots und vollständiges E2E-Protokoll](https://github.com/moto-nrw/project-phoenix/pull/2521#issuecomment-5383245371)

Geprüfte Viewports: 375×667, 390×844, 430×932, 820×1180, 1024×1366 und 1440×900. Kein horizontaler Overflow.

## Tests

- ✅ alle verpflichtenden GitHub-CI-Checks
- ✅ `pnpm run check`
- ✅ gezielte Frontend-Tests: 42/42
- ✅ gezielte Backend-Service-, Handler- und Hermetik-Tests
- ✅ `pnpm run generate:guides`: 4/4

<details>
<summary>Weitere lokale Full-Suite-Läufe</summary>

- `scripts/test-backend.sh`: 23.612 Tests; zwei unabhängige Bestands-Flakes durch parallelen `applog`-Globalzustand und einen uhrzeitabhängigen Active-Test
- `pnpm run test:run`: 14.184/14.185; ein unabhängiger bestehender Substring-Test in `time-tracking/page.test.tsx`

</details>

## Verständlichkeit

- Automatische Folgen und manuelle Restarbeit sind klar getrennt.
- Der erste Klick auf `Freigeben` öffnet nur die Vorschau.
- Die Oberfläche nennt Gruppe, Tage, erstes Datum, Terminanzahl und nächsten Schritt.
- Ohne manuellen Konflikt erscheint keine Arbeitsaufforderung.

Fixes #2416
