### PR TITLE
feat(iot): offer daily checkout from all rooms per tenant

### DIFF
--- a/backend/api/iot/checkin/schulhof_daily_checkout_test.go
+++ b/backend/api/iot/checkin/schulhof_daily_checkout_test.go
@@ -106,12 +106,10 @@ func TestDeviceCheckout_SchulhofOffersNachHauseWithoutAutoSendingHome(t *testing
 		`the yard must not auto-send the child home: PyrePortal renders its destination modal only for "checked_out"`)
 }
 
-// TestDeviceCheckout_OrdinaryRoomDoesNotOfferNachHause is the counterpart: the
-// Schulhof branch must not have opened "nach Hause" everywhere. A child leaving
-// an ordinary room that is neither their group room nor the yard is still only
-// moving between rooms.
+// TestDeviceCheckout_OrdinaryRoomOffersNachHauseWithoutAutoSendingHome pins the
+// default for tenants created after the all-room setting was introduced.
 // Deliberately NOT parallel: mutates process-global configuration.
-func TestDeviceCheckout_OrdinaryRoomDoesNotOfferNachHause(t *testing.T) {
+func TestDeviceCheckout_OrdinaryRoomOffersNachHauseWithoutAutoSendingHome(t *testing.T) {
 	ctx := setupTestContext(t)
 
 	previousCheckoutTime, hadCheckoutTime := os.LookupEnv("STUDENT_DAILY_CHECKOUT_TIME")
@@ -175,8 +173,8 @@ func TestDeviceCheckout_OrdinaryRoomDoesNotOfferNachHause(t *testing.T) {
 
 	checkoutData := responseData(t, checkoutRR.Body.Bytes())
 	assert.Equal(t, "checked_out", checkoutData["action"])
-	assert.Equal(t, false, checkoutData["daily_checkout_available"],
-		"an ordinary room must not offer nach Hause")
+	assert.Equal(t, true, checkoutData["daily_checkout_available"],
+		"a new tenant must offer nach Hause from an ordinary room")
 }
 
 // responseData unwraps the standard {"data": {...}} envelope.

--- a/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants.go
+++ b/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants.go
@@ -27,10 +27,18 @@ func dailyCheckoutAllRoomsExistingTenantsUp(ctx context.Context, db *bun.DB) err
 	fmt.Println("Migration 1.15.321: Preserving the daily-checkout room policy for existing tenants...")
 
 	if _, err := db.NewRaw(`
-		INSERT INTO config.setting_values (tenant_id, setting_key, value)
-		SELECT id, ?, 'false'::jsonb
-		FROM platform.schools
-		ON CONFLICT (tenant_id, setting_key) DO NOTHING;
+		WITH inserted AS (
+			INSERT INTO config.setting_values (tenant_id, setting_key, value)
+			SELECT id, ?, 'false'::jsonb
+			FROM platform.schools
+			ON CONFLICT (tenant_id, setting_key) DO NOTHING
+			RETURNING tenant_id, setting_key, value
+		)
+		INSERT INTO config.setting_audit (
+			tenant_id, setting_key, old_value, new_value, action, changed_by
+		)
+		SELECT tenant_id, setting_key, NULL, value, 'set', NULL
+		FROM inserted;
 	`, dailyCheckoutAllRoomsSettingKey).Exec(ctx); err != nil {
 		return fmt.Errorf("failed backfilling daily-checkout room policy: %w", err)
 	}
@@ -38,15 +46,9 @@ func dailyCheckoutAllRoomsExistingTenantsUp(ctx context.Context, db *bun.DB) err
 	return nil
 }
 
-func dailyCheckoutAllRoomsExistingTenantsDown(ctx context.Context, db *bun.DB) error {
-	fmt.Println("Rolling back migration 1.15.321: Removing the daily-checkout room policy overrides...")
-
-	if _, err := db.NewRaw(`
-		DELETE FROM config.setting_audit WHERE setting_key = ?;
-		DELETE FROM config.setting_values WHERE setting_key = ?;
-	`, dailyCheckoutAllRoomsSettingKey, dailyCheckoutAllRoomsSettingKey).Exec(ctx); err != nil {
-		return fmt.Errorf("failed removing daily-checkout room policy overrides: %w", err)
-	}
-
+// Stored values may have been changed after rollout and carry no migration
+// provenance. Old binaries safely ignore the unknown key, so rollback is a no-op.
+func dailyCheckoutAllRoomsExistingTenantsDown(_ context.Context, _ *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.321: keeping daily-checkout room policy values...")
 	return nil
 }

--- a/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants.go
+++ b/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants.go
@@ -1,0 +1,52 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+const (
+	dailyCheckoutAllRoomsExistingTenantsVersion     = "1.15.321"
+	dailyCheckoutAllRoomsExistingTenantsDescription = "Preserve the existing daily-checkout room policy for current tenants"
+	dailyCheckoutAllRoomsSettingKey                 = "checkout.daily_checkout_from_all_rooms_enabled"
+)
+
+func init() {
+	MigrationRegistry.Register(&Migration{
+		Version:     dailyCheckoutAllRoomsExistingTenantsVersion,
+		Description: dailyCheckoutAllRoomsExistingTenantsDescription,
+		DependsOn:   []string{configSettingValuesVersion},
+	})
+
+	Migrations.MustRegister(dailyCheckoutAllRoomsExistingTenantsUp, dailyCheckoutAllRoomsExistingTenantsDown)
+}
+
+func dailyCheckoutAllRoomsExistingTenantsUp(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Migration 1.15.321: Preserving the daily-checkout room policy for existing tenants...")
+
+	if _, err := db.NewRaw(`
+		INSERT INTO config.setting_values (tenant_id, setting_key, value)
+		SELECT id, ?, 'false'::jsonb
+		FROM platform.schools
+		ON CONFLICT (tenant_id, setting_key) DO NOTHING;
+	`, dailyCheckoutAllRoomsSettingKey).Exec(ctx); err != nil {
+		return fmt.Errorf("failed backfilling daily-checkout room policy: %w", err)
+	}
+
+	return nil
+}
+
+func dailyCheckoutAllRoomsExistingTenantsDown(ctx context.Context, db *bun.DB) error {
+	fmt.Println("Rolling back migration 1.15.321: Removing the daily-checkout room policy overrides...")
+
+	if _, err := db.NewRaw(`
+		DELETE FROM config.setting_audit WHERE setting_key = ?;
+		DELETE FROM config.setting_values WHERE setting_key = ?;
+	`, dailyCheckoutAllRoomsSettingKey, dailyCheckoutAllRoomsSettingKey).Exec(ctx); err != nil {
+		return fmt.Errorf("failed removing daily-checkout room policy overrides: %w", err)
+	}
+
+	return nil
+}

--- a/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants_mock_test.go
+++ b/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants_mock_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/uptrace/bun/dialect/pgdialect"
 )
 
-func TestDailyCheckoutAllRoomsExistingTenantsBackfill(t *testing.T) {
-	t.Parallel()
-
+func newDailyCheckoutMigrationMockDB(t *testing.T) (*bun.DB, sqlmock.Sqlmock) {
+	t.Helper()
 	sqlDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	db := bun.NewDB(sqlDB, pgdialect.New())
@@ -20,10 +19,26 @@ func TestDailyCheckoutAllRoomsExistingTenantsBackfill(t *testing.T) {
 		mock.ExpectClose()
 		require.NoError(t, db.Close())
 	})
+	return db, mock
+}
 
-	mock.ExpectExec(`(?s)INSERT INTO config\.setting_values .*SELECT id, 'checkout\.daily_checkout_from_all_rooms_enabled', 'false'::jsonb.*FROM platform\.schools.*ON CONFLICT \(tenant_id, setting_key\) DO NOTHING`).
+func TestDailyCheckoutAllRoomsExistingTenantsBackfill(t *testing.T) {
+	t.Parallel()
+
+	db, mock := newDailyCheckoutMigrationMockDB(t)
+
+	mock.ExpectExec(`(?s)WITH inserted AS \(.*INSERT INTO config\.setting_values .*SELECT id, 'checkout\.daily_checkout_from_all_rooms_enabled', 'false'::jsonb.*FROM platform\.schools.*ON CONFLICT \(tenant_id, setting_key\) DO NOTHING.*RETURNING tenant_id, setting_key, value.*\).*INSERT INTO config\.setting_audit .*SELECT tenant_id, setting_key, NULL, value, 'set', NULL.*FROM inserted`).
 		WillReturnResult(sqlmock.NewResult(0, 4))
 
 	require.NoError(t, dailyCheckoutAllRoomsExistingTenantsUp(context.Background(), db))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDailyCheckoutAllRoomsExistingTenantsRollbackPreservesValues(t *testing.T) {
+	t.Parallel()
+
+	db, mock := newDailyCheckoutMigrationMockDB(t)
+
+	require.NoError(t, dailyCheckoutAllRoomsExistingTenantsDown(context.Background(), db))
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants_mock_test.go
+++ b/backend/database/migrations/001015321_daily_checkout_all_rooms_existing_tenants_mock_test.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+func TestDailyCheckoutAllRoomsExistingTenantsBackfill(t *testing.T) {
+	t.Parallel()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	db := bun.NewDB(sqlDB, pgdialect.New())
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, db.Close())
+	})
+
+	mock.ExpectExec(`(?s)INSERT INTO config\.setting_values .*SELECT id, 'checkout\.daily_checkout_from_all_rooms_enabled', 'false'::jsonb.*FROM platform\.schools.*ON CONFLICT \(tenant_id, setting_key\) DO NOTHING`).
+		WillReturnResult(sqlmock.NewResult(0, 4))
+
+	require.NoError(t, dailyCheckoutAllRoomsExistingTenantsUp(context.Background(), db))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/models/config/keys.go
+++ b/backend/models/config/keys.go
@@ -70,9 +70,10 @@ const (
 
 // Checkout button settings (devices tab).
 const (
-	KeyCheckoutRaumwechselEnabled = "checkout.raumwechsel_enabled"
-	KeyCheckoutSchulhofEnabled    = "checkout.schulhof_enabled"
-	KeyCheckoutWCEnabled          = "checkout.wc_enabled"
+	KeyCheckoutRaumwechselEnabled       = "checkout.raumwechsel_enabled"
+	KeyCheckoutSchulhofEnabled          = "checkout.schulhof_enabled"
+	KeyCheckoutWCEnabled                = "checkout.wc_enabled"
+	KeyCheckoutDailyFromAllRoomsEnabled = "checkout.daily_checkout_from_all_rooms_enabled"
 )
 
 // Checkin capacity-detail disclosure settings (issue #1879, devices tab).

--- a/backend/services/config/defaults/defaults_test.go
+++ b/backend/services/config/defaults/defaults_test.go
@@ -51,6 +51,7 @@ func TestAllSettingsRegistered(t *testing.T) {
 		"checkout.raumwechsel_enabled",
 		"checkout.schulhof_enabled",
 		"checkout.wc_enabled",
+		"checkout.daily_checkout_from_all_rooms_enabled",
 		// Capacity-detail disclosure toggles (issue #1879, devices tab).
 		"checkin.activity_capacity_details_enabled",
 		"checkin.room_capacity_details_enabled",
@@ -1320,6 +1321,7 @@ func TestDevicesSettings(t *testing.T) {
 		"checkout.raumwechsel_enabled",
 		"checkout.schulhof_enabled",
 		"checkout.wc_enabled",
+		"checkout.daily_checkout_from_all_rooms_enabled",
 	}
 	for _, key := range keys {
 		def := config.GetDefinition(key)
@@ -1343,6 +1345,9 @@ func TestDevicesSettings(t *testing.T) {
 	assert.Equal(t, false, schulhof.Default, "schulhof should default to false (opt-in)")
 	wc := config.GetDefinition("checkout.wc_enabled")
 	assert.Equal(t, false, wc.Default, "wc should default to false (opt-in)")
+
+	allRooms := config.GetDefinition("checkout.daily_checkout_from_all_rooms_enabled")
+	assert.Equal(t, true, allRooms.Default, "new tenants should offer daily checkout from every room")
 }
 
 func TestCheckinCapacityDetailSettings(t *testing.T) {

--- a/backend/services/config/defaults/devices.go
+++ b/backend/services/config/defaults/devices.go
@@ -47,6 +47,20 @@ func init() {
 		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
 	})
 
+	config.Register(config.Definition{
+		Key:             config.KeyCheckoutDailyFromAllRoomsEnabled,
+		Label:           "„Nach Hause“ in jedem Raum anzeigen",
+		Description:     "Zeigt „Nach Hause“ nach der Abholzeit in jedem Raum. Ausgeschaltet erscheint die Auswahl nur im Gruppenraum und auf dem Schulhof.",
+		Type:            config.FieldBoolean,
+		Default:         true,
+		ReadPermission:  "config:read",
+		WritePermission: "config:update",
+		Tab:             "devices",
+		Category:        "checkout",
+		SortOrder:       13,
+		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
+	})
+
 	// Capacity-detail disclosure toggles (issue #1879). When enabled, the
 	// device checkin 409 includes the `details` object (name + occupancy)
 	// that the kiosk renders as a rich German message; when disabled, the
@@ -63,7 +77,7 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "devices",
 		Category:        "kapazität",
-		SortOrder:       13,
+		SortOrder:       14,
 		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
 	})
 
@@ -77,7 +91,7 @@ func init() {
 		WritePermission: "config:update",
 		Tab:             "devices",
 		Category:        "kapazität",
-		SortOrder:       14,
+		SortOrder:       15,
 		DependsOn:       config.DependsOnEq(config.KeyAttendanceNFCEnabled, true),
 	})
 

--- a/backend/services/iot/checkin/checkout_gate.go
+++ b/backend/services/iot/checkin/checkout_gate.go
@@ -172,11 +172,9 @@ func (s *CheckinService) isAfterGlobalCheckoutTime(ctx context.Context) bool {
 // "checked_out_daily" therefore shows the child NO buttons, so this predicate
 // must stay independent of ShouldUpgradeToDailyCheckout rather than share it.
 //
-// Two rooms qualify as "on the way out":
-//   - the child's own group room (or any room, when the group has none), and
-//   - the Schulhof, which since #2161 is a regular room but is precisely the
-//     route home. Without it a yard kiosk never offered "nach Hause" and
-//     children stayed "unterwegs" until staff logged them out by hand (#2377).
+// When checkout.daily_checkout_from_all_rooms_enabled is active, every room
+// qualifies. Otherwise the previous own-group-room plus Schulhof policy is
+// preserved for existing tenants.
 func (s *CheckinService) ShouldShowDailyCheckoutWithGroup(ctx context.Context, student *users.Student, currentVisit *active.Visit) bool {
 	if !dailyCheckoutPreconditions(student, currentVisit) {
 		return false
@@ -186,6 +184,10 @@ func (s *CheckinService) ShouldShowDailyCheckoutWithGroup(ctx context.Context, s
 		return false
 	}
 
+	if s.dailyCheckoutFromAllRoomsEnabled(ctx) {
+		return true
+	}
+
 	if s.isFromOwnGroupRoom(ctx, student, currentVisit) {
 		return true
 	}
@@ -193,6 +195,22 @@ func (s *CheckinService) ShouldShowDailyCheckoutWithGroup(ctx context.Context, s
 	// Checked last: it costs a room lookup, and the common case is a child
 	// leaving their own group room.
 	return s.isSchulhofRoom(ctx, currentVisit.ActiveGroup.RoomID)
+}
+
+func (s *CheckinService) dailyCheckoutFromAllRoomsEnabled(ctx context.Context) bool {
+	if s.settings == nil {
+		return false
+	}
+
+	enabled, err := s.settings.ResolveBool(ctx, configModel.KeyCheckoutDailyFromAllRoomsEnabled)
+	if err != nil {
+		s.getLogger().WarnContext(ctx, "could not resolve daily-checkout room policy",
+			slog.String("key", configModel.KeyCheckoutDailyFromAllRoomsEnabled),
+			slog.String("error", err.Error()),
+		)
+		return false
+	}
+	return enabled
 }
 
 // isFromOwnGroupRoom reports whether the visit being closed happened in the

--- a/backend/services/iot/checkin/checkout_gate_internal_test.go
+++ b/backend/services/iot/checkin/checkout_gate_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	"github.com/moto-nrw/project-phoenix/models/active"
 	"github.com/moto-nrw/project-phoenix/models/base"
+	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	"github.com/moto-nrw/project-phoenix/models/education"
 	facilityModels "github.com/moto-nrw/project-phoenix/models/facilities"
 	"github.com/moto-nrw/project-phoenix/models/users"
@@ -636,6 +637,29 @@ func TestShouldShowDailyCheckoutWithGroup_OrdinaryRoom_NotOffered(t *testing.T) 
 
 	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
 	assert.False(t, result, "an ordinary room must not offer nach Hause")
+}
+
+func TestShouldShowDailyCheckoutWithGroup_OrdinaryRoom_OfferedWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	groupRoomID := int64(42)
+	s := &CheckinService{
+		now: func() time.Time {
+			return time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+		},
+		settings: newMockSettingsService(map[string]string{
+			configModel.KeyStudentDailyCheckoutTime: "00:00",
+		}, map[string]bool{
+			configModel.KeyCheckoutDailyFromAllRoomsEnabled: true,
+		}, nil),
+		education: &mockEducationService{group: &education.Group{Model: base.Model{ID: 1}, RoomID: &groupRoomID}},
+	}
+	groupID := int64(1)
+	student := &users.Student{Model: base.Model{ID: 1}, GroupID: &groupID}
+	visit := &active.Visit{ActiveGroup: &active.Group{RoomID: 99}}
+
+	result := s.ShouldShowDailyCheckoutWithGroup(context.Background(), student, visit)
+	assert.True(t, result, "an ordinary room must offer nach Hause when the tenant setting is enabled")
 }
 
 // Deliberately NOT parallel: the test reaches process-global state (env

--- a/frontend/src/components/help/guide-data.ts
+++ b/frontend/src/components/help/guide-data.ts
@@ -2536,7 +2536,7 @@ export const nfcChapters: readonly GuideChapter[] = [
         ],
         callout: {
           title: "Welche Buttons erscheinen",
-          body: "Welche Ziele unter `Wohin geht ...?` angezeigt werden, steuern Sie in den Einstellungen unter `Geräte` (siehe Kapitel „NFC-Einstellungen prüfen“). `Schulhof` und `Toilette` legen automatisch einen passenden Raum an. `nach Hause` erscheint beim Auschecken aus dem eigenen Gruppenraum und vom Schulhof; ist eine Checkout-Zeit hinterlegt, erst ab dieser Uhrzeit.",
+          body: "Unter `Geräte` legen Sie die Ziele unter `Wohin geht ...?` fest. Für `Schulhof` und `Toilette` legt moto passende Räume an. `„Nach Hause“ in jedem Raum anzeigen` erweitert die Auswahl. Sie erscheint dann auch in der Mensa. Die `Tägliche Abmeldezeit` gilt weiterhin.",
           tone: "gray",
         },
         screenshot:
@@ -2628,7 +2628,7 @@ export const nfcChapters: readonly GuideChapter[] = [
         steps: [
           "Im Browser die `Einstellungen` öffnen und den Tab `Geräte` wählen.",
           "Unter `OGS Geräte-PIN` die 4-stellige PIN setzen, mit der sich das Team am Tablet anmeldet.",
-          "Mit `Raumwechsel-Button anzeigen`, `Schulhof-Button anzeigen` und `Toilette-Button anzeigen` festlegen, welche Ziele beim Auschecken (`Wohin geht ...?`) erscheinen.",
+          "Legen Sie fest, welche Ziele beim Auschecken erscheinen. Dafür gibt es `Raumwechsel-Button anzeigen`, `Schulhof-Button anzeigen` und `Toilette-Button anzeigen`. `„Nach Hause“ in jedem Raum anzeigen` erweitert die Auswahl auf alle Räume.",
           "Mit `Details bei voller Aktivität anzeigen` und `Details bei vollem Raum anzeigen` steuern Sie, ob das Tablet bei erreichten Kapazitäten den Namen und die Belegung nennt oder nur einen allgemeinen Hinweis zeigt.",
           "Änderungen werden automatisch gespeichert und beim nächsten Start vom Tablet übernommen.",
         ],


### PR DESCRIPTION
## Description

Adds the tenant setting `checkout.daily_checkout_from_all_rooms_enabled` for the kiosk checkout destination.

When enabled, the backend offers `Nach Hause` after the existing time gate from every active room, including Mensa. Ordinary room checkouts remain `checked_out`, so the child still chooses a destination. Automatic daily checkout remains limited to the existing unambiguous own-group-room path.

The rollout keeps current schools unchanged:

- The registry default is `true`, so schools created after this deployment get the new behavior.
- Migration 1.15.321 writes an explicit `false` override for every school that already exists.
- `ON CONFLICT DO NOTHING` preserves an explicit tenant choice.
- No school ID or slug is hardcoded.

The NFC help now explains the new setting and the unchanged daily checkout time gate.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Configuration change
- [x] Test addition/modification

## Related Issues

- Fixes #2404
- Related to #2385

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [x] Testing documentation updated

Checks completed:

- `go build ./...`
- Settings registry and checkout policy tests
- IoT API tests for Schulhof and ordinary rooms
- Migration registry and SQL contract tests
- `pnpm run check`
- Full normal pre-push hook: git-secrets, Go Vet, GolangCI-Lint, deadcode, Knip, Dependency-Cruise, frontend check
- Two-axis standards and spec review, no remaining findings

The full backend suite also exposed an unrelated existing failure in `services/schedule`, test `skips_children_whose_care_has_ended_instead_of_failing_the_class`. The failure reproduces in isolation and this PR does not touch that area.

## Security Checklist

- [x] I have followed the security guidelines
- [x] No sensitive information is committed
- [x] No environment variable changes
- [x] No hardcoded secrets
- [x] No auth, tenancy boundary, or data exposure changes

## Missverständnis-Check

Checked the generated setting label, description, and NFC help copy using the simple-language rules. The text names the action, Mensa behavior, fallback behavior, and unchanged time gate. No visual layout or custom component changed. A running-app visual check was not performed.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Help guide updated
- [x] No new warnings or errors in the normal push checks
- [x] No merge conflicts

## Deployment Notes

After production deployment, set `checkout.daily_checkout_from_all_rooms_enabled` to `true` for GS Barnstorf. The migration intentionally gives Barnstorf the same `false` compatibility override as every existing school.