### PR TITLE
fix: restore development backend CI

### DIFF
--- a/backend/services/schedule/arrival_service.go
+++ b/backend/services/schedule/arrival_service.go
@@ -1089,6 +1089,33 @@ func (s *arrivalScheduleService) upsertClassArrivalTimes(
 	updatedBy int64,
 	authorize func(context.Context, *users.Student) (bool, error),
 ) (*BulkUpsertResult, error) {
+	touched, err := classArrivalTimeChanges(schedules)
+	if err != nil {
+		return nil, err
+	}
+
+	students, err := s.studentRepo.FindBySchoolClass(ctx, schoolClass)
+	if err != nil {
+		return nil, &ScheduleError{
+			Op:  opBulkUpsertArrivalSchedules,
+			Err: fmt.Errorf("failed to find students for school class %s: %w", schoolClass, err),
+		}
+	}
+	students = dropDepartedStudents(students)
+
+	students, err = s.writeClassArrivalTimes(ctx, schoolClass, touched, updatedBy, students, authorize)
+	if err != nil {
+		return nil, &ScheduleError{Op: opBulkUpsertArrivalSchedules, Err: err}
+	}
+	result := &BulkUpsertResult{OverwrittenStudents: make([]OverwriteWarning, 0)}
+	result.StudentsAffected = len(students)
+	for _, student := range students {
+		result.AffectedStudentIDs = append(result.AffectedStudentIDs, student.ID)
+	}
+	return result, nil
+}
+
+func classArrivalTimeChanges(schedules []ArrivalScheduleInput) (map[int]string, error) {
 	touched := make(map[int]string, len(schedules))
 	for _, input := range schedules {
 		if input.Weekday < schedule.WeekdayMonday || input.Weekday > schedule.WeekdayFriday {
@@ -1099,46 +1126,25 @@ func (s *arrivalScheduleService) upsertClassArrivalTimes(
 		}
 		touched[input.Weekday] = strings.TrimSpace(input.ArrivalTime)
 	}
+	return touched, nil
+}
 
-	students, err := s.studentRepo.FindBySchoolClass(ctx, schoolClass)
-	if err != nil {
-		return nil, &ScheduleError{
-			Op:  opBulkUpsertArrivalSchedules,
-			Err: fmt.Errorf("failed to find students for school class %s: %w", schoolClass, err),
+func (s *arrivalScheduleService) writeClassArrivalTimes(
+	ctx context.Context,
+	schoolClass string,
+	touched map[int]string,
+	updatedBy int64,
+	students []*users.Student,
+	authorize func(context.Context, *users.Student) (bool, error),
+) ([]*users.Student, error) {
+	err := tenant.WithTenantTx(ctx, s.db, tenant.FromContext(ctx), func(txCtx context.Context, _ bun.Tx) error {
+		var lockErr error
+		students, lockErr = s.lockClassArrivalStudents(txCtx, schoolClass, students, authorize)
+		if lockErr != nil {
+			return lockErr
 		}
-	}
-
-	result := &BulkUpsertResult{OverwrittenStudents: make([]OverwriteWarning, 0)}
-	tenantID := tenant.FromContext(ctx)
-	err = tenant.WithTenantTx(ctx, s.db, tenantID, func(txCtx context.Context, _ bun.Tx) error {
-		// A class row affects every matched child, so its authorization boundary
-		// is the complete class, not merely the caller's selected filter.
-		sort.Slice(students, func(i, j int) bool { return students[i].ID < students[j].ID })
-		lockedStudents := make([]*users.Student, 0, len(students))
-		for _, selected := range students {
-			fresh, lockErr := s.studentRepo.FindByIDForUpdate(txCtx, selected.ID)
-			if lockErr != nil {
-				if errors.Is(lockErr, sql.ErrNoRows) {
-					return fmt.Errorf("%w: student %d", ErrBulkStudentNotFound, selected.ID)
-				}
-				return fmt.Errorf("lock selected student %d: %w", selected.ID, lockErr)
-			}
-			if fresh.Status == users.StudentStatusAlumnus || !strings.EqualFold(strings.TrimSpace(fresh.SchoolClass), schoolClass) {
-				return fmt.Errorf("%w: student %d", ErrBulkStudentNotFound, fresh.ID)
-			}
-			if authorize != nil {
-				allowed, authorizeErr := authorize(txCtx, fresh)
-				if authorizeErr != nil || !allowed {
-					return fmt.Errorf("%w: student %d", ErrBulkStudentUnauthorized, fresh.ID)
-				}
-			}
-			lockedStudents = append(lockedStudents, fresh)
-		}
-		students = lockedStudents
-
-		// The row may not exist yet, so SELECT ... FOR UPDATE cannot serialize
-		// all read-modify-write cases. The repository's transaction advisory lock
-		// covers concurrent first inserts as well.
+		// The row may not exist yet, so its transaction advisory lock covers
+		// concurrent first inserts as well as updates.
 		if lockErr := s.classTimes.LockClass(txCtx, schoolClass); lockErr != nil {
 			return fmt.Errorf("lock class arrival times for %s: %w", schoolClass, lockErr)
 		}
@@ -1151,14 +1157,41 @@ func (s *arrivalScheduleService) upsertClassArrivalTimes(
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, &ScheduleError{Op: opBulkUpsertArrivalSchedules, Err: err}
+	return students, err
+}
+
+func (s *arrivalScheduleService) lockClassArrivalStudents(
+	ctx context.Context,
+	schoolClass string,
+	students []*users.Student,
+	authorize func(context.Context, *users.Student) (bool, error),
+) ([]*users.Student, error) {
+	// A class row affects every matched child, so authorize the complete class.
+	sort.Slice(students, func(i, j int) bool { return students[i].ID < students[j].ID })
+	locked := make([]*users.Student, 0, len(students))
+	for _, selected := range students {
+		fresh, err := s.studentRepo.FindByIDForUpdate(ctx, selected.ID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("%w: student %d", ErrBulkStudentNotFound, selected.ID)
+			}
+			return nil, fmt.Errorf("lock selected student %d: %w", selected.ID, err)
+		}
+		if fresh.CareEndedOn(timezone.TodayDate()) {
+			continue
+		}
+		if fresh.Status == users.StudentStatusAlumnus || !strings.EqualFold(strings.TrimSpace(fresh.SchoolClass), schoolClass) {
+			return nil, fmt.Errorf("%w: student %d", ErrBulkStudentNotFound, fresh.ID)
+		}
+		if authorize != nil {
+			allowed, authorizeErr := authorize(ctx, fresh)
+			if authorizeErr != nil || !allowed {
+				return nil, fmt.Errorf("%w: student %d", ErrBulkStudentUnauthorized, fresh.ID)
+			}
+		}
+		locked = append(locked, fresh)
 	}
-	result.StudentsAffected = len(students)
-	for _, student := range students {
-		result.AffectedStudentIDs = append(result.AffectedStudentIDs, student.ID)
-	}
-	return result, nil
+	return locked, nil
 }
 
 // mergedClassRow folds the touched weekdays into whatever the class already

--- a/backend/services/schedule/arrival_service_test.go
+++ b/backend/services/schedule/arrival_service_test.go
@@ -1499,8 +1499,10 @@ func TestArrivalScheduleService_BulkUpsertArrivalSchedules(t *testing.T) {
 	// with a message naming a child the office cannot even see any more.
 	t.Run("skips children whose care has ended instead of failing the class", func(t *testing.T) {
 		className := fmt.Sprintf("BCCARE-%d", time.Now().UnixNano())
+		staffID := createArrivalServiceTestStaffID(t, db)
 		staying := testpkg.CreateTestStudent(t, db, "BulkCare", "Bleibt", className)
 		departed := testpkg.CreateTestStudent(t, db, "BulkCare", "Weg", className)
+		testpkg.CreateTestArrivalSchedule(t, db, staying.ID, 1, staffID, "")
 		_, err := db.NewUpdate().
 			Table("users.students").
 			Set("enrolled_until = ?", timezone.TodayDate().AddDays(-1)).
@@ -1513,7 +1515,7 @@ func TestArrivalScheduleService_BulkUpsertArrivalSchedules(t *testing.T) {
 			ctx,
 			schedule.ArrivalScheduleBulkFilter{SchoolClass: className},
 			schedules,
-			createArrivalServiceTestStaffID(t, db),
+			staffID,
 		)
 
 		require.NoError(t, err, "one departed child must not abort the whole class")

--- a/scripts/backend-affected-packages.sh
+++ b/scripts/backend-affected-packages.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
 base=${1:-origin/development}
 merge_base=$(git merge-base HEAD "$base")
 

--- a/scripts/backend-affected-packages_test.sh
+++ b/scripts/backend-affected-packages_test.sh
@@ -59,12 +59,14 @@ git -C "$fixture" add .
 git -C "$fixture" commit -qm baseline
 
 select_packages() {
-  (cd "$fixture" && "$repo_root/scripts/backend-affected-packages.sh" HEAD)
+  working_directory=${1:-$fixture}
+  (cd "$working_directory" && "$repo_root/scripts/backend-affected-packages.sh" HEAD)
 }
 
 assert_output() {
   expected=$1
-  actual=$(select_packages)
+  working_directory=${2:-$fixture}
+  actual=$(select_packages "$working_directory")
   if [ "$actual" != "$expected" ]; then
     printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
     exit 1
@@ -93,6 +95,7 @@ git -C "$fixture" restore backend/core/core_test.go
 
 printf '\n// changed\n' >>"$fixture/backend/core/core.go"
 assert_output $'example.test/project/consumer\nexample.test/project/core'
+assert_output $'example.test/project/consumer\nexample.test/project/core' "$fixture/backend"
 git -C "$fixture" restore backend/core/core.go
 
 mkdir -p "$fixture/backend/consumer/testdata"


### PR DESCRIPTION
## Description

- Exclude children whose care has ended from class-wide arrival schedule authorization and result counts, including a second check after locking each student row.
- Preserve class timetable writes even when no active children remain.
- Make backend affected-package discovery independent of the caller working directory so CI cannot silently select zero packages from `backend/`.
- Add regressions for the departed-care fixture and root-versus-backend selector invocation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [x] Refactoring
- [ ] Performance improvement
- [x] Test addition/modification
- [x] CI/CD improvement

## Related Issues
- Related to #2414
- Related to #2487

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

Commands and results:
- `scripts/backend-affected-packages_test.sh` — passed from repository and backend working-directory cases
- Focused arrival schedule regressions with `-count=2` — passed
- `scripts/test-backend.sh` — 23,702 tests passed; 12 expected skips; 0 failures
- Pre-push hooks — `go vet`, `golangci-lint` (0 issues), dead-code analysis, and secret scanning passed

## Security Checklist
- [x] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Not applicable; backend service and CI tooling only.

## Missverständnis-Check

nicht user-sichtbar

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] The in-app help guide does not apply because this is backend/CI-only
- [x] The Verständlichkeit checklist does not apply because this is not user-visible
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

The CI selector regression explains why the earlier PR could appear green while the same backend test failed after merge: the selector resolved `backend/` relative to an already changed `backend/` working directory and returned no packages.