### PR TITLE
fix(schedule): dynamische Zielgruppen im Verlustwarner berücksichtigen

### DIFF
--- a/backend/services/schedule/edited_instance_detection.go
+++ b/backend/services/schedule/edited_instance_detection.go
@@ -150,6 +150,17 @@ func (s *materializationService) DetectEditedInWindow(
 		if err != nil {
 			return nil, &ScheduleError{Op: "detect edited: load enrollments", Err: err}
 		}
+		targetStudentIDs := make([]int64, 0)
+		if targetRepo, ok := s.groupRepo.(activities.GroupTargetRepository); ok {
+			targetStudentIDs, err = targetRepo.FindTargetStudentIDs(ctx, activityGroupID)
+			if err != nil {
+				return nil, &ScheduleError{Op: "detect edited: load target students", Err: err}
+			}
+		}
+		careBounds, err := s.loadCareBounds(ctx, targetStudentIDs, enrollments)
+		if err != nil {
+			return nil, &ScheduleError{Op: "detect edited: load care bounds", Err: err}
+		}
 		supervisors, err := s.supervisorRepo.FindByGroupID(ctx, activityGroupID)
 		if err != nil {
 			return nil, &ScheduleError{Op: "detect edited: load supervisors", Err: err}
@@ -172,10 +183,17 @@ func (s *materializationService) DetectEditedInWindow(
 				exceptionIdx[exceptionKey{tmpl.ID, inst.Date}],
 				inst.Date,
 			)
-			changes := diffOccurrence(
+			expectedStudentIDs := expectedStudentIDsOn(
+				enrollments,
+				targetStudentIDs,
+				careBounds,
+				inst.Date,
+				calendarPeriodID(inst),
+			)
+			changes := diffOccurrenceWithExpectedStudents(
 				inst,
 				tmpl.Name,
-				enrollments,
+				expectedStudentIDs,
 				supervisors,
 				staffByInstance[inst.ID],
 				studentsByInstance[inst.ID],
@@ -323,10 +341,9 @@ func (s *materializationService) studentRosterByInstance(ctx context.Context, id
 	return byInstance, nil
 }
 
-// diffOccurrence returns the field categories on which one planned occurrence
-// diverges from its template projection. Pure (no DB) so the truth table is
-// unit-testable. `expected` is what the template would materialize on the
-// occurrence's date (see expectedSlotsOn) — already date- and exception-aware.
+// diffOccurrence keeps the enrollment-only pure seam used by the established
+// truth-table tests. Production detection passes the shared manual + dynamic
+// roster projection to diffOccurrenceWithExpectedStudents below.
 func diffOccurrence(
 	inst *schedule.ActivityInstance,
 	templateTitle string,
@@ -336,31 +353,61 @@ func diffOccurrence(
 	studentRows []*schedule.InstanceStudent,
 	expected []materialParams,
 ) []string {
-	var changes []string
+	expectedStudentIDs := expectedStudentIDsOn(
+		enrollments,
+		nil,
+		nil,
+		inst.Date,
+		calendarPeriodID(inst),
+	)
+	return diffOccurrenceWithExpectedStudents(
+		inst,
+		templateTitle,
+		expectedStudentIDs,
+		supervisors,
+		staffRows,
+		studentRows,
+		expected,
+	)
+}
 
-	// Title — materialization copies the template name verbatim.
+// diffOccurrenceWithExpectedStudents returns the field categories on which
+// one planned occurrence diverges from its template projection. Both slot and
+// student inputs already contain the exact values materialization would write.
+func diffOccurrenceWithExpectedStudents(
+	inst *schedule.ActivityInstance,
+	templateTitle string,
+	expectedStudentIDs []int64,
+	supervisors []*activities.SupervisorPlanned,
+	staffRows []*schedule.InstanceStaff,
+	studentRows []*schedule.InstanceStudent,
+	expected []materialParams,
+) []string {
+	changes := diffOccurrenceText(inst, templateTitle)
+	changes = append(changes, diffOccurrenceSlot(inst, expected)...)
+	if staffRosterChanged(inst, supervisors, staffRows) {
+		changes = append(changes, EditedChangeStaff)
+	}
+	changes = append(changes, diffOccurrenceStudents(expectedStudentIDs, studentRows)...)
+	sort.Strings(changes)
+	return changes
+}
+
+func diffOccurrenceText(inst *schedule.ActivityInstance, templateTitle string) []string {
+	var changes []string
 	if inst.Title != templateTitle {
 		changes = append(changes, EditedChangeTitle)
 	}
-	// Description & notes — materialization writes neither, so any non-empty
-	// value is a deliberate per-occurrence edit (description is settable via the
-	// instance PUT and would otherwise be discarded silently on re-plan).
 	if inst.Description != nil && strings.TrimSpace(*inst.Description) != "" {
 		changes = append(changes, EditedChangeDescription)
 	}
 	if inst.Notes != nil && strings.TrimSpace(*inst.Notes) != "" {
 		changes = append(changes, EditedChangeNotes)
 	}
+	return changes
+}
 
-	periodID := int64(0)
-	if inst.CalendarPeriodID != nil {
-		periodID = *inst.CalendarPeriodID
-	}
-
-	// Room + time. Match the occurrence to the template slot the materializer
-	// would produce on THIS date at the occurrence's start time. No match means
-	// the day/start was moved (or the date is off-cycle/out-of-range) and
-	// ReplanWeek would delete it without recreating it → a lost `time` edit.
+func diffOccurrenceSlot(inst *schedule.ActivityInstance, expected []materialParams) []string {
 	var match *materialParams
 	instStart := formatTimeOfDay(inst.StartTime)
 	for i := range expected {
@@ -370,21 +417,24 @@ func diffOccurrence(
 		}
 	}
 	if match == nil {
-		changes = append(changes, EditedChangeTime)
-	} else {
-		if match.RoomID > 0 && inst.RoomID != match.RoomID {
-			changes = append(changes, EditedChangeRoom)
-		}
-		if !sameClock(inst.EndTime, match.EndTime) {
-			changes = append(changes, EditedChangeTime)
-		}
+		return []string{EditedChangeTime}
 	}
+	var changes []string
+	if match.RoomID > 0 && inst.RoomID != match.RoomID {
+		changes = append(changes, EditedChangeRoom)
+	}
+	if !sameClock(inst.EndTime, match.EndTime) {
+		changes = append(changes, EditedChangeTime)
+	}
+	return changes
+}
 
-	// Staff. Expected = template supervisors valid on this date (with their
-	// primary flag). Actual = planned (non-substitute) instance_staff rows.
-	// Substitutes and is_absent flags are Vertretungsplan deviations ReplanWeek
-	// preserves, so they must not count as edits (an absent planned staff still
-	// counts as planned).
+func staffRosterChanged(
+	inst *schedule.ActivityInstance,
+	supervisors []*activities.SupervisorPlanned,
+	staffRows []*schedule.InstanceStaff,
+) bool {
+	periodID := calendarPeriodID(inst)
 	primaryStaffID, hasPrimary := effectivePrimarySupervisor(supervisors, inst.Date, periodID)
 	expectedStaff := make(map[int64]bool)
 	for _, sup := range supervisors {
@@ -394,27 +444,20 @@ func diffOccurrence(
 	}
 	actualStaff := make(map[int64]bool)
 	for _, row := range staffRows {
-		if row.IsSubstitute {
-			continue
+		if !row.IsSubstitute {
+			actualStaff[row.StaffID] = row.IsPrimary
 		}
-		actualStaff[row.StaffID] = row.IsPrimary
 	}
-	if !sameStaffSet(expectedStaff, actualStaff) {
-		changes = append(changes, EditedChangeStaff)
-	}
+	return !sameStaffSet(expectedStaff, actualStaff)
+}
 
-	// Students. Expected = template enrollments valid on this date; actual =
-	// instance_students membership. Graduated (alumnus) students are excluded to
-	// mirror copyEnrollments — materialization no longer copies them, so counting
-	// their enrollment here would flag a phantom "students changed" edit (#405).
-	// Attendance status is not membership: a status-day absence keeps the child
-	// on the roster (#2225). Manual/observed states that rematerialization
-	// would discard are a separate attendance category.
-	expectedStudents := make(map[int64]struct{})
-	for _, e := range enrollments {
-		if isEnrollmentValidOn(e, inst.Date, periodID) && !enrollmentStudentIsAlumnus(e) {
-			expectedStudents[e.StudentID] = struct{}{}
-		}
+func diffOccurrenceStudents(
+	expectedStudentIDs []int64,
+	studentRows []*schedule.InstanceStudent,
+) []string {
+	expectedStudents := make(map[int64]struct{}, len(expectedStudentIDs))
+	for _, studentID := range expectedStudentIDs {
+		expectedStudents[studentID] = struct{}{}
 	}
 	studentSet := make(map[int64]struct{}, len(studentRows))
 	attendanceLost := false
@@ -427,6 +470,7 @@ func diffOccurrence(
 			attendanceLost = true
 		}
 	}
+	var changes []string
 	if !sameIDSet(expectedStudents, studentSet) {
 		changes = append(changes, EditedChangeStudents)
 	}
@@ -434,8 +478,14 @@ func diffOccurrence(
 		changes = append(changes, EditedChangeAttendance)
 	}
 
-	sort.Strings(changes)
 	return changes
+}
+
+func calendarPeriodID(inst *schedule.ActivityInstance) int64 {
+	if inst == nil || inst.CalendarPeriodID == nil {
+		return 0
+	}
+	return *inst.CalendarPeriodID
 }
 
 // sameListKind reports whether two optional list_kind values are equivalent,

--- a/backend/services/schedule/edited_instance_detection_integration_test.go
+++ b/backend/services/schedule/edited_instance_detection_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	activitiesRepo "github.com/moto-nrw/project-phoenix/database/repositories/activities"
 	scheduleRepo "github.com/moto-nrw/project-phoenix/database/repositories/schedule"
 	"github.com/moto-nrw/project-phoenix/internal/timezone"
 	activeModels "github.com/moto-nrw/project-phoenix/models/active"
@@ -69,6 +70,56 @@ func TestDetectEditedInWindow_Pristine(t *testing.T) {
 	materializeSingleInstance(t, s)
 
 	assert.Empty(t, detect(t, s), "a freshly materialized occurrence matches its template")
+}
+
+func TestDetectEditedInWindow_DynamicTargetRosterMatchesMaterialization(t *testing.T) {
+	t.Parallel()
+
+	for _, targetType := range []string{
+		activitiesModels.TargetGroupTypeKlasse,
+		activitiesModels.TargetGroupTypeJahrgang,
+		activitiesModels.TargetGroupTypeGruppe,
+	} {
+		t.Run(targetType, func(t *testing.T) {
+			s := makeScenario(t, activitiesModels.WeekdayMonday, editWindowStart)
+			replaceScenarioTarget(t, s, targetType)
+
+			result, err := s.svc.MaterializeForTenant(
+				s.ctx, editWindowStart, editWindowStart.AddDays(6), scheduleSvc.MaterializationSourceManual,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, 3, result.InstanceStudentsCreated,
+				"manual and dynamic memberships form one deduplicated roster")
+			assert.Empty(t, detect(t, s),
+				"automatically targeted students are not single-occurrence edits")
+		})
+	}
+}
+
+func replaceScenarioTarget(t *testing.T, s *scenarioSetup, targetType string) {
+	t.Helper()
+	target := &activitiesModels.GroupTarget{TargetGroupType: targetType}
+	switch targetType {
+	case activitiesModels.TargetGroupTypeKlasse:
+		schoolClass := "3a"
+		target.TargetSchoolClass = &schoolClass
+	case activitiesModels.TargetGroupTypeJahrgang:
+		grade := int16(3)
+		target.TargetGradeLevel = &grade
+	case activitiesModels.TargetGroupTypeGruppe:
+		group := testpkg.CreateTestEducationGroupForTenant(t, s.db, s.tenantID, "Zielgruppe-2526")
+		target.EducationGroupID = &group.ID
+		_, err := s.db.NewUpdate().
+			Table("users.students").
+			Set("group_id = ?", group.ID).
+			Where("tenant_id = ?", s.tenantID).
+			Where("id = ?", s.students[2]).
+			Exec(s.ctx)
+		require.NoError(t, err)
+	}
+	targetRepo, ok := activitiesRepo.NewGroupRepository(s.db).(activitiesModels.GroupTargetRepository)
+	require.True(t, ok)
+	require.NoError(t, targetRepo.ReplaceTargets(s.ctx, s.template.ID, []*activitiesModels.GroupTarget{target}))
 }
 
 func TestDetectEditedInWindow_TitleEdit(t *testing.T) {

--- a/backend/services/schedule/materialization_service.go
+++ b/backend/services/schedule/materialization_service.go
@@ -246,8 +246,8 @@ func (s *materializationService) MaterializeForTenant(
 		}
 		// Then the grade-transition gate, in that order (see
 		// education.TenantTransitionsLockKey — recurrence first, transitions
-		// second, everywhere). copyEnrollments decides whether to insert a roster
-		// row from the student status this pass read; a grade transition
+		// second, everywhere). expectedStudentIDsOn decides whether to insert a
+		// roster row from the student status this pass read; a grade transition
 		// committing its graduation and its roster-archive pass in between would
 		// leave a departed child on an upcoming roster with nothing left to
 		// remove them (#405 review).
@@ -469,6 +469,40 @@ func careEndedOnDate(bounds map[int64]timezone.Date, studentID int64, date timez
 	return ok && date.After(bound)
 }
 
+// expectedStudentIDsOn projects the deduplicated roster the template would
+// materialize on one date. Both materialization and lost-edit detection use
+// this function so manual enrollments and dynamic targets cannot drift apart.
+func expectedStudentIDsOn(
+	enrollments []*activities.StudentEnrollment,
+	targetStudentIDs []int64,
+	careBounds map[int64]timezone.Date,
+	date timezone.Date,
+	periodID int64,
+) []int64 {
+	seen := make(map[int64]struct{}, len(enrollments)+len(targetStudentIDs))
+	for _, enrollment := range enrollments {
+		if !isEnrollmentValidOn(enrollment, date, periodID) ||
+			enrollmentStudentIsAlumnus(enrollment) ||
+			careEndedOnDate(careBounds, enrollment.StudentID, date) {
+			continue
+		}
+		seen[enrollment.StudentID] = struct{}{}
+	}
+	for _, studentID := range targetStudentIDs {
+		if studentID <= 0 || careEndedOnDate(careBounds, studentID, date) {
+			continue
+		}
+		seen[studentID] = struct{}{}
+	}
+
+	ids := make([]int64, 0, len(seen))
+	for studentID := range seen {
+		ids = append(ids, studentID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
 // materializeTemplate runs the inner loop for a single template. Extracted so
 // the main entry point stays readable.
 func (s *materializationService) materializeTemplate(
@@ -643,10 +677,17 @@ func (s *materializationService) materializeTemplate(
 			existingIdx[key] = struct{}{}
 			result.InstancesCreated++
 
-			if err := s.copyEnrollments(ctx, instance.ID, enrollments, careBounds, date, period.ID, result); err != nil {
-				return err
-			}
-			if err := s.copyTargetStudents(ctx, instance.ID, targetStudentIDs, enrollments, careBounds, date, period.ID, result); err != nil {
+			if err := s.copyExpectedStudents(
+				ctx,
+				instance.ID,
+				enrollments,
+				targetStudentIDs,
+				careBounds,
+				date,
+				period.ID,
+				result,
+				"materialize template: copy expected student",
+			); err != nil {
 				return err
 			}
 			if err := s.copySupervisors(ctx, instance.ID, supervisors, date, period.ID, result); err != nil {
@@ -658,114 +699,30 @@ func (s *materializationService) materializeTemplate(
 	return nil
 }
 
-func (s *materializationService) copyTargetStudents(
+func (s *materializationService) copyExpectedStudents(
 	ctx context.Context,
 	instanceID int64,
-	studentIDs []int64,
 	enrollments []*activities.StudentEnrollment,
+	targetStudentIDs []int64,
 	careBounds map[int64]timezone.Date,
 	date timezone.Date,
 	periodID int64,
 	result *MaterializationResult,
+	errorOp string,
 ) error {
-	seen := make(map[int64]struct{}, len(enrollments)+len(studentIDs))
-	for _, enrollment := range enrollments {
-		if isEnrollmentValidOn(enrollment, date, periodID) && !enrollmentStudentIsAlumnus(enrollment) {
-			seen[enrollment.StudentID] = struct{}{}
-		}
-	}
-	created := 0
+	studentIDs := expectedStudentIDsOn(enrollments, targetStudentIDs, careBounds, date, periodID)
 	for _, studentID := range studentIDs {
-		if studentID <= 0 {
-			continue
-		}
-		if _, exists := seen[studentID]; exists {
-			continue
-		}
-		// A dynamic source answers "who belongs to this Jahrgang / class /
-		// group", which stays true right up to the child's last care day and
-		// stops being true the day after (#2487).
-		if careEndedOnDate(careBounds, studentID, date) {
-			seen[studentID] = struct{}{}
-			continue
-		}
-		seen[studentID] = struct{}{}
 		row := &schedule.InstanceStudent{
 			InstanceID: instanceID,
 			StudentID:  studentID,
 			Status:     schedule.AttendanceStatusExpected,
 		}
 		if err := s.studentRepo.Create(ctx, row); err != nil {
-			return &ScheduleError{Op: "materialize template: copy target student", Err: err}
-		}
-		created++
-		result.InstanceStudentsCreated++
-	}
-	if created == 0 {
-		return nil
-	}
-	if _, err := s.studentRepo.ApplyActiveStatusDaysForInstance(ctx, instanceID, date); err != nil {
-		return &ScheduleError{Op: "materialize template: apply target student status days", Err: err}
-	}
-	if _, err := s.studentRepo.ApplyActivePartialAbsencesForInstance(ctx, instanceID, date); err != nil {
-		return &ScheduleError{Op: "materialize template: apply target student partial absences", Err: err}
-	}
-	return nil
-}
-
-func (s *materializationService) copyEnrollments(
-	ctx context.Context,
-	instanceID int64,
-	enrollments []*activities.StudentEnrollment,
-	careBounds map[int64]timezone.Date,
-	date timezone.Date,
-	periodID int64,
-	result *MaterializationResult,
-) error {
-	seen := make(map[int64]struct{}, len(enrollments))
-	for _, e := range enrollments {
-		if !isEnrollmentValidOn(e, date, periodID) {
-			continue
-		}
-		// A graduated (alumnus) student is soft-deleted: their enrollment rows
-		// survive for transition reverts, but future planning must never copy
-		// them into a new instance_students row — otherwise upcoming cards,
-		// staffing ratios, slot-list exports and instance completion keep
-		// counting a departed child. Historical rows already materialized before
-		// graduation stay untouched (this service is insert-only). (#405)
-		if enrollmentStudentIsAlumnus(e) {
-			s.getLogger().Debug("skipping graduated student on materialization",
-				slog.Int64("instance_id", instanceID),
-				slog.Int64("student_id", e.StudentID),
-				slog.String("date", date.String()),
-			)
-			continue
-		}
-		// Ending a child's care already caps their enrollments, so this is the
-		// backstop for a row created afterwards by another path (#2487).
-		if careEndedOnDate(careBounds, e.StudentID, date) {
-			continue
-		}
-		if _, dup := seen[e.StudentID]; dup {
-			s.getLogger().Warn("student listed twice on template — skipping duplicate",
-				slog.Int64("instance_id", instanceID),
-				slog.Int64("student_id", e.StudentID),
-				slog.String("date", date.String()),
-			)
-			continue
-		}
-		seen[e.StudentID] = struct{}{}
-		row := &schedule.InstanceStudent{
-			InstanceID: instanceID,
-			StudentID:  e.StudentID,
-			Status:     schedule.AttendanceStatusExpected,
-		}
-		if err := s.studentRepo.Create(ctx, row); err != nil {
-			return &ScheduleError{Op: "materialize template: copy enrollment", Err: err}
+			return &ScheduleError{Op: errorOp, Err: err}
 		}
 		result.InstanceStudentsCreated++
 	}
-	if len(seen) == 0 {
+	if len(studentIDs) == 0 {
 		return nil
 	}
 	if _, err := s.studentRepo.ApplyActiveStatusDaysForInstance(ctx, instanceID, date); err != nil {
@@ -775,6 +732,31 @@ func (s *materializationService) copyEnrollments(
 		return &ScheduleError{Op: "materialize template: apply student partial absences", Err: err}
 	}
 	return nil
+}
+
+// copyEnrollments keeps the narrow helper used by pure branch tests. The real
+// materialization path calls copyExpectedStudents with manual and dynamic
+// memberships together.
+func (s *materializationService) copyEnrollments(
+	ctx context.Context,
+	instanceID int64,
+	enrollments []*activities.StudentEnrollment,
+	careBounds map[int64]timezone.Date,
+	date timezone.Date,
+	periodID int64,
+	result *MaterializationResult,
+) error {
+	return s.copyExpectedStudents(
+		ctx,
+		instanceID,
+		enrollments,
+		nil,
+		careBounds,
+		date,
+		periodID,
+		result,
+		"materialize template: copy enrollment",
+	)
 }
 
 func (s *materializationService) copySupervisors(

--- a/backend/services/schedule/materialization_service_test.go
+++ b/backend/services/schedule/materialization_service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/models/activities"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/models/schedule"
+	"github.com/moto-nrw/project-phoenix/models/users"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -239,6 +240,30 @@ func TestEnrollmentStudentIsAlumnus_UnloadedStudent(t *testing.T) {
 
 	enrollment := &activities.StudentEnrollment{}
 	assert.False(t, enrollmentStudentIsAlumnus(enrollment))
+}
+
+func TestExpectedStudentIDsOn_AppliesSharedRosterRules(t *testing.T) {
+	t.Parallel()
+
+	date := timezone.NewDate(2026, time.April, 20)
+	periodID := int64(400)
+	otherPeriodID := int64(401)
+	endedBefore := date.AddDays(-1)
+	alumnus := &users.Student{Status: users.StudentStatusAlumnus}
+	enrollments := []*activities.StudentEnrollment{
+		{StudentID: 501, ValidFrom: date.AddDays(-1), CalendarPeriodID: &periodID},
+		{StudentID: 502, ValidFrom: date.AddDays(1)},
+		{StudentID: 503, ValidFrom: date.AddDays(-1), CalendarPeriodID: &otherPeriodID},
+		{StudentID: 504, ValidFrom: date.AddDays(-1), SelectedWeekdays: []int{2}},
+		{StudentID: 505, ValidFrom: date.AddDays(-1), Student: alumnus},
+		{StudentID: 506, ValidFrom: date.AddDays(-1)},
+	}
+	targetStudentIDs := []int64{501, 507, 508, 507}
+	careBounds := map[int64]timezone.Date{506: endedBefore, 507: date, 508: endedBefore}
+
+	assert.Equal(t, []int64{501, 507}, expectedStudentIDsOn(
+		enrollments, targetStudentIDs, careBounds, date, periodID,
+	))
 }
 
 // -----------------------------------------------------------------------------

--- a/frontend/src/components/timetable/timetable-event-modal.test.tsx
+++ b/frontend/src/components/timetable/timetable-event-modal.test.tsx
@@ -2866,6 +2866,34 @@ describe("TimetableEventModal", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("continues 'Ab jetzt dauerhaft' when dynamic target children produce no lost edits (#2526)", async () => {
+    mockCountEditedInWindow.mockResolvedValue({ count: 0, occurrences: [] });
+    renderModal({
+      initialInstance: { ...savedInstance, activityGroupId: "7" },
+    });
+
+    await screen.findByText("Wiederholenden Termin ändern");
+    fireEvent.click(screen.getByRole("button", { name: /Ab jetzt dauerhaft/ }));
+
+    await waitFor(() => expect(screen.getByLabelText("Raum*")).toBeEnabled());
+    await clickSave();
+
+    // The backend integration test establishes the dynamic-target cause. This
+    // test pins the UI contract for its zero-lost-edits response.
+    await waitFor(() =>
+      expect(mockCountEditedInWindow).toHaveBeenCalledWith(
+        "7",
+        expect.any(String),
+        expect.any(String),
+        true,
+      ),
+    );
+    await waitFor(() => expect(mockSplitTemplate).toHaveBeenCalled());
+    expect(
+      screen.queryByText("Einzelanpassungen gehen verloren"),
+    ).not.toBeInTheDocument();
+  });
+
   it("preserves the fetched staffing override for an untouched following edit", async () => {
     mockGetTemplate.mockResolvedValue({
       ...template,


### PR DESCRIPTION
# Pull Request

## Beschreibung

Der Verlustwarner und die Materialisierung verwenden jetzt dieselbe Projektion für erwartete Kinderlisten. Manuelle Anmeldungen und dynamische Zielgruppen aus Jahrgang, Klasse und Gruppe werden dedupliziert; Datums-, Perioden-, Wochentags-, Alumni- und Betreuungsende-Regeln bleiben identisch.

Korrekt materialisierte Zielgruppen-Kinder lösen damit keine falsche Warnung mehr aus. Echte Hinzufügungen oder Entfernungen an einem Einzeltermin werden weiterhin erkannt.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [x] Test addition/modification
- [ ] Breaking change
- [ ] Documentation update
- [ ] Configuration change
- [ ] Security improvement
- [ ] Performance improvement
- [ ] CI/CD improvement

## Related Issues

- Fixes #2526
- Related to #1875
- Related to #2225

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] Testing documentation updated

Ausgeführt:

- `scripts/test-backend.sh` — 23.707 Tests bestanden, 13 planmäßige Skips
- `cd frontend && pnpm exec vitest run src/components/timetable/timetable-event-modal.test.tsx` — 152 Tests bestanden
- `cd frontend && pnpm run check`
- `golangci-lint run --timeout 10m ./services/schedule`
- `scripts/test-changed.sh origin/development`

Read-only Produktionsabgleich ohne Namen oder IDs: Zwei passende Klassen-Zielgruppen-Serien mit jeweils 67 Terminen zeigten gegen nur manuelle Anmeldungen 67/67 Abweichungen, gegen die gemeinsame Projektion 0/67. Es wurden keine Produktionsdaten verändert.

## Security Checklist

- [x] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Nicht anwendbar: Es gibt keine visuelle oder textliche Änderung. Geändert wird nur, ob der bestehende Warn-Dialog bei einem Fehlalarm erscheint.

## Missverständnis-Check

Geprüfte Blöcke: Serien-Speichern über „Ab jetzt dauerhaft“ und der Dialog „Einzelanpassungen gehen verloren“. Text, Layout und Bedienlogik bleiben unverändert. Bei ausschließlich automatisch eingeplanten Zielgruppen-Kindern erscheint der Dialog nicht; echte Einzeltermin-Abweichungen bleiben sichtbar. Integrationstest und gerenderter Component-Test sichern beide Zweige ab.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially where needed
- [x] I have updated the documentation as needed
- [x] The in-app help guide does not document this internal warning projection; no guide content or screenshot changed
- [x] The Verständlichkeit checklist is recorded above; no copy, layout, or affordance changed
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts
