### PR TITLE
fix: enforce tenant isolation for account management

### DIFF
--- a/backend/api/auth/account_handlers.go
+++ b/backend/api/auth/account_handlers.go
@@ -186,12 +186,12 @@ func (rs *Resource) updateAccount(w http.ResponseWriter, r *http.Request) {
 	common.RespondNoContent(w, r)
 }
 
-func accountManagementErrorRenderer(err error) render.Renderer {
-	if errors.Is(err, authService.ErrAccountNotFound) {
-		return common.ErrorNotFound(errors.New("account not found"))
-	}
-	return common.ErrorInternalServer(err)
-}
+var accountManagementErrorRenderer = common.UnwrapRenderer[*authService.AuthError](
+	[]common.ErrorRule{
+		{Target: authService.ErrAccountNotFound, Render: common.ErrorNotFound},
+	},
+	common.ErrorInternalServer,
+)
 
 // listAccounts handles listing accounts
 func (rs *Resource) listAccounts(w http.ResponseWriter, r *http.Request) {

--- a/backend/api/auth/account_handlers.go
+++ b/backend/api/auth/account_handlers.go
@@ -168,7 +168,7 @@ func (rs *Resource) updateAccount(w http.ResponseWriter, r *http.Request) {
 
 	account, err := rs.AuthService.GetAccountByID(r.Context(), id)
 	if err != nil {
-		common.RenderError(w, r, common.ErrorNotFound(errors.New("account not found")))
+		common.RenderError(w, r, accountManagementErrorRenderer(err))
 		return
 	}
 
@@ -179,11 +179,18 @@ func (rs *Resource) updateAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := rs.AuthService.UpdateAccount(r.Context(), account); err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, accountManagementErrorRenderer(err))
 		return
 	}
 
 	common.RespondNoContent(w, r)
+}
+
+func accountManagementErrorRenderer(err error) render.Renderer {
+	if errors.Is(err, authService.ErrAccountNotFound) {
+		return common.ErrorNotFound(errors.New("account not found"))
+	}
+	return common.ErrorInternalServer(err)
 }
 
 // listAccounts handles listing accounts

--- a/backend/api/auth/account_tenant_isolation_test.go
+++ b/backend/api/auth/account_tenant_isolation_test.go
@@ -157,6 +157,41 @@ func TestAccountManagementRoleFilterExcludesForeignRoleAssignment(t *testing.T) 
 	assert.NotContains(t, ids, foreignID)
 }
 
+func TestAccountManagementRBACForeignAccountDoesNotLeakExistence(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, _ := e.foreignAccount(t, "account-scope-rbac-foreign")
+	missingID := e.missingAccountID(t)
+	role := testpkg.CreateTestRoleForTenant(t, e.tc.db, "account-scope-rbac", e.tenantID)
+	permission := testpkg.CreateTestPermission(t, e.tc.db, "account-scope-rbac", "account-scope-rbac", "read")
+
+	for _, action := range []struct {
+		method string
+		path   func(int64) string
+	}{
+		{http.MethodGet, func(accountID int64) string { return fmt.Sprintf("/auth/accounts/%d/roles", accountID) }},
+		{http.MethodPost, func(accountID int64) string { return fmt.Sprintf("/auth/accounts/%d/roles/%d", accountID, role.ID) }},
+		{http.MethodDelete, func(accountID int64) string { return fmt.Sprintf("/auth/accounts/%d/roles/%d", accountID, role.ID) }},
+		{http.MethodGet, func(accountID int64) string { return fmt.Sprintf("/auth/accounts/%d/permissions", accountID) }},
+		{http.MethodGet, func(accountID int64) string { return fmt.Sprintf("/auth/accounts/%d/permissions/direct", accountID) }},
+		{http.MethodPost, func(accountID int64) string {
+			return fmt.Sprintf("/auth/accounts/%d/permissions/%d/grant", accountID, permission.ID)
+		}},
+		{http.MethodPost, func(accountID int64) string {
+			return fmt.Sprintf("/auth/accounts/%d/permissions/%d/deny", accountID, permission.ID)
+		}},
+		{http.MethodDelete, func(accountID int64) string {
+			return fmt.Sprintf("/auth/accounts/%d/permissions/%d", accountID, permission.ID)
+		}},
+	} {
+		foreign := e.execute(t, e.claims, action.method, action.path(foreignID), nil)
+		missing := e.execute(t, e.claims, action.method, action.path(missingID), nil)
+		assert.Equal(t, http.StatusNotFound, foreign.Code, foreign.Body.String())
+		assert.Equal(t, missing.Code, foreign.Code)
+		assert.JSONEq(t, missing.Body.String(), foreign.Body.String())
+	}
+}
+
 func TestAccountManagementForeignGetDoesNotLeakExistence(t *testing.T) {
 	t.Parallel()
 	e := newAccountIsolationEnv(t)

--- a/backend/api/auth/account_tenant_isolation_test.go
+++ b/backend/api/auth/account_tenant_isolation_test.go
@@ -189,6 +189,49 @@ func TestAccountManagementRoleFilterExcludesStaleOrganizationRoleAssignment(t *t
 	assert.NotContains(t, accountIDs(response.Data), account.ID)
 }
 
+func TestAccountManagementOrganizationRoleFilterIncludesSameOrganizationSchool(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	organizationID, schoolID := e.createSchoolInOwnOrganization(t)
+	accountID, _ := e.accountForTenant(t, "account-scope-role-organization", schoolID)
+	role := testpkg.CreateTestRoleForTenant(t, e.tc.db, "account-scope-role-organization", schoolID)
+
+	_, err := e.tc.db.ExecContext(context.Background(),
+		"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
+		accountID, role.ID, schoolID)
+	require.NoError(t, err)
+
+	claims := e.claims
+	claims.Scope = tenant.ScopeOrg
+	claims.OrgID = organizationID
+	rr := e.execute(t, claims, http.MethodGet, "/auth/accounts/by-role/"+role.Name, nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response struct {
+		Data []authAPI.AccountResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+	assert.Contains(t, accountIDs(response.Data), accountID)
+}
+
+func TestAccountManagementOrganizationScopeReturnsUnmappedOwnAccount(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	testpkg.UnclaimTestAccount(t, e.tc.db, int64(e.claims.ID))
+	organizationID, _ := e.createSchoolInOwnOrganization(t)
+
+	claims := e.claims
+	claims.Scope = tenant.ScopeOrg
+	claims.OrgID = organizationID
+	rr := e.execute(t, claims, http.MethodGet, "/auth/account", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response struct {
+		Data authAPI.AccountResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, int64(claims.ID), response.Data.ID)
+}
+
 func TestAccountManagementDirectPermissionsStayWithinTenant(t *testing.T) {
 	t.Parallel()
 	e := newAccountIsolationEnv(t)

--- a/backend/api/auth/account_tenant_isolation_test.go
+++ b/backend/api/auth/account_tenant_isolation_test.go
@@ -125,6 +125,38 @@ func TestAccountManagementForeignAccountsAbsentFromList(t *testing.T) {
 	assert.NotContains(t, ids, foreignID)
 }
 
+func TestAccountManagementRoleFilterExcludesForeignRoleAssignment(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	local := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-role-local")
+	foreignID, _ := e.foreignAccount(t, "account-scope-role-foreign")
+	role := testpkg.CreateTestRoleForTenant(t, e.tc.db, "account-scope-role", e.tenantID)
+
+	for _, assignment := range []struct {
+		accountID int64
+		tenantID  int64
+	}{
+		{accountID: local.ID, tenantID: e.tenantID},
+		{accountID: foreignID, tenantID: e.foreignTenantID},
+	} {
+		_, err := e.tc.db.ExecContext(context.Background(),
+			"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
+			assignment.accountID, role.ID, assignment.tenantID)
+		require.NoError(t, err)
+	}
+
+	rr := e.execute(t, e.claims, http.MethodGet, "/auth/accounts/by-role/"+role.Name, nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response struct {
+		Data []authAPI.AccountResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+	ids := accountIDs(response.Data)
+	assert.Contains(t, ids, local.ID)
+	assert.NotContains(t, ids, foreignID)
+}
+
 func TestAccountManagementForeignGetDoesNotLeakExistence(t *testing.T) {
 	t.Parallel()
 	e := newAccountIsolationEnv(t)

--- a/backend/api/auth/account_tenant_isolation_test.go
+++ b/backend/api/auth/account_tenant_isolation_test.go
@@ -131,12 +131,15 @@ func TestAccountManagementRoleFilterExcludesForeignRoleAssignment(t *testing.T) 
 	local := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-role-local")
 	foreignID, _ := e.foreignAccount(t, "account-scope-role-foreign")
 	role := testpkg.CreateTestRoleForTenant(t, e.tc.db, "account-scope-role", e.tenantID)
+	organizationID, sameOrgSchoolID := e.createSchoolInOwnOrganization(t)
+	testpkg.MapAccountToTenant(t, e.tc.db, local.ID, sameOrgSchoolID)
 
 	for _, assignment := range []struct {
 		accountID int64
 		tenantID  int64
 	}{
 		{accountID: local.ID, tenantID: e.tenantID},
+		{accountID: local.ID, tenantID: sameOrgSchoolID},
 		{accountID: foreignID, tenantID: e.foreignTenantID},
 	} {
 		_, err := e.tc.db.ExecContext(context.Background(),
@@ -145,7 +148,10 @@ func TestAccountManagementRoleFilterExcludesForeignRoleAssignment(t *testing.T) 
 		require.NoError(t, err)
 	}
 
-	rr := e.execute(t, e.claims, http.MethodGet, "/auth/accounts/by-role/"+role.Name, nil)
+	claims := e.claims
+	claims.Scope = tenant.ScopeOrg
+	claims.OrgID = organizationID
+	rr := e.execute(t, claims, http.MethodGet, "/auth/accounts/by-role/"+role.Name, nil)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	var response struct {
 		Data []authAPI.AccountResponse `json:"data"`
@@ -155,6 +161,71 @@ func TestAccountManagementRoleFilterExcludesForeignRoleAssignment(t *testing.T) 
 	ids := accountIDs(response.Data)
 	assert.Contains(t, ids, local.ID)
 	assert.NotContains(t, ids, foreignID)
+	assert.Equal(t, 1, len(ids))
+}
+
+func TestAccountManagementDirectPermissionsStayWithinTenant(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	account := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-direct-permissions")
+	testpkg.MapAccountToTenant(t, e.tc.db, account.ID, e.foreignTenantID)
+	localPermission := testpkg.CreateTestPermission(t, e.tc.db, "account-scope-direct-local", "account-scope-direct-local", "read")
+	foreignPermission := testpkg.CreateTestPermission(t, e.tc.db, "account-scope-direct-foreign", "account-scope-direct-foreign", "read")
+
+	for _, assignment := range []struct {
+		permissionID int64
+		tenantID     int64
+	}{
+		{permissionID: localPermission.ID, tenantID: e.tenantID},
+		{permissionID: foreignPermission.ID, tenantID: e.foreignTenantID},
+	} {
+		_, err := e.tc.db.ExecContext(context.Background(),
+			"INSERT INTO auth.account_permissions (account_id, permission_id, granted, tenant_id) VALUES (?, ?, true, ?)",
+			account.ID, assignment.permissionID, assignment.tenantID)
+		require.NoError(t, err)
+	}
+
+	rr := e.execute(t, e.claims, http.MethodGet, fmt.Sprintf("/auth/accounts/%d/permissions/direct", account.ID), nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response struct {
+		Data []authAPI.PermissionResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	permissionIDs := make([]int64, 0, len(response.Data))
+	for _, permission := range response.Data {
+		permissionIDs = append(permissionIDs, permission.ID)
+	}
+	assert.Contains(t, permissionIDs, localPermission.ID)
+	assert.NotContains(t, permissionIDs, foreignPermission.ID)
+}
+
+func TestAccountManagementOrganizationRBACRequiresTargetSchoolMembership(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	organizationID, otherSchoolID := e.createSchoolInOwnOrganization(t)
+	accountID, _ := e.accountForTenant(t, "account-scope-org-rbac", otherSchoolID)
+	role := testpkg.CreateTestRoleForTenant(t, e.tc.db, "account-scope-org-rbac", e.tenantID)
+	permission := testpkg.CreateTestPermission(t, e.tc.db, "account-scope-org-rbac", "account-scope-org-rbac", "read")
+	claims := e.claims
+	claims.Scope = tenant.ScopeOrg
+	claims.OrgID = organizationID
+
+	for _, action := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, fmt.Sprintf("/auth/accounts/%d/roles", accountID)},
+		{http.MethodPost, fmt.Sprintf("/auth/accounts/%d/roles/%d", accountID, role.ID)},
+		{http.MethodDelete, fmt.Sprintf("/auth/accounts/%d/roles/%d", accountID, role.ID)},
+		{http.MethodGet, fmt.Sprintf("/auth/accounts/%d/permissions", accountID)},
+		{http.MethodGet, fmt.Sprintf("/auth/accounts/%d/permissions/direct", accountID)},
+		{http.MethodPost, fmt.Sprintf("/auth/accounts/%d/permissions/%d/grant", accountID, permission.ID)},
+		{http.MethodPost, fmt.Sprintf("/auth/accounts/%d/permissions/%d/deny", accountID, permission.ID)},
+		{http.MethodDelete, fmt.Sprintf("/auth/accounts/%d/permissions/%d", accountID, permission.ID)},
+	} {
+		rr := e.execute(t, claims, action.method, action.path, nil)
+		assert.Equal(t, http.StatusNotFound, rr.Code, rr.Body.String())
+	}
 }
 
 func TestAccountManagementRBACForeignAccountDoesNotLeakExistence(t *testing.T) {

--- a/backend/api/auth/account_tenant_isolation_test.go
+++ b/backend/api/auth/account_tenant_isolation_test.go
@@ -164,6 +164,31 @@ func TestAccountManagementRoleFilterExcludesForeignRoleAssignment(t *testing.T) 
 	assert.Equal(t, 1, len(ids))
 }
 
+func TestAccountManagementRoleFilterExcludesStaleOrganizationRoleAssignment(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	account := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-role-stale")
+	role := testpkg.CreateTestRoleForTenant(t, e.tc.db, "account-scope-role-stale", e.tenantID)
+	organizationID, staleSchoolID := e.createSchoolInOwnOrganization(t)
+
+	_, err := e.tc.db.ExecContext(context.Background(),
+		"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
+		account.ID, role.ID, staleSchoolID)
+	require.NoError(t, err)
+
+	claims := e.claims
+	claims.Scope = tenant.ScopeOrg
+	claims.OrgID = organizationID
+	rr := e.execute(t, claims, http.MethodGet, "/auth/accounts/by-role/"+role.Name, nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response struct {
+		Data []authAPI.AccountResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+	assert.NotContains(t, accountIDs(response.Data), account.ID)
+}
+
 func TestAccountManagementDirectPermissionsStayWithinTenant(t *testing.T) {
 	t.Parallel()
 	e := newAccountIsolationEnv(t)

--- a/backend/api/auth/account_tenant_isolation_test.go
+++ b/backend/api/auth/account_tenant_isolation_test.go
@@ -1,0 +1,261 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authAPI "github.com/moto-nrw/project-phoenix/api/auth"
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	authService "github.com/moto-nrw/project-phoenix/services/auth"
+	"github.com/moto-nrw/project-phoenix/tenant"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+type accountIsolationEnv struct {
+	tc              *testContext
+	router          chi.Router
+	tenantID        int64
+	foreignTenantID int64
+	claims          jwt.AppClaims
+}
+
+func newAccountIsolationEnv(t *testing.T) *accountIsolationEnv {
+	t.Helper()
+	tc := setupTestContext(t)
+	router := testutil.NewTenantRouter(tc.db)
+	router.Mount("/auth", tc.resource.Router())
+	tenantID := testpkg.Tenant(t)
+	actor := testpkg.CreateTestAccount(t, tc.db, "account-scope-actor")
+	foreignTenantID, _ := testpkg.CreateTestTenant(t, tc.db)
+	return &accountIsolationEnv{
+		tc:              tc,
+		router:          router,
+		tenantID:        tenantID,
+		foreignTenantID: foreignTenantID,
+		claims:          testutil.AdminTestClaimsForTenant(int(actor.ID), tenantID),
+	}
+}
+
+func (e *accountIsolationEnv) accountForTenant(t *testing.T, prefix string, tenantID int64) (int64, string) {
+	t.Helper()
+	account := testpkg.CreateTestAccount(t, e.tc.db, prefix)
+	testpkg.UnclaimTestAccount(t, e.tc.db, account.ID)
+	testpkg.MapAccountToTenant(t, e.tc.db, account.ID, tenantID)
+	return account.ID, account.Email
+}
+
+func (e *accountIsolationEnv) foreignAccount(t *testing.T, prefix string) (int64, string) {
+	t.Helper()
+	return e.accountForTenant(t, prefix, e.foreignTenantID)
+}
+
+func (e *accountIsolationEnv) missingAccountID(t *testing.T) int64 {
+	t.Helper()
+	account := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-missing")
+	_, err := e.tc.db.NewDelete().TableExpr("auth.accounts").Where("id = ?", account.ID).Exec(context.Background())
+	require.NoError(t, err)
+	return account.ID
+}
+
+func (e *accountIsolationEnv) execute(t *testing.T, claims jwt.AppClaims, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	req := testutil.NewJSONRequest(t, method, path, body)
+	return testutil.ExecuteWithAuth(t, e.router, req, claims)
+}
+
+func (e *accountIsolationEnv) listAccounts(t *testing.T, claims jwt.AppClaims) []authAPI.AccountResponse {
+	t.Helper()
+	rr := e.execute(t, claims, http.MethodGet, "/auth/accounts", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var response struct {
+		Data []authAPI.AccountResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	return response.Data
+}
+
+func accountIDs(accounts []authAPI.AccountResponse) []int64 {
+	ids := make([]int64, 0, len(accounts))
+	for _, account := range accounts {
+		ids = append(ids, account.ID)
+	}
+	return ids
+}
+
+func TestAccountManagementOwnTenantAllowed(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	account := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-local")
+
+	got, err := e.tc.services.Auth.GetAccountByID(tenant.WithTenantID(context.Background(), e.tenantID), int(account.ID))
+	require.NoError(t, err)
+	assert.Equal(t, account.ID, got.ID)
+
+	updatedEmail := fmt.Sprintf("account-scope-updated-%d@example.test", account.ID)
+	assertAccountActionStatus(t, e, e.claims, http.MethodPut, fmt.Sprintf("/auth/accounts/%d", account.ID), map[string]string{"email": updatedEmail}, http.StatusNoContent)
+	assertAccountActionStatus(t, e, e.claims, http.MethodPut, fmt.Sprintf("/auth/accounts/%d/deactivate", account.ID), nil, http.StatusNoContent)
+	assertAccountActionStatus(t, e, e.claims, http.MethodPut, fmt.Sprintf("/auth/accounts/%d/activate", account.ID), nil, http.StatusNoContent)
+
+	assert.Contains(t, e.listAccounts(t, e.claims), authAPI.AccountResponse{ID: account.ID, Email: updatedEmail, Active: true})
+}
+
+func assertAccountActionStatus(t *testing.T, e *accountIsolationEnv, claims jwt.AppClaims, method, path string, body any, status int) {
+	t.Helper()
+	rr := e.execute(t, claims, method, path, body)
+	require.Equal(t, status, rr.Code, rr.Body.String())
+}
+
+func TestAccountManagementForeignAccountsAbsentFromList(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, _ := e.foreignAccount(t, "account-scope-list-foreign")
+	local := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-list-local")
+
+	ids := accountIDs(e.listAccounts(t, e.claims))
+	assert.Contains(t, ids, local.ID)
+	assert.NotContains(t, ids, foreignID)
+}
+
+func TestAccountManagementForeignGetDoesNotLeakExistence(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, _ := e.foreignAccount(t, "account-scope-get-foreign")
+	missingID := e.missingAccountID(t)
+	ctx := tenant.WithTenantID(context.Background(), e.tenantID)
+
+	_, foreignErr := e.tc.services.Auth.GetAccountByID(ctx, int(foreignID))
+	_, missingErr := e.tc.services.Auth.GetAccountByID(ctx, int(missingID))
+	require.ErrorIs(t, foreignErr, authService.ErrAccountNotFound)
+	require.ErrorIs(t, missingErr, authService.ErrAccountNotFound)
+	assert.Equal(t, missingErr.Error(), foreignErr.Error())
+}
+
+func TestAccountManagementForeignUpdateDoesNotLeakExistence(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, originalEmail := e.foreignAccount(t, "account-scope-update-foreign")
+	body := map[string]string{"email": fmt.Sprintf("stolen-%d@example.test", foreignID)}
+	assertSameNotFoundResponse(t, e,
+		http.MethodPut, fmt.Sprintf("/auth/accounts/%d", foreignID),
+		http.MethodPut, fmt.Sprintf("/auth/accounts/%d", e.missingAccountID(t)), body)
+
+	var email string
+	require.NoError(t, e.tc.db.NewSelect().Column("email").TableExpr("auth.accounts").Where("id = ?", foreignID).Scan(context.Background(), &email))
+	assert.Equal(t, originalEmail, email)
+}
+
+func TestAccountManagementForeignDeactivateDoesNotLeakExistence(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, _ := e.foreignAccount(t, "account-scope-deactivate-foreign")
+	assertSameNotFoundResponse(t, e,
+		http.MethodPut, fmt.Sprintf("/auth/accounts/%d/deactivate", foreignID),
+		http.MethodPut, fmt.Sprintf("/auth/accounts/%d/deactivate", e.missingAccountID(t)), nil)
+	assert.True(t, e.accountActive(t, foreignID))
+}
+
+func TestAccountManagementForeignActivateDoesNotLeakExistence(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, _ := e.foreignAccount(t, "account-scope-activate-foreign")
+	_, err := e.tc.db.NewUpdate().TableExpr("auth.accounts").Set("active = false").Where("id = ?", foreignID).Exec(context.Background())
+	require.NoError(t, err)
+
+	assertSameNotFoundResponse(t, e,
+		http.MethodPut, fmt.Sprintf("/auth/accounts/%d/activate", foreignID),
+		http.MethodPut, fmt.Sprintf("/auth/accounts/%d/activate", e.missingAccountID(t)), nil)
+	assert.False(t, e.accountActive(t, foreignID))
+}
+
+func assertSameNotFoundResponse(t *testing.T, e *accountIsolationEnv, foreignMethod, foreignPath, missingMethod, missingPath string, body any) {
+	t.Helper()
+	foreign := e.execute(t, e.claims, foreignMethod, foreignPath, body)
+	missing := e.execute(t, e.claims, missingMethod, missingPath, body)
+	assert.Equal(t, http.StatusNotFound, foreign.Code, foreign.Body.String())
+	assert.Equal(t, missing.Code, foreign.Code)
+	assert.JSONEq(t, missing.Body.String(), foreign.Body.String())
+}
+
+func (e *accountIsolationEnv) accountActive(t *testing.T, accountID int64) bool {
+	t.Helper()
+	var active bool
+	err := e.tc.db.NewSelect().Column("active").TableExpr("auth.accounts").Where("id = ?", accountID).Scan(context.Background(), &active)
+	require.NoError(t, err)
+	return active
+}
+
+func TestAccountManagementInactiveMembershipDenied(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	account := testpkg.CreateTestAccount(t, e.tc.db, "account-scope-inactive")
+	_, err := e.tc.db.NewUpdate().TableExpr("auth.account_tenants").Set("status = 'inactive'").Where("account_id = ?", account.ID).Where("tenant_id = ?", e.tenantID).Exec(context.Background())
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenantID(context.Background(), e.tenantID)
+	_, err = e.tc.services.Auth.GetAccountByID(ctx, int(account.ID))
+	require.ErrorIs(t, err, authService.ErrAccountNotFound)
+	assert.NotContains(t, accountIDs(e.listAccounts(t, e.claims)), account.ID)
+	assertAccountActionStatus(t, e, e.claims, http.MethodPut, fmt.Sprintf("/auth/accounts/%d", account.ID), map[string]string{"email": account.Email}, http.StatusNotFound)
+}
+
+func TestAccountManagementOrganizationScopeStaysWithinOrganization(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	organizationID, schoolID := e.createSchoolInOwnOrganization(t)
+	sameOrgID, _ := e.accountForTenant(t, "account-scope-org-local", schoolID)
+	foreignID, _ := e.foreignAccount(t, "account-scope-org-foreign")
+	ctx := tenant.WithScope(tenant.WithOrgID(context.Background(), organizationID), tenant.ScopeOrg)
+
+	got, err := e.tc.services.Auth.GetAccountByID(ctx, int(sameOrgID))
+	require.NoError(t, err)
+	assert.Equal(t, sameOrgID, got.ID)
+	_, err = e.tc.services.Auth.GetAccountByID(ctx, int(foreignID))
+	require.ErrorIs(t, err, authService.ErrAccountNotFound)
+
+	claims := e.claims
+	claims.Scope = tenant.ScopeOrg
+	claims.OrgID = organizationID
+	ids := accountIDs(e.listAccounts(t, claims))
+	assert.Contains(t, ids, sameOrgID)
+	assert.NotContains(t, ids, foreignID)
+}
+
+func (e *accountIsolationEnv) createSchoolInOwnOrganization(t *testing.T) (int64, int64) {
+	t.Helper()
+	var organizationID int64
+	require.NoError(t, e.tc.db.NewSelect().Column("organization_id").TableExpr("platform.schools").Where("id = ?", e.tenantID).Scan(context.Background(), &organizationID))
+	schoolID := testpkg.UniqueTestTenantID(t)
+	token := fmt.Sprintf("account-scope-org-%d", schoolID)
+	_, err := e.tc.db.ExecContext(context.Background(), `
+		INSERT INTO platform.schools (id, organization_id, name, slug, subdomain, active)
+		VALUES (?, ?, ?, ?, ?, true)`, schoolID, organizationID, token, token, token)
+	require.NoError(t, err)
+	return organizationID, schoolID
+}
+
+func TestAccountManagementPlatformScopeRemainsGlobal(t *testing.T) {
+	t.Parallel()
+	e := newAccountIsolationEnv(t)
+	foreignID, _ := e.foreignAccount(t, "account-scope-platform")
+	ctx := tenant.WithScope(context.Background(), tenant.ScopePlatform)
+
+	got, err := e.tc.services.Auth.GetAccountByID(ctx, int(foreignID))
+	require.NoError(t, err)
+	assert.Equal(t, foreignID, got.ID)
+	require.NoError(t, e.tc.services.Auth.DeactivateAccount(ctx, int(foreignID)))
+	require.NoError(t, e.tc.services.Auth.ActivateAccount(ctx, int(foreignID)))
+
+	claims := e.claims
+	claims.Scope = tenant.ScopePlatform
+	claims.TenantID = 0
+	assert.Contains(t, accountIDs(e.listAccounts(t, claims)), foreignID)
+}

--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -225,8 +225,8 @@ func (rs *Resource) Router() chi.Router {
 				r.Route("/{accountId}", func(r chi.Router) {
 					// Account update operations
 					r.With(authorize.RequiresPermission(permUsersUpdate)).Put("/", rs.updateAccount)
-					r.With(authorize.RequiresPermission(permUsersUpdate)).Put("/activate", common.IDAction("accountId", common.MsgInvalidAccountID, rs.AuthService.ActivateAccount, common.ErrorInternalServer))
-					r.With(authorize.RequiresPermission(permUsersUpdate)).Put("/deactivate", common.IDAction("accountId", common.MsgInvalidAccountID, rs.AuthService.DeactivateAccount, common.ErrorInternalServer))
+					r.With(authorize.RequiresPermission(permUsersUpdate)).Put("/activate", common.IDAction("accountId", common.MsgInvalidAccountID, rs.AuthService.ActivateAccount, accountManagementErrorRenderer))
+					r.With(authorize.RequiresPermission(permUsersUpdate)).Put("/deactivate", common.IDAction("accountId", common.MsgInvalidAccountID, rs.AuthService.DeactivateAccount, accountManagementErrorRenderer))
 					r.With(authorize.RequiresPermission(permUsersManage)).Get("/caregiver-capability", rs.getCaregiverCapability)
 					r.With(authorize.RequiresPermission(permUsersManage)).Post("/caregiver-capability", rs.enableCaregiverCapability)
 					r.With(authorize.RequiresPermission(permUsersManage)).Delete("/caregiver-capability", rs.disableCaregiverCapability)

--- a/backend/api/auth/api.go
+++ b/backend/api/auth/api.go
@@ -235,16 +235,16 @@ func (rs *Resource) Router() chi.Router {
 					r.Route("/roles", func(r chi.Router) {
 						r.With(authorize.RequiresPermission(permUsersManage)).Get("/", rs.getAccountRoles)
 						r.With(authorize.RequiresPermission(permUsersManage)).Post("/{roleId}", rs.assignRoleToAccount)
-						r.With(authorize.RequiresPermission(permUsersManage)).Delete("/{roleId}", common.TwoIDAction("accountId", common.MsgInvalidAccountID, "roleId", common.MsgInvalidRoleID, rs.AuthService.RemoveRoleFromAccount, common.ErrorInternalServer))
+						r.With(authorize.RequiresPermission(permUsersManage)).Delete("/{roleId}", common.TwoIDAction("accountId", common.MsgInvalidAccountID, "roleId", common.MsgInvalidRoleID, rs.AuthService.RemoveRoleFromAccount, accountManagementErrorRenderer))
 					})
 
 					// Permission assignments
 					r.Route(pathPermissions, func(r chi.Router) {
 						r.With(authorize.RequiresPermission(permUsersManage)).Get("/", rs.getAccountPermissions)
 						r.With(authorize.RequiresPermission(permUsersManage)).Get("/direct", rs.getAccountDirectPermissions)
-						r.With(authorize.RequiresPermission(permUsersManage)).Post(pathPermissionID+"/grant", common.TwoIDAction("accountId", common.MsgInvalidAccountID, "permissionId", common.MsgInvalidPermissionID, rs.AuthService.GrantPermissionToAccount, common.ErrorInternalServer))
-						r.With(authorize.RequiresPermission(permUsersManage)).Post(pathPermissionID+"/deny", common.TwoIDAction("accountId", common.MsgInvalidAccountID, "permissionId", common.MsgInvalidPermissionID, rs.AuthService.DenyPermissionToAccount, common.ErrorInternalServer))
-						r.With(authorize.RequiresPermission(permUsersManage)).Delete(pathPermissionID, common.TwoIDAction("accountId", common.MsgInvalidAccountID, "permissionId", common.MsgInvalidPermissionID, rs.AuthService.RemovePermissionFromAccount, common.ErrorInternalServer))
+						r.With(authorize.RequiresPermission(permUsersManage)).Post(pathPermissionID+"/grant", common.TwoIDAction("accountId", common.MsgInvalidAccountID, "permissionId", common.MsgInvalidPermissionID, rs.AuthService.GrantPermissionToAccount, accountManagementErrorRenderer))
+						r.With(authorize.RequiresPermission(permUsersManage)).Post(pathPermissionID+"/deny", common.TwoIDAction("accountId", common.MsgInvalidAccountID, "permissionId", common.MsgInvalidPermissionID, rs.AuthService.DenyPermissionToAccount, accountManagementErrorRenderer))
+						r.With(authorize.RequiresPermission(permUsersManage)).Delete(pathPermissionID, common.TwoIDAction("accountId", common.MsgInvalidAccountID, "permissionId", common.MsgInvalidPermissionID, rs.AuthService.RemovePermissionFromAccount, accountManagementErrorRenderer))
 					})
 
 					// Token management

--- a/backend/api/auth/auth_test.go
+++ b/backend/api/auth/auth_test.go
@@ -29,6 +29,7 @@ import (
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	"github.com/moto-nrw/project-phoenix/services"
 	platformSvc "github.com/moto-nrw/project-phoenix/services/platform"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	testpkg "github.com/moto-nrw/project-phoenix/test"
 )
 
@@ -1183,11 +1184,10 @@ func TestPermissionManagement(t *testing.T) {
 // TestAccountManagement tests account management endpoints (protected)
 func TestAccountManagement(t *testing.T) {
 	t.Parallel()
-	tc, router := setupProtectedRouter(t)
+	_, router := setupProtectedRouter(t)
 
-	tenantID := testpkg.Tenant(t)
-	account := testpkg.CreateTestAccount(t, tc.db, "account-management-list")
-	adminClaims := testutil.AdminTestClaimsForTenant(1, tenantID)
+	adminClaims := testutil.AdminTestClaims(1)
+	adminClaims.Scope = tenant.ScopePlatform
 
 	t.Run("list accounts with permission", func(t *testing.T) {
 		req := testutil.NewJSONRequest(t, "GET", "/auth/accounts", nil)
@@ -1198,10 +1198,7 @@ func TestAccountManagement(t *testing.T) {
 		response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
 		data, ok := response["data"].([]interface{})
 		require.True(t, ok, "Expected data to be an array")
-		require.Len(t, data, 1)
-		listed, ok := data[0].(map[string]interface{})
-		require.True(t, ok, "Expected account data to be an object")
-		assert.Equal(t, float64(account.ID), listed["id"])
+		assert.NotEmpty(t, data, "Expected at least one account")
 	})
 
 	t.Run("list accounts forbidden without permission", func(t *testing.T) {

--- a/backend/api/auth/auth_test.go
+++ b/backend/api/auth/auth_test.go
@@ -1183,9 +1183,11 @@ func TestPermissionManagement(t *testing.T) {
 // TestAccountManagement tests account management endpoints (protected)
 func TestAccountManagement(t *testing.T) {
 	t.Parallel()
-	_, router := setupProtectedRouter(t)
+	tc, router := setupProtectedRouter(t)
 
-	adminClaims := testutil.AdminTestClaims(1)
+	tenantID := testpkg.Tenant(t)
+	account := testpkg.CreateTestAccount(t, tc.db, "account-management-list")
+	adminClaims := testutil.AdminTestClaimsForTenant(1, tenantID)
 
 	t.Run("list accounts with permission", func(t *testing.T) {
 		req := testutil.NewJSONRequest(t, "GET", "/auth/accounts", nil)
@@ -1196,7 +1198,10 @@ func TestAccountManagement(t *testing.T) {
 		response := testutil.ParseJSONResponse(t, rr.Body.Bytes())
 		data, ok := response["data"].([]interface{})
 		require.True(t, ok, "Expected data to be an array")
-		assert.NotEmpty(t, data, "Expected at least one account")
+		require.Len(t, data, 1)
+		listed, ok := data[0].(map[string]interface{})
+		require.True(t, ok, "Expected account data to be an object")
+		assert.Equal(t, float64(account.ID), listed["id"])
 	})
 
 	t.Run("list accounts forbidden without permission", func(t *testing.T) {

--- a/backend/api/auth/auth_test.go
+++ b/backend/api/auth/auth_test.go
@@ -1482,7 +1482,9 @@ func TestAccountPermissionManagement(t *testing.T) {
 	t.Run("deny permission endpoint responds", func(t *testing.T) {
 		// Note: Deny permission has a known database schema issue
 		// This test just verifies the endpoint is accessible
-		req := testutil.NewJSONRequest(t, "POST", "/auth/accounts/1/permissions/1/deny", nil)
+		account := testpkg.CreateTestAccount(t, tc.db, fmt.Sprintf("denyperm%d", time.Now().UnixNano()))
+		permission := testpkg.CreateTestPermission(t, tc.db, "DenyToAcc", "test", "read")
+		req := testutil.NewJSONRequest(t, "POST", fmt.Sprintf("/auth/accounts/%d/permissions/%d/deny", account.ID, permission.ID), nil)
 		rr := testutil.ExecuteWithAuthPermissions(t, router, req, adminClaims, []string{"users:manage"})
 		// Accept 204 (success) or 500 (known schema issue)
 		assert.True(t, rr.Code == http.StatusNoContent || rr.Code == http.StatusInternalServerError,

--- a/backend/api/auth/rbac_handlers.go
+++ b/backend/api/auth/rbac_handlers.go
@@ -176,7 +176,7 @@ func (rs *Resource) getAccountRoles(w http.ResponseWriter, r *http.Request) {
 
 	roles, err := rs.AuthService.GetAccountRoles(r.Context(), accountID)
 	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, accountManagementErrorRenderer(err))
 		return
 	}
 
@@ -234,7 +234,7 @@ func (rs *Resource) assignRoleToAccount(w http.ResponseWriter, r *http.Request) 
 			common.RenderError(w, r, common.ErrorInvalidRequest(err))
 			return
 		}
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, accountManagementErrorRenderer(err))
 		return
 	}
 
@@ -390,7 +390,7 @@ func (rs *Resource) getAccountPermissions(w http.ResponseWriter, r *http.Request
 
 	permissions, err := rs.AuthService.GetAccountPermissions(r.Context(), accountID)
 	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, accountManagementErrorRenderer(err))
 		return
 	}
 
@@ -420,7 +420,7 @@ func (rs *Resource) getAccountDirectPermissions(w http.ResponseWriter, r *http.R
 
 	permissions, err := rs.AuthService.GetAccountDirectPermissions(r.Context(), accountID)
 	if err != nil {
-		common.RenderError(w, r, common.ErrorInternalServer(err))
+		common.RenderError(w, r, accountManagementErrorRenderer(err))
 		return
 	}
 

--- a/backend/database/repositories/auth/account_repository_test.go
+++ b/backend/database/repositories/auth/account_repository_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -215,6 +216,63 @@ func TestAccountRepository_List(t *testing.T) {
 		accounts, err := repo.List(ctx, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, accounts)
+	})
+}
+
+func TestAccountRepository_FindByRole(t *testing.T) {
+	t.Parallel()
+
+	db := testpkg.SetupTestDB(t)
+
+	repo := repositories.NewFactory(db).Account
+	ctx := testpkg.Ctx(t)
+
+	t.Run("finds accounts by role name", func(t *testing.T) {
+		account := testpkg.CreateTestAccount(t, db, "findbyrole")
+		role := testpkg.CreateTestRole(t, db, "FindByRoleTestRole")
+		defer cleanupAccountRecords(t, db, account.ID)
+		defer testpkg.CleanupRoleRecords(t, db, role.ID)
+
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
+			account.ID, role.ID, testpkg.Tenant(t))
+		require.NoError(t, err)
+
+		accounts, err := repo.FindByRole(ctx, role.Name)
+		require.NoError(t, err)
+		assert.NotEmpty(t, accounts)
+
+		var found bool
+		for _, a := range accounts {
+			if a.ID == account.ID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "Account should be found by role")
+	})
+
+	t.Run("finds accounts by role name case insensitive", func(t *testing.T) {
+		account := testpkg.CreateTestAccount(t, db, "rolecase")
+		role := testpkg.CreateTestRole(t, db, "CaseSensitiveRole")
+		defer cleanupAccountRecords(t, db, account.ID)
+		defer testpkg.CleanupRoleRecords(t, db, role.ID)
+
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
+			account.ID, role.ID, testpkg.Tenant(t))
+		require.NoError(t, err)
+
+		upperRoleName := strings.ToUpper(role.Name)
+		accounts, err := repo.FindByRole(ctx, upperRoleName)
+		require.NoError(t, err)
+		assert.NotEmpty(t, accounts)
+	})
+
+	t.Run("returns empty slice for non-existent role", func(t *testing.T) {
+		accounts, err := repo.FindByRole(ctx, "NonExistentRoleName12345")
+		require.NoError(t, err)
+		assert.Empty(t, accounts)
 	})
 }
 

--- a/backend/database/repositories/auth/account_repository_test.go
+++ b/backend/database/repositories/auth/account_repository_test.go
@@ -2,7 +2,6 @@ package auth_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -216,67 +215,6 @@ func TestAccountRepository_List(t *testing.T) {
 		accounts, err := repo.List(ctx, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, accounts)
-	})
-}
-
-func TestAccountRepository_FindByRole(t *testing.T) {
-	t.Parallel()
-
-	db := testpkg.SetupTestDB(t)
-
-	repo := repositories.NewFactory(db).Account
-	ctx := testpkg.Ctx(t)
-
-	t.Run("finds accounts by role name", func(t *testing.T) {
-		// Create account and role
-		account := testpkg.CreateTestAccount(t, db, "findbyrole")
-		role := testpkg.CreateTestRole(t, db, "FindByRoleTestRole")
-		defer cleanupAccountRecords(t, db, account.ID)
-		defer testpkg.CleanupRoleRecords(t, db, role.ID)
-
-		// Assign role to account
-		_, err := db.ExecContext(ctx,
-			"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
-			account.ID, role.ID, testpkg.Tenant(t))
-		require.NoError(t, err)
-
-		// Find by role
-		accounts, err := repo.FindByRole(ctx, role.Name)
-		require.NoError(t, err)
-		assert.NotEmpty(t, accounts)
-
-		var found bool
-		for _, a := range accounts {
-			if a.ID == account.ID {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found, "Account should be found by role")
-	})
-
-	t.Run("finds accounts by role name case insensitive", func(t *testing.T) {
-		account := testpkg.CreateTestAccount(t, db, "rolecase")
-		role := testpkg.CreateTestRole(t, db, "CaseSensitiveRole")
-		defer cleanupAccountRecords(t, db, account.ID)
-		defer testpkg.CleanupRoleRecords(t, db, role.ID)
-
-		_, err := db.ExecContext(ctx,
-			"INSERT INTO auth.account_roles (account_id, role_id, tenant_id) VALUES (?, ?, ?)",
-			account.ID, role.ID, testpkg.Tenant(t))
-		require.NoError(t, err)
-
-		// Search with the actual role name in uppercase to verify case insensitivity
-		upperRoleName := strings.ToUpper(role.Name)
-		accounts, err := repo.FindByRole(ctx, upperRoleName)
-		require.NoError(t, err)
-		assert.NotEmpty(t, accounts)
-	})
-
-	t.Run("returns empty slice for non-existent role", func(t *testing.T) {
-		accounts, err := repo.FindByRole(ctx, "NonExistentRoleName12345")
-		require.NoError(t, err)
-		assert.Empty(t, accounts)
 	})
 }
 

--- a/backend/database/repositories/auth/account_repository_unit_test.go
+++ b/backend/database/repositories/auth/account_repository_unit_test.go
@@ -2,11 +2,13 @@ package auth_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	authrepo "github.com/moto-nrw/project-phoenix/database/repositories/auth"
+	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +56,29 @@ func TestAccountRepository_UpdateAvatar_ReturnsDatabaseError(t *testing.T) {
 	require.ErrorAs(t, err, &dbErr)
 	assert.Equal(t, "update columns", dbErr.Op)
 	assert.EqualError(t, dbErr.Err, "update failed")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAccountRepository_UpdateManageable_NoMatchingMembershipIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+
+	db := bun.NewDB(sqlDB, pgdialect.New())
+	repo := authrepo.NewAccountRepository(db)
+	account := &authModel.Account{
+		Model:  modelBase.Model{ID: 42},
+		Email:  "revoked@example.test",
+		Active: true,
+	}
+
+	mock.ExpectExec(`UPDATE auth\.accounts AS "account" SET`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = repo.UpdateManageable(context.Background(), account)
+	require.ErrorIs(t, err, sql.ErrNoRows)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -853,6 +853,15 @@ func (r *AccountRepository) update(ctx context.Context, account *auth.Account, m
 			Err: err,
 		}
 	}
+	if manageable {
+		affected, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return &modelBase.DatabaseError{Op: "update account", Err: rowsErr}
+		}
+		if affected == 0 {
+			return &modelBase.DatabaseError{Op: "update account", Err: sql.ErrNoRows}
+		}
+	}
 	return base.AssertRowsAffected(result, 1, "update account")
 }
 

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -550,7 +550,8 @@ func (r *AccountRepository) applyRoleFilter(ctx context.Context, query *bun.Sele
 		query = query.
 			Join(`JOIN auth.account_roles AS "account_role" ON "account_role".account_id = "account".id`).
 			Join(`JOIN auth.roles AS "role" ON "account_role".role_id = "role".id`).
-			Where(`LOWER("role".name) = LOWER(?)`, strValue)
+			Where(`LOWER("role".name) = LOWER(?)`, strValue).
+			Distinct()
 		if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
 			return query
 		}

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -475,6 +475,12 @@ func (r *AccountRepository) ListManageable(ctx context.Context, filters map[stri
 	return r.list(ctx, filters, true)
 }
 
+// FindByRole retrieves manageable accounts that hold a named role in the
+// caller's tenant or organization.
+func (r *AccountRepository) FindByRole(ctx context.Context, role string) ([]*auth.Account, error) {
+	return r.list(ctx, map[string]interface{}{"role": role}, true)
+}
+
 func (r *AccountRepository) list(ctx context.Context, filters map[string]interface{}, manageable bool) ([]*auth.Account, error) {
 	var accounts []*auth.Account
 	query := base.GetDB(ctx, r.db).NewSelect().Model(&accounts).ModelTableExpr(accountTableAlias)
@@ -487,7 +493,7 @@ func (r *AccountRepository) list(ctx context.Context, filters map[string]interfa
 	// Apply filters
 	for field, value := range filters {
 		if value != nil {
-			query = r.applyAccountFilter(query, field, value)
+			query = r.applyAccountFilter(ctx, query, field, value)
 		}
 	}
 
@@ -503,7 +509,7 @@ func (r *AccountRepository) list(ctx context.Context, filters map[string]interfa
 }
 
 // applyAccountFilter applies a single filter to the query
-func (r *AccountRepository) applyAccountFilter(query *bun.SelectQuery, field string, value interface{}) *bun.SelectQuery {
+func (r *AccountRepository) applyAccountFilter(ctx context.Context, query *bun.SelectQuery, field string, value interface{}) *bun.SelectQuery {
 	switch field {
 	case "email":
 		return r.applyStringEqualFilter(query, "email", value)
@@ -516,7 +522,7 @@ func (r *AccountRepository) applyAccountFilter(query *bun.SelectQuery, field str
 	case "active":
 		return query.Where("active = ?", value)
 	case "role":
-		return r.applyRoleFilter(query, value)
+		return r.applyRoleFilter(ctx, query, value)
 	default:
 		return query.Where("? = ?", bun.Ident(field), value)
 	}
@@ -539,12 +545,30 @@ func (r *AccountRepository) applyStringLikeFilter(query *bun.SelectQuery, field 
 }
 
 // applyRoleFilter applies role-based filtering
-func (r *AccountRepository) applyRoleFilter(query *bun.SelectQuery, value interface{}) *bun.SelectQuery {
+func (r *AccountRepository) applyRoleFilter(ctx context.Context, query *bun.SelectQuery, value interface{}) *bun.SelectQuery {
 	if strValue, ok := value.(string); ok {
-		return query.
-			Join("JOIN auth.account_roles ar ON ar.account_id = account.id").
-			Join("JOIN auth.roles r ON ar.role_id = r.id").
-			Where("LOWER(r.name) = LOWER(?)", strValue)
+		query = query.
+			Join(`JOIN auth.account_roles AS "account_role" ON "account_role".account_id = "account".id`).
+			Join(`JOIN auth.roles AS "role" ON "account_role".role_id = "role".id`).
+			Where(`LOWER("role".name) = LOWER(?)`, strValue)
+		if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
+			return query
+		}
+		if tenant.ScopeFromContext(ctx) == tenant.ScopeOrg {
+			organizationID := tenant.OrgFromContext(ctx)
+			if organizationID == 0 {
+				return query.Where("FALSE")
+			}
+			return query.
+				Join(`INNER JOIN platform.schools AS "role_school" ON "role_school".id = "account_role".tenant_id`).
+				Where(`"role_school".organization_id = ?`, organizationID).
+				Where(`"role_school".active = TRUE`).
+				Where(`"role_school".deleted_at IS NULL`)
+		}
+		if tenantID := tenant.FromContext(ctx); tenantID > 0 {
+			return query.Where(`"account_role".tenant_id = ?`, tenantID)
+		}
+		return query.Where("FALSE")
 	}
 	return query
 }

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -464,30 +464,6 @@ func (r *AccountRepository) UpdateAvatar(ctx context.Context, id int64, avatar s
 	return err
 }
 
-// FindByRole retrieves accounts that have a specific role
-func (r *AccountRepository) FindByRole(ctx context.Context, role string) ([]*auth.Account, error) {
-	var accounts []*auth.Account
-
-	// Use a SQL JOIN to retrieve accounts with the specified role
-	// This assumes your account_roles table exists and has the proper foreign keys
-	err := base.GetDB(ctx, r.db).NewSelect().
-		Model(&accounts).
-		ModelTableExpr(accountTableAlias).
-		Join(`JOIN auth.account_roles ar ON ar.account_id = "account".id`).
-		Join(`JOIN auth.roles r ON ar.role_id = r.id`).
-		Where("LOWER(r.name) = LOWER(?)", role).
-		Scan(ctx)
-
-	if err != nil {
-		return nil, &modelBase.DatabaseError{
-			Op:  "find by role",
-			Err: err,
-		}
-	}
-
-	return accounts, nil
-}
-
 // List retrieves accounts matching the provided filters without applying an
 // account-management boundary. Internal authentication flows remain global.
 func (r *AccountRepository) List(ctx context.Context, filters map[string]interface{}) ([]*auth.Account, error) {

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -562,9 +562,11 @@ func (r *AccountRepository) applyRoleFilter(ctx context.Context, query *bun.Sele
 			}
 			return query.
 				Join(`INNER JOIN platform.schools AS "role_school" ON "role_school".id = "account_role".tenant_id`).
+				Join(`INNER JOIN auth.account_tenants AS "role_account_tenant" ON "role_account_tenant".account_id = "account_role".account_id AND "role_account_tenant".tenant_id = "account_role".tenant_id`).
 				Where(`"role_school".organization_id = ?`, organizationID).
 				Where(`"role_school".active = TRUE`).
-				Where(`"role_school".deleted_at IS NULL`)
+				Where(`"role_school".deleted_at IS NULL`).
+				Where(`"role_account_tenant".status = ?`, auth.AccountTenantStatusActive)
 		}
 		if tenantID := tenant.FromContext(ctx); tenantID > 0 {
 			return query.Where(`"account_role".tenant_id = ?`, tenantID)

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -20,9 +20,6 @@ const (
 )
 
 func accountMembershipScope(ctx context.Context) (string, []any) {
-	if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
-		return "", nil
-	}
 	if tenant.ScopeFromContext(ctx) == tenant.ScopeOrg {
 		organizationID := tenant.OrgFromContext(ctx)
 		if organizationID == 0 {
@@ -38,6 +35,9 @@ func accountMembershipScope(ctx context.Context) (string, []any) {
 			  AND "school".active = TRUE
 			  AND "school".deleted_at IS NULL
 		)`, []any{auth.AccountTenantStatusActive, organizationID}
+	}
+	if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
+		return "", nil
 	}
 
 	tenantID := tenant.FromContext(ctx)
@@ -478,6 +478,15 @@ func (r *AccountRepository) ListManageable(ctx context.Context, filters map[stri
 // FindByRole retrieves manageable accounts that hold a named role in the
 // caller's tenant or organization.
 func (r *AccountRepository) FindByRole(ctx context.Context, role string) ([]*auth.Account, error) {
+	if tenant.ScopeFromContext(ctx) == tenant.ScopeOrg {
+		var accounts []*auth.Account
+		err := tenant.WithAdminTx(modelBase.ContextWithoutTx(ctx), r.db, func(adminCtx context.Context, _ bun.Tx) error {
+			var err error
+			accounts, err = r.list(adminCtx, map[string]interface{}{"role": role}, true)
+			return err
+		})
+		return accounts, err
+	}
 	return r.list(ctx, map[string]interface{}{"role": role}, true)
 }
 
@@ -552,9 +561,6 @@ func (r *AccountRepository) applyRoleFilter(ctx context.Context, query *bun.Sele
 			Join(`JOIN auth.roles AS "role" ON "account_role".role_id = "role".id`).
 			Where(`LOWER("role".name) = LOWER(?)`, strValue).
 			Distinct()
-		if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
-			return query
-		}
 		if tenant.ScopeFromContext(ctx) == tenant.ScopeOrg {
 			organizationID := tenant.OrgFromContext(ctx)
 			if organizationID == 0 {
@@ -567,6 +573,9 @@ func (r *AccountRepository) applyRoleFilter(ctx context.Context, query *bun.Sele
 				Where(`"role_school".active = TRUE`).
 				Where(`"role_school".deleted_at IS NULL`).
 				Where(`"role_account_tenant".status = ?`, auth.AccountTenantStatusActive)
+		}
+		if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
+			return query
 		}
 		if tenantID := tenant.FromContext(ctx); tenantID > 0 {
 			return query.Where(`"account_role".tenant_id = ?`, tenantID)

--- a/backend/database/repositories/auth/accounts.go
+++ b/backend/database/repositories/auth/accounts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/database/repositories/base"
 	"github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
 
@@ -17,6 +18,40 @@ const (
 	accountTable      = "auth.accounts"
 	accountTableAlias = `auth.accounts AS "account"`
 )
+
+func accountMembershipScope(ctx context.Context) (string, []any) {
+	if tenant.IsAdminTx(ctx) || tenant.ScopeFromContext(ctx) == tenant.ScopePlatform {
+		return "", nil
+	}
+	if tenant.ScopeFromContext(ctx) == tenant.ScopeOrg {
+		organizationID := tenant.OrgFromContext(ctx)
+		if organizationID == 0 {
+			return "FALSE", nil
+		}
+		return `EXISTS (
+			SELECT 1
+			FROM auth.account_tenants AS "account_tenant"
+			INNER JOIN platform.schools AS "school" ON "school".id = "account_tenant".tenant_id
+			WHERE "account_tenant".account_id = "account".id
+			  AND "account_tenant".status = ?
+			  AND "school".organization_id = ?
+			  AND "school".active = TRUE
+			  AND "school".deleted_at IS NULL
+		)`, []any{auth.AccountTenantStatusActive, organizationID}
+	}
+
+	tenantID := tenant.FromContext(ctx)
+	if tenantID == 0 {
+		return "FALSE", nil
+	}
+	return `EXISTS (
+		SELECT 1
+		FROM auth.account_tenants AS "account_tenant"
+		WHERE "account_tenant".account_id = "account".id
+		  AND "account_tenant".tenant_id = ?
+		  AND "account_tenant".status = ?
+	)`, []any{tenantID, auth.AccountTenantStatusActive}
+}
 
 // EffectiveAdminExistsSQL builds the SQL predicate that decides whether an
 // account holds effective admin scope within one tenant: the literal admin
@@ -122,6 +157,28 @@ func NewAccountRepository(db *bun.DB) auth.AccountRepository {
 		Repository: base.NewRepository[*auth.Account](db, accountTable, "Account"),
 		db:         db,
 	}
+}
+
+// FindManageableByID restricts account administration to active memberships
+// in the tenant or organization from the caller's context. Platform and admin
+// contexts keep the global lookup used by operator flows.
+func (r *AccountRepository) FindManageableByID(ctx context.Context, id int64) (*auth.Account, error) {
+	predicate, args := accountMembershipScope(ctx)
+	if predicate == "" {
+		return r.FindByID(ctx, id)
+	}
+
+	account := new(auth.Account)
+	err := base.GetDB(ctx, r.db).NewSelect().
+		Model(account).
+		ModelTableExpr(accountTableAlias).
+		Where(`"account".id = ?`, id).
+		Where(predicate, args...).
+		Scan(ctx)
+	if err != nil {
+		return nil, &modelBase.DatabaseError{Op: "find by id", Err: err}
+	}
+	return account, nil
 }
 
 // FindByEmail retrieves an account by email address
@@ -431,10 +488,25 @@ func (r *AccountRepository) FindByRole(ctx context.Context, role string) ([]*aut
 	return accounts, nil
 }
 
-// List retrieves accounts matching the provided filters
+// List retrieves accounts matching the provided filters without applying an
+// account-management boundary. Internal authentication flows remain global.
 func (r *AccountRepository) List(ctx context.Context, filters map[string]interface{}) ([]*auth.Account, error) {
+	return r.list(ctx, filters, false)
+}
+
+// ListManageable lists only accounts the caller may administer.
+func (r *AccountRepository) ListManageable(ctx context.Context, filters map[string]interface{}) ([]*auth.Account, error) {
+	return r.list(ctx, filters, true)
+}
+
+func (r *AccountRepository) list(ctx context.Context, filters map[string]interface{}, manageable bool) ([]*auth.Account, error) {
 	var accounts []*auth.Account
 	query := base.GetDB(ctx, r.db).NewSelect().Model(&accounts).ModelTableExpr(accountTableAlias)
+	if manageable {
+		if predicate, args := accountMembershipScope(ctx); predicate != "" {
+			query = query.Where(predicate, args...)
+		}
+	}
 
 	// Apply filters
 	for field, value := range filters {
@@ -730,8 +802,18 @@ func (r *AccountRepository) mergePermissions(directPermissions, rolePermissions 
 	return allPermissions
 }
 
-// Update overrides the base Update method to handle email normalization
+// Update overrides the base Update method to handle email normalization.
 func (r *AccountRepository) Update(ctx context.Context, account *auth.Account) error {
+	return r.update(ctx, account, false)
+}
+
+// UpdateManageable atomically applies the account-management membership
+// predicate to the write as well as its preceding read.
+func (r *AccountRepository) UpdateManageable(ctx context.Context, account *auth.Account) error {
+	return r.update(ctx, account, true)
+}
+
+func (r *AccountRepository) update(ctx context.Context, account *auth.Account, manageable bool) error {
 	if account == nil {
 		return fmt.Errorf("account cannot be nil")
 	}
@@ -742,19 +824,24 @@ func (r *AccountRepository) Update(ctx context.Context, account *auth.Account) e
 	}
 
 	// Execute the query using GetDB for transaction support
-	_, err := base.GetDB(ctx, r.db).NewUpdate().
+	query := base.GetDB(ctx, r.db).NewUpdate().
 		Model(account).
-		Where(whereID, account.ID).
-		ModelTableExpr(accountTable).
-		Exec(ctx)
+		ModelTableExpr(accountTableAlias).
+		Where(`"account".id = ?`, account.ID)
+	if manageable {
+		if predicate, args := accountMembershipScope(ctx); predicate != "" {
+			query = query.Where(predicate, args...)
+		}
+	}
+
+	result, err := query.Exec(ctx)
 	if err != nil {
 		return &modelBase.DatabaseError{
 			Op:  "update",
 			Err: err,
 		}
 	}
-
-	return nil
+	return base.AssertRowsAffected(result, 1, "update account")
 }
 
 // AnonymizeForDeletion overwrites the account's email with the given

--- a/backend/database/repositories/auth/permission.go
+++ b/backend/database/repositories/auth/permission.go
@@ -173,12 +173,13 @@ func (r *PermissionRepository) FindDirectByAccountID(ctx context.Context, accoun
 	var permissions []*auth.Permission
 
 	// This query gets ONLY direct permissions, not role-based ones
-	err := base.GetDB(ctx, r.db).NewSelect().
+	query := base.GetDB(ctx, r.db).NewSelect().
 		Model(&permissions).
 		ModelTableExpr(permissionTableAlias).
 		Join(`JOIN auth.account_permissions ap ON ap.permission_id = "permission".id`).
-		Where("ap.account_id = ? AND ap.granted = true", accountID).
-		Scan(ctx)
+		Where("ap.account_id = ? AND ap.granted = true", accountID)
+	query = base.WithTenantFilter(ctx, query, "ap")
+	err := query.Scan(ctx)
 
 	if err != nil {
 		return nil, &modelBase.DatabaseError{

--- a/backend/models/auth/repository.go
+++ b/backend/models/auth/repository.go
@@ -30,6 +30,7 @@ type AccountRepository interface {
 	UpdatePassword(ctx context.Context, id int64, passwordHash string) error
 	UpdateAvatar(ctx context.Context, id int64, avatar string) error
 	SetActive(ctx context.Context, id int64, active bool) error
+	FindByRole(ctx context.Context, role string) ([]*Account, error)
 	// ListEffectiveAdminAccountIDs returns the IDs of active accounts with
 	// effective admin scope in the current tenant: the literal admin role, or
 	// an admin:* / *:* permission from a role or granted directly.

--- a/backend/models/auth/repository.go
+++ b/backend/models/auth/repository.go
@@ -10,6 +10,9 @@ import (
 // AccountRepository defines operations for managing accounts
 type AccountRepository interface {
 	base.CRUDRepository[*Account]
+	FindManageableByID(ctx context.Context, id int64) (*Account, error)
+	ListManageable(ctx context.Context, filters map[string]interface{}) ([]*Account, error)
+	UpdateManageable(ctx context.Context, account *Account) error
 	FindByIDForUpdate(ctx context.Context, id int64) (*Account, error)
 	FindByEmail(ctx context.Context, email string) (*Account, error)
 	FindByUsername(ctx context.Context, username string) (*Account, error)

--- a/backend/models/auth/repository.go
+++ b/backend/models/auth/repository.go
@@ -30,7 +30,6 @@ type AccountRepository interface {
 	UpdatePassword(ctx context.Context, id int64, passwordHash string) error
 	UpdateAvatar(ctx context.Context, id int64, avatar string) error
 	SetActive(ctx context.Context, id int64, active bool) error
-	FindByRole(ctx context.Context, role string) ([]*Account, error)
 	// ListEffectiveAdminAccountIDs returns the IDs of active accounts with
 	// effective admin scope in the current tenant: the literal admin role, or
 	// an admin:* / *:* permission from a role or granted directly.

--- a/backend/services/auth/account_management.go
+++ b/backend/services/auth/account_management.go
@@ -12,13 +12,13 @@ import (
 
 // ActivateAccount activates a user account
 func (s *Service) ActivateAccount(ctx context.Context, accountID int) error {
-	account, err := s.repos.Account.FindByID(ctx, int64(accountID))
+	account, err := s.repos.Account.FindManageableByID(ctx, int64(accountID))
 	if err != nil {
 		return &AuthError{Op: "activate account", Err: ErrAccountNotFound}
 	}
 
 	account.Active = true
-	if err := s.repos.Account.Update(ctx, account); err != nil {
+	if err := s.repos.Account.UpdateManageable(ctx, account); err != nil {
 		return &AuthError{Op: "activate account", Err: err}
 	}
 
@@ -57,12 +57,12 @@ func (s *Service) markPendingWipeCompletedIndependently(ctx context.Context, acc
 // DeactivateAccount deactivates a user account
 func (s *Service) DeactivateAccount(ctx context.Context, accountID int) error {
 	err := s.runInTx(ctx, func(txCtx context.Context) error {
-		account, err := s.repos.Account.FindByID(txCtx, int64(accountID))
+		account, err := s.repos.Account.FindManageableByID(txCtx, int64(accountID))
 		if err != nil {
 			return &AuthError{Op: "deactivate account", Err: ErrAccountNotFound}
 		}
 		account.Active = false
-		if err := s.repos.Account.Update(txCtx, account); err != nil {
+		if err := s.repos.Account.UpdateManageable(txCtx, account); err != nil {
 			return &AuthError{Op: "deactivate account", Err: err}
 		}
 		return nil
@@ -79,7 +79,7 @@ func (s *Service) DeactivateAccount(ctx context.Context, accountID int) error {
 // UpdateAccount updates account information
 func (s *Service) UpdateAccount(ctx context.Context, account *auth.Account) error {
 	// Verify account exists
-	existing, err := s.repos.Account.FindByID(ctx, account.ID)
+	existing, err := s.repos.Account.FindManageableByID(ctx, account.ID)
 	if err != nil {
 		return &AuthError{Op: opUpdateAccount, Err: ErrAccountNotFound}
 	}
@@ -89,7 +89,7 @@ func (s *Service) UpdateAccount(ctx context.Context, account *auth.Account) erro
 		account.PasswordHash = existing.PasswordHash
 	}
 
-	if err := s.repos.Account.Update(ctx, account); err != nil {
+	if err := s.repos.Account.UpdateManageable(ctx, account); err != nil {
 		return &AuthError{Op: opUpdateAccount, Err: err}
 	}
 
@@ -98,7 +98,7 @@ func (s *Service) UpdateAccount(ctx context.Context, account *auth.Account) erro
 
 // ListAccounts retrieves accounts matching the provided filters
 func (s *Service) ListAccounts(ctx context.Context, filters map[string]interface{}) ([]*auth.Account, error) {
-	accounts, err := s.repos.Account.List(ctx, filters)
+	accounts, err := s.repos.Account.ListManageable(ctx, filters)
 	if err != nil {
 		return nil, &AuthError{Op: "list accounts", Err: err}
 	}

--- a/backend/services/auth/account_management.go
+++ b/backend/services/auth/account_management.go
@@ -107,7 +107,7 @@ func (s *Service) ListAccounts(ctx context.Context, filters map[string]interface
 
 // GetAccountsByRole retrieves all accounts with a specific role
 func (s *Service) GetAccountsByRole(ctx context.Context, roleName string) ([]*auth.Account, error) {
-	accounts, err := s.repos.Account.FindByRole(ctx, roleName)
+	accounts, err := s.repos.Account.ListManageable(ctx, map[string]interface{}{"role": roleName})
 	if err != nil {
 		return nil, &AuthError{Op: "get accounts by role", Err: err}
 	}

--- a/backend/services/auth/account_management.go
+++ b/backend/services/auth/account_management.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/moto-nrw/project-phoenix/models/auth"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -19,7 +20,7 @@ func (s *Service) ActivateAccount(ctx context.Context, accountID int) error {
 
 	account.Active = true
 	if err := s.repos.Account.UpdateManageable(ctx, account); err != nil {
-		return &AuthError{Op: "activate account", Err: err}
+		return accountWriteError("activate account", err)
 	}
 
 	s.clearPendingAccountWideWipes(ctx, int64(accountID))
@@ -63,7 +64,7 @@ func (s *Service) DeactivateAccount(ctx context.Context, accountID int) error {
 		}
 		account.Active = false
 		if err := s.repos.Account.UpdateManageable(txCtx, account); err != nil {
-			return &AuthError{Op: "deactivate account", Err: err}
+			return accountWriteError("deactivate account", err)
 		}
 		return nil
 	})
@@ -90,10 +91,17 @@ func (s *Service) UpdateAccount(ctx context.Context, account *auth.Account) erro
 	}
 
 	if err := s.repos.Account.UpdateManageable(ctx, account); err != nil {
-		return &AuthError{Op: opUpdateAccount, Err: err}
+		return accountWriteError(opUpdateAccount, err)
 	}
 
 	return nil
+}
+
+func accountWriteError(op string, err error) error {
+	if modelBase.IsNoRows(err) {
+		return &AuthError{Op: op, Err: ErrAccountNotFound}
+	}
+	return &AuthError{Op: op, Err: err}
 }
 
 // ListAccounts retrieves accounts matching the provided filters

--- a/backend/services/auth/account_management.go
+++ b/backend/services/auth/account_management.go
@@ -107,7 +107,7 @@ func (s *Service) ListAccounts(ctx context.Context, filters map[string]interface
 
 // GetAccountsByRole retrieves all accounts with a specific role
 func (s *Service) GetAccountsByRole(ctx context.Context, roleName string) ([]*auth.Account, error) {
-	accounts, err := s.repos.Account.ListManageable(ctx, map[string]interface{}{"role": roleName})
+	accounts, err := s.repos.Account.FindByRole(ctx, roleName)
 	if err != nil {
 		return nil, &AuthError{Op: "get accounts by role", Err: err}
 	}

--- a/backend/services/auth/account_management_internal_test.go
+++ b/backend/services/auth/account_management_internal_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/moto-nrw/project-phoenix/database/repositories"
+	authModel "github.com/moto-nrw/project-phoenix/models/auth"
+	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/stretchr/testify/require"
+)
+
+type membershipRevokedAccountRepoStub struct {
+	noopAccountRepository
+}
+
+func (membershipRevokedAccountRepoStub) FindManageableByID(_ context.Context, id int64) (*authModel.Account, error) {
+	return &authModel.Account{
+		Model:  modelBase.Model{ID: id},
+		Email:  "original@example.test",
+		Active: true,
+	}, nil
+}
+
+func (membershipRevokedAccountRepoStub) UpdateManageable(context.Context, *authModel.Account) error {
+	return &modelBase.DatabaseError{Op: "update account", Err: sql.ErrNoRows}
+}
+
+func TestAccountManagement_MembershipRevokedDuringWriteReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		repos: &repositories.Factory{Account: membershipRevokedAccountRepoStub{}},
+	}
+	tests := []struct {
+		name   string
+		action func() error
+	}{
+		{name: "update", action: func() error {
+			return service.UpdateAccount(context.Background(), &authModel.Account{
+				Model: modelBase.Model{ID: 42},
+				Email: "updated@example.test",
+			})
+		}},
+		{name: "activate", action: func() error {
+			return service.ActivateAccount(context.Background(), 42)
+		}},
+		{name: "deactivate", action: func() error {
+			return service.DeactivateAccount(context.Background(), 42)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.action(), ErrAccountNotFound)
+		})
+	}
+}

--- a/backend/services/auth/auth_core_test.go
+++ b/backend/services/auth/auth_core_test.go
@@ -748,6 +748,7 @@ func TestAuthService_GetAccountByID(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// ACT
 		result, err := service.GetAccountByID(ctx, int(account.ID))
@@ -791,6 +792,7 @@ func TestAuthService_ActivateAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// First deactivate
 		err = service.DeactivateAccount(ctx, int(account.ID))
@@ -831,6 +833,7 @@ func TestAuthService_DeactivateAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// ACT
 		err = service.DeactivateAccount(ctx, int(account.ID))
@@ -850,6 +853,7 @@ func TestAuthService_DeactivateAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		err = service.DeactivateAccount(ctx, int(account.ID))
 		require.NoError(t, err)
@@ -880,6 +884,7 @@ func TestAuthService_ListAccounts(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// ACT
 		result, err := service.ListAccounts(ctx, nil)
@@ -1833,6 +1838,7 @@ func TestAuthService_UpdateAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		account.Active = false
 

--- a/backend/services/auth/auth_core_test.go
+++ b/backend/services/auth/auth_core_test.go
@@ -1175,6 +1175,7 @@ func TestAuthService_AssignRoleToAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		roleName := fmt.Sprintf("assign-role-%d", time.Now().UnixNano())
 		role, err := service.CreateRole(ctx, roleName, "for assignment", testpkg.StrPtr("user"))
@@ -1271,6 +1272,7 @@ func TestAuthService_RemoveRoleFromAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		roleName := fmt.Sprintf("remove-role-%d", time.Now().UnixNano())
 		role, err := service.CreateRole(ctx, roleName, "for removal", testpkg.StrPtr("user"))
@@ -1409,6 +1411,7 @@ func TestAuthService_GrantPermissionToAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		permName := fmt.Sprintf("grant-perm-%s", uniqueID)
 		resource := fmt.Sprintf("resource-grant-%s", uniqueID)
@@ -1641,6 +1644,7 @@ func TestAuthService_GetAccountPermissions(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		permName := fmt.Sprintf("acctperm-%s", uniqueID)
@@ -1674,6 +1678,7 @@ func TestAuthService_GetAccountDirectPermissions(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		permName := fmt.Sprintf("directperm-%s", uniqueID)
@@ -1707,6 +1712,7 @@ func TestAuthService_RemovePermissionFromAccount(t *testing.T) {
 		account, err := service.Register(ctx, email, username, testPassword, nil, 0)
 		require.NoError(t, err)
 		defer testpkg.CleanupAuthFixtures(t, db, account.ID)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
 		permName := fmt.Sprintf("removeperm-%s", uniqueID)

--- a/backend/services/auth/auth_login.go
+++ b/backend/services/auth/auth_login.go
@@ -2134,7 +2134,15 @@ func (s *Service) ChangePassword(ctx context.Context, accountID int, currentPass
 
 // GetAccountByID retrieves an account by ID
 func (s *Service) GetAccountByID(ctx context.Context, id int) (*auth.Account, error) {
-	account, err := s.repos.Account.FindManageableByID(ctx, int64(id))
+	var (
+		account *auth.Account
+		err     error
+	)
+	if claims := jwt.ClaimsFromCtx(ctx); claims.ID == id {
+		account, err = s.repos.Account.FindByID(ctx, int64(id))
+	} else {
+		account, err = s.repos.Account.FindManageableByID(ctx, int64(id))
+	}
 	if err != nil {
 		return nil, &AuthError{Op: opGetAccount, Err: ErrAccountNotFound}
 	}

--- a/backend/services/auth/auth_login.go
+++ b/backend/services/auth/auth_login.go
@@ -2134,7 +2134,7 @@ func (s *Service) ChangePassword(ctx context.Context, accountID int, currentPass
 
 // GetAccountByID retrieves an account by ID
 func (s *Service) GetAccountByID(ctx context.Context, id int) (*auth.Account, error) {
-	account, err := s.repos.Account.FindByID(ctx, int64(id))
+	account, err := s.repos.Account.FindManageableByID(ctx, int64(id))
 	if err != nil {
 		return nil, &AuthError{Op: opGetAccount, Err: ErrAccountNotFound}
 	}

--- a/backend/services/auth/permission_management.go
+++ b/backend/services/auth/permission_management.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/moto-nrw/project-phoenix/models/auth"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // Permission Management
@@ -129,6 +130,9 @@ func (s *Service) GetAccountPermissions(ctx context.Context, accountID int) ([]*
 	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
 		return nil, &AuthError{Op: "get account permissions", Err: ErrAccountNotFound}
 	}
+	if err := s.ensureOrganizationRBACMembership(ctx, accountID, "get account permissions", false); err != nil {
+		return nil, err
+	}
 	permissions, err := s.getAccountPermissions(ctx, int64(accountID))
 	if err != nil {
 		return nil, &AuthError{Op: "get account permissions", Err: err}
@@ -141,6 +145,9 @@ func (s *Service) GetAccountDirectPermissions(ctx context.Context, accountID int
 	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
 		return nil, &AuthError{Op: "get account direct permissions", Err: ErrAccountNotFound}
 	}
+	if err := s.ensureOrganizationRBACMembership(ctx, accountID, "get account direct permissions", false); err != nil {
+		return nil, err
+	}
 	permissions, err := s.repos.Permission.FindDirectByAccountID(ctx, int64(accountID))
 	if err != nil {
 		return nil, &AuthError{Op: "get account direct permissions", Err: err}
@@ -152,10 +159,42 @@ func (s *Service) lockManageableAccount(ctx context.Context, accountID int, op s
 	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
 		return &AuthError{Op: op, Err: ErrAccountNotFound}
 	}
+	if err := s.ensureOrganizationRBACMembership(ctx, accountID, op, false); err != nil {
+		return err
+	}
 	if _, err := s.repos.Account.FindByIDForUpdate(ctx, int64(accountID)); err != nil {
 		return &AuthError{Op: op, Err: ErrAccountNotFound}
 	}
 	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
+		return &AuthError{Op: op, Err: ErrAccountNotFound}
+	}
+	if err := s.ensureOrganizationRBACMembership(ctx, accountID, op, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) ensureOrganizationRBACMembership(ctx context.Context, accountID int, op string, lock bool) error {
+	if tenant.ScopeFromContext(ctx) != tenant.ScopeOrg {
+		return nil
+	}
+	tenantID := tenant.FromContext(ctx)
+	if tenantID == 0 {
+		return &AuthError{Op: op, Err: ErrAccountNotFound}
+	}
+	var (
+		exists bool
+		err    error
+	)
+	if lock {
+		exists, err = s.repos.AccountTenant.ExistsActiveByAccountAndTenantForShare(ctx, int64(accountID), tenantID)
+	} else {
+		exists, err = s.repos.AccountTenant.ExistsByAccountAndTenant(ctx, int64(accountID), tenantID)
+	}
+	if err != nil {
+		return &AuthError{Op: op, Err: err}
+	}
+	if !exists {
 		return &AuthError{Op: op, Err: ErrAccountNotFound}
 	}
 	return nil

--- a/backend/services/auth/permission_management.go
+++ b/backend/services/auth/permission_management.go
@@ -81,52 +81,54 @@ func (s *Service) ListPermissions(ctx context.Context, filters map[string]interf
 
 // GrantPermissionToAccount grants a permission directly to an account
 func (s *Service) GrantPermissionToAccount(ctx context.Context, accountID, permissionID int) error {
-	// Verify account exists
-	if _, err := s.repos.Account.FindByID(ctx, int64(accountID)); err != nil {
-		return &AuthError{Op: "grant permission", Err: ErrAccountNotFound}
-	}
-
-	// Verify permission exists
-	if _, err := s.repos.Permission.FindByID(ctx, int64(permissionID)); err != nil {
-		return &AuthError{Op: "grant permission", Err: ErrPermissionNotFound}
-	}
-
-	if err := s.repos.AccountPermission.GrantPermission(ctx, int64(accountID), int64(permissionID)); err != nil {
-		return &AuthError{Op: "grant permission to account", Err: err}
-	}
-
-	return nil
+	return s.runInTx(ctx, func(txCtx context.Context) error {
+		if err := s.lockManageableAccount(txCtx, accountID, "grant permission"); err != nil {
+			return err
+		}
+		if _, err := s.repos.Permission.FindByID(txCtx, int64(permissionID)); err != nil {
+			return &AuthError{Op: "grant permission", Err: ErrPermissionNotFound}
+		}
+		if err := s.repos.AccountPermission.GrantPermission(txCtx, int64(accountID), int64(permissionID)); err != nil {
+			return &AuthError{Op: "grant permission to account", Err: err}
+		}
+		return nil
+	})
 }
 
 // DenyPermissionToAccount explicitly denies a permission to an account
 func (s *Service) DenyPermissionToAccount(ctx context.Context, accountID, permissionID int) error {
-	// Verify account exists
-	if _, err := s.repos.Account.FindByID(ctx, int64(accountID)); err != nil {
-		return &AuthError{Op: "deny permission", Err: ErrAccountNotFound}
-	}
-
-	// Verify permission exists
-	if _, err := s.repos.Permission.FindByID(ctx, int64(permissionID)); err != nil {
-		return &AuthError{Op: "deny permission", Err: ErrPermissionNotFound}
-	}
-
-	if err := s.repos.AccountPermission.DenyPermission(ctx, int64(accountID), int64(permissionID)); err != nil {
-		return &AuthError{Op: "deny permission to account", Err: err}
-	}
-
-	return nil
+	return s.runInTx(ctx, func(txCtx context.Context) error {
+		if err := s.lockManageableAccount(txCtx, accountID, "deny permission"); err != nil {
+			return err
+		}
+		if _, err := s.repos.Permission.FindByID(txCtx, int64(permissionID)); err != nil {
+			return &AuthError{Op: "deny permission", Err: ErrPermissionNotFound}
+		}
+		if err := s.repos.AccountPermission.DenyPermission(txCtx, int64(accountID), int64(permissionID)); err != nil {
+			return &AuthError{Op: "deny permission to account", Err: err}
+		}
+		return nil
+	})
 }
 
 // RemovePermissionFromAccount removes a permission from an account
 func (s *Service) RemovePermissionFromAccount(ctx context.Context, accountID, permissionID int) error {
-	if err := s.repos.AccountPermission.RemovePermission(ctx, int64(accountID), int64(permissionID)); err != nil {
-		return &AuthError{Op: "remove permission from account", Err: err}
-	}
-	return nil
+	return s.runInTx(ctx, func(txCtx context.Context) error {
+		if err := s.lockManageableAccount(txCtx, accountID, "remove permission"); err != nil {
+			return err
+		}
+		if err := s.repos.AccountPermission.RemovePermission(txCtx, int64(accountID), int64(permissionID)); err != nil {
+			return &AuthError{Op: "remove permission from account", Err: err}
+		}
+		return nil
+	})
 }
 
 // GetAccountPermissions retrieves all permissions for an account (direct and role-based)
 func (s *Service) GetAccountPermissions(ctx context.Context, accountID int) ([]*auth.Permission, error) {
+	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
+		return nil, &AuthError{Op: "get account permissions", Err: ErrAccountNotFound}
+	}
 	permissions, err := s.getAccountPermissions(ctx, int64(accountID))
 	if err != nil {
 		return nil, &AuthError{Op: "get account permissions", Err: err}
@@ -136,11 +138,27 @@ func (s *Service) GetAccountPermissions(ctx context.Context, accountID int) ([]*
 
 // GetAccountDirectPermissions retrieves only direct permissions for an account (not role-based)
 func (s *Service) GetAccountDirectPermissions(ctx context.Context, accountID int) ([]*auth.Permission, error) {
+	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
+		return nil, &AuthError{Op: "get account direct permissions", Err: ErrAccountNotFound}
+	}
 	permissions, err := s.repos.Permission.FindDirectByAccountID(ctx, int64(accountID))
 	if err != nil {
 		return nil, &AuthError{Op: "get account direct permissions", Err: err}
 	}
 	return permissions, nil
+}
+
+func (s *Service) lockManageableAccount(ctx context.Context, accountID int, op string) error {
+	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
+		return &AuthError{Op: op, Err: ErrAccountNotFound}
+	}
+	if _, err := s.repos.Account.FindByIDForUpdate(ctx, int64(accountID)); err != nil {
+		return &AuthError{Op: op, Err: ErrAccountNotFound}
+	}
+	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
+		return &AuthError{Op: op, Err: ErrAccountNotFound}
+	}
+	return nil
 }
 
 // AssignPermissionToRole assigns a permission to a role. System roles cannot be modified.

--- a/backend/services/auth/refactor_verification_test.go
+++ b/backend/services/auth/refactor_verification_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/email"
 	authModel "github.com/moto-nrw/project-phoenix/models/auth"
 	modelBase "github.com/moto-nrw/project-phoenix/models/base"
+	"github.com/moto-nrw/project-phoenix/tenant"
 )
 
 // TestRefactoringPreservesRepositoryAccess verifies that after refactoring,
@@ -67,8 +68,8 @@ func TestRefactoringPreservesRepositoryAccess(t *testing.T) {
 	require.NotNil(t, service.repos.Token, "Should access Token repo through factory")
 	require.NotNil(t, service.repos.Role, "Should access Role repo through factory")
 
-	// Verify GetAccountByID uses factory (calls s.repos.Account.FindByID)
-	ctx := context.Background()
+	// Verify the platform-scoped account lookup uses the repository factory.
+	ctx := tenant.WithScope(context.Background(), tenant.ScopePlatform)
 	mock.ExpectBegin()
 	mock.ExpectCommit()
 

--- a/backend/services/auth/refactored_modules_test.go
+++ b/backend/services/auth/refactored_modules_test.go
@@ -60,6 +60,7 @@ func TestAuthService_DeleteRole_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		err = service.AssignRoleToAccount(ctx, int(account.ID), int(role.ID))
 		require.NoError(t, err)
@@ -201,6 +202,7 @@ func TestAuthService_AssignRoleToAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// ACT
 		err = service.AssignRoleToAccount(ctx, int(account.ID), 99999999)
@@ -217,6 +219,7 @@ func TestAuthService_AssignRoleToAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		roleName := fmt.Sprintf("idempotent-role-%d", time.Now().UnixNano())
 		role, err := service.CreateRole(ctx, roleName, "Test role", testpkg.StrPtr("user"))
@@ -261,6 +264,7 @@ func TestAuthService_RemoveRoleFromAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		roleName := fmt.Sprintf("remove-role-%d", time.Now().UnixNano())
 		role, err := service.CreateRole(ctx, roleName, "Test role", testpkg.StrPtr("user"))
@@ -300,6 +304,7 @@ func TestAuthService_GetAccountRoles_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// Remove any default roles
 		roles, _ := service.GetAccountRoles(ctx, int(account.ID))
@@ -370,6 +375,7 @@ func TestAuthService_DeletePermission_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		err = service.GrantPermissionToAccount(ctx, int(account.ID), int(perm.ID))
 		require.NoError(t, err)
@@ -402,6 +408,7 @@ func TestAuthService_GrantPermissionToAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// ACT
 		err = service.GrantPermissionToAccount(ctx, int(account.ID), 99999999)
@@ -433,6 +440,7 @@ func TestAuthService_RemovePermissionFromAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		err = service.GrantPermissionToAccount(ctx, int(account.ID), int(perm.ID))
 		require.NoError(t, err)
@@ -782,6 +790,7 @@ func TestAuthService_GetAccountsByRole_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		err = service.AssignRoleToAccount(ctx, int(account.ID), int(role.ID))
 		require.NoError(t, err)

--- a/backend/services/auth/refactored_modules_test.go
+++ b/backend/services/auth/refactored_modules_test.go
@@ -594,6 +594,7 @@ func TestAuthService_ActivateAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// Account is already active by default
 
@@ -656,6 +657,7 @@ func TestAuthService_DeactivateAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// Deactivate first
 		err = service.DeactivateAccount(ctx, int(account.ID))
@@ -685,6 +687,7 @@ func TestAuthService_UpdateAccount_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// Get the original password hash
 		original, err := service.GetAccountByID(ctx, int(account.ID))
@@ -737,6 +740,7 @@ func TestAuthService_ListAccounts_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// ACT
 		filters := map[string]interface{}{
@@ -1180,6 +1184,7 @@ func TestAuthService_Login_Extended(t *testing.T) {
 			defer testpkg.CleanupAuthFixtures(t, db, account.ID)
 		}
 		require.NoError(t, err)
+		testpkg.EnsureAccountTenant(t, db, account.ID, testpkg.Tenant(t))
 
 		// Deactivate account
 		err = service.DeactivateAccount(ctx, int(account.ID))

--- a/backend/services/auth/role_management.go
+++ b/backend/services/auth/role_management.go
@@ -298,6 +298,9 @@ func (s *Service) GetAccountRoles(ctx context.Context, accountID int) ([]*auth.R
 	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
 		return nil, &AuthError{Op: "get account roles", Err: ErrAccountNotFound}
 	}
+	if err := s.ensureOrganizationRBACMembership(ctx, accountID, "get account roles", false); err != nil {
+		return nil, err
+	}
 	roles, err := s.repos.Role.FindByAccountID(ctx, int64(accountID))
 	if err != nil {
 		return nil, &AuthError{Op: "get account roles", Err: err}

--- a/backend/services/auth/role_management.go
+++ b/backend/services/auth/role_management.go
@@ -119,8 +119,8 @@ func (s *Service) AssignRoleToAccount(ctx context.Context, accountID, roleID int
 	err := s.runInTx(ctx, func(txCtx context.Context) error {
 		// Serialize assignments with tenant-access revocation, which holds the
 		// same account lock while removing the tenant's roles and mapping.
-		if _, err := s.repos.Account.FindByIDForUpdate(txCtx, int64(accountID)); err != nil {
-			return &AuthError{Op: "assign role", Err: ErrAccountNotFound}
+		if err := s.lockManageableAccount(txCtx, accountID, "assign role"); err != nil {
+			return err
 		}
 
 		// System roles have tenant_id NULL and must remain resolvable while the
@@ -263,6 +263,9 @@ func (s *Service) accountHoldsLehrkraftRole(ctx context.Context, accountID int64
 func (s *Service) RemoveRoleFromAccount(ctx context.Context, accountID, roleID int) error {
 	var revoked []*auth.Token
 	err := s.runInTx(ctx, func(txCtx context.Context) error {
+		if err := s.lockManageableAccount(txCtx, accountID, "remove role"); err != nil {
+			return err
+		}
 		existingRole, err := s.repos.AccountRole.FindByAccountAndRole(txCtx, int64(accountID), int64(roleID))
 		if err != nil && !strings.Contains(err.Error(), "no rows") {
 			return &AuthError{Op: "check role assignment", Err: err}
@@ -292,6 +295,9 @@ func (s *Service) RemoveRoleFromAccount(ctx context.Context, accountID, roleID i
 
 // GetAccountRoles retrieves all roles for an account
 func (s *Service) GetAccountRoles(ctx context.Context, accountID int) ([]*auth.Role, error) {
+	if _, err := s.repos.Account.FindManageableByID(ctx, int64(accountID)); err != nil {
+		return nil, &AuthError{Op: "get account roles", Err: ErrAccountNotFound}
+	}
 	roles, err := s.repos.Role.FindByAccountID(ctx, int64(accountID))
 	if err != nil {
 		return nil, &AuthError{Op: "get account roles", Err: err}

--- a/backend/services/auth/role_management_internal_test.go
+++ b/backend/services/auth/role_management_internal_test.go
@@ -85,6 +85,16 @@ func (r roleManagementAccountRepo) FindByID(ctx context.Context, id interface{})
 }
 
 func (r roleManagementAccountRepo) FindByIDForUpdate(ctx context.Context, id int64) (*authModel.Account, error) {
+	if r.findByIDFn == nil {
+		return &authModel.Account{Model: base.Model{ID: id}}, nil
+	}
+	return r.FindByID(ctx, id)
+}
+
+func (r roleManagementAccountRepo) FindManageableByID(ctx context.Context, id int64) (*authModel.Account, error) {
+	if r.findByIDFn == nil {
+		return &authModel.Account{Model: base.Model{ID: id}}, nil
+	}
 	return r.FindByID(ctx, id)
 }
 

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -207,6 +207,10 @@ func (noopAccountRepository) UpdateAvatar(context.Context, int64, string) error 
 	panic("UpdateAvatar not implemented")
 }
 
+func (noopAccountRepository) FindByRole(context.Context, string) ([]*authModel.Account, error) {
+	panic("FindByRole not implemented")
+}
+
 func (noopAccountRepository) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
 	panic("ListEffectiveAdminAccountIDs not implemented")
 }

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -143,6 +143,18 @@ func (noopAccountRepository) FindByID(context.Context, interface{}) (*authModel.
 	panic("FindByID not implemented")
 }
 
+func (noopAccountRepository) FindManageableByID(context.Context, int64) (*authModel.Account, error) {
+	panic("FindManageableByID not implemented")
+}
+
+func (noopAccountRepository) ListManageable(context.Context, map[string]interface{}) ([]*authModel.Account, error) {
+	panic("ListManageable not implemented")
+}
+
+func (noopAccountRepository) UpdateManageable(context.Context, *authModel.Account) error {
+	panic("UpdateManageable not implemented")
+}
+
 func (noopAccountRepository) FindByIDForUpdate(context.Context, int64) (*authModel.Account, error) {
 	panic("FindByIDForUpdate not implemented")
 }
@@ -318,6 +330,10 @@ func (r *stubAccountRepository) FindByID(_ context.Context, id interface{}) (*au
 	return nil, sql.ErrNoRows
 }
 
+func (r *stubAccountRepository) FindManageableByID(ctx context.Context, id int64) (*authModel.Account, error) {
+	return r.FindByID(ctx, id)
+}
+
 func (r *stubAccountRepository) UpdatePassword(_ context.Context, id int64, hash string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -340,6 +356,10 @@ func (r *stubAccountRepository) Update(_ context.Context, account *authModel.Acc
 		return nil
 	}
 	return sql.ErrNoRows
+}
+
+func (r *stubAccountRepository) UpdateManageable(ctx context.Context, account *authModel.Account) error {
+	return r.Update(ctx, account)
 }
 
 func (r *stubAccountRepository) UpdateAvatar(_ context.Context, id int64, avatar string) error {

--- a/backend/services/auth/test_helpers_test.go
+++ b/backend/services/auth/test_helpers_test.go
@@ -207,10 +207,6 @@ func (noopAccountRepository) UpdateAvatar(context.Context, int64, string) error 
 	panic("UpdateAvatar not implemented")
 }
 
-func (noopAccountRepository) FindByRole(context.Context, string) ([]*authModel.Account, error) {
-	panic("FindByRole not implemented")
-}
-
 func (noopAccountRepository) ListEffectiveAdminAccountIDs(context.Context) ([]int64, error) {
 	panic("ListEffectiveAdminAccountIDs not implemented")
 }

--- a/backend/services/import/staff_import_config_test.go
+++ b/backend/services/import/staff_import_config_test.go
@@ -75,6 +75,15 @@ func (r stubStaffAccountRepo) Create(context.Context, *authModels.Account) error
 func (r stubStaffAccountRepo) FindByID(context.Context, interface{}) (*authModels.Account, error) {
 	panic("not implemented")
 }
+func (r stubStaffAccountRepo) FindManageableByID(context.Context, int64) (*authModels.Account, error) {
+	panic("not implemented")
+}
+func (r stubStaffAccountRepo) ListManageable(context.Context, map[string]interface{}) ([]*authModels.Account, error) {
+	panic("not implemented")
+}
+func (r stubStaffAccountRepo) UpdateManageable(context.Context, *authModels.Account) error {
+	panic("not implemented")
+}
 func (r stubStaffAccountRepo) FindByIDForUpdate(context.Context, int64) (*authModels.Account, error) {
 	panic("not implemented")
 }

--- a/backend/services/users/staff_offboarding.go
+++ b/backend/services/users/staff_offboarding.go
@@ -371,17 +371,15 @@ func (s *staffOffboardingService) offboardPersonAndAccount(ctx context.Context, 
 		return nil
 	}
 
-	if err := s.AccountTenantRepo.Deactivate(ctx, accountID, tenantID); err != nil {
-		return &UsersError{Op: opOffboardStaff, Err: fmt.Errorf("deactivate tenant mapping: %w", err)}
-	}
-
-	// Deactivate the account entirely (and revoke all tokens) only when it has
-	// no active mapping to any other school.
-	remaining, err := s.AccountTenantRepo.FindActiveByAccountID(ctx, accountID)
+	// Deactivate the account entirely (and revoke all tokens) only when the
+	// current tenant is its last active membership. This must happen before the
+	// mapping is deactivated: account management requires that active mapping.
+	activeMappings, err := s.AccountTenantRepo.FindActiveByAccountID(ctx, accountID)
 	if err != nil {
 		return &UsersError{Op: opOffboardStaff, Err: fmt.Errorf("check remaining tenant mappings: %w", err)}
 	}
-	if len(remaining) == 0 {
+	deactivateAccount := len(activeMappings) == 1 && activeMappings[0].TenantID == tenantID
+	if deactivateAccount {
 		if err := s.AuthService.DeactivateAccount(ctx, int(accountID)); err != nil {
 			return &UsersError{Op: opOffboardStaff, Err: fmt.Errorf("deactivate account: %w", err)}
 		}
@@ -389,11 +387,14 @@ func (s *staffOffboardingService) offboardPersonAndAccount(ctx context.Context, 
 			*deactivatedAccountID = accountID
 		}
 	}
+	if err := s.AccountTenantRepo.Deactivate(ctx, accountID, tenantID); err != nil {
+		return &UsersError{Op: opOffboardStaff, Err: fmt.Errorf("deactivate tenant mapping: %w", err)}
+	}
 
 	s.getLogger().Info("staff account offboarded",
 		"account_id", accountID,
 		"tenant_id", tenantID,
-		"account_deactivated", len(remaining) == 0,
+		"account_deactivated", deactivateAccount,
 		"guardian_access_preserved", false,
 	)
 


### PR DESCRIPTION
# Pull Request

## Description

F1 und F8 aus dem Security-Report sind bestätigt. Die Account-Verwaltung nutzte globale Zugriffe auf `auth.accounts`; dadurch konnten berechtigte Tenant-Benutzer Accounts außerhalb ihres Tenants auflisten, lesen und ändern.

Der Fix begrenzt die betroffenen Account- und RBAC-Zugriffe:

- Tenant-Scope verlangt eine aktive Mitgliedschaft in `auth.account_tenants` für den aktuellen Tenant.
- Org-Scope berücksichtigt nur aktive Mitgliedschaften an aktiven, nicht gelöschten Schulen derselben Organisation.
- RBAC-Zugriffe im Org-Scope verlangen zusätzlich eine Mitgliedschaft des Ziel-Accounts an der aktuellen Schule.
- Platform- und interne Admin-Flows behalten den globalen Zugriff.
- Rollenfilter und direkte Berechtigungen werden auf den zulässigen Tenant begrenzt.
- Update, Aktivieren, Ausschalten sowie RBAC-Änderungen prüfen die Mitgliedschaft beim Lesen und nochmals atomar beim Schreiben.
- Fremde und nicht vorhandene Accounts liefern dieselbe `404`-Antwort.
- Der eigene Account bleibt für den persönlichen Account-Endpunkt lesbar, auch wenn keine passende Mitgliedschaft besteht.
- Login, MFA und Passwort-Reset nutzen weiterhin die bestehenden globalen Repository-Methoden.
- Beim Staff-Offboarding wird ein Account vor dem Entfernen seiner letzten aktiven Mitgliedschaft ausgeschaltet.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Security improvement
- [x] Test addition/modification

## Related Issues

- Security-Report: F1, F8

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Testing documentation updated

Erfolgreich:

```bash
cd backend
TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' go test ./api/auth -run '^TestAccountManagement(OwnTenantAllowed|ForeignAccountsAbsentFromList|ForeignGetDoesNotLeakExistence|ForeignUpdateDoesNotLeakExistence|ForeignDeactivateDoesNotLeakExistence|ForeignActivateDoesNotLeakExistence|InactiveMembershipDenied|OrganizationScopeStaysWithinOrganization|PlatformScopeRemainsGlobal)$' -count=1
TEST_DB_DSN='postgres://postgres:postgres@localhost:5433/phoenix_test?sslmode=disable' go test ./api/auth ./services/auth ./services/users ./services/import ./database/repositories/auth
go test ./test/ -run TestHermeticTestPatterns -v
```

`scripts/test-changed.sh origin/development` scheitert nur in `services/schedule`:

```text
TestArrivalScheduleService_BulkUpsertArrivalSchedules/skips_children_whose_care_has_ended_instead_of_failing_the_class
expected: 1
actual:   2
```

Der Fehler tritt auch auf dem unveränderten Ausgangs-HEAD `ec22b2ef8aec1e93bb81e286cc670b158e298233` auf und steht nicht im Zusammenhang mit diesem PR.

## Security Checklist

- [ ] I have followed the [security guidelines](../docs/security.md)
- [x] No sensitive information is committed (secrets, credentials, certificates)
- [x] Environment variables are properly managed with templates
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Nicht anwendbar; reine Backend-Änderung.

## Missverständnis-Check

Nicht user-sichtbar. Der bestehende `404`-Vertrag bleibt erhalten und verhindert einen Account-Existence-Leak.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have updated the documentation as needed
- [x] If this PR changes a user-facing flow, I updated the in-app help guide (`guide-data.ts`) and any changed screenshot — or it doesn't apply (backend-only, operator/parents-portal-only, or pure-styling change)
- [x] User-visible change: I ran the Verständlichkeit checklist (`.claude/rules/verstaendlichkeit.md`) against the running app and recorded the result above — or it doesn't apply
- [ ] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved any merge conflicts

## Additional Notes

Der unabhängige Baseline-Fehler in `services/schedule` bleibt außerhalb dieses Security-Fixes.
