### PR TITLE
Complete SSE fan-out deduplication

### DIFF
--- a/backend/realtime/events.go
+++ b/backend/realtime/events.go
@@ -77,9 +77,9 @@ const (
 	EventStaffingDeviationChanged EventType = "staffing_deviation_changed"
 
 	// Tenant-wide refresh event — tells every client of the tenant to re-fetch
-	// dashboard counts. Attendance/activity emitters also use this legacy wire
-	// type for their combined supervision refresh during rolling deploys; those
-	// events carry ActiveGroupID and Reason in addition to GroupIDs (#2115).
+	// dashboard counts. Attendance/activity emitters use this wire type for their
+	// combined dashboard and supervision refresh; those events carry
+	// ActiveGroupID and Reason in addition to GroupIDs (#2115).
 	// Broadcast via BroadcastToTenant (issue #2057; it was
 	// BroadcastToAll before, which fanned every school's check-in traffic out to
 	// every OTHER school's clients). Carries GroupIDs (educational group ids,
@@ -119,11 +119,10 @@ const (
 	// clients re-fetch their permission-scoped time-tracking views.
 	EventStaffTimeTrackingChanged EventType = "staff_time_tracking_changed"
 
-	// Active supervision refresh event — normally a tenant-wide signal that the
-	// active supervision view is stale regardless of whether the cause was IoT,
-	// NFC, timetable operations, or another lifecycle action. Attendance hot
-	// paths also send a group-scoped copy during rolling deploys so the previous
-	// frontend release keeps its timetable roster live (#2115).
+	// Active supervision refresh event — a tenant-wide signal emitted by
+	// timetable operations, schedule instance lifecycle changes, and the overdue
+	// scheduler. Attendance hot paths fold the same invalidation into
+	// dashboard_counts_changed instead (#2115).
 	//
 	// Carries NO child identity (#2085), for the same reason
 	// arrival_schedule_changed and pickup_schedule_changed are id-less: it
@@ -133,10 +132,9 @@ const (
 	// API responses redact for that person. It may carry the active_group_id,
 	// instance_id and a reason: room/session/instance scope, never who.
 	//
-	// The per-child detail-cache invalidation rides the group-scoped
-	// student_checkin / student_checkout events instead, which are emitted
-	// alongside it to the active-group and edu:{id} topics and therefore reach
-	// exactly the supervisors entitled to that child's data.
+	// Attendance invalidates per-child detail caches through the separate
+	// group-scoped student_checkin / student_checkout events, which reach exactly
+	// the supervisors entitled to that child's data.
 	EventActiveSupervisionChanged EventType = "active_supervision_changed"
 
 	// Arrival schedule events affect derived "not arriving today" badges and

--- a/backend/services/active/active_service.go
+++ b/backend/services/active/active_service.go
@@ -1024,7 +1024,6 @@ func (s *service) emitVisitCheckout(
 			slog.String("student_id", studentID),
 		)
 	}
-	s.broadcastRosterRefreshToTopics(ctx, activeGroupID, studentRec, eduGroupIDs)
 
 	// Notify every client of the tenant so dashboard counts refresh, scoped to
 	// the affected educational group when known (#2057).

--- a/backend/services/active/attendance_broadcast_test.go
+++ b/backend/services/active/attendance_broadcast_test.go
@@ -206,8 +206,8 @@ func TestCheckout_WebCheckoutWithOpenVisitBroadcasts(t *testing.T) {
 	assert.Empty(t, broadcaster.CallsByMethod("all"), "must not fan out across tenants")
 
 	require.NotNil(t, counts[0].Event.Data.Reason, "combined refresh must carry supervision semantics")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 1,
-		"checkout must preserve the legacy tenant supervision refresh")
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged),
+		"checkout must fold supervision invalidation into the combined refresh")
 
 	// #2085: the child id rides the group-scoped topics only.
 	testpkg.AssertNoTenantWideStudentIdentity(t, broadcaster)
@@ -262,7 +262,7 @@ func TestCheckout_OrphanedVisitWithoutAttendanceBroadcasts(t *testing.T) {
 		"the healed visit must emit an educational-group checkout")
 	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged), 1,
 		"the healed visit must emit one aggregate refresh")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 1)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged))
 	assert.True(t, broadcaster.HasEventType(realtime.EventDashboardCountsChanged),
 		"ending the orphaned visit changed the room roster")
 
@@ -418,7 +418,7 @@ func TestCheckout_DailyCheckoutWithOpenVisitPreservesSource(t *testing.T) {
 
 	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged), 1,
 		"the daily checkout must emit one aggregate refresh")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 1)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged))
 }
 
 // =============================================================================
@@ -568,5 +568,5 @@ func TestCheckin_RoomCheckinBroadcastsOnce(t *testing.T) {
 		"exactly one student_checkin on the edu:{id} topic")
 	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged), 1,
 		"exactly one aggregate refresh")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 1)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged))
 }

--- a/backend/services/active/broadcast_test.go
+++ b/backend/services/active/broadcast_test.go
@@ -88,7 +88,7 @@ func TestBroadcast_CreateVisitSendsOnePreciseRefresh(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, broadcaster.HasEventType(realtime.EventDashboardCountsChanged),
-		"expected the rolling-deploy-compatible combined refresh after CreateVisit")
+		"expected the combined refresh after CreateVisit")
 
 	// #2057: the supervision refresh is tenant-scoped (not broadcast to every
 	// school on the deployment) and carries the student's educational group id
@@ -98,13 +98,15 @@ func TestBroadcast_CreateVisitSendsOnePreciseRefresh(t *testing.T) {
 	require.Len(t, refreshes, 1, "CreateVisit must emit one aggregate refresh, not a paired dashboard event")
 	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
 	assert.NotZero(t, refreshes[0].TenantID, "tenant id from the request context must reach the broadcast")
+	assert.Equal(t, strconv.FormatInt(activeGroup.ID, 10), refreshes[0].Event.ActiveGroupID)
 	require.NotNil(t, refreshes[0].Event.Data.GroupIDs, "combined refresh must carry the educational group id")
 	assert.Equal(t, []string{eduGroupIDStr}, *refreshes[0].Event.Data.GroupIDs)
 	require.NotNil(t, refreshes[0].Event.Data.Reason, "combined refresh must carry supervision semantics")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 1,
-		"CreateVisit must preserve the legacy tenant supervision refresh")
-	assert.Len(t, broadcaster.EventsOfType(realtime.EventActiveSupervisionChanged), 3,
-		"topic and tenant compatibility frames keep older roster clients live during rolling deploys")
+	assert.Equal(t, "student_moved", *refreshes[0].Event.Data.Reason)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged),
+		"CreateVisit must fold supervision invalidation into the combined refresh")
+	assert.Empty(t, broadcaster.EventsOfType(realtime.EventActiveSupervisionChanged),
+		"CreateVisit must not emit legacy compatibility frames")
 
 	// The scoped student_checkin carries the edu group id too, so the client's
 	// backpressure fallback path (checkin delivered, counts event dropped)
@@ -149,18 +151,20 @@ func TestBroadcast_EndVisitSendsOnePreciseRefresh(t *testing.T) {
 	assert.Equal(t, []int64{student.ID}, waker.studentIDs)
 
 	assert.True(t, broadcaster.HasEventType(realtime.EventDashboardCountsChanged),
-		"expected the rolling-deploy-compatible combined refresh after EndVisit")
+		"expected the combined refresh after EndVisit")
 
 	// #2057: tenant-scoped, carrying the student's educational group id.
 	eduGroupIDStr := strconv.FormatInt(eduGroup.ID, 10)
 	refreshes := tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged)
 	require.Len(t, refreshes, 1, "EndVisit must emit one aggregate refresh, not a paired dashboard event")
 	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
+	assert.Equal(t, strconv.FormatInt(activeGroup.ID, 10), refreshes[0].Event.ActiveGroupID)
 	require.NotNil(t, refreshes[0].Event.Data.GroupIDs, "combined refresh must carry the educational group id")
 	assert.Equal(t, []string{eduGroupIDStr}, *refreshes[0].Event.Data.GroupIDs)
 	require.NotNil(t, refreshes[0].Event.Data.Reason, "combined refresh must carry supervision semantics")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 1,
-		"EndVisit must preserve the legacy tenant supervision refresh")
+	assert.Equal(t, "student_moved", *refreshes[0].Event.Data.Reason)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged),
+		"EndVisit must fold supervision invalidation into the combined refresh")
 
 	checkouts := broadcaster.EventsOfType(realtime.EventStudentCheckOut)
 	require.NotEmpty(t, checkouts)
@@ -221,8 +225,34 @@ func TestBroadcast_UpdateVisitMoveSendsMovementEvents(t *testing.T) {
 
 	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged), 2,
 		"source checkout and target checkin each need one precise aggregate refresh")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 2,
-		"visit move must preserve one legacy refresh per attendance change")
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged),
+		"visit move must fold both supervision invalidations into the combined refreshes")
+}
+
+func TestBroadcast_StartActivitySessionSendsOneCombinedRefresh(t *testing.T) {
+	t.Parallel()
+
+	svc, broadcaster := setupServiceWithBroadcaster(t)
+	db := testpkg.SetupTestDB(t)
+
+	activity := testpkg.CreateTestActivityGroup(t, db, "broadcast-session-start")
+	room := testpkg.CreateTestRoom(t, db, "Broadcast Session Start Room")
+	device := testpkg.CreateTestDevice(t, db, "broadcast-session-start-device")
+	staff := testpkg.CreateTestStaff(t, db, "Broadcast", "SessionStarter")
+
+	session, err := svc.StartActivitySessionWithSupervisors(
+		testpkg.Ctx(t), activity.ID, device.ID, []int64{staff.ID}, &room.ID,
+	)
+	require.NoError(t, err)
+
+	refreshes := tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged)
+	require.Len(t, refreshes, 1, "session start must emit one combined tenant refresh")
+	assert.Equal(t, strconv.FormatInt(session.ID, 10), refreshes[0].Event.ActiveGroupID)
+	require.NotNil(t, refreshes[0].Event.Data.Reason)
+	assert.Equal(t, "activity_started", *refreshes[0].Event.Data.Reason)
+	assert.Nil(t, refreshes[0].Event.Data.GroupIDs)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged),
+		"session start must not emit a separate supervision refresh")
 }
 
 func TestBroadcast_EndActivitySessionSendsBoundedRefreshes(t *testing.T) {
@@ -253,9 +283,13 @@ func TestBroadcast_EndActivitySessionSendsBoundedRefreshes(t *testing.T) {
 	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
 	for _, c := range refreshes {
 		assert.Nil(t, c.Event.Data.GroupIDs, "no educational group -> group_ids must be omitted entirely")
+		assert.Equal(t, strconv.FormatInt(session.ID, 10), c.Event.ActiveGroupID)
+		require.NotNil(t, c.Event.Data.Reason)
 	}
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 2,
-		"batch checkout and activity end must preserve legacy tenant refreshes")
+	assert.Equal(t, "student_moved", *refreshes[0].Event.Data.Reason)
+	assert.Equal(t, "activity_ended", *refreshes[1].Event.Data.Reason)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged),
+		"batch checkout and activity end must not emit separate supervision refreshes")
 }
 
 // TestBroadcast_EndActivitySessionBatchesCheckouts verifies the issue #848 fix:
@@ -313,7 +347,7 @@ func TestBroadcast_EndActivitySessionBatchesCheckouts(t *testing.T) {
 	// checkout batch fires one and broadcastActivityEndEvent fires one.
 	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged), 2,
 		"session end fires a fixed number of aggregate refreshes regardless of student count")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 2)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged))
 }
 
 // TestBroadcast_EndActivitySessionBatchesPerEducationGroup verifies the edu-group
@@ -407,10 +441,16 @@ func TestBroadcast_EndActivitySessionBatchesPerEducationGroup(t *testing.T) {
 	// (session end affects room occupancy across groups -> broad refresh).
 	refreshes := tenantCallsOfType(broadcaster, realtime.EventDashboardCountsChanged)
 	require.Len(t, refreshes, 2, "batch + activity end fire one aggregate refresh each")
+	assert.Equal(t, sessionIDStr, refreshes[0].Event.ActiveGroupID)
+	require.NotNil(t, refreshes[0].Event.Data.Reason)
+	assert.Equal(t, "student_moved", *refreshes[0].Event.Data.Reason)
 	require.NotNil(t, refreshes[0].Event.Data.GroupIDs, "batch refresh must carry the affected edu group ids")
 	assert.ElementsMatch(t, []string{gidX, gidY}, *refreshes[0].Event.Data.GroupIDs)
+	assert.Equal(t, sessionIDStr, refreshes[1].Event.ActiveGroupID)
+	require.NotNil(t, refreshes[1].Event.Data.Reason)
+	assert.Equal(t, "activity_ended", *refreshes[1].Event.Data.Reason)
 	assert.Nil(t, refreshes[1].Event.Data.GroupIDs, "activity-end refresh is deliberately unscoped")
-	assert.Len(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged), 2)
+	assert.Empty(t, tenantCallsOfType(broadcaster, realtime.EventActiveSupervisionChanged))
 	assert.Empty(t, broadcaster.CallsByMethod("all"), "dashboard refresh must not use cross-tenant BroadcastToAll")
 }
 

--- a/backend/services/active/sse_adapter.go
+++ b/backend/services/active/sse_adapter.go
@@ -11,9 +11,8 @@ import (
 )
 
 // broadcastSupervisionRefresh sends the tenant-wide refresh used by attendance
-// and activity changes. It preserves both legacy event types during a rolling
-// deploy: older clients use active_supervision_changed for supervision rosters,
-// while current clients recognize dashboard_counts_changed with Reason.
+// and activity changes. The dashboard event carries the union of the former
+// dashboard-count and active-supervision invalidation scopes.
 //
 // Carries no child identity (#2085). The scoped student_checkin /
 // student_checkout emitted alongside it still carry the id.
@@ -33,16 +32,6 @@ func (s *service) broadcastSupervisionRefresh(ctx context.Context, activeGroupID
 	event := realtime.NewEvent(realtime.EventDashboardCountsChanged, activeGroupID, data)
 	if err := s.Broadcaster.BroadcastToTenant(tenantID, event); err != nil {
 		s.getLogger().Warn("SSE combined supervision broadcast failed",
-			slog.String("error", err.Error()),
-			slog.String("active_group_id", activeGroupID),
-			slog.String("reason", reason),
-			slog.Int64("tenant_id", tenantID),
-		)
-	}
-
-	legacyEvent := realtime.NewEvent(realtime.EventActiveSupervisionChanged, activeGroupID, data)
-	if err := s.Broadcaster.BroadcastToTenant(tenantID, legacyEvent); err != nil {
-		s.getLogger().Warn("SSE legacy supervision broadcast failed",
 			slog.String("error", err.Error()),
 			slog.String("active_group_id", activeGroupID),
 			slog.String("reason", reason),

--- a/backend/services/active/visit_helpers.go
+++ b/backend/services/active/visit_helpers.go
@@ -416,30 +416,10 @@ func (s *service) emitVisitCreated(ctx context.Context, visit *active.Visit, sna
 			slog.String("student_id", studentID),
 		)
 	}
-	s.broadcastRosterRefreshToTopics(ctx, activeGroupID, studentRec, eduGroupIDs)
 
 	// One precise tenant event replaces the old dashboard_counts_changed +
 	// active_supervision_changed pair.
 	s.broadcastSupervisionRefresh(ctx, activeGroupID, activeSupervisionReasonStudentMoved, eduGroupIDs)
-}
-
-// broadcastRosterRefreshToTopics preserves active-supervision invalidation for
-// an older frontend during a rolling deploy. It is group-scoped rather than
-// tenant-wide, so only clients entitled to this roster pay for the compatibility
-// frame; BroadcastToGroups still deduplicates clients subscribed to both topics.
-func (s *service) broadcastRosterRefreshToTopics(ctx context.Context, activeGroupID string, studentRec *userModels.Student, eduGroupIDs []string) {
-	reason := activeSupervisionReasonStudentMoved
-	data := realtime.EventData{Reason: &reason}
-	if len(eduGroupIDs) > 0 {
-		data.GroupIDs = &eduGroupIDs
-	}
-	event := realtime.NewEvent(realtime.EventActiveSupervisionChanged, activeGroupID, data)
-	if err := s.broadcastVisitEvent(ctx, activeGroupID, studentRec, event); err != nil {
-		s.getLogger().Warn("SSE roster compatibility broadcast failed",
-			slog.String("error", err.Error()),
-			slog.String("active_group_id", activeGroupID),
-		)
-	}
 }
 
 func (s *service) broadcastVisitEvent(ctx context.Context, activeGroupID string, studentRec *userModels.Student, event realtime.Event) error {

--- a/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
+++ b/frontend/src/lib/hooks/__tests__/use-global-sse.test.ts
@@ -302,17 +302,12 @@ describe("useGlobalSSE", () => {
     it("load budget: one remote check-in revalidates the supervision aggregate once", () => {
       renderHook(() => useGlobalSSE());
 
-      // Current backends emit the scoped movement, one group-scoped legacy
-      // roster refresh, and one combined tenant refresh (#2115).
+      // Current backends emit the scoped movement and one combined tenant
+      // refresh (#2115).
       fire({
         type: "student_checkin",
         active_group_id: "123",
         data: { student_id: "42", group_ids: ["7"] },
-      });
-      fire({
-        type: "active_supervision_changed",
-        active_group_id: "123",
-        data: { reason: "student_moved", group_ids: ["7"] },
       });
       fire({
         type: "dashboard_counts_changed",
@@ -344,11 +339,6 @@ describe("useGlobalSSE", () => {
         type: "student_checkin",
         active_group_id: "123",
         data: { student_id: "42", group_ids: ["7"] },
-      });
-      fire({
-        type: "active_supervision_changed",
-        active_group_id: "123",
-        data: { reason: "student_moved", group_ids: ["7"] },
       });
       fire({
         type: "dashboard_counts_changed",
@@ -791,7 +781,7 @@ describe("useGlobalSSE", () => {
       expect(matcher("tenant:staff-dashboard-summary-month")).toBe(false);
     });
 
-    it("treats a reasoned dashboard event as the combined rolling-deploy refresh", () => {
+    it("treats a reasoned dashboard event as the combined supervision refresh", () => {
       renderHook(() => useGlobalSSE());
 
       fire({

--- a/frontend/src/lib/hooks/use-global-sse.ts
+++ b/frontend/src/lib/hooks/use-global-sse.ts
@@ -872,8 +872,8 @@ export function useGlobalSSE(): SSEHookState {
       if (event.data.group_ids && event.data.group_ids.length > 0) {
         collectEduGroupScope(event.data.group_ids);
       } else {
-        // During a frontend-first rolling deploy, the legacy dashboard
-        // companion may still supply the precise group scope before flush.
+        // Unpaired supervision emitters carry no educational-group scope, so
+        // their invalidation must stay broad.
         hasPendingUnscopedActiveEvent.current = true;
       }
       if (
@@ -985,17 +985,16 @@ export function useGlobalSSE(): SSEHookState {
         }
 
         case "active_supervision_changed": {
-          // Kept for unpaired emitters and a frontend-first rolling deploy.
+          // Kept for the schedule and scheduler emitters that have no paired
+          // dashboard-count change.
           collectActiveSupervisionChange(event);
           scheduleFlush();
           break;
         }
 
         case "dashboard_counts_changed": {
-          // The current backend folds the former paired supervision signal
-          // into this legacy event type. Old frontends still refresh their
-          // dashboard/OGS caches; current frontends recognize `reason` and
-          // apply the union of both former invalidation sets (#2115).
+          // A reason marks the combined dashboard/supervision signal. Apply
+          // the union of both former invalidation sets (#2115).
           hasPendingDashboardEvent.current = true;
           collectEduGroupScope(event.data.group_ids);
           if (event.data.reason) {


### PR DESCRIPTION
## Summary

- Deduplicate identical group-scoped attendance events across overlapping active-group and `edu:{id}` subscriptions.
- Replace the paired tenant-wide dashboard/supervision frames with one reasoned `dashboard_counts_changed` event.
- Preserve topic-specific bulk-checkout payloads and the three unpaired `active_supervision_changed` emitters.

## Validation

- `cd frontend && pnpm run check`
- `cd frontend && pnpm run test` — 14,227 tests passed
- Focused `realtime`, `services/active`, `services/schedule`, and `services/scheduler` tests passed
- Full backend run: 23,650 tests passed; unrelated `TestGetStudentStatusDaysOverview_AdminSeesEntries` failed once and passed on isolated rerun
- Pre-commit and pre-push checks passed

## Rollout

Already-open tabs running the previous frontend may need one refresh after deployment because the legacy compatibility frames are intentionally removed.

## Verständlichkeit

No user-visible copy or UI flow changed; the checklist is not applicable.

Closes #2115
