### PR TITLE
Deduplicate Codex skill catalog

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,6 +2,32 @@
 [features]
 hooks = true
 
+[skills]
+config = [
+  # Prefer native Codex skills over their Claude variants.
+  { path = ".claude/skills/creating-team-skills/SKILL.md", enabled = false },
+  { path = ".claude/skills/env-docker-sync/SKILL.md", enabled = false },
+  { path = ".claude/skills/find-skills/SKILL.md", enabled = false },
+  { path = ".claude/skills/help-guide-sync/SKILL.md", enabled = false },
+  { path = ".claude/skills/moto-einfache-sprache/SKILL.md", enabled = false },
+  { path = ".claude/skills/settings/SKILL.md", enabled = false },
+
+  # Prefer this repository's skills over personal copies while in this project.
+  { path = "~/.agents/skills/code-review/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/codebase-design/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/diagnosing-bugs/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/domain-modeling/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/find-skills/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/grilling/SKILL.md", enabled = false },
+  { path = "~/.claude/skills/moto-einfache-sprache/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/prototype/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/research/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/resolving-merge-conflicts/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/tdd/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/wizard/SKILL.md", enabled = false },
+  { path = "~/.agents/skills/writing-for-agents/SKILL.md", enabled = false },
+]
+
 [shell_environment_policy]
 inherit = "core"
 


### PR DESCRIPTION
## Summary
- prefer repository `.agents` skills over duplicate `.claude` variants in Codex
- suppress matching personal skill copies only while working in this project
- keep personal skills available in other repositories and leave Claude behavior unchanged

## Validation
- parsed `.codex/config.toml` as TOML
- rendered the Codex prompt with this configuration: 57 entries, 57 unique names, 0 duplicates
- passed the repository pre-commit hook