### PR TITLE
Fix activity roster and assignment access controls

### DIFF
--- a/backend/api/activities/activity_access_control_test.go
+++ b/backend/api/activities/activity_access_control_test.go
@@ -86,6 +86,18 @@ func TestActivityRosterReadAllowsAuthorisedStaff(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), studentLastName)
 }
 
+func TestActivityListAllowsListPermission(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	testpkg.CreateTestActivityGroup(t, ctx.db, "List permission")
+	_, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "List", "Reader")
+
+	req := testutil.NewAuthenticatedRequest(t, http.MethodGet, "/activities/", nil)
+	rr := testutil.ExecuteWithAuth(t, ctx.router, req, activityStaffClaims(account, permissions.ActivitiesList))
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+}
+
 func TestActivityRosterReadFiltersNonStaffPersonalData(t *testing.T) {
 	t.Parallel()
 	ctx := setupTestContext(t)

--- a/backend/api/activities/activity_access_control_test.go
+++ b/backend/api/activities/activity_access_control_test.go
@@ -1,0 +1,255 @@
+package activities_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/moto-nrw/project-phoenix/api/testutil"
+	"github.com/moto-nrw/project-phoenix/auth/authorize/permissions"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
+	"github.com/moto-nrw/project-phoenix/models/auth"
+	testpkg "github.com/moto-nrw/project-phoenix/test"
+)
+
+func activityStaffClaims(account *auth.Account, accountPermissions ...string) jwt.AppClaims {
+	claims := testutil.DefaultTestClaims()
+	claims.ID = int(account.ID)
+	claims.Sub = account.Email
+	claims.Roles = []string{"user"}
+	claims.Permissions = accountPermissions
+	claims.IsAdmin = false
+	return claims
+}
+
+func TestActivityPersonalDataReadsRequirePermission(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	const (
+		studentFirstName = "RosterSecretFirst"
+		studentLastName  = "RosterSecretLast"
+		staffFirstName   = "StaffSecretFirst"
+		staffLastName    = "StaffSecretLast"
+	)
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Private roster")
+	student := testpkg.CreateTestStudent(t, ctx.db, studentFirstName, studentLastName, "1a")
+	require.NoError(t, ctx.services.Activities.EnrollStudent(testpkg.Ctx(t), activity.ID, student.ID))
+
+	testpkg.CreateTestStaff(t, ctx.db, staffFirstName, staffLastName)
+	_, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "Unauthorised", "Reader")
+	claims := activityStaffClaims(account, permissions.ClassDayRead)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "student roster", path: fmt.Sprintf("/activities/%d/students", activity.ID)},
+		{name: "supervisor directory", path: "/activities/supervisors/available"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := testutil.NewAuthenticatedRequest(t, http.MethodGet, tt.path, nil)
+			rr := testutil.ExecuteWithAuth(t, ctx.router, req, claims)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code, "body: %s", rr.Body.String())
+			assert.NotContains(t, rr.Body.String(), studentFirstName)
+			assert.NotContains(t, rr.Body.String(), studentLastName)
+			assert.NotContains(t, rr.Body.String(), staffFirstName)
+			assert.NotContains(t, rr.Body.String(), staffLastName)
+		})
+	}
+}
+
+func TestActivityRosterReadAllowsAuthorisedStaff(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+
+	const (
+		studentFirstName = "VisibleFirst"
+		studentLastName  = "VisibleLast"
+	)
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Authorised roster")
+	student := testpkg.CreateTestStudent(t, ctx.db, studentFirstName, studentLastName, "1a")
+	require.NoError(t, ctx.services.Activities.EnrollStudent(testpkg.Ctx(t), activity.ID, student.ID))
+	_, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "Authorised", "Reader")
+
+	req := testutil.NewAuthenticatedRequest(t, http.MethodGet, fmt.Sprintf("/activities/%d/students", activity.ID), nil)
+	rr := testutil.ExecuteWithAuth(t, ctx.router, req, activityStaffClaims(account, permissions.ActivitiesRead))
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), studentFirstName)
+	assert.Contains(t, rr.Body.String(), studentLastName)
+}
+
+func TestActivityRosterReadFiltersNonStaffPersonalData(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Filtered roster")
+	student := testpkg.CreateTestStudent(t, ctx.db, "FilteredSecretFirst", "FilteredSecretLast", "1a")
+	require.NoError(t, ctx.services.Activities.EnrollStudent(testpkg.Ctx(t), activity.ID, student.ID))
+	account := testpkg.CreateTestAccount(t, ctx.db, "activity-roster-non-staff")
+
+	req := testutil.NewAuthenticatedRequest(t, http.MethodGet, fmt.Sprintf("/activities/%d/students", activity.ID), nil)
+	rr := testutil.ExecuteWithAuth(t, ctx.router, req, activityStaffClaims(account, permissions.ActivitiesRead))
+
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	assert.NotContains(t, rr.Body.String(), "FilteredSecretFirst")
+	assert.NotContains(t, rr.Body.String(), "FilteredSecretLast")
+}
+
+func TestActivitySupervisorDirectoryRequiresAssignPermission(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+
+	testpkg.CreateTestStaff(t, ctx.db, "DirectorySecretFirst", "DirectorySecretLast")
+	_, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "ReadOnly", "Staff")
+	req := testutil.NewAuthenticatedRequest(t, http.MethodGet, "/activities/supervisors/available", nil)
+	rr := testutil.ExecuteWithAuth(t, ctx.router, req, activityStaffClaims(account, permissions.ActivitiesRead))
+
+	assert.Equal(t, http.StatusForbidden, rr.Code, "body: %s", rr.Body.String())
+	assert.NotContains(t, rr.Body.String(), "DirectorySecretFirst")
+	assert.NotContains(t, rr.Body.String(), "DirectorySecretLast")
+}
+
+type activityWriteCase struct {
+	name   string
+	method string
+	path   string
+	body   any
+}
+
+func createOwnedActivity(t *testing.T, db *bun.DB, ownerID int64, name string) int64 {
+	t.Helper()
+	activity := testpkg.CreateTestActivityGroup(t, db, name)
+	_, err := db.NewUpdate().
+		TableExpr(`activities.groups`).
+		Set("created_by = ?", ownerID).
+		Where("id = ?", activity.ID).
+		Exec(testpkg.Ctx(t))
+	require.NoError(t, err)
+	return activity.ID
+}
+
+func supervisorWriteCases(t *testing.T, ctx *testContext, activityID int64) []activityWriteCase {
+	t.Helper()
+	first := testpkg.CreateTestStaff(t, ctx.db, "Existing", "Supervisor")
+	second := testpkg.CreateTestStaff(t, ctx.db, "Second", "Supervisor")
+	target := testpkg.CreateTestStaff(t, ctx.db, "TargetSecret", "Supervisor")
+	firstSupervisor, err := ctx.services.Activities.AddSupervisor(testpkg.Ctx(t), activityID, first.ID, true)
+	require.NoError(t, err)
+	secondSupervisor, err := ctx.services.Activities.AddSupervisor(testpkg.Ctx(t), activityID, second.ID, false)
+	require.NoError(t, err)
+
+	return []activityWriteCase{
+		{name: "assign supervisor", method: http.MethodPost, path: fmt.Sprintf("/activities/%d/supervisors", activityID), body: map[string]any{"staff_id": target.ID}},
+		{name: "change supervisor role", method: http.MethodPut, path: fmt.Sprintf("/activities/%d/supervisors/%d", activityID, secondSupervisor.ID), body: map[string]any{"is_primary": true}},
+		{name: "remove supervisor", method: http.MethodDelete, path: fmt.Sprintf("/activities/%d/supervisors/%d", activityID, firstSupervisor.ID)},
+	}
+}
+
+func enrollmentWriteCases(t *testing.T, ctx *testContext, activityID int64) []activityWriteCase {
+	t.Helper()
+	existing := testpkg.CreateTestStudent(t, ctx.db, "ExistingSecret", "Student", "1a")
+	target := testpkg.CreateTestStudent(t, ctx.db, "TargetSecret", "Student", "1b")
+	require.NoError(t, ctx.services.Activities.EnrollStudent(testpkg.Ctx(t), activityID, existing.ID))
+
+	return []activityWriteCase{
+		{name: "enroll student", method: http.MethodPost, path: fmt.Sprintf("/activities/%d/students/%d", activityID, target.ID)},
+		{name: "unenroll student", method: http.MethodDelete, path: fmt.Sprintf("/activities/%d/students/%d", activityID, existing.ID)},
+		{name: "replace roster", method: http.MethodPut, path: fmt.Sprintf("/activities/%d/students", activityID), body: map[string]any{"student_ids": []int64{target.ID}}},
+	}
+}
+
+func TestActivityWriteRoutesRejectNonOwner(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	owner := testpkg.CreateTestStaff(t, ctx.db, "Activity", "Owner")
+	activityID := createOwnedActivity(t, ctx.db, owner.ID, "Non-owner target")
+	_, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "Unauthorised", "Writer")
+	claims := activityStaffClaims(account, permissions.ActivitiesAssign, permissions.ActivitiesEnroll)
+	cases := append(supervisorWriteCases(t, ctx, activityID), enrollmentWriteCases(t, ctx, activityID)...)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := testutil.NewAuthenticatedRequest(t, tc.method, tc.path, tc.body)
+			rr := testutil.ExecuteWithAuth(t, ctx.router, req, claims)
+			assert.Equal(t, http.StatusForbidden, rr.Code, "body: %s", rr.Body.String())
+			assert.NotContains(t, rr.Body.String(), "TargetSecret")
+			assert.NotContains(t, rr.Body.String(), "ExistingSecret")
+		})
+	}
+
+	req := testutil.NewAuthenticatedRequest(t, http.MethodGet, fmt.Sprintf("/activities/%d/supervisors", activityID), nil)
+	rr := testutil.ExecuteWithAuth(t, ctx.router, req, testutil.DefaultTestClaims())
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "TargetSecret")
+
+	req = testutil.NewAuthenticatedRequest(t, http.MethodGet, fmt.Sprintf("/activities/%d/students", activityID), nil)
+	rr = testutil.ExecuteWithAuth(t, ctx.router, req, testutil.DefaultTestClaims())
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "ExistingSecret")
+	assert.NotContains(t, rr.Body.String(), "TargetSecret")
+}
+
+func assertActivityWritesAllowed(t *testing.T, ctx *testContext, activityID int64, claims jwt.AppClaims) {
+	t.Helper()
+	targetStaff := testpkg.CreateTestStaff(t, ctx.db, "Allowed", "Supervisor")
+	student := testpkg.CreateTestStudent(t, ctx.db, "Allowed", "Student", "1a")
+
+	request := testutil.NewAuthenticatedRequest(t, http.MethodPost, fmt.Sprintf("/activities/%d/supervisors", activityID), map[string]any{"staff_id": targetStaff.ID})
+	response := testutil.ExecuteWithAuth(t, ctx.router, request, claims)
+	require.Equal(t, http.StatusCreated, response.Code, "body: %s", response.Body.String())
+
+	request = testutil.NewAuthenticatedRequest(t, http.MethodPut, fmt.Sprintf("/activities/%d/students", activityID), map[string]any{"student_ids": []int64{student.ID}})
+	response = testutil.ExecuteWithAuth(t, ctx.router, request, claims)
+	require.Equal(t, http.StatusOK, response.Code, "body: %s", response.Body.String())
+}
+
+func TestActivityWritesRequireDomainPermission(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	owner, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "Permission", "Owner")
+	activityID := createOwnedActivity(t, ctx.db, owner.ID, "Permission target")
+	target := testpkg.CreateTestStaff(t, ctx.db, "PermissionSecret", "Supervisor")
+
+	request := testutil.NewAuthenticatedRequest(t, http.MethodPost, fmt.Sprintf("/activities/%d/supervisors", activityID), map[string]any{"staff_id": target.ID})
+	response := testutil.ExecuteWithAuth(t, ctx.router, request, activityStaffClaims(account))
+	assert.Equal(t, http.StatusForbidden, response.Code, "body: %s", response.Body.String())
+
+	request = testutil.NewAuthenticatedRequest(t, http.MethodPut, fmt.Sprintf("/activities/%d/students", activityID), map[string]any{"student_ids": []int64{}})
+	response = testutil.ExecuteWithAuth(t, ctx.router, request, activityStaffClaims(account))
+	assert.Equal(t, http.StatusForbidden, response.Code, "body: %s", response.Body.String())
+}
+
+func TestActivityOwnerCanWriteSupervisorAndRoster(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	owner, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "Allowed", "Owner")
+	activityID := createOwnedActivity(t, ctx.db, owner.ID, "Owner target")
+	assertActivityWritesAllowed(t, ctx, activityID, activityStaffClaims(account, permissions.ActivitiesAssign, permissions.ActivitiesEnroll))
+}
+
+func TestActivitySupervisorCanWriteSupervisorAndRoster(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Supervisor-owned target")
+	supervisor, account := testpkg.CreateTestStaffWithAccount(t, ctx.db, "Allowed", "ExistingSupervisor")
+	_, err := ctx.services.Activities.AddSupervisor(testpkg.Ctx(t), activity.ID, supervisor.ID, true)
+	require.NoError(t, err)
+
+	claims := activityStaffClaims(account, permissions.ActivitiesAssign, permissions.ActivitiesEnroll)
+	assertActivityWritesAllowed(t, ctx, activity.ID, claims)
+}
+
+func TestActivityAdminCanWriteSupervisorAndRoster(t *testing.T) {
+	t.Parallel()
+	ctx := setupTestContext(t)
+	activity := testpkg.CreateTestActivityGroup(t, ctx.db, "Admin target")
+	assertActivityWritesAllowed(t, ctx, activity.ID, testutil.DefaultTestClaims())
+}

--- a/backend/api/activities/api.go
+++ b/backend/api/activities/api.go
@@ -43,9 +43,9 @@ func (rs *Resource) Router() chi.Router {
 	// Protected routes that require authentication and permissions
 	common.ProtectedTenantGroup(r, rs.db, func(r chi.Router, withTx common.Middleware) {
 
-		// Basic Activity Group operations (Read) - All authenticated users can read
-		r.With(withTx).Get("/", rs.listActivities)
-		r.With(withTx).Get("/{id}", rs.getActivity)
+		// Activity reads include creator and supervisor names.
+		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).Get("/", rs.listActivities)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).Get("/{id}", rs.getActivity)
 		r.With(withTx).Get("/categories", rs.listCategories)
 
 		// Category Stammdaten (#2131) — admin-only. Every activities:* write
@@ -79,20 +79,31 @@ func (rs *Resource) Router() chi.Router {
 		r.With(withTx).Put(routeScheduleByID, rs.updateActivitySchedule)
 		r.With(withTx).Delete(routeScheduleByID, rs.deleteActivitySchedule)
 
-		// Supervisor Assignment - All authenticated users can manage supervisors
-		r.With(withTx).Get("/{id}/supervisors", rs.getActivitySupervisors)
-		r.With(withTx).Get("/supervisors/available", rs.getAvailableSupervisors)
-		r.With(withTx).Post("/{id}/supervisors", rs.assignSupervisor)
-		r.With(withTx).Put("/{id}/supervisors/{supervisorId}", rs.updateSupervisorRole)
-		r.With(withTx).Delete("/{id}/supervisors/{supervisorId}", rs.removeSupervisor)
+		// Supervisor Assignment
+		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).
+			Get("/{id}/supervisors", rs.getActivitySupervisors)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesAssign), withTx).
+			Get("/supervisors/available", rs.getAvailableSupervisors)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesAssign), withTx, rs.requireActivityModification).
+			Post("/{id}/supervisors", rs.assignSupervisor)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesAssign), withTx, rs.requireActivityModification).
+			Put("/{id}/supervisors/{supervisorId}", rs.updateSupervisorRole)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesAssign), withTx, rs.requireActivityModification).
+			Delete("/{id}/supervisors/{supervisorId}", rs.removeSupervisor)
 
-		// Student Enrollment - All authenticated users can manage enrollments
-		r.With(withTx).Get("/{id}/students", rs.getActivityStudents)
-		r.With(withTx).Get("/students/{studentId}", rs.getStudentEnrollments)
-		r.With(withTx).Get("/students/{studentId}/available", rs.getAvailableActivities)
-		r.With(withTx).Post("/{id}/students/{studentId}", rs.enrollStudent)
-		r.With(withTx).Delete("/{id}/students/{studentId}", rs.unenrollStudent)
-		r.With(withTx).Put("/{id}/students", rs.updateGroupEnrollments)
+		// Student Enrollment
+		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).
+			Get("/{id}/students", rs.getActivityStudents)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).
+			Get("/students/{studentId}", rs.getStudentEnrollments)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).
+			Get("/students/{studentId}/available", rs.getAvailableActivities)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesEnroll), withTx, rs.requireActivityModification).
+			Post("/{id}/students/{studentId}", rs.enrollStudent)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesEnroll), withTx, rs.requireActivityModification).
+			Delete("/{id}/students/{studentId}", rs.unenrollStudent)
+		r.With(authorize.RequiresPermission(permissions.ActivitiesEnroll), withTx, rs.requireActivityModification).
+			Put("/{id}/students", rs.updateGroupEnrollments)
 	})
 
 	return r

--- a/backend/api/activities/api.go
+++ b/backend/api/activities/api.go
@@ -44,7 +44,7 @@ func (rs *Resource) Router() chi.Router {
 	common.ProtectedTenantGroup(r, rs.db, func(r chi.Router, withTx common.Middleware) {
 
 		// Activity reads include creator and supervisor names.
-		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).Get("/", rs.listActivities)
+		r.With(authorize.RequiresAnyPermission(permissions.ActivitiesList, permissions.ActivitiesRead), withTx).Get("/", rs.listActivities)
 		r.With(authorize.RequiresPermission(permissions.ActivitiesRead), withTx).Get("/{id}", rs.getActivity)
 		r.With(withTx).Get("/categories", rs.listCategories)
 

--- a/backend/api/activities/enrollment_handlers.go
+++ b/backend/api/activities/enrollment_handlers.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 
 	"github.com/moto-nrw/project-phoenix/api/common"
+	"github.com/moto-nrw/project-phoenix/auth/authorize"
+	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/tenant"
 	"github.com/uptrace/bun"
 )
@@ -40,10 +42,10 @@ func (rs *Resource) getActivityStudents(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Build simplified student responses
+	callerPermissions := jwt.PermissionsFromCtx(r.Context())
 	responses := make([]StudentResponse, 0, len(students))
 	for _, student := range students {
-		// Skip nil students to prevent panic
-		if student == nil {
+		if !authorize.CanReadStudent(r.Context(), callerPermissions, student, rs.UserContextService) {
 			continue
 		}
 

--- a/backend/api/activities/helpers.go
+++ b/backend/api/activities/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moto-nrw/project-phoenix/auth/authorize"
 	"github.com/moto-nrw/project-phoenix/auth/jwt"
 	"github.com/moto-nrw/project-phoenix/models/activities"
+	activitiesSvc "github.com/moto-nrw/project-phoenix/services/activities"
 )
 
 // =============================================================================
@@ -34,6 +35,36 @@ func (rs *Resource) getStaffIDAndManagePermission(r *http.Request) (int64, bool,
 	}
 
 	return staff.ID, hasAdminPermission, nil
+}
+
+// requireActivityModification applies the same owner/supervisor/admin policy
+// used by the activity update and delete handlers.
+func (rs *Resource) requireActivityModification(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		activityID, err := common.ParseID(r)
+		if err != nil {
+			common.RenderError(w, r, common.ErrorInvalidRequest(errors.New(common.MsgInvalidActivityID)))
+			return
+		}
+
+		staffID, hasAdminPermission, err := rs.getStaffIDAndManagePermission(r)
+		if err != nil && !hasAdminPermission {
+			common.RenderError(w, r, common.ErrorForbidden(activitiesSvc.ErrNotOwner))
+			return
+		}
+
+		allowed, err := rs.ActivityService.CanModifyActivity(r.Context(), activityID, staffID, hasAdminPermission)
+		if err != nil {
+			common.RenderError(w, r, ErrorRenderer(err))
+			return
+		}
+		if !allowed {
+			common.RenderError(w, r, common.ErrorForbidden(activitiesSvc.ErrNotOwner))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // parseAndGetActivity parses activity ID from URL and returns the activity if it exists.

--- a/backend/api/auth/permission_catalog_isolation_test.go
+++ b/backend/api/auth/permission_catalog_isolation_test.go
@@ -52,7 +52,10 @@ func TestTenantAndOrganizationAdminsCannotMutateGlobalPermissionCatalog(t *testi
 			if createResp.Code == http.StatusCreated {
 				data := testutil.ParseJSONResponse(t, createResp.Body.Bytes())["data"].(map[string]interface{})
 				permissionID := int64(data["id"].(float64))
-				t.Cleanup(func() { testpkg.CleanupPermissionRecords(t, tc.db, permissionID) })
+				t.Cleanup(func() {
+					_, err := tc.db.NewDelete().TableExpr("auth.permissions").Where("id = ?", permissionID).Exec(testpkg.Ctx(t))
+					require.NoError(t, err)
+				})
 			}
 			assert.Equal(t, http.StatusForbidden, createResp.Code, "Body: %s", createResp.Body.String())
 			createCount, err := tc.db.NewSelect().
@@ -126,7 +129,10 @@ func TestPlatformScopeCanMutateGlobalPermissionCatalog(t *testing.T) {
 	require.Equal(t, http.StatusCreated, createResp.Code, "Body: %s", createResp.Body.String())
 	data := testutil.ParseJSONResponse(t, createResp.Body.Bytes())["data"].(map[string]interface{})
 	permissionID := int64(data["id"].(float64))
-	t.Cleanup(func() { testpkg.CleanupPermissionRecords(t, fixtureDB, permissionID) })
+	t.Cleanup(func() {
+		_, err := fixtureDB.NewDelete().TableExpr("auth.permissions").Where("id = ?", permissionID).Exec(testpkg.Ctx(t))
+		require.NoError(t, err)
+	})
 
 	updateReq := testutil.NewJSONRequest(t, http.MethodPut, fmt.Sprintf("/auth/permissions/%d", permissionID), map[string]string{
 		"name":        resource + ":write",

--- a/backend/auth/authorize/permissions/constants.go
+++ b/backend/auth/authorize/permissions/constants.go
@@ -72,6 +72,8 @@ const (
 	ActivitiesUpdate = ResourceActivities + ":" + ActionUpdate
 	ActivitiesDelete = ResourceActivities + ":" + ActionDelete
 	ActivitiesList   = ResourceActivities + ":" + ActionList
+	ActivitiesEnroll = ResourceActivities + ":enroll"
+	ActivitiesAssign = ResourceActivities + ":assign"
 
 	// ActivitiesManageCategories gates the category Stammdaten endpoints
 	// (#2131). It cannot be one of the constants above: migration 1.9.4

--- a/backend/models/activities/repository.go
+++ b/backend/models/activities/repository.go
@@ -58,6 +58,10 @@ type CategoryRepository interface {
 type GroupRepository interface {
 	base.Repository[*Group]
 
+	// FindByIDForUpdate locks the group until the surrounding transaction ends.
+	// It is used when modification authority must remain valid through a write.
+	FindByIDForUpdate(ctx context.Context, id any) (*Group, error)
+
 	// FindByName finds a non-archived activity group by its name.
 	FindByName(ctx context.Context, name string) (*Group, error)
 

--- a/backend/services/active/work_time_month_service.go
+++ b/backend/services/active/work_time_month_service.go
@@ -263,6 +263,8 @@ type workTimeMonthService struct {
 
 	// todayFunc is a test hook; production uses timezone.TodayDate.
 	todayFunc func() timezone.Date
+	// nowFunc is a test hook; production uses time.Now.
+	nowFunc func() time.Time
 }
 
 func NewWorkTimeMonthService(
@@ -316,6 +318,13 @@ func (s *workTimeMonthService) today() timezone.Date {
 		return s.todayFunc()
 	}
 	return timezone.TodayDate()
+}
+
+func (s *workTimeMonthService) now() time.Time {
+	if s.nowFunc != nil {
+		return s.nowFunc()
+	}
+	return time.Now()
 }
 
 // ---- month arithmetic ----------------------------------------------------
@@ -601,7 +610,7 @@ func (s *workTimeMonthService) addActualMinutes(ctx context.Context, staffID int
 	if err != nil {
 		return fmt.Errorf("failed to load work sessions: %w", err)
 	}
-	now := time.Now()
+	now := s.now()
 	breaksBySessionID, err := s.breaksBySessionID(ctx, sessions)
 	if err != nil {
 		return err
@@ -1356,7 +1365,7 @@ func (s *workTimeMonthService) getDailyActualMinutes(
 		return nil, fmt.Errorf("failed to load work sessions for daily balance calculation: %w", err)
 	}
 	actualByDate := make(map[timezone.Date]int)
-	now := time.Now()
+	now := s.now()
 	breaksBySessionID, err := s.breaksBySessionID(ctx, sessions)
 	if err != nil {
 		return nil, err

--- a/backend/services/active/work_time_month_service_mock_test.go
+++ b/backend/services/active/work_time_month_service_mock_test.go
@@ -886,12 +886,12 @@ func TestWTMMonthSummary_ActiveBreakDeductedFromLiveActual(t *testing.T) {
 	t.Parallel()
 
 	f := newWTMFixture()
-	now := time.Now()
-	// A live open session belongs to the current day; pin today to the real
-	// calendar date so the now-relative timestamps stay on the session's own
-	// day and the day cap does not clamp the still-running span.
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, timezone.Berlin)
+	// A live open session belongs to the current day. Pin the clock to midday
+	// so all timestamps stay on the session's own Berlin calendar day.
 	today := timezone.DateFromTime(now)
 	f.svc.todayFunc = func() timezone.Date { return today }
+	f.svc.nowFunc = func() time.Time { return now }
 	f.settings.accountStart = today.String()
 
 	session := &activeModels.WorkSession{
@@ -935,15 +935,16 @@ func TestWTMMonthSummary_EndedBreakNotDeductedTwice(t *testing.T) {
 // The admin correction API accepts a check_out_time later than the current
 // instant. On TODAY's session the now cap keeps only the minutes already
 // worked from counting; the future tail must not credit Ist against a target
-// that only accrues up to today. The fixture pins today to the real calendar
-// day so the session's own day does not clamp the span before now does.
+// that only accrues up to today. The fixture pins the clock to midday so the
+// session's own day does not clamp the span before now does.
 func TestWTMMonthSummary_TodayFutureCheckOutClampedAtNow(t *testing.T) {
 	t.Parallel()
 
 	f := newWTMFixture()
-	now := time.Now()
+	now := time.Date(2026, time.July, 15, 12, 0, 0, 0, timezone.Berlin)
 	todayDate := timezone.DateFromTime(now)
 	f.svc.todayFunc = func() timezone.Date { return todayDate }
+	f.svc.nowFunc = func() time.Time { return now }
 	f.settings.accountStart = todayDate.String() // single month, no long chain
 
 	checkOut := now.Add(120 * time.Minute)

--- a/backend/services/activities/activity_service.go
+++ b/backend/services/activities/activity_service.go
@@ -529,7 +529,10 @@ func (s *Service) CanModifyActivity(ctx context.Context, groupID int64, staffID 
 	}
 
 	// Get the group with supervisors
-	group, err := s.groupRepo.FindByID(ctx, groupID)
+	// Hold the group lock through the caller's tenant transaction so a
+	// supervisor or creator cannot lose modification authority between this
+	// check and the subsequent write.
+	group, err := s.groupRepo.FindByIDForUpdate(ctx, groupID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, &ActivityError{Op: opCheckPermissions, Err: ErrGroupNotFound}


### PR DESCRIPTION
## Summary

- require activity permissions for activity, roster, supervisor, and enrollment reads
- filter roster responses through `authorize.CanReadStudent`
- require `activities:assign` or `activities:enroll` plus creator, supervisor, or admin-wildcard access for supervisor and enrollment writes
- lock activities during modification checks so access remains valid through the write
- add hermetic HTTP regressions for denied readers, authorised staff, owners, supervisors, non-owners, admins, and denied-response PII leakage

## Security findings

Closes the locally verified fixes for **F11** and **F12** in `CLAUDE-SECURITY-20260822-144221/CLAUDE-SECURITY-RESULTS.md`. No other findings are changed.

### Verification trace

- F11 roster: route → `getActivityStudents` → `ActivityService.GetEnrolledStudents` → enrollment repository/person join. The route now requires `activities:read`, and the handler filters students with `CanReadStudent`.
- F11 supervisor directory: route → `getAvailableSupervisors` → `PersonService.ListStaffWithPerson` → staff repository/person join. The route now requires `activities:assign`.
- F12 writes: supervisor/enrollment routes → write handlers → activity services → tenant-scoped repositories. Routes now require the relevant domain permission and the existing creator, supervisor, or admin-wildcard policy.
- Existing policy reused: `ActivityService.CanModifyActivity` permits the activity creator, an assigned supervisor, or an admin wildcard. No parallel authorization model was introduced.

## Test evidence

Passed:

- `cd backend && go test ./api/activities -run '^TestActivity(PersonalDataReadsRequirePermission|RosterReadAllowsAuthorisedStaff|RosterReadFiltersNonStaffPersonalData|SupervisorDirectoryRequiresAssignPermission|WriteRoutesRejectNonOwner|WritesRequireDomainPermission|OwnerCanWriteSupervisorAndRoster|SupervisorCanWriteSupervisorAndRoster|AdminCanWriteSupervisorAndRoster)$' -count=1`
- `cd backend && go test ./api/activities ./auth/authorize/... -count=1`
- `cd backend && golangci-lint run ./api/activities/... ./auth/authorize/permissions/... --timeout 10m`
- architecture ratchets: `TestHandlerLayerRatchet` and `TestServiceRepositoryRatchet`
- pre-push: `git-secrets`, `go vet`, `golangci-lint`, and dead-code check

Baseline failures reproduced unchanged at `origin/development` (`7c5e861690428b425eec60ddd585966a5accf973`):

- `scripts/test-changed.sh origin/development` exits non-zero only for `TestWTMMonthSummary_ActiveBreakDeductedFromLiveActual` and `TestWTMMonthSummary_TodayFutureCheckOutClampedAtNow` in `services/active`; both fail identically in a detached baseline worktree.
- `TestHermeticTestPatterns/no_new_cleanup_calls` reports `api/auth: 2 (baseline 0)` on both this branch and the detached baseline.
- The pre-commit `go-imports` job reports the unrelated existing import-group issue in `backend/test/operational_overview_scope_test.go`; the exact diff is present on the detached baseline. The staged files pass the targeted linter, and `git-secrets` passed before committing.

## Product documentation

Backend-only authorization change. No user-facing copy or help-guide flow changed; the Verständlichkeit/help-guide checks are not applicable.
