### PR TITLE
fix: restore development CI integrity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     outputs:
-      # Test jobs cross-run after merge to produce complete Sonar coverage.
+      # Every protected-branch push rechecks both full suites. A docs-only push
+      # must not report green while inheriting a broken development head.
       # Lint/build jobs stay scoped to the side that changed.
-      run-backend: ${{ steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && steps.filter.outputs.frontend == 'true') }}
-      run-frontend: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.frontend-test-infra == 'true' || steps.filter.outputs.ci == 'true' || (github.event_name == 'push' && (steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true')) }}
+      run-backend: ${{ github.event_name == 'push' || steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true' || steps.filter.outputs.ci == 'true' }}
+      run-frontend: ${{ github.event_name == 'push' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.frontend-test-infra == 'true' || steps.filter.outputs.ci == 'true' }}
       run-backend-lint: ${{ steps.filter.outputs.backend-lint == 'true' || steps.filter.outputs.ci == 'true' }}
       run-frontend-lint: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
       # The seed smoke drives runtime API contracts. Test-only edits and

--- a/backend/api/auth/permission_catalog_isolation_test.go
+++ b/backend/api/auth/permission_catalog_isolation_test.go
@@ -49,14 +49,6 @@ func TestTenantAndOrganizationAdminsCannotMutateGlobalPermissionCatalog(t *testi
 				"action":      "read",
 			})
 			createResp := testutil.ExecuteWithAuthPermissions(t, router, createReq, claims, permissions)
-			if createResp.Code == http.StatusCreated {
-				data := testutil.ParseJSONResponse(t, createResp.Body.Bytes())["data"].(map[string]interface{})
-				permissionID := int64(data["id"].(float64))
-				t.Cleanup(func() {
-					_, err := tc.db.NewDelete().TableExpr("auth.permissions").Where("id = ?", permissionID).Exec(testpkg.Ctx(t))
-					require.NoError(t, err)
-				})
-			}
 			assert.Equal(t, http.StatusForbidden, createResp.Code, "Body: %s", createResp.Body.String())
 			createCount, err := tc.db.NewSelect().
 				TableExpr("auth.permissions").
@@ -129,10 +121,6 @@ func TestPlatformScopeCanMutateGlobalPermissionCatalog(t *testing.T) {
 	require.Equal(t, http.StatusCreated, createResp.Code, "Body: %s", createResp.Body.String())
 	data := testutil.ParseJSONResponse(t, createResp.Body.Bytes())["data"].(map[string]interface{})
 	permissionID := int64(data["id"].(float64))
-	t.Cleanup(func() {
-		_, err := fixtureDB.NewDelete().TableExpr("auth.permissions").Where("id = ?", permissionID).Exec(testpkg.Ctx(t))
-		require.NoError(t, err)
-	})
 
 	updateReq := testutil.NewJSONRequest(t, http.MethodPut, fmt.Sprintf("/auth/permissions/%d", permissionID), map[string]string{
 		"name":        resource + ":write",

--- a/backend/test/operational_overview_scope_test.go
+++ b/backend/test/operational_overview_scope_test.go
@@ -24,6 +24,7 @@ import (
 	configModel "github.com/moto-nrw/project-phoenix/models/config"
 	usersModel "github.com/moto-nrw/project-phoenix/models/users"
 	configService "github.com/moto-nrw/project-phoenix/services/config"
+
 	// Registers the real setting definitions — the gate resolves the key
 	// against the production registry, not a test stand-in.
 	_ "github.com/moto-nrw/project-phoenix/services/config/defaults"

--- a/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
+++ b/frontend/src/app/[tenant]/(protected)/time-tracking/page.test.tsx
@@ -1457,22 +1457,28 @@ describe("TimeTrackingPage", () => {
   // of a range by intersection instead of by stored date.
   describe("abgelaufene und übergreifende Blöcke (#2402)", () => {
     it("stops counting a block whose live limit has passed", () => {
-      const threeDaysAgo = new Date(today);
-      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-      const staleISO = `${threeDaysAgo.getFullYear()}-${String(threeDaysAgo.getMonth() + 1).padStart(2, "0")}-${String(threeDaysAgo.getDate()).padStart(2, "0")}`;
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-15T12:00:00+01:00"));
+      try {
+        const threeDaysAgo = new Date();
+        threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+        const staleISO = `${threeDaysAgo.getFullYear()}-${String(threeDaysAgo.getMonth() + 1).padStart(2, "0")}-${String(threeDaysAgo.getDate()).padStart(2, "0")}`;
 
-      setupDefaultMocks({
-        currentSession: {
-          ...mockActiveSession,
-          date: staleISO,
-          checkInTime: testTimestamp(staleISO, "08:00"),
-        },
-      });
-      const { container } = render(<TimeTrackingPage />);
+        setupDefaultMocks({
+          currentSession: {
+            ...mockActiveSession,
+            date: staleISO,
+            checkInTime: testTimestamp(staleISO, "08:00"),
+          },
+        });
+        const { container } = render(<TimeTrackingPage />);
 
-      // The block ended at the end of its own Berlin day — server-side too, so
-      // running it through `now` would print days of work the Saldo denies.
-      expect(container.querySelector(".text-4xl")).toHaveTextContent("0min");
+        // The block ended at the end of its own Berlin day — server-side too, so
+        // running it through `now` would print days of work the Saldo denies.
+        expect(container.querySelector(".text-4xl")).toHaveTextContent("0min");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("keeps counting a block that is still inside its live window", () => {

--- a/frontend/src/components/students/offering-request-review-item.test.tsx
+++ b/frontend/src/components/students/offering-request-review-item.test.tsx
@@ -777,7 +777,9 @@ describe("OfferingRequestReviewItem — Gültig ab", () => {
       expect(mockPreview).toHaveBeenCalledWith("77", [], "2027-03-01"),
     );
 
-    fireEvent.click(screen.getByLabelText("Anderes Datum wählen"));
+    const editDateCheckbox = screen.getByLabelText("Anderes Datum wählen");
+    await waitFor(() => expect(editDateCheckbox).toBeEnabled());
+    fireEvent.click(editDateCheckbox);
 
     await waitFor(() =>
       expect(screen.getByText("01.02.2027")).toBeInTheDocument(),

--- a/scripts/backend-affected-packages.sh
+++ b/scripts/backend-affected-packages.sh
@@ -105,21 +105,22 @@ production_changed=$(printf '%s\n' "$changed_dirs" | awk -v module="$module" '
   }
 ')
 
-if [ -z "$production_changed" ]; then
-  printf '%s\n' "$changed" | sort -u
-  exit 0
-fi
-
 {
   printf '%s\n' "$changed"
-  go list -test -f '{{if .ForTest}}{{.ForTest}}{{range .Deps}} {{.}}{{end}}{{end}}' ./... |
-    awk 'NR == FNR { changed[$0] = 1; next }
-      {
-        for (field = 2; field <= NF; field++) {
-          if ($field in changed) {
-            print $1
-            next
+  # The test package contains repository-wide source scanners and ratchets.
+  # Import-graph selection cannot discover that dependency, so every non-empty
+  # backend selection must include it explicitly.
+  printf '%s/test\n' "$module"
+  if [ -n "$production_changed" ]; then
+    go list -test -f '{{if .ForTest}}{{.ForTest}}{{range .Deps}} {{.}}{{end}}{{end}}' ./... |
+      awk 'NR == FNR { changed[$0] = 1; next }
+        {
+          for (field = 2; field <= NF; field++) {
+            if ($field in changed) {
+              print $1
+              next
+            }
           }
-        }
-      }' <(printf '%s\n' "$production_changed") -
+        }' <(printf '%s\n' "$production_changed") -
+  fi
 } | sort -u

--- a/scripts/backend-affected-packages_test.sh
+++ b/scripts/backend-affected-packages_test.sh
@@ -13,7 +13,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$fixture/backend"/{core,consumer,corex,localeconsumer,localization,exportconsumer,services/listexport/assets,templates/email}
+mkdir -p "$fixture/backend"/{core,consumer,corex,localeconsumer,localization,exportconsumer,services/listexport/assets,templates/email,test}
 printf 'module example.test/project\n\ngo 1.25\n' >"$fixture/backend/go.mod"
 printf 'package core\n\nconst Value = 1\n' >"$fixture/backend/core/core.go"
 cat >"$fixture/backend/core/core_test.go" <<'EOF'
@@ -34,6 +34,7 @@ printf 'package corex\n' >"$fixture/backend/corex/corex_test.go"
 printf 'package localization\n\nconst Value = 1\n' >"$fixture/backend/localization/locales.go"
 printf 'package listexport\n\nconst Value = 1\n' >"$fixture/backend/services/listexport/export.go"
 printf 'package email\n' >"$fixture/backend/templates/email/template_test.go"
+printf 'package test\n' >"$fixture/backend/test/test.go"
 cat >"$fixture/backend/localeconsumer/consumer.go" <<'EOF'
 package localeconsumer
 
@@ -89,30 +90,40 @@ assert_workflow_filter() {
   fi
 }
 
+assert_workflow_output_contains() {
+  output=$1
+  fragment=$2
+  line=$(grep -F "      $output:" "$repo_root/.github/workflows/main.yml" || true)
+  if [[ "$line" != *"$fragment"* ]]; then
+    echo "workflow output $output: expected to contain $fragment" >&2
+    exit 1
+  fi
+}
+
 printf '\n// changed\n' >>"$fixture/backend/core/core_test.go"
-assert_output 'example.test/project/core'
+assert_output $'example.test/project/core\nexample.test/project/test'
 git -C "$fixture" restore backend/core/core_test.go
 
 printf '\n// changed\n' >>"$fixture/backend/core/core.go"
-assert_output $'example.test/project/consumer\nexample.test/project/core'
-assert_output $'example.test/project/consumer\nexample.test/project/core' "$fixture/backend"
+assert_output $'example.test/project/consumer\nexample.test/project/core\nexample.test/project/test'
+assert_output $'example.test/project/consumer\nexample.test/project/core\nexample.test/project/test' "$fixture/backend"
 git -C "$fixture" restore backend/core/core.go
 
 mkdir -p "$fixture/backend/consumer/testdata"
 printf 'fixture\n' >"$fixture/backend/consumer/testdata/input.golden"
-assert_output 'example.test/project/consumer'
+assert_output $'example.test/project/consumer\nexample.test/project/test'
 rm "$fixture/backend/consumer/testdata/input.golden"
 
 printf 'template\n' >"$fixture/backend/templates/email/probe.html"
-assert_output 'example.test/project/templates/email'
+assert_output $'example.test/project/templates/email\nexample.test/project/test'
 rm "$fixture/backend/templates/email/probe.html"
 
 printf '{}\n' >"$fixture/backend/localization/locales.json"
-assert_output $'example.test/project/localeconsumer\nexample.test/project/localization'
+assert_output $'example.test/project/localeconsumer\nexample.test/project/localization\nexample.test/project/test'
 rm "$fixture/backend/localization/locales.json"
 
 printf 'asset\n' >"$fixture/backend/services/listexport/assets/probe.txt"
-assert_output $'example.test/project/exportconsumer\nexample.test/project/services/listexport'
+assert_output $'example.test/project/exportconsumer\nexample.test/project/services/listexport\nexample.test/project/test'
 rm "$fixture/backend/services/listexport/assets/probe.txt"
 
 printf '\n// changed\n' >>"$fixture/backend/go.mod"
@@ -141,5 +152,8 @@ for pattern in \
   assert_workflow_filter backend-tests "$pattern" present
   assert_workflow_filter backend-production "$pattern" present
 done
+
+assert_workflow_output_contains run-backend '${{ github.event_name == '\''push'\'' ||'
+assert_workflow_output_contains run-frontend '${{ github.event_name == '\''push'\'' ||'
 
 echo 'backend affected-package selector tests passed'


### PR DESCRIPTION
## Description

Der PR repariert die CI-Integrität von `development`:

- entfernt die direkten Permission-DELETEs, mit denen der Hermetik-Ratchet umgangen wurde
- führt das globale Backend-Paket `test` bei jeder nicht leeren Affected-Package-Auswahl aus
- führt nach jedem Push auf die konfigurierten Hauptbranches beide vollständigen Testsuiten aus
- stabilisiert die beiden bestätigten Frontend-Flakes mit festen beziehungsweise abgewarteten Zeitgrenzen
- korrigiert die bereits auf `development` fehlerhafte Go-Import-Gruppierung

Damit kann ein späterer Docs-/Tooling-Push keinen grünen Development-Lauf mehr erzeugen, während Backend und Frontend vollständig übersprungen werden.

## Type of Change
- [x] Bug fix
- [x] Configuration change
- [x] Test addition/modification
- [x] CI/CD improvement

## Related Issues
- Related to #2550
- Follow-up to #2549

## Testing
- [x] Unit tests added/updated
- [x] Integration tests updated
- [x] Full backend suite: 23,740 tests passed, 5 expected skips
- [x] Full frontend suite: 14,133 tests passed
- [x] `pnpm run check`
- [x] `scripts/backend-affected-packages_test.sh`
- [x] Hermetik-Ratchet twice plus both affected auth integration tests

## Security Checklist
- [x] I have followed the security guidelines
- [x] No sensitive information is committed
- [x] Environment variables are unchanged
- [x] Code does not contain hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Screenshots or Examples

Nicht anwendbar: keine sichtbare UI-Änderung.

## Missverständnis-Check

Nicht user-sichtbar.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a two-axis self-review
- [x] I have commented the non-obvious CI selection rule
- [x] Documentation changes are not needed
- [x] Help guide changes do not apply
- [x] Verständlichkeit checklist does not apply
- [x] All tests are passing
- [x] My changes generate no new warnings or errors
- [x] I have checked for and resolved merge conflicts

## Additional Notes

`development` enthält den Backend-Clock-Fix bereits über `ce039742`; dieser PR dupliziert ihn nicht. Nach dem PR wird `ci-gate` in der Branch Protection für `development` verpflichtend und für Admins erzwungen.
