### PR TITLE
Stabilize time-dependent backend tests

### DIFF
--- a/backend/api/enrollment/change_request_review_list_router_test.go
+++ b/backend/api/enrollment/change_request_review_list_router_test.go
@@ -362,7 +362,7 @@ func TestChangeRequestReviewList_FiltersByNameStatusAndPeriod(t *testing.T) {
 	t.Parallel()
 
 	env := setupReviewListTest(t)
-	base := time.Now().UTC().Add(-2 * time.Hour)
+	base := timezone.NewDate(2026, 8, 19).BerlinMidnight().Add(12 * time.Hour)
 
 	approved := env.insertChangeRequest(t, enrollmentModels.ChangeRequestStatusApproved, base, env.childIDs[0], true)
 	rejected := env.insertChangeRequest(t, enrollmentModels.ChangeRequestStatusRejected, base.Add(-time.Minute), env.childIDs[1], true)

--- a/backend/services/active/work_session_service_test.go
+++ b/backend/services/active/work_session_service_test.go
@@ -1824,11 +1824,12 @@ func TestWSGetHistory_Success(t *testing.T) {
 	t.Parallel()
 	svc, sessionRepo, breakRepo, auditRepo, _ := wsCreateTestService()
 	staffID := int64(100)
-	from := timezone.TodayDate().AddDays(-7)
-	to := timezone.TodayDate()
+	day := timezone.NewDate(2026, 8, 19)
+	from := day.AddDays(-3)
+	to := day.AddDays(3)
 
-	checkIn := time.Now().Add(-8 * time.Hour)
-	checkOut := time.Now().Add(-2 * time.Hour)
+	checkIn := day.BerlinMidnight().Add(8 * time.Hour)
+	checkOut := checkIn.Add(6 * time.Hour)
 	sessionRepo.getHistoryByStaffIDFunc = func(_ context.Context, _ int64, _, _ timezone.Date) ([]*activeModels.WorkSession, error) {
 		return []*activeModels.WorkSession{
 			{


### PR DESCRIPTION
## Description

Fixes the two backend test flakes that failed the development workflow after #2555:

- pins the enrollment review period fixture to a fixed Berlin midday, so its approved and rejected decisions cannot land on different dates
- pins the work-session history fixture to a fixed Wednesday and fixed clock times, so it cannot cross a day or ISO-week boundary based on wall-clock execution time

No production code changes.

## Type of Change

- [x] Bug fix
- [x] Test addition/modification
- [x] CI/CD improvement

## Testing

- [x] Work-session target: 20 consecutive passes
- [x] Enrollment target: passes against a fresh self-managed test database
- [x] `scripts/test-changed.sh origin/development`
- [x] Pre-push architecture, vet, golangci-lint, dead-code, and secret checks

## Security Checklist

- [x] I have followed the security guidelines
- [x] No sensitive information is committed
- [x] No environment-variable changes
- [x] No hardcoded secrets
- [x] No potential security vulnerabilities introduced

## Missverständnis-Check

nicht user-sichtbar

## Checklist

- [x] Project style followed
- [x] Self-review completed
- [x] Documentation not needed: test-only change
- [x] Help guide not applicable
- [x] Verständlichkeit checklist not applicable
- [x] All affected tests pass
- [x] No new warnings or errors
- [x] No merge conflicts
