### PR TITLE
Prevent dynamic route collisions before merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,14 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
 
+      - name: Check frontend route invariants
+        if: ${{ inputs.is-pr }}
+        working-directory: frontend
+        run: >-
+          pnpm vitest run
+          src/lib/app-route-invariants.test.ts
+          src/lib/analytics-routes.test.ts
+
       - name: Run changed frontend tests
         if: ${{ inputs.is-pr && ! inputs.full-frontend-suite && inputs.base_ref != '' }}
         working-directory: frontend

--- a/frontend/src/app/[tenant]/(protected)/enrollment-phases/[id]/rollover/page.tsx
+++ b/frontend/src/app/[tenant]/(protected)/enrollment-phases/[id]/rollover/page.tsx
@@ -14,11 +14,11 @@ import { useTenantMutate } from "~/lib/swr";
 const logger = createLogger({ component: "MobileRolloverPage" });
 
 interface PageProps {
-  readonly params: Promise<{ phaseId: string }>;
+  readonly params: Promise<{ id: string }>;
 }
 
 export default function MobileRolloverPage({ params }: PageProps) {
-  const { phaseId } = use(params);
+  const { id } = use(params);
   const { isReady } = useRequireAdmin();
   const tenantPath = useTenantAwarePath();
   const tenantMutate = useTenantMutate();
@@ -27,7 +27,7 @@ export default function MobileRolloverPage({ params }: PageProps) {
 
   useEffect(() => {
     if (!isReady) return;
-    getPhase(phaseId)
+    getPhase(id)
       .then(setPhase)
       .catch((err: unknown) => {
         const message =
@@ -37,7 +37,7 @@ export default function MobileRolloverPage({ params }: PageProps) {
         logger.error("rollover_phase_load_failed", { error: message });
         setError(message);
       });
-  }, [isReady, phaseId]);
+  }, [isReady, id]);
 
   if (!isReady || (phase === null && error === null)) {
     return (

--- a/frontend/src/lib/analytics-routes.ts
+++ b/frontend/src/lib/analytics-routes.ts
@@ -46,6 +46,7 @@ export const TRACKED_TENANT_ROUTE_TEMPLATES = [
   "/enrollment-form",
   "/enrollment-phases",
   "/enrollment-phases/:id/review",
+  "/enrollment-phases/:id/rollover",
   "/info-displays",
   "/invitations",
   "/klassen",

--- a/frontend/src/lib/app-route-invariants.test.ts
+++ b/frontend/src/lib/app-route-invariants.test.ts
@@ -1,0 +1,44 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function collectDynamicSiblingConflicts(
+  directory: string,
+  appRoot = directory,
+): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const directories = entries.filter((entry) => entry.isDirectory());
+  const dynamicDirectories = directories
+    .filter((entry) => entry.name.startsWith("[") && entry.name.endsWith("]"))
+    .map((entry) => entry.name)
+    .sort();
+  const conflicts =
+    dynamicDirectories.length > 1
+      ? [
+          `${path.relative(appRoot, directory) || "."}: ${dynamicDirectories.join(", ")}`,
+        ]
+      : [];
+
+  for (const entry of directories) {
+    conflicts.push(
+      ...collectDynamicSiblingConflicts(
+        path.join(directory, entry.name),
+        appRoot,
+      ),
+    );
+  }
+
+  return conflicts;
+}
+
+describe("Next.js app route filesystem invariants", () => {
+  it("uses at most one dynamic child directory per filesystem parent", () => {
+    const appRoot = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../app",
+    );
+
+    expect(collectDynamicSiblingConflicts(appRoot)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the development CI failure introduced by the enrollment rollover route and add a fast PR guardrail for the same failure class.

- move the rollover page under the existing `[id]` segment
- register the rollover page in the tenant analytics route allowlist
- reject multiple dynamic child directories under one App Router filesystem parent
- always run the route and analytics invariant tests on frontend PRs

## Root cause

PR CI used Vitest changed-test selection, which did not select the filesystem-based analytics inventory test for a new page. The push-only guide build then became the first job to start the production server, where Next.js rejected sibling `[id]` and `[phaseId]` directories.

## Testing

- [x] Regression test failed before the route rename with `[id], [phaseId]`
- [x] `cd frontend && pnpm run check`
- [x] `cd frontend && pnpm vitest run src/lib/app-route-invariants.test.ts src/lib/analytics-routes.test.ts`
- [x] Full frontend suite: 1,022 files / 14,143 tests
- [x] `cd frontend && pnpm run build`
- [x] Production Next.js server started and `/help` returned HTTP 200
- [x] Staged diff reviewed against repository standards and the approved spec

## Security

- [x] No secrets or authentication behavior changed
- [x] No API or data-contract changes
- [x] No environment-variable changes

## Missverständnis-Check

Nicht user-sichtbar. URL, Oberfläche und Texte bleiben unverändert.

## Documentation

Help guide and screenshots are not applicable because this repair has no visible product change.