### PR TITLE
chore: gitignore local .codex-work directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -504,3 +504,6 @@ tmp-screens-1841/
 # IoT simulator config written by the seed command — carries per-device API
 # keys for the local dev fleet and is regenerated on every seed
 backend/simulator/iot/simulator.yaml
+
+# Local Codex agent working directory (never tracked)
+.codex-work/


### PR DESCRIPTION
Adds `.codex-work/` to `.gitignore`. It is a local agent working directory and should never be tracked.

**Missverständnis-Check**: nicht user-sichtbar.

https://claude.ai/code/session_01X44bQZnq9FMtXDSX84hfqZ