### PR TITLE
Speed up backend lint for pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       run-backend:
         type: boolean
         default: true
+      full-backend:
+        type: boolean
+        default: true
       run-frontend:
         type: boolean
         default: true
@@ -92,17 +95,48 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Setup Go with cache
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: backend/go.mod
           cache: true
           cache-dependency-path: backend/go.sum
+      - name: Select backend packages
+        id: packages
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          FULL_BACKEND: ${{ inputs.full-backend }}
+        run: |
+          packages=(./...)
+          if [[ "$EVENT_NAME" == "pull_request" && "$FULL_BACKEND" != "true" ]]; then
+            module=$(cd backend && go list -m)
+            affected_output=$(scripts/backend-affected-packages.sh "origin/$BASE_REF")
+            mapfile -t affected_packages <<< "$affected_output"
+
+            if [[ -n "$affected_output" ]]; then
+              packages=()
+              for package in "${affected_packages[@]}"; do
+                if [[ "$package" == "$module" ]]; then
+                  packages+=(.)
+                elif [[ "$package" == "$module/"* ]]; then
+                  packages+=(".${package#"$module"}")
+                else
+                  packages+=("$package")
+                fi
+              done
+            fi
+          fi
+
+          echo "Linting ${#packages[@]} backend package target(s): ${packages[*]}"
+          printf 'args=%s\n' "${packages[*]}" >> "$GITHUB_OUTPUT"
       - name: golang ci lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v6
         with:
           version: v2.12.2 # pinned: v2.13.0 crashes (staticcheck nilness panics on sentry-go)
-          args: --timeout 10m
+          args: --timeout 10m ${{ steps.packages.outputs.args }}
           working-directory: backend
 
   frontend-quality:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       run-backend: ${{ github.event_name == 'push' || steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true' || steps.filter.outputs.ci == 'true' }}
       run-frontend: ${{ github.event_name == 'push' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.frontend-test-infra == 'true' || steps.filter.outputs.ci == 'true' }}
       run-backend-lint: ${{ steps.filter.outputs.backend-lint == 'true' || steps.filter.outputs.ci == 'true' }}
+      full-backend-lint: ${{ github.event_name == 'push' || steps.filter.outputs.backend-lint-full == 'true' || steps.filter.outputs.ci == 'true' }}
       run-frontend-lint: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
       # The seed smoke drives runtime API contracts. Test-only edits and
       # frontend-only pushes cannot affect it and must not buy another runner.
@@ -71,7 +72,15 @@ jobs:
               - 'backend/.go-arch-lint.yml'
               - 'backend/tools/go.mod'
               - 'backend/tools/go.sum'
+              - 'scripts/backend-affected-packages.sh'
+              - 'scripts/backend-affected-packages_test.sh'
               - 'scripts/backend-architecture.sh'
+            backend-lint-full:
+              - 'backend/go.mod'
+              - 'backend/go.sum'
+              - 'backend/.golangci.yml'
+              - 'scripts/backend-affected-packages.sh'
+              - 'scripts/backend-affected-packages_test.sh'
             backend-production:
               - 'backend/**/*.go'
               - '!backend/**/*_test.go'
@@ -110,6 +119,7 @@ jobs:
     uses: ./.github/workflows/lint.yml
     with:
       run-backend: ${{ needs.detect-changes.outputs.run-backend-lint == 'true' }}
+      full-backend: ${{ needs.detect-changes.outputs.full-backend-lint == 'true' }}
       run-frontend: ${{ needs.detect-changes.outputs.run-frontend-lint == 'true' }}
 
   test:

--- a/scripts/backend-affected-packages.sh
+++ b/scripts/backend-affected-packages.sh
@@ -112,7 +112,10 @@ production_changed=$(printf '%s\n' "$changed_dirs" | awk -v module="$module" '
   # backend selection must include it explicitly.
   printf '%s/test\n' "$module"
   if [ -n "$production_changed" ]; then
-    go list -test -f '{{if .ForTest}}{{.ForTest}}{{range .Deps}} {{.}}{{end}}{{end}}' ./... |
+    {
+      go list -f '{{.ImportPath}}{{range .Deps}} {{.}}{{end}}' ./...
+      go list -test -f '{{if .ForTest}}{{.ForTest}}{{range .Deps}} {{.}}{{end}}{{end}}' ./...
+    } |
       awk 'NR == FNR { changed[$0] = 1; next }
         {
           for (field = 2; field <= NF; field++) {

--- a/scripts/backend-affected-packages_test.sh
+++ b/scripts/backend-affected-packages_test.sh
@@ -13,7 +13,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$fixture/backend"/{core,consumer,corex,localeconsumer,localization,exportconsumer,services/listexport/assets,templates/email,test}
+mkdir -p "$fixture/backend"/{core,consumer,consumerwithouttests,corex,localeconsumer,localization,exportconsumer,services/listexport/assets,templates/email,test}
 printf 'module example.test/project\n\ngo 1.25\n' >"$fixture/backend/go.mod"
 printf 'package core\n\nconst Value = 1\n' >"$fixture/backend/core/core.go"
 cat >"$fixture/backend/core/core_test.go" <<'EOF'
@@ -29,6 +29,13 @@ import "example.test/project/core"
 const Value = core.Value
 EOF
 printf 'package consumer\n' >"$fixture/backend/consumer/consumer_test.go"
+cat >"$fixture/backend/consumerwithouttests/consumer.go" <<'EOF'
+package consumerwithouttests
+
+import "example.test/project/core"
+
+const Value = core.Value
+EOF
 printf 'package corex\n' >"$fixture/backend/corex/corex.go"
 printf 'package corex\n' >"$fixture/backend/corex/corex_test.go"
 printf 'package localization\n\nconst Value = 1\n' >"$fixture/backend/localization/locales.go"
@@ -105,8 +112,8 @@ assert_output $'example.test/project/core\nexample.test/project/test'
 git -C "$fixture" restore backend/core/core_test.go
 
 printf '\n// changed\n' >>"$fixture/backend/core/core.go"
-assert_output $'example.test/project/consumer\nexample.test/project/core\nexample.test/project/test'
-assert_output $'example.test/project/consumer\nexample.test/project/core\nexample.test/project/test' "$fixture/backend"
+assert_output $'example.test/project/consumer\nexample.test/project/consumerwithouttests\nexample.test/project/core\nexample.test/project/test'
+assert_output $'example.test/project/consumer\nexample.test/project/consumerwithouttests\nexample.test/project/core\nexample.test/project/test' "$fixture/backend"
 git -C "$fixture" restore backend/core/core.go
 
 mkdir -p "$fixture/backend/consumer/testdata"
@@ -145,6 +152,16 @@ fi
 
 assert_workflow_filter backend-tests 'backend/**/testdata/**' present
 assert_workflow_filter backend-production 'backend/**/testdata/**' absent
+assert_workflow_filter backend-lint 'scripts/backend-affected-packages.sh' present
+assert_workflow_filter backend-lint 'scripts/backend-affected-packages_test.sh' present
+for pattern in \
+  'backend/go.mod' \
+  'backend/go.sum' \
+  'backend/.golangci.yml' \
+  'scripts/backend-affected-packages.sh' \
+  'scripts/backend-affected-packages_test.sh'; do
+  assert_workflow_filter backend-lint-full "$pattern" present
+done
 for pattern in \
   'backend/templates/email/**' \
   'backend/localization/locales.json' \
@@ -155,5 +172,6 @@ done
 
 assert_workflow_output_contains run-backend '${{ github.event_name == '\''push'\'' ||'
 assert_workflow_output_contains run-frontend '${{ github.event_name == '\''push'\'' ||'
+assert_workflow_output_contains full-backend-lint '${{ github.event_name == '\''push'\'' ||'
 
 echo 'backend affected-package selector tests passed'


### PR DESCRIPTION
## Summary
- lint only changed backend packages and their production/test reverse dependencies on ordinary pull requests
- keep full backend lint for protected-branch pushes, module/linter/CI changes, and fail-safe fallback cases
- cover production dependents without test files and pin selector changes to the backend-lint path filter

## Performance
This does not speed up every run. Small or leaf-package PRs benefit most; central-package changes may remain near-full. This CI-only PR deliberately runs a full lint.

## Safety
- `full-backend` defaults to `true`
- `development` and `main` pushes always lint `./...`
- `go.mod`, `go.sum`, `.golangci.yml`, selector, and CI changes force full lint
- affected selection includes ordinary production and test dependency graphs plus repository-wide ratchets

## Verification
- `scripts/backend-affected-packages_test.sh`
- `actionlint -ignore 'label .* is unknown' -ignore 'SC2034' .github/workflows/lint.yml .github/workflows/main.yml`
- `cd backend && golangci-lint run --timeout 10m ./...`
- `git diff --check`
- pre-push backend lint, vet, architecture, dead-code, and frontend checks

Verständlichkeit checklist: not applicable (CI-only change; no user-facing flow or copy).
