### PR TITLE
Fix backend lint selection contracts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,26 +110,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           FULL_BACKEND: ${{ inputs.full-backend }}
         run: |
-          packages=(./...)
-          if [[ "$EVENT_NAME" == "pull_request" && "$FULL_BACKEND" != "true" ]]; then
-            module=$(cd backend && go list -m)
-            affected_output=$(scripts/backend-affected-packages.sh "origin/$BASE_REF")
-            mapfile -t affected_packages <<< "$affected_output"
-
-            if [[ -n "$affected_output" ]]; then
-              packages=()
-              for package in "${affected_packages[@]}"; do
-                if [[ "$package" == "$module" ]]; then
-                  packages+=(.)
-                elif [[ "$package" == "$module/"* ]]; then
-                  packages+=(".${package#"$module"}")
-                else
-                  packages+=("$package")
-                fi
-              done
-            fi
-          fi
-
+          packages_output=$(scripts/backend-lint-packages.sh)
+          mapfile -t packages <<< "$packages_output"
           echo "Linting ${#packages[@]} backend package target(s): ${packages[*]}"
           printf 'args=%s\n' "${packages[*]}" >> "$GITHUB_OUTPUT"
       - name: golang ci lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
     outputs:
       # Every protected-branch push rechecks both full suites. A docs-only push
       # must not report green while inheriting a broken development head.
-      # Lint/build jobs stay scoped to the side that changed.
+      # Backend lint also runs in full; frontend lint/build stays change-scoped.
       run-backend: ${{ github.event_name == 'push' || steps.filter.outputs.backend-tests == 'true' || steps.filter.outputs.backend-test-infra == 'true' || steps.filter.outputs.ci == 'true' }}
       run-frontend: ${{ github.event_name == 'push' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.frontend-test-infra == 'true' || steps.filter.outputs.ci == 'true' }}
-      run-backend-lint: ${{ steps.filter.outputs.backend-lint == 'true' || steps.filter.outputs.ci == 'true' }}
+      run-backend-lint: ${{ github.event_name == 'push' || steps.filter.outputs.backend-lint == 'true' || steps.filter.outputs.ci == 'true' }}
       full-backend-lint: ${{ github.event_name == 'push' || steps.filter.outputs.backend-lint-full == 'true' || steps.filter.outputs.ci == 'true' }}
       run-frontend-lint: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
       # The seed smoke drives runtime API contracts. Test-only edits and
@@ -74,6 +74,7 @@ jobs:
               - 'backend/tools/go.sum'
               - 'scripts/backend-affected-packages.sh'
               - 'scripts/backend-affected-packages_test.sh'
+              - 'scripts/backend-lint-packages.sh'
               - 'scripts/backend-architecture.sh'
             backend-lint-full:
               - 'backend/go.mod'
@@ -81,6 +82,7 @@ jobs:
               - 'backend/.golangci.yml'
               - 'scripts/backend-affected-packages.sh'
               - 'scripts/backend-affected-packages_test.sh'
+              - 'scripts/backend-lint-packages.sh'
             backend-production:
               - 'backend/**/*.go'
               - '!backend/**/*_test.go'
@@ -95,6 +97,7 @@ jobs:
             backend-test-infra:
               - 'scripts/backend-affected-packages.sh'
               - 'scripts/backend-affected-packages_test.sh'
+              - 'scripts/backend-lint-packages.sh'
               - 'scripts/test-backend.sh'
               - 'scripts/test-changed.sh'
             frontend-test-infra:

--- a/scripts/backend-affected-packages_test.sh
+++ b/scripts/backend-affected-packages_test.sh
@@ -65,10 +65,22 @@ git -C "$fixture" config user.name selector-test
 git -C "$fixture" config commit.gpgSign false
 git -C "$fixture" add .
 git -C "$fixture" commit -qm baseline
+git -C "$fixture" update-ref refs/remotes/origin/base HEAD
 
 select_packages() {
   working_directory=${1:-$fixture}
   (cd "$working_directory" && "$repo_root/scripts/backend-affected-packages.sh" HEAD)
+}
+
+select_lint_packages() {
+  event_name=$1
+  full_backend=$2
+  working_directory=${3:-$fixture}
+  (
+    cd "$working_directory"
+    BASE_REF=base EVENT_NAME="$event_name" FULL_BACKEND="$full_backend" \
+      "$repo_root/scripts/backend-lint-packages.sh"
+  )
 }
 
 assert_output() {
@@ -77,6 +89,17 @@ assert_output() {
   actual=$(select_packages "$working_directory")
   if [ "$actual" != "$expected" ]; then
     printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_lint_output() {
+  event_name=$1
+  full_backend=$2
+  expected=$3
+  actual=$(select_lint_packages "$event_name" "$full_backend")
+  if [ "$actual" != "$expected" ]; then
+    printf 'expected lint packages:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
     exit 1
   fi
 }
@@ -114,7 +137,20 @@ git -C "$fixture" restore backend/core/core_test.go
 printf '\n// changed\n' >>"$fixture/backend/core/core.go"
 assert_output $'example.test/project/consumer\nexample.test/project/consumerwithouttests\nexample.test/project/core\nexample.test/project/test'
 assert_output $'example.test/project/consumer\nexample.test/project/consumerwithouttests\nexample.test/project/core\nexample.test/project/test' "$fixture/backend"
+assert_lint_output pull_request false $'./consumer\n./consumerwithouttests\n./core\n./test'
 git -C "$fixture" restore backend/core/core.go
+
+assert_lint_output pull_request false './...'
+assert_lint_output pull_request true './...'
+assert_lint_output push false './...'
+if (
+  cd "$fixture"
+  BASE_REF=missing EVENT_NAME=pull_request FULL_BACKEND=false \
+    "$repo_root/scripts/backend-lint-packages.sh" >/dev/null 2>&1
+); then
+  echo 'partial lint unexpectedly ignored a missing base ref' >&2
+  exit 1
+fi
 
 mkdir -p "$fixture/backend/consumer/testdata"
 printf 'fixture\n' >"$fixture/backend/consumer/testdata/input.golden"
@@ -154,12 +190,15 @@ assert_workflow_filter backend-tests 'backend/**/testdata/**' present
 assert_workflow_filter backend-production 'backend/**/testdata/**' absent
 assert_workflow_filter backend-lint 'scripts/backend-affected-packages.sh' present
 assert_workflow_filter backend-lint 'scripts/backend-affected-packages_test.sh' present
+assert_workflow_filter backend-lint 'scripts/backend-lint-packages.sh' present
+assert_workflow_filter backend-test-infra 'scripts/backend-lint-packages.sh' present
 for pattern in \
   'backend/go.mod' \
   'backend/go.sum' \
   'backend/.golangci.yml' \
   'scripts/backend-affected-packages.sh' \
-  'scripts/backend-affected-packages_test.sh'; do
+  'scripts/backend-affected-packages_test.sh' \
+  'scripts/backend-lint-packages.sh'; do
   assert_workflow_filter backend-lint-full "$pattern" present
 done
 for pattern in \
@@ -172,6 +211,12 @@ done
 
 assert_workflow_output_contains run-backend '${{ github.event_name == '\''push'\'' ||'
 assert_workflow_output_contains run-frontend '${{ github.event_name == '\''push'\'' ||'
+assert_workflow_output_contains run-backend-lint '${{ github.event_name == '\''push'\'' ||'
 assert_workflow_output_contains full-backend-lint '${{ github.event_name == '\''push'\'' ||'
+if ! grep -Fq 'packages_output=$(scripts/backend-lint-packages.sh)' \
+  "$repo_root/.github/workflows/lint.yml"; then
+  echo 'lint workflow does not propagate selector failures' >&2
+  exit 1
+fi
 
 echo 'backend affected-package selector tests passed'

--- a/scripts/backend-lint-packages.sh
+++ b/scripts/backend-lint-packages.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Prints golangci-lint package targets relative to backend/. Pull requests use
+# affected packages; every other case fails safe to a full backend lint.
+set -euo pipefail
+
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${FULL_BACKEND:?FULL_BACKEND is required}"
+
+packages=(./...)
+if [ "$EVENT_NAME" = pull_request ] && [ "$FULL_BACKEND" != true ]; then
+  : "${BASE_REF:?BASE_REF is required for partial pull-request lint}"
+  repo_root=$(git rev-parse --show-toplevel)
+  script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+  module=$(cd "$repo_root/backend" && go list -m)
+  affected_output=$("$script_dir/backend-affected-packages.sh" "origin/$BASE_REF")
+
+  if [ -n "$affected_output" ]; then
+    packages=()
+    while IFS= read -r package; do
+      if [ "$package" = "$module" ]; then
+        packages+=(.)
+      elif [[ "$package" == "$module/"* ]]; then
+        packages+=(".${package#"$module"}")
+      else
+        packages+=("$package")
+      fi
+    done <<< "$affected_output"
+  fi
+fi
+
+printf '%s\n' "${packages[@]}"


### PR DESCRIPTION
## Summary

- Ensure protected-branch pushes run the full backend lint.
- Extract backend lint target selection into a fail-fast, tested script.
- Run selector contract tests when selector infrastructure changes.

Follow-up correction to [#2575](https://github.com/moto-nrw/project-phoenix/issues/2575).

## Verification

- `scripts/backend-affected-packages_test.sh`
- `bash -n scripts/backend-affected-packages.sh scripts/backend-lint-packages.sh scripts/backend-affected-packages_test.sh`
- `scripts/test-backend.sh` — 23,807 passed, 1 seeded-stack test skipped
- `cd frontend && pnpm run test:run` — 14,151 passed
- `cd frontend && pnpm run check`

## End-to-end QA

GitHub Actions execution and browser evidence will be added in a PR comment after checks complete.

Verständlichkeit checklist: not applicable (CI-only change; no user-facing flow or copy).
