### PR TITLE
Fix activity-instance wall-clock CI flake

### DIFF
--- a/.claude/rules/calendar-dates.md
+++ b/.claude/rules/calendar-dates.md
@@ -91,13 +91,20 @@ zero-Date sentinel.
    code; sub-day alignment needs `//nolint:forbidigo // <why>`.
 4. **oxlint** `date-safety/no-utc-date-extraction` bans
    `.toISOString().{split,slice,substring,substr}` in the frontend.
+5. **`TestActivityInstanceWallClockRatchet`**
+   (`backend/test/wall_clock_verification_test.go`) rejects
+   `ActivityInstance.StartTime`/`EndTime` assignments derived from
+   `time.Now()` or `timezone.Now()` unless they pass through
+   `timezone.WallClock()`. These fields map to PostgreSQL `TIME`; binding a
+   Berlin instant converts it to UTC and can reverse the clock interval around
+   UTC midnight.
 
 ## Detection
 
 ```bash
 rg --type go 'time\.Time' backend/models/ | rg -i '`bun:"[^"]*"' | rg -i 'date|day|birthday|valid_'  # suspect fields
 rg --type go 'Truncate\(24 \* time\.Hour\)' backend/
-cd backend && go test ./test/ -run TestDateColumnTypes                        # the registry check
+cd backend && go test ./test/ -run 'Test(DateColumnTypes|ActivityInstanceWallClockRatchet)' # backend date/time gates
 rg -n '\.toISOString\(\)\s*\.\s*(split|slice)' frontend/src/                  # frontend UTC extraction
 ```
 
@@ -113,6 +120,8 @@ rg -n '\.toISOString\(\)\s*\.\s*(split|slice)' frontend/src/                  # 
 
 ## Scope boundary
 
-TIME WITHOUT TIME ZONE columns (wall-clock times like `11:30`) are a separate,
-already-solved concern: normalize via `timezone.WallClock()` (see rule 11 in
-CLAUDE.md). Instants (TIMESTAMPTZ) stay `time.Time` everywhere.
+TIME WITHOUT TIME ZONE columns (wall-clock times like `11:30`) are a separate
+concern: normalize via `timezone.WallClock()` (see rule 11 in CLAUDE.md).
+`ActivityInstance` writes have a source ratchet; other TIME-backed models still
+rely on their repository/service normalization and code review. Instants
+(TIMESTAMPTZ) stay `time.Time` everywhere.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -93,6 +93,11 @@ Transactions propagate via context (`base.ContextWithTx` / `base.TxFromContext`)
 
 Every model field mapped to a `DATE` column MUST be `timezone.Date` (or `*timezone.Date`), never `time.Time` — bun binds `time.Time` as UTC and Berlin-midnight dates land one day behind. `TestDateColumnTypes` fails CI on violations. Full API and rules: `.claude/rules/calendar-dates.md`.
 
+Clock values mapped to PostgreSQL `TIME` must pass through
+`timezone.WallClock()`. `TestActivityInstanceWallClockRatchet` blocks raw
+current-time values in `ActivityInstance.StartTime`/`EndTime`; do not extend an
+allowlist around it.
+
 ## Tenant-Scoped Settings
 
 Per-school config resolves tenant DB override → registry default; the service does **not** check env vars. Consumers needing env var backward compatibility must check `HasTenantOverride()` first, then fall back to `os.Getenv()` manually. Use `Resolve*(ctx, key)` inside tenant middleware, `Resolve*ForTenant(ctx, tenantID, key)` outside it (device auth, scheduler loops). Everything else — registry, field types, permissions, add/edit/delete workflows: `.claude/rules/settings-system.md`.

--- a/backend/api/school/school_supervisions_test.go
+++ b/backend/api/school/school_supervisions_test.go
@@ -331,12 +331,11 @@ func TestSchoolSupervisionsCrossTenant(t *testing.T) {
 	otherRoom := testpkg.CreateTestRoomForTenant(t, f.db, otherTenantID, fmt.Sprintf("Fremdraum-%d", time.Now().UnixNano()))
 	otherCtx := testpkg.TenantContext(otherTenantID)
 
-	now := timezone.Now()
 	foreign := &scheduleModel.ActivityInstance{
 		Date:      timezone.TodayDate(),
 		Title:     "Fremde Schule",
-		StartTime: now.Add(-30 * time.Minute),
-		EndTime:   now.Add(90 * time.Minute),
+		StartTime: timezone.WallClock(time.Date(2000, 1, 1, 10, 0, 0, 0, time.UTC)),
+		EndTime:   timezone.WallClock(time.Date(2000, 1, 1, 11, 0, 0, 0, time.UTC)),
 		RoomID:    otherRoom.ID,
 		Status:    scheduleModel.InstanceStatusPlanned,
 	}

--- a/backend/test/wall_clock_verification_test.go
+++ b/backend/test/wall_clock_verification_test.go
@@ -1,0 +1,248 @@
+// Package test: wall-clock enforcement. See .claude/rules/calendar-dates.md.
+//
+// PostgreSQL TIME columns carry a clock value, not an instant. ActivityInstance
+// uses time.Time for those columns, so assignments derived from time.Now or
+// timezone.Now must pass through timezone.WallClock before persistence.
+package test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestActivityInstanceWallClockRatchet(t *testing.T) {
+	t.Parallel()
+
+	backendRoot, err := findBackendRoot()
+	if err != nil {
+		t.Skipf("Could not find backend root: %v", err)
+		return
+	}
+
+	violations, err := findRawActivityInstanceWallClocks(backendRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) > 0 {
+		t.Errorf("Found %d ActivityInstance wall-clock assignment(s) derived from a current instant:\n\n%s\n\n"+
+			"schedule.activity_instances.start_time/end_time are PostgreSQL TIME columns. "+
+			"Normalize dynamic values with timezone.WallClock, or use a fixed UTC-anchored clock in tests.",
+			len(violations), strings.Join(violations, "\n"))
+	}
+}
+
+func TestActivityInstanceWallClockRatchetDetectsAliasedInstantSources(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := `package sample
+
+import (
+	stdtime "time"
+	tz "github.com/moto-nrw/project-phoenix/internal/timezone"
+	"github.com/moto-nrw/project-phoenix/models/schedule"
+)
+
+func examples() {
+	raw := stdtime.Now()
+	berlinNow := tz.Now()
+	_ = &schedule.ActivityInstance{StartTime: raw}
+	_ = &schedule.ActivityInstance{EndTime: berlinNow.Add(90 * stdtime.Minute)}
+	_ = &schedule.ActivityInstance{StartTime: tz.WallClock(berlinNow)}
+	_ = &schedule.ActivityInstance{StartTime: stdtime.Date(2000, 1, 1, 10, 0, 0, 0, stdtime.UTC)}
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "sample.go"), []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	violations, err := findRawActivityInstanceWallClocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected raw time.Now and timezone.Now assignments to fail while normalized/fixed clocks pass; got %v", violations)
+	}
+}
+
+func findRawActivityInstanceWallClocks(backendRoot string) ([]string, error) {
+	fset := token.NewFileSet()
+	var violations []string
+	err := filepath.Walk(backendRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		rel, _ := filepath.Rel(backendRoot, path)
+		if rel == filepath.Join("test", "wall_clock_verification_test.go") {
+			return nil
+		}
+		found, scanErr := findRawActivityInstanceWallClocksInFile(path, rel, fset)
+		violations = append(violations, found...)
+		return scanErr
+	})
+	return violations, err
+}
+
+func findRawActivityInstanceWallClocksInFile(path, rel string, fset *token.FileSet) ([]string, error) {
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", rel, err)
+	}
+	timePackages, timezonePackages := timeImportNames(file)
+	var violations []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		body, ok := functionBody(node)
+		if !ok {
+			return true
+		}
+		instantVars := currentInstantVariables(body, timePackages, timezonePackages)
+		violations = append(violations, wallClockViolations(body, rel, fset, instantVars, timePackages, timezonePackages)...)
+		return false
+	})
+	return violations, nil
+}
+
+func wallClockViolations(body *ast.BlockStmt, rel string, fset *token.FileSet, instantVars, timePackages, timezonePackages map[string]bool) []string {
+	var violations []string
+	ast.Inspect(body, func(node ast.Node) bool {
+		literal, ok := node.(*ast.CompositeLit)
+		if !ok || expressionName(literal.Type) != "ActivityInstance" {
+			return true
+		}
+		for _, elt := range literal.Elts {
+			field, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			name, ok := field.Key.(*ast.Ident)
+			if !ok || (name.Name != "StartTime" && name.Name != "EndTime") {
+				continue
+			}
+			if expressionUsesCurrentInstant(field.Value, instantVars, timePackages, timezonePackages) {
+				pos := fset.Position(field.Value.Pos())
+				violations = append(violations, formatViolation(rel, pos.Line,
+					name.Name+" must normalize the current instant with timezone.WallClock"))
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+func functionBody(node ast.Node) (*ast.BlockStmt, bool) {
+	switch fn := node.(type) {
+	case *ast.FuncDecl:
+		return fn.Body, fn.Body != nil
+	case *ast.FuncLit:
+		return fn.Body, true
+	default:
+		return nil, false
+	}
+}
+
+func currentInstantVariables(body *ast.BlockStmt, timePackages, timezonePackages map[string]bool) map[string]bool {
+	instantVars := map[string]bool{}
+	changed := true
+	for changed {
+		changed = false
+		ast.Inspect(body, func(node ast.Node) bool {
+			switch stmt := node.(type) {
+			case *ast.AssignStmt:
+				for i, lhs := range stmt.Lhs {
+					if i >= len(stmt.Rhs) || !expressionUsesCurrentInstant(stmt.Rhs[i], instantVars, timePackages, timezonePackages) {
+						continue
+					}
+					if id, ok := lhs.(*ast.Ident); ok && !instantVars[id.Name] {
+						instantVars[id.Name] = true
+						changed = true
+					}
+				}
+			case *ast.ValueSpec:
+				for i, name := range stmt.Names {
+					if i < len(stmt.Values) && expressionUsesCurrentInstant(stmt.Values[i], instantVars, timePackages, timezonePackages) && !instantVars[name.Name] {
+						instantVars[name.Name] = true
+						changed = true
+					}
+				}
+			}
+			return true
+		})
+	}
+	return instantVars
+}
+
+func expressionUsesCurrentInstant(expr ast.Expr, instantVars, timePackages, timezonePackages map[string]bool) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return instantVars[e.Name]
+	case *ast.ParenExpr:
+		return expressionUsesCurrentInstant(e.X, instantVars, timePackages, timezonePackages)
+	case *ast.CallExpr:
+		if isImportedCall(e.Fun, timezonePackages, "WallClock") {
+			return false
+		}
+		if isImportedCall(e.Fun, timePackages, "Now") || isImportedCall(e.Fun, timezonePackages, "Now") {
+			return true
+		}
+		selector, ok := e.Fun.(*ast.SelectorExpr)
+		return ok && expressionUsesCurrentInstant(selector.X, instantVars, timePackages, timezonePackages)
+	case *ast.SelectorExpr:
+		return expressionUsesCurrentInstant(e.X, instantVars, timePackages, timezonePackages)
+	case *ast.StarExpr:
+		return expressionUsesCurrentInstant(e.X, instantVars, timePackages, timezonePackages)
+	default:
+		return false
+	}
+}
+
+func isImportedCall(expr ast.Expr, packageNames map[string]bool, functionName string) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != functionName {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && packageNames[pkg.Name]
+}
+
+func timeImportNames(file *ast.File) (map[string]bool, map[string]bool) {
+	timePackages := map[string]bool{}
+	timezonePackages := map[string]bool{}
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := pathpkg.Base(importPath)
+		if spec.Name != nil && spec.Name.Name != "." && spec.Name.Name != "_" {
+			name = spec.Name.Name
+		}
+		switch {
+		case importPath == "time":
+			timePackages[name] = true
+		case strings.HasSuffix(importPath, "/internal/timezone"):
+			timezonePackages[name] = true
+		}
+	}
+	return timePackages, timezonePackages
+}
+
+func expressionName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	case *ast.StarExpr:
+		return expressionName(e.X)
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- replace the midnight-sensitive cross-tenant fixture with fixed wall-clock values
- add a CI ratchet that rejects current instants assigned to `ActivityInstance` `TIME` fields without `timezone.WallClock()`
- correct the time-standard docs to distinguish enforced `DATE` rules from the remaining `TIME` scope

## Root cause
BUN converts `time.Time` to UTC before binding it to PostgreSQL. The test passed Berlin instants into `TIME` columns, so its interval reversed around UTC midnight and violated `check_activity_instance_times`.

## Verification
- `go test ./test ./api/school`
- `go vet ./test ./api/school`
- `golangci-lint run --timeout 5m` (Go 1.25.12 toolchain)
- pre-commit and pre-push hooks

## Verständlichkeit
Not applicable: test and agent-documentation changes only; no user-facing flow or copy.